### PR TITLE
Add FXIOS-11798 Web view context menu telemetry

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1406,6 +1406,7 @@
 		C787D8C32C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */; };
 		C7CDBEFD2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CDBEFC2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift */; };
 		C7F051522D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */; };
+		C7F051562D9EF87D00EC52C0 /* ContextMenuTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */; };
 		C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80685D026A0C93900DCD895 /* UserResearch.swift */; };
 		C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */; };
 		C80C11EE28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80C11ED28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift */; };
@@ -9166,6 +9167,7 @@
 		C7DB49358A6A84AA7391EEE6 /* ta */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ta; path = ta.lproj/Intro.strings; sourceTree = "<group>"; };
 		C7F0514F2D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDeletionUtilityTelemetryTests.swift; sourceTree = "<group>"; };
 		C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDeletionUtilityTelemetry.swift; sourceTree = "<group>"; };
+		C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetry.swift; sourceTree = "<group>"; };
 		C80685D026A0C93900DCD895 /* UserResearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResearch.swift; sourceTree = "<group>"; };
 		C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagManagerTests.swift; sourceTree = "<group>"; };
 		C80C11ED28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMetadataTrackerTests.swift; sourceTree = "<group>"; };
@@ -14923,6 +14925,7 @@
 				8A359EF42A1FD4CF004A5BB7 /* Wrapper */,
 				613489A22D942A020009AF01 /* ToastTelemetry.swift */,
 				C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */,
+				C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -17373,6 +17376,7 @@
 				C8610DAA2A0EBF7100B79FF1 /* OnboardingCardDelegate.swift in Sources */,
 				3BB50E111D6274CD004B33DF /* TopSiteItemCell.swift in Sources */,
 				C7CDBEFD2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift in Sources */,
+				C7F051562D9EF87D00EC52C0 /* ContextMenuTelemetry.swift in Sources */,
 				0E4AF8652D764046002E4238 /* DownloadProgressManager.swift in Sources */,
 				819656192C80ECFE00E62323 /* MainMenuMiddleware.swift in Sources */,
 				E127313D28B6AD99006F39D2 /* WallpaperSettingsViewModel.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -718,7 +718,7 @@
 		78F28FC02CB81FDF00DA862E /* InactiveTabsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F28FBF2CB81FDF00DA862E /* InactiveTabsTest.swift */; };
 		78FE1E892B040E7000338465 /* FirefoxSuggestTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78FE1E872B040E7000338465 /* FirefoxSuggestTest.swift */; };
 		7AC7E0502C160FF800051D4D /* ReaderPanelEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC7E04F2C160FF800051D4D /* ReaderPanelEmptyStateView.swift */; };
-		7ADC1D192C27D35B003ED924 /* ActionProviderBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADC1D182C27D35B003ED924 /* ActionProviderBuilder.swift */; };
+		7ADC1D192C27D35B003ED924 /* WebContextMenuActionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADC1D182C27D35B003ED924 /* WebContextMenuActionsProvider.swift */; };
 		7B2142FE1E5E055000CDD3FC /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7B2142FC1E5E055000CDD3FC /* InfoPlist.strings */; };
 		7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */; };
 		7B8A47F61D01D3B400C07734 /* PassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B8A47F51D01D3B400C07734 /* PassKit.framework */; };
@@ -7907,7 +7907,7 @@
 		7AC7E04F2C160FF800051D4D /* ReaderPanelEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPanelEmptyStateView.swift; sourceTree = "<group>"; };
 		7ACC4EB59896863B677D102A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		7AD14377A3F3B824C049E709 /* ta */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ta; path = ta.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
-		7ADC1D182C27D35B003ED924 /* ActionProviderBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionProviderBuilder.swift; sourceTree = "<group>"; };
+		7ADC1D182C27D35B003ED924 /* WebContextMenuActionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContextMenuActionsProvider.swift; sourceTree = "<group>"; };
 		7AEF4108BAAE5BBD5949E64C /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/FindInPage.strings"; sourceTree = "<group>"; };
 		7B0A456E95C86CC158227349 /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		7B0B49C7B69DC54BC3CA5972 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ErrorPages.strings; sourceTree = "<group>"; };
@@ -11712,7 +11712,7 @@
 			isa = PBXGroup;
 			children = (
 				5A2918CA2B522338002B197E /* GeneralBrowserAction.swift */,
-				7ADC1D182C27D35B003ED924 /* ActionProviderBuilder.swift */,
+				7ADC1D182C27D35B003ED924 /* WebContextMenuActionsProvider.swift */,
 				8A8D277C2CC000BE0076AD3A /* NavigationBrowserAction.swift */,
 			);
 			path = Actions;
@@ -18063,7 +18063,7 @@
 				4393932029AC6CE900DC5A85 /* EnvironmentValues+Extension.swift in Sources */,
 				ABEF80D12A24D2BE003F52C4 /* CreditCardBottomSheetViewModel.swift in Sources */,
 				21AFCFF02AE80D370027E9CE /* RemoteTabsCoordinator.swift in Sources */,
-				7ADC1D192C27D35B003ED924 /* ActionProviderBuilder.swift in Sources */,
+				7ADC1D192C27D35B003ED924 /* WebContextMenuActionsProvider.swift in Sources */,
 				43162A2F2492DB7800F91658 /* EmptyPrivateTabsView.swift in Sources */,
 				E1380B8D2AEA897C00630AFA /* SidebarEnabledView.swift in Sources */,
 				9636D92E27F9E5D900771F5E /* GleanPlumbMessage.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1407,6 +1407,7 @@
 		C7CDBEFD2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CDBEFC2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift */; };
 		C7F051522D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */; };
 		C7F051562D9EF87D00EC52C0 /* ContextMenuTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */; };
+		C7F051582D9F098200EC52C0 /* ContextMenuTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */; };
 		C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80685D026A0C93900DCD895 /* UserResearch.swift */; };
 		C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */; };
 		C80C11EE28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80C11ED28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift */; };
@@ -9168,6 +9169,7 @@
 		C7F0514F2D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDeletionUtilityTelemetryTests.swift; sourceTree = "<group>"; };
 		C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDeletionUtilityTelemetry.swift; sourceTree = "<group>"; };
 		C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetry.swift; sourceTree = "<group>"; };
+		C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetryTests.swift; sourceTree = "<group>"; };
 		C80685D026A0C93900DCD895 /* UserResearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResearch.swift; sourceTree = "<group>"; };
 		C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagManagerTests.swift; sourceTree = "<group>"; };
 		C80C11ED28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMetadataTrackerTests.swift; sourceTree = "<group>"; };
@@ -12840,6 +12842,7 @@
 				0A686B3B2CDB70DC0090E146 /* MainMenuTelemetryTests.swift */,
 				613489A42D9443610009AF01 /* ToastTelemetryTests.swift */,
 				C7F0514F2D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift */,
+				C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -18236,6 +18239,7 @@
 				03CCC9181AF05E7300DBF30D /* RelativeDatesTests.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
 				81DAB2F12C88F02500F4BE98 /* MainMenuViewControllerTests.swift in Sources */,
+				C7F051582D9F098200EC52C0 /* ContextMenuTelemetryTests.swift in Sources */,
 				219935F12B07DFA200E5966F /* TabDisplayPanelTests.swift in Sources */,
 				0B7B053D2D647D00007FD7AC /* TemporaryDocumentTests.swift in Sources */,
 				E16941B42C4E4A2E00FF5F4E /* BrowserViewControllerStateTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -8,7 +8,7 @@ import Photos
 import Shared
 import Storage
 
-class ActionProviderBuilder {
+class WebContextMenuActionsProvider {
     private var actions = [UIAction]()
     private var taskId = UIBackgroundTaskIdentifier(rawValue: 0)
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -24,6 +24,7 @@ class WebContextMenuActionsProvider {
                 identifier: UIAction.Identifier(rawValue: "linkContextMenu.openInNewTab")
             ) { _ in
                 addTab(url, false, currentTab)
+                ContextMenuTelemetry().optionSelected(option: .openInNewTab, origin: .webLink)
             })
     }
 
@@ -35,6 +36,7 @@ class WebContextMenuActionsProvider {
                 identifier: UIAction.Identifier("linkContextMenu.openInNewPrivateTab")
             ) { _ in
                 addTab(url, true, currentTab)
+                ContextMenuTelemetry().optionSelected(option: .openInNewPrivateTab, origin: .webLink)
             })
     }
 
@@ -46,8 +48,8 @@ class WebContextMenuActionsProvider {
                 identifier: UIAction.Identifier("linkContextMenu.bookmarkLink")
             ) { _ in
                 addBookmark(url.absoluteString, title, nil)
-                let bookmarksTelemetry = BookmarksTelemetry()
-                bookmarksTelemetry.addBookmark(eventLabel: .pageActionMenu)
+                ContextMenuTelemetry().optionSelected(option: .bookmarkLink, origin: .webLink)
+                BookmarksTelemetry().addBookmark(eventLabel: .pageActionMenu)
             }
         )
     }
@@ -67,8 +69,8 @@ class WebContextMenuActionsProvider {
                 identifier: UIAction.Identifier("linkContextMenu.removeBookmarkLink")
             ) { _ in
                 removeBookmark(urlString, title, nil)
-                let bookmarksTelemetry = BookmarksTelemetry()
-                bookmarksTelemetry.deleteBookmark(eventLabel: .pageActionMenu)
+                ContextMenuTelemetry().optionSelected(option: .removeBookmark, origin: .webLink)
+                BookmarksTelemetry().deleteBookmark(eventLabel: .pageActionMenu)
             }
         )
     }
@@ -89,6 +91,7 @@ class WebContextMenuActionsProvider {
                 assignWebView(currentTab.webView)
                 let request = URLRequest(url: url)
                 currentTab.webView?.load(request)
+                ContextMenuTelemetry().optionSelected(option: .downloadLink, origin: .webLink)
             }
         })
     }
@@ -100,6 +103,7 @@ class WebContextMenuActionsProvider {
             identifier: UIAction.Identifier("linkContextMenu.copyLink")
         ) { _ in
             UIPasteboard.general.url = url
+            ContextMenuTelemetry().optionSelected(option: .copyLink, origin: .webLink)
         })
     }
 
@@ -130,6 +134,7 @@ class WebContextMenuActionsProvider {
                 toastContainer: contentContainer,
                 popoverArrowDirection: .unknown
             )
+            ContextMenuTelemetry().optionSelected(option: .shareLink, origin: .webLink)
         })
     }
 
@@ -151,6 +156,7 @@ class WebContextMenuActionsProvider {
                     writeToPhotoAlbum(image)
                 }
             }
+            ContextMenuTelemetry().optionSelected(option: .saveImage, origin: .webLink)
         })
     }
 
@@ -189,6 +195,7 @@ class WebContextMenuActionsProvider {
 
                 application.endBackgroundTask(self.taskId)
             }.resume()
+            ContextMenuTelemetry().optionSelected(option: .copyImage, origin: .webLink)
         })
     }
 
@@ -198,6 +205,7 @@ class WebContextMenuActionsProvider {
             identifier: UIAction.Identifier("linkContextMenu.copyImageLink")
         ) { _ in
             UIPasteboard.general.url = url as URL
+            ContextMenuTelemetry().optionSelected(option: .copyImageLink, origin: .webLink)
         })
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -222,6 +222,6 @@ class WebContextMenuActionsProvider {
     private func recordOptionSelectedTelemetry(option: ContextMenuTelemetry.OptionExtra) {
         let originExtra = menuType == .image ? ContextMenuTelemetry.OriginExtra.imageLink
                                              : ContextMenuTelemetry.OriginExtra.webLink
-        ContextMenuTelemetry().optionSelected(option: .copyImageLink, origin: originExtra)
+        ContextMenuTelemetry().optionSelected(option: option, origin: originExtra)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -220,7 +220,8 @@ class WebContextMenuActionsProvider {
     }
 
     private func recordOptionSelectedTelemetry(option: ContextMenuTelemetry.OptionExtra) {
-        let originExtra = menuType == .image ? ContextMenuTelemetry.OriginExtra.imageLink : ContextMenuTelemetry.OriginExtra.webLink
+        let originExtra = menuType == .image ? ContextMenuTelemetry.OriginExtra.imageLink
+                                             : ContextMenuTelemetry.OriginExtra.webLink
         ContextMenuTelemetry().optionSelected(option: .copyImageLink, origin: originExtra)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -300,7 +300,7 @@ extension BrowserViewController: WKUIDelegate {
                        image: URL?,
                        currentTab: Tab,
                        webView: WKWebView) -> [UIAction] {
-        let actionBuilder = ActionProviderBuilder()
+        let actionBuilder = WebContextMenuActionsProvider()
         let isJavascriptScheme = (url.scheme?.caseInsensitiveCompare("javascript") == .orderedSame)
 
         if !isPrivate && !isJavascriptScheme {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -186,13 +186,19 @@ extension BrowserViewController: WKUIDelegate {
     }
 
     // MARK: - Helpers
-    private func contextMenuConfiguration(for url: URL, webView: WKWebView, elements: ContextMenuHelper.Elements) -> UIContextMenuConfiguration {
+    private func contextMenuConfiguration(for url: URL,
+                                          webView: WKWebView,
+                                          elements: ContextMenuHelper.Elements) -> UIContextMenuConfiguration {
         return UIContextMenuConfiguration(identifier: nil,
                                           previewProvider: contextMenuPreviewProvider(for: url, webView: webView),
-                                          actionProvider: contextMenuActionProvider(for: url, webView: webView, elements: elements))
+                                          actionProvider: contextMenuActionProvider(for: url,
+                                                                                    webView: webView,
+                                                                                    elements: elements))
     }
 
-    private func contextMenuActionProvider(for url: URL, webView: WKWebView, elements: ContextMenuHelper.Elements) -> UIContextMenuActionProvider {
+    private func contextMenuActionProvider(for url: URL,
+                                           webView: WKWebView,
+                                           elements: ContextMenuHelper.Elements) -> UIContextMenuActionProvider {
         return { [self] (suggested) -> UIMenu? in
             guard let currentTab = tabManager.selectedTab else { return nil }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -150,8 +150,25 @@ extension BrowserViewController: WKUIDelegate {
         contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
         completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
     ) {
-        guard let url = elementInfo.linkURL else { return }
-        completionHandler(contextMenuConfiguration(for: url, webView: webView))
+        guard let url = elementInfo.linkURL,
+              let currentTab = tabManager.selectedTab,
+              let contextHelper = currentTab.getContentScript(
+                name: ContextMenuHelper.name()
+              ) as? ContextMenuHelper,
+              let elements = contextHelper.elements
+        else { return }
+        completionHandler(contextMenuConfiguration(for: url, webView: webView, elements: elements))
+        ContextMenuTelemetry().shown(origin: elements.image != nil ? .imageLink : .webLink)
+    }
+
+    func webView(_ webView: WKWebView, contextMenuDidEndForElement elementInfo: WKContextMenuElementInfo) {
+        guard let currentTab = tabManager.selectedTab,
+              let contextHelper = currentTab.getContentScript(
+                name: ContextMenuHelper.name()
+              ) as? ContextMenuHelper,
+              let elements = contextHelper.elements
+        else { return }
+        ContextMenuTelemetry().dismissed(origin: elements.image != nil ? .imageLink : .webLink)
     }
 
     func webView(_ webView: WKWebView,
@@ -169,20 +186,15 @@ extension BrowserViewController: WKUIDelegate {
     }
 
     // MARK: - Helpers
-    private func contextMenuConfiguration(for url: URL, webView: WKWebView) -> UIContextMenuConfiguration {
+    private func contextMenuConfiguration(for url: URL, webView: WKWebView, elements: ContextMenuHelper.Elements) -> UIContextMenuConfiguration {
         return UIContextMenuConfiguration(identifier: nil,
                                           previewProvider: contextMenuPreviewProvider(for: url, webView: webView),
-                                          actionProvider: contextMenuActionProvider(for: url, webView: webView))
+                                          actionProvider: contextMenuActionProvider(for: url, webView: webView, elements: elements))
     }
 
-    private func contextMenuActionProvider(for url: URL, webView: WKWebView) -> UIContextMenuActionProvider {
+    private func contextMenuActionProvider(for url: URL, webView: WKWebView, elements: ContextMenuHelper.Elements) -> UIContextMenuActionProvider {
         return { [self] (suggested) -> UIMenu? in
-            guard let currentTab = tabManager.selectedTab,
-                  let contextHelper = currentTab.getContentScript(
-                    name: ContextMenuHelper.name()
-                  ) as? ContextMenuHelper,
-                  let elements = contextHelper.elements
-            else { return nil }
+            guard let currentTab = tabManager.selectedTab else { return nil }
 
             let isPrivate = currentTab.isPrivate
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -300,7 +300,7 @@ extension BrowserViewController: WKUIDelegate {
                        image: URL?,
                        currentTab: Tab,
                        webView: WKWebView) -> [UIAction] {
-        let actionBuilder = WebContextMenuActionsProvider()
+        let actionBuilder = WebContextMenuActionsProvider(menuType: image != nil ? .image : .web)
         let isJavascriptScheme = (url.scheme?.caseInsensitiveCompare("javascript") == .orderedSame)
 
         if !isPrivate && !isJavascriptScheme {

--- a/firefox-ios/Client/Telemetry/ContextMenuTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/ContextMenuTelemetry.swift
@@ -32,7 +32,7 @@ struct ContextMenuTelemetry {
 
     func optionSelected(option: OptionExtra, origin: OriginExtra) {
         let optionSelectedExtras = GleanMetrics.ContextMenu.OptionSelectedExtra(
-            optionSelected: option.rawValue,
+            option: option.rawValue,
             origin: origin.rawValue
         )
         gleanWrapper.recordEvent(for: GleanMetrics.ContextMenu.optionSelected, extras: optionSelectedExtras)

--- a/firefox-ios/Client/Telemetry/ContextMenuTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/ContextMenuTelemetry.swift
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+struct ContextMenuTelemetry {
+    enum OptionExtra: String {
+        case openInNewTab
+        case openInNewPrivateTab
+        case bookmarkLink
+        case removeBookmark
+        case downloadLink
+        case copyLink
+        case shareLink
+        case saveImage
+        case copyImage
+        case copyImageLink
+    }
+
+    enum OriginExtra: String {
+        case webLink
+    }
+
+    private let gleanWrapper: GleanWrapper
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
+    func optionSelected(option: OptionExtra, origin: OriginExtra) {
+        let optionSelectedExtras = GleanMetrics.ContextMenu.OptionSelectedExtra(
+            optionSelected: option.rawValue,
+            origin: origin.rawValue
+        )
+        gleanWrapper.recordEvent(for: GleanMetrics.ContextMenu.optionSelected, extras: optionSelectedExtras)
+    }
+
+    func shown(origin: OriginExtra) {
+        let shownExtras = GleanMetrics.ContextMenu.ShownExtra(origin: origin.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.ContextMenu.shown, extras: shownExtras)
+    }
+
+    func dismissed(origin: OriginExtra) {
+        let dismissedExtras = GleanMetrics.ContextMenu.DismissedExtra(origin: origin.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.ContextMenu.shown, extras: dismissedExtras)
+    }
+}

--- a/firefox-ios/Client/Telemetry/ContextMenuTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/ContextMenuTelemetry.swift
@@ -45,6 +45,6 @@ struct ContextMenuTelemetry {
 
     func dismissed(origin: OriginExtra) {
         let dismissedExtras = GleanMetrics.ContextMenu.DismissedExtra(origin: origin.rawValue)
-        gleanWrapper.recordEvent(for: GleanMetrics.ContextMenu.shown, extras: dismissedExtras)
+        gleanWrapper.recordEvent(for: GleanMetrics.ContextMenu.dismissed, extras: dismissedExtras)
     }
 }

--- a/firefox-ios/Client/Telemetry/ContextMenuTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/ContextMenuTelemetry.swift
@@ -21,6 +21,7 @@ struct ContextMenuTelemetry {
 
     enum OriginExtra: String {
         case webLink
+        case imageLink
     }
 
     private let gleanWrapper: GleanWrapper

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -599,7 +599,7 @@ context_menu:
     description: |
       Records when the user selects an option from a context menu.
     extra_keys:
-      option_selected:
+      option:
         type: string
         description: |
           The type of option selected.

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -597,7 +597,7 @@ context_menu:
   option_selected:
     type: event
     description: |
-      Records when the user selects an option from a context menu
+      Records when the user selects an option from a context menu.
     extra_keys:
       option_selected:
         type: string
@@ -610,7 +610,7 @@ context_menu:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-11798
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25805
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-01"
@@ -620,7 +620,7 @@ context_menu:
   shown:
     type: event
     description: |
-      Records when a context menu is shown
+      Records when a context menu is shown.
     extra_keys:
       origin:
         type: string
@@ -629,7 +629,7 @@ context_menu:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-11798
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25805
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-01"
@@ -639,7 +639,7 @@ context_menu:
   dismissed:
     type: event
     description: |
-      Records when a context menu is dismissed
+      Records when a context menu is dismissed.
     extra_keys:
       origin:
         type: string
@@ -648,7 +648,7 @@ context_menu:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-11798
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25805
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-01"

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -592,6 +592,70 @@ bookmarks:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-07-01"
 
+# Context menus
+context_menu:
+  option_selected:
+    type: event
+    description: |
+      Records when the user selects an option from a context menu
+    extra_keys:
+      option_selected:
+        type: string
+        description: |
+          The type of option selected.
+      origin:
+        type: string
+        description: |
+          The type of context menu the option was selected from.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-11798
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-06-01"
+    metadata:
+      tags:
+        - ContextMenu
+  shown:
+    type: event
+    description: |
+      Records when a context menu is shown
+    extra_keys:
+      origin:
+        type: string
+        description: |
+          The type of context menu the option was selected from.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-11798
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-06-01"
+    metadata:
+      tags:
+        - ContextMenu
+  dismissed:
+    type: event
+    description: |
+      Records when a context menu is dismissed
+    extra_keys:
+      origin:
+        type: string
+        description: |
+          The type of context menu the option was selected from.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-11798
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-06-01"
+    metadata:
+      tags:
+        - ContextMenu
+
 # Default browser card metrics
 default_browser_card:
   dismiss_pressed:

--- a/firefox-ios/Client/tags.yaml
+++ b/firefox-ios/Client/tags.yaml
@@ -14,6 +14,9 @@ $schema: moz://mozilla.org/schemas/glean/tags/1-0-0
 AppIconSelection:
   description: Corresponds to the feature where users can change their default app icon in the settings.
 
+ContextMenu:
+  description: Corresponds to any context menu in the app.
+
 Library:
   description: Corresponds to library, containing bookmarks, history, reading list, and downloads.
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ContextMenuTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ContextMenuTelemetryTests.swift
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+import XCTest
+
+@testable import Client
+
+final class ContextMenuTelemetryTests: XCTestCase {
+    let x = BookmarksTelemetry()
+    var subject: ContextMenuTelemetry?
+    var gleanWrapper: MockGleanWrapper!
+
+    override func setUp() {
+        super.setUp()
+        gleanWrapper = MockGleanWrapper()
+        subject = ContextMenuTelemetry(gleanWrapper: gleanWrapper)
+    }
+
+    override func tearDown() {
+        subject = nil
+        gleanWrapper = nil
+        super.tearDown()
+    }
+
+    func testRecordEvent_OptionSelected() throws {
+        let event = GleanMetrics.ContextMenu.optionSelected
+        typealias EventExtrasType = GleanMetrics.ContextMenu.OptionSelectedExtra
+
+        let expectedOption = ContextMenuTelemetry.OptionExtra.openInNewTab
+        let expectedOrigin = ContextMenuTelemetry.OriginExtra.webLink
+        let expectedMetricType = type(of: event)
+
+        subject?.optionSelected(option: expectedOption, origin: expectedOrigin)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.option, expectedOption.rawValue)
+        XCTAssertEqual(savedExtras.origin, expectedOrigin.rawValue)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func testRecordEvent_Shown() throws {
+        let event = GleanMetrics.ContextMenu.shown
+        typealias EventExtrasType = GleanMetrics.ContextMenu.ShownExtra
+
+        let expectedOrigin = ContextMenuTelemetry.OriginExtra.webLink
+        let expectedMetricType = type(of: event)
+
+        subject?.shown(origin: expectedOrigin)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.origin, expectedOrigin.rawValue)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func testRecordEvent_Dismissed() throws {
+        let event = GleanMetrics.ContextMenu.dismissed
+        typealias EventExtrasType = GleanMetrics.ContextMenu.DismissedExtra
+
+        let expectedOrigin = ContextMenuTelemetry.OriginExtra.webLink
+        let expectedMetricType = type(of: event)
+
+        subject?.dismissed(origin: expectedOrigin)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.origin, expectedOrigin.rawValue)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11798)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25727)

## :bulb: Description
- Adds telemetry for showing, hiding, and action presses for the web view context menu

### 📝 Notes
- Updated the naming of `ActionProviderBuilder` to `WebContextMenuActionsProvider` since this provider is only used in the context of web link context menus

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

