### PR TITLE
Bugfix FXIOS-11739 [iOS Bookmark Evolution] Disables autocapitalization for urlTextfield

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
@@ -41,6 +41,7 @@ class EditBookmarkCell: UITableViewCell,
         }), for: .editingChanged)
         view.adjustsFontSizeToFitWidth = true
         view.accessibilityIdentifier = AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.urlTextField
+        view.autocapitalizationType = .none
     }
     var onTitleFieldUpdate: ((String) -> Void)?
     var onURLFieldUpdate: ((String) -> Void)?


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11739)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25600)

## :bulb: Description
Sets UITextAutocapitalizationType.none for URLTextField in EditBookmarkCell because it only supports URLs. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

