### PR TITLE
Bugfix FXIOS-10170 [Homepage] a11y bugs relate to headings + discover more 

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
@@ -31,6 +31,7 @@ class LabelButtonHeaderView: UICollectionReusableView,
         label.font = FXFontStyles.Bold.title3.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
+        label.accessibilityTraits.insert(.header)
     }
 
     private(set) lazy var moreButton: ActionButton = .build { button in

--- a/firefox-ios/Client/Frontend/Home/Pocket/PocketDiscoverCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Pocket/PocketDiscoverCell.swift
@@ -18,6 +18,7 @@ class PocketDiscoverCell: UICollectionViewCell, ReusableCell {
         label.font = FXFontStyles.Bold.title3.scaledFont()
         label.numberOfLines = 0
         label.textAlignment = .left
+        label.accessibilityTraits.insert(.button)
     }
 
     // MARK: - Initializers
@@ -37,7 +38,6 @@ class PocketDiscoverCell: UICollectionViewCell, ReusableCell {
 
     func configure(text: String, theme: Theme) {
         itemTitle.text = text
-
         applyTheme(theme: theme)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11732)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11734)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25586)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25590)

## :bulb: Description
Add heading trait for section headings and add button trait for discover more.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

