### PR TITLE
Remove FXIOS [Component Library] unused dependency related to engineProvider

### DIFF
--- a/SampleComponentLibraryApp/SampleComponentLibraryApp/Dependency/DependencyHelper.swift
+++ b/SampleComponentLibraryApp/SampleComponentLibraryApp/Dependency/DependencyHelper.swift
@@ -15,9 +15,6 @@ class DependencyHelper {
         let themeManager: ThemeManager = appDelegate.themeManager
         AppContainer.shared.register(service: themeManager)
 
-        let engineProvider = appDelegate.engineProvider
-        AppContainer.shared.register(service: engineProvider)
-
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }


### PR DESCRIPTION
## :bulb: Description
Sample Component library was not building due to this error, so I remove the code referencing the `engineProvider`.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/3d9712a5-b6da-48ec-90bf-ff59f1d48ae5" />

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

