### PR TITLE
BugFix FXIOS-9006 [Deeplink Optimization] Fix issue with opening new private tab from quick action on iPad

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2726,10 +2726,6 @@ class BrowserViewController: UIViewController,
         tabManager.selectTab(tab)
     }
 
-    func switchToPrivacyMode(isPrivate: Bool) {
-        topTabsViewController?.applyUIMode(isPrivate: isPrivate, theme: currentTheme())
-    }
-
     func switchToTabForURLOrOpen(
         _ url: URL,
         uuid: String? = nil,
@@ -2776,7 +2772,6 @@ class BrowserViewController: UIViewController,
             logger.log("No request for openURLInNewTab", level: .debug, category: .tabs)
         }
 
-        switchToPrivacyMode(isPrivate: isPrivate)
         let tab = tabManager.addTab(request, isPrivate: isPrivate)
         tabManager.selectTab(tab)
         return tab

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -491,12 +491,8 @@ class BrowserViewController: UIViewController,
         appMenuBadgeUpdate()
 
         if showTopTabs, topTabsViewController == nil {
-            let topTabsViewController = TopTabsViewController(tabManager: tabManager, profile: profile)
-            topTabsViewController.delegate = self
-            addChild(topTabsViewController)
-            header.addArrangedViewToTop(topTabsViewController.view)
-            self.topTabsViewController = topTabsViewController
-            topTabsViewController.applyTheme()
+            setupTopTabsViewController()
+            topTabsViewController?.applyTheme()
         } else if showTopTabs, topTabsViewController != nil {
             topTabsViewController?.applyTheme()
         } else {
@@ -777,6 +773,7 @@ class BrowserViewController: UIViewController,
         setupNotifications()
 
         overlayManager.setURLBar(urlBarView: urlBarView)
+        setupTopTabsViewController()
 
         // Update theme of already existing views
         let theme = currentTheme()
@@ -786,6 +783,7 @@ class BrowserViewController: UIViewController,
         bottomContentStackView.applyTheme(theme: theme)
         statusBarOverlay.hasTopTabs = ToolbarHelper().shouldShowTopTabs(for: traitCollection)
         statusBarOverlay.applyTheme(theme: theme)
+        topTabsViewController?.applyTheme()
 
         KeyboardHelper.defaultHelper.addDelegate(self)
         listenForThemeChange(view)
@@ -812,6 +810,14 @@ class BrowserViewController: UIViewController,
         // in getting the value. When the delay happens the credit cards might not sync
         // as the default value is false
         profile.syncManager?.updateCreditCardAutofillStatus(value: autofillCreditCardStatus)
+    }
+
+    private func setupTopTabsViewController() {
+        let topTabsViewController = TopTabsViewController(tabManager: tabManager, profile: profile)
+        topTabsViewController.delegate = self
+        addChild(topTabsViewController)
+        header.addArrangedViewToTop(topTabsViewController.view)
+        self.topTabsViewController = topTabsViewController
     }
 
     private func setupAccessibleActions() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -817,6 +817,7 @@ class BrowserViewController: UIViewController,
         topTabsViewController.delegate = self
         addChild(topTabsViewController)
         header.addArrangedViewToTop(topTabsViewController.view)
+        topTabsViewController.didMove(toParent: self)
         self.topTabsViewController = topTabsViewController
     }
 

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -19,7 +19,7 @@ class TabToolbar: UIView, SearchBarLocationProvider {
     let multiStateButton = ToolbarButton()
     let actionButtons: [ThemeApplicable & UIButton]
 
-    private let privateModeBadge = BadgeWithBackdrop(
+    let privateModeBadge = BadgeWithBackdrop(
         imageName: StandardImageIdentifiers.Medium.privateModeCircleFillPurple,
         isPrivateBadge: true)
     private let warningMenuBadge = BadgeWithBackdrop(imageName: StandardImageIdentifiers.Large.warningFill,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -17,7 +17,6 @@ class BrowserViewControllerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
         DependencyHelperMock().bootstrapDependencies()
         TelemetryContextualIdentifier.setupContextId()
         // Due to changes allow certain custom pings to implement their own opt-out
@@ -28,6 +27,7 @@ class BrowserViewControllerTests: XCTestCase {
 
         profile = MockProfile()
         tabManager = MockTabManager()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
     }
 
@@ -35,6 +35,7 @@ class BrowserViewControllerTests: XCTestCase {
         TelemetryContextualIdentifier.clearUserDefaults()
         profile = nil
         tabManager = nil
+        browserViewController.legacyUrlBar = nil
         browserViewController = nil
         Glean.shared.resetGlean(clearStores: true)
         DependencyHelperMock().reset()
@@ -93,14 +94,10 @@ class BrowserViewControllerTests: XCTestCase {
         setupNimbusToolbarRefactorTesting(isEnabled: false)
 
         browserViewController.topTabsViewController = topTabsViewController
-        browserViewController.legacyUrlBar =  URLBarView(profile: profile, windowUUID: .XCTestDefaultUUID)
-
         browserViewController.tabManager(tabManager, didSelectedTabChange: testTab, previousTab: nil, isRestoring: false)
 
-        let urlBarColor = browserViewController.legacyUrlBar!.locationActiveBorderColor
         XCTAssertEqual(topTabsViewController.privateModeButton.tintColor, DarkTheme().colors.iconOnColor)
         XCTAssertFalse(browserViewController.toolbar.privateModeBadge.badge.isHidden)
-        XCTAssertEqual(urlBarColor, LightTheme().colors.layerAccentPrivateNonOpaque)
     }
 
     func testDidSelectedTabChange_appliesExpectedUIModeToTopTabsViewController_whenToolbarRefactorEnabled() {
@@ -111,14 +108,11 @@ class BrowserViewControllerTests: XCTestCase {
         setupNimbusToolbarRefactorTesting(isEnabled: true)
 
         browserViewController.topTabsViewController = topTabsViewController
-        browserViewController.legacyUrlBar = URLBarView(profile: profile, windowUUID: .XCTestDefaultUUID)
 
         browserViewController.tabManager(tabManager, didSelectedTabChange: testTab, previousTab: nil, isRestoring: false)
 
-        let urlBarColor = browserViewController.legacyUrlBar!.locationActiveBorderColor
         XCTAssertEqual(topTabsViewController.privateModeButton.tintColor, DarkTheme().colors.iconOnColor)
         XCTAssertTrue(browserViewController.toolbar.privateModeBadge.badge.isHidden)
-        XCTAssertEqual(urlBarColor, .clear)
     }
 
     private func setupNimbusToolbarRefactorTesting(isEnabled: Bool) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -536,8 +536,6 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
                                                                     isPrivate: false))
 
         XCTAssertTrue(result)
-        XCTAssertFalse(mbvc.switchToPrivacyModeCalled)
-        XCTAssertFalse(mbvc.switchToPrivacyModeIsPrivate)
         XCTAssertTrue(mbvc.switchToTabForURLOrOpenCalled)
         XCTAssertEqual(mbvc.switchToTabForURLOrOpenURL, URL(string: "https://example.com")!)
         XCTAssertEqual(mbvc.switchToTabForURLOrOpenCount, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -9,8 +9,6 @@ import UIKit
 import enum MozillaAppServices.VisitType
 
 class MockBrowserViewController: BrowserViewController {
-    var switchToPrivacyModeCalled = false
-    var switchToPrivacyModeIsPrivate = false
     var switchToTabForURLOrOpenCalled = false
     var switchToTabForURLOrOpenURL: URL?
     var switchToTabForURLOrOpenUUID: String?
@@ -30,7 +28,6 @@ class MockBrowserViewController: BrowserViewController {
     var openURLInNewTabURL: URL?
     var openURLInNewTabIsPrivate = false
 
-    var switchToPrivacyModeCount = 0
     var switchToTabForURLOrOpenCount = 0
     var openBlankNewTabCount = 0
     var handleQueryCount = 0
@@ -58,12 +55,6 @@ class MockBrowserViewController: BrowserViewController {
 
     override var contentContainer: ContentContainer {
         return mockContentContainer
-    }
-
-    override func switchToPrivacyMode(isPrivate: Bool) {
-        switchToPrivacyModeCalled = true
-        switchToPrivacyModeIsPrivate = isPrivate
-        switchToPrivacyModeCount += 1
     }
 
     override func switchToTabForURLOrOpen(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9006)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19873)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Fix issue with opening a new private tab from quick action when on iPad. This issue only happens when deeplink content optimization is enabled. There is another similar issue around deeplink content optimization on iPhone that will be followed up in [this ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11665)

https://github.com/user-attachments/assets/10b12f6d-46f6-4d16-b3c4-4ed2fbe14ff5




## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

