### PR TITLE
Bugfix FXIOS-11753 ⁃ TOS incorrect padding for learn more button

### DIFF
--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedLearnMoreTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedLearnMoreTableViewCell.swift
@@ -11,8 +11,6 @@ class ThemedLearnMoreTableViewCell: ThemedTableViewCell {
         static let horizontalMargin: CGFloat = 15
         static let verticalMargin: CGFloat = 10
         static let labelsSpacing: CGFloat = 3
-        static let negativeLabelsSpacing: CGFloat = -5
-        static let minimumHeight: CGFloat = 44
         static let learnMoreInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
     }
 
@@ -87,8 +85,7 @@ class ThemedLearnMoreTableViewCell: ThemedTableViewCell {
             learnMoreButton.topAnchor.constraint(equalTo: labelsStackView.bottomAnchor, constant: UX.labelsSpacing),
             learnMoreButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: UX.horizontalMargin),
             bottomConstraint,
-            learnMoreButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.horizontalMargin),
-            learnMoreButton.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.minimumHeight)
+            learnMoreButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.horizontalMargin)
         ])
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11753)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25637)

## :bulb: Description
Removed the minimum 44pt for Learn More button

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

