### PR TITLE
Refactor FXIOS-11737 [Tab tray UI experiment] Missing fade effect in private browsing tab tray

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -131,21 +131,9 @@ class TabDisplayPanelViewController: UIViewController,
             backgroundPrivacyOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
 
-        if isTabTrayUIExperimentsEnabled, !tabsState.isPrivateTabsEmpty, isCompactLayout {
-            gradientLayer.locations = [0.0, 0.02, 0.08, 0.12]
-            fadeView.layer.addSublayer(gradientLayer)
-            view.addSubview(fadeView)
-
-            NSLayoutConstraint.activate([
-                fadeView.topAnchor.constraint(equalTo: view.topAnchor),
-                fadeView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                fadeView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-                fadeView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-            ])
-        }
-
         backgroundPrivacyOverlay.isHidden = true
         setupEmptyView()
+        setupFadeView()
     }
 
     private func setupEmptyView() {
@@ -168,6 +156,28 @@ class TabDisplayPanelViewController: UIViewController,
     private func shouldShowEmptyView(_ shouldShowEmptyView: Bool) {
         emptyPrivateTabsView.isHidden = !shouldShowEmptyView
         tabDisplayView.isHidden = shouldShowEmptyView
+    }
+
+    private func setupFadeView() {
+        guard isTabTrayUIExperimentsEnabled, isCompactLayout else { return }
+        gradientLayer.locations = [0.0, 0.02, 0.08, 0.12]
+        fadeView.layer.addSublayer(gradientLayer)
+        view.addSubview(fadeView)
+
+        NSLayoutConstraint.activate([
+            fadeView.topAnchor.constraint(equalTo: view.topAnchor),
+            fadeView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            fadeView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            fadeView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        shouldShowFadeView()
+    }
+
+    private func shouldShowFadeView() {
+        guard isTabTrayUIExperimentsEnabled, isCompactLayout else { return }
+        let isPrivateModeFadeViewNeeded = !tabsState.tabs.isEmpty && tabsState.isPrivateMode
+        let shouldShow = !tabsState.isPrivateMode || isPrivateModeFadeViewNeeded
+        fadeView.isHidden = !shouldShow
     }
 
     private func currentTheme() -> Theme {
@@ -223,6 +233,7 @@ class TabDisplayPanelViewController: UIViewController,
         tabsState = state
         tabDisplayView.newState(state: tabsState)
         shouldShowEmptyView(tabsState.isPrivateTabsEmpty)
+        shouldShowFadeView()
     }
 
     // MARK: EmptyPrivateTabsViewDelegate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11737)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25595)

## :bulb: Description
`isPrivateTabsEmpty` was not proper at the point I was checking it, resulting in the fade view not applied in private mode.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

