### PR TITLE
Bugfix FXIOS-11690 [A-S] Initialize NSS in unit tests

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -28121,7 +28121,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 138.0.20250318050322;
+				version = 138.0.20250320050323;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "9582f35e6d527eba0edaedeb16f2c25e46149b46",
-        "version" : "138.0.20250318050322"
+        "revision" : "58d75f4ebf87f947cb329d0b82a100943dfef09d",
+        "version" : "138.0.20250320050323"
       }
     },
     {

--- a/firefox-ios/Client/Application/UnitTestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UnitTestAppDelegate.swift
@@ -3,9 +3,18 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
+import MozillaAppServices
 
 @objc(UnitTestAppDelegate)
 final class UnitTestAppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication,
+                     willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        /// Initialize app services ( including NSS ). Must be called before any other calls to rust components.
+        /// This needs to be called early on, otherwise stuff like enc/dec fails.
+        MozillaAppServices.initialize()
+        return true
+    }
+
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Remove any cached scene configurations to ensure that

--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -7256,7 +7256,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 138.0.20250318050322;
+				version = 138.0.20250320050323;
 			};
 		};
 		8A0E7F2C2BA0F0E0006BC6B6 /* XCRemoteSwiftPackageReference "Fuzi" */ = {

--- a/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift",
         "state": {
           "branch": null,
-          "revision": "9582f35e6d527eba0edaedeb16f2c25e46149b46",
-          "version": "138.0.20250318050322"
+          "revision": "58d75f4ebf87f947cb329d0b82a100943dfef09d",
+          "version": "138.0.20250320050323"
         }
       },
       {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11690)
[Github issue](https://mozilla-hub.atlassian.net/browse/FXIOS-11690)

## :bulb: Description
This PR:
- Now that rust calls `ensure_initialize` ([e.g.](https://github.com/mozilla/application-services/blob/14b1cd6cde0911e720620858951ab7b73d0c89ec/components/push/src/internal/crypto.rs#L185)) we need to make sure NSS is also initialized in unit tests too, otherwise enc/dec of logins, credit cards ( and other services that need nss )  fails in tests.
- Bumps A-S to latest version
- Unblocks https://github.com/mozilla-mobile/firefox-ios/pull/25471

Kudos @RyanSafa for helping out with this ❤️ 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

