### PR TITLE
Refactor FXIOS-11192: Update Live Activity progress text and circle based on content-encoded downloads 

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -69,6 +69,7 @@ class DownloadsPanel: UIViewController,
                 object: nil
             )
         }
+        startDownloadLiveActivity()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -69,7 +69,6 @@ class DownloadsPanel: UIViewController,
                 object: nil
             )
         }
-        startDownloadLiveActivity()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -208,8 +208,7 @@ struct DownloadLiveActivity: Widget {
         .frame(width: UX.LockScreen.circleRadius, height: UX.LockScreen.circleRadius)
     }
 
-    private func leadingExpandedRegion
-    (liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>)
+    private func leadingExpandedRegion(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>)
     -> DynamicIslandExpandedRegion<some View> {
       DynamicIslandExpandedRegion(.leading) {
         ZStack {
@@ -228,8 +227,7 @@ struct DownloadLiveActivity: Widget {
                              trailing: DownloadLiveActivity.UX.DynamicIsland.iconRightPadding))
       }
     }
-    private func centerExpandedRegion
-    (liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>)
+    private func centerExpandedRegion(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>)
     -> DynamicIslandExpandedRegion<some View> {
       DynamicIslandExpandedRegion(.center) {
           Text(liveDownload.state.downloads.count == 1 ?
@@ -266,8 +264,7 @@ struct DownloadLiveActivity: Widget {
         }
       }
     }
-    private func trailingExpandedRegion
-    (liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>)
+    private func trailingExpandedRegion(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>)
     -> DynamicIslandExpandedRegion<some View> {
       let circleProgressPercentage = min(
         liveDownload.state.containsOnlyEncodedFiles ? 1.0 : liveDownload.state.totalProgress, 1.0

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -107,7 +107,7 @@ struct DownloadLiveActivity: Widget {
             static let stateIconSize: CGFloat = 24
             static let downloadingFontSize: CGFloat = 17
             static let progressFontSize: CGFloat = 15
-            static let wordsTopPadding: CGFloat = 0
+            static let wordsTopPadding: CGFloat = 4
             static let wordsLeftPadding: CGFloat = 5
             static let wordsRightPadding: CGFloat = 5
             static let wordsBottomPadding: CGFloat = 0

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -107,7 +107,8 @@ struct DownloadLiveActivity: Widget {
             static let stateIconSize: CGFloat = 24
             static let downloadingFontSize: CGFloat = 17
             static let progressFontSize: CGFloat = 15
-            static let wordsTopPadding: CGFloat = 4
+            static let wordsTopPadding: CGFloat = 0
+            static let wordsTopPaddingNoSubtitle: CGFloat = 4
             static let wordsLeftPadding: CGFloat = 5
             static let wordsRightPadding: CGFloat = 5
             static let wordsBottomPadding: CGFloat = 0
@@ -237,7 +238,9 @@ struct DownloadLiveActivity: Widget {
           .font(.headline)
           .frame(maxWidth: .infinity,
                  alignment: .leading)
-          .padding(EdgeInsets(top: DownloadLiveActivity.UX.DynamicIsland.wordsTopPadding,
+          .padding(EdgeInsets(top: liveDownload.state.containsOnlyEncodedFiles ?
+                              DownloadLiveActivity.UX.DynamicIsland.wordsTopPaddingNoSubtitle :
+                              DownloadLiveActivity.UX.DynamicIsland.wordsTopPadding,
                               leading: DownloadLiveActivity.UX.DynamicIsland.wordsLeftPadding,
                               bottom: DownloadLiveActivity.UX.DynamicIsland.wordsBottomPadding,
                               trailing: DownloadLiveActivity.UX.DynamicIsland.wordsRightPadding))

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
@@ -13,7 +13,7 @@ class DownloadLiveActivityAttributesTests: XCTestCase {
         let download2 = makeDownload(type: DownloadType.contentEncoded, isComplete: true)
         let download3 = makeDownload(type: DownloadType.nilExpectedBytes, isComplete: false)
         let download4 = makeDownload(type: DownloadType.normal, totalBytesExpected: nil, isComplete: false)
-        var contentState = DownloadLiveActivityAttributes.ContentState(
+        let contentState = DownloadLiveActivityAttributes.ContentState(
             downloads: [download1, download2, download3, download4]
         )
 
@@ -25,7 +25,7 @@ class DownloadLiveActivityAttributesTests: XCTestCase {
     func testContentStateContainsOnlyEncodedFilesProperty() {
         let download1 = makeDownload(type: DownloadType.contentEncoded, isComplete: false)
         let download2 = makeDownload(type: DownloadType.contentEncoded, isComplete: true)
-        var contentState = DownloadLiveActivityAttributes.ContentState(
+        let contentState = DownloadLiveActivityAttributes.ContentState(
             downloads: [download1, download2]
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
@@ -13,12 +13,16 @@ class DownloadLiveActivityAttributesTests: XCTestCase {
         let download2 = makeDownload(type: DownloadType.contentEncoded, isComplete: true)
         let download3 = makeDownload(type: DownloadType.nilExpectedBytes, isComplete: false)
         let download4 = makeDownload(type: DownloadType.normal, totalBytesExpected: nil, isComplete: false)
-        let contentState = DownloadLiveActivityAttributes.ContentState(
+        var contentState = DownloadLiveActivityAttributes.ContentState(
             downloads: [download1, download2, download3, download4]
         )
 
         XCTAssertEqual(contentState.completedDownloads, 2)
         XCTAssertEqual(contentState.totalDownloads, 4)
+        XCTAssertEqual(contentState.containsOnlyEncodedFiles, false)
+
+        contentState = DownloadLiveActivityAttributes.ContentState(downloads: [download2])
+        XCTAssertEqual(contentState.containsOnlyEncodedFiles, true)
     }
 
     func testGetDownloadProgress() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
@@ -22,7 +22,7 @@ class DownloadLiveActivityAttributesTests: XCTestCase {
         XCTAssertEqual(contentState.containsOnlyEncodedFiles, false)
     }
 
-    func testContainsOnlyEncodedFilesProperty() {
+    func testContentStateContainsOnlyEncodedFilesProperty() {
         let download1 = makeDownload(type: DownloadType.contentEncoded, isComplete: false)
         let download2 = makeDownload(type: DownloadType.contentEncoded, isComplete: true)
         var contentState = DownloadLiveActivityAttributes.ContentState(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
@@ -21,7 +21,7 @@ class DownloadLiveActivityAttributesTests: XCTestCase {
         XCTAssertEqual(contentState.totalDownloads, 4)
         XCTAssertEqual(contentState.containsOnlyEncodedFiles, false)
     }
-  
+
     func testContainsOnlyEncodedFilesProperty() {
         let download1 = makeDownload(type: DownloadType.contentEncoded, isComplete: false)
         let download2 = makeDownload(type: DownloadType.contentEncoded, isComplete: true)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
@@ -20,8 +20,15 @@ class DownloadLiveActivityAttributesTests: XCTestCase {
         XCTAssertEqual(contentState.completedDownloads, 2)
         XCTAssertEqual(contentState.totalDownloads, 4)
         XCTAssertEqual(contentState.containsOnlyEncodedFiles, false)
+    }
+  
+    func testContainsOnlyEncodedFilesProperty() {
+        let download1 = makeDownload(type: DownloadType.contentEncoded, isComplete: false)
+        let download2 = makeDownload(type: DownloadType.contentEncoded, isComplete: true)
+        var contentState = DownloadLiveActivityAttributes.ContentState(
+            downloads: [download1, download2]
+        )
 
-        contentState = DownloadLiveActivityAttributes.ContentState(downloads: [download2])
         XCTAssertEqual(contentState.containsOnlyEncodedFiles, true)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11192)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24375)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR updates the progress text and the circular progress bar on both the lock screen and dynamic island views to handle content-encoded files. More specifically:
| | No Content-Encoded files | Some Content-Encoded files | Only Content-Encoded files |
|--------|--------|--------|--------|
| Progress Text |Visible | Visible, progress calculated only from non-encoded files | Not visible |
| Circular Progress | Normal | Normal, progress calculated only from non-encoded files | Hard-coded to 100% |

<p align="center">
  <img src="https://github.com/user-attachments/assets/1c52a3be-cc48-4f89-bc47-d3256f736237" width="45%" />
  <img src="https://github.com/user-attachments/assets/4c0cbbdf-1aa9-4ccc-b710-8e3244a89e31" width="45%" />
</p>

<p align="center">
  <img src="https://github.com/user-attachments/assets/a2c5f472-54bf-43a4-a830-01bab6f79842" width="22%" />
  <img src="https://github.com/user-attachments/assets/7dcc394e-e588-4c8b-ac6d-4d47c1a93fc1" width="22%" />
  <img src="https://github.com/user-attachments/assets/326070f4-348b-42ea-b607-cd71ac6f21fb" width="22%" />
  <img src="https://github.com/user-attachments/assets/6ec2cf90-3030-4f40-a241-ce2c54201b20" width="22%" />
</p>

From left to right:
1. Hard-coded 100% progress bar
2. Hidden bytes progress text on iPhone 16 pro max
3. Hidden bytes progress text on iPhone 16 
4. Text with non-encoded content (unchanged, same as original design) on iPhone 16 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

