### PR TITLE
Bugfix MTE-4412 Homepage redesign for XCUITest

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -33,8 +33,7 @@ class ActivityStreamTest: BaseTestCase {
                                LaunchArguments.DisableAnimations]
         }
         launchArguments.append(LaunchArguments.SkipAddingGoogleTopSite)
-        // Commented out so that the sponsors shortcuts are shown after the homepage redesign.
-        // https://mozilla-hub.atlassian.net/browse/FXIOS-11668
+        // Comment out so that the sponsors shortcuts are shown after the homepage redesign. (FXIOS-11668)
         // launchArguments.append(LaunchArguments.SkipSponsoredShortcuts)
         super.setUp()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -87,10 +87,11 @@ class ActivityStreamTest: BaseTestCase {
         navigator.performAction(Action.AcceptClearPrivateData)
         if iPad() {
             navigator.goto(NewTabScreen)
+            checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
         } else {
             navigator.goto(HomePanelsScreen)
+            checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         }
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         mozWaitForElementToNotExist(app.cells.staticTexts[newTopSite["bookmarkLabel"]!])
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -86,11 +86,10 @@ class ActivityStreamTest: BaseTestCase {
         navigator.performAction(Action.AcceptClearPrivateData)
         if iPad() {
             navigator.goto(NewTabScreen)
-            checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
         } else {
             navigator.goto(HomePanelsScreen)
-            checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         }
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         mozWaitForElementToNotExist(app.cells.staticTexts[newTopSite["bookmarkLabel"]!])
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -50,7 +50,7 @@ class ActivityStreamTest: BaseTestCase {
             waitForExistence(TopSiteCellgroup, timeout: TIMEOUT_LONG)
         }
         mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView])
-        // There should be 6 top sites by default
+        // There should be 5 top sites by default
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         // Check their names so that test is added to Smoketest
         waitForElementsToExist(

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -12,7 +12,7 @@ let newTopSite = [
     "topSiteLabel": "Mozilla",
     "bookmarkLabel": "Mozilla - Internet for people, not profit (US)"
 ]
-let allDefaultTopSites = ["Pinned: Google", "Facebook", "YouTube", "Amazon", "Wikipedia", "X"]
+let allDefaultTopSites = ["Facebook", "YouTube", "Amazon", "Wikipedia", "X"]
 
 class ActivityStreamTest: BaseTestCase {
     typealias TopSites = AccessibilityIdentifiers.FirefoxHomepage.TopSites
@@ -32,9 +32,9 @@ class ActivityStreamTest: BaseTestCase {
                                LaunchArguments.SkipContextualHints,
                                LaunchArguments.DisableAnimations]
         }
-        // These launchArguments are commented out so that the shortcuts are shown after
-        // the homepage redesign.
-        // launchArguments.append(LaunchArguments.SkipAddingGoogleTopSite)
+        launchArguments.append(LaunchArguments.SkipAddingGoogleTopSite)
+        // Commented out so that the sponsors shortcuts are shown after the homepage redesign.
+        // https://mozilla-hub.atlassian.net/browse/FXIOS-11668
         // launchArguments.append(LaunchArguments.SkipSponsoredShortcuts)
         super.setUp()
     }
@@ -51,7 +51,7 @@ class ActivityStreamTest: BaseTestCase {
         }
         mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView])
         // There should be 6 top sites by default
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         // Check their names so that test is added to Smoketest
         waitForElementsToExist(
             [
@@ -113,7 +113,7 @@ class ActivityStreamTest: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         let topSitesCells = app.collectionViews.links["TopSitesCell"]
         waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 7)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
         topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].press(forDuration: 1)
         selectOptionFromContextMenu(option: "Pin")
         waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
@@ -125,7 +125,7 @@ class ActivityStreamTest: BaseTestCase {
         navigator.performAction(Action.AcceptClearPrivateData)
         navigator.goto(HomePanelsScreen)
         waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!])
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 7)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2272514
@@ -146,7 +146,7 @@ class ActivityStreamTest: BaseTestCase {
         }
         mozWaitForElementToExist(allTopSites.staticTexts[topSiteSecondCell])
         mozWaitForElementToNotExist(allTopSites.staticTexts[topSiteFirstCell])
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 4)
         // Check top site in first cell now
         let updatedAllTopSites = app.collectionViews.links.matching(identifier: "TopSitesCell")
         waitForExistence(updatedAllTopSites.element(boundBy: 0))

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -50,7 +50,7 @@ class ActivityStreamTest: BaseTestCase {
             waitForExistence(TopSiteCellgroup, timeout: TIMEOUT_LONG)
         }
         mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView])
-        // There should be 5 top sites by default
+        // There should be 6 top sites by default
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
         // Check their names so that test is added to Smoketest
         waitForElementsToExist(

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -12,7 +12,7 @@ let newTopSite = [
     "topSiteLabel": "Mozilla",
     "bookmarkLabel": "Mozilla - Internet for people, not profit (US)"
 ]
-let allDefaultTopSites = ["Facebook", "YouTube", "Amazon", "Wikipedia", "X"]
+let allDefaultTopSites = ["Pinned: Google", "Facebook", "YouTube", "Amazon", "Wikipedia", "X"]
 
 class ActivityStreamTest: BaseTestCase {
     typealias TopSites = AccessibilityIdentifiers.FirefoxHomepage.TopSites
@@ -32,8 +32,10 @@ class ActivityStreamTest: BaseTestCase {
                                LaunchArguments.SkipContextualHints,
                                LaunchArguments.DisableAnimations]
         }
-        launchArguments.append(LaunchArguments.SkipAddingGoogleTopSite)
-        launchArguments.append(LaunchArguments.SkipSponsoredShortcuts)
+        // These launchArguments are commented out so that the shortcuts are shown after
+        // the homepage redesign.
+        // launchArguments.append(LaunchArguments.SkipAddingGoogleTopSite)
+        // launchArguments.append(LaunchArguments.SkipSponsoredShortcuts)
         super.setUp()
     }
     override func tearDown() {
@@ -49,7 +51,7 @@ class ActivityStreamTest: BaseTestCase {
         }
         mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView])
         // There should be 5 top sites by default
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
         // Check their names so that test is added to Smoketest
         waitForElementsToExist(
             [
@@ -110,7 +112,7 @@ class ActivityStreamTest: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         let topSitesCells = app.collectionViews.links["TopSitesCell"]
         waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 7)
         topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].press(forDuration: 1)
         selectOptionFromContextMenu(option: "Pin")
         waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
@@ -122,7 +124,7 @@ class ActivityStreamTest: BaseTestCase {
         navigator.performAction(Action.AcceptClearPrivateData)
         navigator.goto(HomePanelsScreen)
         waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!])
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 7)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2272514
@@ -143,7 +145,7 @@ class ActivityStreamTest: BaseTestCase {
         }
         mozWaitForElementToExist(allTopSites.staticTexts[topSiteSecondCell])
         mozWaitForElementToNotExist(allTopSites.staticTexts[topSiteFirstCell])
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 4)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         // Check top site in first cell now
         let updatedAllTopSites = app.collectionViews.links.matching(identifier: "TopSitesCell")
         waitForExistence(updatedAllTopSites.element(boundBy: 0))

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -156,7 +156,7 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.goto(SettingsScreen)
         navigator.goto(HomePanelsScreen)
         mozWaitForElementToExist(app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
-        XCTAssertTrue(app.collectionViews.cells.staticTexts
+        XCTAssertTrue(app.collectionViews.links.staticTexts
             .elementContainingText("Mozilla - Internet for people").exists)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -162,10 +162,8 @@ class JumpBackInTests: BaseTestCase {
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         navigator.performAction(Action.GoToHomePage)
-        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
-
         // After homepage redesign, "Jump back in" is no longer visible (FXIOS-11644)
-        // https://github.com/mozilla-mobile/firefox-ios/pull/25357
+        // mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
         //        app.cells["JumpBackInCell"].firstMatch.press(forDuration: 2)
         //        // The context menu opens, having the correct options
         //        let ContextMenuTable = app.tables["Context Menu"]

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -163,17 +163,20 @@ class JumpBackInTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         navigator.performAction(Action.GoToHomePage)
         mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
-        app.cells["JumpBackInCell"].firstMatch.press(forDuration: 2)
-        // The context menu opens, having the correct options
-        let ContextMenuTable = app.tables["Context Menu"]
-        waitForElementsToExist(
-            [
-                ContextMenuTable,
-                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.plus],
-                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.privateMode],
-                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.bookmark],
-                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.share]
-            ]
-        )
+
+        // After homepage redesign, "Jump back in" is no longer visible (FXIOS-11644)
+        // https://github.com/mozilla-mobile/firefox-ios/pull/25357
+        //        app.cells["JumpBackInCell"].firstMatch.press(forDuration: 2)
+        //        // The context menu opens, having the correct options
+        //        let ContextMenuTable = app.tables["Context Menu"]
+        //        waitForElementsToExist(
+        //            [
+        //                ContextMenuTable,
+        //                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.plus],
+        //                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.privateMode],
+        //                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.bookmark],
+        //                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.share]
+        //            ]
+        //        )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4412)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR (cherry-pick from https://github.com/mozilla-mobile/firefox-ios/pull/25403) contains just the changes related to the homepage redesign.

This PR demonstrates the following:
* Some `launchArguments`'s behaviour changes (see ActivityStreamTests)
* "Jump Back In" section missing (see JumpBackInTests)

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

