### PR TITLE
BugFix FXIOS-10918  #23859 EXC_BAD_ACCESS crash `TopSite.__deallocating_deinit`

### DIFF
--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
@@ -6,7 +6,7 @@ import Foundation
 import Storage
 
 // Top site UI class, used in the home top site section
-final class TopSite: FeatureFlaggable {
+struct TopSite: FeatureFlaggable {
     let site: Site
     let title: String
 

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
@@ -10,8 +10,8 @@ struct TopSite: FeatureFlaggable {
     let site: Site
     let title: String
 
-    var sponsoredText: String {
-        return .FirefoxHomepage.Shortcuts.Sponsored
+    private var isSuggested: Bool {
+        site.isSuggestedSite
     }
 
     private var pinnedTitle: String {
@@ -25,34 +25,33 @@ struct TopSite: FeatureFlaggable {
         isPinned ? pinnedTitle : title
     }
 
-    var accessibilityLabel: String? {
-        return isSponsored ? "\(pinnedStatusTitle), \(sponsoredText)" : pinnedStatusTitle
-    }
-
-    var isPinned: Bool {
-        return site.isPinnedSite
-    }
-
-    var isSuggested: Bool {
-        return site.isSuggestedSite
-    }
-
-    var isSponsored: Bool {
-        return site.isSponsoredSite
-    }
-
-    var type: SiteType {
-        return site.type
-    }
-
     var isGooglePinnedTile: Bool {
         guard case SiteType.pinnedSite(let siteInfo) = site.type else { return false }
-
         return siteInfo.isGooglePinnedTile
     }
 
+    var sponsoredText: String {
+        .FirefoxHomepage.Shortcuts.Sponsored
+    }
+
+    var accessibilityLabel: String? {
+        isSponsored ? "\(pinnedStatusTitle), \(sponsoredText)" : pinnedStatusTitle
+    }
+
+    var isPinned: Bool {
+        site.isPinnedSite
+    }
+
+    var isSponsored: Bool {
+        site.isSponsoredSite
+    }
+
+    var type: SiteType {
+        site.type
+    }
+
     var isGoogleURL: Bool {
-        return site.url == GoogleTopSiteManager.Constants.usUrl || site.url == GoogleTopSiteManager.Constants.rowUrl
+        site.url == GoogleTopSiteManager.Constants.usUrl || site.url == GoogleTopSiteManager.Constants.rowUrl
     }
 
     var identifier = UUID().uuidString
@@ -67,7 +66,6 @@ struct TopSite: FeatureFlaggable {
     }
 
     // MARK: Telemetry
-
     func getTelemetrySiteType() -> String {
         if isGooglePinnedTile {
             return "google"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10918)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23859)

## :bulb: Description
The `TopSite` class wraps `Site` structure internally and does not have any mutable state. It makes more sense to make it a Value type rather than reference type so that it it safe for multi threading. 
This PR makes `TopSite` to a structure and arranges the variables into an order as a refactor. 
(See the commits)

More info given in the issue #23859 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

