### PR TITLE
Bugfix MTE-4467 "Discover more" button

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
@@ -83,9 +83,9 @@ class PocketTests: BaseTestCase {
                         direction: SwipeDirection.up,
                         maxSwipes: MAX_SWIPE)
         app.swipeUp()
-        scrollToElement(app.cells.staticTexts["Discover more"], direction: .left, maxSwipes: MAX_SWIPE)
+        scrollToElement(app.buttons["Discover more"], direction: .left, maxSwipes: MAX_SWIPE)
 
-        app.cells.staticTexts["Discover more"].waitAndTap()
+        app.buttons["Discover more"].waitAndTap()
         waitUntilPageLoad()
         mozWaitForElementToExist(url)
         XCTAssertEqual(url.value as? String, "getpocket.com", "The url textField is empty")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4467)

## :bulb: Description
"Discover more" from Pocket is now a button not a cell.
<img src="https://github.com/user-attachments/assets/44a281ac-a931-408b-b6d7-1b82c3982164" width="200" />


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

