### PR TITLE
Fix #25341 - Resolve nil reference in bookmark undo-edit flow

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1840,7 +1840,11 @@ class BrowserViewController: UIViewController,
                                                                      bookmarkNode: bookmarkItem,
                                                                      parentBookmarkFolder: parentFolder,
                                                                      presentedFromToast: true) { [weak self] in
-                        self?.showBookmarkToast(action: .remove)
+                        self?.showBookmarkToast(
+                            urlString: bookmarkItem.url,
+                            title: bookmarkItem.title,
+                            action: .remove
+                        )
                     }
                     let controller: DismissableNavigationViewController
                     controller = DismissableNavigationViewController(rootViewController: detailController)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25341)

## :bulb: Description
This PR fixes a nil reference error in the bookmark undo-edit-remove flow (issue #25341). 

Previously, calling self?.showBookmarkToast(action: .remove) could lead to a nil reference unexpected behavior, including the addition of an incorrect bookmark with the URL internal://local/about/home#panel=0. 

This change updates the toast call to include urlString and title parameters, ensuring the correct bookmark data is passed and avoiding the nil reference issue.

Changed self?.showBookmarkToast(action: .remove) to self?.showBookmarkToast(urlString: bookmarkItem.url, title: bookmarkItem.title, action: .remove).

Resolves the nil reference incorrect bookmark addition.

Tested by following the reproduction steps in #25341; confirmed the issue no longer occurs.

## :pencil: Checklist
You have to check all boxes before merging
- [x ] Filled in the above information (tickets numbers and description of your work)
- [ x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

