### PR TITLE
Bugfix FXIOS-9101 #20180 [UX Fundamentals] ⁃ Hit zone for the tab close button in tabs view is too small

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -19,10 +19,10 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         static let fallbackFaviconSize = CGSize(width: 24, height: 24)
         static let closeButtonSize: CGFloat = 32
         static let textBoxHeight: CGFloat = 32
-        static let closeButtonEdgeInset = NSDirectionalEdgeInsets(top: 10,
-                                                                  leading: 10,
-                                                                  bottom: 10,
-                                                                  trailing: 10)
+        static let closeButtonEdgeInset = NSDirectionalEdgeInsets(top: 12,
+                                                                  leading: 12,
+                                                                  bottom: 12,
+                                                                  trailing: 12)
         static let closeButtonTop: CGFloat = 6
         static let closeButtonTrailing: CGFloat = 8
         static let closeButtonOverlaySpacing: CGFloat = 16

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -20,11 +20,12 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         static let faviconYOffset: CGFloat = 10.0
         static let faviconSize: CGFloat = 20
         static let closeButtonSize: CGFloat = 32
-        static let textBoxHeight: CGFloat = 32
-        static let closeButtonEdgeInset = NSDirectionalEdgeInsets(top: 10,
-                                                                  leading: 10,
-                                                                  bottom: 10,
-                                                                  trailing: 10)
+        static let textBoxHeight: CGFloat = 44
+        static let closeButtonTrailing: CGFloat = 4
+        static let closeButtonEdgeInset = NSDirectionalEdgeInsets(top: 12,
+                                                                  leading: 12,
+                                                                  bottom: 12,
+                                                                  trailing: 12)
 
         // Using the same sizes for fallback favicon as the top sites on the homepage
         static let imageBackgroundSize = TopSiteItemCell.UX.imageBackgroundSize
@@ -263,7 +264,8 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
             closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
             closeButton.centerYAnchor.constraint(equalTo: headerView.contentView.centerYAnchor),
-            closeButton.trailingAnchor.constraint(equalTo: headerView.trailingAnchor),
+            closeButton.trailingAnchor.constraint(equalTo: headerView.trailingAnchor,
+                                                  constant: -UX.closeButtonTrailing),
 
             titleText.leadingAnchor.constraint(equalTo: favicon.trailingAnchor,
                                                constant: UX.subviewDefaultPadding),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9101)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20180)

## :bulb: Description
- Increase the edge inset of the close button for cells in TabTray (ExperimentTabCell and TabCell) to reach 44 pt of tap area as recommended by Apple [here](https://developer.apple.com/design/human-interface-guidelines/buttons#Best-practices)
- Adjust trailing constraint for regular tab cell adding padding 

### 📸 Screenshots
| Before | After |
| ------------- | ------------- |
| <img width="550" alt="no-experiment-before" src="https://github.com/user-attachments/assets/d6388f0b-afb2-4e45-9ae0-7480c0723f63" /> |<img width="550" alt="no-experiment-after" src="https://github.com/user-attachments/assets/2edabec3-3628-4d6a-b9ca-b71d5a2d6b1c" />  |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

