### PR TITLE
Bugfix MTE-4379 Use --legacy flag for xcresult_extract.py

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1569,7 +1569,7 @@ workflows:
             set -ex
 
             # get dependency
-            cd ./test-fixtures && git clone https://github.com/isabelrios/xcresult_extract.git
+            cd ./test-fixtures && git clone https://github.com/clarmso/xcresult_extract.git
 
             # pull firebase xcresult and rename it to extract measurement data
             mkdir test_firebase_xcresult


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4379)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The `xcresult_extract.py` script in my fork contains the `--legacy` flag required for `xcrun xcresulttool` to work with the latest Xcode.

(Similar usage of the script is found in line https://github.com/mozilla-mobile/firefox-ios/blob/main/bitrise.yml#L1273 for `Bitrise_Performance_Test`.)

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

