### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from LegacyBookmarkDetailPanel.swift, and decrease threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,8 +103,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 49
-  error: 49
+  warning: 45
+  error: 45
 
 file_header:
   required_string: |

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
@@ -272,49 +272,6 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
 
                     var bookmarkFolders: [(folder: BookmarkFolderData, indent: Int)] = []
 
-                    func addFolderAndDescendants(_ folder: BookmarkFolderData, indent: Int = 0) {
-                        // Do not append itself and the top "root" folder to this list as
-                        // bookmarks cannot be stored directly within it.
-                        if folder.guid != BookmarkRoots.RootGUID && folder.guid != self.bookmarkNodeGUID {
-                            bookmarkFolders.append((folder, indent))
-                        }
-
-                        var folderChildren: [BookmarkNodeData]?
-                        // Suitable to be appended
-                        if folder.guid != self.bookmarkNodeGUID {
-                            folderChildren = folder.children
-                        }
-
-                        func addFolder(childFolder: BookmarkFolderData) {
-                            // Any "root" folders (i.e. "Mobile Bookmarks") should
-                            // have an indentation of 0.
-                            if childFolder.isRoot {
-                                addFolderAndDescendants(childFolder)
-                            }
-                            // Otherwise, all non-root folder should increase the
-                            // indentation by 1.
-                            else {
-                                addFolderAndDescendants(childFolder, indent: indent + 1)
-                            }
-                        }
-
-                        for case let childFolder as BookmarkFolderData in folderChildren ?? [] {
-                            // Only append desktop folders if they already contain bookmarks
-                            if !BookmarkRoots.DesktopRoots.contains(childFolder.guid) {
-                                addFolder(childFolder: childFolder)
-                            } else {
-                                switch bookmarksCountResult {
-                                case .success(let bookmarkCount):
-                                    if (bookmarkCount > 0 && BookmarkRoots.DesktopRoots.contains(childFolder.guid))
-                                        || !self.isBookmarkRefactorEnabled {
-                                        addFolder(childFolder: childFolder)
-                                    }
-                                case .failure(let error):
-                                    self.logger.log("Error counting bookmarks: \(error)", level: .debug, category: .library)
-                                }
-                            }
-                        }
-                    }
                     self.addFolderAndDescendants(rootFolder,
                                                  bookmarkFolders: &bookmarkFolders,
                                                  bookmarksCountResult: bookmarksCountResult)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
@@ -315,7 +315,9 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
                             }
                         }
                     }
-                    addFolderAndDescendants(rootFolder)
+                    self.addFolderAndDescendants(rootFolder,
+                                                 bookmarkFolders: &bookmarkFolders,
+                                                 bookmarksCountResult: bookmarksCountResult)
                     self.bookmarkFolders = bookmarkFolders
                     self.tableView.reloadData()
                 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
@@ -323,6 +323,58 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
             }
     }
 
+    private func addFolderAndDescendants(_ folder: BookmarkFolderData,
+                                         bookmarkFolders: inout [(folder: BookmarkFolderData, indent: Int)],
+                                         bookmarksCountResult: Result<Int, any Error>,
+                                         indent: Int = 0) {
+        // Do not append itself and the top "root" folder to this list as
+        // bookmarks cannot be stored directly within it.
+        if folder.guid != BookmarkRoots.RootGUID && folder.guid != self.bookmarkNodeGUID {
+            bookmarkFolders.append((folder, indent))
+        }
+
+        var folderChildren: [BookmarkNodeData]?
+        // Suitable to be appended
+        if folder.guid != self.bookmarkNodeGUID {
+            folderChildren = folder.children
+        }
+
+        func addFolder(childFolder: BookmarkFolderData) {
+            // Any "root" folders (i.e. "Mobile Bookmarks") should
+            // have an indentation of 0.
+            if childFolder.isRoot {
+                addFolderAndDescendants(childFolder,
+                                        bookmarkFolders: &bookmarkFolders,
+                                        bookmarksCountResult: bookmarksCountResult)
+            }
+            // Otherwise, all non-root folder should increase the
+            // indentation by 1.
+            else {
+                addFolderAndDescendants(childFolder,
+                                        bookmarkFolders: &bookmarkFolders,
+                                        bookmarksCountResult: bookmarksCountResult,
+                                        indent: indent + 1)
+            }
+        }
+
+        for case let childFolder as BookmarkFolderData in folderChildren ?? [] {
+            // Only append desktop folders if they already contain bookmarks
+            if !BookmarkRoots.DesktopRoots.contains(childFolder.guid) {
+                addFolder(childFolder: childFolder)
+            } else {
+                switch bookmarksCountResult {
+                case .success(let bookmarkCount):
+                    if (bookmarkCount > 0 && BookmarkRoots.DesktopRoots.contains(childFolder.guid))
+                        || !self.isBookmarkRefactorEnabled {
+                        addFolder(childFolder: childFolder)
+                    }
+                case .failure(let error):
+                    logger.log("Error counting bookmarks: \(error)", level: .debug, category: .library)
+                }
+            }
+        }
+    }
+
     func updateSaveButton() {
         guard bookmarkNodeType == .bookmark else { return }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `LegacyBookmarkDetailPanel.swift` file, and decrease threshold to 45.

To achieve this, I extracted an inner function `addFolderAndDescendants` into an external function. The downside with this approach was the need to use the `inout` keyword to allow in-place modification of `bookmarkFolders`, requiring the array to be passed with `&`.

Although I'm not entirely comfortable with this change, I believe it won't be an issue since this class is legacy. I also noticed an extension of `BookmarksRefactorFeatureFlagProvider` where this feature flag is implemented, suggesting that `LegacyBookmarkDetailPanel.swift` will likely be removed in the future.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

