### PR TITLE
Fix DownloadsPanelViewModel Unit Test

### DIFF
--- a/BrowserKit/Sources/Shared/TimeConstants.swift
+++ b/BrowserKit/Sources/Shared/TimeConstants.swift
@@ -130,6 +130,9 @@ extension Date {
     public var lastHour: Date {
         return Calendar.current.date(byAdding: .hour, value: -1, to: self) ?? Date()
     }
+    public var lastTwentyFourHours: Date {
+        return Calendar.current.date(byAdding: .hour, value: -24, to: self) ?? Date()
+    }
     public var lastTwoWeek: Date {
         return Calendar.current.date(byAdding: .day, value: -14, to: noon) ?? Date()
     }
@@ -173,6 +176,11 @@ extension Date {
     /// Comparison date is used to control unit tests outcome.
     public func isWithinLastHour(comparisonDate: Date = Date()) -> Bool {
         return (comparisonDate.lastHour ... comparisonDate).contains(self)
+    }
+
+    /// Comparison date is used to control unit tests outcome.
+    public func isWithinLastTwentyFourHours(comparisonDate: Date = Date()) -> Bool {
+        return (comparisonDate.lastTwentyFourHours ... comparisonDate).contains(self)
     }
 }
 

--- a/BrowserKit/Sources/Shared/TimeConstants.swift
+++ b/BrowserKit/Sources/Shared/TimeConstants.swift
@@ -162,26 +162,6 @@ extension Date {
     public func isYesterday() -> Bool {
         return Calendar.current.isDateInYesterday(self)
     }
-
-    /// Comparison date is used to control unit tests outcome.
-    public func isWithinLast7Days(comparisonDate: Date = Date()) -> Bool {
-        return (comparisonDate.lastWeek ... comparisonDate).contains(self)
-    }
-
-    /// Comparison date is used to control unit tests outcome.
-    public func isWithinLast14Days(comparisonDate: Date = Date()) -> Bool {
-        return (comparisonDate.lastTwoWeek ... comparisonDate).contains(self)
-    }
-
-    /// Comparison date is used to control unit tests outcome.
-    public func isWithinLastHour(comparisonDate: Date = Date()) -> Bool {
-        return (comparisonDate.lastHour ... comparisonDate).contains(self)
-    }
-
-    /// Comparison date is used to control unit tests outcome.
-    public func isWithinLastTwentyFourHours(comparisonDate: Date = Date()) -> Bool {
-        return (comparisonDate.lastTwentyFourHours ... comparisonDate).contains(self)
-    }
 }
 
 let MaxTimestampAsDouble = Double(UInt64.max)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/DownloadsPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/DownloadsPanelViewModelTests.swift
@@ -111,7 +111,7 @@ class DownloadsPanelViewModelTests: XCTestCase {
         }
 
         XCTAssertEqual(downloadFile.path.absoluteString, "https://test1.file.com")
-        XCTAssertTrue(downloadFile.lastModified.isToday())
+        XCTAssertTrue(downloadFile.lastModified.isWithinLastTwentyFourHours())
     }
 
     func testGetNumberOfItems_ForLastTwentyFourHours() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/DownloadsPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/DownloadsPanelViewModelTests.swift
@@ -202,3 +202,9 @@ class MockDownloadFileFetcher: DownloadFileFetcher {
         return downloadedFile
     }
 }
+
+extension Date {
+    public func isWithinLastTwentyFourHours(comparisonDate: Date = Date()) -> Bool {
+        return (comparisonDate.lastTwentyFourHours ... comparisonDate).contains(self)
+    }
+}


### PR DESCRIPTION
## :bulb: Description
- Fixes a unit test in `DownloadsPanelViewModel` that was checking for the incorrect time frame. This unit test should have been updated with #25614

## :pencil: Checklist
You have to check all boxes before merging
- [] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

