### PR TITLE
Fix MTE-4424 Moved TabTrayTests to A11y test plan

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1728,7 +1728,7 @@
 		E13E9AB42AAB0FB5001A0E9D /* FakespotCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13E9AB12AAB0FB4001A0E9D /* FakespotCoordinator.swift */; };
 		E13E9AB52AAB0FB5001A0E9D /* FakespotViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13E9AB22AAB0FB4001A0E9D /* FakespotViewModel.swift */; };
 		E13F8C342928194800BDC8B4 /* PhotonActionSheetSiteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13F8C332928194800BDC8B4 /* PhotonActionSheetSiteHeaderView.swift */; };
-		E143BF652CE36FFD00A1D2D9 /* TabTrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143BF642CE36FF800A1D2D9 /* TabTrayTests.swift */; };
+		E143BF652CE36FFD00A1D2D9 /* A11yTabTrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143BF642CE36FF800A1D2D9 /* A11yTabTrayTests.swift */; };
 		E1442FBF294782B6003680B0 /* CGRect+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1442FBE294782B6003680B0 /* CGRect+Extension.swift */; };
 		E1442FC0294782B6003680B0 /* CGRect+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1442FBE294782B6003680B0 /* CGRect+Extension.swift */; };
 		E1442FCF294782D9003680B0 /* UIView+Screenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1442FC4294782D7003680B0 /* UIView+Screenshot.swift */; };
@@ -9888,7 +9888,7 @@
 		E13E9AB12AAB0FB4001A0E9D /* FakespotCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FakespotCoordinator.swift; path = Client/Frontend/Fakespot/FakespotCoordinator.swift; sourceTree = SOURCE_ROOT; };
 		E13E9AB22AAB0FB4001A0E9D /* FakespotViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FakespotViewModel.swift; path = Client/Frontend/Fakespot/FakespotViewModel.swift; sourceTree = SOURCE_ROOT; };
 		E13F8C332928194800BDC8B4 /* PhotonActionSheetSiteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetSiteHeaderView.swift; sourceTree = "<group>"; };
-		E143BF642CE36FF800A1D2D9 /* TabTrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayTests.swift; sourceTree = "<group>"; };
+		E143BF642CE36FF800A1D2D9 /* A11yTabTrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A11yTabTrayTests.swift; sourceTree = "<group>"; };
 		E1442FBE294782B6003680B0 /* CGRect+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGRect+Extension.swift"; sourceTree = "<group>"; };
 		E1442FC4294782D7003680B0 /* UIView+Screenshot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Screenshot.swift"; sourceTree = "<group>"; };
 		E1442FC5294782D7003680B0 /* UIAlertController+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extension.swift"; sourceTree = "<group>"; };
@@ -11450,7 +11450,7 @@
 				0BC9C9C31F26F54D000E8AB5 /* SiteLoadTest.swift */,
 				2CEDADA120207EC400223A89 /* SyncFAUITests.swift */,
 				4F2A06BD26F8E46E0017DA05 /* TabCounterTests.swift */,
-				E143BF642CE36FF800A1D2D9 /* TabTrayTests.swift */,
+				E143BF642CE36FF800A1D2D9 /* A11yTabTrayTests.swift */,
 				3BFE4B4F1D34673D00DDF53F /* ThirdPartySearchTest.swift */,
 				5FF4AF5B2CC69CC900BABC62 /* TodayWidgetTests.swift */,
 				B12DDFEC2A8DE825008CE9CF /* ToolbarMenuTests.swift */,
@@ -16933,7 +16933,7 @@
 				B1B95C622D3680DB00FD1337 /* ShareToolbarTests.swift in Sources */,
 				B1F90EC12BB3F6B600A4D431 /* ZoomingTests.swift in Sources */,
 				8AEAD9F92C3DB0CD001A2C5A /* MicrosurveyTests.swift in Sources */,
-				E143BF652CE36FFD00A1D2D9 /* TabTrayTests.swift in Sources */,
+				E143BF652CE36FFD00A1D2D9 /* A11yTabTrayTests.swift in Sources */,
 				D4AFA84E2AFA5482000BFEAA /* ExperimentIntegrationTests.swift in Sources */,
 				3DEFED081F55EBE300F8620C /* TrackingProtectionTests.swift in Sources */,
 				2CEDADA220207EC400223A89 /* SyncFAUITests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -55,6 +55,8 @@
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",
         "A11ySearchTest\/testA11ySearchSuggestions()",
+        "A11yTabTrayTests",
+        "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
         "ActivityStreamTest",
         "AddressesTests",

--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -22,6 +22,8 @@
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",
         "A11ySearchTest\/testA11ySearchSuggestions()",
+        "A11yTabTrayTests",
+        "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
         "ActivityStreamTest",
         "AddressesTests",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
@@ -23,6 +23,8 @@
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",
         "A11ySearchTest\/testA11ySearchSuggestions()",
+        "A11yTabTrayTests",
+        "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
         "ActivityStreamTest",
         "ActivityStreamTest\/testContextMenuInLandscape()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
@@ -23,6 +23,8 @@
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",
         "A11ySearchTest\/testA11ySearchSuggestions()",
+        "A11yTabTrayTests",
+        "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
         "ActivityStreamTest",
         "AddressesTests\/testAddNewAddressAllFieldsFilled()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
@@ -23,6 +23,8 @@
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",
         "A11ySearchTest\/testA11ySearchSuggestions()",
+        "A11yTabTrayTests",
+        "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
         "ActivityStreamTest",
         "AddressesTests\/testAddNewAddressCityFilled()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
@@ -23,6 +23,8 @@
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",
         "A11ySearchTest\/testA11ySearchSuggestions()",
+        "A11yTabTrayTests",
+        "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
         "ActivityStreamTest\/testContextMenuInLandscape()",
         "ActivityStreamTest\/testLongTapOnTopSiteOptions()",

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
@@ -45,6 +45,8 @@
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",
         "A11ySearchTest\/testA11ySearchSuggestions()",
+        "A11yTabTrayTests",
+        "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
         "ActivityStreamTest",
         "AddressesTests",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yTabTrayTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yTabTrayTests.swift
@@ -4,7 +4,7 @@
 
 import XCTest
 
-class TabTrayTests: BaseTestCase {
+class A11yTabTrayTests: BaseTestCase {
     func testAccessibility() throws {
         guard #available(iOS 17.0, *), !skipPlatform else { return }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4424)

## :bulb: Description
The TabTrayTest contains only an A11y test, so I've moved the test under the accessibility test plan and I've renamed it.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

