### PR TITLE
Bugfix DISCO-3388 Update RemoteSettingsContext construction

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -28809,7 +28809,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 138.0.20250328200527;
+				version = 139.0.20250401050332;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "4665d9f788280035787b1ea98e5f05e50fe4f016",
-        "version" : "138.0.20250328200527"
+        "revision" : "b15397c437ca2e92c0125ad62ebc9b770c188df3",
+        "version" : "139.0.20250401050332"
       }
     },
     {

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -761,7 +761,6 @@ open class BrowserProfile: Profile {
     }()
 
     private func remoteSettingsAppContext() -> RemoteSettingsContext {
-        let encoder = JSONEncoder()
         let appInfo = BrowserKitInformation.shared
         let uiDevice = UIDevice.current
         let formFactor = switch uiDevice.userInterfaceIdiom {
@@ -769,33 +768,15 @@ open class BrowserProfile: Profile {
         case .mac: "desktop"
         default: "phone"
         }
-        var customTargetingAttributes: String?
-        let customTargetingAttributesData = try? encoder.encode([
-                "formFactor": formFactor,
-                "country": Locale.current.regionCode,
-        ])
-        if let data = customTargetingAttributesData {
-            customTargetingAttributes = String(
-                decoding: data,
-                as: UTF8.self)
-        }
         return RemoteSettingsContext(
-            appName: "Firefox iOS",
-            appId: AppInfo.bundleIdentifier,
             channel: appInfo.buildChannel?.rawValue ?? "release",
             appVersion: AppInfo.appVersion,
-            appBuild: AppInfo.buildNumber,
-            architecture: nil,
-            deviceManufacturer: "Apple",
-            deviceModel: DeviceInfo.deviceModel(),
+            appId: AppInfo.bundleIdentifier,
             locale: Locale.current.identifier,
             os: "iOS",
             osVersion: uiDevice.systemVersion,
-            androidSdkVersion: nil,
-            debugTag: nil,
-            installationDate: nil,
-            homeDirectory: nil,
-            customTargetingAttributes: customTargetingAttributes)
+            formFactor: formFactor,
+            country: Locale.current.regionCode)
     }
 
     func hasAccount() -> Bool {

--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -7256,7 +7256,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 138.0.20250328200527;
+				version = 139.0.20250401050332;
 			};
 		};
 		8A0E7F2C2BA0F0E0006BC6B6 /* XCRemoteSwiftPackageReference "Fuzi" */ = {

--- a/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift",
         "state": {
           "branch": null,
-          "revision": "4665d9f788280035787b1ea98e5f05e50fe4f016",
-          "version": "138.0.20250328200527"
+          "revision": "b15397c437ca2e92c0125ad62ebc9b770c188df3",
+          "version": "139.0.20250401050332"
         }
       },
       {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/DISCO-3387)

## :bulb: Description

Update the `RemoteSettingsContext` construction based on the changes from https://github.com/mozilla/application-services/pull/6663/.  This will be needed to resolve the breaking changes from the next nightly that has that PR merged.  I think that will be tomorrow (2025-04-01) but it might be the next day.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

