### PR TITLE
Refactor FXIOS-11810 Put testDeleteAddress back to smoketest1

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
@@ -61,7 +61,6 @@
         "AddressesTests\/testAutofillAddressesByTapingPhoneField()",
         "AddressesTests\/testAutofillAddressesByTapingPostalCodeField()",
         "AddressesTests\/testAutofillAddressesByTapingStateField()",
-        "AddressesTests\/testDeleteAddress()",
         "AddressesTests\/testDeleteAllAddresses()",
         "AddressesTests\/testRedirectToSettingsByTappingManageAddresses()",
         "AddressesTests\/testToggleAddressOnOff()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
@@ -567,11 +567,7 @@ class AddressesTests: BaseTestCase {
     }
 
     private func reachEditAndRemoveAddress() {
-        if iPad() {
-            app.collectionViews.buttons.element(boundBy: 0).tapWithRetry()
-        } else {
-            app.collectionViews.buttons.element(boundBy: 1).tapWithRetry()
-        }
+        app.collectionViews.cells.buttons.staticTexts.firstMatch.tapWithRetry()
         // Update the all addresses fields
         tapEdit()
         // Remove address


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11810)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Let's put `testDeleteAddress()` back to smoketest1. https://github.com/mozilla-mobile/firefox-ios/pull/25756 failed smoketest initially for an unrelated change. AddressTests have been updated a few days ago. Let's see if the test still fails on Bitrise. @cyndichin 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

