### PR TITLE
Refactor FXIOS-11351 Use prod for Remote Settings

### DIFF
--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -708,8 +708,11 @@ open class BrowserProfile: Profile {
 
     lazy var remoteSettingsService: RemoteSettingsService? = {
         do {
-            let server = AppConstants.buildChannel == .developer ? RemoteSettingsServer.stage : RemoteSettingsServer.prod
-            let bucketName = (server == .prod ? "main" : "main-preview")
+            // let server = AppConstants.buildChannel == .developer ? RemoteSettingsServer.stage : RemoteSettingsServer.prod
+            // let bucketName = (server == .prod ? "main" : "main-preview")
+            // For now we're always using prod, per AS team guidance
+            let server = RemoteSettingsServer.prod
+            let bucketName = "main"
             let config = RemoteSettingsConfig2(server: server,
                                                bucketName: bucketName,
                                                appContext: remoteSettingsAppContext())


### PR DESCRIPTION
## :scroll: Tickets
Minor change related to: [Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8469)

## :bulb: Description

Use prod server for Remote Settings, per AS team. Support for switching between staging for QA/testing will be forthcoming later.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

