### PR TITLE
Bugfix [Deeplink optimization] FXIOS-11269 ensure tab restoration is called after deeplink handling

### DIFF
--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -237,7 +237,6 @@ class SceneDelegate: UIResponder,
 
         if isDeeplinkOptimizationRefactorEnabled {
             sceneCoordinator.findAndHandle(route: route)
-            AppEventQueue.signal(event: .recordStartupTimeOpenDeeplinkComplete)
         } else {
             AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(sceneCoordinator.windowUUID)]) { [weak self] in
                 self?.logger.log("Start up flow and restoration done, will handle route",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -17,10 +17,9 @@ final class SceneCoordinatorTests: XCTestCase {
     }
 
     override func tearDown() {
-        setIsDeeplinkOptimizationRefactorEnabled(false)
+        super.tearDown()
         mockRouter = nil
         AppContainer.shared.reset()
-        super.tearDown()
     }
 
     func testInitialState() {
@@ -72,16 +71,6 @@ final class SceneCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertNotNil(subject.childCoordinators.first as? BrowserCoordinator)
-    }
-
-    func testLaunchBrowser_signalRecordStartupComplete_whenSavedRoutePresent() {
-        let subject = createSubject()
-        setIsDeeplinkOptimizationRefactorEnabled(true)
-
-        subject.savedRoute = .search(url: nil, isPrivate: false, options: nil)
-        subject.launchBrowser()
-
-        XCTAssertTrue(AppEventQueue.hasSignalled(.recordStartupTimeOpenDeeplinkComplete))
     }
 
     func testChildLaunchCoordinatorIsDone_startsBrowser() throws {
@@ -158,11 +147,5 @@ final class SceneCoordinatorTests: XCTestCase {
         let result = subject.canHandle(route: route)
         subject.handle(route: route)
         return result
-    }
-
-    private func setIsDeeplinkOptimizationRefactorEnabled(_ enabled: Bool) {
-        FxNimbus.shared.features.deeplinkOptimizationRefactorFeature.with { _, _ in
-            return DeeplinkOptimizationRefactorFeature(enabled: enabled)
-        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -17,9 +17,10 @@ final class SceneCoordinatorTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
+        setIsDeeplinkOptimizationRefactorEnabled(false)
         mockRouter = nil
         AppContainer.shared.reset()
+        super.tearDown()
     }
 
     func testInitialState() {
@@ -71,6 +72,16 @@ final class SceneCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertNotNil(subject.childCoordinators.first as? BrowserCoordinator)
+    }
+
+    func testLaunchBrowser_signalRecordStartupComplete_whenSavedRoutePresent() {
+        let subject = createSubject()
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+
+        subject.savedRoute = .search(url: nil, isPrivate: false, options: nil)
+        subject.launchBrowser()
+
+        XCTAssertTrue(AppEventQueue.hasSignalled(.recordStartupTimeOpenDeeplinkComplete))
     }
 
     func testChildLaunchCoordinatorIsDone_startsBrowser() throws {
@@ -147,5 +158,11 @@ final class SceneCoordinatorTests: XCTestCase {
         let result = subject.canHandle(route: route)
         subject.handle(route: route)
         return result
+    }
+
+    private func setIsDeeplinkOptimizationRefactorEnabled(_ enabled: Bool) {
+        FxNimbus.shared.features.deeplinkOptimizationRefactorFeature.with { _, _ in
+            return DeeplinkOptimizationRefactorFeature(enabled: enabled)
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11269)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24513)

## :bulb: Description
Move `AppEventQueue.signal(.recordStartupTimeCompleted)` to `SceneCoordinator` to ensure tab restoration actually fires only when the deeplink tab has being handled.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

