### PR TITLE
Bugfix FXIOS-11656 ⁃ iPad - Toast "Downloads" button doesn't navigate to downloads panel

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toast.swift
@@ -35,6 +35,7 @@ class Toast: UIView, ThemeApplicable, Notifiable {
 
     lazy var gestureRecognizer: UITapGestureRecognizer = {
         let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        gestureRecognizer.delegate = self
         gestureRecognizer.cancelsTouchesInView = false
         return gestureRecognizer
     }()
@@ -144,5 +145,12 @@ class Toast: UIView, ThemeApplicable, Notifiable {
             adjustLayoutForA11ySizeCategory()
         default: break
         }
+    }
+}
+
+extension Toast: UIGestureRecognizerDelegate {
+    // Do not handle tap on toast when a button, from the Toast, is tapped
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        return !(touch.view is UIButton)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11656)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25404)

## :bulb: Description
Added a extension for Toast class with UIGestureRecognizerDelegate

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

