### PR TITLE
Bugfix FXIOS-11782 Missing experiment related image identifiers 

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
@@ -68,7 +68,7 @@ class TabCounterTests: BaseTestCase {
             XCTAssertTrue(tabsOpenTabTray.hasSuffix("2"))
 
             app.otherElements["Tabs Tray"].cells
-                .element(boundBy: 0).buttons[AccessibilityIdentifiers.TabTray.closeButton].waitAndTap()
+                .element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
         }
 
         app.otherElements["Tabs Tray"].cells.element(boundBy: 0).waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -442,7 +442,7 @@ class TabsTests: BaseTestCase {
         } else {
             // Tap "x"
             app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"]
-                .buttons[AccessibilityIdentifiers.TabTray.closeButton].waitAndTap()
+                .buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
             mozWaitForElementToNotExist(app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"])
 
             // Long press tab. Tap "Close Tab" from the context menu


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11782)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

After the experiment is disabled, the "x" button should now be `StandardImageIdentifiers.Large.cross` for iPhones. The change should've been in https://github.com/mozilla-mobile/firefox-ios/pull/25690 😄 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

