### PR TITLE
Bugfix FXIOS-11703 [App Icon 2025] Fix app icon telemetetry misreporting the previous icon selection

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconSelectionView.swift
@@ -94,7 +94,7 @@ struct AppIconSelectionView: View, ThemeApplicable {
                 return
             }
 
-            telemetry.selectedIcon(appIcon, previousIcon: self.currentAppIcon)
+            telemetry.selectedIcon(appIcon, previousIcon: previousIcon)
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11703)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25510)

## :bulb: Description
Fix issue with telemetry misreporting the old vs. new name when selecting an icon name.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

