### PR TITLE
Bugfix FXIOS-11684 [UX Fundamentals] Handle .pkpass from blob url

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -4,7 +4,6 @@
 
 import Common
 import Foundation
-import PassKit
 
 extension BrowserViewController: DownloadQueueDelegate {
     func downloadQueue(_ downloadQueue: DownloadQueue, didStartDownload download: Download) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -35,16 +35,11 @@ extension BrowserViewController: DownloadQueueDelegate {
 
     func downloadQueue(_ downloadQueue: DownloadQueue, download: Download, didFinishDownloadingTo location: URL) {
         // Handle Passbook Pass downloads
-        if download.mimeType == MIMEType.Passbook {
-            do {
-                let pass = try PKPass(data: (download as? BlobDownload)!.data)
-                let vc = PKAddPassesViewController(pass: pass)
-
-                present(vc!, animated: true)
-            } catch {
-                print("Failed to open .pkpass file: \(error.localizedDescription)")
+        if OpenPassBookHelper.shouldOpenWithPassBook(mimeType: download.mimeType) {
+            passBookHelper = OpenPassBookHelper(presenter: self)
+            passBookHelper?.open(data: (download as? BlobDownload)!.data) {
+                self.passBookHelper = nil
             }
-            return
         }
 
         // Handle toast notification

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -34,9 +34,10 @@ extension BrowserViewController: DownloadQueueDelegate {
 
     func downloadQueue(_ downloadQueue: DownloadQueue, download: Download, didFinishDownloadingTo location: URL) {
         // Handle Passbook Pass downloads
-        if OpenPassBookHelper.shouldOpenWithPassBook(mimeType: download.mimeType) {
+        if let download = (download as? BlobDownload),
+           OpenPassBookHelper.shouldOpenWithPassBook(mimeType: download.mimeType) {
             passBookHelper = OpenPassBookHelper(presenter: self)
-            passBookHelper?.open(data: (download as? BlobDownload)!.data) {
+            passBookHelper?.open(data: download.data) {
                 self.passBookHelper = nil
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -12,7 +12,7 @@ extension BrowserViewController: DownloadQueueDelegate {
         guard download.originWindow == uuid else { return }
 
         // Do not need toast message for Passbook Passes since we don't save the download
-        guard download.mimeType != MIMEType.Passbook else { return}
+        guard download.mimeType != MIMEType.Passbook else { return }
 
         // If no other download toast is shown, create a new download toast and show it.
         guard let downloadToast = self.downloadToast else {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -602,7 +602,6 @@ extension BrowserViewController: WKNavigationDelegate {
         // This is the normal case, opening a http or https url, which we handle by loading them in this WKWebView.
         // We always allow this. Additionally, data URIs are also handled just like normal web pages.
         if let scheme = url.scheme, ["http", "https", "blob", "file"].contains(scheme) {
-
             if navigationAction.targetFrame?.isMainFrame ?? false {
                 tab.changedUserAgent = Tab.ChangeUserAgent.contains(url: url, isPrivate: tab.isPrivate)
             }
@@ -626,7 +625,6 @@ extension BrowserViewController: WKNavigationDelegate {
                 decisionHandler(.cancel)
                 return
             }
-
 
             if navigationAction.navigationType == .linkActivated && url != webView.url {
                 if profile.prefs.boolForKey(PrefsKeys.BlockOpeningExternalApps) ?? false {
@@ -682,15 +680,14 @@ extension BrowserViewController: WKNavigationDelegate {
         let forceDownload = webView == pendingDownloadWebView
         let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
 
-        if OpenPassBookHelper.shouldOpenWithPassBook(response: response,
-                                                     forceDownload: forceDownload) {
-            passBookHelper = OpenPassBookHelper(response: response,
-                                                cookieStore: cookieStore,
-                                                presenter: self)
+        if let mimeType = response.mimeType, OpenPassBookHelper.shouldOpenWithPassBook(
+            mimeType: mimeType,
+            forceDownload: forceDownload) {
+            passBookHelper = OpenPassBookHelper(presenter: self)
             // Open our helper and nullifies the helper when done with it
-            passBookHelper?.open {
+            passBookHelper?.open(response: response, cookieStore: cookieStore, completion: {
                 self.passBookHelper = nil
-            }
+            })
 
             // Cancel this response from the webview.
             decisionHandler(.cancel)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -601,7 +601,8 @@ extension BrowserViewController: WKNavigationDelegate {
 
         // This is the normal case, opening a http or https url, which we handle by loading them in this WKWebView.
         // We always allow this. Additionally, data URIs are also handled just like normal web pages.
-        if ["http", "https", "blob", "file"].contains(url.scheme) {
+        if let scheme = url.scheme, ["http", "https", "blob", "file"].contains(scheme) {
+
             if navigationAction.targetFrame?.isMainFrame ?? false {
                 tab.changedUserAgent = Tab.ChangeUserAgent.contains(url: url, isPrivate: tab.isPrivate)
             }
@@ -614,6 +615,18 @@ extension BrowserViewController: WKNavigationDelegate {
             } else {
                 webView.customUserAgent = UserAgent.getUserAgent(domain: url.baseDomain ?? "")
             }
+
+            // Blob URL's are downloaded via DownloadHelper.js where we check if we need to handle any special cases like:
+            // - If the blob response has a .pkpass MIME type (FXIOS-11684)
+            // - The <a> tag pressed has a "download" attribute enoting a file download (FXIOS-11125)
+            // Once inspected, if there are no special cases to handle, we will then navigate to the blob URL's location
+            // via JS since we are cancelling the navigation here
+            if scheme == "blob" && navigationAction.navigationType != .other {
+                _ = DownloadContentScript.requestBlobDownload(url: url, tab: tab)
+                decisionHandler(.cancel)
+                return
+            }
+
 
             if navigationAction.navigationType == .linkActivated && url != webView.url {
                 if profile.prefs.boolForKey(PrefsKeys.BlockOpeningExternalApps) ?? false {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -615,9 +615,9 @@ extension BrowserViewController: WKNavigationDelegate {
                 webView.customUserAgent = UserAgent.getUserAgent(domain: url.baseDomain ?? "")
             }
 
-            // Blob URL's are downloaded via DownloadHelper.js where we check if we need to handle any special cases like:
+            // Blob URLs are downloaded via DownloadHelper.js where we check if we need to handle any special cases like:
             // - If the blob response has a .pkpass MIME type (FXIOS-11684)
-            // - The <a> tag pressed has a "download" attribute enoting a file download (FXIOS-11125)
+            // - The <a> tag pressed has a "download" attribute, indicating a file download (FXIOS-11125)
             // Once inspected, if there are no special cases to handle, we will then navigate to the blob URL's location
             // via JS since we are cancelling the navigation here
             if scheme == "blob" && navigationAction.navigationType != .other {

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
@@ -66,6 +66,15 @@ class Download: NSObject {
 
         return proposedPath
     }
+
+    // Determines if we want to save the download to the downloads panel
+    fileprivate func shouldWriteToDisk() -> Bool {
+        // If we downloaded a Passbook Pass, we want to open this immediately instead of saving it to downloads
+        if self.mimeType == MIMEType.Passbook {
+            return false
+        }
+        return true
+    }
 }
 
 class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate {
@@ -198,7 +207,7 @@ class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate
 }
 
 class BlobDownload: Download {
-    private let data: Data
+    let data: Data
 
     init(originWindow: WindowUUID, filename: String, mimeType: String, size: Int64, data: Data) {
         self.data = data
@@ -215,10 +224,13 @@ class BlobDownload: Download {
         // Wait momentarily before continuing here and firing off the delegate
         // callbacks. Otherwise, these may end up getting called before the
         // delegate is set up and the UI may never be notified of completion.
+        // No need to do any actual downloading as download occurred in DownloadHelper.js.
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
             do {
                 let destination = try self.uniqueDownloadPathForFilename(self.filename)
-                try self.data.write(to: destination)
+                if self.shouldWriteToDisk() {
+                    try self.data.write(to: destination)
+                }
                 self.isComplete = true
                 self.delegate?.download(self, didFinishDownloadingTo: destination)
             } catch let error {

--- a/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
@@ -40,6 +40,15 @@ class OpenPassBookHelper {
         return mimeType == MIMEType.Passbook && PKAddPassesViewController.canAddPasses() && !forceDownload
     }
 
+    func open(data: Data, completion: @escaping () -> Void) {
+        do {
+            try open(passData: data)
+        } catch {
+            sendLogError(with: error.localizedDescription)
+            presentErrorAlert(completion: completion)
+        }
+    }
+
     func open(response: URLResponse, cookieStore: WKHTTPCookieStore, completion: @escaping () -> Void) {
         do {
             try openPassWithContentsOfURL(url: response.url)

--- a/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
@@ -25,39 +25,28 @@ class OpenPassBookHelper {
         }
     }
 
-    private var response: URLResponse
-    private var url: URL?
     private let presenter: Presenter
-    private let cookieStore: WKHTTPCookieStore
     private lazy var session = makeURLSession(userAgent: UserAgent.fxaUserAgent,
                                               configuration: .ephemeralMPTCP)
     private let logger: Logger
 
-    init(response: URLResponse,
-         cookieStore: WKHTTPCookieStore,
-         presenter: Presenter,
+    init(presenter: Presenter,
          logger: Logger = DefaultLogger.shared) {
-        self.response = response
-        self.url = response.url
-        self.cookieStore = cookieStore
         self.presenter = presenter
         self.logger = logger
     }
 
-    static func shouldOpenWithPassBook(response: URLResponse,
-                                       forceDownload: Bool) -> Bool {
-        guard let mimeType = response.mimeType, response.url != nil else { return false }
-
+    static func shouldOpenWithPassBook(mimeType: String, forceDownload: Bool = false) -> Bool {
         return mimeType == MIMEType.Passbook && PKAddPassesViewController.canAddPasses() && !forceDownload
     }
 
-    func open(completion: @escaping () -> Void) {
+    func open(response: URLResponse, cookieStore: WKHTTPCookieStore, completion: @escaping () -> Void) {
         do {
-            try openPassWithContentsOfURL()
+            try openPassWithContentsOfURL(url: response.url)
             completion()
         } catch let error as InvalidPassError {
             sendLogError(with: error.description)
-            openPassWithCookies { error in
+            openPassWithCookies(url: response.url, cookieStore: cookieStore) { error in
                 if error != nil {
                     self.presentErrorAlert(completion: completion)
                 } else {
@@ -70,14 +59,17 @@ class OpenPassBookHelper {
         }
     }
 
-    private func openPassWithCookies(completion: @escaping (InvalidPassError?) -> Void) {
-        configureCookies { [weak self] in
-            self?.openPassFromDataTask(completion: completion)
+    private func openPassWithCookies(
+        url: URL?,
+        cookieStore: WKHTTPCookieStore,
+        completion: @escaping (InvalidPassError?) -> Void) {
+        configureCookies(cookieStore: cookieStore) { [weak self] in
+            self?.openPassFromDataTask(url: url, completion: completion)
         }
     }
 
-    private func openPassFromDataTask(completion: @escaping (InvalidPassError?) -> Void) {
-        getData(completion: { data in
+    private func openPassFromDataTask(url: URL?, completion: @escaping (InvalidPassError?) -> Void) {
+        getData(url: url, completion: { data in
             guard let data = data else {
                 completion(InvalidPassError.dataTaskURL)
                 return
@@ -92,7 +84,7 @@ class OpenPassBookHelper {
         })
     }
 
-    private func getData(completion: @escaping (Data?) -> Void) {
+    private func getData(url: URL?, completion: @escaping (Data?) -> Void) {
         guard let url = url else {
             completion(nil)
             return
@@ -111,7 +103,7 @@ class OpenPassBookHelper {
     }
 
     /// Get webview cookies to add onto download session
-    private func configureCookies(completion: @escaping () -> Void) {
+    private func configureCookies(cookieStore: WKHTTPCookieStore, completion: @escaping () -> Void) {
         cookieStore.getAllCookies { [weak self] cookies in
             for cookie in cookies {
                 self?.session.configuration.httpCookieStorage?.setCookie(cookie)
@@ -121,7 +113,7 @@ class OpenPassBookHelper {
         }
     }
 
-    private func openPassWithContentsOfURL() throws {
+    private func openPassWithContentsOfURL(url: URL?) throws {
         guard let url = url, let passData = try? Data(contentsOf: url) else {
             throw InvalidPassError.contentsOfURL
         }

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
@@ -37,7 +37,13 @@ Object.defineProperty(window.__firefox__, "download", {
         }
 
         var blob = this.response;
-
+        
+        // Checking if the blob is a pkpass (Passbook Pass) or download, if not, continue navigation
+        if (blob.type != "application/vnd.apple.pkpass" && !fileName) {
+          window.location.href = url;
+          return
+        }
+      
         blobToBase64String(blob, function(base64String) {
           webkit.messageHandlers.downloadManager.postMessage({
             url: url,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11684)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25452)

## :bulb: Description
- Fixes a "Failed to Add Pass" error that would prevent the user from adding a pass to their Apple Wallet in scenarios where the pass was created from a blob url 

### 📝 Discussion
#### Root cause
- The root cause of the issue was that we were trying to access the data of a blob url (eg: `blob:https://download.passentry.com/c83fa22e-ef61-49c3-b72d-17d6b1ae5f76`) by way of [Data(contentsOf:)](https://developer.apple.com/documentation/foundation/nsdata/1413892-init), which does not support blob url's, causing the error seen in the "Before" video below.

#### Solution
- The solution is, once we know we are navigating to a blob url in [webView(_:decidePolicyFor:decisionHandler:)](https://developer.apple.com/documentation/webkit/wknavigationdelegate/webview(_:decidepolicyfor:decisionhandler:)-2ni62), instead of trying to open the response with `PassKit`, first utilize [DownloadHelper.js](https://github.com/mozilla-mobile/firefox-ios/blob/main/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js) to get the data from the blob url, and pass it back to swift where we can get the contents of the base64 data.

#### Other technical notes
- We can do a few things with a blob url. Currently, our options are to navigate to it, download it (see #24782 for extra detail), and now, open it with `PassKit`. In all cases, the first thing we want to do is send a request to the blob via our [DownloadHelper script](https://github.com/mozilla-mobile/firefox-ios/blob/main/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js). From there, if we have a passbook MIME type (`application/vnd.apple.pkpass`) we know we should pass the data back to Swift for handling, but if we have a simple MIME type like `text/plain`, we just want to open this in our `webView`, so in that case, the `DownloadHelper` script will now request to navigate to that url via `window.location.href`, and no data will be sent back to Swift (but a new navigation request will occur, navigating us to the blob url). The reason this won't result in an infinite loop (request blob url -> download blob (where `type: "text/plain"`) -> request blob url) is because we also check the [WKNavigationType](https://developer.apple.com/documentation/webkit/wknavigationtype) before deciding to navigate to the blob url, or download it. When the link to the blob url is pressed the first time, the `navigationType` will be [WKNavigationType.linkActivated](https://developer.apple.com/documentation/webkit/wknavigationtype/linkactivated), but when it's directed from JS, it will be [WKNavigationType.other](https://developer.apple.com/documentation/webkit/wknavigationtype/other)
- Passes downloaded from blobs (like passes downloaded otherwise) will occur silently, meaning, there will not be any toast notifications for when the download starts or finishes, and the file will not show up in the downloads panel of the library. There is no change in behavior here. 
- `OpenPassbookHelper` was refactored such that it could be used outside of the `WKNavigationDelegate` function, such that it no longer has a `URLResponse` dependency.


### 🎥 Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/0f9aa232-a797-4ea0-9423-16087894ee98

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/5e5c51c8-b0ce-4fbb-ac70-1d38f5f24c36

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

