### PR TITLE
Bugfix FXIOS-9665 [UX Fundamentals] Increase WallpaperSelector description font size

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -35,7 +35,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
     }
 
     private lazy var instructionLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.caption1.scaledFont()
+        label.font = FXFontStyles.Regular.footnote.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.text = .Onboarding.Wallpaper.SelectorDescription
         label.textAlignment = .center


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9665)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21269)

## :bulb: Description
- Increase the font size of the description in the wallpaper selector modal from `caption1` (12pt) to `footnote` (13pt)

### 📸 Screenshots
| Before | After |
| ------------- | ------------- |
| <img width="559" alt="Screenshot 2025-03-28 at 5 43 27 PM" src="https://github.com/user-attachments/assets/bc308454-2170-4794-abeb-614585c53469" /> |<img width="515" alt="Screenshot 2025-03-28 at 5 47 18 PM" src="https://github.com/user-attachments/assets/6a340416-1336-4494-8d0b-81299191bc9a" />  |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

