### PR TITLE
Bugfix FXIOS-3820 - [UX Fundamentals] #10114 ⁃ [iPad] No way to stop address/tab bar from auto hiding

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
@@ -36,18 +36,6 @@ class BrowsingSettingsViewController: SettingsTableViewController, FeatureFlagga
     override func generateSettings() -> [SettingSection] {
         var settings = [SettingSection]()
 
-        if featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildOnly) {
-            let inactiveTabsSetting = BoolSetting(with: .inactiveTabs,
-                                                  titleText: NSAttributedString(string: .Settings.Tabs.InactiveTabs))
-            settings.append(
-                SettingSection(
-                    title: NSAttributedString(string: .Settings.Browsing.Tabs),
-                    footerTitle: NSAttributedString(string: .Settings.Tabs.InactiveTabsDescription),
-                    children: [inactiveTabsSetting]
-                )
-            )
-        }
-
         // Setting only available for iPad
         if let profile, UIDevice.current.userInterfaceIdiom == .pad {
             var generalSettings = [Setting]()
@@ -59,6 +47,18 @@ class BrowsingSettingsViewController: SettingsTableViewController, FeatureFlagga
             generalSettings.append(toolbarHide)
             settings.append(SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle),
                                            children: generalSettings))
+        }
+
+        if featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildOnly) {
+            let inactiveTabsSetting = BoolSetting(with: .inactiveTabs,
+                                                  titleText: NSAttributedString(string: .Settings.Tabs.InactiveTabs))
+            settings.append(
+                SettingSection(
+                    title: NSAttributedString(string: .Settings.Browsing.Tabs),
+                    footerTitle: NSAttributedString(string: .Settings.Tabs.InactiveTabsDescription),
+                    children: [inactiveTabsSetting]
+                )
+            )
         }
 
         var linksSettings: [Setting] = [OpenWithSetting(settings: self, settingsDelegate: parentCoordinator)]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3820)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/10114)

## :bulb: Description
- Move General settings to be the first option in BrowsingSettings

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

