### PR TITLE
Add undo toast telemetry

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -668,7 +668,8 @@
 		612194E32CE507CF001664BB /* WallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */; };
 		612194E62CE50A93001664BB /* WallpaperAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E52CE50A93001664BB /* WallpaperAction.swift */; };
 		612194E82CE50A9B001664BB /* WallpaperState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E72CE50A9B001664BB /* WallpaperState.swift */; };
-		613489A32D942A020009AF01 /* TabTrayTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613489A22D942A020009AF01 /* TabTrayTelemetry.swift */; };
+		613489A32D942A020009AF01 /* ToastTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613489A22D942A020009AF01 /* ToastTelemetry.swift */; };
+		613489A52D9443610009AF01 /* ToastTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613489A42D9443610009AF01 /* ToastTelemetryTests.swift */; };
 		615532D42D7AA5F30046347F /* ScreenshotHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615532D32D7AA5F30046347F /* ScreenshotHelperTests.swift */; };
 		619FE8932CE6595B004F83E2 /* WallpaperMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */; };
 		61A164492CE7BE84001D6058 /* WallpaperStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */; };
@@ -7683,7 +7684,8 @@
 		612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperBackgroundView.swift; sourceTree = "<group>"; };
 		612194E52CE50A93001664BB /* WallpaperAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperAction.swift; sourceTree = "<group>"; };
 		612194E72CE50A9B001664BB /* WallpaperState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperState.swift; sourceTree = "<group>"; };
-		613489A22D942A020009AF01 /* TabTrayTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayTelemetry.swift; sourceTree = "<group>"; };
+		613489A22D942A020009AF01 /* ToastTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastTelemetry.swift; sourceTree = "<group>"; };
+		613489A42D9443610009AF01 /* ToastTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastTelemetryTests.swift; sourceTree = "<group>"; };
 		615532D32D7AA5F30046347F /* ScreenshotHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotHelperTests.swift; sourceTree = "<group>"; };
 		619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMiddleware.swift; sourceTree = "<group>"; };
 		61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperStateTests.swift; sourceTree = "<group>"; };
@@ -12804,6 +12806,7 @@
 				0ABCD45C2D356006005D704A /* TermsOfServiceTelemetryTests.swift */,
 				8AC225642B6D3FA400CDA7FD /* HomepageTelemetryTests.swift */,
 				0A686B3B2CDB70DC0090E146 /* MainMenuTelemetryTests.swift */,
+				613489A42D9443610009AF01 /* ToastTelemetryTests.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -14884,7 +14887,7 @@
 				1DD4B26D2CA4D09100B51945 /* TabErrorTelemetryHelper.swift */,
 				8A0727452B4890B50071BB9F /* WebviewTelemetry.swift */,
 				8A359EF42A1FD4CF004A5BB7 /* Wrapper */,
-				613489A22D942A020009AF01 /* TabTrayTelemetry.swift */,
+				613489A22D942A020009AF01 /* ToastTelemetry.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -17825,7 +17828,7 @@
 				C4E3984C1D21F2FD004E89BA /* TabTrayButtonExtensions.swift in Sources */,
 				ED07C0E62CCACD7E006C0627 /* Locale+possibilitiesForLanguageIdentifier.swift in Sources */,
 				437A857827E43FE100E42764 /* FxAWebViewTelemetry.swift in Sources */,
-				613489A32D942A020009AF01 /* TabTrayTelemetry.swift in Sources */,
+				613489A32D942A020009AF01 /* ToastTelemetry.swift in Sources */,
 				E13E9AB42AAB0FB5001A0E9D /* FakespotCoordinator.swift in Sources */,
 				E1442FD1294782D9003680B0 /* UIModalPresentationStyle+Photon.swift in Sources */,
 				21EEAA1D2D4005DE00595119 /* NativeErrorPageFeatureFlag.swift in Sources */,
@@ -18325,6 +18328,7 @@
 				0B7B05432D64C08F007FD7AC /* MockURLProtocol.swift in Sources */,
 				8ADAFAC628AEBF6300FFEBE3 /* HomeLogoHeaderViewModelTests.swift in Sources */,
 				E1EAA5EF2D49182700D3039C /* NavigationBarStateTests.swift in Sources */,
+				613489A52D9443610009AF01 /* ToastTelemetryTests.swift in Sources */,
 				8A75F1B828B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift in Sources */,
 				E14BF33E2950B1230039758D /* MailProvidersTests.swift in Sources */,
 				C889D7CE2858C4B500121E1D /* ContextMenuHelperTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -668,6 +668,7 @@
 		612194E32CE507CF001664BB /* WallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */; };
 		612194E62CE50A93001664BB /* WallpaperAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E52CE50A93001664BB /* WallpaperAction.swift */; };
 		612194E82CE50A9B001664BB /* WallpaperState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E72CE50A9B001664BB /* WallpaperState.swift */; };
+		613489A32D942A020009AF01 /* TabTrayTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613489A22D942A020009AF01 /* TabTrayTelemetry.swift */; };
 		615532D42D7AA5F30046347F /* ScreenshotHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615532D32D7AA5F30046347F /* ScreenshotHelperTests.swift */; };
 		619FE8932CE6595B004F83E2 /* WallpaperMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */; };
 		61A164492CE7BE84001D6058 /* WallpaperStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */; };
@@ -7682,6 +7683,7 @@
 		612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperBackgroundView.swift; sourceTree = "<group>"; };
 		612194E52CE50A93001664BB /* WallpaperAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperAction.swift; sourceTree = "<group>"; };
 		612194E72CE50A9B001664BB /* WallpaperState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperState.swift; sourceTree = "<group>"; };
+		613489A22D942A020009AF01 /* TabTrayTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayTelemetry.swift; sourceTree = "<group>"; };
 		615532D32D7AA5F30046347F /* ScreenshotHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotHelperTests.swift; sourceTree = "<group>"; };
 		619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMiddleware.swift; sourceTree = "<group>"; };
 		61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperStateTests.swift; sourceTree = "<group>"; };
@@ -14882,6 +14884,7 @@
 				1DD4B26D2CA4D09100B51945 /* TabErrorTelemetryHelper.swift */,
 				8A0727452B4890B50071BB9F /* WebviewTelemetry.swift */,
 				8A359EF42A1FD4CF004A5BB7 /* Wrapper */,
+				613489A22D942A020009AF01 /* TabTrayTelemetry.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -17822,6 +17825,7 @@
 				C4E3984C1D21F2FD004E89BA /* TabTrayButtonExtensions.swift in Sources */,
 				ED07C0E62CCACD7E006C0627 /* Locale+possibilitiesForLanguageIdentifier.swift in Sources */,
 				437A857827E43FE100E42764 /* FxAWebViewTelemetry.swift in Sources */,
+				613489A32D942A020009AF01 /* TabTrayTelemetry.swift in Sources */,
 				E13E9AB42AAB0FB5001A0E9D /* FakespotCoordinator.swift in Sources */,
 				E1442FD1294782D9003680B0 /* UIModalPresentationStyle+Photon.swift in Sources */,
 				21EEAA1D2D4005DE00595119 /* NativeErrorPageFeatureFlag.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -461,7 +461,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
     /// Handles undoing the close tab action, gets the backup tab from `TabManager`
     private func undoCloseTab(state: AppState, uuid: WindowUUID) {
-        toastTelemetry.closedSingleTabToastUndoSelected()
+        toastTelemetry.undoClosedSingleTab()
         let tabManager = tabManager(for: uuid)
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: uuid),
               tabManager.backupCloseTab != nil
@@ -535,7 +535,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     }
 
     private func undoCloseAllTabs(uuid: WindowUUID) {
-        toastTelemetry.closedAllTabsToastUndoSelected()
+        toastTelemetry.undoClosedAllTabs()
         let tabManager = tabManager(for: uuid)
         tabManager.undoCloseAllTabs()
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -15,7 +15,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     private let logger: Logger
     private let inactiveTabTelemetry = InactiveTabsTelemetry()
     private let bookmarksSaver: BookmarksSaver
-    private let tabTrayTelemetry: TabTrayTelemetry
+    private let toastTelemetry: ToastTelemetry
 
     private var isTabTrayUIExperimentsEnabled: Bool {
         return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
@@ -30,7 +30,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
         self.profile = profile
         self.logger = logger
         self.bookmarksSaver = bookmarksSaver ?? DefaultBookmarksSaver(profile: profile)
-        self.tabTrayTelemetry = TabTrayTelemetry(gleanWrapper: gleanWrapper)
+        self.toastTelemetry = ToastTelemetry(gleanWrapper: gleanWrapper)
     }
 
     lazy var tabsPanelProvider: Middleware<AppState> = { state, action in
@@ -461,7 +461,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
     /// Handles undoing the close tab action, gets the backup tab from `TabManager`
     private func undoCloseTab(state: AppState, uuid: WindowUUID) {
-        tabTrayTelemetry.undoSelectedOnToastForClosingOneTab()
+        toastTelemetry.closedSingleTabToastUndoSelected()
         let tabManager = tabManager(for: uuid)
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: uuid),
               tabManager.backupCloseTab != nil
@@ -535,7 +535,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     }
 
     private func undoCloseAllTabs(uuid: WindowUUID) {
-        tabTrayTelemetry.undoSelectedOnToastForClosingAllTabs()
+        toastTelemetry.closedAllTabsToastUndoSelected()
         let tabManager = tabManager(for: uuid)
         tabManager.undoCloseAllTabs()
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -15,6 +15,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     private let logger: Logger
     private let inactiveTabTelemetry = InactiveTabsTelemetry()
     private let bookmarksSaver: BookmarksSaver
+    private let tabTrayTelemetry: TabTrayTelemetry
 
     private var isTabTrayUIExperimentsEnabled: Bool {
         return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
@@ -23,11 +24,13 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
     init(profile: Profile = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared,
-         bookmarksSaver: BookmarksSaver? = nil
+         bookmarksSaver: BookmarksSaver? = nil,
+         gleanWrapper: GleanWrapper = DefaultGleanWrapper()
     ) {
         self.profile = profile
         self.logger = logger
         self.bookmarksSaver = bookmarksSaver ?? DefaultBookmarksSaver(profile: profile)
+        self.tabTrayTelemetry = TabTrayTelemetry(gleanWrapper: gleanWrapper)
     }
 
     lazy var tabsPanelProvider: Middleware<AppState> = { state, action in
@@ -458,6 +461,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
     /// Handles undoing the close tab action, gets the backup tab from `TabManager`
     private func undoCloseTab(state: AppState, uuid: WindowUUID) {
+        tabTrayTelemetry.undoSelectedOnToastForClosingOneTab()
         let tabManager = tabManager(for: uuid)
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: uuid),
               tabManager.backupCloseTab != nil
@@ -531,6 +535,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     }
 
     private func undoCloseAllTabs(uuid: WindowUUID) {
+        tabTrayTelemetry.undoSelectedOnToastForClosingAllTabs()
         let tabManager = tabManager(for: uuid)
         tabManager.undoCloseAllTabs()
 

--- a/firefox-ios/Client/Telemetry/TabTrayTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabTrayTelemetry.swift
@@ -5,20 +5,18 @@
 import Foundation
 import Glean
 
-/// Note: We will be slowly migrating our existing tabs telemetry probes
-/// over to a "tab_tray" namespace.
-struct TabTrayTelemetry {
+struct ToastTelemetry {
     private let gleanWrapper: GleanWrapper
 
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.gleanWrapper = gleanWrapper
     }
 
-    func undoSelectedOnToastForClosingAllTabs() {
+    func closedSingleTabToastUndoSelected() {
         gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseAllTabs.undoSelected)
     }
 
-    func undoSelectedOnToastForClosingOneTab() {
+    func closedAllTabsToastUndoSelected() {
         gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseSingleTab.undoSelected)
     }
 }

--- a/firefox-ios/Client/Telemetry/TabTrayTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabTrayTelemetry.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+/// Note: We will be slowly migrating our existing tabs telemetry probes
+/// over to a "tab_tray" namespace.
+struct TabTrayTelemetry {
+    private let gleanWrapper: GleanWrapper
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
+    func undoSelectedOnToastForClosingAllTabs() {
+        gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseAllTabs.undoSelected)
+    }
+
+    func undoSelectedOnToastForClosingOneTab() {
+        gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseSingleTab.undoSelected)
+    }
+}

--- a/firefox-ios/Client/Telemetry/ToastTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/ToastTelemetry.swift
@@ -13,10 +13,10 @@ struct ToastTelemetry {
     }
 
     func undoClosedSingleTab() {
-        gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseSingleTab.undoSelected)
+        gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseSingleTab.undoTapped)
     }
 
     func undoClosedAllTabs() {
-        gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseAllTabs.undoSelected)
+        gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseAllTabs.undoTapped)
     }
 }

--- a/firefox-ios/Client/Telemetry/ToastTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/ToastTelemetry.swift
@@ -13,10 +13,10 @@ struct ToastTelemetry {
     }
 
     func closedSingleTabToastUndoSelected() {
-        gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseAllTabs.undoSelected)
+        gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseSingleTab.undoSelected)
     }
 
     func closedAllTabsToastUndoSelected() {
-        gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseSingleTab.undoSelected)
+        gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseAllTabs.undoSelected)
     }
 }

--- a/firefox-ios/Client/Telemetry/ToastTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/ToastTelemetry.swift
@@ -12,11 +12,11 @@ struct ToastTelemetry {
         self.gleanWrapper = gleanWrapper
     }
 
-    func closedSingleTabToastUndoSelected() {
+    func undoClosedSingleTab() {
         gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseSingleTab.undoSelected)
     }
 
-    func closedAllTabsToastUndoSelected() {
+    func undoClosedAllTabs() {
         gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseAllTabs.undoSelected)
     }
 }

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4396,7 +4396,7 @@ toasts.close_single_tab:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-11714
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/25029
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25569
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-01"
@@ -4413,7 +4413,7 @@ toasts.close_all_tabs:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-11714
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/25029
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25569
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-01"

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4389,7 +4389,7 @@ tabs:
 
 # Toasts
 toasts.close_single_tab:
-  undo_selected:
+  undo_tapped:
     type: event
     description: | 
       Records when the user selects undo after closing a tab.
@@ -4406,7 +4406,7 @@ toasts.close_single_tab:
         - TabsPanel
 
 toasts.close_all_tabs:
-  undo_selected:
+  undo_tapped:
     type: event
     description: | 
       Records when the user selects undo after closing all tabs.

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4387,6 +4387,41 @@ tabs:
       - fx-ios-data-stewards@mozilla.com
     expires: never
 
+# Toasts
+toasts.close_single_tab:
+  undo_selected:
+    type: event
+    description: | 
+      Records when the user selects undo after closing a tab.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-11714
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25029
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-06-01"
+    metadata:
+      tags:
+        - Toasts
+        - TabPanel
+
+toasts.close_all_tabs:
+  undo_selected:
+    type: event
+    description: | 
+      Records when the user selects undo after closing all tabs.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-11714
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25029
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-06-01"
+    metadata:
+      tags:
+        - Toasts
+        - TabPanel
+  
 # Enhanced Tracking Protection metrics
 tracking_protection:
   enabled:

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4403,7 +4403,7 @@ toasts.close_single_tab:
     metadata:
       tags:
         - Toasts
-        - TabPanel
+        - TabsPanel
 
 toasts.close_all_tabs:
   undo_selected:
@@ -4420,7 +4420,7 @@ toasts.close_all_tabs:
     metadata:
       tags:
         - Toasts
-        - TabPanel
+        - TabsPanel
   
 # Enhanced Tracking Protection metrics
 tracking_protection:

--- a/firefox-ios/Client/tags.yaml
+++ b/firefox-ios/Client/tags.yaml
@@ -21,8 +21,8 @@ TopSites:
   description: Corresponds to the [Feature:TopSites](https://mozilla-hub.atlassian.net/browse/FXIOS-3464)
     label on GitHub.
   
-TabPanel:
-  description: Corresponds to all things related to all things related to the tab panel.
+TabsPanel:
+  description: Corresponds to all things related to the tab panel.
 
 Toasts:
   description: Corresponds to any events around toasts in the app. Toasts are the shortlived banners that 

--- a/firefox-ios/Client/tags.yaml
+++ b/firefox-ios/Client/tags.yaml
@@ -20,3 +20,10 @@ Settings:
 TopSites:
   description: Corresponds to the [Feature:TopSites](https://mozilla-hub.atlassian.net/browse/FXIOS-3464)
     label on GitHub.
+  
+TabPanel:
+  description: Corresponds to all things related to all things related to the tab panel.
+
+Toasts:
+  description: Corresponds to any events around toasts in the app. Toasts are the shortlived banners that 
+    appear when an action is taken.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ToastTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ToastTelemetryTests.swift
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+import XCTest
+
+@testable import Client
+
+final class ToastTelemetryTests: XCTestCase {
+    var mockGleanWrapper: MockGleanWrapper!
+    override func setUp() {
+        super.setUp()
+
+        mockGleanWrapper = MockGleanWrapper()
+    }
+
+    func testClosedSingleTabToastUndoSelected_callsGlean() throws {
+        let event = GleanMetrics.ToastsCloseSingleTab.undoSelected
+        let expectedMetricType = type(of: event)
+        let subject = createSubject()
+
+        subject.closedSingleTabToastUndoSelected()
+
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents?.first as? EventMetricType<NoExtras>
+        )
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func testClosedAllTabsToastUndoSelected_callsGlean() throws {
+        let event = GleanMetrics.ToastsCloseAllTabs.undoSelected
+        let expectedMetricType = type(of: event)
+        let subject = createSubject()
+
+        subject.closedAllTabsToastUndoSelected()
+
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents?.first as? EventMetricType<NoExtras>
+        )
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func createSubject() -> ToastTelemetry {
+        return ToastTelemetry(gleanWrapper: mockGleanWrapper)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ToastTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ToastTelemetryTests.swift
@@ -17,11 +17,11 @@ final class ToastTelemetryTests: XCTestCase {
     }
 
     func testClosedSingleTabToastUndoSelected_callsGlean() throws {
-        let event = GleanMetrics.ToastsCloseSingleTab.undoSelected
+        let event = GleanMetrics.ToastsCloseSingleTab.undoTapped
         let expectedMetricType = type(of: event)
         let subject = createSubject()
 
-        subject.closedSingleTabToastUndoSelected()
+        subject.undoClosedSingleTab()
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents?.first as? EventMetricType<NoExtras>
@@ -34,11 +34,11 @@ final class ToastTelemetryTests: XCTestCase {
     }
 
     func testClosedAllTabsToastUndoSelected_callsGlean() throws {
-        let event = GleanMetrics.ToastsCloseAllTabs.undoSelected
+        let event = GleanMetrics.ToastsCloseAllTabs.undoTapped
         let expectedMetricType = type(of: event)
         let subject = createSubject()
 
-        subject.closedAllTabsToastUndoSelected()
+        subject.undoClosedAllTabs()
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents?.first as? EventMetricType<NoExtras>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11714)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25534)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add telemetry for undo after tab deletion. Since undo is a toast we will namespace it under toasts and add `ToastTelemetry` to hold toast glean calls.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

