### PR TITLE
Bugfix FXIOS-11254 ⁃ Parent folder selector missing line separators

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -38,7 +38,6 @@ class EditFolderViewController: UIViewController,
         view.register(cellType: OneLineTableViewCell.self)
         view.register(UITableViewHeaderFooterView.self,
                       forHeaderFooterViewReuseIdentifier: UX.parentFolderHeaderIdentifier)
-        view.separatorStyle = .none
         let headerSpacerView = UIView(frame: CGRect(origin: .zero,
                                                     size: CGSize(width: 0, height: UX.editFolderCellTopPadding)))
         view.tableHeaderView = headerSpacerView


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-24470)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24470)

## :bulb: Description
Removed de .none separator

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

