### PR TITLE
Bugfix FXIOS-11668 [Homepage] ActivityStreamTests that was broken

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -78,7 +78,7 @@ struct TopSitesSectionState: StateType, Equatable {
             topSitesData: sites,
             numberOfRows: state.numberOfRows,
             numberOfTilesPerRow: state.numberOfTilesPerRow,
-            shouldShowSection: !sites.isEmpty && state.shouldShowSection
+            shouldShowSection: state.shouldShowSection
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -33,8 +33,7 @@ class ActivityStreamTest: BaseTestCase {
                                LaunchArguments.DisableAnimations]
         }
         launchArguments.append(LaunchArguments.SkipAddingGoogleTopSite)
-        // Comment out so that the sponsors shortcuts are shown after the homepage redesign. (FXIOS-11668)
-        // launchArguments.append(LaunchArguments.SkipSponsoredShortcuts)
+        launchArguments.append(LaunchArguments.SkipSponsoredShortcuts)
         super.setUp()
     }
     override func tearDown() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11668)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25533)

## :bulb: Description
Changing the homepage rebuild feature flag ON caused the `ActivityStreamTests` to fail due to not showing the top sites section when the sponsored sites are empty. While this was not an issue that we saw in the app, it was failing the tests. Remove the check for if sites is empty in the state seems to fix this issue. The piece of code was also leftover since we do the check again when setting up the snapshot, so adding the logic check to the state is also redundant.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)