### PR TITLE
Add FXIOS-11502 [SEC] [WIP] Search order preference migration

### DIFF
--- a/BrowserKit/Sources/Shared/NSUserDefaultsPrefs.swift
+++ b/BrowserKit/Sources/Shared/NSUserDefaultsPrefs.swift
@@ -100,6 +100,10 @@ open class NSUserDefaultsPrefs: Prefs {
         return userDefaults.object(forKey: qualifyKey(defaultName)) as? T
     }
 
+    open func hasObjectForKey(_ defaultName: String) -> Bool {
+        return userDefaults.object(forKey: qualifyKey(defaultName)) != nil
+    }
+
     open func intForKey(_ defaultName: String) -> Int32? {
         return nsNumberForKey(defaultName)?.int32Value
     }

--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -228,6 +228,7 @@ public protocol Prefs {
     func setObject(_ value: Any?, forKey defaultName: String)
     func stringForKey(_ defaultName: String) -> String?
     func objectForKey<T: Any>(_ defaultName: String) -> T?
+    func hasObjectForKey(_ defaultName: String) -> Bool
     func boolForKey(_ defaultName: String) -> Bool?
     func intForKey(_ defaultName: String) -> Int32?
     func timestampForKey(_ defaultName: String) -> Timestamp?
@@ -305,6 +306,10 @@ open class MockProfilePrefs: Prefs {
 
     open func objectForKey<T: Any>(_ defaultName: String) -> T? {
         return things[name(defaultName)] as? T
+    }
+
+    open func hasObjectForKey(_ defaultName: String) -> Bool {
+        return (things[name(defaultName)] != nil)
     }
 
     open func timestampForKey(_ defaultName: String) -> Timestamp? {

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -146,6 +146,8 @@
 		1D2F68AD2ACB266300524B92 /* RemoteTabsPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AC2ACB266300524B92 /* RemoteTabsPanelState.swift */; };
 		1D2F68AF2ACB272500524B92 /* RemoteTabsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */; };
 		1D2F68B12ACCA22000524B92 /* RemoteTabsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */; };
+		1D35644F2D90999300F52F12 /* ASSearchEnginePrefsMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D35644E2D90998900F52F12 /* ASSearchEnginePrefsMigrator.swift */; };
+		1D3564502D909D7900F52F12 /* ASSearchEnginePrefsMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D35644E2D90998900F52F12 /* ASSearchEnginePrefsMigrator.swift */; };
 		1D3822E92BAB99250046BC5E /* UIView+ThemeUUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3822E82BAB99250046BC5E /* UIView+ThemeUUIDIdentifiable.swift */; };
 		1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */; };
 		1D4D79462BF2F4E7007C6796 /* SimpleTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E69EAF254D064E00B591C2 /* SimpleTab.swift */; };
@@ -2672,6 +2674,7 @@
 		1D2F68AC2ACB266300524B92 /* RemoteTabsPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanelState.swift; sourceTree = "<group>"; };
 		1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsTableViewController.swift; sourceTree = "<group>"; };
 		1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsEmptyView.swift; sourceTree = "<group>"; };
+		1D35644E2D90998900F52F12 /* ASSearchEnginePrefsMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASSearchEnginePrefsMigrator.swift; sourceTree = "<group>"; };
 		1D3822E82BAB99250046BC5E /* UIView+ThemeUUIDIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ThemeUUIDIdentifiable.swift"; sourceTree = "<group>"; };
 		1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabPanelTests.swift; sourceTree = "<group>"; };
 		1D558A562BED7ECB001EF527 /* MockWindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWindowManager.swift; sourceTree = "<group>"; };
@@ -10826,6 +10829,7 @@
 				1DCEC3F52D600C3D00129966 /* ASSearchEngineIconRecord.swift */,
 				1DCEC4132D83B7E600129966 /* ASSearchEngineIconDataFetcher.swift */,
 				1DCEC4112D8372DD00129966 /* ASSearchEngineUtilities.swift */,
+				1D35644E2D90998900F52F12 /* ASSearchEnginePrefsMigrator.swift */,
 			);
 			path = "Application Services";
 			sourceTree = "<group>";
@@ -17149,6 +17153,7 @@
 				8A5D1CA82A30D6D3005AD35C /* HomeSetting.swift in Sources */,
 				1DFE57FF27BAE3150025DE58 /* HomepageSectionType.swift in Sources */,
 				C2D1A10D2A66C70000205DCC /* BookmarksCoordinator.swift in Sources */,
+				1D35644F2D90999300F52F12 /* ASSearchEnginePrefsMigrator.swift in Sources */,
 				8C46E1B72B2209F000F56521 /* FakespotAdsEvent.swift in Sources */,
 				8A8D277D2CC000BE0076AD3A /* NavigationBrowserAction.swift in Sources */,
 				396E38F11EE0C8EC00CC180F /* FxAPushMessageHandler.swift in Sources */,
@@ -18548,6 +18553,7 @@
 				E1CD81C6290C6D5800124B27 /* HelpView.swift in Sources */,
 				E1D6F2D828E325D100B2C8CC /* InstructionsView.swift in Sources */,
 				BD2577982C9D85B5007B344C /* AnyHashable.swift in Sources */,
+				1D3564502D909D7900F52F12 /* ASSearchEnginePrefsMigrator.swift in Sources */,
 				FA6B2AC41D41F02D00429414 /* String+Punycode.swift in Sources */,
 				EDDF340B2CDD1B7C008BB6A4 /* SearchEngineModel.swift in Sources */,
 				E1D6F2D928E32A5300B2C8CC /* ImageIdentifiers.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		1D2F68B12ACCA22000524B92 /* RemoteTabsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */; };
 		1D35644F2D90999300F52F12 /* ASSearchEnginePrefsMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D35644E2D90998900F52F12 /* ASSearchEnginePrefsMigrator.swift */; };
 		1D3564502D909D7900F52F12 /* ASSearchEnginePrefsMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D35644E2D90998900F52F12 /* ASSearchEnginePrefsMigrator.swift */; };
+		1D3564542D9329FA00F52F12 /* SearchPrefsMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3564532D9329FA00F52F12 /* SearchPrefsMigrationTests.swift */; };
 		1D3822E92BAB99250046BC5E /* UIView+ThemeUUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3822E82BAB99250046BC5E /* UIView+ThemeUUIDIdentifiable.swift */; };
 		1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */; };
 		1D4D79462BF2F4E7007C6796 /* SimpleTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E69EAF254D064E00B591C2 /* SimpleTab.swift */; };
@@ -2675,6 +2676,7 @@
 		1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsTableViewController.swift; sourceTree = "<group>"; };
 		1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsEmptyView.swift; sourceTree = "<group>"; };
 		1D35644E2D90998900F52F12 /* ASSearchEnginePrefsMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASSearchEnginePrefsMigrator.swift; sourceTree = "<group>"; };
+		1D3564532D9329FA00F52F12 /* SearchPrefsMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPrefsMigrationTests.swift; sourceTree = "<group>"; };
 		1D3822E82BAB99250046BC5E /* UIView+ThemeUUIDIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ThemeUUIDIdentifiable.swift"; sourceTree = "<group>"; };
 		1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabPanelTests.swift; sourceTree = "<group>"; };
 		1D558A562BED7ECB001EF527 /* MockWindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWindowManager.swift; sourceTree = "<group>"; };
@@ -13091,6 +13093,7 @@
 			isa = PBXGroup;
 			children = (
 				8AFC4E462CAF53E100C54B43 /* RemoteDataTypeTests.swift */,
+				1D3564532D9329FA00F52F12 /* SearchPrefsMigrationTests.swift */,
 				8ABE9F1C2CB462730080E1DF /* RemoteSettingsFetchConfigTests.swift */,
 			);
 			path = RemoteSettings;
@@ -18467,6 +18470,7 @@
 				8AABBD032A001CBC0089941E /* MockApplicationHelper.swift in Sources */,
 				8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */,
 				2173326829CCDA8E007F20C7 /* TabScrollControllerTests.swift in Sources */,
+				1D3564542D9329FA00F52F12 /* SearchPrefsMigrationTests.swift in Sources */,
 				BA1C68BA2B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift in Sources */,
 				9614BF4228A53FDF00D3F7EA /* ContextualHintEligibilityUtilityTests.swift in Sources */,
 				615532D42D7AA5F30046347F /* ScreenshotHelperTests.swift in Sources */,

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
@@ -51,7 +51,6 @@ final class ASSearchEngineIconDataFetcher: ASSearchEngineIconDataFetcherProtocol
             let engineIdentifier = engine.identifier
 
             for iconRecord in iconRecords {
-                // TODO: [FXIOS-11605] Client-side filtering of multiple icon records [?]. TBD.
                 let iconIdentifiers = iconRecord.engineIdentifiers
                 var matchFound = false
 

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEnginePrefsMigrator.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEnginePrefsMigrator.swift
@@ -23,12 +23,12 @@ struct DefaultSearchEnginePrefsMigrator: SearchEnginePreferencesMigrator {
                               to expectedVersion: SearchEngineOrderingPrefsVersion,
                               availableEngines: [OpenSearchEngine]) -> SearchEnginePrefs {
         guard prefs.version != expectedVersion else {
-            logInfo("No migration needed for search prefs.")
+            logInfo("[SEC] No migration needed for search prefs.")
             return prefs
         }
 
         guard let inputIdentifiers = prefs.engineIdentifiers, !inputIdentifiers.isEmpty else {
-            logWarning("Migration input engine list was empty or nil.")
+            logWarning("[SEC] Migration input engine list was empty or nil.")
             return SearchEnginePrefs(engineIdentifiers: nil,
                                      disabledEngines: prefs.disabledEngines,
                                      version: expectedVersion)

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEnginePrefsMigrator.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEnginePrefsMigrator.swift
@@ -5,9 +5,9 @@
 import Common
 
 protocol SearchEnginePreferencesMigrator {
-    func migratePrefsIfNeeded(_ prefs: SearchEngineOrderingPrefs,
+    func migratePrefsIfNeeded(_ prefs: SearchEnginePrefs,
                               to expectedVersion: SearchEngineOrderingPrefsVersion,
-                              availableEngines: [OpenSearchEngine]) -> SearchEngineOrderingPrefs
+                              availableEngines: [OpenSearchEngine]) -> SearchEnginePrefs
 }
 
 struct DefaultSearchEnginePrefsMigrator: SearchEnginePreferencesMigrator {
@@ -19,9 +19,9 @@ struct DefaultSearchEnginePrefsMigrator: SearchEnginePreferencesMigrator {
 
     // MARK: - SearchEnginePreferencesMigrator
 
-    func migratePrefsIfNeeded(_ prefs: SearchEngineOrderingPrefs,
+    func migratePrefsIfNeeded(_ prefs: SearchEnginePrefs,
                               to expectedVersion: SearchEngineOrderingPrefsVersion,
-                              availableEngines: [OpenSearchEngine]) -> SearchEngineOrderingPrefs {
+                              availableEngines: [OpenSearchEngine]) -> SearchEnginePrefs {
         guard prefs.version != expectedVersion else {
             logInfo("No migration needed for search prefs.")
             return prefs
@@ -29,45 +29,59 @@ struct DefaultSearchEnginePrefsMigrator: SearchEnginePreferencesMigrator {
 
         guard let inputIdentifiers = prefs.engineIdentifiers, !inputIdentifiers.isEmpty else {
             logWarning("Migration input engine list was empty or nil.")
-            return SearchEngineOrderingPrefs(engineIdentifiers: nil, version: expectedVersion)
+            return SearchEnginePrefs(engineIdentifiers: nil,
+                                     disabledEngines: prefs.disabledEngines,
+                                     version: expectedVersion)
         }
+        let inputDisabledEngines = prefs.disabledEngines ?? []
 
         // Keeping the ordering intact, iterate over the name or ID of each engine and try to convert
         // that to the name or ID of the available engine. v1 prefs utilize the engine shortName while
         // v2 preferences will use the engine identifier.
         let engineIdentifiers: [String]
-        if expectedVersion == .v2 {
+        let disabledEngines: [String]
+        switch expectedVersion {
+        case .v2:
             // Map existing short names of XML engines to the AS-based engines
-            engineIdentifiers = inputIdentifiers.compactMap {
-                let shortName = $0.lowercased()
-                // This may perform multiple O(N) loops but these are extremely small collections (typically 5-7 elements)
-                let engine = availableEngines.first { return $0.engineID.lowercased() == shortName }
-                ?? availableEngines.first { return $0.shortName.lowercased() == shortName }
-                ?? availableEngines.first {
-                    return $0.engineID.lowercased().hasPrefix(shortName) || $0.shortName.lowercased().hasPrefix(shortName)
-                }
-                if let engine { logInfo("[SEC] Mapped v1 '\(shortName)' to v2 '\(engine.engineID)'") }
-                return engine?.engineID
-            }
-        } else {
+            engineIdentifiers = inputIdentifiers.compactMap { mapV1ShortNameToV2EngineID($0, availableEngines) }
+            disabledEngines = inputDisabledEngines.compactMap { mapV1ShortNameToV2EngineID($0, availableEngines) }
+        case .v1:
             // Moving backwards. This should be rare but we should support it anyway.
             // A user may move out of the SEC experiment group and back to the XML engines.
-
             // Map existing identifiers of AS-based engines to our XML engines
-            engineIdentifiers = inputIdentifiers.compactMap {
-                let identifier = $0.lowercased()
-                let engine = availableEngines.first { return $0.shortName.lowercased() == identifier }
-                ?? availableEngines.first { return $0.engineID.lowercased() == identifier }
-                ?? availableEngines.first {
-                    return $0.engineID.lowercased().hasPrefix(identifier) || $0.shortName.lowercased().hasPrefix(identifier)
-                }
-                if let engine { logInfo("[SEC] Mapped v2 '\(identifier)' to v1 '\(engine.shortName)'") }
-                return engine?.shortName
-            }
+            engineIdentifiers = inputIdentifiers.compactMap { mapV2EngineIDToV1ShortName($0, availableEngines) }
+            disabledEngines = inputDisabledEngines.compactMap { mapV1ShortNameToV2EngineID($0, availableEngines) }
         }
 
-        let newPrefs = SearchEngineOrderingPrefs(engineIdentifiers: engineIdentifiers, version: expectedVersion)
+        let newPrefs = SearchEnginePrefs(engineIdentifiers: engineIdentifiers,
+                                         disabledEngines: disabledEngines,
+                                         version: expectedVersion)
         return newPrefs
+    }
+
+    // MARK: - Internal
+
+    private func mapV1ShortNameToV2EngineID(_ input: String, _ availableEngines: [OpenSearchEngine]) -> String? {
+        let shortName = input.lowercased()
+        // Performs several O(N) loops but data sets are very small (typically 4-5 elements)
+        let engine = availableEngines.first { return $0.engineID.lowercased() == shortName }
+        ?? availableEngines.first { return $0.shortName.lowercased() == shortName }
+        ?? availableEngines.first {
+            return $0.engineID.lowercased().hasPrefix(shortName) || $0.shortName.lowercased().hasPrefix(shortName)
+        }
+        if let engine { logInfo("[SEC] Mapped v1 '\(shortName)' to v2 '\(engine.engineID)'") }
+        return engine?.engineID
+    }
+
+    private func mapV2EngineIDToV1ShortName(_ input: String, _ availableEngines: [OpenSearchEngine]) -> String? {
+        let identifier = input.lowercased()
+        let engine = availableEngines.first { return $0.shortName.lowercased() == identifier }
+        ?? availableEngines.first { return $0.engineID.lowercased() == identifier }
+        ?? availableEngines.first {
+            return $0.engineID.lowercased().hasPrefix(identifier) || $0.shortName.lowercased().hasPrefix(identifier)
+        }
+        if let engine { logInfo("[SEC] Mapped v2 '\(identifier)' to v1 '\(engine.shortName)'") }
+        return engine?.shortName
     }
 
     // MARK: - Utility

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEnginePrefsMigrator.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEnginePrefsMigrator.swift
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+
+protocol SearchEnginePreferencesMigrator {
+    func migratePrefsIfNeeded(_ prefs: SearchEngineOrderingPrefs,
+                              to expectedVersion: SearchEngineOrderingPrefsVersion,
+                              availableEngines: [OpenSearchEngine]) -> SearchEngineOrderingPrefs
+}
+
+struct DefaultSearchEnginePrefsMigrator: SearchEnginePreferencesMigrator {
+    private let logger: Logger
+
+    init(logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+    }
+
+    // MARK: - SearchEnginePreferencesMigrator
+
+    func migratePrefsIfNeeded(_ prefs: SearchEngineOrderingPrefs,
+                              to expectedVersion: SearchEngineOrderingPrefsVersion,
+                              availableEngines: [OpenSearchEngine]) -> SearchEngineOrderingPrefs {
+        guard prefs.version != expectedVersion else {
+            logInfo("No migration needed for search prefs.")
+            return prefs
+        }
+
+        guard let inputIdentifiers = prefs.engineIdentifiers, !inputIdentifiers.isEmpty else {
+            logWarning("Migration input engine list was empty or nil.")
+            return SearchEngineOrderingPrefs(engineIdentifiers: nil, version: expectedVersion)
+        }
+
+        // Keeping the ordering intact, iterate over the name or ID of each engine and try to convert
+        // that to the name or ID of the available engine. v1 prefs utilize the engine shortName while
+        // v2 preferences will use the engine identifier.
+        let engineIdentifiers: [String]
+        if expectedVersion == .v2 {
+            // Map existing short names of XML engines to the AS-based engines
+            engineIdentifiers = inputIdentifiers.compactMap {
+                let shortName = $0.lowercased()
+                // This may perform multiple O(N) loops but these are extremely small collections (typically 5-7 elements)
+                let engine = availableEngines.first { return $0.engineID.lowercased() == shortName }
+                ?? availableEngines.first { return $0.shortName.lowercased() == shortName }
+                ?? availableEngines.first {
+                    return $0.engineID.lowercased().hasPrefix(shortName) || $0.shortName.lowercased().hasPrefix(shortName)
+                }
+                if let engine { logInfo("[SEC] Mapped v1 '\(shortName)' to v2 '\(engine.engineID)'") }
+                return engine?.engineID
+            }
+        } else {
+            // Moving backwards. This should be rare but we should support it anyway.
+            // A user may move out of the SEC experiment group and back to the XML engines.
+
+            // Map existing identifiers of AS-based engines to our XML engines
+            engineIdentifiers = inputIdentifiers.compactMap {
+                let identifier = $0.lowercased()
+                let engine = availableEngines.first { return $0.shortName.lowercased() == identifier }
+                ?? availableEngines.first { return $0.engineID.lowercased() == identifier }
+                ?? availableEngines.first {
+                    return $0.engineID.lowercased().hasPrefix(identifier) || $0.shortName.lowercased().hasPrefix(identifier)
+                }
+                if let engine { logInfo("[SEC] Mapped v2 '\(identifier)' to v1 '\(engine.shortName)'") }
+                return engine?.shortName
+            }
+        }
+
+        let newPrefs = SearchEngineOrderingPrefs(engineIdentifiers: engineIdentifiers, version: expectedVersion)
+        return newPrefs
+    }
+
+    // MARK: - Utility
+
+    private func logInfo(_ msg: String) {
+        logger.log(msg, level: .info, category: .remoteSettings)
+    }
+
+    private func logWarning(_ msg: String) {
+        logger.log(msg, level: .warning, category: .remoteSettings)
+    }
+}

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEnginePrefsMigrator.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEnginePrefsMigrator.swift
@@ -23,9 +23,10 @@ struct DefaultSearchEnginePrefsMigrator: SearchEnginePreferencesMigrator {
                               to expectedVersion: SearchEngineOrderingPrefsVersion,
                               availableEngines: [OpenSearchEngine]) -> SearchEnginePrefs {
         guard prefs.version != expectedVersion else {
-            logInfo("[SEC] No migration needed for search prefs.")
+            logInfo("[SEC] No migration needed for search prefs (already \(expectedVersion)).")
             return prefs
         }
+        logInfo("[SEC] Will migrate \(prefs.version) to \(expectedVersion)")
 
         guard let inputIdentifiers = prefs.engineIdentifiers, !inputIdentifiers.isEmpty else {
             logWarning("[SEC] Migration input engine list was empty or nil.")

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEnginePrefsMigrator.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEnginePrefsMigrator.swift
@@ -50,7 +50,7 @@ struct DefaultSearchEnginePrefsMigrator: SearchEnginePreferencesMigrator {
             // A user may move out of the SEC experiment group and back to the XML engines.
             // Map existing identifiers of AS-based engines to our XML engines
             engineIdentifiers = inputIdentifiers.compactMap { mapV2EngineIDToV1ShortName($0, availableEngines) }
-            disabledEngines = inputDisabledEngines.compactMap { mapV1ShortNameToV2EngineID($0, availableEngines) }
+            disabledEngines = inputDisabledEngines.compactMap { mapV2EngineIDToV1ShortName($0, availableEngines) }
         }
 
         let newPrefs = SearchEnginePrefs(engineIdentifiers: engineIdentifiers,

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
@@ -32,9 +32,9 @@ final class ASSearchEngineProvider: SearchEngineProvider {
     let preferencesVersion: SearchEngineOrderingPrefsVersion = .v2
 
     func getOrderedEngines(customEngines: [OpenSearchEngine],
-                           engineOrderingPrefs: SearchEngineOrderingPrefs,
+                           engineOrderingPrefs: SearchEnginePrefs,
                            prefsMigrator: SearchEnginePreferencesMigrator,
-                           completion: @escaping ([OpenSearchEngine]) -> Void) {
+                           completion: @escaping SearchEngineCompletion) {
         // Note: this currently duplicates the logic from DefaultSearchEngineProvider.
         // Eventually that class will be removed once we switch fully to consolidated search.
 
@@ -53,7 +53,7 @@ final class ASSearchEngineProvider: SearchEngineProvider {
             guard let orderedEngineNames = finalEngineOrderingPrefs.engineIdentifiers,
                   !orderedEngineNames.isEmpty else {
                 // We haven't persisted the engine order, so return whatever order we got from disk.
-                ensureMainThread { completion(unorderedEngines) }
+                ensureMainThread { completion(finalEngineOrderingPrefs, unorderedEngines) }
                 return
             }
 
@@ -77,7 +77,7 @@ final class ASSearchEngineProvider: SearchEngineProvider {
                 }
             }
 
-            ensureMainThread { completion(orderedEngines) }
+            ensureMainThread { completion(finalEngineOrderingPrefs, orderedEngines) }
         })
     }
 

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
@@ -29,7 +29,7 @@ final class ASSearchEngineProvider: SearchEngineProvider {
 
     // MARK: - SearchEngineProvider
 
-    var preferencesVersion: SearchEngineOrderingPrefsVersion { .v2 }
+    let preferencesVersion: SearchEngineOrderingPrefsVersion = .v2
 
     func getOrderedEngines(customEngines: [OpenSearchEngine],
                            engineOrderingPrefs: SearchEngineOrderingPrefs,

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/DefaultSearchEngineProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/DefaultSearchEngineProvider.swift
@@ -39,7 +39,7 @@ class DefaultSearchEngineProvider: SearchEngineProvider {
         self.logger = logger
     }
 
-    var preferencesVersion: SearchEngineOrderingPrefsVersion { .v1 }
+    let preferencesVersion: SearchEngineOrderingPrefsVersion = .v1
 
     func getOrderedEngines(customEngines: [OpenSearchEngine],
                            engineOrderingPrefs: SearchEngineOrderingPrefs,

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/DefaultSearchEngineProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/DefaultSearchEngineProvider.swift
@@ -17,7 +17,7 @@ protocol SearchEngineProvider {
                            engineOrderingPrefs: SearchEngineOrderingPrefs,
                            prefsMigrator: SearchEnginePreferencesMigrator,
                            completion: @escaping ([OpenSearchEngine]) -> Void)
-    
+
     /// Returns the search ordering preference format that this provider utilizes.
     var preferencesVersion: SearchEngineOrderingPrefsVersion { get }
 }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -38,6 +38,12 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
         case engineID
     }
 
+    override var debugDescription: String {
+        let className = String(describing: type(of: self))
+        let memAddr = Unmanaged.passUnretained(self).toOpaque()
+        return "<\(className): \(memAddr)> Name: '\(shortName)' ID: '\(engineID)' Custom: \(isCustomEngine)"
+    }
+
     init(engineID: String,
          shortName: String,
          image: UIImage,

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -27,7 +27,7 @@ final class SearchEngineSelectionMiddleware {
 
             guard !searchEngines.isEmpty else {
                 // The SearchEngineManager should have loaded these by now, but if not, attempt to fetch the search engines
-                self.searchEnginesManager.getOrderedEngines { [weak self] searchEngines in
+                self.searchEnginesManager.getOrderedEngines { [weak self] preferences, searchEngines in
                     self?.notifyDidLoad(windowUUID: action.windowUUID, searchEngines: searchEngines)
                 }
                 return

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -153,9 +153,9 @@ class SearchEnginesManager: SearchEnginesManagerProvider {
     private lazy var disabledEngines: [String] = getDisabledEngines() {
         didSet {
             if isSECEnabled {
-                self.prefs.setObject(Array(self.disabledEngines), forKey: disabledEngineIDsPrefsKey)
+                prefs.setObject(Array(disabledEngines), forKey: disabledEngineIDsPrefsKey)
             } else {
-                self.prefs.setObject(Array(self.disabledEngines), forKey: legacy_disabledEngineNamesPrefsKey)
+                prefs.setObject(Array(disabledEngines), forKey: legacy_disabledEngineNamesPrefsKey)
             }
         }
     }
@@ -163,9 +163,9 @@ class SearchEnginesManager: SearchEnginesManagerProvider {
     var orderedEngines: [OpenSearchEngine] {
         didSet {
             if isSECEnabled {
-                self.prefs.setObject(self.orderedEngines.map { $0.engineID }, forKey: orderedEngineIDsPrefsKey)
+                prefs.setObject(orderedEngines.map { $0.engineID }, forKey: orderedEngineIDsPrefsKey)
             } else {
-                self.prefs.setObject(self.orderedEngines.map { $0.shortName }, forKey: legacy_orderedEngineNamesPrefsKey)
+                prefs.setObject(orderedEngines.map { $0.shortName }, forKey: legacy_orderedEngineNamesPrefsKey)
             }
         }
     }
@@ -174,7 +174,7 @@ class SearchEnginesManager: SearchEnginesManagerProvider {
     ///
     /// The results can be empty if the user disables all search engines besides the default (which can't be disabled).
     var quickSearchEngines: [OpenSearchEngine] {
-        return self.orderedEngines.filter({ (engine) in !self.isEngineDefault(engine) && self.isEngineEnabled(engine) })
+        return orderedEngines.filter({ (engine) in !self.isEngineDefault(engine) && self.isEngineEnabled(engine) })
     }
 
     var shouldShowSearchSuggestions = true {

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -43,8 +43,10 @@ struct SearchEngineProviderFactory {
 /// The search engines are ordered and can be enabled and disabled by the user. Order and disabled state are backed by a
 /// write-through cache into a Prefs instance (i.e. UserDefaults).
 ///
-/// Default search engines are localized and given by the `SearchEngineProvider` (from list.json). The user may add
-/// additional custom search engines. Custom search engines entered by the user are saved to a file.
+/// Originally, default search engines were localized and given by the `SearchEngineProvider` (from list.json). With the
+/// forthcoming updates for Search Consolidation (FXIOS-8469) this will be changing, and the engines will be vended via
+/// Application Services. The user may add additional custom search engines. Custom search engines entered by the user are
+/// saved to a file.
 ///
 /// The first search engine is distinguished and labeled the "default" search engine; it can never be disabled.
 /// [FIXME FXIOS-10187 this will change soon ->] Search suggestions should always be sourced from the default search engine

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -326,22 +326,25 @@ class SearchEnginesManager: SearchEnginesManagerProvider {
     private func getOrderingPrefs() -> SearchEngineOrderingPrefs {
         let enginePrefs: SearchEngineOrderingPrefs
 
+        let v2PrefsKey = orderedEngineIDsPrefsKey
+        let v1PrefsKey = legacy_orderedEngineNamesPrefsKey
+
         func fetchPrefs(_ version: SearchEngineOrderingPrefsVersion) -> SearchEngineOrderingPrefs {
             switch version {
             case .v2:
-                let engineStrings = prefs.stringArrayForKey(orderedEngineIDsPrefsKey)
+                let engineStrings = prefs.stringArrayForKey(v2PrefsKey)
                 return SearchEngineOrderingPrefs(engineIdentifiers: engineStrings, version: .v2)
             case .v1:
-                let engineStrings = prefs.stringArrayForKey(legacy_orderedEngineNamesPrefsKey)
+                let engineStrings = prefs.stringArrayForKey(v1PrefsKey)
                 return SearchEngineOrderingPrefs(engineIdentifiers: engineStrings, version: .v1)
             }
         }
 
         if isSECEnabled {
-            if prefs.hasObjectForKey(orderedEngineIDsPrefsKey) {
+            if prefs.hasObjectForKey(v2PrefsKey) {
                 // v2 (SEC) preferences are available on-disk
                 enginePrefs = fetchPrefs(.v2)
-            } else if prefs.hasObjectForKey(legacy_orderedEngineNamesPrefsKey) {
+            } else if prefs.hasObjectForKey(v1PrefsKey) {
                 // We're running for the first time with SEC enabled but haven't yet saved ordering
                 // prefs for those engines. We send the v1 preferences which will be migrated.
                 enginePrefs = fetchPrefs(.v1)
@@ -350,9 +353,9 @@ class SearchEnginesManager: SearchEnginesManagerProvider {
                 enginePrefs = SearchEngineOrderingPrefs(engineIdentifiers: nil, version: .v2)
             }
         } else {
-            if prefs.hasObjectForKey(legacy_orderedEngineNamesPrefsKey) {
+            if prefs.hasObjectForKey(v1PrefsKey) {
                 enginePrefs = fetchPrefs(.v1)
-            } else if prefs.hasObjectForKey(orderedEngineIDsPrefsKey) {
+            } else if prefs.hasObjectForKey(v2PrefsKey) {
                 // Unlikely, but it's possible a new user installed during SEC experiment, and then was
                 // moved out of the SEC experiment.
                 enginePrefs = fetchPrefs(.v2)

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -330,7 +330,7 @@ class SearchEnginesManager: SearchEnginesManagerProvider {
                 enginePrefs = SearchEngineOrderingPrefs(engineIdentifiers: engineStrings, version: .v2)
             } else if prefs.hasObjectForKey(legacy_orderedEngineNamesPrefsKey) {
                 // We're running for the first time with SEC enabled but haven't yet saved ordering
-                // prefs for those engines. We send the v1  preferences which will be migrated.
+                // prefs for those engines. We send the v1 preferences which will be migrated.
                 let engineStrings = prefs.stringArrayForKey(legacy_orderedEngineNamesPrefsKey)
                 enginePrefs = SearchEngineOrderingPrefs(engineIdentifiers: engineStrings, version: .v1)
             } else {

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -327,10 +327,11 @@ class SearchEnginesManager: SearchEnginesManagerProvider {
         let enginePrefs: SearchEngineOrderingPrefs
 
         func fetchPrefs(_ version: SearchEngineOrderingPrefsVersion) -> SearchEngineOrderingPrefs {
-            if version == .v2 {
+            switch version {
+            case .v2:
                 let engineStrings = prefs.stringArrayForKey(orderedEngineIDsPrefsKey)
                 return SearchEngineOrderingPrefs(engineIdentifiers: engineStrings, version: .v2)
-            } else if version == .v1 {
+            case .v1:
                 let engineStrings = prefs.stringArrayForKey(legacy_orderedEngineNamesPrefsKey)
                 return SearchEngineOrderingPrefs(engineIdentifiers: engineStrings, version: .v1)
             }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
@@ -63,10 +63,16 @@ class MockSearchEngineProvider: SearchEngineProvider {
         unorderedEngines?(mockEngines)
     }
 
-    func getOrderedEngines(customEngines: [OpenSearchEngine],
-                           engineOrderingPrefs: SearchEngineOrderingPrefs,
-                           prefsMigrator: SearchEnginePreferencesMigrator,
-                           completion: @escaping ([OpenSearchEngine]) -> Void) {
+    func getOrderedEngines(
+        customEngines: [OpenSearchEngine],
+        engineOrderingPrefs: SearchEngineOrderingPrefs,
+        prefsMigrator: any SearchEnginePreferencesMigrator,
+        completion: @escaping (
+            [OpenSearchEngine]
+        ) -> Void
+    ) {
         completion(mockEngines)
     }
+
+    let preferencesVersion: SearchEngineOrderingPrefsVersion = .v1
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
@@ -65,13 +65,10 @@ class MockSearchEngineProvider: SearchEngineProvider {
 
     func getOrderedEngines(
         customEngines: [OpenSearchEngine],
-        engineOrderingPrefs: SearchEngineOrderingPrefs,
+        engineOrderingPrefs: SearchEnginePrefs,
         prefsMigrator: any SearchEnginePreferencesMigrator,
-        completion: @escaping (
-            [OpenSearchEngine]
-        ) -> Void
-    ) {
-        completion(mockEngines)
+        completion: @escaping SearchEngineCompletion) {
+        completion(engineOrderingPrefs, mockEngines)
     }
 
     let preferencesVersion: SearchEngineOrderingPrefsVersion = .v1

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
@@ -64,7 +64,8 @@ class MockSearchEngineProvider: SearchEngineProvider {
     }
 
     func getOrderedEngines(customEngines: [OpenSearchEngine],
-                           orderedEngineNames: [String]?,
+                           engineOrderingPrefs: SearchEngineOrderingPrefs,
+                           prefsMigrator: SearchEnginePreferencesMigrator,
                            completion: @escaping ([OpenSearchEngine]) -> Void) {
         completion(mockEngines)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEnginesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEnginesManagerTests.swift
@@ -39,7 +39,7 @@ class SearchEnginesManagerTests: XCTestCase {
         // Verify that the set of shipped engines includes the expected subset.
         let expectation = expectation(description: "Completed parse engines")
 
-        searchEnginesManager.getOrderedEngines { result in
+        searchEnginesManager.getOrderedEngines { prefs, result in
             XCTAssertEqual(self.searchEnginesManager.orderedEngines.count, 6)
             expectation.fulfill()
         }
@@ -99,7 +99,7 @@ class SearchEnginesManagerTests: XCTestCase {
         // Persistence can't be tested without the default fixture changing.
         // Remaining engines should be appended in alphabetical order.
         let expectation = expectation(description: "Completed parse engines")
-        searchEnginesManager.getOrderedEngines { [weak self] orderedEngines in
+        searchEnginesManager.getOrderedEngines { [weak self] prefs, orderedEngines in
             guard let self = self else {
                 XCTFail("Could not weakify self.")
                 return
@@ -189,7 +189,7 @@ class SearchEnginesManagerTests: XCTestCase {
         // Verify that the set of shipped engines includes the expected subset.
         let expectation = expectation(description: "Completed parse engines")
 
-        searchEnginesManager.getOrderedEngines { result in
+        searchEnginesManager.getOrderedEngines { prefs, result in
             XCTAssert(self.searchEnginesManager.orderedEngines.count > 1, "There should be more than one search engine")
             XCTAssertEqual(self.searchEnginesManager.orderedEngines.first?.shortName, "ATester")
             expectation.fulfill()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
@@ -21,7 +21,15 @@ class MockSearchEnginesManager: SearchEnginesManagerProvider {
         self.searchEngines = searchEngines
     }
 
-    func getOrderedEngines(completion: @escaping ([OpenSearchEngine]) -> Void) {
-        completion(searchEngines)
+    func getOrderedEngines(completion: @escaping SearchEngineCompletion) {
+        completion(
+            SearchEnginePrefs(
+                engineIdentifiers: searchEngines.map {
+                    $0.shortName
+                },
+                disabledEngines: [],
+                version: .v1),
+            searchEngines
+        )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/SearchPrefsMigrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/SearchPrefsMigrationTests.swift
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+import XCTest
+import WebKit
+
+class SearchPrefsMigrationTests: XCTestCase {
+    private let mockV1Prefs: SearchEngineOrderingPrefs = {
+        let engines = ["Google", "Custom", "Wikipedia", "DuckDuckGo"]
+        return SearchEngineOrderingPrefs(engineIdentifiers: engines, version: .v1)
+    }()
+
+    private let mockV2Prefs: SearchEngineOrderingPrefs = {
+        let engines = ["google", "Custom", "wikipedia", "duckduckgo"]
+        return SearchEngineOrderingPrefs(engineIdentifiers: engines, version: .v2)
+    }()
+
+    private let mockRemoteSettingsEngines: [OpenSearchEngine] = [
+        OpenSearchEngine(
+            engineID: "google",
+            shortName: "Google",
+            image: UIImage(),
+            searchTemplate: "",
+            suggestTemplate: "",
+            isCustomEngine: false
+        ),
+        OpenSearchEngine(
+            engineID: "ddg",
+            shortName: "DuckDuckGo",
+            image: UIImage(),
+            searchTemplate: "",
+            suggestTemplate: "",
+            isCustomEngine: false
+        ),
+        OpenSearchEngine(
+            engineID: "wikipedia",
+            shortName: "Wikipedia (en)",
+            image: UIImage(),
+            searchTemplate: "",
+            suggestTemplate: "",
+            isCustomEngine: false
+        ),
+        OpenSearchEngine(
+            engineID: "Custom-1234-1234-1234-1234",
+            shortName: "Custom",
+            image: UIImage(),
+            searchTemplate: "",
+            suggestTemplate: "",
+            isCustomEngine: true
+        ),
+    ]
+
+    func testMigrateV1toV2Preferences() async throws {
+        let migrator = createSubject()
+        let prefs = mockV1Prefs
+        let output = migrator.migratePrefsIfNeeded(prefs, to: .v2, availableEngines: mockRemoteSettingsEngines)
+
+        XCTAssertEqual(output.version, .v2)
+        XCTAssertEqual(output.engineIdentifiers, ["google", "Custom-1234-1234-1234-1234", "wikipedia", "ddg"])
+    }
+
+    private func createSubject() -> DefaultSearchEnginePrefsMigrator {
+        return DefaultSearchEnginePrefsMigrator(logger: MockLogger())
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/SearchPrefsMigrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/SearchPrefsMigrationTests.swift
@@ -7,14 +7,20 @@ import XCTest
 import WebKit
 
 class SearchPrefsMigrationTests: XCTestCase {
-    private let mockV1Prefs: SearchEngineOrderingPrefs = {
+    private let mockV1Prefs: SearchEnginePrefs = {
         let engines = ["Google", "MyWebsite", "Wikipedia", "DuckDuckGo"]
-        return SearchEngineOrderingPrefs(engineIdentifiers: engines, version: .v1)
+        let disabled = ["Wikipedia"]
+        return SearchEnginePrefs(engineIdentifiers: engines,
+                                 disabledEngines: disabled,
+                                 version: .v1)
     }()
 
-    private let mockV2Prefs: SearchEngineOrderingPrefs = {
+    private let mockV2Prefs: SearchEnginePrefs = {
         let engines = ["google", "Custom-1234-1234-1234-1234", "wikipedia", "duckduckgo"]
-        return SearchEngineOrderingPrefs(engineIdentifiers: engines, version: .v2)
+        let disabled = ["wikipedia"]
+        return SearchEnginePrefs(engineIdentifiers: engines,
+                                 disabledEngines: disabled,
+                                 version: .v2)
     }()
 
     private let mockRemoteSettingsEngines: [OpenSearchEngine] = [
@@ -94,6 +100,7 @@ class SearchPrefsMigrationTests: XCTestCase {
 
         XCTAssertEqual(output.version, .v2)
         XCTAssertEqual(output.engineIdentifiers, ["google", "Custom-1234-1234-1234-1234", "wikipedia", "ddg"])
+        XCTAssertEqual(output.disabledEngines, ["wikipedia"])
     }
 
     func testMigrateV2toV1Preferences() {
@@ -104,6 +111,7 @@ class SearchPrefsMigrationTests: XCTestCase {
         XCTAssertEqual(output.version, .v1)
         // Note: currently handling for v2 -> v1 migration is TBD, so aspects of this are in flux.
         XCTAssertEqual(output.engineIdentifiers, ["Google", "MyWebsite", "Wikipedia", "DuckDuckGo"])
+        XCTAssertEqual(output.disabledEngines, ["Wikipedia"])
     }
 
     private func createSubject() -> DefaultSearchEnginePrefsMigrator {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11502)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25033)

## :bulb: Description

Early work to support preference migration for search engines in preparation for our transition to Consolidated Search.

This is an early WIP and there are a few additional pieces still forthcoming:
- [x] Migration of disabled search engines prefs _(need to take a closer look at this)_
- [x] Unit tests
- [x] Some additional logging, cleanup, and refactors

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

