### PR TITLE
Add instruction to remove all venvs when running bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,6 +11,9 @@ if [ "$1" == "--force" ]; then
     rm -rf build
 fi
 
+# Delete all virtual envs folders.
+find . -type d -name ".venv" -exec rm -rf {} +
+
 # Download the nimbus-fml.sh script from application-services.
 NIMBUS_FML_FILE=./firefox-ios/nimbus.fml.yaml
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/mozilla/application-services/main/components/nimbus/ios/scripts/bootstrap.sh | bash -s -- --directory ./firefox-ios/bin $NIMBUS_FML_FILE


### PR DESCRIPTION
## :scroll: Tickets
~~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~~
~~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~~

## :bulb: Description
Add instruction to remove all venv folders into the project when running `bootstrap.sh`.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

