### PR TITLE
Bugfix FXIOS-11676 #25437 [UX Fundamentals] [Widgets] ⁃ Blank page icon is not visible in Firefox Quick View widget

### DIFF
--- a/firefox-ios/WidgetKit/Assets.xcassets/globeLarge.imageset/Contents.json
+++ b/firefox-ios/WidgetKit/Assets.xcassets/globeLarge.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -36,9 +36,10 @@ struct OpenTabsView: View {
                 HStack(alignment: .center, spacing: 15) {
                     if let favIcon = entry.favicons[tab.imageKey] {
                         favIcon.resizable().frame(width: 16, height: 16)
+                            .foregroundColor(Color("openTabsContentColor"))
                     } else {
                         Image(decorative: StandardImageIdentifiers.Large.globe)
-                            .foregroundColor(Color.white)
+                            .foregroundColor(Color("openTabsContentColor"))
                             .frame(width: 16, height: 16)
                     }
 
@@ -133,5 +134,19 @@ struct OpenTabsView: View {
     private func linkToContainingApp(_ urlSuffix: String = "", query: String) -> URL {
         let urlString = "\(scheme)://\(query)\(urlSuffix)"
         return URL(string: urlString, invalidCharacters: false)!
+    }
+}
+
+struct OpenTabsPreview: PreviewProvider {
+    static let favIcons = ["globe":
+                            Image(decorative: StandardImageIdentifiers.Large.globe)]
+    static let tabs = [SimpleTab(lastUsedTime: nil)]
+    static let testEntry = OpenTabsEntry(date: Date(),
+                                         favicons: favIcons,
+                                         tabs: [SimpleTab]())
+    static var previews: some View {
+        Group {
+            OpenTabsView(entry: testEntry)
+        }
     }
 }

--- a/firefox-ios/WidgetKit/OpenTabs/SimpleTab.swift
+++ b/firefox-ios/WidgetKit/OpenTabs/SimpleTab.swift
@@ -19,9 +19,7 @@ struct SimpleTab: Hashable, Codable {
     var imageKey: String {
         return url?.baseDomain ?? ""
     }
-}
 
-extension SimpleTab {
     static func getSimpleTabs() -> [String: SimpleTab] {
         if let tbs = userDefaults.object(forKey: PrefsKeys.WidgetKitSimpleTabKey) as? Data {
             do {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11676)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25437)

## :bulb: Description
- Add `emplate-rendering-intent` to the image and use color that reacts to theming changes
- Add PreviewProvider code to test in XCode > Canvas if ever loads

### 🎥 Screenshot
<details>
<summary>Quick View widget changes background and icon in light/dark mode </summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-03-28 at 10 59 33](https://github.com/user-attachments/assets/a8843a1f-b995-4bd1-8217-f705e160837b)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-28 at 11 06 11](https://github.com/user-attachments/assets/c7cc2a3c-5e80-4720-96a6-d77688010b2e)

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

