### PR TITLE
Bugfix FXIOS-11710 [A-S] Call NSS initialize when using firefox as external provider for passwords

### DIFF
--- a/firefox-ios/CredentialProvider/CredentialProviderViewController.swift
+++ b/firefox-ios/CredentialProvider/CredentialProviderViewController.swift
@@ -5,6 +5,7 @@
 import AuthenticationServices
 import LocalAuthentication
 
+import MozillaAppServices
 import Shared
 import Storage
 
@@ -38,6 +39,9 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        // Initialize app services ( including NSS ). Must be called before any other calls to rust components.
+        // In this case we need to call this before we try to decrypt any passwords, otherwise decryption fails.
+        MozillaAppServices.initialize()
         self.presenter = CredentialProviderPresenter(view: self)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11710)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25521)

Also fixes https://github.com/mozilla-mobile/firefox-ios/issues/25507 and [FXIOS-11702](https://mozilla-hub.atlassian.net/browse/FXIOS-11702)
## :bulb: Description
This PR:
- Call NSS initialize when using Firefox password manager as external provider. This is necessary since  rust components internally call `ensure_initialized` now, we need to make sure that they are initialized before we try to decrypt logins, otherwise it will fail.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)



[FXIOS-11702]: https://mozilla-hub.atlassian.net/browse/FXIOS-11702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ