### PR TITLE
Bugfix MTE-4452 numTabs may not work on iOS 15

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -307,7 +307,10 @@ class HistoryTests: BaseTestCase {
                 app.tables.cells.staticTexts[bookOfMozilla["label"]!]
             ]
         )
-        XCTAssertEqual(userState.numTabs, 1)
+        // userState.numTabs does not work on iOS 15
+        if #available(iOS 16, *) {
+            XCTAssertEqual(userState.numTabs, 1)
+        }
         app.tables.cells.staticTexts[bookOfMozilla["label"]!].press(forDuration: 1)
         mozWaitForElementToExist(app.tables["Context Menu"])
         app.tables.otherElements[StandardImageIdentifiers.Large.plus].waitAndTap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4452)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
`HistoryTests/testOpenInNewTabRecentlyClosedItem()` fails on iOS 15 only because userState.numTabs does not work below iOS 15.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

