### PR TITLE
Refactor FXIOS-11782 [Tab tray UI Experiment] Disable experiment dev build

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -104,11 +104,7 @@ class ActivityStreamTest: BaseTestCase {
         waitUntilPageLoad()
         // navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.goto(TabTray)
-        if iPad() {
-            app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
-        } else {
-            app.cells.buttons[AccessibilityIdentifiers.TabTray.closeButton].firstMatch.waitAndTap()
-        }
+        app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
@@ -200,11 +196,14 @@ class ActivityStreamTest: BaseTestCase {
         waitForTabsButton()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         waitForExistence(app.cells.staticTexts[defaultTopSite["bookmarkLabel"]!])
-        let numTabsOpen = app.otherElements["Tabs Tray"].collectionViews.cells.count
+        var numTabsOpen = app.collectionViews.element(boundBy: 1).cells.count
         if iPad() {
             navigator.goto(TabTray)
+            numTabsOpen = app.otherElements["Tabs Tray"].collectionViews.cells.count
+            waitForExistence(app.otherElements["Tabs Tray"].collectionViews.cells.firstMatch)
+        } else {
+            waitForExistence(app.collectionViews.element(boundBy: 1).cells.firstMatch)
         }
-        waitForExistence(app.otherElements["Tabs Tray"].collectionViews.cells.firstMatch)
         XCTAssertEqual(numTabsOpen, 1, "New tab not open")
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -109,7 +109,18 @@ class DragAndDropTests: BaseTestCase {
                 dropOnElement: app.collectionViews.cells[secondWebsite.tabName].firstMatch
             )
             checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
-            XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+
+            if !iPad() {
+                let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
+
+                if let urlString = url.value as? String {
+                    XCTAssert(secondWebsite.url.contains(urlString), "The tab has not been dropped correctly")
+                } else {
+                    XCTFail("Failed to retrieve a valid URL string from the browser's URL bar")
+                }
+            } else {
+                XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+            }
         }
     }
 
@@ -131,7 +142,17 @@ class DragAndDropTests: BaseTestCase {
             )
             checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: homeTabName)
             // Check that focus is kept on last website open
-            XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+            if !iPad() {
+                let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
+
+                if let urlString = url.value as? String {
+                    XCTAssert(secondWebsite.url.contains(urlString), "The tab has not been dropped correctly")
+                } else {
+                    XCTFail("Failed to retrieve a valid URL string from the browser's URL bar")
+                }
+            } else {
+                XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+            }
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -875,11 +875,11 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             privateModeSelector = app.navigationBars.segmentedControls.buttons.element(boundBy: 1)
             syncModeSelector = app.navigationBars.segmentedControls.buttons.element(boundBy: 2)
         } else {
-            regularModeSelector = app
+            regularModeSelector = app.toolbars["Toolbar"]
                 .segmentedControls[AccessibilityIdentifiers.TabTray.navBarSegmentedControl].buttons.element(boundBy: 0)
-            privateModeSelector = app
+            privateModeSelector = app.toolbars["Toolbar"]
                 .segmentedControls[AccessibilityIdentifiers.TabTray.navBarSegmentedControl].buttons.element(boundBy: 1)
-            syncModeSelector = app
+            syncModeSelector = app.toolbars["Toolbar"]
                 .segmentedControls[AccessibilityIdentifiers.TabTray.navBarSegmentedControl].buttons.element(boundBy: 2)
         }
         screenState.tap(regularModeSelector, forAction: Action.ToggleRegularMode) { userState in

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -321,7 +321,7 @@ class HistoryTests: BaseTestCase {
         if isTablet {
             mozWaitForElementToExist(app.navigationBars.segmentedControls["navBarTabTray"])
         } else {
-            mozWaitForElementToExist(app.segmentedControls["navBarTabTray"])
+            mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
         }
         mozWaitForElementToExist(app.staticTexts[bookOfMozilla["title"]!])
         // userState.numTabs does not work on iOS 15
@@ -355,14 +355,14 @@ class HistoryTests: BaseTestCase {
         if isTablet {
             mozWaitForElementToExist(app.navigationBars.segmentedControls["navBarTabTray"])
         } else {
-            mozWaitForElementToExist(app.segmentedControls["navBarTabTray"])
+            mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
         }
         XCTAssertFalse(app.staticTexts[bookOfMozilla["title"]!].isHittable)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         if isTablet {
             XCTAssertTrue(app.segmentedControls.buttons["Private"].isSelected)
         } else {
-            XCTAssertTrue(app.segmentedControls["navBarTabTray"].buttons["privateModeLarge"].isSelected)
+            mozWaitForElementToExist(app.staticTexts["Private Browsing"])
         }
         mozWaitForElementToExist(app.staticTexts[bookOfMozilla["title"]!])
         XCTAssertEqual(userState.numTabs, 1)
@@ -384,11 +384,7 @@ class HistoryTests: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
         mozWaitForElementToExist(app.cells.staticTexts[webpage["label"]!])
-        if iPad() {
-            app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
-        } else {
-            app.cells.buttons[AccessibilityIdentifiers.TabTray.closeButton].firstMatch.waitAndTap()
-        }
+        app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
 
         // On private mode, the "Recently Closed Tabs List" is empty
         navigator.performAction(Action.OpenNewTabFromTabTray)
@@ -472,11 +468,7 @@ class HistoryTests: BaseTestCase {
     private func closeFirstTabByX() {
         waitForTabsButton()
         navigator.goto(TabTray)
-        if iPad() {
-            app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
-        } else {
-            app.cells.buttons[AccessibilityIdentifiers.TabTray.closeButton].firstMatch.waitAndTap()
-        }
+        app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
     }
 
     private func closeKeyboard() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -132,11 +132,10 @@ class JumpBackInTests: BaseTestCase {
         navigator.goto(TabTray)
         if isTablet {
             mozWaitForElementToExist(app.navigationBars.segmentedControls["navBarTabTray"])
-            app.cells["Example Domain"].buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
         } else {
-            mozWaitForElementToExist(app.segmentedControls["navBarTabTray"])
-            app.cells["Example Domain"].buttons[AccessibilityIdentifiers.TabTray.closeButton].waitAndTap()
+            mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
         }
+        app.cells["Example Domain"].buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
 
         // Revisit the "Jump Back In" section
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -255,15 +255,12 @@ class PrivateBrowsingTest: BaseTestCase {
         XCTAssertEqual(0, numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
         mozWaitForElementToExist(app.staticTexts["Private Browsing"])
 
-        // "Undo" toast message is displayed. Tap on "Undo" button
-        // Tab tray UI experiment doesn't have toasts notifications anymore
-        // https://github.com/mozilla-mobile/firefox-ios/issues/25343
-//        app.buttons["Undo"].waitAndTap()
-//
-//        // All the private tabs are restored
-//        navigator.goto(TabTray)
-//        numTab = app.otherElements["Tabs Tray"].cells.count
-//        XCTAssertEqual(4, numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
+        app.buttons["Undo"].waitAndTap()
+
+        // All the private tabs are restored
+        navigator.goto(TabTray)
+        numTab = app.otherElements["Tabs Tray"].cells.count
+        XCTAssertEqual(4, numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307003

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -103,11 +103,7 @@ class TabsTests: BaseTestCase {
 
         mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
         // Close the tab using 'x' button
-        if iPad() {
-            app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
-        } else {
-            app.cells.buttons[AccessibilityIdentifiers.TabTray.closeButton].firstMatch.waitAndTap()
-        }
+        app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
 
         // After removing only one tab it automatically goes to HomepanelView
         mozWaitForElementToExist(
@@ -124,7 +120,7 @@ class TabsTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306865
     // Smoketest
-    func testCloseAllTabsUndo() throws {
+    func testCloseAllTabsUndo() {
         navigator.nowAt(NewTabScreen)
         // A different tab than home is open to do the proper checks
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
@@ -146,28 +142,27 @@ class TabsTests: BaseTestCase {
         }
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
 
-        throw XCTSkip("Skipping since the tab UI experiment doesn't have this toast anymore")
-//        // Close all tabs, undo it and check that the number of tabs is correct
-//        navigator.performAction(Action.AcceptRemovingAllTabs)
-//
-//        app.otherElements.buttons.staticTexts["Undo"].waitAndTap()
-//
-//        mozWaitForElementToExist(
-//            app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
-//        )
-//        navigator.nowAt(BrowserTab)
-//        if !iPad() {
-//            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
-//        }
-//
-//        if iPad() {
-//            navigator.goto(TabTray)
-//        } else {
-//            navigator.performAction(Action.CloseURLBarOpen)
-//        }
-//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-//
-//        mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
+        // Close all tabs, undo it and check that the number of tabs is correct
+        navigator.performAction(Action.AcceptRemovingAllTabs)
+
+        app.otherElements.buttons.staticTexts["Undo"].waitAndTap()
+
+        mozWaitForElementToExist(
+            app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
+        )
+        navigator.nowAt(BrowserTab)
+        if !iPad() {
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
+        }
+
+        if iPad() {
+            navigator.goto(TabTray)
+        } else {
+            navigator.performAction(Action.CloseURLBarOpen)
+        }
+        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+
+        mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2354473
@@ -379,35 +374,34 @@ class TabsTests: BaseTestCase {
     func testTabTrayCloseMultipleTabs() {
         navigator.nowAt(NewTabScreen)
         validateToastWhenClosingMultipleTabs()
-        // Tab tray UI experiment doesn't have toasts notifications anymore
-        // https://github.com/mozilla-mobile/firefox-ios/issues/25343
         // Choose to undo the action
-//        app.buttons["Undo"].waitAndTap()
-//        waitUntilPageLoad()
-//        // Only the latest tab closed is restored
-//        navigator.nowAt(BrowserTab)
-//        waitForTabsButton()
-//        navigator.goto(TabTray)
-//        let tabsTrayCell = app.otherElements["Tabs Tray"].cells
-//        if !iPad() {
-//            let numTab = app.buttons.element(boundBy: 3).label
-//            XCTAssertEqual(Int(numTab), tabsTrayCell.count)
-//        } else {
-//            XCTAssertEqual(tabsTrayCell.count, 2)
-//            XCTAssertTrue(app.buttons.elementContainingText("2").exists)
-//        }
-//        mozWaitForElementToExist(app.otherElements.cells.staticTexts[urlLabelExample])
-//        // Repeat for private browsing mode
-//        navigator.performAction(Action.TogglePrivateMode)
-//        validateToastWhenClosingMultipleTabs()
-//        // Choose to undo the action
-//        app.buttons["Undo"].waitAndTap()
-//        // Only the latest tab closed is restored
-//        if !iPad() {
-//            let tabsTrayCell = app.otherElements["Tabs Tray"].cells
-//            XCTAssertEqual(1, tabsTrayCell.count)
-//        }
-//        mozWaitForElementToExist(app.otherElements.cells.staticTexts[urlLabelExample])
+        app.buttons["Undo"].waitAndTap()
+        waitUntilPageLoad()
+        // Only the latest tab closed is restored
+        navigator.nowAt(BrowserTab)
+        waitForTabsButton()
+        navigator.goto(TabTray)
+        let tabsTrayCell = app.otherElements["Tabs Tray"].cells
+        if !iPad() {
+            let button = AccessibilityIdentifiers.Toolbar.tabsButton
+            let numTab = app.buttons[button].value as? String
+            XCTAssertEqual(numTab, "\(tabsTrayCell.count)")
+        } else {
+            XCTAssertEqual(tabsTrayCell.count, 2)
+            XCTAssertTrue(app.buttons.elementContainingText("2").exists)
+        }
+        mozWaitForElementToExist(app.otherElements.cells.staticTexts[urlLabelExample])
+        // Repeat for private browsing mode
+        navigator.performAction(Action.TogglePrivateMode)
+        validateToastWhenClosingMultipleTabs()
+        // Choose to undo the action
+        app.buttons["Undo"].waitAndTap()
+        // Only the latest tab closed is restored
+        if !iPad() {
+            let tabsTrayCell = app.otherElements["Tabs Tray"].cells
+            XCTAssertEqual(1, tabsTrayCell.count)
+        }
+        mozWaitForElementToExist(app.otherElements.cells.staticTexts[urlLabelExample])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306867
@@ -476,27 +470,25 @@ class TabsTests: BaseTestCase {
         }
         navigator.nowAt(BrowserTab)
         navigator.goto(TabTray)
-        // Tab tray UI experiment doesn't have toasts notifications anymore
-        // https://github.com/mozilla-mobile/firefox-ios/issues/25343
         // Close multiple tabs by pressing X button
-//        let closeButton = AccessibilityIdentifiers.TabTray.closeButton
-//        for _ in 0...3 {
-//            app.collectionViews.cells["Homepage. Currently selected tab."].buttons[closeButton].waitAndTap()
-//            // A toast notification is displayed with the message "Tab Closed" and the Undo option
-//            waitForElementsToExist(
-//                [
-//                    app.buttons["Undo"],
-//                    app.staticTexts["Tab Closed"]
-//                ]
-//            )
-//        }
-//        app.collectionViews.buttons[closeButton].waitAndTap()
-//        waitForElementsToExist(
-//            [
-//                app.buttons["Undo"],
-//                app.staticTexts["Tab Closed"]
-//            ]
-//        )
+        let closeButton = StandardImageIdentifiers.Large.cross
+        for _ in 0...3 {
+            app.collectionViews.cells["Homepage. Currently selected tab."].buttons[closeButton].waitAndTap()
+            // A toast notification is displayed with the message "Tab Closed" and the Undo option
+            waitForElementsToExist(
+                [
+                    app.buttons["Undo"],
+                    app.staticTexts["Tab Closed"]
+                ]
+            )
+        }
+        app.collectionViews.buttons[closeButton].waitAndTap()
+        waitForElementsToExist(
+            [
+                app.buttons["Undo"],
+                app.staticTexts["Tab Closed"]
+            ]
+        )
     }
 
     private func addTabsAndUndoCloseTabAction(nrOfTabs: Int) {
@@ -511,7 +503,7 @@ class TabsTests: BaseTestCase {
         XCTAssertEqual("4", numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
         navigator.goto(TabTray)
         // Long press on the tab tray to open the context menu
-        // let tabsTrayCell = app.otherElements["Tabs Tray"].cells
+        let tabsTrayCell = app.otherElements["Tabs Tray"].cells
         app.otherElements["Tabs Tray"].cells.staticTexts.element(boundBy: 3).press(forDuration: 1.6)
         // Context menu opens
         waitForElementsToExist(
@@ -522,21 +514,19 @@ class TabsTests: BaseTestCase {
         )
         // Choose to close the tab
         app.buttons["Close Tab"].waitAndTap()
-        // Tab tray UI experiment doesn't have toasts notifications anymore
-        // https://github.com/mozilla-mobile/firefox-ios/issues/25343
         // A toast notification is displayed with the message "Tab Closed" and the Undo option
-//        waitForElementsToExist(
-//            [
-//                app.buttons["Undo"],
-//                app.staticTexts["Tab Closed"]
-//            ]
-//        )
-//        app.buttons["Undo"].waitAndTap()
-//        mozWaitForElementToNotExist(app.buttons["Undo"])
-//        mozWaitForElementToNotExist(app.staticTexts["Tab Closed"])
-//        // The tab closed is restored
-//        mozWaitForElementToExist(tabsTrayCell.element(boundBy: 3))
-//        XCTAssertEqual(Int(numTab!), tabsTrayCell.count)
+        waitForElementsToExist(
+            [
+                app.buttons["Undo"],
+                app.staticTexts["Tab Closed"]
+            ]
+        )
+        app.buttons["Undo"].waitAndTap()
+        mozWaitForElementToNotExist(app.buttons["Undo"])
+        mozWaitForElementToNotExist(app.staticTexts["Tab Closed"])
+        // The tab closed is restored
+        mozWaitForElementToExist(tabsTrayCell.element(boundBy: 3))
+        XCTAssertEqual(Int(numTab!), tabsTrayCell.count)
     }
 }
 

--- a/firefox-ios/nimbus-features/tabTrayUIExperiments.yaml
+++ b/firefox-ios/nimbus-features/tabTrayUIExperiments.yaml
@@ -15,5 +15,5 @@ features:
           enabled: false
       - channel: developer
         value:
-          enabled: true
+          enabled: false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11782)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25686)

## :bulb: Description
@clarmso @dragosb01 The tab tray UI experiment was enabled in developer builds around a month ago to enable UI tests for the experiment. Turns out this was a mistake and I shouldn't have enabled it in developer builds. We don't have a reliable way yet to create UI tests for experiments, but in the meantime experiments should be disabled in developer builds. I am then reverting some of the UI tests changes that were required. Sorry for the back and forth, let me know if I miss any PRs I can make the adjustements needed. Thank you!

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

