### PR TITLE
Bugfix FXIOS-11437 ⁃ Unable to select parent folder before entering a folder title when creating a folder

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -71,8 +71,7 @@ class EditFolderViewModel {
 
     private func getFolderStructure(_ selectedFolder: Folder) {
         Task { @MainActor [weak self] in
-            guard let currentGuid = self?.folder?.guid else { return }
-            let folders = await self?.folderFetcher.fetchFolders(excludedGuids: [currentGuid])
+            let folders = await self?.folderFetcher.fetchFolders(excludedGuids: [self?.folder?.guid ?? ""])
             guard let folders else { return }
             self?.folderStructures = folders
             self?.onFolderStatusUpdate?()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11437)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24901)

## :bulb: Description
Use a default guid when folder var is not initalised

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

