### PR TITLE
Bugfix [PDF Refactor] FXIOS fix PDFs refactor related issue

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -225,7 +225,7 @@ class BrowserCoordinator: BaseCoordinator,
             browserViewController.frontEmbeddedContent(webviewController)
             logger.log("Webview content was updated", level: .info, category: .coordinator)
         } else {
-            let webviewViewController = WebviewViewController(webView: webView, windowUUID: windowUUID)
+            let webviewViewController = WebviewViewController(webView: webView)
             webviewController = webviewViewController
             let isEmbedded = browserViewController.embedContent(webviewViewController)
             logger.log("Webview controller was created and embedded \(isEmbedded)", level: .info, category: .coordinator)
@@ -1200,7 +1200,8 @@ class BrowserCoordinator: BaseCoordinator,
     private func tryDownloadingTabFileToShare(shareType: ShareType) async -> ShareType {
         // We can only try to download files for `.tab` type shares that have a TemporaryDocument
         guard case let ShareType.tab(_, tab) = shareType,
-              let temporaryDocument = tab.temporaryDocument else {
+              let temporaryDocument = tab.temporaryDocument,
+              !temporaryDocument.isDownloading else {
             return shareType
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -788,6 +788,7 @@ extension BrowserViewController: WKNavigationDelegate {
                            request: URLRequest) {
         navigationHandler?.showDocumentLoading()
         scrollController.showToolbars(animated: false)
+
         let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
         cookieStore.getAllCookies { [weak tab, weak webView, weak self] cookies in
             let tempPDF = DefaultTemporaryDocument(
@@ -814,6 +815,14 @@ extension BrowserViewController: WKNavigationDelegate {
                 self?.showErrorPage(webView: webView, error: error)
             }
             tab?.enqueueDocument(tempPDF)
+            if let url = request.url {
+                self?.observeValue(
+                    forKeyPath: KVOConstants.URL.rawValue,
+                    of: webView,
+                    change: [.newKey: url],
+                    context: nil
+                )
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1502,12 +1502,14 @@ class BrowserViewController: UIViewController,
         documentLoadingView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(documentLoadingView)
         NSLayoutConstraint.activate([
-            documentLoadingView.topAnchor.constraint(equalTo: contentContainer.topAnchor),
+            documentLoadingView.topAnchor.constraint(equalTo: header.bottomAnchor),
             documentLoadingView.bottomAnchor.constraint(equalTo: contentContainer.bottomAnchor),
             documentLoadingView.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor),
             documentLoadingView.leadingAnchor.constraint(equalTo: contentContainer.leadingAnchor),
         ])
 
+        view.bringSubviewToFront(header)
+        view.bringSubviewToFront(overKeyboardContainer)
         documentLoadingView.animateLoadingAppearanceIfNeeded()
         documentLoadingView.applyTheme(theme: currentTheme())
         self.documentLoadingView = documentLoadingView
@@ -2001,7 +2003,15 @@ class BrowserViewController: UIViewController,
             }
 
             // Ensure we do have a URL from that observer
-            guard let url = webView.url else { return }
+            // If the URL is coming from the observer and PDF refactor is enabled then take URL from there
+            let url: URL? = if let webURL = webView.url {
+                webURL
+            } else if let changeURL = change?[.newKey] as? URL, isPDFRefactorEnabled {
+                changeURL
+            } else {
+                nil
+            }
+            guard let url else { break }
 
             // Security safety check (Bugzilla #1933079)
             if let internalURL = InternalURL(url), internalURL.isErrorPage, !internalURL.isAuthorized {

--- a/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -9,31 +9,12 @@ import Common
 
 class WebviewViewController: UIViewController,
                              ContentContainable,
-                             ScreenshotableView,
-                             Themeable,
-                             InjectedThemeUUIDIdentifiable {
-    private struct UX {
-        static let documentLoadingViewAnimationDuration: CGFloat = 0.3
-    }
-    private var documentLoadingView: TemporaryDocumentLoadingView?
+                             ScreenshotableView {
     private var webView: WKWebView
     var contentType: ContentType = .webview
-    var themeManager: ThemeManager
-    var notificationCenter: NotificationProtocol
-    var themeObserver: NSObjectProtocol?
-    let windowUUID: WindowUUID
-    var currentWindowUUID: WindowUUID? {
-        return windowUUID
-    }
 
-    init(webView: WKWebView,
-         windowUUID: WindowUUID,
-         themeManager: ThemeManager = AppContainer.shared.resolve(),
-         notificationCenter: NotificationProtocol = NotificationCenter.default) {
+    init(webView: WKWebView) {
         self.webView = webView
-        self.windowUUID = windowUUID
-        self.themeManager = themeManager
-        self.notificationCenter = notificationCenter
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -44,7 +25,6 @@ class WebviewViewController: UIViewController,
     override func viewDidLoad() {
         super.viewDidLoad()
         setupWebView()
-        listenForThemeChange(view)
     }
 
     private func setupWebView() {
@@ -55,15 +35,6 @@ class WebviewViewController: UIViewController,
     func update(webView: WKWebView) {
         self.webView = webView
         setupWebView()
-        guard let documentLoadingView else { return }
-        view.bringSubviewToFront(documentLoadingView)
-    }
-
-    // MARK: - Themeable
-
-    func applyTheme() {
-        let theme = themeManager.getCurrentTheme(for: windowUUID)
-        documentLoadingView?.applyTheme(theme: theme)
     }
 
     // MARK: - ScreenshotableView

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/StatefulButton.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/StatefulButton.swift
@@ -43,7 +43,7 @@ class StatefulButton: UIButton {
             case .stop:
                 setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: .normal)
             case .disabled:
-                self.isHidden = true
+                isHidden = true
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -97,14 +97,14 @@ final class ContentContainerTests: XCTestCase {
 
     func testCanAddWebview() {
         let subject = ContentContainer(frame: .zero)
-        let webview = WebviewViewController(webView: WKWebView(), windowUUID: UUID())
+        let webview = WebviewViewController(webView: WKWebView())
 
         XCTAssertTrue(subject.canAdd(content: webview))
     }
 
     func testCanAddWebviewOnceOnly() {
         let subject = ContentContainer(frame: .zero)
-        let webview = WebviewViewController(webView: WKWebView(), windowUUID: UUID())
+        let webview = WebviewViewController(webView: WKWebView())
 
         subject.add(content: webview)
         XCTAssertFalse(subject.canAdd(content: webview))
@@ -127,7 +127,7 @@ final class ContentContainerTests: XCTestCase {
 
     func testHasHomepage_falseWhenWebview() {
         let subject = ContentContainer(frame: .zero)
-        let webview = WebviewViewController(webView: WKWebView(), windowUUID: UUID())
+        let webview = WebviewViewController(webView: WKWebView())
         subject.add(content: webview)
 
         XCTAssertFalse(subject.hasHomepage)
@@ -155,7 +155,7 @@ final class ContentContainerTests: XCTestCase {
 
     func testHasNewHomepage_returnsFalseWhenWebview() {
         let subject = ContentContainer(frame: .zero)
-        let webview = WebviewViewController(webView: WKWebView(), windowUUID: UUID())
+        let webview = WebviewViewController(webView: WKWebView())
         subject.add(content: webview)
 
         XCTAssertFalse(subject.hasHomepage)
@@ -181,7 +181,7 @@ final class ContentContainerTests: XCTestCase {
 
     func testHasPrivateHomepage_returnsFalseWhenWebview() {
         let subject = ContentContainer(frame: .zero)
-        let webview = WebviewViewController(webView: WKWebView(), windowUUID: UUID())
+        let webview = WebviewViewController(webView: WKWebView())
         subject.add(content: webview)
 
         XCTAssertFalse(subject.hasPrivateHomepage)
@@ -304,7 +304,7 @@ final class ContentContainerTests: XCTestCase {
 
     func test_update_hasWebView_returnsTrue() {
         let subject = ContentContainer(frame: .zero)
-        let webview = WebviewViewController(webView: WKWebView(), windowUUID: UUID())
+        let webview = WebviewViewController(webView: WKWebView())
         subject.update(content: webview)
         XCTAssertTrue(subject.hasWebView)
         XCTAssertFalse(subject.hasLegacyHomepage)

--- a/firefox-ios/nimbus-features/pdfRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/pdfRefactorFeature.yaml
@@ -12,7 +12,7 @@ features:
     defaults:
       - channel: beta
         value:
-          enabled: false
+          enabled: true
       - channel: developer
         value:
-          enabled: false
+          enabled: true

--- a/firefox-ios/nimbus-features/pdfRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/pdfRefactorFeature.yaml
@@ -12,7 +12,7 @@ features:
     defaults:
       - channel: beta
         value:
-          enabled: true
+          enabled: false
       - channel: developer
         value:
-          enabled: true
+          enabled: false


### PR DESCRIPTION
## :scroll: Tickets
### Accessibility
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11529)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25094)

### Cancel PDF don't work from homepage
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11519)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25076)

## :bulb: Description
Fix PDF related issue. Fixed issue when opening directly a PDF from homepage that wasn't updating toolbars. 
To test it simply copy paste an url of a PDF directly from homepage.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

