### PR TITLE
Bugfix MTE-4379 Use --legacy flag for xcresulttool

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1611,7 +1611,7 @@ workflows:
             mv "$FIREBASE_XCRESULT" "$BITRISE_XCRESULT"
 
             # create and print perf data object for perfherder ingest via taskcluster log output
-            xcrun xcresulttool graph --path "$BITRISE_XCRESULT"
+            xcrun xcresulttool graph --path "$BITRISE_XCRESULT" --legacy
             ls ..
             # If this ever breaks, check the xcresult_extract.py function find_xcresult_path 
             # and figure out exactly what it is doing because we are using Fennec as the scheme


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4379)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

The performance tests pass on Firebase:
https://console.firebase.google.com/u/0/project/moz-firefox-ios-230118/testlab/histories/bh.edf3c7143e2d5284/matrices/6990721509211723561/executions/bs.ab6998fb88d26ee8/logs

But the workflow fails in the last step "Create Perfherder Data Object from Firebase":
https://app.bitrise.io/build/8effb4f7-c7b7-4b9f-b9e0-09bd27020416

`xcresulttool` requires the `--legacy` flag for the current usage.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

