### PR TITLE
Refactor DISCO-3269 - Stop calling `SuggestStoreBuilder.remoteSetting…

### DIFF
--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -9,7 +9,6 @@ import class MozillaAppServices.RemoteSettingsService
 import class MozillaAppServices.SuggestStoreBuilder
 import class MozillaAppServices.Viaduct
 import enum MozillaAppServices.SuggestionProvider
-import enum MozillaAppServices.RemoteSettingsServer
 import struct MozillaAppServices.SuggestIngestionConstraints
 import struct MozillaAppServices.SuggestionQuery
 
@@ -46,15 +45,10 @@ public class RustFirefoxSuggest: RustFirefoxSuggestProtocol {
     public init(
         dataPath: String,
         cachePath: String,
-        remoteSettingsServer: RemoteSettingsServer? = nil,
         remoteSettingsService: RemoteSettingsService
     ) throws {
         var builder = SuggestStoreBuilder()
             .dataPath(path: dataPath)
-
-        if let remoteSettingsServer {
-            builder = builder.remoteSettingsServer(server: remoteSettingsServer)
-        }
 
         builder = builder.remoteSettingsService(rsService: remoteSettingsService)
 


### PR DESCRIPTION
…sServer`

This has been replaced with `SuggestStoreBuilder.remoteSettingsService` and the app-services code is now ignoring the
`SuggestStoreBuilder.remoteSettingsServer` call, so let's stop sending it.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

