### PR TITLE
Add FXIOS-11633 Ensure AS engine sort ordering

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
@@ -52,7 +52,9 @@ final class ASSearchEngineProvider: SearchEngineProvider {
 
             guard let orderedEngineNames = finalEngineOrderingPrefs.engineIdentifiers,
                   !orderedEngineNames.isEmpty else {
-                // We haven't persisted the engine order, so return whatever order we got from disk.
+                // We haven't persisted the engine order, so use the default engine ordering.
+                // For AS-based engines we are guaranteed the preferred default to be at index 0
+                // (this happens in `fetchSearchEngines()`).
                 ensureMainThread { completion(finalEngineOrderingPrefs, unorderedEngines) }
                 return
             }

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
@@ -47,10 +47,30 @@ final class ASSearchEngineSelector: ASSearchEngineSelectorProtocol {
                                              version: AppInfo.appVersion,
                                              deviceType: deviceType)
 
-             let filtered = try engineSelector.filterEngineConfiguration(userEnvironment: env)
-             completion(filtered, nil)
+             var searchResultsConfig = try engineSelector.filterEngineConfiguration(userEnvironment: env)
+
+             // We want to be sure that our default engines list is always sorted with the default in position 0
+             // This is important in the case of new installs, for example, where the user does not have any
+             // search engine ordering preferences saved. Generally the `engines` should already be sorted this
+             // way but this code should be very fast on this small collection so we ensure the sort order here.
+             searchResultsConfig.sortDefaultEngineToIndex0()
+
+             completion(searchResultsConfig, nil)
          } catch {
              completion(nil, error)
          }
+    }
+}
+
+extension RefinedSearchConfig {
+    /// Ensures that the default engine is always at position 0 in the engines list.
+    /// Per AS team we should not rely on the provided sort order of `engines`.
+    mutating func sortDefaultEngineToIndex0() {
+        guard let defaultEngineID = appDefaultEngineId else { return }
+        guard let idx = engines.firstIndex(where: { $0.identifier == defaultEngineID }) else { return }
+        guard idx != 0 else { return }
+        let engine = engines[idx]
+        engines.remove(at: idx)
+        engines.insert(engine, at: 0)
     }
 }

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
@@ -66,9 +66,9 @@ extension RefinedSearchConfig {
     /// Ensures that the default engine is always at position 0 in the engines list.
     /// Per AS team we should not rely on the provided sort order of `engines`.
     mutating func sortDefaultEngineToIndex0() {
-        guard let defaultEngineID = appDefaultEngineId else { return }
-        guard let idx = engines.firstIndex(where: { $0.identifier == defaultEngineID }) else { return }
-        guard idx != 0 else { return }
+        guard let defaultEngineID = appDefaultEngineId,
+              let idx = engines.firstIndex(where: { $0.identifier == defaultEngineID }),
+              idx != 0 else { return }
         let engine = engines[idx]
         engines.remove(at: idx)
         engines.insert(engine, at: 0)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11633)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25336)

## :bulb: Description

Ensures the default search engine for Remote Settings based engines is always in position 0 in the sort order.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

