### PR TITLE
Refactor MTE-2096 bitrise.yml uses release version from version.txt file

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -927,11 +927,9 @@ workflows:
         stack: osx-xcode-16.2.x
         machine_type_id: g2.mac.large
   SPM_Deploy_Prod_Beta:
+    before_run:
+    - SPM_Common_Steps
     steps:
-    - activate-ssh-key@4.1:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@6.2: {}
-    - certificate-and-profile-installer@1: {}
     - script@1.2.1:
         inputs:
         - content: |-
@@ -1055,11 +1053,9 @@ workflows:
       BITRISE_SCHEME: Firefox
     description: This step is to build, archive and upload Firefox Release and Beta
   SPM_Deploy_Beta_Only:
+    before_run:
+    - SPM_Common_Steps
     steps:
-    - activate-ssh-key@4.1.1:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@6.2: {}
-    - certificate-and-profile-installer@1.11.4: {}
     - script@1.2.1:
         inputs:
         - content: |-
@@ -1248,6 +1244,26 @@ workflows:
         is_expand: false
       BITRISE_SCHEME: Firefox
     description: This step is to build, archive and upload Firefox Release and Beta
+  
+  SPM_Common_Steps:
+    steps:
+    - activate-ssh-key@4.1.1:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@6.2: {}
+    - certificate-and-profile-installer@1.11.4: {}
+    - script@1.2.1:
+        is_always_run: true
+        title: Read version from version.txt file
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            pwd
+            ls
+            version=$(cat /Users/vagrant/git/version.txt)
+            echo "Version: $version"
+            # Save version in BITRISE_RELEASE_VERSION
+            envman add --key BITRISE_RELEASE_VERSION --value "$version"
+            envman add --key BITRISE_BETA_VERSION --value "$version"
 
   Bitrise_Performance_Test:
     steps:
@@ -1797,11 +1813,9 @@ workflows:
   # # FOCUS UTILITIES WORKFLOWS
   focus-clone-and-build-dependencies:
     description: Clones the repo and builds dependencies
+    before_run:
+    - SPM_Common_Steps
     steps:
-    - activate-ssh-key@4.1.1:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@6.2: {}
-    - certificate-and-profile-installer@1.11.4: {}
     - script@1.2.1:
         inputs:
         - content: |-
@@ -2161,12 +2175,7 @@ app:
   - opts:
       is_expand: false
     BITRISE_NIGHTLY_VERSION: '9000'
-  - opts:
-      is_expand: false
-    BITRISE_RELEASE_VERSION: '138.0'
-  - opts:
-      is_expand: false
-    BITRISE_BETA_VERSION: '138.0'
+
 
 trigger_map:
 - push_branch: main

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2182,7 +2182,7 @@ trigger_map:
   pipeline: pipeline_build_and_test
 - push_branch: epic-branch/*
   pipeline: pipeline_build_and_test
-- push_branch: release/v138
+- push_branch: release/*
   pipeline: pipeline_build_and_test
 - pull_request_target_branch: main
   pipeline: pipeline_build_and_test


### PR DESCRIPTION
add before run with step

So that we don't need to update the bitrise.yml file manually, let's read the version from the version.txt file

## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/MTE-2096)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

