### PR TITLE
Refactor FXIOS-11654 credit card keychain logic

### DIFF
--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -774,6 +774,11 @@ open class BrowserProfile: Profile {
         var creditCardCanary: String?
 
         if rustKeychainEnabled {
+            // Long before the new rust keychain logic was introduced, there was a bug in this logic caused by the canary not
+            // being saved with the key. We are correcting this in the new logic below but leaving the old logic unchanged.
+            // This is because we do not want to risk introducing another bug in the old code in case it is required as a
+            // fail safe should these changes need to be rolled back.
+
             (creditCardKey, creditCardCanary) = keychain.getCreditCardKeyData()
             (loginsKey, loginsCanary) = keychain.getLoginsKeyData()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11654)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25389)

## :bulb: Description
There were two minor requested changes for PR #25152 that are being addressed in this PR:
- Added a comment to `BrowserProfile.removeAccount` to explain the canary logic
- Refactored `RustKeychain.createCreditCardsKeyData` to decrease nesting

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

