### PR TITLE
Bugfix FXIOS-11392 #24794 ⁃ [iOS Bookmarks Evolution] The confirmation snackbar uses the incorrect label when a bookmark is deleted from homepage context menu

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1849,7 +1849,7 @@ class BrowserViewController: UIViewController,
             let messageTitle: String = if let title {
                 String(format: .Bookmarks.Menu.DeletedBookmark, title)
             } else {
-                .MainMenu.Submenus.Tools.ZoomNegativeSymbol
+                .LegacyAppMenu.RemoveBookmarkConfirmMessage
             }
             self.showToast(
                 urlString,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1849,7 +1849,7 @@ class BrowserViewController: UIViewController,
             self.showToast(
                 urlString,
                 title,
-                message: .LegacyAppMenu.RemoveBookmarkConfirmMessage,
+                message: String(format: .Bookmarks.Menu.DeletedBookmark, title ?? ""),
                 toastAction: .removeBookmark
             )
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1846,10 +1846,15 @@ class BrowserViewController: UIViewController,
                 )
             }
         case .remove:
+            let messageTitle: String = if let title {
+                String(format: .Bookmarks.Menu.DeletedBookmark, title)
+            } else {
+                .MainMenu.Submenus.Tools.ZoomNegativeSymbol
+            }
             self.showToast(
                 urlString,
                 title,
-                message: String(format: .Bookmarks.Menu.DeletedBookmark, title ?? ""),
+                message: messageTitle,
                 toastAction: .removeBookmark
             )
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1851,7 +1851,7 @@ class BrowserViewController: UIViewController,
             } else {
                 .LegacyAppMenu.RemoveBookmarkConfirmMessage
             }
-            self.showToast(
+            showToast(
                 urlString,
                 title,
                 message: messageTitle,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11392)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24794)

## :bulb: Description
Replaced the string for delete bookmark toast

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

