### PR TITLE
Bugfix FXIOS-3820 #10114 ⁃ [iPad] No way to stop address/tab bar from auto hiding

### DIFF
--- a/BrowserKit/Sources/Common/Protocols/DeviceTypeProvider.swift
+++ b/BrowserKit/Sources/Common/Protocols/DeviceTypeProvider.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+public protocol DeviceTypeProvider {
+    var userInterfaceIdiom: UIUserInterfaceIdiom { get }
+}
+
+extension UIDevice: DeviceTypeProvider {}

--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -107,6 +107,7 @@ public struct PrefsKeys {
         public static let SponsoredShortcuts = "SponsoredShortcutsUserPrefsKey"
         public static let StartAtHome = "StartAtHomeUserPrefsKey"
         public static let TopSiteSection = "TopSitesUserPrefsKey"
+        public static let TabsAndAddressBarAutoHide = "TabsAndAddressBarAutoHidePrefsKey"
     }
 
     // Firefox contextual hint

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		21534904288201E300FADB4D /* GleanPlumbMessageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215349022881FA3C00FADB4D /* GleanPlumbMessageManagerTests.swift */; };
 		215349062886007900FADB4D /* GleanPlumbMessageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215349052886007900FADB4D /* GleanPlumbMessageStoreTests.swift */; };
 		215360652D9475DA00D9B8E6 /* BrowsingSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215360642D9475DA00D9B8E6 /* BrowsingSettingsViewControllerTests.swift */; };
+		215360672D948A7900D9B8E6 /* MockDeviceTypeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215360662D948A7900D9B8E6 /* MockDeviceTypeProvider.swift */; };
 		215B457F27D7FD4B00E5E800 /* LegacyTabGroupData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B457E27D7FD4B00E5E800 /* LegacyTabGroupData.swift */; };
 		215B458027D7FD7D00E5E800 /* LegacyTabGroupData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B457E27D7FD4B00E5E800 /* LegacyTabGroupData.swift */; };
 		215B458227DA420400E5E800 /* LegacyTabMetadataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B458127DA420400E5E800 /* LegacyTabMetadataManager.swift */; };
@@ -2757,6 +2758,7 @@
 		215349022881FA3C00FADB4D /* GleanPlumbMessageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageManagerTests.swift; sourceTree = "<group>"; };
 		215349052886007900FADB4D /* GleanPlumbMessageStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageStoreTests.swift; sourceTree = "<group>"; };
 		215360642D9475DA00D9B8E6 /* BrowsingSettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingSettingsViewControllerTests.swift; sourceTree = "<group>"; };
+		215360662D948A7900D9B8E6 /* MockDeviceTypeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDeviceTypeProvider.swift; sourceTree = "<group>"; };
 		215B457E27D7FD4B00E5E800 /* LegacyTabGroupData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabGroupData.swift; sourceTree = "<group>"; };
 		215B458127DA420400E5E800 /* LegacyTabMetadataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabMetadataManager.swift; sourceTree = "<group>"; };
 		215B458327DA87FC00E5E800 /* TabMetadataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMetadataManagerTests.swift; sourceTree = "<group>"; };
@@ -13726,6 +13728,7 @@
 		C889D7D22858C85200121E1D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				215360662D948A7900D9B8E6 /* MockDeviceTypeProvider.swift */,
 				0B7B05422D64C08F007FD7AC /* MockURLProtocol.swift */,
 				0B7B05402D64C087007FD7AC /* MockURLResponse.swift */,
 				0B7B053E2D64C022007FD7AC /* MockTabWebView.swift */,
@@ -18408,6 +18411,7 @@
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* PasswordManagerSelectionHelperTests.swift in Sources */,
 				C8610DA82A0EBD4100B79FF1 /* OnboardingButtonActionTests.swift in Sources */,
+				215360672D948A7900D9B8E6 /* MockDeviceTypeProvider.swift in Sources */,
 				4331D3EF2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift in Sources */,
 				8A827E322C20C8AE008D5E3C /* MockMicrosurveySurfaceManager.swift in Sources */,
 				39D0DA7629D767DE000760B8 /* NimbusMessagingTriggerTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		2152473E2D6E4A4A0078D78A /* AutoFillPasswordSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152473D2D6E4A4A0078D78A /* AutoFillPasswordSettingsViewController.swift */; };
 		21534904288201E300FADB4D /* GleanPlumbMessageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215349022881FA3C00FADB4D /* GleanPlumbMessageManagerTests.swift */; };
 		215349062886007900FADB4D /* GleanPlumbMessageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215349052886007900FADB4D /* GleanPlumbMessageStoreTests.swift */; };
+		215360652D9475DA00D9B8E6 /* BrowsingSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215360642D9475DA00D9B8E6 /* BrowsingSettingsViewControllerTests.swift */; };
 		215B457F27D7FD4B00E5E800 /* LegacyTabGroupData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B457E27D7FD4B00E5E800 /* LegacyTabGroupData.swift */; };
 		215B458027D7FD7D00E5E800 /* LegacyTabGroupData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B457E27D7FD4B00E5E800 /* LegacyTabGroupData.swift */; };
 		215B458227DA420400E5E800 /* LegacyTabMetadataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B458127DA420400E5E800 /* LegacyTabMetadataManager.swift */; };
@@ -2755,6 +2756,7 @@
 		2152473D2D6E4A4A0078D78A /* AutoFillPasswordSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFillPasswordSettingsViewController.swift; sourceTree = "<group>"; };
 		215349022881FA3C00FADB4D /* GleanPlumbMessageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageManagerTests.swift; sourceTree = "<group>"; };
 		215349052886007900FADB4D /* GleanPlumbMessageStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageStoreTests.swift; sourceTree = "<group>"; };
+		215360642D9475DA00D9B8E6 /* BrowsingSettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingSettingsViewControllerTests.swift; sourceTree = "<group>"; };
 		215B457E27D7FD4B00E5E800 /* LegacyTabGroupData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabGroupData.swift; sourceTree = "<group>"; };
 		215B458127DA420400E5E800 /* LegacyTabMetadataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabMetadataManager.swift; sourceTree = "<group>"; };
 		215B458327DA87FC00E5E800 /* TabMetadataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMetadataManagerTests.swift; sourceTree = "<group>"; };
@@ -12385,6 +12387,7 @@
 				EDADF7832D70DAF800C39295 /* SettingsTelemetryTests.swift */,
 				212985E52A72B22800546684 /* ThemeSettingsControllerTests.swift */,
 				DACDE995225E537900C8F37F /* VersionSettingTests.swift */,
+				215360642D9475DA00D9B8E6 /* BrowsingSettingsViewControllerTests.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -18279,6 +18282,7 @@
 				8A13FA8F2AD83F00007527AB /* DefaultBackgroundTabLoaderTests.swift in Sources */,
 				8A827E362C20CB5B008D5E3C /* MicrosurveyPromptMiddlewareTests.swift in Sources */,
 				5A31275828906422001F30FA /* BookmarksDelegateMock.swift in Sources */,
+				215360652D9475DA00D9B8E6 /* BrowsingSettingsViewControllerTests.swift in Sources */,
 				C2B808B12A77FA3F00A65487 /* DownloadsCoordinatorTests.swift in Sources */,
 				5A475E9129DB8AA7009C13FD /* MockDiskImageStore.swift in Sources */,
 				DFA51484276103A000266AA0 /* HistoryHighlightsManagerTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -296,9 +296,7 @@ extension BrowserViewController: WKUIDelegate {
 
         self.recordObservationForSearchTermGroups(currentTab: currentTab, addedTab: tab)
 
-        guard !topTabsVisible else { return }
-
-        // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
+        // We are showing the toast always now
         showToastBy(isPrivate: isPrivate, tab: tab)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -131,10 +131,18 @@ class TabScrollingController: NSObject,
         return bottomContainerHeight
     }
 
+    var isAutoHideBarEnabled: Bool {
+        // check PrefsKeys.UserFeatureFlagPrefs.TopTabsAndAddressBarAutoHide && isIpad
+        guard UIDevice.current.userInterfaceIdiom == .pad,
+              let prefs = tab?.profile.prefs else { return true }
+  
+        return prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide) ?? true
+    }
+
     // If scrollview contentSize height is bigger that device height plus delta
     var isAbleToScroll: Bool {
         return (UIScreen.main.bounds.size.height + 2 * UIConstants.ToolbarHeight) <
-            contentSize.height
+            contentSize.height && isAutoHideBarEnabled
     }
 
     deinit {

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -139,6 +139,7 @@ class TabScrollingController: NSObject,
     }
 
     // If scrollview contentSize height is bigger that device height plus delta
+    // New settings to disable bar autohide only for iPad
     var isAbleToScroll: Bool {
         return (UIScreen.main.bounds.size.height + 2 * UIConstants.ToolbarHeight) <
             contentSize.height && isAutoHideBarEnabled

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -132,10 +132,9 @@ class TabScrollingController: NSObject,
     }
 
     var isAutoHideBarEnabled: Bool {
-        // check PrefsKeys.UserFeatureFlagPrefs.TopTabsAndAddressBarAutoHide && isIpad
         guard UIDevice.current.userInterfaceIdiom == .pad,
               let prefs = tab?.profile.prefs else { return true }
-  
+
         return prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide) ?? true
     }
 

--- a/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
@@ -48,6 +48,19 @@ class BrowsingSettingsViewController: SettingsTableViewController, FeatureFlagga
             )
         }
 
+        // Setting only available for iPad
+        if let profile, UIDevice.current.userInterfaceIdiom == .pad {
+            var generalSettings = [Setting]()
+            let toolbarHide = BoolSetting(prefs: profile.prefs,
+                                          theme: themeManager.getCurrentTheme(for: windowUUID),
+                                          prefKey: PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide,
+                                          defaultValue: true,
+                                          titleText: .Settings.General.ScrollToHideTabAndAddressBar.Title)
+            generalSettings.append(toolbarHide)
+            settings.append(SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle),
+                                           children: generalSettings))
+        }
+
         var linksSettings: [Setting] = [OpenWithSetting(settings: self, settingsDelegate: parentCoordinator)]
         var mediaSection = [Setting]()
         if let profile {

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -345,16 +345,6 @@ class AppSettingsTableViewController: SettingsTableViewController,
             SiriPageSetting(settings: self, settingsDelegate: parentCoordinator)
         ]
 
-        // And iPad only??
-        if let profile {
-            let toolbarHide = BoolSetting(prefs: profile.prefs,
-                                          theme: themeManager.getCurrentTheme(for: windowUUID),
-                                          prefKey: PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide,
-                                          defaultValue: true,
-                                          titleText: .Settings.General.ScrollToHideTabAndAddressBar.Title)
-            generalSettings.append(toolbarHide)
-        }
-
         return [SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle),
                                children: generalSettings)]
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -345,6 +345,16 @@ class AppSettingsTableViewController: SettingsTableViewController,
             SiriPageSetting(settings: self, settingsDelegate: parentCoordinator)
         ]
 
+        // And iPad only??
+        if let profile {
+            let toolbarHide = BoolSetting(prefs: profile.prefs,
+                                          theme: themeManager.getCurrentTheme(for: windowUUID),
+                                          prefKey: PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide,
+                                          defaultValue: true,
+                                          titleText: .Settings.General.ScrollToHideTabAndAddressBar.Title)
+            generalSettings.append(toolbarHide)
+        }
+
         return [SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle),
                                children: generalSettings)]
     }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2116,6 +2116,17 @@ extension String {
                 comment: "A label indicating the action that a user can rate the Firefox app in the App store.")
         }
 
+        public struct General {
+            public struct ScrollToHideTabAndAddressBar {
+                public static let Title = MZLocalizedString(
+                    key: "Settings.ScrollToHideTabAndAddressBar.Title.v138",
+                    tableName: "Settings",
+                    value: "Scroll to Hide Tab and Address Bar",
+                    comment: "In the settings menu, in the General section, this is the title for the option that allows user to disable the autohide feature of the tab and address bar."
+                )
+            }
+        }
+
         public struct Homepage {
             public struct Current {
                 public static let Description = MZLocalizedString(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
@@ -5,6 +5,8 @@
 import XCTest
 import WebKit
 import Common
+import Shared
+
 @testable import Client
 
 final class TabScrollControllerTests: XCTestCase {
@@ -30,6 +32,33 @@ final class TabScrollControllerTests: XCTestCase {
         mockProfile = nil
         tab = nil
         super.tearDown()
+    }
+
+    func testIsAbleToScrollTrue_ForIpadWhenAutoHideSettingIsEnabled() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+        mockProfile.prefs.setBool(true,
+                                  forKey: PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide)
+
+        XCTAssertTrue(subject.isAbleToScroll)
+    }
+
+    func testIsAbleToScrollTrue_ForIpaWhenAutoHideSettingIsDisabled() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+        mockProfile.prefs.setBool(false,
+                                  forKey: PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide)
+
+        XCTAssertFalse(subject.isAbleToScroll)
+    }
+
+    func testIsAbleToScrollTrue_WhenDeviceisIphone() {
+        let subject = createSubject(isIpad: false)
+        setupTabScroll(with: subject)
+        mockProfile.prefs.setBool(false,
+                                  forKey: PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide)
+
+        XCTAssertTrue(subject.isAbleToScroll)
     }
 
     func testHandlePan_ScrollingUp() {
@@ -142,8 +171,10 @@ final class TabScrollControllerTests: XCTestCase {
         subject.header = header
     }
 
-    private func createSubject() -> TabScrollingController {
-        let subject = TabScrollingController(windowUUID: .XCTestDefaultUUID)
+    private func createSubject(isIpad: Bool = true) -> TabScrollingController {
+        let deviceType = MockDeviceTypeProvider(idiom: isIpad ? .pad : .phone)
+        let subject = TabScrollingController(windowUUID: .XCTestDefaultUUID,
+                                             deviceType: deviceType)
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockDeviceTypeProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockDeviceTypeProvider.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+
+@testable import Client
+
+class MockDeviceTypeProvider: DeviceTypeProvider {
+    var userInterfaceIdiom: UIUserInterfaceIdiom
+
+    init(idiom: UIUserInterfaceIdiom) {
+        self.userInterfaceIdiom = idiom
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/BrowsingSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/BrowsingSettingsViewControllerTests.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Testing
+
+import XCTest
+
+@testable import Client
+
+final class BrowsingSettingsViewControllerTests: XCTestCase {
+    private var profile: Profile!
+    private var delegate: MockSettingsDelegate!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        self.profile = MockProfile()
+        self.delegate = MockSettingsDelegate()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        DependencyHelperMock().reset()
+        self.profile = nil
+        self.delegate = nil
+    }
+
+    func testHomePageSettingsLeaks_InitCall() throws {
+        let subject = createSubject()
+        trackForMemoryLeaks(subject)
+    }
+
+    // MARK: - Helper
+    private func createSubject() -> BrowsingSettingsViewController {
+        let subject = BrowsingSettingsViewController(profile: profile,
+                                                     windowUUID: .XCTestDefaultUUID)
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3820)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/10114)

## :bulb: Description
- New settings for iPad to allow auto hide of Tab and Address bar when scrolling
- Remove code that avoided to show Toast when a new tab was open in iPad
- Create protocols and mocks to test

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

