### PR TITLE
FXIOS-11807 #25751 ⁃ Send tab notification just says "Firefox Sync / Tap to begin" without showing the received URL

### DIFF
--- a/firefox-ios/Extensions/NotificationService/NotificationService.swift
+++ b/firefox-ios/Extensions/NotificationService/NotificationService.swift
@@ -6,8 +6,7 @@ import Common
 import Account
 import Shared
 import UserNotifications
-
-import class MozillaAppServices.Viaduct
+import MozillaAppServices
 
 class NotificationService: UNNotificationServiceExtension {
     var display: SyncDataDisplay?
@@ -25,6 +24,7 @@ class NotificationService: UNNotificationServiceExtension {
         // Set-up Rust network stack. This is needed in addition to the call
         // from the AppDelegate due to the fact that this uses a separate process
         Viaduct.shared.useReqwestBackend()
+        MozillaAppServices.initialize()
 
         let userInfo = request.content.userInfo
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11807)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25751)

## :bulb: Description
Added MozillaAppServices.initialize() for NotificationService

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

