### PR TITLE
Fix - MTE-4465 - testPocketEnabledByDefault test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -324,8 +324,10 @@ class CreditCardsTests: BaseTestCase {
             app.buttons[useSavedCard].waitAndTap()
             unlockLoginsView()
             mozWaitForElementToExist(app.staticTexts["Use saved card"])
-            mozWaitForElementToExist(app.scrollViews.otherElements.tables.cells["creditCardCell_2"])
-            app.scrollViews.otherElements.tables.cells["creditCardCell_2"].waitAndTap()
+            let creditCardCell2 = app.scrollViews.otherElements.tables.cells["creditCardCell_2"]
+            mozWaitForElementToExist(creditCardCell2)
+            creditCardCell2.swipeUp()
+            creditCardCell2.waitAndTap()
             validateAutofillCardInfo(cardNr: "5346755600299631", expYear: "2040", expMonth: "07", name: "Test3")
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
@@ -82,10 +82,9 @@ class PocketTests: BaseTestCase {
         scrollToElement(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.Pocket.footerLearnMoreLabel],
                         direction: SwipeDirection.up,
                         maxSwipes: MAX_SWIPE)
-        app.swipeUp()
-        scrollToElement(app.cells.staticTexts["Discover more"], direction: .left, maxSwipes: MAX_SWIPE)
+        scrollToElement(app.cells.buttons["Discover more"], direction: .left, maxSwipes: MAX_SWIPE)
 
-        app.cells.staticTexts["Discover more"].waitAndTap()
+        app.cells.buttons["Discover more"].waitAndTap()
         waitUntilPageLoad()
         mozWaitForElementToExist(url)
         XCTAssertEqual(url.value as? String, "getpocket.com", "The url textField is empty")


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4465

## :bulb: Description
"Discover more" cell from pocket changed from static text to button
Included also a fix for testVerifyThatMultipleCardsCanBeAdded to make sure we are selecting the last credit card when having multiple added.
