### PR TITLE
Add FXIOS-11719 [SEC] Support PDF search engine icons

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		1DA3CE5F24EEE7C600422BB2 /* LegacyTabDataRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5E24EEE7C600422BB2 /* LegacyTabDataRetriever.swift */; };
 		1DA6F6512B48B42900BB5AD6 /* WindowEventCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA6F6502B48B42900BB5AD6 /* WindowEventCoordinator.swift */; };
 		1DA710072AE7106B00677F6B /* AppDataUsageReportSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA710062AE7106B00677F6B /* AppDataUsageReportSetting.swift */; };
+		1DAEEE002D93532900F4B42D /* UIImage+RenderingUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAEEDFF2D93532400F4B42D /* UIImage+RenderingUtilities.swift */; };
 		1DC372022B23C80F000F96C8 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC372012B23C80F000F96C8 /* WindowManager.swift */; };
 		1DCEC3F22D5D1FEC00129966 /* ASSearchEngineSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCEC3F12D5D1FDD00129966 /* ASSearchEngineSelector.swift */; };
 		1DCEC3F42D600AE000129966 /* ASSearchEngineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCEC3F32D600ADC00129966 /* ASSearchEngineProvider.swift */; };
@@ -2693,6 +2694,7 @@
 		1DA64656B1F6A74800D22055 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		1DA6F6502B48B42900BB5AD6 /* WindowEventCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowEventCoordinator.swift; sourceTree = "<group>"; };
 		1DA710062AE7106B00677F6B /* AppDataUsageReportSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataUsageReportSetting.swift; sourceTree = "<group>"; };
+		1DAEEDFF2D93532400F4B42D /* UIImage+RenderingUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+RenderingUtilities.swift"; sourceTree = "<group>"; };
 		1DC372012B23C80F000F96C8 /* WindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManager.swift; sourceTree = "<group>"; };
 		1DCEC3F12D5D1FDD00129966 /* ASSearchEngineSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASSearchEngineSelector.swift; sourceTree = "<group>"; };
 		1DCEC3F32D600ADC00129966 /* ASSearchEngineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASSearchEngineProvider.swift; sourceTree = "<group>"; };
@@ -11150,6 +11152,7 @@
 				E12BD0AF28AC3A7E0029AAF0 /* UIEdgeInsets+Extension.swift */,
 				C80E1A0F2A0943640025B9E1 /* UIFont+Extension.swift */,
 				E12BD0AD28AC38480029AAF0 /* UIImage+Extension.swift */,
+				1DAEEDFF2D93532400F4B42D /* UIImage+RenderingUtilities.swift */,
 				E1442FC6294782D7003680B0 /* UIModalPresentationStyle+Photon.swift */,
 				E1442FCD294782D8003680B0 /* UIPasteboard+Extension.swift */,
 				E1442FCB294782D8003680B0 /* UIView+Extension.swift */,
@@ -17709,6 +17712,7 @@
 				8AB893A62C73AFBA00DAEED7 /* MockLoginProvider.swift in Sources */,
 				2F44FCC51A9E85E900FD20CC /* SettingsTableViewController.swift in Sources */,
 				211046C92A7ADE9000A7309F /* BlockPopupSetting.swift in Sources */,
+				1DAEEE002D93532900F4B42D /* UIImage+RenderingUtilities.swift in Sources */,
 				8A3233FC286270CF003E1C33 /* FxBookmarkNode.swift in Sources */,
 				E1CEC2022A28C3F100B177D5 /* LoginDetailCenteredTableViewCell.swift in Sources */,
 				C2D71B972A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift in Sources */,

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
@@ -94,8 +94,11 @@ final class ASSearchEngineIconDataFetcher: ASSearchEngineIconDataFetcherProtocol
         guard let client else { return nil }
         do {
             let data = try client.getAttachment(record: iconRecord.backingRecord)
-            if iconRecord.mimeType?.hasPrefix("image/svg") ?? false {
+            let mimeType = iconRecord.mimeType
+            if mimeType?.hasPrefix("image/svg") ?? false {
                 return SVG(data: data)?.rasterize()
+            } else if mimeType?.hasPrefix("application/pdf") ?? false {
+                return UIImage.imageFromPDF(data: data, minimumSize: CGSize(width: 64.0, height: 64.0))
             } else {
                 return UIImage(data: data)
             }

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
@@ -94,10 +94,10 @@ final class ASSearchEngineIconDataFetcher: ASSearchEngineIconDataFetcherProtocol
         guard let client else { return nil }
         do {
             let data = try client.getAttachment(record: iconRecord.backingRecord)
-            let mimeType = iconRecord.mimeType
-            if mimeType?.hasPrefix("image/svg") ?? false {
+            let mimeType = iconRecord.mimeType ?? ""
+            if mimeType.hasPrefix("image/svg") {
                 return SVG(data: data)?.rasterize()
-            } else if mimeType?.hasPrefix("application/pdf") ?? false {
+            } else if mimeType.hasPrefix("application/pdf") {
                 return UIImage.imageFromPDF(data: data, minimumSize: CGSize(width: 64.0, height: 64.0))
             } else {
                 return UIImage(data: data)

--- a/firefox-ios/Client/Extensions/UIImage+RenderingUtilities.swift
+++ b/firefox-ios/Client/Extensions/UIImage+RenderingUtilities.swift
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import PDFKit
+
+extension UIImage {
+    /// Renders PDF data as a UIImage.
+    /// - Parameters:
+    ///   - data: the PDF data.
+    ///   - targetSize: the target size for the image. Leave nil to use the default.
+    ///   - minimumSize: the minimum size for the image. It will be scaled up to this size
+    ///   if needed (keeping proportions).
+    /// - Returns: an image of the PDF. Returns nil if an issue occurs or the PDF data is invalid.
+    static func imageFromPDF(data: Data, targetSize: CGSize? = nil, minimumSize: CGSize? = nil) -> UIImage? {
+        guard let document = PDFDocument(data: data), let page = document.page(at: 0) else {
+            return nil
+        }
+
+        // Get target size for output image
+        let pageRect = page.bounds(for: .mediaBox)
+        let baseSize = targetSize ?? pageRect.size
+
+        // Scale proportionately to optional minimum size.
+        let size: CGSize
+        if let minSize = minimumSize {
+            let xScaleRatio = minSize.width / baseSize.width
+            let yScaleRatio = minSize.height / baseSize.height
+            let scaleRatio = max(max(xScaleRatio, yScaleRatio), 1.0)
+            size = CGSize(width: baseSize.width * scaleRatio, height: baseSize.height * scaleRatio)
+        } else {
+            size = baseSize
+        }
+
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            let cgContext = context.cgContext
+
+            UIColor.white.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+
+            // Coordinate system must be flipped to match PDF rendering
+            cgContext.translateBy(x: 0, y: size.height)
+            cgContext.scaleBy(x: 1, y: -1)
+            page.draw(with: .mediaBox, to: cgContext)
+        }
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11719)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25553)

## :bulb: Description

Early work to support PDF icons for Remote Settings based search engines. Part of larger WIP for Search Consolidation.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

