### PR TITLE
Bugfix FXIOS-9753 Fix Tabs TPS tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -140,9 +140,10 @@ class IntegrationTests: BaseTestCase {
         signInFxAccounts()
 
         // We only sync tabs if the user is signed in
+        navigator.nowAt(BrowserTab)
+        waitForTabsButton()
         navigator.openURL(testingURL)
         waitUntilPageLoad()
-        navigator.goto(BrowserTabMenu)
 
         // Wait for initial sync to complete
         waitForInitialSyncComplete()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -143,7 +143,7 @@ class IntegrationTests: BaseTestCase {
         signInFxAccounts()
 
         // Wait for initial sync to complete
-        navigator.nowAt(BrowserTab)
+        waitForInitialSyncComplete()
         // This is only to check that the device's name changed
         navigator.goto(SettingsScreen)
         app.tables.cells.element(boundBy: 1).waitAndTap()
@@ -154,10 +154,7 @@ class IntegrationTests: BaseTestCase {
         )
 
         // Sync again just to make sure to sync after new name is shown
-        app.buttons["Settings"].waitAndTap()
-        mozWaitForElementToExist(app.staticTexts["ACCOUNT"])
-        app.tables.cells.element(boundBy: 2).waitAndTap()
-        mozWaitForElementToExist(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
+        waitForInitialSyncComplete()
     }
 
     func testFxASyncLogins () {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -154,6 +154,9 @@ class IntegrationTests: BaseTestCase {
         )
 
         // Sync again just to make sure to sync after new name is shown
+        app.buttons["Settings"].waitAndTap()
+        navigator.nowAt(SettingsScreen)
+        navigator.goto(BrowserTab)
         waitForInitialSyncComplete()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -137,10 +137,12 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncTabs () {
+        signInFxAccounts()
+
+        // We only sync tabs if the user is signed in
         navigator.openURL(testingURL)
         waitUntilPageLoad()
         navigator.goto(BrowserTabMenu)
-        signInFxAccounts()
 
         // Wait for initial sync to complete
         waitForInitialSyncComplete()


### PR DESCRIPTION
This fixes the tabs TPS test that has started failing: https://bugzilla.mozilla.org/show_bug.cgi?id=1956924

This patch https://github.com/mozilla-mobile/firefox-ios/pull/25401 slightly changed the order of operations for tab syncing. Which means we wait until 5s of no tab actions before storing tabs and syncing. Previously, we'd immediately store and sync after any tab action.

It seems that TPS test should be updated anyways to use the `waitForInitialSyncComplete` since that does the right thing here and all other tests uses that aswell.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

