### PR TITLE
Added FXIOS-11458 new selector UI component for tab tray

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -621,6 +621,9 @@
 		5A8FD0EE293A7D6D00333AA7 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 5A8FD0ED293A7D6D00333AA7 /* SnapKit */; };
 		5A8FD0F2293A7D9000333AA7 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 5A8FD0F1293A7D9000333AA7 /* SnapKit */; };
 		5A96FB5A2D94357800917B12 /* ScreenshotSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A96FB592D94356C00917B12 /* ScreenshotSetting.swift */; };
+		5A96FB5F2D96DAA300917B12 /* TabTraySelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A96FB5E2D96DA9700917B12 /* TabTraySelectorView.swift */; };
+		5A96FB622D97076200917B12 /* CenterSnappingFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A96FB612D97075F00917B12 /* CenterSnappingFlowLayout.swift */; };
+		5A96FB642D97077F00917B12 /* TabTraySelectorCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A96FB632D97077C00917B12 /* TabTraySelectorCell.swift */; };
 		5A984D312C89FD88007938C9 /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = 5A984D302C89FD88007938C9 /* SiteImageView */; };
 		5A984D342C8A31C6007938C9 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 5A984D332C8A31C6007938C9 /* Kingfisher */; };
 		5A984D362C8A3407007938C9 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 5A984D352C8A3407007938C9 /* Kingfisher */; };
@@ -7611,6 +7614,10 @@
 		5A81C5DC2A4C981A00BE88C2 /* PasswordManagerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordManagerCoordinatorTests.swift; sourceTree = "<group>"; };
 		5A96FB592D94356C00917B12 /* ScreenshotSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSetting.swift; sourceTree = "<group>"; };
 		5A96FB5D2D9447E600917B12 /* FirefoxStaging.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FirefoxStaging.xcconfig; path = Configuration/FirefoxStaging.xcconfig; sourceTree = "<group>"; };
+		5A96FB5D2D9447E600917B12 /* FirefoxStaging.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FirefoxStaging.xcconfig; path = Configuration/FirefoxStaging.xcconfig; sourceTree = "<group>"; };
+		5A96FB5E2D96DA9700917B12 /* TabTraySelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTraySelectorView.swift; sourceTree = "<group>"; };
+		5A96FB612D97075F00917B12 /* CenterSnappingFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSnappingFlowLayout.swift; sourceTree = "<group>"; };
+		5A96FB632D97077C00917B12 /* TabTraySelectorCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTraySelectorCell.swift; sourceTree = "<group>"; };
 		5A9A09D128AFD51900B6F51E /* MockHomepageDataModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHomepageDataModelDelegate.swift; sourceTree = "<group>"; };
 		5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTelemetryWrapper.swift; sourceTree = "<group>"; };
 		5A9A09D528B01FD500B6F51E /* MockURLBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLBarView.swift; sourceTree = "<group>"; };
@@ -11014,6 +11021,7 @@
 		21C5B3582AF2A7130093F366 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				5A96FB602D97073C00917B12 /* CustomSelectorView */,
 				8AC6F2252D6E263500D10A9F /* ExperimentRemoteTabsEmptyView.swift */,
 				8AC6F2232D6E243F00D10A9F /* ExperimentEmptyPrivateTabsView.swift */,
 				8A2068362D6D52830063A77B /* ExperimentTabCell.swift */,
@@ -11773,6 +11781,16 @@
 				5A70EF18295E2E1600790249 /* DependencyHelperMock.swift */,
 			);
 			path = DependencyInjection;
+			sourceTree = "<group>";
+		};
+		5A96FB602D97073C00917B12 /* CustomSelectorView */ = {
+			isa = PBXGroup;
+			children = (
+				5A96FB632D97077C00917B12 /* TabTraySelectorCell.swift */,
+				5A96FB612D97075F00917B12 /* CenterSnappingFlowLayout.swift */,
+				5A96FB5E2D96DA9700917B12 /* TabTraySelectorView.swift */,
+			);
+			path = CustomSelectorView;
 			sourceTree = "<group>";
 		};
 		5A9FFB3629C0F99C001793A0 /* Legacy */ = {
@@ -17253,6 +17271,7 @@
 				215B457F27D7FD4B00E5E800 /* LegacyTabGroupData.swift in Sources */,
 				E12BD0B028AC3A7E0029AAF0 /* UIEdgeInsets+Extension.swift in Sources */,
 				C2D80BE72AADE38100CDF7A9 /* CredentialAutofillCoordinator.swift in Sources */,
+				5A96FB622D97076200917B12 /* CenterSnappingFlowLayout.swift in Sources */,
 				8A62B15D2CED408B0045F46E /* ContextMenuState.swift in Sources */,
 				C8BE692729BA2FBB0015C4A2 /* SurveySurfaceInfoModel.swift in Sources */,
 				D0152245229855A8009DE753 /* OneLineTableViewCell.swift in Sources */,
@@ -17342,6 +17361,7 @@
 				21B359C62AEAC20300FF09E3 /* TabsSectionManager.swift in Sources */,
 				21BFEEF52A040EF40033048D /* TabMigrationUtility.swift in Sources */,
 				8AEAD9F52C3D7BA9001A2C5A /* FeatureFlagsDebugViewController.swift in Sources */,
+				5A96FB642D97077F00917B12 /* TabTraySelectorCell.swift in Sources */,
 				810CD9C12BB346D800E290C2 /* OnboardingCardViewController.swift in Sources */,
 				8AD3AFC32D143EF600CFC887 /* HomepageDimensionImplementation.swift in Sources */,
 				C8A012F126AB07D70096A7A7 /* JumpBackInViewModel.swift in Sources */,
@@ -17478,6 +17498,7 @@
 				8A4B148B2CF919C800FCE2D0 /* UnifiedAdsConverter.swift in Sources */,
 				1D5CBF492B17E3CB0001D033 /* NotificationPayloads.swift in Sources */,
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,
+				5A96FB5F2D96DAA300917B12 /* TabTraySelectorView.swift in Sources */,
 				AB9CBC052C53B64C00102610 /* TrackingProtectionState.swift in Sources */,
 				D0E89A2920910917001CE5C7 /* DownloadsPanel.swift in Sources */,
 				D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */,
@@ -18248,7 +18269,6 @@
 				3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */,
 				8A7892072CF9228700490CA4 /* UnifiedAdsCallbackTelemetryTests.swift in Sources */,
 				0AFF7F662C7784F100265214 /* TrackingProtectionModelTests.swift in Sources */,
-				C7F051502D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift in Sources */,
 				C80C11EE28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift in Sources */,
 				0A686B3C2CDB70DC0090E146 /* MainMenuTelemetryTests.swift in Sources */,
 				8C8D8C7A2AA067AD00490D32 /* FakespotCoordinatorTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/CenterSnappingFlowLayout.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/CenterSnappingFlowLayout.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-class CenterSnappingFlowLayout: UICollectionViewFlowLayout {
+final class CenterSnappingFlowLayout: UICollectionViewFlowLayout {
     override func targetContentOffset(
         forProposedContentOffset proposedContentOffset: CGPoint,
         withScrollingVelocity velocity: CGPoint

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/CenterSnappingFlowLayout.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/CenterSnappingFlowLayout.swift
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+class CenterSnappingFlowLayout: UICollectionViewFlowLayout {
+    override func targetContentOffset(
+        forProposedContentOffset proposedContentOffset: CGPoint,
+        withScrollingVelocity velocity: CGPoint
+    ) -> CGPoint {
+        guard let collectionView = collectionView else { return proposedContentOffset }
+
+        let targetRect = CGRect(
+            x: proposedContentOffset.x,
+            y: 0,
+            width: collectionView.bounds.width,
+            height: collectionView.bounds.height
+        )
+
+        guard let layoutAttributes = super.layoutAttributesForElements(in: targetRect) else {
+            return proposedContentOffset
+        }
+
+        let centerX = proposedContentOffset.x + collectionView.bounds.width / 2
+        let closest = layoutAttributes.min(by: {
+            abs($0.center.x - centerX) < abs($1.center.x - centerX)
+        })
+
+        guard let closestAttr = closest else { return proposedContentOffset }
+
+        let newOffsetX = closestAttr.center.x - collectionView.bounds.width / 2
+        return CGPoint(x: newOffsetX, y: proposedContentOffset.y)
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+class TabTraySelectorCell: UICollectionViewCell {
+    private let label = UILabel()
+    private let padding = UIEdgeInsets(
+        top: TabTraySelectorUX.cellVerticalPadding,
+        left: TabTraySelectorUX.cellHorizontalPadding,
+        bottom: TabTraySelectorUX.cellVerticalPadding,
+        right: TabTraySelectorUX.cellHorizontalPadding
+    )
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(label)
+        contentView.layer.cornerRadius = TabTraySelectorUX.cornerRadius
+        contentView.layer.masksToBounds = true
+
+        label.textAlignment = .center
+        label.numberOfLines = 1
+        label.adjustsFontForContentSizeCategory = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: contentView.topAnchor, constant: padding.top),
+            label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -padding.bottom),
+            label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: padding.left),
+            label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -padding.right)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(title: String, selected: Bool) {
+        label.text = title
+        label.font = selected ? TabTraySelectorUX.selectedFont : TabTraySelectorUX.unselectedFont
+        label.textColor = selected ? TabTraySelectorUX.selectedTextColor : TabTraySelectorUX.unselectedTextColor
+        contentView.backgroundColor = selected ? TabTraySelectorUX.selectedBackgroundColor : TabTraySelectorUX.unselectedBackgroundColor
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
@@ -3,8 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
+import Common
 
-class TabTraySelectorCell: UICollectionViewCell {
+class TabTraySelectorCell: UICollectionViewCell,
+                           ReusableCell,
+                           ThemeApplicable {
     private let label = UILabel()
     private let padding = UIEdgeInsets(
         top: TabTraySelectorUX.cellVerticalPadding,
@@ -36,12 +39,17 @@ class TabTraySelectorCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(title: String, selected: Bool) {
+    func configure(title: String, selected: Bool, theme: Theme?) {
+        isSelected = selected
         label.text = title
-        label.font = selected ? TabTraySelectorUX.selectedFont : TabTraySelectorUX.unselectedFont
-        label.textColor = selected ? TabTraySelectorUX.selectedTextColor : TabTraySelectorUX.unselectedTextColor
-        contentView.backgroundColor = selected ?
-                                    TabTraySelectorUX.selectedBackgroundColor :
-                                    TabTraySelectorUX.unselectedBackgroundColor
+        label.font = selected ? FXFontStyles.Bold.body.scaledFont() : FXFontStyles.Regular.body.scaledFont()
+        applyTheme(theme: theme ?? LightTheme())
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        label.textColor = theme.colors.textPrimary
+        contentView.backgroundColor = isSelected ? theme.colors.layer4 : .clear
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
@@ -40,6 +40,8 @@ class TabTraySelectorCell: UICollectionViewCell {
         label.text = title
         label.font = selected ? TabTraySelectorUX.selectedFont : TabTraySelectorUX.unselectedFont
         label.textColor = selected ? TabTraySelectorUX.selectedTextColor : TabTraySelectorUX.unselectedTextColor
-        contentView.backgroundColor = selected ? TabTraySelectorUX.selectedBackgroundColor : TabTraySelectorUX.unselectedBackgroundColor
+        contentView.backgroundColor = selected ?
+                                    TabTraySelectorUX.selectedBackgroundColor :
+                                    TabTraySelectorUX.unselectedBackgroundColor
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
@@ -5,9 +5,9 @@
 import UIKit
 import Common
 
-class TabTraySelectorCell: UICollectionViewCell,
-                           ReusableCell,
-                           ThemeApplicable {
+final class TabTraySelectorCell: UICollectionViewCell,
+                                 ReusableCell,
+                                 ThemeApplicable {
     private let label = UILabel()
     private let padding = UIEdgeInsets(
         top: TabTraySelectorUX.cellVerticalPadding,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -7,15 +7,12 @@ import Common
 
 // MARK: - UX Constants
 struct TabTraySelectorUX {
-    static let cellSpacing: CGFloat = 20
+    static let cellSpacing: CGFloat = 4
     static let cellHorizontalPadding: CGFloat = 12
     static let cellVerticalPadding: CGFloat = 8
     static let estimatedCellWidth: CGFloat = 100
-    static let selectedBackgroundColor: UIColor = .blue
-    static let unselectedBackgroundColor: UIColor = .clear
-    static let selectedTextColor: UIColor = .white
-    static let unselectedTextColor: UIColor = .black
     static let cornerRadius: CGFloat = 12
+    static let verticalInsets: CGFloat = 4
 }
 
 class TabTraySelectorView: UIView,
@@ -86,8 +83,8 @@ class TabTraySelectorView: UIView,
         collectionView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            collectionView.topAnchor.constraint(equalTo: topAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            collectionView.topAnchor.constraint(equalTo: topAnchor, constant: -TabTraySelectorUX.verticalInsets),
+            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: TabTraySelectorUX.verticalInsets),
             collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
@@ -160,5 +157,6 @@ class TabTraySelectorView: UIView,
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         collectionView.backgroundColor = theme.colors.layer1
+        backgroundColor = theme.colors.layer1
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -5,6 +5,10 @@
 import UIKit
 import Common
 
+protocol TabTraySelectorDelegate: AnyObject {
+    func didSelectSection(section: Int)
+}
+
 // MARK: - UX Constants
 struct TabTraySelectorUX {
     static let cellSpacing: CGFloat = 4
@@ -24,7 +28,10 @@ class TabTraySelectorView: UIView,
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
 
+    weak var delegate: TabTraySelectorDelegate?
+
     private let windowUUID: WindowUUID
+    private var selectedIndex = 1
 
     var items: [String] = [] {
         didSet {
@@ -32,17 +39,6 @@ class TabTraySelectorView: UIView,
             scrollToItem(at: selectedIndex, animated: false)
         }
     }
-
-    var selectedIndex = 0 {
-        didSet {
-            if oldValue != selectedIndex {
-                collectionView.reloadData()
-                onSelectionChanged?(selectedIndex)
-            }
-        }
-    }
-
-    var onSelectionChanged: ((Int) -> Void)?
 
     // MARK: - Layout & Views
     private lazy var layout: CenterSnappingFlowLayout = {
@@ -131,8 +127,7 @@ class TabTraySelectorView: UIView,
 
     // MARK: - UICollectionViewDelegate
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        selectedIndex = indexPath.item
-        scrollToItem(at: selectedIndex, animated: true)
+        selectNewSection(newIndex: indexPath.item)
     }
 
     // MARK: - Scroll Snap
@@ -147,9 +142,16 @@ class TabTraySelectorView: UIView,
     private func snapToNearestItem() {
         let center = convert(CGPoint(x: bounds.midX, y: bounds.midY), to: collectionView)
         if let indexPath = collectionView.indexPathForItem(at: center) {
-            selectedIndex = indexPath.item
-            scrollToItem(at: selectedIndex, animated: true)
+            selectNewSection(newIndex: indexPath.item)
         }
+    }
+
+    func selectNewSection(newIndex: Int) {
+        guard selectedIndex != newIndex else { return }
+        selectedIndex = newIndex
+        collectionView.reloadData()
+        scrollToItem(at: selectedIndex, animated: true)
+        delegate?.didSelectSection(section: newIndex)
     }
 
     // MARK: - Theamable

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -19,11 +19,11 @@ struct TabTraySelectorUX {
     static let verticalInsets: CGFloat = 4
 }
 
-class TabTraySelectorView: UIView,
-                           UICollectionViewDelegateFlowLayout,
-                           UICollectionViewDataSource,
-                           UIScrollViewDelegate,
-                           Themeable {
+final class TabTraySelectorView: UIView,
+                                 UICollectionViewDelegateFlowLayout,
+                                 UICollectionViewDataSource,
+                                 UIScrollViewDelegate,
+                                 Themeable {
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -39,6 +39,7 @@ class TabTrayViewController: UIViewController,
         static let fixedSpaceWidth: CGFloat = 32
         static let segmentedControlTopSpacing: CGFloat = 8
         static let segmentedControlHorizontalSpacing: CGFloat = 16
+        static let segmentedControlMinHeight: CGFloat = 70
     }
 
     // MARK: Theme
@@ -104,7 +105,7 @@ class TabTrayViewController: UIViewController,
     }()
 
     private lazy var newSegmentControl: TabTraySelectorView = {
-        let selector = TabTraySelectorView()
+        let selector = TabTraySelectorView(windowUUID: windowUUID)
         selector.items = ["Private", "Tabs", "Sync"]
 
         // TODO: Update with a delegate insetead
@@ -408,7 +409,7 @@ class TabTrayViewController: UIViewController,
                                                            constant: UX.segmentedControlHorizontalSpacing),
                 newSegmentControl.trailingAnchor.constraint(equalTo: containerView.trailingAnchor,
                                                             constant: -UX.segmentedControlHorizontalSpacing),
-                newSegmentControl.heightAnchor.constraint(greaterThanOrEqualToConstant: 50)
+                newSegmentControl.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.segmentedControlMinHeight)
             ])
         } else {
             view.addSubview(navigationToolbar)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -103,6 +103,17 @@ class TabTrayViewController: UIViewController,
                                       a11yId: AccessibilityIdentifiers.TabTray.navBarSegmentedControl)
     }()
 
+    private lazy var newSegmentControl: TabTraySelectorView = {
+        let selector = TabTraySelectorView()
+        selector.items = ["Private", "Tabs", "Sync"]
+
+        // TODO: Update with a delegate insetead
+        selector.onSelectionChanged = { index in
+            print("Selected tab at index: \(index)")
+        }
+        return selector
+    }()
+
     lazy var countLabel: UILabel = {
         let label = UILabel(frame: CGRect(width: 24, height: 24))
         label.font = TabsButton.UX.titleFont
@@ -376,6 +387,10 @@ class TabTrayViewController: UIViewController,
         if isTabTrayUIExperimentsEnabled {
             containerView.addSubview(segmentedControl)
             segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+
+            containerView.addSubview(newSegmentControl)
+            newSegmentControl.translatesAutoresizingMaskIntoConstraints = false
+
             NSLayoutConstraint.activate([
                 containerView.topAnchor.constraint(equalTo: view.topAnchor),
                 containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -386,7 +401,14 @@ class TabTrayViewController: UIViewController,
                                                           constant: UX.segmentedControlHorizontalSpacing),
                 segmentedControl.bottomAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.bottomAnchor),
                 segmentedControl.trailingAnchor.constraint(equalTo: containerView.trailingAnchor,
-                                                           constant: -UX.segmentedControlHorizontalSpacing)
+                                                           constant: -UX.segmentedControlHorizontalSpacing),
+
+                newSegmentControl.bottomAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.bottomAnchor),
+                newSegmentControl.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
+                                                           constant: UX.segmentedControlHorizontalSpacing),
+                newSegmentControl.trailingAnchor.constraint(equalTo: containerView.trailingAnchor,
+                                                            constant: -UX.segmentedControlHorizontalSpacing),
+                newSegmentControl.heightAnchor.constraint(greaterThanOrEqualToConstant: 50)
             ])
         } else {
             view.addSubview(navigationToolbar)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -39,7 +39,7 @@ class TabTrayViewController: UIViewController,
         static let fixedSpaceWidth: CGFloat = 32
         static let segmentedControlTopSpacing: CGFloat = 8
         static let segmentedControlHorizontalSpacing: CGFloat = 16
-        static let segmentedControlMinHeight: CGFloat = 70
+        static let segmentedControlMinHeight: CGFloat = 45
     }
 
     // MARK: Theme
@@ -585,7 +585,7 @@ class TabTrayViewController: UIViewController,
                 panel.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
                 panel.view.topAnchor.constraint(equalTo: containerView.topAnchor),
                 panel.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-                panel.view.bottomAnchor.constraint(equalTo: segmentedControl.topAnchor,
+                panel.view.bottomAnchor.constraint(equalTo: newSegmentControl.topAnchor,
                                                    constant: -UX.segmentedControlTopSpacing),
             ])
         } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11458)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24927)

## :bulb: Description
Adds the UI component to handle selecting sections on the tab tray. 

- There is a bug with snapping the correct cell to the centre at the right time. I will follow up with another PR to fix that.
- The old segment control still lives underneath the new one, still trying to decide if it's worth pulling it out when the experiment is on or leave it be and clear up later once the experiment is done.
- Sizing for accessibility is proving a bit awkward so I'm also kicking that can down the road. The collection view really wants to put the cells over multiple lines whenever I let it grow.
- I didn't add any tests, I'm not sure there are any useful unit tests I can add and this is still too unstable with the scrolling bug to add UI tests. 


https://github.com/user-attachments/assets/d6b0e900-8351-4aa2-b3fb-48e5e8ab3206


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

