### PR TITLE
Add FXIOS-11581 Remote Settings sync() coordination

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -96,6 +96,11 @@ public struct PrefsKeys {
         public static let showSearchSuggestions = "FirefoxSuggestShowSearchSuggestions"
     }
 
+    public struct RemoteSettings {
+        public static let lastRemoteSettingsServiceSyncTimestamp =
+        "LastRemoteSettingsServiceSyncTimestamp"
+    }
+
     public struct Sync {
         public static let numberOfSyncedDevices = "numberOfSyncedDevicesKey"
         public static let signedInFxaAccount = "signedInFxaAccountKey"

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -133,6 +133,10 @@
 		15DE98FD27FCED4F00F1ECDB /* RustRemoteTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DE98FC27FCED4F00F1ECDB /* RustRemoteTabs.swift */; };
 		1BE7A4902C636AC800460798 /* URLSession+sharedMPTCP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE7A48F2C636AC800460798 /* URLSession+sharedMPTCP.swift */; };
 		1BE7A4922C636AEA00460798 /* URLSessionConfiguration+defaultMPTCP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE7A4912C636AEA00460798 /* URLSessionConfiguration+defaultMPTCP.swift */; };
+		1D05C9832D9CCF720081540C /* RemoteSettingsServiceSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D05C9822D9CCF690081540C /* RemoteSettingsServiceSyncCoordinator.swift */; };
+		1D05C9842D9CD2080081540C /* RemoteSettingsServiceSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D05C9822D9CCF690081540C /* RemoteSettingsServiceSyncCoordinator.swift */; };
+		1D05C9852D9CD2080081540C /* RemoteSettingsServiceSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D05C9822D9CCF690081540C /* RemoteSettingsServiceSyncCoordinator.swift */; };
+		1D05C9862D9CD20F0081540C /* RemoteSettingsServiceSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D05C9822D9CCF690081540C /* RemoteSettingsServiceSyncCoordinator.swift */; };
 		1D06AE6624FEE4D5000B092B /* TopSitesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D06AE6524FEE4D5000B092B /* TopSitesProvider.swift */; };
 		1D06AE6A24FEE8D6000B092B /* TabProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D06AE6924FEE8D6000B092B /* TabProvider.swift */; };
 		1D0BA05C24F46A0400D731B5 /* TopSitesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0BA05B24F46A0400D731B5 /* TopSitesProvider.swift */; };
@@ -1408,7 +1412,6 @@
 		C706CBEF2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C706CBEE2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift */; };
 		C787D8C32C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */; };
 		C7CDBEFD2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CDBEFC2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift */; };
-		C7F051502D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F0514F2D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift */; };
 		C7F051522D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */; };
 		C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80685D026A0C93900DCD895 /* UserResearch.swift */; };
 		C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */; };
@@ -2682,6 +2685,7 @@
 		1CC941B9B66D41C29A97783E /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		1CCD466289861742D68C9CA6 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/ErrorPages.strings"; sourceTree = "<group>"; };
 		1CDB4EDFA0D3B346BC539F73 /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		1D05C9822D9CCF690081540C /* RemoteSettingsServiceSyncCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSettingsServiceSyncCoordinator.swift; sourceTree = "<group>"; };
 		1D06AE6524FEE4D5000B092B /* TopSitesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesProvider.swift; sourceTree = "<group>"; };
 		1D06AE6924FEE8D6000B092B /* TabProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabProvider.swift; sourceTree = "<group>"; };
 		1D0BA05B24F46A0400D731B5 /* TopSitesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesProvider.swift; sourceTree = "<group>"; };
@@ -7614,7 +7618,6 @@
 		5A81C5DC2A4C981A00BE88C2 /* PasswordManagerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordManagerCoordinatorTests.swift; sourceTree = "<group>"; };
 		5A96FB592D94356C00917B12 /* ScreenshotSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSetting.swift; sourceTree = "<group>"; };
 		5A96FB5D2D9447E600917B12 /* FirefoxStaging.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FirefoxStaging.xcconfig; path = Configuration/FirefoxStaging.xcconfig; sourceTree = "<group>"; };
-		5A96FB5D2D9447E600917B12 /* FirefoxStaging.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FirefoxStaging.xcconfig; path = Configuration/FirefoxStaging.xcconfig; sourceTree = "<group>"; };
 		5A96FB5E2D96DA9700917B12 /* TabTraySelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTraySelectorView.swift; sourceTree = "<group>"; };
 		5A96FB612D97075F00917B12 /* CenterSnappingFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSnappingFlowLayout.swift; sourceTree = "<group>"; };
 		5A96FB632D97077C00917B12 /* TabTraySelectorCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTraySelectorCell.swift; sourceTree = "<group>"; };
@@ -10854,6 +10857,7 @@
 		1DCEC3EF2D5C1BA700129966 /* Application Services */ = {
 			isa = PBXGroup;
 			children = (
+				1D05C9822D9CCF690081540C /* RemoteSettingsServiceSyncCoordinator.swift */,
 				1DCEC40F2D822F1500129966 /* ASRemoteSettingsCollection.swift */,
 				1DCEC3F12D5D1FDD00129966 /* ASSearchEngineSelector.swift */,
 				1DCEC3F32D600ADC00129966 /* ASSearchEngineProvider.swift */,
@@ -16956,6 +16960,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1D05C9842D9CD2080081540C /* RemoteSettingsServiceSyncCoordinator.swift in Sources */,
 				397848DE1ED86605004C0C0B /* NotificationService.swift in Sources */,
 				F8B710A12ABE38980029726E /* RustErrors.swift in Sources */,
 				45355B232A269E7100B1EA8E /* Autopush.swift in Sources */,
@@ -17139,6 +17144,7 @@
 			files = (
 				8AB8574227D963290075C173 /* UIConstants.swift in Sources */,
 				6025B10C267B6BEA00F59F6B /* LoginRecordExtension.swift in Sources */,
+				1D05C9862D9CD20F0081540C /* RemoteSettingsServiceSyncCoordinator.swift in Sources */,
 				F8A0B08529AD647B0091C75B /* RustSyncManager.swift in Sources */,
 				C8CE38BB265E71FE0009B09E /* ItemListCell.swift in Sources */,
 				F8324A0A2649A188007E4BFA /* CredentialProviderViewController.swift in Sources */,
@@ -17720,6 +17726,7 @@
 				D51EA5CF26406D8300334331 /* ExperimentsViewController.swift in Sources */,
 				ED7A08DB2CF674730035EC8F /* ShareMessage.swift in Sources */,
 				8CA4E80D2D22C066007207C1 /* GleanUsageReporting.swift in Sources */,
+				1D05C9832D9CCF720081540C /* RemoteSettingsServiceSyncCoordinator.swift in Sources */,
 				1DFE57FB27B2CB870025DE58 /* HighlightItem.swift in Sources */,
 				CA77ABFD24773C92005079F9 /* BreachAlertsManager.swift in Sources */,
 				8AB8572727D93AEC0075C173 /* TopSiteHistoryManager.swift in Sources */,
@@ -18629,6 +18636,7 @@
 				EB6E0C60207E6C3100FBFF7E /* SendToDevice.swift in Sources */,
 				D3C744CF1A687D6C004CE85D /* URIFixup.swift in Sources */,
 				EB94075320850C9F00702E05 /* photon-colors.swift in Sources */,
+				1D05C9852D9CD2080081540C /* RemoteSettingsServiceSyncCoordinator.swift in Sources */,
 				210E0EB9298D9D4B00BB4F33 /* DefaultSearchEngineProvider.swift in Sources */,
 				D38B2D8C1A8D98D90040E6B5 /* OpenSearchParser.swift in Sources */,
 				D04CD74D216CF86F004FF5B0 /* DevicePickerViewController.swift in Sources */,

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsServiceSyncCoordinator.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsServiceSyncCoordinator.swift
@@ -42,7 +42,7 @@ final class RemoteSettingsServiceSyncCoordinator {
     // MARK: - Private API
 
     private func syncIfNeeded() {
-        let lastSync = (prefs.objectForKey(prefsKey) as Any? as? Date) ?? Date.distantPast
+        let lastSync = prefs.objectForKey(prefsKey) as Date? ?? .distantPast
         let timeSince = lastSync.timeIntervalSinceNow
         if timeSince <= -maxSyncFrequency {
             // Persist our sync time. Note that this will persist the timestamp

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsServiceSyncCoordinator.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsServiceSyncCoordinator.swift
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import MozillaAppServices
+import Shared
+import Common
+
+final class RemoteSettingsServiceSyncCoordinator {
+    private weak var service: RemoteSettingsService?
+    private let prefs: Prefs
+    private let prefsKey = PrefsKeys.RemoteSettings.lastRemoteSettingsServiceSyncTimestamp
+    private let logger: Logger
+    private var syncTimer: Timer?
+    private let maxSyncFrequency: Double = 60 * 60 * 24 // 24 hours
+
+    init(service: RemoteSettingsService,
+         prefs: Prefs,
+         logger: Logger = DefaultLogger.shared) {
+        self.service = service
+        self.prefs = prefs
+        self.logger = logger
+        NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            guard let self else { return }
+            // Don't perform sync immediately upon becoming active, give the app
+            // some time to allow any other work or threads to take priority
+            syncTimer?.invalidate()
+            syncTimer = Timer.scheduledTimer(
+                withTimeInterval: 5.0,
+                repeats: false
+            ) { [weak self] _ in
+                self?.syncIfNeeded()
+                self?.syncTimer = nil
+            }
+        }
+    }
+
+    // MARK: - Private API
+
+    private func syncIfNeeded() {
+        let lastSync = (prefs.objectForKey(prefsKey) as Any? as? Date) ?? Date.distantPast
+        let timeSince = lastSync.timeIntervalSinceNow
+        if timeSince <= -maxSyncFrequency {
+            guard let service else {
+                logger.log(
+                    "Remote Settings needs sync but service instance is nil.",
+                    level: .warning,
+                    category: .remoteSettings
+                )
+                return
+            }
+            do {
+                let syncResults = try service.sync()
+                updateLastSyncTime()
+                logger.log(
+                    "Remote Settings Service sync'd: \(syncResults)",
+                    level: .info,
+                    category: .remoteSettings
+                )
+            } catch {
+                logger.log(
+                    "Remote Settings sync error: \(error)",
+                    level: .warning,
+                    category: .remoteSettings
+                )
+            }
+        }
+    }
+
+    private func updateLastSyncTime() {
+        prefs.setObject(Date(), forKey: prefsKey)
+    }
+}

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -725,10 +725,9 @@ open class BrowserProfile: Profile {
                 try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
             }
             let service = try RemoteSettingsService(storageDir: path, config: config)
-            serviceSyncCoordinator = RemoteSettingsServiceSyncCoordinator(
-                service: service,
-                prefs: prefs
-            )
+            #if !MOZ_TARGET_NOTIFICATIONSERVICE && !MOZ_TARGET_SHARETO && !MOZ_TARGET_CREDENTIAL_PROVIDER
+            serviceSyncCoordinator = RemoteSettingsServiceSyncCoordinator(service: service, prefs: prefs)
+            #endif
             return service
         } catch {
             logger.log("Failed to instantiate RemoteSettingsService",

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -724,7 +724,12 @@ open class BrowserProfile: Profile {
             if !FileManager.default.fileExists(atPath: path) {
                 try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
             }
-            return try RemoteSettingsService(storageDir: path, config: config)
+            let service = try RemoteSettingsService(storageDir: path, config: config)
+            serviceSyncCoordinator = RemoteSettingsServiceSyncCoordinator(
+                service: service,
+                prefs: prefs
+            )
+            return service
         } catch {
             logger.log("Failed to instantiate RemoteSettingsService",
                        level: .fatal,
@@ -732,6 +737,8 @@ open class BrowserProfile: Profile {
             return nil
         }
     }()
+
+    private var serviceSyncCoordinator: RemoteSettingsServiceSyncCoordinator?
 
     lazy var firefoxSuggest: RustFirefoxSuggestProtocol? = {
         do {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11581)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25215)

## :bulb: Description

Initial work to provide a unified coordinator for syncing our remote settings service. This is currently based off early feedback from the App Services team for Search Consolidation but will also impact any other clients that are created using the shared service on our `Profile.`. ([Example discussion, also see other threads in this channel](https://mozilla.slack.com/archives/C05VCNPLFFT/p1742592274052339))

## Results

```
2025-04-01 19:33:00.394 💙 INFO [remoteSettings] RemoteSettingsServiceSyncCoordinator - Remote Settings Service sync'd: ["fakespot-suggest-products", "quicksuggest-amp", "quicksuggest-other"]
```

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

