### PR TITLE
Bugfix FXIOS-11527 #25091 ⁃ PowerPoint or Google Slides don't play through Firefox Browser

### DIFF
--- a/BrowserKit/Sources/Shared/AppName.swift
+++ b/BrowserKit/Sources/Shared/AppName.swift
@@ -46,4 +46,5 @@ public enum KVOConstants: String {
     case canGoForward
     case contentSize
     case hasOnlySecureContent
+    case fullscreenState
 }

--- a/BrowserKit/Sources/WebEngine/FullscreenDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/FullscreenDelegate.swift
@@ -12,8 +12,7 @@ import Foundation
 ///
 /// Due to limited documentation on this behavior, the following methods handle
 /// fullscreen transitions based on trial and error.
-protocol FullscreenDelegate: AnyObject {
-    
+public protocol FullscreenDelegate: AnyObject {
     /// Called when the web view enters fullscreen mode.
     ///
     /// When `WKWebView` is removed from the view hierarchy, two updates must be made
@@ -23,7 +22,7 @@ protocol FullscreenDelegate: AnyObject {
     ///
     /// These adjustments ensure the web page is displayed correctly.
     func enteringFullscreen()
-    
+
     /// Called when the web view exits fullscreen mode.
     ///
     /// The `WKWebView` must be re-added to the app’s view hierarchy to restore normal behavior.

--- a/BrowserKit/Sources/WebEngine/FullscreenDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/FullscreenDelegate.swift
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Delegate to handle fullscreen state changes for a `WKWebView`.
+///
+/// According to Apple’s documentation, when a webpage requests fullscreen mode,
+/// the system removes the `WKWebView` from the app’s view hierarchy. See:
+/// [WKPreferences.isElementFullscreenEnabled](https://developer.apple.com/documentation/webkit/wkpreferences/iselementfullscreenenabled)
+///
+/// Due to limited documentation on this behavior, the following methods handle
+/// fullscreen transitions based on trial and error.
+protocol FullscreenDelegate: AnyObject {
+    
+    /// Called when the web view enters fullscreen mode.
+    ///
+    /// When `WKWebView` is removed from the view hierarchy, two updates must be made
+    /// to restore proper rendering:
+    /// 1. Set `translatesAutoresizingMaskIntoConstraints = true`
+    /// 2. Set a flexible `autoresizingMask`
+    ///
+    /// These adjustments ensure the web page is displayed correctly.
+    func enteringFullscreen()
+    
+    /// Called when the web view exits fullscreen mode.
+    ///
+    /// The `WKWebView` must be re-added to the app’s view hierarchy to restore normal behavior.
+    func exitingFullscreen()
+}

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineView.swift
@@ -5,11 +5,6 @@
 import Common
 import UIKit
 
-protocol FullscreenDelegate: AnyObject {
-    func enteringFullscreen()
-    func exitingFullscreen()
-}
-
 class WKEngineView: UIView, EngineView, FullscreenDelegate {
     private var session: WKEngineSession?
     private var logger: Logger

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockFullscreenDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockFullscreenDelegate.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import WebEngine
 
-class MockFullscreenDelegate: FullscreenDelegate {
+final class MockFullscreenDelegate: FullscreenDelegate {
     var onFullscreeChangeCalled = 0
     var savedFullscreenState = false
 

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		21A43CDD291461C700B1206D /* ReaderModeFontTypeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A43CDC291461C700B1206D /* ReaderModeFontTypeButton.swift */; };
 		21A7C44E283539170071D996 /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C44D283539170071D996 /* IntroViewModel.swift */; };
 		21A7C45028353D0E0071D996 /* OnboardingBasicCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C44F28353D0E0071D996 /* OnboardingBasicCardViewController.swift */; };
+		21AE78522D8B54B8002FDC9E /* WebviewViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AE78512D8B54B8002FDC9E /* WebviewViewControllerTests.swift */; };
 		21AFCFEE2AE80B700027E9CE /* TabsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AFCFED2AE80B700027E9CE /* TabsCoordinator.swift */; };
 		21AFCFF02AE80D370027E9CE /* RemoteTabsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AFCFEF2AE80D370027E9CE /* RemoteTabsCoordinator.swift */; };
 		21B337BB29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B337BA29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift */; };
@@ -2783,6 +2784,7 @@
 		21A43CDC291461C700B1206D /* ReaderModeFontTypeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontTypeButton.swift; sourceTree = "<group>"; };
 		21A7C44D283539170071D996 /* IntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModel.swift; sourceTree = "<group>"; };
 		21A7C44F28353D0E0071D996 /* OnboardingBasicCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBasicCardViewController.swift; sourceTree = "<group>"; };
+		21AE78512D8B54B8002FDC9E /* WebviewViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebviewViewControllerTests.swift; sourceTree = "<group>"; };
 		21AFCFED2AE80B700027E9CE /* TabsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsCoordinator.swift; sourceTree = "<group>"; };
 		21AFCFEF2AE80D370027E9CE /* RemoteTabsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsCoordinator.swift; sourceTree = "<group>"; };
 		21B337BA29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerWebViewDelegateTests.swift; sourceTree = "<group>"; };
@@ -15170,6 +15172,7 @@
 				8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */,
 				0ECB6B672CCFE663006A7C82 /* DateGroupedTableDataTests.swift */,
 				0B7B053C2D647D00007FD7AC /* TemporaryDocumentTests.swift */,
+				21AE78512D8B54B8002FDC9E /* WebviewViewControllerTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -18379,6 +18382,7 @@
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
 				C89C91AD2A1FE9E900BE57B1 /* OnboardingTelemetryDelegationTests.swift in Sources */,
 				8A36BE2C29EDE16C00AC1C5C /* ContentContainerTests.swift in Sources */,
+				21AE78522D8B54B8002FDC9E /* WebviewViewControllerTests.swift in Sources */,
 				ED4589402CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift in Sources */,
 				5A9A09D228AFD51900B6F51E /* MockHomepageDataModelDelegate.swift in Sources */,
 				D525DFB325FBE5E000B18763 /* TabTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -227,6 +227,7 @@ class BrowserCoordinator: BaseCoordinator,
         } else {
             let webviewViewController = WebviewViewController(webView: webView)
             webviewController = webviewViewController
+            browserViewController.fullscreenDelegate = webviewViewController
             let isEmbedded = browserViewController.embedContent(webviewViewController)
             logger.log("Webview controller was created and embedded \(isEmbedded)", level: .info, category: .coordinator)
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -66,11 +66,13 @@ class BrowserViewController: UIViewController,
         .canGoForward,
         .URL,
         .title,
-        .hasOnlySecureContent
+        .hasOnlySecureContent,
+        .fullscreenState
     ]
 
     weak var browserDelegate: BrowserDelegate?
     weak var navigationHandler: BrowserNavigationHandler?
+    weak var fullscreenDelegate: FullscreenDelegate?
 
     var urlBarView: (URLBarViewProtocol & TopBottomInterchangeable & Autocompletable) {
         if !isToolbarRefactorEnabled, let legacyUrlBar {
@@ -2097,6 +2099,16 @@ class BrowserViewController: UIViewController,
             if !isToolbarRefactorEnabled {
                 legacyUrlBar?.locationView.hasSecureContent = webView.hasOnlySecureContent
                 legacyUrlBar?.locationView.showTrackingProtectionButton(for: webView.url)
+            }
+        case .fullscreenState:
+            if #available(iOS 16.0, *) {
+                guard webView.fullscreenState == .enteringFullscreen ||
+                        webView.fullscreenState == .exitingFullscreen else { return }
+                if webView.fullscreenState == .enteringFullscreen {
+                    fullscreenDelegate?.enteringFullscreen()
+                } else {
+                    fullscreenDelegate?.exitingFullscreen()
+                }
             }
         default:
             assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -13,6 +13,7 @@ import Account
 import MobileCoreServices
 import Common
 import Redux
+import WebEngine
 
 import class MozillaAppServices.BookmarkFolderData
 import class MozillaAppServices.BookmarkItemData

--- a/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -5,12 +5,8 @@
 import Foundation
 import Shared
 import WebKit
+import WebEngine
 import Common
-
-protocol FullscreenDelegate: AnyObject {
-    func enteringFullscreen()
-    func exitingFullscreen()
-}
 
 class WebviewViewController: UIViewController,
                              ContentContainable,
@@ -71,6 +67,7 @@ class WebviewViewController: UIViewController,
     }
 
     // MARK: - FullscreenDelegate
+
     func enteringFullscreen() {
         isFullScreen = true
         webView.translatesAutoresizingMaskIntoConstraints = true

--- a/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -18,6 +18,7 @@ class WebviewViewController: UIViewController,
                              FullscreenDelegate {
     private var webView: WKWebView
     var contentType: ContentType = .webview
+    var isFullScreen = false
 
     init(webView: WKWebView) {
         self.webView = webView
@@ -40,6 +41,9 @@ class WebviewViewController: UIViewController,
 
     func update(webView: WKWebView) {
         self.webView = webView
+
+        // Avoid updating constraints while on fullscreen mode
+        guard !isFullScreen else { return }
         setupWebView()
     }
 
@@ -68,11 +72,13 @@ class WebviewViewController: UIViewController,
 
     // MARK: - FullscreenDelegate
     func enteringFullscreen() {
+        isFullScreen = true
         webView.translatesAutoresizingMaskIntoConstraints = true
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     }
 
     func exitingFullscreen() {
         setupWebView()
+        isFullScreen = false
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -7,9 +7,15 @@ import Shared
 import WebKit
 import Common
 
+protocol FullscreenDelegate: AnyObject {
+    func enteringFullscreen()
+    func exitingFullscreen()
+}
+
 class WebviewViewController: UIViewController,
                              ContentContainable,
-                             ScreenshotableView {
+                             ScreenshotableView,
+                             FullscreenDelegate {
     private var webView: WKWebView
     var contentType: ContentType = .webview
 
@@ -58,5 +64,15 @@ class WebviewViewController: UIViewController,
                 completionHandler(nil)
             }
         }
+    }
+
+    // MARK: - FullscreenDelegate
+    func enteringFullscreen() {
+        webView.translatesAutoresizingMaskIntoConstraints = true
+        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    }
+
+    func exitingFullscreen() {
+        setupWebView()
     }
 }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -198,6 +198,9 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         // We do this to go against the configuration of the <meta name="viewport">
         // tag to behave the same way as Safari :-(
         configuration.ignoresViewportScaleLimits = true
+        if #available(iOS 15.4, *) {
+            configuration.preferences.isElementFullscreenEnabled = true
+        }
         if isPrivate {
             configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
         } else {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewViewControllerTests.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Storage
+import XCTest
+import Glean
+
+@testable import Client
+
+class WebviewViewControllerTests: XCTestCase {
+    var webview: WKWebViewMock!
+
+    override func setUp() {
+        super.setUp()
+
+        webview = WKWebViewMock( URL(string: "https://foo.com")!)
+    }
+
+    override func tearDown() {
+        webview = nil
+        super.tearDown()
+    }
+
+    func testEnteringFullScreenCall_FullScreenStateTrue() {
+        let subject = createSubject()
+        subject.enteringFullscreen()
+        XCTAssertTrue(subject.isFullScreen)
+        XCTAssertTrue(webview.translatesAutoresizingMaskIntoConstraints)
+    }
+
+    func testExitingFullScreenCall_FullScreenStateFalse() {
+        let subject = createSubject()
+        subject.exitingFullscreen()
+        XCTAssertFalse(subject.isFullScreen)
+        XCTAssertFalse(webview.translatesAutoresizingMaskIntoConstraints)
+    }
+
+    // MARK: Helper
+    private func createSubject() -> WebviewViewController {
+        let subject = WebviewViewController(webView: webview)
+        trackForMemoryLeaks(subject)
+
+        return subject
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11527)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25091)

## :bulb: Description
- Enable webview fullscreen configuration and observe value
- Add FullscreenDelegate and react to change in state
Relates to https://github.com/mozilla-mobile/firefox-ios/pull/25391

### 🎥 Screenshot
<details>
<summary>Enable fullscreen mode fixes slideshow for powerpoint</summary>


https://github.com/user-attachments/assets/b2ba7c1d-13aa-4ba3-94fb-d982cba6b5bc


</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

