### PR TITLE
Remove FXIOS-11797 [Tab tray UI experiment] Scrolling on TabTraySelectorView

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -56,6 +56,7 @@ final class TabTraySelectorView: UIView,
         collectionView.decelerationRate = .fast
         collectionView.delegate = self
         collectionView.dataSource = self
+        collectionView.isScrollEnabled = false
         return collectionView
     }()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11797)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25726)

## :bulb: Description
I tried and failed to fix the issue in a reasonable amount of time, so proposing the band-aid fix to disable the scrolling on the collection view in the meantime. I noted down in the [decisions document](https://docs.google.com/document/d/1yUylBrv2XnZFpV3_0CBLH0-r4Xw4xu3kp4Wl5D_pjww/edit?tab=t.0#heading=h.nd8afq56wj29) this needs to be fixed if the experiment is successful.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

