### PR TITLE
Refactor FXIOS-11818 [New Toolbar experiment] [iPad] Menu Button and Tab Tray Button Positions Should Be Interchanged

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -998,10 +998,17 @@ struct AddressBarState: StateType, Equatable {
         let menuIcon = layout == .version1 ? StandardImageIdentifiers.Large.moreHorizontalRound
                                            : StandardImageIdentifiers.Large.appMenu
 
-        actions.append(contentsOf: [
-            tabsAction(numberOfTabs: numberOfTabs, isPrivateMode: toolbarState.isPrivateMode),
-            menuAction(iconName: menuIcon, showWarningBadge: showWarningBadge)
-        ])
+        if layout == .version1 {
+            actions.append(contentsOf: [
+                menuAction(iconName: menuIcon, showWarningBadge: showWarningBadge),
+                tabsAction(numberOfTabs: numberOfTabs, isPrivateMode: toolbarState.isPrivateMode)
+            ])
+        } else {
+            actions.append(contentsOf: [
+                tabsAction(numberOfTabs: numberOfTabs, isPrivateMode: toolbarState.isPrivateMode),
+                menuAction(iconName: menuIcon, showWarningBadge: showWarningBadge)
+            ])
+        }
 
         return actions
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11818)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25772)

## :bulb: Description
Changes the position of the menu and tabs button for the experiment on iPad.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

