### PR TITLE
Bugfix FXIOS-11808 [Blueprint Download Manager] - Remove Motion Blur When Progress is Updated

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -42,6 +42,7 @@ extension BrowserViewController: DownloadQueueDelegate {
            featureFlags.isFeatureEnabled(.downloadLiveActivities, checking: .buildOnly),
             let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
             downloadLiveActivityWrapper.end(durationToDismissal: .none)
+            self.downloadLiveActivityWrapper = nil
         }
         self.downloadProgressManager = nil
 

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -167,6 +167,7 @@ struct DownloadLiveActivity: Widget {
                     Text(subtitle).font(.system(size: UX.LockScreen.subtitleFont))
                         .opacity(0.8)
                         .foregroundColor(UX.LockScreen.labelColor)
+                        .contentTransition(.identity)
                 }
                 Spacer()
                 ZStack {
@@ -239,6 +240,7 @@ struct DownloadLiveActivity: Widget {
                               leading: DownloadLiveActivity.UX.DynamicIsland.wordsLeftPadding,
                               bottom: DownloadLiveActivity.UX.DynamicIsland.wordsBottomPadding,
                               trailing: DownloadLiveActivity.UX.DynamicIsland.wordsRightPadding))
+          .contentTransition(.identity)
       }
     }
     private func trailingExpandedRegion


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11808)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25752)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Removed motion blur that would happen for state transitions related to the download progress.
<details>
<summary>Blur Before</summary>

https://github.com/user-attachments/assets/86aa4b81-0f21-4c65-aee5-c1a1ce1fa974

</details>

<details>
<summary>Blur After</summary>

https://github.com/user-attachments/assets/8cbc0991-d0c5-4ccf-bd0e-6983298dcba6

</details>

Note: Actually testing this pr might be tricky since updating hasn't been merged in yet (#25306). If you want to test it out yourself change the state of `DownloadLiveActivityWrapper.swift` to https://pastebin.com/FqMC34r3


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

