### PR TITLE
Bugfix FIXIOS-11813 [Tab Tray Experiments] Fix tab selector starting on tabs every time

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -6,7 +6,7 @@ import UIKit
 import Common
 
 protocol TabTraySelectorDelegate: AnyObject {
-    func didSelectSection(section: Int)
+    func didSelectSection(panelType: TabTrayPanelType)
 }
 
 // MARK: - UX Constants
@@ -31,7 +31,7 @@ final class TabTraySelectorView: UIView,
     weak var delegate: TabTraySelectorDelegate?
 
     private let windowUUID: WindowUUID
-    private var selectedIndex = 1
+    var selectedIndex: Int
 
     var items: [String] = [] {
         didSet {
@@ -61,9 +61,11 @@ final class TabTraySelectorView: UIView,
     }()
 
     // MARK: - Init
-    init(windowUUID: WindowUUID,
+    init(selectedIndex: Int,
+         windowUUID: WindowUUID,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationCenter = NotificationCenter.default) {
+        self.selectedIndex = selectedIndex
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
@@ -152,7 +154,16 @@ final class TabTraySelectorView: UIView,
         selectedIndex = newIndex
         collectionView.reloadData()
         scrollToItem(at: selectedIndex, animated: true)
-        delegate?.didSelectSection(section: newIndex)
+
+        var panelType: TabTrayPanelType = .tabs
+        if selectedIndex == 0 {
+            panelType = .privateTabs
+        } else if selectedIndex == 1 {
+            panelType = .tabs
+        } else if selectedIndex == 2 {
+            panelType = .syncedTabs
+        }
+        delegate?.didSelectSection(panelType: panelType)
     }
 
     // MARK: - Theamable

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -31,7 +31,7 @@ final class TabTraySelectorView: UIView,
     weak var delegate: TabTraySelectorDelegate?
 
     private let windowUUID: WindowUUID
-    var selectedIndex: Int
+    private var selectedIndex: Int
 
     var items: [String] = [] {
         didSet {
@@ -166,7 +166,7 @@ final class TabTraySelectorView: UIView,
         delegate?.didSelectSection(panelType: panelType)
     }
 
-    // MARK: - Theamable
+    // MARK: - Themeable
 
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -106,13 +106,25 @@ class TabTrayViewController: UIViewController,
     }()
 
     private lazy var experimentSegmentControl: TabTraySelectorView = {
-        let selector = TabTraySelectorView(windowUUID: windowUUID)
+        // Temporary offset of numbers to account for the different order in the experiment
+        // Order can be updated in TabTrayPanelType once the experiment is done
+        var selectedIndex = 0
+        switch tabTrayState.selectedPanel {
+        case .privateTabs:
+            selectedIndex = 0
+        case .tabs:
+            selectedIndex = 1
+        case .syncedTabs:
+            selectedIndex = 2
+        }
+
+        let selector = TabTraySelectorView(selectedIndex: selectedIndex, windowUUID: windowUUID)
         selector.delegate = self
         selector.items = [TabTrayPanelType.privateTabs.label,
                           TabTrayPanelType.tabs.label,
                           TabTrayPanelType.syncedTabs.label]
 
-        didSelectSection(section: 1)
+        didSelectSection(panelType: tabTrayState.selectedPanel)
         return selector
     }()
 
@@ -682,15 +694,8 @@ class TabTrayViewController: UIViewController,
 
     // MARK: - TabTraySelectorDelegate
 
-    func didSelectSection(section: Int) {
-        // Temporary offset of numbers to account for the different order in the experiment
-        // Order can be updated in TabTrayPanelType once the experiment is done
-        var newSection = section
-        if section == 0 { newSection = 1 } else
-        if section == 1 { newSection = 0 }
-
-        guard let panelType = TabTrayPanelType(rawValue: newSection),
-              tabTrayState.selectedPanel != panelType else { return }
+    func didSelectSection(panelType: TabTrayPanelType) {
+        guard tabTrayState.selectedPanel != panelType else { return }
 
         setupOpenPanel(panelType: panelType)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11813)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25760)

## :bulb: Description
When the tab tray was opened it would always default to being in the tabs section, even if they user was currently on private. This fix addresses that.

## Before
https://github.com/user-attachments/assets/c355ab04-e521-404f-a90e-bb226d0fe2cc

## After
https://github.com/user-attachments/assets/59d9d93c-ea51-45ee-ab9d-d0abb8f96c25

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

