### PR TITLE
Fix FXIOS-11434 24895 flaky unit tests JumpBackInDataAdaptorTests

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -412,6 +412,7 @@
 		3D9CA9841EF456A8002434DD /* NightModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9CA9831EF456A8002434DD /* NightModeTests.swift */; };
 		3D9CAA1C1EFCD655002434DD /* ClipBoardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9CAA1B1EFCD655002434DD /* ClipBoardTests.swift */; };
 		3DEFED081F55EBE300F8620C /* TrackingProtectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DEFED071F55EBE300F8620C /* TrackingProtectionTests.swift */; };
+		401F68A32D83C7F300786D0C /* MockJumpBackInDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401F68A22D83C7F300786D0C /* MockJumpBackInDelegate.swift */; };
 		43017ECB278E0C6700CED011 /* RustMozillaAppServices.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 43BE578A278BA4D900491291 /* RustMozillaAppServices.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		43079D1F2C85D3BB0047C28D /* Bookmarks.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43079D1D2C85D3BB0047C28D /* Bookmarks.strings */; };
 		43079D232C85D3BB0047C28D /* MainMenu.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43079D212C85D3BB0047C28D /* MainMenu.strings */; };
@@ -3139,6 +3140,7 @@
 		3F6E4BE58FC960ED572CD7C1 /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/Storage.strings; sourceTree = "<group>"; };
 		3FBA4868964EB1ADEC1BD10A /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		401A4085A3E85986AF89B292 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
+		401F68A22D83C7F300786D0C /* MockJumpBackInDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockJumpBackInDelegate.swift; sourceTree = "<group>"; };
 		40364407BBB70494930FE68D /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		406E4E6094EB97EBD3574628 /* gd */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gd; path = gd.lproj/Search.strings; sourceTree = "<group>"; };
 		40A64D0FB8B16BBEA2A423A1 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
@@ -13689,6 +13691,7 @@
 				8A9D31632D1355E900171502 /* MockFxBookmarkNode.swift */,
 				8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */,
 				21B548962B1E6AC300DC1DF8 /* MockInactiveTabsManager.swift */,
+				401F68A22D83C7F300786D0C /* MockJumpBackInDelegate.swift */,
 				8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */,
 				8AFCE50829DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift */,
 				8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */,
@@ -18252,6 +18255,7 @@
 				215B458427DA87FC00E5E800 /* TabMetadataManagerTests.swift in Sources */,
 				215349062886007900FADB4D /* GleanPlumbMessageStoreTests.swift in Sources */,
 				2173326A29CCF901007F20C7 /* UIPanGestureRecognizerMock.swift in Sources */,
+				401F68A32D83C7F300786D0C /* MockJumpBackInDelegate.swift in Sources */,
 				635183FB2CF5555C00EDFCE2 /* NativeErrorPageStateTests.swift in Sources */,
 				5A9A09D628B01FD500B6F51E /* MockURLBarView.swift in Sources */,
 				0B7FC3D32CAE811F005C5CCE /* DefaultBookmarksSaverTests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
@@ -119,7 +119,6 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
         XCTAssertEqual(syncTab?.tab.URL, remoteClientTabs.last?.URL)
     }
 
-
     // MARK: Helpers
     private func createSubject(file: StaticString = #file, line: UInt = #line) -> JumpBackInDataAdaptorImplementation {
         let dispatchQueue = MockDispatchQueue()
@@ -144,8 +143,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
         await delegate.waitForNewData()
     }
 
-    private func createTab(profile: MockProfile,
-                   urlString: String? = "www.website.com") -> Tab {
+    private func createTab(profile: MockProfile, urlString: String? = "www.website.com") -> Tab {
         let tab = Tab(profile: profile, windowUUID: windowUUID)
 
         if let urlString = urlString {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
@@ -27,7 +27,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
     }
 
     func testEmptyData() async {
-        let subject = await createSubject()
+        let subject = createSubject()
         await loadNewData(for: subject)
 
         let recentTabs = await subject.getRecentTabData()
@@ -39,7 +39,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
     func testGetRecentTabs() async {
         mockTabManager = MockTabManager(recentlyAccessedNormalTabs: createTabs())
         mockProfile.hasSyncableAccountMock = false
-        let subject = await createSubject()
+        let subject = createSubject()
         await loadNewData(for: subject)
 
         let recentTabs = await subject.getRecentTabData()
@@ -51,7 +51,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
         mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteDesktopClient(),
                                                        tabs: remoteTabs(idRange: 1...3))]
 
-        let subject = await createSubject()
+        let subject = createSubject()
         await loadNewData(for: subject)
 
         let recentTabs = await subject.getRecentTabData()
@@ -62,7 +62,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
     }
 
     func testSyncTab_whenNoSyncTabsData_notReturned() async {
-        let subject = await createSubject()
+        let subject = createSubject()
         await loadNewData(for: subject)
 
         let syncTab = await subject.getSyncedTabData()
@@ -73,7 +73,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
         mockProfile.hasSyncableAccountMock = false
         mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteDesktopClient(),
                                                        tabs: remoteTabs(idRange: 1...3))]
-        let subject = await createSubject()
+        let subject = createSubject()
         await loadNewData(for: subject)
 
         let syncTab = await subject.getSyncedTabData()
@@ -83,7 +83,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
     func testSyncTab_noDesktopClients_notReturned() async {
         mockProfile.hasSyncableAccountMock = false
         mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteClient, tabs: remoteTabs(idRange: 1...2))]
-        let subject = await createSubject()
+        let subject = createSubject()
         await loadNewData(for: subject)
 
         let syncTab = await subject.getSyncedTabData()
@@ -95,7 +95,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
         let remoteTabs = remoteTabs(idRange: 1...3)
         mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteClient, tabs: remoteTabs)]
 
-        let subject = await createSubject()
+        let subject = createSubject()
         await loadNewData(for: subject)
 
         let syncTab = await subject.getSyncedTabData()
@@ -110,7 +110,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
         mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteDesktopClient(), tabs: remoteTabs(idRange: 1...5)),
                                          ClientAndTabs(client: remoteClient, tabs: remoteClientTabs)]
 
-        let subject = await createSubject()
+        let subject = createSubject()
         await loadNewData(for: subject)
 
         let syncTab = await subject.getSyncedTabData()
@@ -118,18 +118,19 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
         XCTAssertEqual(syncTab?.tab.title, remoteClientTabs.last?.title)
         XCTAssertEqual(syncTab?.tab.URL, remoteClientTabs.last?.URL)
     }
-}
 
-// MARK: Helpers
-private extension JumpBackInDataAdaptorTests {
-    func createSubject(file: StaticString = #file, line: UInt = #line) async -> JumpBackInDataAdaptorImplementation {
+
+    // MARK: Helpers
+    private func createSubject(file: StaticString = #file, line: UInt = #line) -> JumpBackInDataAdaptorImplementation {
         let dispatchQueue = MockDispatchQueue()
         let notificationCenter = MockNotificationCenter()
 
-        let subject = JumpBackInDataAdaptorImplementation(profile: mockProfile,
-                                                          tabManager: mockTabManager,
-                                                          mainQueue: dispatchQueue,
-                                                          notificationCenter: notificationCenter)
+        let subject = JumpBackInDataAdaptorImplementation(
+            profile: mockProfile,
+            tabManager: mockTabManager,
+            mainQueue: dispatchQueue,
+            notificationCenter: notificationCenter
+        )
 
         trackForMemoryLeaks(subject, file: file, line: line)
         trackForMemoryLeaks(dispatchQueue, file: file, line: line)
@@ -137,13 +138,13 @@ private extension JumpBackInDataAdaptorTests {
         return subject
     }
 
-    func loadNewData(for subject: JumpBackInDataAdaptorImplementation) async {
+    private func loadNewData(for subject: JumpBackInDataAdaptorImplementation) async {
         let delegate = MockJumpBackInDelegate()
         await subject.setDelegate(delegate: delegate)
         await delegate.waitForNewData()
     }
 
-    func createTab(profile: MockProfile,
+    private func createTab(profile: MockProfile,
                    urlString: String? = "www.website.com") -> Tab {
         let tab = Tab(profile: profile, windowUUID: windowUUID)
 
@@ -153,7 +154,7 @@ private extension JumpBackInDataAdaptorTests {
         return tab
     }
 
-    var remoteClient: RemoteClient {
+    private var remoteClient: RemoteClient {
         return RemoteClient(guid: nil,
                             name: "Fake client",
                             modified: 1,
@@ -164,7 +165,7 @@ private extension JumpBackInDataAdaptorTests {
                             fxaDeviceId: nil)
     }
 
-    func remoteDesktopClient(name: String = "Fake client") -> RemoteClient {
+    private func remoteDesktopClient(name: String = "Fake client") -> RemoteClient {
         return RemoteClient(guid: nil,
                             name: name,
                             modified: 1,
@@ -175,7 +176,7 @@ private extension JumpBackInDataAdaptorTests {
                             fxaDeviceId: nil)
     }
 
-    func remoteTabs(idRange: ClosedRange<Int> = 1...1) -> [RemoteTab] {
+    private func remoteTabs(idRange: ClosedRange<Int> = 1...1) -> [RemoteTab] {
         var remoteTabs: [RemoteTab] = []
 
         for index in idRange {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
@@ -48,7 +48,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
 
     func testGetRecentTabsAndSyncedData() async {
         mockTabManager = MockTabManager(recentlyAccessedNormalTabs: createTabs())
-        mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteDesktopClient(),
+        mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteClient(type: "desktop"),
                                                        tabs: remoteTabs(idRange: 1...3))]
 
         let subject = createSubject()
@@ -71,7 +71,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
 
     func testSyncTab_whenNoSyncAccount_notReturned() async {
         mockProfile.hasSyncableAccountMock = false
-        mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteDesktopClient(),
+        mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteClient(type: "desktop"),
                                                        tabs: remoteTabs(idRange: 1...3))]
         let subject = createSubject()
         await loadNewData(for: subject)
@@ -82,7 +82,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
 
     func testSyncTab_noDesktopClients_notReturned() async {
         mockProfile.hasSyncableAccountMock = false
-        mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteClient, tabs: remoteTabs(idRange: 1...2))]
+        mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteClient(), tabs: remoteTabs(idRange: 1...2))]
         let subject = createSubject()
         await loadNewData(for: subject)
 
@@ -91,7 +91,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
     }
 
     func testSyncTab_oneDesktopClient_returned() async {
-        let remoteClient = remoteDesktopClient()
+        let remoteClient = remoteClient(type: "desktop")
         let remoteTabs = remoteTabs(idRange: 1...3)
         mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteClient, tabs: remoteTabs)]
 
@@ -105,9 +105,9 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
     }
 
     func testSyncTab_multipleDesktopClients_returnsLast() async {
-        let remoteClient = remoteDesktopClient(name: "Fake Client 2")
+        let remoteClient = remoteClient(name: "Fake Client 2", type: "desktop")
         let remoteClientTabs = remoteTabs(idRange: 7...9)
-        mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteDesktopClient(), tabs: remoteTabs(idRange: 1...5)),
+        mockProfile.mockClientAndTabs = [ClientAndTabs(client: remoteClient, tabs: remoteTabs(idRange: 1...5)),
                                          ClientAndTabs(client: remoteClient, tabs: remoteClientTabs)]
 
         let subject = createSubject()
@@ -152,22 +152,11 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
         return tab
     }
 
-    private var remoteClient: RemoteClient {
-        return RemoteClient(guid: nil,
-                            name: "Fake client",
-                            modified: 1,
-                            type: nil,
-                            formfactor: nil,
-                            os: nil,
-                            version: nil,
-                            fxaDeviceId: nil)
-    }
-
-    private func remoteDesktopClient(name: String = "Fake client") -> RemoteClient {
+    private func remoteClient(name: String = "Fake client", type: String? = nil) -> RemoteClient {
         return RemoteClient(guid: nil,
                             name: name,
                             modified: 1,
-                            type: "desktop",
+                            type: type,
                             formfactor: nil,
                             os: nil,
                             version: nil,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockJumpBackInDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockJumpBackInDelegate.swift
@@ -7,10 +7,8 @@ import XCTest
 
 final class MockJumpBackInDelegate: JumpBackInDelegate {
     private var continuation: CheckedContinuation<Void, Never>?
-
-    init() {}
-
     var didLoadNewDataCount = 0
+    
     func didLoadNewData() {
         didLoadNewDataCount += 1
         continuation?.resume()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockJumpBackInDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockJumpBackInDelegate.swift
@@ -8,7 +8,7 @@ import XCTest
 final class MockJumpBackInDelegate: JumpBackInDelegate {
     private var continuation: CheckedContinuation<Void, Never>?
     var didLoadNewDataCount = 0
-    
+
     func didLoadNewData() {
         didLoadNewDataCount += 1
         continuation?.resume()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockJumpBackInDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockJumpBackInDelegate.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class MockJumpBackInDelegate: JumpBackInDelegate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    init() {}
+
+    var didLoadNewDataCount = 0
+    func didLoadNewData() {
+        didLoadNewDataCount += 1
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func waitForNewData() async {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11434)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24895)

## :bulb: Description
I added logic to listen to delegate's `didLoadNewData` method instead of relying on `Task.Sleep`. May be we could have increased Sleep time but it is not the best way to handle this.

- Added `MockJumpBackInDelegate` so we can await until data is loaded
- await for data after `createSubject`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

