### PR TITLE
Bugfix FXIOS-11854 [Tab tray UI experiment] Selector view theming

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -23,14 +23,10 @@ final class TabTraySelectorView: UIView,
                                  UICollectionViewDelegateFlowLayout,
                                  UICollectionViewDataSource,
                                  UIScrollViewDelegate,
-                                 Themeable {
-    var themeManager: ThemeManager
-    var themeObserver: NSObjectProtocol?
-    var notificationCenter: NotificationProtocol
-
+                                 ThemeApplicable {
     weak var delegate: TabTraySelectorDelegate?
 
-    private let windowUUID: WindowUUID
+    private var theme: Theme
     private var selectedIndex: Int
 
     var items: [String] = [] {
@@ -62,13 +58,9 @@ final class TabTraySelectorView: UIView,
 
     // MARK: - Init
     init(selectedIndex: Int,
-         windowUUID: WindowUUID,
-         themeManager: ThemeManager = AppContainer.shared.resolve(),
-         notificationCenter: NotificationCenter = NotificationCenter.default) {
+         theme: Theme) {
         self.selectedIndex = selectedIndex
-        self.windowUUID = windowUUID
-        self.themeManager = themeManager
-        self.notificationCenter = notificationCenter
+        self.theme = theme
         super.init(frame: .zero)
         setup()
     }
@@ -88,7 +80,7 @@ final class TabTraySelectorView: UIView,
             collectionView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
 
-        applyTheme()
+        applyTheme(theme: theme)
     }
 
     override func layoutSubviews() {
@@ -153,9 +145,8 @@ final class TabTraySelectorView: UIView,
     }
 
     // MARK: - Themeable
-
-    func applyTheme() {
-        let theme = themeManager.getCurrentTheme(for: windowUUID)
+    func applyTheme(theme: Theme) {
+        self.theme = theme
         collectionView.backgroundColor = theme.colors.layer1
         backgroundColor = theme.colors.layer1
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -116,7 +116,7 @@ final class TabTraySelectorView: UIView,
         }
         cell.configure(title: items[indexPath.item],
                        selected: indexPath.item == selectedIndex,
-                       theme: themeManager.getCurrentTheme(for: windowUUID),
+                       theme: theme,
                        position: indexPath.item,
                        total: indexPath.count)
         return cell

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -108,7 +108,8 @@ class TabTrayViewController: UIViewController,
 
     private lazy var experimentSegmentControl: TabTraySelectorView = {
         let selectedIndex = experimentConvertSelectedIndex()
-        let selector = TabTraySelectorView(selectedIndex: selectedIndex, windowUUID: windowUUID)
+        let selector = TabTraySelectorView(selectedIndex: selectedIndex,
+                                           theme: themeManager.getCurrentTheme(for: windowUUID))
         selector.delegate = self
         selector.items = [TabTrayPanelType.privateTabs.label,
                           TabTrayPanelType.tabs.label,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11854)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25826)

## :bulb: Description
The selector should be `ThemeApplicable` so it can be notified automatically when the theme changes and react to it.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

