### PR TITLE
Refactor FXIOS-11745 [SEC] Fetch ordered engines in background

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
@@ -38,6 +38,22 @@ final class ASSearchEngineProvider: SearchEngineProvider {
         // Note: this currently duplicates the logic from DefaultSearchEngineProvider.
         // Eventually that class will be removed once we switch fully to consolidated search.
 
+        DispatchQueue.global().async { [weak self] in
+            self?.fetchUnorderedEnginesAndApplyOrdering(
+                customEngines: customEngines,
+                engineOrderingPrefs: engineOrderingPrefs,
+                prefsMigrator: prefsMigrator,
+                completion: completion
+            )
+        }
+    }
+
+    // MARK: - Private Utilities
+
+    private func fetchUnorderedEnginesAndApplyOrdering(customEngines: [OpenSearchEngine],
+                                                       engineOrderingPrefs: SearchEnginePrefs,
+                                                       prefsMigrator: SearchEnginePreferencesMigrator,
+                                                       completion: @escaping SearchEngineCompletion) {
         let locale = Locale(identifier: Locale.preferredLanguages.first ?? Locale.current.identifier)
         let prefsVersion = preferencesVersion
 
@@ -82,8 +98,6 @@ final class ASSearchEngineProvider: SearchEngineProvider {
             ensureMainThread { completion(finalEngineOrderingPrefs, orderedEngines) }
         })
     }
-
-    // MARK: - Private Utilities
 
     private func getUnorderedBundledEnginesFor(locale: Locale,
                                                possibleLanguageIdentifier: [String],

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
@@ -35,10 +35,9 @@ final class ASSearchEngineProvider: SearchEngineProvider {
                            engineOrderingPrefs: SearchEnginePrefs,
                            prefsMigrator: SearchEnginePreferencesMigrator,
                            completion: @escaping SearchEngineCompletion) {
-        // Note: this currently duplicates the logic from DefaultSearchEngineProvider.
-        // Eventually that class will be removed once we switch fully to consolidated search.
-
         DispatchQueue.global().async { [weak self] in
+            // Note: this currently duplicates the logic from DefaultSearchEngineProvider.
+            // Eventually that class will be removed once we switch fully to consolidated search.
             self?.fetchUnorderedEnginesAndApplyOrdering(
                 customEngines: customEngines,
                 engineOrderingPrefs: engineOrderingPrefs,

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
@@ -32,33 +32,33 @@ final class ASSearchEngineSelector: ASSearchEngineSelectorProtocol {
     func fetchSearchEngines(locale: String,
                             region: String,
                             completion: @escaping ((RefinedSearchConfig?, Error?) -> Void)) {
-         do {
-             try engineSelector.useRemoteSettingsServer(service: service, applyEngineOverrides: false)
-             if SearchEngineFlagManager.temp_dbg_forceASSync { _ = try? service.sync() }
+        do {
+            try engineSelector.useRemoteSettingsServer(service: service, applyEngineOverrides: false)
+            if SearchEngineFlagManager.temp_dbg_forceASSync { _ = try? service.sync() }
 
-             let deviceType: SearchDeviceType = UIDevice.current.userInterfaceIdiom == .pad ? .tablet : .smartphone
-             // TODO: What happens if the locale or region changes during app runtime?
-             let env = SearchUserEnvironment(locale: locale,
-                                             region: region,
-                                             updateChannel: SearchUpdateChannel.release,
-                                             distributionId: "",    // Confirmed with AS: leave empty, no distr on iOS
-                                             experiment: "",        // Confirmed with AS: leave empty
-                                             appName: .firefoxIos,
-                                             version: AppInfo.appVersion,
-                                             deviceType: deviceType)
+            let deviceType: SearchDeviceType = UIDevice.current.userInterfaceIdiom == .pad ? .tablet : .smartphone
+            // TODO: What happens if the locale or region changes during app runtime?
+            let env = SearchUserEnvironment(locale: locale,
+                                            region: region,
+                                            updateChannel: SearchUpdateChannel.release,
+                                            distributionId: "",    // Confirmed with AS: leave empty, no distr on iOS
+                                            experiment: "",        // Confirmed with AS: leave empty
+                                            appName: .firefoxIos,
+                                            version: AppInfo.appVersion,
+                                            deviceType: deviceType)
 
-             var searchResultsConfig = try engineSelector.filterEngineConfiguration(userEnvironment: env)
+            var searchResultsConfig = try engineSelector.filterEngineConfiguration(userEnvironment: env)
 
-             // We want to be sure that our default engines list is always sorted with the default in position 0
-             // This is important in the case of new installs, for example, where the user does not have any
-             // search engine ordering preferences saved. Generally the `engines` should already be sorted this
-             // way but this code should be very fast on this small collection so we ensure the sort order here.
-             searchResultsConfig.sortDefaultEngineToIndex0()
+            // We want to be sure that our default engines list is always sorted with the default in position 0
+            // This is important in the case of new installs, for example, where the user does not have any
+            // search engine ordering preferences saved. Generally the `engines` should already be sorted this
+            // way but this code should be very fast on this small collection so we ensure the sort order here.
+            searchResultsConfig.sortDefaultEngineToIndex0()
 
-             completion(searchResultsConfig, nil)
-         } catch {
-             completion(nil, error)
-         }
+            completion(searchResultsConfig, nil)
+        } catch {
+            completion(nil, error)
+        }
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11745)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25615)

## :bulb: Description

Minor refactor; offloads the AS-based search engine fetching, icon fetching, prefs migration, and sorting to a background thread. Initially explored Task but it ended up being simpler to use GCD, especially since our existing protocols/patterns for the search providers are using completion callbacks, though I would like to revisit this at some point to explore async/await for this (after we have removed the older search engine providers would probably the ideal time, there will be half as much code to update, since the protocols all have to be updated to mark the methods `async`).

Note: per the AS team, the APIs for fetching the engines and icon records are thread-safe.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

