### PR TITLE
Bugfix FXIOS-11722 - [Toolbar UI Experiments] - Toolbar is moved to bottom after activating the experiment

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceCardViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceCardViewController.swift
@@ -250,8 +250,6 @@ class OnboardingMultipleChoiceCardViewController: OnboardingCardViewController {
     private func isSelectedButton<T: OnboardingCardInfoModelProtocol>(
         buttonModel: OnboardingMultipleChoiceButtonModel,
         viewModel: T) -> Bool {
-            let isToolbarBottom = buttonModel.action == .toolbarBottom
-            let isToolbarTop = buttonModel.action == .toolbarTop
             let toolbarLayout = FxNimbus.shared.features
                 .toolbarRefactorFeature
                 .value()
@@ -259,8 +257,12 @@ class OnboardingMultipleChoiceCardViewController: OnboardingCardViewController {
 
             switch toolbarLayout {
             case .version1:
-                return if isToolbarBottom { true } else {
-                    !isToolbarTop && buttonModel == viewModel.multipleChoiceButtons.first
+                let isToolbarBottomAction = buttonModel.action == .toolbarBottom
+                let isToolbarTopAction = buttonModel.action == .toolbarTop
+                if isToolbarBottomAction {
+                    return true
+                } else {
+                    return !isToolbarTopAction && buttonModel == viewModel.multipleChoiceButtons.first
                 }
             default: return buttonModel == viewModel.multipleChoiceButtons.first
             }

--- a/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceCardViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceCardViewController.swift
@@ -242,13 +242,38 @@ class OnboardingMultipleChoiceCardViewController: OnboardingCardViewController {
         view.addSubview(scrollView)
     }
 
+    /// Determines whether a given button is the selected button based on the toolbar layout, button properties,
+    /// and the `version1` experiment.
+    ///
+    /// - Description: For the `version1` experiment, the bottom toolbar button is set as the default selected button.
+    ///   For other layouts, the first button in the multiple choice buttons list is used as the default.
+    private func isSelectedButton<T: OnboardingCardInfoModelProtocol>(
+        buttonModel: OnboardingMultipleChoiceButtonModel,
+        viewModel: T) -> Bool {
+            let isToolbarBottom = buttonModel.action == .toolbarBottom
+            let isToolbarTop = buttonModel.action == .toolbarTop
+            let toolbarLayout = FxNimbus.shared.features
+                .toolbarRefactorFeature
+                .value()
+                .layout
+
+            switch toolbarLayout {
+            case .version1:
+                return if isToolbarBottom { true } else {
+                    !isToolbarTop && buttonModel == viewModel.multipleChoiceButtons.first
+                }
+            default: return buttonModel == viewModel.multipleChoiceButtons.first
+            }
+        }
+
     private func buildButtonViews() {
         multipleChoiceButtons.removeAll()
         multipleChoiceButtons = viewModel.multipleChoiceButtons.map({ buttonModel in
+            let isSelectedButton = isSelectedButton(buttonModel: buttonModel, viewModel: viewModel)
             return OnboardingMultipleChoiceButtonView(
                 windowUUID: windowUUID,
                 viewModel: OnboardingMultipleChoiceButtonViewModel(
-                    isSelected: buttonModel == viewModel.multipleChoiceButtons.first,
+                    isSelected: isSelectedButton,
                     info: buttonModel,
                     presentingCardName: viewModel.name,
                     a11yIDRoot: viewModel.a11yIdRoot
@@ -258,7 +283,6 @@ class OnboardingMultipleChoiceCardViewController: OnboardingCardViewController {
             )
         })
     }
-
     // MARK: - Button Actions
     @objc
     override func primaryAction() {

--- a/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceCardViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceCardViewController.swift
@@ -250,23 +250,23 @@ class OnboardingMultipleChoiceCardViewController: OnboardingCardViewController {
     private func isSelectedButton<T: OnboardingCardInfoModelProtocol>(
         buttonModel: OnboardingMultipleChoiceButtonModel,
         viewModel: T) -> Bool {
-            let toolbarLayout = FxNimbus.shared.features
-                .toolbarRefactorFeature
-                .value()
-                .layout
+        let toolbarLayout = FxNimbus.shared.features
+            .toolbarRefactorFeature
+            .value()
+            .layout
 
-            switch toolbarLayout {
-            case .version1:
-                let isToolbarBottomAction = buttonModel.action == .toolbarBottom
-                let isToolbarTopAction = buttonModel.action == .toolbarTop
-                if isToolbarBottomAction {
-                    return true
-                } else {
-                    return !isToolbarTopAction && buttonModel == viewModel.multipleChoiceButtons.first
-                }
-            default: return buttonModel == viewModel.multipleChoiceButtons.first
+        switch toolbarLayout {
+        case .version1:
+            let isToolbarBottomAction = buttonModel.action == .toolbarBottom
+            let isToolbarTopAction = buttonModel.action == .toolbarTop
+            if isToolbarBottomAction {
+                return true
+            } else {
+                return !isToolbarTopAction && buttonModel == viewModel.multipleChoiceButtons.first
             }
+        default: return buttonModel == viewModel.multipleChoiceButtons.first
         }
+    }
 
     private func buildButtonViews() {
         multipleChoiceButtons.removeAll()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11722)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25563)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Update the onboarding card for when the `version1` experiment is on to select by default the bottom toolbar.

### Screenshot
![bottom](https://github.com/user-attachments/assets/e0ab61cb-900d-4063-9283-176534f778d5)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

