### PR TITLE
Revert FXIOS-11556 Revert change in ActivityStreamTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -48,8 +48,8 @@ class ActivityStreamTest: BaseTestCase {
             waitForExistence(TopSiteCellgroup, timeout: TIMEOUT_LONG)
         }
         mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView])
-        // There should be 7 top sites by default
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 7)
+        // There should be 5 top sites by default
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         // Check their names so that test is added to Smoketest
         waitForElementsToExist(
             [


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11556)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

The top sites issues has been fixed. The branch from https://github.com/mozilla-mobile/firefox-ios/pull/25450 seems to be based in an older version of `main`. Reverting the workaround for `testDefaultSites()`.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

