### PR TITLE
Bugfix FXIOS-11612 #25290 ⁃ "Sync and Save Data" features two overlapping icons

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -193,6 +193,7 @@ class SyncNowSetting: WithAccountSetting {
 
     override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
         super.onConfigureCell(cell, theme: theme)
+
         cell.textLabel?.attributedText = title
         cell.textLabel?.numberOfLines = 0
         cell.textLabel?.lineBreakMode = .byWordWrapping
@@ -224,6 +225,13 @@ class SyncNowSetting: WithAccountSetting {
         }
         cell.accessoryType = accessoryType
         cell.isUserInteractionEnabled = !(profile?.syncManager?.isSyncing ?? false) && DeviceInfo.hasConnectivity()
+
+        configureImageCell(for: cell)
+    }
+
+    private func configureImageCell(for cell: UITableViewCell) {
+        // Reset imageview to avoid showing wrong image
+        cell.imageView?.image = nil
 
         // Animation that loops continuously until stopped
         continuousRotateAnimation.fromValue = 0.0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11612)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25290)

## :bulb: Description
Reset the image to fix the bug where sync icon is showing after disconnecting the account

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

