### PR TITLE
Refactor FXIOS-11860 [Tab tray UI experiment] Fix a11y on tab tray

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -438,6 +438,7 @@ struct AccessibilityIdentifiers {
         static let doneButton = "doneButtonTabTray"
         static let syncTabsButton = "syncTabsButtonTabTray"
         static let navBarSegmentedControl = "navBarTabTray"
+        static let selectorCell = "selectorCell"
         static let syncDataButton = "syncDataButton"
         static let learnMoreButton = "learnMoreButton"
         static let collectionView = "TabDisplayView.collectionView"

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
@@ -26,6 +26,7 @@ final class TabTraySelectorCell: UICollectionViewCell,
         label.numberOfLines = 1
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.accessibilityTraits = [.button]
 
         NSLayoutConstraint.activate([
             label.topAnchor.constraint(equalTo: contentView.topAnchor, constant: padding.top),
@@ -39,10 +40,14 @@ final class TabTraySelectorCell: UICollectionViewCell,
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(title: String, selected: Bool, theme: Theme?) {
+    func configure(title: String, selected: Bool, theme: Theme?, position: Int, total: Int) {
         isSelected = selected
         label.text = title
         label.font = selected ? FXFontStyles.Bold.body.scaledFont() : FXFontStyles.Regular.body.scaledFont()
+        label.accessibilityIdentifier = "\(AccessibilityIdentifiers.TabTray.selectorCell)\(position)"
+        label.accessibilityHint = String(format: .TabTraySelectorAccessibilityHint,
+                                         NSNumber(value: position + 1),
+                                         NSNumber(value: total + 1))
         applyTheme(theme: theme ?? LightTheme())
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
@@ -45,7 +45,7 @@ final class TabTraySelectorCell: UICollectionViewCell,
         label.text = title
         label.font = selected ? FXFontStyles.Bold.body.scaledFont() : FXFontStyles.Regular.body.scaledFont()
         label.accessibilityIdentifier = "\(AccessibilityIdentifiers.TabTray.selectorCell)\(position)"
-        label.accessibilityHint = String(format: .TabTraySelectorAccessibilityHint,
+        label.accessibilityHint = String(format: .TabsTray.TabTraySelectorAccessibilityHint,
                                          NSNumber(value: position + 1),
                                          NSNumber(value: total + 1))
         applyTheme(theme: theme ?? LightTheme())

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -124,29 +124,15 @@ final class TabTraySelectorView: UIView,
         }
         cell.configure(title: items[indexPath.item],
                        selected: indexPath.item == selectedIndex,
-                       theme: themeManager.getCurrentTheme(for: windowUUID))
+                       theme: themeManager.getCurrentTheme(for: windowUUID),
+                       position: indexPath.item,
+                       total: indexPath.count)
         return cell
     }
 
     // MARK: - UICollectionViewDelegate
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectNewSection(newIndex: indexPath.item)
-    }
-
-    // MARK: - Scroll Snap
-    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        if !decelerate { snapToNearestItem() }
-    }
-
-    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        snapToNearestItem()
-    }
-
-    private func snapToNearestItem() {
-        let center = convert(CGPoint(x: bounds.midX, y: bounds.midY), to: collectionView)
-        if let indexPath = collectionView.indexPathForItem(at: center) {
-            selectNewSection(newIndex: indexPath.item)
-        }
     }
 
     func selectNewSection(newIndex: Int) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -69,6 +69,8 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     private lazy var screenshotView: UIImageView = .build { view in
         view.contentMode = .scaleAspectFill
         view.clipsToBounds = true
+        view.isAccessibilityElement = false
+        view.accessibilityElementsHidden = true
     }
 
     private lazy var titleText: UILabel = .build { label in

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -403,6 +403,9 @@ class TabTrayViewController: UIViewController,
         if isTabTrayUIExperimentsEnabled {
             containerView.addSubview(segmentedControl)
             segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+            // Out of simplicity for the experiment, turn off a11y for the old segmented control
+            segmentedControl.isAccessibilityElement = false
+            segmentedControl.isHidden = true
 
             containerView.addSubview(experimentSegmentControl)
             experimentSegmentControl.translatesAutoresizingMaskIntoConstraints = false

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2984,6 +2984,12 @@ extension String {
                 value: "Share",
                 comment: "Action button for sharing downloaded files in the Downloads panel.")
         }
+
+        public static let TabTraySelectorAccessibilityHint = MZLocalizedString(
+            key: "TabTraySelectorAccessibilityHint.v139",
+            tableName: "TabsTray",
+            value: "%1$@ of %2$@",
+            comment: "Message spoken by VoiceOver saying the position of the currently selected page in the tab tray selector (%1$@), along with the total number of selector (%2$@). E.g. “1 of 3” says that page 1 is visible, out of 3 pages total.")
     }
 }
 
@@ -7019,11 +7025,6 @@ extension String {
         tableName: nil,
         value: "Tabs %1$@ to %2$@ of %3$@",
         comment: "Message spoken by VoiceOver saying the range of tabs that are currently visible in Tabs Tray (%1$@ to %2$@), along with the total number of tabs (%3$@). E.g. “Tabs 8 to 10 of 15” says tabs 8, 9 and 10 are visible, out of 15 tabs total.")
-    public static let TabTraySelectorAccessibilityHint = MZLocalizedString(
-        key: "TabTraySelectorAccessibilityHint.v139",
-        tableName: nil,
-        value: "%1$@ of %2$@",
-        comment: "Message spoken by VoiceOver saying the position of the currently selected page in the tab tray selector (%1$@), along with the total number of selector (%2$@). E.g. “1 of 3” says that page 1 is visible, out of 3 pages total.")
     public static let TabTrayClosingTabAccessibilityMessage =  MZLocalizedString(
         key: "Closing tab",
         tableName: nil,

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -7019,6 +7019,11 @@ extension String {
         tableName: nil,
         value: "Tabs %1$@ to %2$@ of %3$@",
         comment: "Message spoken by VoiceOver saying the range of tabs that are currently visible in Tabs Tray (%1$@ to %2$@), along with the total number of tabs (%3$@). E.g. “Tabs 8 to 10 of 15” says tabs 8, 9 and 10 are visible, out of 15 tabs total.")
+    public static let TabTraySelectorAccessibilityHint = MZLocalizedString(
+        key: "TabTraySelectorAccessibilityHint.v139",
+        tableName: nil,
+        value: "%1$@ of %2$@",
+        comment: "Message spoken by VoiceOver saying the position of the currently selected page in the tab tray selector (%1$@), along with the total number of selector (%2$@). E.g. “1 of 3” says that page 1 is visible, out of 3 pages total.")
     public static let TabTrayClosingTabAccessibilityMessage =  MZLocalizedString(
         key: "Closing tab",
         tableName: nil,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11860)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25833)

## :bulb: Description
Ensure accessibility Voice Over is functioning for the experiment with latest changes. This will need further improvement (as noted in this document if the experiment moves on), but at least it's not in a broken state anymore.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

