### PR TITLE
Refactor FXIOS-6765 #15058 ⁃ [UX Fundamentals] previous to default page zoom setting Part 1

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -240,6 +240,8 @@
 		213BF7532AC21D1B00C53A64 /* TabDisplayPanelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213BF7522AC21D1B00C53A64 /* TabDisplayPanelViewController.swift */; };
 		21420EF72ABA338D00B28550 /* TabTrayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21420EF62ABA338D00B28550 /* TabTrayCoordinator.swift */; };
 		21420EF92ABC75A400B28550 /* TabTrayCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21420EF82ABC75A400B28550 /* TabTrayCoordinatorTests.swift */; };
+		2142B12C2D9F1284003AA82F /* ZoomPageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2142B12A2D9F1284003AA82F /* ZoomPageManager.swift */; };
+		2142B12D2D9F1284003AA82F /* ZoomPageBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2142B1292D9F1284003AA82F /* ZoomPageBar.swift */; };
 		214EF4152AC5D5D0005BCCDA /* TabDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214EF4142AC5D5D0005BCCDA /* TabDisplayView.swift */; };
 		2152473E2D6E4A4A0078D78A /* AutoFillPasswordSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152473D2D6E4A4A0078D78A /* AutoFillPasswordSettingsViewController.swift */; };
 		21534904288201E300FADB4D /* GleanPlumbMessageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215349022881FA3C00FADB4D /* GleanPlumbMessageManagerTests.swift */; };
@@ -1715,7 +1717,6 @@
 		D8FDEB57220CFE970069A582 /* UIImage+ImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = D8FDEB55220CFE970069A582 /* UIImage+ImageEffects.m */; };
 		D980063D26D8308700321BC1 /* RustPlacesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D980063C26D8308700321BC1 /* RustPlacesTests.swift */; };
 		DA27EEDB28BADF4700DD6F5D /* MenuBuilderHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA27EEDA28BADF4700DD6F5D /* MenuBuilderHelper.swift */; };
-		DA4F826729AD221600189590 /* ZoomPageBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4F826629AD221600189590 /* ZoomPageBar.swift */; };
 		DA9FD88424E213B500168D1E /* SmallQuickLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9FD88224E213B400168D1E /* SmallQuickLink.swift */; };
 		DA9FD88624E213CD00168D1E /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9FD88524E213CC00168D1E /* Helpers.swift */; };
 		DA9FD88824E213DD00168D1E /* QuickLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9FD88724E213DC00168D1E /* QuickLink.swift */; };
@@ -2782,6 +2783,8 @@
 		213BF7522AC21D1B00C53A64 /* TabDisplayPanelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayPanelViewController.swift; sourceTree = "<group>"; };
 		21420EF62ABA338D00B28550 /* TabTrayCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayCoordinator.swift; sourceTree = "<group>"; };
 		21420EF82ABC75A400B28550 /* TabTrayCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayCoordinatorTests.swift; sourceTree = "<group>"; };
+		2142B1292D9F1284003AA82F /* ZoomPageBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomPageBar.swift; sourceTree = "<group>"; };
+		2142B12A2D9F1284003AA82F /* ZoomPageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomPageManager.swift; sourceTree = "<group>"; };
 		214EF4142AC5D5D0005BCCDA /* TabDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayView.swift; sourceTree = "<group>"; };
 		2152473D2D6E4A4A0078D78A /* AutoFillPasswordSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFillPasswordSettingsViewController.swift; sourceTree = "<group>"; };
 		215349022881FA3C00FADB4D /* GleanPlumbMessageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageManagerTests.swift; sourceTree = "<group>"; };
@@ -9845,7 +9848,6 @@
 		DA2240A6BF2630FC0A8A0B8F /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/ClearPrivateDataConfirm.strings"; sourceTree = "<group>"; };
 		DA27EEDA28BADF4700DD6F5D /* MenuBuilderHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MenuBuilderHelper.swift; path = Helpers/MenuBuilderHelper.swift; sourceTree = "<group>"; };
 		DA4446B0870E847782CEFAF4 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/ErrorPages.strings; sourceTree = "<group>"; };
-		DA4F826629AD221600189590 /* ZoomPageBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomPageBar.swift; sourceTree = "<group>"; };
 		DA654F2582BF9863A719CB00 /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/Shared.strings"; sourceTree = "<group>"; };
 		DA744D888927B768AD70ECF4 /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		DA9FD88224E213B400168D1E /* SmallQuickLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SmallQuickLink.swift; sourceTree = "<group>"; };
@@ -10882,6 +10884,15 @@
 				2137785E297F3B1B00D01309 /* DownloadsPanelViewModel.swift */,
 			);
 			path = Downloads;
+			sourceTree = "<group>";
+		};
+		2142B12B2D9F1284003AA82F /* Zoom */ = {
+			isa = PBXGroup;
+			children = (
+				2142B1292D9F1284003AA82F /* ZoomPageBar.swift */,
+				2142B12A2D9F1284003AA82F /* ZoomPageManager.swift */,
+			);
+			path = Zoom;
 			sourceTree = "<group>";
 		};
 		216A0D6F2A40D0E4008077BA /* Redux */ = {
@@ -14302,7 +14313,7 @@
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				884CA7482344A301002E4711 /* TextContentDetector.swift */,
 				E1877A7F286E0EFD00F5BDF2 /* WebView */,
-				DA4F826629AD221600189590 /* ZoomPageBar.swift */,
+				2142B12B2D9F1284003AA82F /* Zoom */,
 				E1380B8C2AEA897C00630AFA /* SidebarEnabledView.swift */,
 				5A2918CC2B522381002B197E /* ToastType.swift */,
 			);
@@ -18078,6 +18089,8 @@
 				E633E2DA1C21EAF8001FFF6C /* PasswordDetailViewController.swift in Sources */,
 				8A9AC46B276D11280047F5B0 /* PocketViewModel.swift in Sources */,
 				8A7653BF28A2C92600924ABF /* PocketStandardCellViewModel.swift in Sources */,
+				2142B12C2D9F1284003AA82F /* ZoomPageManager.swift in Sources */,
+				2142B12D2D9F1284003AA82F /* ZoomPageBar.swift in Sources */,
 				0B8BF3752CA2EFC000E9812D /* EditBookmarkCell.swift in Sources */,
 				8A5D1CAE2A30D71A005AD35C /* ThemeSetting.swift in Sources */,
 				1BE7A4902C636AC800460798 /* URLSession+sharedMPTCP.swift in Sources */,
@@ -18096,7 +18109,6 @@
 				213B7AF02D779D2400DF0123 /* Download.swift in Sources */,
 				BDD262562CE3AC8200DF2C62 /* PrivacyWindowHelper.swift in Sources */,
 				DF1E6AAB2A976FE7000D4854 /* FakespotNoAnalysisCardView.swift in Sources */,
-				DA4F826729AD221600189590 /* ZoomPageBar.swift in Sources */,
 				59A68E0B4ABBF55E14819668 /* LegacyBookmarksPanel.swift in Sources */,
 				810FF3582B1784E7009F062C /* PrivateModeAction.swift in Sources */,
 				21EA466A2B04130500AAAB2D /* TabsPanelState.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -31,8 +31,6 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         static let stepperShadowOffset = CGSize(width: 0, height: 4)
         static let separatorWidth: CGFloat = 1
         static let separatorHeightMultiplier = 0.74
-        static let lowerZoomLimit: CGFloat = 0.5
-        static let upperZoomLimit: CGFloat = 2.0
     }
 
     // MARK: - Properties
@@ -229,9 +227,9 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     }
 
     private func checkPageZoomLimits() {
-        if tab.pageZoom <= UX.lowerZoomLimit {
+        if tab.pageZoom <= ZoomConstants.lowerZoomLimit {
             zoomOutButton.isEnabled = false
-        } else if tab.pageZoom >= UX.upperZoomLimit {
+        } else if tab.pageZoom >= ZoomConstants.upperZoomLimit {
             zoomInButton.isEnabled = false
         } else { enableZoomButtons() }
     }
@@ -261,7 +259,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         updateZoomLabel()
         delegate?.didChangeZoomLevel()
         zoomOutButton.isEnabled = true
-        if tab.pageZoom >= UX.upperZoomLimit {
+        if tab.pageZoom >= ZoomConstants.upperZoomLimit {
             zoomInButton.isEnabled = false
         }
     }
@@ -272,7 +270,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         updateZoomLabel()
         delegate?.didChangeZoomLevel()
         zoomInButton.isEnabled = true
-        if tab.pageZoom <= UX.lowerZoomLimit {
+        if tab.pageZoom <= ZoomConstants.lowerZoomLimit {
             zoomOutButton.isEnabled = false
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Storage
+
+struct ZoomConstants {
+    static let defaultZoomLimit: CGFloat = 1.0
+    static let lowerZoomLimit: CGFloat = 0.5
+    static let upperZoomLimit: CGFloat = 2.0
+}
+
+class ZoomPageManager {
+    let windowUUID: WindowUUID
+
+    init(windowUUID: WindowUUID) {
+        self.windowUUID = windowUUID
+    }
+
+    // Regular step is 0.25 except for the cases close to regular zoom
+    // where we provide smaller step
+    @objc
+    func zoomIn(value: CGFloat) -> CGFloat {
+        guard value < ZoomConstants.upperZoomLimit else { return value}
+
+        switch value {
+        case 0.75:
+            return 0.9
+        case 0.9:
+            return 1.0
+        case 1.0:
+            return 1.10
+        case 1.10:
+            return 1.25
+        default:
+            return value + 0.25
+        }
+    }
+
+    // Regular step is 0.25 except for the cases close to regular zoom
+    // where we provide smaller step
+    @objc
+    func zoomOut(value: CGFloat) -> CGFloat {
+        guard value > ZoomConstants.lowerZoomLimit else { return value}
+
+        switch value {
+        case 0.9:
+            return 0.75
+        case 1.0:
+            return 0.9
+        case 1.10:
+            return 1.0
+        case 1.25:
+            return 1.10
+        default:
+            return value - 0.25
+        }
+    }
+
+    /// Saves the zoom level for a given host and notifies other windows of the change
+    /// - Parameters:
+    ///   - host: The domain or host for which the zoom level is being saved
+    ///   - zoomLevel: The zoom level value to save
+    func saveZoomLevel(for host: String, zoomLevel: CGFloat) {
+        let domainZoomLevel = DomainZoomLevel(host: host, zoomLevel: zoomLevel)
+        ZoomLevelStore.shared.save(domainZoomLevel)
+
+        // Notify other windows of zoom change (other pages with identical host should also update)
+        let userInfo: [AnyHashable: Any] = [WindowUUID.userInfoKey: windowUUID, "zoom": domainZoomLevel]
+        NotificationCenter.default.post(name: .PageZoomLevelUpdated, withUserInfo: userInfo)
+    }
+
+    /// Retrieves the previously saved zoom level for a given domain.
+    /// - Parameter host: The domain or host to load the zoom level for.
+    /// - Returns: The saved zoom level if found, otherwise returns the default zoom level
+    func setZoomLevelforDomain(for host: String?) -> CGFloat {
+        guard let host = host,
+              let domainZoomLevel = ZoomLevelStore.shared.findZoomLevel(forDomain: host) else {
+            return ZoomConstants.defaultZoomLimit
+        }
+
+        return domainZoomLevel.zoomLevel
+    }
+}

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -324,11 +324,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
            internalUrl.isAboutHomeURL {
             return true
         }
-        // TODO: Find a new home for this FXIOS-8527
-        // A computed variable should not be making view level changes
-        ensureMainThread {
-            self.setZoomLevelforDomain()
-        }
         return false
     }
 
@@ -441,6 +436,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     }
 
     var profile: Profile
+    var zoomPageManager: ZoomPageManager
 
     /// Returns true if this tab is considered inactive (has not been executed for more than a specific number of days).
     /// Note: When `FasterInactiveTabsOverride` is enabled, tabs become inactive very quickly for testing purposes.
@@ -489,6 +485,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         self.lastExecutedTime = tabCreatedTime.toTimestamp()
         self.firstCreatedTime = tabCreatedTime.toTimestamp()
         self.logger = logger
+        self.zoomPageManager = ZoomPageManager(windowUUID: windowUUID)
         super.init()
         self.isPrivate = isPrivate
 
@@ -772,55 +769,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         reload()
     }
 
-    @objc
-    func zoomIn() {
-        switch pageZoom {
-        case 0.75:
-            pageZoom = 0.9
-        case 0.9:
-            pageZoom = 1.0
-        case 1.0:
-            pageZoom = 1.10
-        case 1.10:
-            pageZoom = 1.25
-        case 2.0:
-            return
-        default:
-            pageZoom += 0.25
-        }
-    }
-
-    @objc
-    func zoomOut() {
-        switch pageZoom {
-        case 0.5:
-            return
-        case 0.9:
-            pageZoom = 0.75
-        case 1.0:
-            pageZoom = 0.9
-        case 1.10:
-            pageZoom = 1.0
-        case 1.25:
-            pageZoom = 1.10
-        default:
-            pageZoom -= 0.25
-        }
-    }
-
-    func resetZoom() {
-        pageZoom = 1.0
-    }
-
-    func setZoomLevelforDomain() {
-        if let host = url?.host,
-           let domainZoomLevel = ZoomLevelStore.shared.findZoomLevel(forDomain: host) {
-            pageZoom = domainZoomLevel.zoomLevel
-        } else {
-            resetZoom()
-        }
-    }
-
     func addContentScript(_ helper: TabContentScript, name: String) {
         contentScriptManager.addContentScript(helper, name: name, forTab: self)
     }
@@ -937,6 +885,28 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         }
 
         return .none
+    }
+
+    // MARK: - Zoom
+
+    @objc
+    func zoomIn() {
+        let newValue = zoomPageManager.zoomIn(value: pageZoom)
+        pageZoom = newValue
+    }
+
+    @objc
+    func zoomOut() {
+        let newValue = zoomPageManager.zoomOut(value: pageZoom)
+        pageZoom = newValue
+    }
+
+    func resetZoom() {
+        pageZoom = 1.0
+    }
+
+    func setZoomLevelforDomain() {
+        pageZoom = zoomPageManager.setZoomLevelforDomain(for: url?.host)
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -966,6 +966,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
         if let tab = selectedTab {
             TabEvent.post(.didGainFocus, for: tab)
+            tab.setZoomLevelforDomain()
         }
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .tab)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6765)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15058)

## :bulb: Description
WIP to refactor Zoom code to prepare for https://mozilla-hub.atlassian.net/browse/FXIOS-6765 opening as a draft to gather early feedback and make small and incremental changes
- Create `ZoomConstants` and `ZoomPageManager` to move Zoom logic scattered though Tab and BVC
- Test will be added at the end of the refactoring  


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

