### PR TITLE
Add FXIOS-11693 [App Icon 2025] Add deeplink support for app icon seleciton in settings

### DIFF
--- a/firefox-ios/Client/Coordinators/Router/Route.swift
+++ b/firefox-ios/Client/Coordinators/Router/Route.swift
@@ -97,6 +97,7 @@ enum Route: Equatable {
     /// An enumeration representing different sections of the settings menu.
     enum SettingsSection: String, CaseIterable, Equatable {
         case addresses
+        case appIcon = "app-icon"
         case contentBlocker
         case clearPrivateData = "clear-private-data"
         case creditCard

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -94,6 +94,14 @@ class SettingsCoordinator: BaseCoordinator,
 
     private func getSettingsViewController(settingsSection section: Route.SettingsSection) -> UIViewController? {
         switch section {
+        case .appIcon:
+            let viewController = UIHostingController(
+                rootView: AppIconSelectionView(
+                    windowUUID: windowUUID
+                )
+            )
+            viewController.title = .Settings.AppIconSelection.ScreenTitle
+            return viewController
         case .addresses:
             let viewModel = AddressAutofillSettingsViewModel(
                 profile: profile,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 
 @testable import Client
+import SwiftUI
 
 final class SettingsCoordinatorTests: XCTestCase {
     private var mockRouter: MockRouter!
@@ -174,6 +175,15 @@ final class SettingsCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(mockRouter.pushCalled, 0)
         XCTAssertNil(mockRouter.pushedViewController)
+    }
+
+    func testAppIconSettingsRoute_showsAppIconSelectionPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .appIcon)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is UIHostingController<AppIconSelectionView>)
     }
 
     // MARK: - Delegate

--- a/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
@@ -51,6 +51,7 @@ import:
               OPEN_SETTINGS_PRIVACY:              ://deep-link?url=settings/clear-private-data
               OPEN_SETTINGS_FXA:                  ://deep-link?url=settings/fxa
               OPEN_SETTINGS_THEME:                ://deep-link?url=settings/theme
+              OPEN_SETTINGS_APP_ICON:             ://deep-link?url=settings/app-icon
               OPEN_URL:                           ://open-url
               VIEW_BOOKMARKS:                     ://deep-link?url=homepanel/bookmarks
               VIEW_TOP_SITES:                     ://deep-link?url=homepanel/top-sites


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11693)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25491)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add deeplink support for setting section: App icon selection.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

