### PR TITLE
Refactor FXIOS-11638 [Tab tray UI experiment] Make sure we disable any changes for iPad

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -20,6 +20,7 @@ class TabsSectionManager: FeatureFlaggable {
 
     private var isTabTrayUIExperimentsEnabled: Bool {
         return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
+        && UIDevice.current.userInterfaceIdiom != .pad
     }
 
     static func leadingInset(traitCollection: UITraitCollection,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -16,6 +16,11 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     private let inactiveTabTelemetry = InactiveTabsTelemetry()
     private let bookmarksSaver: BookmarksSaver
 
+    private var isTabTrayUIExperimentsEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
+        && UIDevice.current.userInterfaceIdiom != .pad
+    }
+
     init(profile: Profile = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared,
          bookmarksSaver: BookmarksSaver? = nil) {
@@ -384,15 +389,13 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
             let shouldDismiss = await self.closeTab(with: tabUUID, uuid: uuid, isPrivate: isPrivate)
             triggerRefresh(uuid: uuid, isPrivate: isPrivate)
 
-            let isTabTrayExperimentEnabled = featureFlags.isFeatureEnabled(.tabTrayUIExperiments,
-                                                                           checking: .buildOnly)
             if isPrivate && tabManager(for: uuid).privateTabs.isEmpty {
                 let didLoadAction = TabPanelViewAction(panelType: isPrivate ? .privateTabs : .tabs,
                                                        windowUUID: uuid,
                                                        actionType: TabPanelViewActionType.tabPanelDidLoad)
                 store.dispatch(didLoadAction)
 
-                if !isTabTrayExperimentEnabled {
+                if !isTabTrayUIExperimentsEnabled {
                     let toastAction = TabPanelMiddlewareAction(toastType: .closedSingleTab,
                                                                windowUUID: uuid,
                                                                actionType: TabPanelMiddlewareActionType.showToast)
@@ -403,14 +406,14 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
                                                   actionType: TabTrayActionType.dismissTabTray)
                 store.dispatch(dismissAction)
 
-                if !isTabTrayExperimentEnabled {
+                if !isTabTrayUIExperimentsEnabled {
                     let toastAction = GeneralBrowserAction(toastType: .closedSingleTab,
                                                            windowUUID: uuid,
                                                            actionType: GeneralBrowserActionType.showToast)
                     store.dispatch(toastAction)
                 }
                 addNewTabIfPrivate(uuid: uuid)
-            } else if !isTabTrayExperimentEnabled {
+            } else if !isTabTrayUIExperimentsEnabled {
                 let toastAction = TabPanelMiddlewareAction(toastType: .closedSingleTab,
                                                            windowUUID: uuid,
                                                            actionType: TabPanelMiddlewareActionType.showToast)
@@ -494,15 +497,13 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
                                                       actionType: TabPanelMiddlewareActionType.refreshTabs)
                 store.dispatch(action)
 
-                let isTabTrayExperimentEnabled = featureFlags.isFeatureEnabled(.tabTrayUIExperiments,
-                                                                               checking: .buildOnly)
-                if tabsState.isPrivateMode && !isTabTrayExperimentEnabled {
+                if tabsState.isPrivateMode && !isTabTrayUIExperimentsEnabled {
                     let action = TabPanelMiddlewareAction(toastType: .closedAllTabs(count: privateCount),
                                                           windowUUID: uuid,
                                                           actionType: TabPanelMiddlewareActionType.showToast)
                     store.dispatch(action)
                 } else {
-                    if !isTabTrayExperimentEnabled {
+                    if !isTabTrayUIExperimentsEnabled {
                         let toastAction = GeneralBrowserAction(toastType: .closedAllTabs(count: normalCount),
                                                                windowUUID: uuid,
                                                                actionType: GeneralBrowserActionType.showToast)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -9,7 +9,7 @@ import Shared
 import SiteImageView
 
 /// Tab cell used in the tab tray under the .tabTrayUIExperiments Nimbus experiment
-class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFlaggable {
+class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     struct UX {
         static let selectedBorderWidth: CGFloat = 3.0
         static let unselectedBorderWidth: CGFloat = 1
@@ -81,10 +81,6 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         configuration.contentInsets = UX.closeButtonEdgeInset
         button.configuration = configuration
         button.alpha = 0.5
-    }
-
-    private var isTabTrayUIExperimentsEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
     }
 
     override func layoutSubviews() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -27,6 +27,11 @@ class RemoteTabsTableViewController: UITableViewController,
     private var hiddenSections = Set<Int>()
     private let logger: Logger
 
+    private var isTabTrayUIExperimentsEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
+        && UIDevice.current.userInterfaceIdiom != .pad
+    }
+
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
@@ -36,7 +41,7 @@ class RemoteTabsTableViewController: UITableViewController,
 
     private var isShowingEmptyView: Bool { state.showingEmptyState != nil }
     private lazy var emptyView: RemoteTabsEmptyViewProtocol = {
-        if featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly) {
+        if isTabTrayUIExperimentsEnabled {
             let view = ExperimentRemoteTabsEmptyView()
             view.translatesAutoresizingMaskIntoConstraints = false
             return view

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -24,6 +24,7 @@ class TabDisplayPanelViewController: UIViewController,
 
     private var isTabTrayUIExperimentsEnabled: Bool {
         return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
+        && UIDevice.current.userInterfaceIdiom != .pad
     }
 
     private lazy var layout: TabTrayLayoutType = {
@@ -44,7 +45,7 @@ class TabDisplayPanelViewController: UIViewController,
     }()
     private var backgroundPrivacyOverlay: UIView = .build()
     private lazy var emptyPrivateTabsView: EmptyPrivateTabView = {
-        if featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly) {
+        if isTabTrayUIExperimentsEnabled {
             let view = ExperimentEmptyPrivateTabsView()
             view.translatesAutoresizingMaskIntoConstraints = false
             return view

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -31,6 +31,7 @@ class TabDisplayView: UIView,
 
     private var isTabTrayUIExperimentsEnabled: Bool {
         return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
+        && UIDevice.current.userInterfaceIdiom != .pad
     }
 
     var shouldHideInactiveTabs: Bool {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -56,6 +56,7 @@ class TabTrayViewController: UIViewController,
 
     private var isTabTrayUIExperimentsEnabled: Bool {
         return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
+        && UIDevice.current.userInterfaceIdiom != .pad
     }
 
     // MARK: - Redux state


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11638)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25350)

## :bulb: Description
Make sure we disable any changes for iPad for this experiment. Multitasking was a bit weird/broken in one scenario, so avoiding any changes there for now.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

