### PR TITLE
Bugfix FXIOS-11260 ⁃ [iOS Bookmarks Evolution][Accessibility] The "delete" button is not read corractly by VoiceOver

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/TextField.swift
+++ b/BrowserKit/Sources/ComponentLibrary/TextField.swift
@@ -7,12 +7,18 @@ import Common
 import UIKit
 
 public struct TextFieldViewModel {
-    public init(clearButtonA11yId: String,
+    public init(formA11yId: String,
+                formA11yLabel: String? = nil,
+                clearButtonA11yId: String,
                 clearButtonA11yLabel: String) {
+        self.formA11yId = formA11yId
+        self.formA11yLabel = formA11yLabel
         self.clearButtonA11yId = clearButtonA11yId
         self.clearButtonA11yLabel = clearButtonA11yLabel
     }
 
+    public let formA11yId: String
+    public let formA11yLabel: String?
     public let clearButtonA11yId: String
     public let clearButtonA11yLabel: String
 }
@@ -48,6 +54,8 @@ public class TextField: UITextField, ThemeApplicable {
     }
 
     public func configure(viewModel: TextFieldViewModel) {
+        accessibilityIdentifier = viewModel.formA11yId
+        accessibilityLabel = viewModel.formA11yLabel
         clearButton.accessibilityIdentifier = viewModel.clearButtonA11yId
         clearButton.accessibilityLabel = viewModel.clearButtonA11yLabel
     }

--- a/BrowserKit/Sources/ComponentLibrary/TextField.swift
+++ b/BrowserKit/Sources/ComponentLibrary/TextField.swift
@@ -7,18 +7,12 @@ import Common
 import UIKit
 
 public struct TextFieldViewModel {
-    public init(formA11yId: String,
-                formA11yLabel: String,
-                clearButtonA11yId: String,
+    public init(clearButtonA11yId: String,
                 clearButtonA11yLabel: String) {
-        self.formA11yId = formA11yId
-        self.formA11yLabel = formA11yLabel
         self.clearButtonA11yId = clearButtonA11yId
         self.clearButtonA11yLabel = clearButtonA11yLabel
     }
 
-    public let formA11yId: String
-    public let formA11yLabel: String
     public let clearButtonA11yId: String
     public let clearButtonA11yLabel: String
 }
@@ -54,8 +48,6 @@ public class TextField: UITextField, ThemeApplicable {
     }
 
     public func configure(viewModel: TextFieldViewModel) {
-        accessibilityIdentifier = viewModel.formA11yId
-        accessibilityLabel = viewModel.formA11yLabel
         clearButton.accessibilityIdentifier = viewModel.clearButtonA11yId
         clearButton.accessibilityLabel = viewModel.clearButtonA11yLabel
     }

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -474,12 +474,12 @@ struct AccessibilityIdentifiers {
             static let bookmarksCellDisclosureButton = ".DisclosureButton"
             static let emptyStateSignInButton = "BookmarksPanel.EmptyState.signInButton"
             static let titleTextField = "BookmarkDetail.titleTextField"
-            static let formTextField = "BookmarkDetail.formTextField"
             static let urlTextField = "BookmarkDetail.urlTextField"
             static let bookmarkParentFolderCell = "BookmarksDetail.ParentFolderSelector.FolderCell"
             static let newFolderCell = "BookmarksDetail.ParentFolderSelector.NewFolderCell"
             static let saveButton = "BookmarksDetail.SaveButton"
-            static let clearButton = "BookmarksDetail.ClearButton"
+            static let titleTextFieldClearButton = "BookmarksDetail.TitleTextFieldClearButton"
+            static let titleUrlTextFieldClearButton = "BookmarksDetail.TitleUrlTextFieldClearButton"
         }
 
         struct HistoryPanel {

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -474,6 +474,7 @@ struct AccessibilityIdentifiers {
             static let bookmarksCellDisclosureButton = ".DisclosureButton"
             static let emptyStateSignInButton = "BookmarksPanel.EmptyState.signInButton"
             static let titleTextField = "BookmarkDetail.titleTextField"
+            static let formTextField = "BookmarkDetail.formTextField"
             static let urlTextField = "BookmarkDetail.urlTextField"
             static let bookmarkParentFolderCell = "BookmarksDetail.ParentFolderSelector.FolderCell"
             static let newFolderCell = "BookmarksDetail.ParentFolderSelector.NewFolderCell"

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -479,7 +479,7 @@ struct AccessibilityIdentifiers {
             static let newFolderCell = "BookmarksDetail.ParentFolderSelector.NewFolderCell"
             static let saveButton = "BookmarksDetail.SaveButton"
             static let titleTextFieldClearButton = "BookmarksDetail.TitleTextFieldClearButton"
-            static let titleUrlTextFieldClearButton = "BookmarksDetail.TitleUrlTextFieldClearButton"
+            static let urlTextFieldClearButton = "BookmarksDetail.UrlTextFieldClearButton"
         }
 
         struct HistoryPanel {

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -478,6 +478,7 @@ struct AccessibilityIdentifiers {
             static let bookmarkParentFolderCell = "BookmarksDetail.ParentFolderSelector.FolderCell"
             static let newFolderCell = "BookmarksDetail.ParentFolderSelector.NewFolderCell"
             static let saveButton = "BookmarksDetail.SaveButton"
+            static let clearButton = "BookmarksDetail.ClearButton"
         }
 
         struct HistoryPanel {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
@@ -59,13 +59,13 @@ class EditBookmarkCell: UITableViewCell,
         let textFieldViewModel = TextFieldViewModel(
             formA11yId: A11y.titleTextField,
             clearButtonA11yId: A11y.titleTextFieldClearButton,
-            clearButtonA11yLabel: String.Bookmarks.Menu.ClearButtonA11yLabel
+            clearButtonA11yLabel: String.Bookmarks.Menu.ClearTextFieldButtonA11yLabel
         )
         titleTextfield.configure(viewModel: textFieldViewModel)
         let urlTextFieldViewModel = TextFieldViewModel(
             formA11yId: A11y.urlTextField,
-            clearButtonA11yId: A11y.titleUrlTextFieldClearButton,
-            clearButtonA11yLabel: String.Bookmarks.Menu.ClearButtonA11yLabel
+            clearButtonA11yId: A11y.urlTextFieldClearButton,
+            clearButtonA11yLabel: String.Bookmarks.Menu.ClearTextFieldButtonA11yLabel
         )
         urlTextfield.configure(viewModel: urlTextFieldViewModel)
         textFieldsContainerView.addArrangedSubview(titleTextfield)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
@@ -55,6 +55,19 @@ class EditBookmarkCell: UITableViewCell,
     }
 
     private func setupSubviews() {
+        typealias A11y = AccessibilityIdentifiers.LibraryPanels.BookmarksPanel
+        let textFieldViewModel = TextFieldViewModel(
+            formA11yId: A11y.titleTextField,
+            clearButtonA11yId: A11y.titleTextFieldClearButton,
+            clearButtonA11yLabel: String.Bookmarks.Menu.ClearButtonA11yLabel
+        )
+        titleTextfield.configure(viewModel: textFieldViewModel)
+        let urlTextFieldViewModel = TextFieldViewModel(
+            formA11yId: A11y.urlTextField,
+            clearButtonA11yId: A11y.titleUrlTextFieldClearButton,
+            clearButtonA11yLabel: String.Bookmarks.Menu.ClearButtonA11yLabel
+        )
+        urlTextfield.configure(viewModel: urlTextFieldViewModel)
         textFieldsContainerView.addArrangedSubview(titleTextfield)
         textFieldsContainerView.addArrangedSubview(textFieldsDivider)
         textFieldsContainerView.addArrangedSubview(urlTextfield)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
@@ -37,8 +37,8 @@ class EditFolderCell: UITableViewCell,
     private func setupSubviews() {
         typealias A11y = AccessibilityIdentifiers.LibraryPanels.BookmarksPanel
         let viewModel = TextFieldViewModel(
-            formA11yId: A11y.formTextField,
-            clearButtonA11yId: A11y.clearButton,
+            formA11yId: A11y.titleTextField,
+            clearButtonA11yId: A11y.titleTextFieldClearButton,
             clearButtonA11yLabel: String.Bookmarks.Menu.ClearButtonA11yLabel
         )
         titleTextField.configure(viewModel: viewModel)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
@@ -35,6 +35,11 @@ class EditFolderCell: UITableViewCell,
     }
 
     private func setupSubviews() {
+        let viewModel = TextFieldViewModel(
+            clearButtonA11yId: AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.clearButton,
+            clearButtonA11yLabel: String.Bookmarks.Menu.ClearButtonA11yLabel
+        )
+        titleTextField.configure(viewModel: viewModel)
         titleTextField.placeholder = .BookmarkDetailFieldTitle
         contentView.addSubview(titleTextField)
         NSLayoutConstraint.activate([

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
@@ -35,8 +35,10 @@ class EditFolderCell: UITableViewCell,
     }
 
     private func setupSubviews() {
+        typealias A11y = AccessibilityIdentifiers.LibraryPanels.BookmarksPanel
         let viewModel = TextFieldViewModel(
-            clearButtonA11yId: AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.clearButton,
+            formA11yId: A11y.formTextField,
+            clearButtonA11yId: A11y.clearButton,
             clearButtonA11yLabel: String.Bookmarks.Menu.ClearButtonA11yLabel
         )
         titleTextField.configure(viewModel: viewModel)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
@@ -39,7 +39,7 @@ class EditFolderCell: UITableViewCell,
         let viewModel = TextFieldViewModel(
             formA11yId: A11y.titleTextField,
             clearButtonA11yId: A11y.titleTextFieldClearButton,
-            clearButtonA11yLabel: String.Bookmarks.Menu.ClearButtonA11yLabel
+            clearButtonA11yLabel: String.Bookmarks.Menu.ClearTextFieldButtonA11yLabel
         )
         titleTextField.configure(viewModel: viewModel)
         titleTextField.placeholder = .BookmarkDetailFieldTitle

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -206,7 +206,7 @@ extension String {
                 key: "Bookmarks.Menu.ClearButtonA11yLabel.v139",
                 tableName: "Bookmarks",
                 value: "Clear",
-                comment: "Accessibility label for the clear button located within every bookmark site cell text field in the bookmarks panel. Pressing this button text field with the bookmark name, is cleared.")
+                comment: "Accessibility label for the clear button located within every bookmark cell text field in the bookmarks panel. Pressing this button will clear the text field's text")
         }
 
         public struct EmptyState {

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -202,8 +202,8 @@ extension String {
                 tableName: "Bookmarks",
                 value: "More options",
                 comment: "Accessibility label for the \"...\" disclosure button located within every bookmark site cell in the bookmarks panel. Pressing this button opens a modal with more actions.")
-            public static let ClearButtonA11yLabel = MZLocalizedString(
-                key: "Bookmarks.Menu.ClearButtonA11yLabel.v139",
+            public static let ClearTextFieldButtonA11yLabel = MZLocalizedString(
+                key: "Bookmarks.Menu.ClearTextFieldButtonA11yLabel.v139",
                 tableName: "Bookmarks",
                 value: "Clear",
                 comment: "Accessibility label for the clear button located within every bookmark cell text field in the bookmarks panel. Pressing this button will clear the text field's text")

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -202,6 +202,11 @@ extension String {
                 tableName: "Bookmarks",
                 value: "More options",
                 comment: "Accessibility label for the \"...\" disclosure button located within every bookmark site cell in the bookmarks panel. Pressing this button opens a modal with more actions.")
+            public static let ClearButtonA11yLabel = MZLocalizedString(
+                key: "Bookmarks.Menu.ClearButtonA11yLabel.v139",
+                tableName: "Bookmarks",
+                value: "Clear",
+                comment: "Accessibility label for the clear button located within every bookmark site cell text field in the bookmarks panel. Pressing this button text field with the bookmark name, is cleared.")
         }
 
         public struct EmptyState {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11260)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24486)

## :bulb: Description
Added a11y label for clear button in edit bookmark cell

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

