### PR TITLE
 Bugfix FXIOS-11644 [Homepage] jump back in triggers to update state

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -869,6 +869,7 @@
 		8A4EA0DB2C0117CD00E4E4F1 /* MobileMessageSurfaceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4EA0DA2C0117CD00E4E4F1 /* MobileMessageSurfaceProtocol.swift */; };
 		8A4EA0DD2C0117F200E4E4F1 /* MicrosurveyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4EA0DC2C0117F200E4E4F1 /* MicrosurveyModel.swift */; };
 		8A5038142A5DFCE000A1B02A /* MockBrowserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5038132A5DFCE000A1B02A /* MockBrowserProfile.swift */; };
+		8A505BA52D9198900070EB44 /* TopTabsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A505BA42D9198900070EB44 /* TopTabsAction.swift */; };
 		8A5189C92C1B614E00CDB668 /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A87AEE02C1B4D17007428B2 /* SearchViewModelTests.swift */; };
 		8A5435562D53CB6800501214 /* JumpBackInAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5435552D53CB6600501214 /* JumpBackInAction.swift */; };
 		8A552AC72CB43AB400564C98 /* HomepageStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */; };
@@ -8143,6 +8144,7 @@
 		8A4EA0DA2C0117CD00E4E4F1 /* MobileMessageSurfaceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileMessageSurfaceProtocol.swift; sourceTree = "<group>"; };
 		8A4EA0DC2C0117F200E4E4F1 /* MicrosurveyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyModel.swift; sourceTree = "<group>"; };
 		8A5038132A5DFCE000A1B02A /* MockBrowserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBrowserProfile.swift; sourceTree = "<group>"; };
+		8A505BA42D9198900070EB44 /* TopTabsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabsAction.swift; sourceTree = "<group>"; };
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
 		8A5435552D53CB6600501214 /* JumpBackInAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInAction.swift; sourceTree = "<group>"; };
 		8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomepageStateTests.swift; sourceTree = "<group>"; };
@@ -10887,6 +10889,7 @@
 				8A8904122D511E6A00A5BB29 /* TabManagerAction.swift */,
 				1D2F68AA2ACB262900524B92 /* RemoteTabsPanelAction.swift */,
 				219914042AF963F900153598 /* TabTrayAction.swift */,
+				8A505BA42D9198900070EB44 /* TopTabsAction.swift */,
 				219935E82B070F9000E5966F /* TabPanelAction.swift */,
 				5A9F833F2B2B4AE800272819 /* TabPeekAction.swift */,
 			);
@@ -17117,6 +17120,7 @@
 				0E12A3152CC2D8410037F8EE /* PasswordGeneratorTelemetry.swift in Sources */,
 				E1CD81BC290C5C3F00124B27 /* DevicePickerTableViewCell.swift in Sources */,
 				8AC8841D2D525F7B0033ABF5 /* CrashTracker.swift in Sources */,
+				8A505BA52D9198900070EB44 /* TopTabsAction.swift in Sources */,
 				1DDE3DB72AC3820A0039363B /* TabModel.swift in Sources */,
 				8A19ACB02A329078001C2147 /* AutofillCreditCardSettings.swift in Sources */,
 				E1E5BE252A28F7BE00248F77 /* PasswordDetailViewControllerModel.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TopTabsAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TopTabsAction.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+
+/// Actions related to top tabs shown on large device layout (i.e. iPad)
+class TopTabsAction: Action { }
+
+enum  TopTabsActionType: ActionType {
+    case didTapNewTab
+    case didTapCloseTab
+}

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -55,7 +55,11 @@ class RemoteTabsPanelMiddleware {
 
     private func resolveHomepageActions(action: Action, state: AppState) {
         switch action.actionType {
-        case HomepageActionType.initialize, JumpBackInActionType.fetchRemoteTabs:
+        case HomepageActionType.viewWillAppear,
+            JumpBackInActionType.fetchRemoteTabs,
+            TabTrayActionType.dismissTabTray,
+            TopTabsActionType.didTapNewTab,
+            TopTabsActionType.didTapCloseTab:
             self.handleFetchingMostRecentRemoteTab(windowUUID: action.windowUUID)
         default:
             break

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -1052,6 +1052,9 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     /// Sends out updated recent tabs which is currently used for the homepage jumpBackIn section
     private func dispatchRecentlyAccessedTabs(action: Action) {
         // TODO: FXIOS-10919 - Consider testing better with Tasks here
+        // and modifying how we fetch recentlyAccessedNormalTabs since
+        // it doesn't retrieve the proper tabs without this task block
+        // See more details on issue here [FXIOS-5149] [FXIOS-11644]
         Task { @MainActor in
             // [FXIOS-5149] Recent tabs need to be accessed from .main thread
             let recentTabs = self.tabManager(for: action.windowUUID).recentlyAccessedNormalTabs

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -211,6 +211,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
     @objc
     func newTabTapped() {
         delegate?.topTabsDidPressNewTab(self.topTabDisplayManager.isPrivate)
+        store.dispatch(TopTabsAction(windowUUID: windowUUID, actionType: TopTabsActionType.didTapNewTab))
     }
 
     @objc
@@ -367,6 +368,7 @@ extension TopTabsViewController: TopTabCellDelegate {
         topTabDisplayManager.closeActionPerformed(forCell: cell)
         delegate?.topTabsShowCloseTabsToast()
         NotificationCenter.default.post(name: .TopTabsTabClosed, object: nil, userInfo: windowUUID.userInfo)
+        store.dispatch(TopTabsAction(windowUUID: windowUUID, actionType: TopTabsActionType.didTapCloseTab))
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -116,11 +116,7 @@ final class HomepageViewController: UIViewController,
             .TopSitesUpdated,
             .DefaultSearchEngineUpdated,
             .BookmarksUpdated,
-            .RustPlacesOpened,
-            .TabDataUpdated,
-            .TabsTrayDidClose,
-            .TabsTrayDidSelectHomeTab,
-            .TopTabsTabClosed
+            .RustPlacesOpened
         ])
 
         subscribeToRedux()
@@ -166,6 +162,12 @@ final class HomepageViewController: UIViewController,
         super.viewWillAppear(animated)
         /// Used as a trigger for showing a microsurvey based on viewing the homepage
         Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
+        store.dispatch(
+            HomepageAction(
+                windowUUID: windowUUID,
+                actionType: HomepageActionType.viewWillAppear
+            )
+        )
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -931,9 +933,6 @@ final class HomepageViewController: UIViewController,
             )
         case .ProfileDidFinishSyncing, .FirefoxAccountChanged:
             dispatchActionToFetchTopSites()
-            dispatchActionToFetchTabs()
-
-        case .TabDataUpdated, .TabsTrayDidClose, .TabsTrayDidSelectHomeTab, .TopTabsTabClosed:
             dispatchActionToFetchTabs()
         default: break
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -25,4 +25,5 @@ enum HomepageActionType: ActionType {
     case initialize
     case traitCollectionDidChange
     case viewWillTransition
+    case viewWillAppear
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -20,10 +20,10 @@ final class ContentContainerTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
         self.profile = nil
         self.overlayModeManager = nil
-        AppContainer.shared.reset()
+        DependencyHelperMock().reset()
+        super.tearDown()
     }
 
     // MARK: - canAddHomepage

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -45,7 +45,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         let sut = createSubject()
 
         XCTAssertEqual(mockThemeManager?.getCurrentThemeCallCount, 0)
-        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 12)
+        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 8)
         XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
                                                            .FirefoxAccountChanged,
                                                            .PrivateDataClearedHistory,
@@ -53,17 +53,13 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
                                                            .TopSitesUpdated,
                                                            .DefaultSearchEngineUpdated,
                                                            .BookmarksUpdated,
-                                                           .RustPlacesOpened,
-                                                           .TabDataUpdated,
-                                                           .TabsTrayDidClose,
-                                                           .TabsTrayDidSelectHomeTab,
-                                                           .TopTabsTabClosed
+                                                           .RustPlacesOpened
         ])
 
         sut.loadViewIfNeeded()
 
         XCTAssertEqual(mockThemeManager?.getCurrentThemeCallCount, 1)
-        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 13)
+        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 9)
         XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
                                                            .FirefoxAccountChanged,
                                                            .PrivateDataClearedHistory,
@@ -72,10 +68,6 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
                                                            .DefaultSearchEngineUpdated,
                                                            .BookmarksUpdated,
                                                            .RustPlacesOpened,
-                                                           .TabDataUpdated,
-                                                           .TabsTrayDidClose,
-                                                           .TabsTrayDidSelectHomeTab,
-                                                           .TopTabsTabClosed,
                                                            .ThemeDidChange
         ])
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabsMiddlewareTests.swift
@@ -27,11 +27,119 @@ final class RemoteTabsMiddlewareTests: XCTestCase, StoreTestUtility {
         super.tearDown()
     }
 
-    func test_homepageInitializeAction_returnsMostRecentTab() throws {
+    func test_jumpBackInAction_returnsMostRecentTab() throws {
+        let subject = createSubject()
+        let action = JumpBackInAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: JumpBackInActionType.fetchRemoteTabs
+        )
+
+        let expectation = XCTestExpectation(description: "Most recent tab should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.remoteTabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? RemoteTabsAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? RemoteTabsMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, RemoteTabsMiddlewareActionType.fetchedMostRecentSyncedTab)
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.client.name, "Fake client")
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.tab.title, "Mozilla 3")
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.tab.URL.absoluteString, "www.mozilla.org")
+    }
+
+    func test_viewWillAppearHomeAction_returnsMostRecentTab() throws {
         let subject = createSubject()
         let action = HomepageAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: HomepageActionType.initialize
+            actionType: HomepageActionType.viewWillAppear
+        )
+
+        let expectation = XCTestExpectation(description: "Most recent tab should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.remoteTabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? RemoteTabsAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? RemoteTabsMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, RemoteTabsMiddlewareActionType.fetchedMostRecentSyncedTab)
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.client.name, "Fake client")
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.tab.title, "Mozilla 3")
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.tab.URL.absoluteString, "www.mozilla.org")
+    }
+
+    func test_dismissTabTrayAction_returnsMostRecentTab() throws {
+        let subject = createSubject()
+        let action = TabTrayAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TabTrayActionType.dismissTabTray
+        )
+
+        let expectation = XCTestExpectation(description: "Most recent tab should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.remoteTabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? RemoteTabsAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? RemoteTabsMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, RemoteTabsMiddlewareActionType.fetchedMostRecentSyncedTab)
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.client.name, "Fake client")
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.tab.title, "Mozilla 3")
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.tab.URL.absoluteString, "www.mozilla.org")
+    }
+
+    func test_topTabsNewTabAction_returnsMostRecentTab() throws {
+        let subject = createSubject()
+        let action = TopTabsAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TopTabsActionType.didTapNewTab
+        )
+
+        let expectation = XCTestExpectation(description: "Most recent tab should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.remoteTabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? RemoteTabsAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? RemoteTabsMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, RemoteTabsMiddlewareActionType.fetchedMostRecentSyncedTab)
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.client.name, "Fake client")
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.tab.title, "Mozilla 3")
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.tab.URL.absoluteString, "www.mozilla.org")
+    }
+
+    func test_topTabsCloseTabAction_returnsMostRecentTab() throws {
+        let subject = createSubject()
+        let action = TopTabsAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TopTabsActionType.didTapNewTab
         )
 
         let expectation = XCTestExpectation(description: "Most recent tab should be returned")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -60,11 +60,112 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, TabPanelMiddlewareActionType.refreshTabs)
     }
 
-    func test_homepageInitializeAction_returnsRecentTabs() throws {
+    // MARK: - Recent Tabs
+    func test_viewWillAppearHomeAction_returnsRecentTabs() throws {
         let subject = createSubject()
         let action = HomepageAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: HomepageActionType.initialize
+            actionType: HomepageActionType.viewWillAppear
+        )
+
+        let expectation = XCTestExpectation(description: "Recent tabs should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.tabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabManagerAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? TabManagerMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
+        XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+    }
+
+    func test_jumpBackInAction_returnsRecentTabs() throws {
+        let subject = createSubject()
+        let action = JumpBackInAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: JumpBackInActionType.fetchLocalTabs
+        )
+
+        let expectation = XCTestExpectation(description: "Recent tabs should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.tabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabManagerAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? TabManagerMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
+        XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+    }
+
+    func test_tabTrayDismissAction_returnsRecentTabs() throws {
+        let subject = createSubject()
+        let action = JumpBackInAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: JumpBackInActionType.fetchLocalTabs
+        )
+
+        let expectation = XCTestExpectation(description: "Recent tabs should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.tabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabManagerAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? TabManagerMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
+        XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+    }
+
+    func test_topTabsNewTabAction_returnsRecentTabs() throws {
+        let subject = createSubject()
+        let action = TopTabsAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TopTabsActionType.didTapNewTab
+        )
+
+        let expectation = XCTestExpectation(description: "Recent tabs should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.tabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabManagerAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? TabManagerMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
+        XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+    }
+
+    func test_topTabsCloseTabAction_returnsRecentTabs() throws {
+        let subject = createSubject()
+        let action = TopTabsAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TopTabsActionType.didTapCloseTab
         )
 
         let expectation = XCTestExpectation(description: "Recent tabs should be returned")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -163,19 +163,19 @@ class JumpBackInTests: BaseTestCase {
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         navigator.performAction(Action.GoToHomePage)
-        // After homepage redesign, "Jump back in" is no longer visible (FXIOS-11644)
-        // mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
-        //        app.cells["JumpBackInCell"].firstMatch.press(forDuration: 2)
-        //        // The context menu opens, having the correct options
-        //        let ContextMenuTable = app.tables["Context Menu"]
-        //        waitForElementsToExist(
-        //            [
-        //                ContextMenuTable,
-        //                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.plus],
-        //                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.privateMode],
-        //                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.bookmark],
-        //                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.share]
-        //            ]
-        //        )
+
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
+        app.cells["JumpBackInCell"].firstMatch.press(forDuration: 2)
+        // The context menu opens, having the correct options
+        let ContextMenuTable = app.tables["Context Menu"]
+        waitForElementsToExist(
+            [
+                ContextMenuTable,
+                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.plus],
+                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.privateMode],
+                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.bookmark],
+                ContextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.share]
+            ]
+        )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11644)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25361)

## :bulb: Description
Use actions instead of notification center to retrieve updated tabs for JumpBackIn section. Also fixes UI tests since previously some notifications were missing and not updating the tab section to show properly.
- Homepage view will appear
- Dismiss Tab Tray
- Tap New Tab on Top Tabs UI
- Tap Close button on Tab for Top Tabs UI  

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

# Screenshots
**iPhone** 

https://github.com/user-attachments/assets/e9ae4be4-a041-4e05-93c5-284aaa6c13f7

**iPad**

https://github.com/user-attachments/assets/fd5585d0-e8d6-4866-acfd-03b98a80b21b


