### PR TITLE
Bugfix MTE-4466 Switching between light/dark modes in SettingsTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -425,7 +425,6 @@ class BaseTestCase: XCTestCase {
         if (app.switches["SystemThemeSwitchValue"].value as? String) == "1" {
             navigator.performAction(Action.SystemThemeSwitch)
         }
-        mozWaitElementHittable(element: app.cells.staticTexts["Dark"], timeout: TIMEOUT)
         if theme == "Dark" {
             app.cells.staticTexts["Dark"].waitAndTap()
         } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4466)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Some `SettingsTests` fails because the light/dark options may not be visible, but they can be tapped via `waitAndTap()`.
<img src="https://github.com/user-attachments/assets/3cad104d-b453-496c-90aa-24d2c68256da" width="200" />

Here's the test report:
https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests/result_1436/build/reports/index.html

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

