### PR TITLE
Remove FXIOS-11766 [Tab tray UI experiments] Hide inactive tabs with this experiment

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -35,7 +35,7 @@ class TabDisplayView: UIView,
     }
 
     var shouldHideInactiveTabs: Bool {
-        guard !tabsState.isPrivateMode else { return true }
+        guard !tabsState.isPrivateMode && !isTabTrayUIExperimentsEnabled else { return true }
         return tabsState.inactiveTabs.isEmpty
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11766)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25665)

## :bulb: Description
Hide inactive tabs section whenever this experiment is enabled

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

