### PR TITLE
Add FXIOS-8259 #18347 ⁃ Handle fullscreen in WebEngine

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
@@ -37,6 +37,9 @@ struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvider {
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = !parameters.blockPopups
         configuration.userContentController = WKUserContentController()
         configuration.allowsInlineMediaPlayback = true
+        if #available(iOS 15.4, *) {
+            configuration.preferences.isElementFullscreenEnabled = true
+        }
         if parameters.isPrivate {
             configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
         } else {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -26,6 +26,7 @@ class WKEngineSession: NSObject,
     private(set) var webView: WKEngineWebView
     var sessionData: WKEngineSessionData
     var telemetryProxy: EngineTelemetryProxy?
+    var fullscreenDelegate: FullscreenDelegate?
 
     private var logger: Logger
     private var contentScriptManager: WKContentScriptManager
@@ -307,6 +308,8 @@ class WKEngineSession: NSObject,
             break
         case .hasOnlySecureContent(let hasOnlySecureContent):
             handleHasOnlySecureContentChanged(hasOnlySecureContent)
+        case .isFullScreen(let isFullScreen):
+            handleFullscreen(isFullScreen: isFullScreen)
         }
     }
 
@@ -354,6 +357,14 @@ class WKEngineSession: NSObject,
 
         // Update session data, inform delegate, fetch metadata
         commitURLChange()
+    }
+
+    func handleFullscreen(isFullScreen: Bool) {
+        if isFullScreen {
+            fullscreenDelegate?.enteringFullscreen()
+        } else {
+            fullscreenDelegate?.exitingFullscreen()
+        }
     }
 
     // MARK: - MetadataFetcherDelegate

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineView.swift
@@ -5,7 +5,7 @@
 import Common
 import UIKit
 
-protocol FullscreenDelegate {
+protocol FullscreenDelegate: AnyObject {
     func enteringFullscreen()
     func exitingFullscreen()
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineView.swift
@@ -5,7 +5,12 @@
 import Common
 import UIKit
 
-class WKEngineView: UIView, EngineView {
+protocol FullscreenDelegate {
+    func enteringFullscreen()
+    func exitingFullscreen()
+}
+
+class WKEngineView: UIView, EngineView, FullscreenDelegate {
     private var session: WKEngineSession?
     private var logger: Logger
 
@@ -37,14 +42,22 @@ class WKEngineView: UIView, EngineView {
     private func remove(session: WKEngineSession) {
         session.webView.removeFromSuperview()
         session.isActive = false
+        session.fullscreenDelegate = nil
     }
 
     private func add(session: WKEngineSession) {
         self.session = session
         session.isActive = true
-        addSubview(session.webView)
+        session.fullscreenDelegate = self
+
+        setupWebViewLayout()
+    }
+
+    private func setupWebViewLayout() {
+        guard let session = session else { return }
 
         let webView = session.webView
+        addSubview(webView)
         webView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             webView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
@@ -52,5 +65,17 @@ class WKEngineView: UIView, EngineView {
             webView.trailingAnchor.constraint(equalTo: trailingAnchor),
             webView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
         ])
+    }
+
+    func enteringFullscreen() {
+        guard let session = session else { return }
+
+        let webView = session.webView
+        webView.translatesAutoresizingMaskIntoConstraints = true
+        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    }
+
+    func exitingFullscreen() {
+        setupWebViewLayout()
     }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -198,6 +198,7 @@ final class DefaultWKEngineWebView: WKWebView, WKEngineWebView, MenuHelperWebVie
             guard let newSize = change.newValue else { return }
             self?.delegate?.webViewPropertyChanged(.contentSize(newSize))
         }
+
         observedTokens.append(
             contentsOf: [
                 loadingToken,
@@ -210,6 +211,19 @@ final class DefaultWKEngineWebView: WKWebView, WKEngineWebView, MenuHelperWebVie
                 contentSizeObserver
             ]
         )
+
+        // Observe fullscreen state, there are four states but we are reacting to `.enteringFullscreen`
+        // and `.exitingFullscreen` only. When the view is on fullscreen is removed from the view hierarchy
+        // so we add it back for `.exitingFullscreen`
+        if #available(iOS 16.0, *) {
+            let fullscreenObserver = observe(\.fullscreenState, options: [.new]) { object, change in
+                guard object.fullscreenState == .enteringFullscreen ||
+                        object.fullscreenState == .exitingFullscreen else { return }
+
+                self.delegate?.webViewPropertyChanged(.isFullScreen(object.fullscreenState == .enteringFullscreen))
+            }
+            observedTokens.append(fullscreenObserver)
+        }
     }
 
     private func removeObservers() {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -216,11 +216,11 @@ final class DefaultWKEngineWebView: WKWebView, WKEngineWebView, MenuHelperWebVie
         // and `.exitingFullscreen` only. When the view is on fullscreen is removed from the view hierarchy
         // so we add it back for `.exitingFullscreen`
         if #available(iOS 16.0, *) {
-            let fullscreenObserver = observe(\.fullscreenState, options: [.new]) { object, change in
+            let fullscreenObserver = observe(\.fullscreenState, options: [.new]) {  [weak self] object, change in
                 guard object.fullscreenState == .enteringFullscreen ||
                         object.fullscreenState == .exitingFullscreen else { return }
 
-                self.delegate?.webViewPropertyChanged(.isFullScreen(object.fullscreenState == .enteringFullscreen))
+                self?.delegate?.webViewPropertyChanged(.isFullScreen(object.fullscreenState == .enteringFullscreen))
             }
             observedTokens.append(fullscreenObserver)
         }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebViewProperty.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebViewProperty.swift
@@ -14,4 +14,5 @@ enum WKEngineWebViewProperty: Equatable {
     case canGoForward(Bool)
     case contentSize(CGSize)
     case hasOnlySecureContent(Bool)
+    case isFullScreen(Bool)
 }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockFullscreenDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockFullscreenDelegate.swift
@@ -8,7 +8,7 @@ import Foundation
 class MockFullscreenDelegate: FullscreenDelegate {
     var onFullscreeChangeCalled = 0
     var savedFullscreenState = false
-    
+
     func enteringFullscreen() {
         onFullscreeChangeCalled += 1
         savedFullscreenState = true

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockFullscreenDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockFullscreenDelegate.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import WebEngine
+
+class MockFullscreenDelegate: FullscreenDelegate {
+    var onFullscreeChangeCalled = 0
+    var savedFullscreenState = false
+    
+    func enteringFullscreen() {
+        onFullscreeChangeCalled += 1
+        savedFullscreenState = true
+    }
+
+    func exitingFullscreen() {
+        onFullscreeChangeCalled += 1
+        savedFullscreenState = false
+    }
+}

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -444,7 +444,7 @@ final class WKEngineSessionTests: XCTestCase {
         XCTAssertEqual(subject?.sessionData.hasOnlySecureContent, true)
         XCTAssertEqual(engineSessionDelegate.onHasOnlySecureContentCalled, 1)
     }
-    
+
     func testFullscreeChangeGivenFullscreenStateThenCallsDelegate() {
         let expectedFullscreenState = true
         let subject = createSubject()
@@ -454,7 +454,7 @@ final class WKEngineSessionTests: XCTestCase {
         XCTAssertEqual(fullscreenDelegate.onFullscreeChangeCalled, 1)
         XCTAssertTrue(fullscreenDelegate.savedFullscreenState)
     }
-    
+
     func testFullscreeChangeGivenNotFullscreenStateThenCallsDelegate() {
         let expectedFullscreenState = false
         let subject = createSubject()

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -14,6 +14,7 @@ final class WKEngineSessionTests: XCTestCase {
     private var userScriptManager: MockWKUserScriptManager!
     private var engineSessionDelegate: MockEngineSessionDelegate!
     private var metadataFetcher: MockMetadataFetcherHelper!
+    private var fullscreenDelegate: MockFullscreenDelegate!
 
     override func setUp() {
         super.setUp()
@@ -23,6 +24,7 @@ final class WKEngineSessionTests: XCTestCase {
         userScriptManager = MockWKUserScriptManager()
         engineSessionDelegate = MockEngineSessionDelegate()
         metadataFetcher = MockMetadataFetcherHelper()
+        fullscreenDelegate = MockFullscreenDelegate()
     }
 
     override func tearDown() {
@@ -33,6 +35,7 @@ final class WKEngineSessionTests: XCTestCase {
         userScriptManager = nil
         engineSessionDelegate = nil
         metadataFetcher = nil
+        fullscreenDelegate = nil
     }
 
     // MARK: Load URL
@@ -440,6 +443,26 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(subject?.sessionData.hasOnlySecureContent, true)
         XCTAssertEqual(engineSessionDelegate.onHasOnlySecureContentCalled, 1)
+    }
+    
+    func testFullscreeChangeGivenFullscreenStateThenCallsDelegate() {
+        let expectedFullscreenState = true
+        let subject = createSubject()
+        subject?.fullscreenDelegate = fullscreenDelegate
+        subject?.webViewPropertyChanged(.isFullScreen(expectedFullscreenState))
+
+        XCTAssertEqual(fullscreenDelegate.onFullscreeChangeCalled, 1)
+        XCTAssertTrue(fullscreenDelegate.savedFullscreenState)
+    }
+    
+    func testFullscreeChangeGivenNotFullscreenStateThenCallsDelegate() {
+        let expectedFullscreenState = false
+        let subject = createSubject()
+        subject?.fullscreenDelegate = fullscreenDelegate
+        subject?.webViewPropertyChanged(.isFullScreen(expectedFullscreenState))
+
+        XCTAssertEqual(fullscreenDelegate.onFullscreeChangeCalled, 1)
+        XCTAssertFalse(fullscreenDelegate.savedFullscreenState)
     }
 
     // MARK: Page Zoom

--- a/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
@@ -68,7 +68,7 @@ final class WKEngineWebViewTests: XCTestCase {
                 hasOnlySecureContentExpectation
             ]
         )
-        
+
         if #available(iOS 16.0, *) {
             let fullscreenExpectation = expectation(that: \WKWebView.fullscreenState, on: subject)
             wait(

--- a/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
@@ -68,6 +68,15 @@ final class WKEngineWebViewTests: XCTestCase {
                 hasOnlySecureContentExpectation
             ]
         )
+        
+        if #available(iOS 16.0, *) {
+            let fullscreenExpectation = expectation(that: \WKWebView.fullscreenState, on: subject)
+            wait(
+                for: [
+                    fullscreenExpectation
+                ]
+            )
+        }
 
         XCTAssertGreaterThan(delegate.webViewPropertyChangedCalled, 0)
         XCTAssertNotNil(delegate.lastWebViewPropertyChanged)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8259)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18347)

## :bulb: Description
- Add support to fullscreen  on Webview for WebEngine and test on SampleBrowser app
- Observe fullscreen state and react removing webview constraints when `.enteringFullscreen` and adding back to view hierarchy when `.exitingFullscreen`
- Add Mocks and Unit test
Note: Adding support for fullscreen on Firefox will fix https://github.com/mozilla-mobile/firefox-ios/issues/25091

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

