### PR TITLE
Bugfix [Deeplink Optimization] FXIOS-11670 Prevent deeplink tab to be added multiple times when restoring

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -700,8 +700,16 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
 
     private func configureNewTab(with tabData: TabData) -> Tab? {
         let newTab: Tab
+
+        let isDeeplinkTabAlreadyAdded: Bool = if let deeplinkTab {
+            tabs.contains { $0.tabUUID == deeplinkTab.tabUUID }
+        } else {
+            false
+        }
+
         if isDeeplinkOptimizationRefactorEnabled,
            let deeplinkTab,
+           !isDeeplinkTabAlreadyAdded,
            deeplinkTab.url?.absoluteString == tabData.siteUrl {
             // if the deeplink tab has the same url of a tab data then use the deeplink tab for the restore
             // in order to prevent a duplicate tab

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -335,6 +335,36 @@ class TabManagerTests: XCTestCase {
         wait(for: [expectation])
     }
 
+    func testRestoreTabs_whenDeeplinkTabPresent_doesnAddDepplinkTabMultipleTimes() throws {
+        let expectation = XCTestExpectation(description: "Tab restoration event should have been called")
+        let testUUID = UUID()
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        // Simulate deeplink tab
+        let deeplinkTabData = try XCTUnwrap(getMockTabData(count: 1).first)
+        let deeplinkTab = Tab(profile: mockProfile, windowUUID: testUUID)
+        deeplinkTab.url = URL(string: deeplinkTabData.siteUrl)
+        deeplinkTab.tabUUID = deeplinkTabData.id.uuidString
+        let subject = createSubject(tabs: [deeplinkTab], windowUUID: testUUID)
+
+        mockTabStore.fetchTabWindowData = WindowData(
+            id: UUID(),
+            activeTabId: UUID(),
+            tabData: getMockTabData(count: 4)
+        )
+
+        AppEventQueue.wait(for: .tabRestoration(testUUID)) {
+            let filteredTabs = subject.tabs.filter {
+                $0.tabUUID == deeplinkTab.tabUUID
+            }
+            // There has to be only one tab present
+            XCTAssertEqual(filteredTabs.count, 1)
+            expectation.fulfill()
+        }
+
+        subject.restoreTabs()
+        wait(for: [expectation])
+    }
+
     // MARK: - Save tabs
 
     func testPreserveTabsWithNoTabs() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -125,6 +125,7 @@
         "TabManagerTests\/testRestoreTabs_whenDeeplinkTabNil_selectsPreviousSelectedTabData()",
         "TabManagerTests\/testRestoreTabs_whenDeeplinkTabNotNil_selectsDeeplinkTab()",
         "TabManagerTests\/testRestoreTabs_whenDeeplinkTabPresent()",
+        "TabManagerTests\/testRestoreTabs_whenDeeplinkTabPresent_doesnAddDepplinkTabMultipleTimes()",
         "TabManagerTests\/testRestoreTabs_whenDeeplinkTabPresent_withSameURLAsRestoredTab()",
         "TabToolbarHelperTests\/testTelemetryForSiteMenu()",
         "TestFavicons\/testFaviconFetcherParse()",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11670)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25433)

## :bulb: Description
Prevent deeplink tab to be added multiple times. This caused issue when opening the app i.e via new tab quick action. It would add the home page tab multiple times if in the previous session where present other home page tabs.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

