### PR TITLE
Bugfix FXIOS-11740 [Homepage] add actions to fetch recent tabs appropriately

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1015,7 +1015,14 @@ class BrowserCoordinator: BaseCoordinator,
         tabTrayCoordinator.start(with: selectedPanel)
 
         navigationController.onViewDismissed = { [weak self] in
-            self?.didDismissTabTray(from: tabTrayCoordinator)
+            guard let self else { return }
+            self.didDismissTabTray(from: tabTrayCoordinator)
+            store.dispatch(
+                TabTrayAction(
+                    windowUUID: self.windowUUID,
+                    actionType: TabTrayActionType.modalSwipedToClose
+                )
+            )
         }
 
         present(navigationController)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
@@ -26,6 +26,8 @@ class TabTrayAction: Action {
 enum  TabTrayActionType: ActionType {
     case tabTrayDidLoad
     case changePanel
+    case doneButtonTapped
+    case modalSwipedToClose
 
     // Middleware actions
     case didLoadTabTray

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -113,6 +113,11 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
         case TabTrayActionType.closePrivateTabsSettingToggled:
             preserveTabs(uuid: action.windowUUID)
+
+        // FXIOS-11740 - This is relate to homepage actions, so if we want to break up this middleware
+        // then this action should go to the homepage specific middleware.
+        case TabTrayActionType.dismissTabTray, TabTrayActionType.modalSwipedToClose, TabTrayActionType.doneButtonTapped:
+            dispatchRecentlyAccessedTabs(action: action)
         default:
             break
         }
@@ -917,7 +922,6 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
             tabManager(for: action.windowUUID).switchPrivacyMode()
         case HomepageActionType.viewWillAppear,
             JumpBackInActionType.fetchLocalTabs,
-            TabTrayActionType.dismissTabTray,
             TopTabsActionType.didTapNewTab,
             TopTabsActionType.didTapCloseTab:
             dispatchRecentlyAccessedTabs(action: action)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -641,6 +641,12 @@ class TabTrayViewController: UIViewController,
     @objc
     private func doneButtonTapped() {
         notificationCenter.post(name: .TabsTrayDidClose, withUserInfo: windowUUID.userInfo)
+        store.dispatch(
+            TabTrayAction(
+                windowUUID: windowUUID,
+                actionType: TabTrayActionType.doneButtonTapped
+            )
+        )
         delegate?.didFinish()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -113,9 +113,59 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
     func test_tabTrayDismissAction_returnsRecentTabs() throws {
         let subject = createSubject()
-        let action = JumpBackInAction(
+        let action = TabTrayAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: JumpBackInActionType.fetchLocalTabs
+            actionType: TabTrayActionType.dismissTabTray
+        )
+
+        let expectation = XCTestExpectation(description: "Recent tabs should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.tabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabManagerAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? TabManagerMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
+        XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+    }
+
+    func test_tabTrayModalSwipedToCloseAction_returnsRecentTabs() throws {
+        let subject = createSubject()
+        let action = TabTrayAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TabTrayActionType.modalSwipedToClose
+        )
+
+        let expectation = XCTestExpectation(description: "Recent tabs should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.tabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabManagerAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? TabManagerMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
+        XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+    }
+
+    func test_tabTrayDoneButtonTappedAction_returnsRecentTabs() throws {
+        let subject = createSubject()
+        let action = TabTrayAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TabTrayActionType.doneButtonTapped
         )
 
         let expectation = XCTestExpectation(description: "Recent tabs should be returned")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11740)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25601)

## :bulb: Description
Because of how we are separating actions in the middleware, the control flow was ending earlier since we have the following check. 

```
        } else if let action = action as? TabTrayAction {
            self.resolveTabTrayActions(action: action, state: state)
 ```
So I moved observing the `TabTrayAction` from homepage actions to tab tray actions section for now. The funny thing is I had tests for checking this case, but I wrote the tests with the wrong action 🤣 .

Additionally, the `dismissTabTray` action call did not get trigger in all cases such as swiping down to close or tapping on the Done button, so added these additional actions.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)