### PR TITLE
Bugfix FXIOS-11864 ⁃ New tab set as custom URL - keyboard is raised up when opening new tab through widget

### DIFF
--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -88,11 +88,11 @@ final class RouteBuilder: FeatureFlaggable {
 
             case .widgetSmallQuickLinkOpenUrl:
                 // Widget Quick links - small - open url private or regular
-                return .search(url: urlQuery, isPrivate: isPrivate, options: [.focusLocationField])
+                return getWidgetRoute(urlQuery: urlQuery, isPrivate: isPrivate)
 
             case .widgetMediumQuickLinkOpenUrl:
                 // Widget Quick Actions - medium - open url private or regular
-                return .search(url: urlQuery, isPrivate: isPrivate, options: [.focusLocationField])
+                return getWidgetRoute(urlQuery: urlQuery, isPrivate: isPrivate)
 
             case .widgetSmallQuickLinkOpenCopied, .widgetMediumQuickLinkOpenCopied:
                 // Widget Quick links - medium - open copied url
@@ -219,6 +219,11 @@ final class RouteBuilder: FeatureFlaggable {
         case .qrCode:
             return .action(action: .showQRCode)
         }
+    }
+
+    private func getWidgetRoute(urlQuery: URL?, isPrivate: Bool) -> Route? {
+        let isCustomLink = prefs?.stringForKey(NewTabAccessors.NewTabPrefKey) == NewTabPage.homePage.rawValue
+        return .search(url: urlQuery, isPrivate: isPrivate, options: isCustomLink ? [] : [.focusLocationField])
     }
 
     // MARK: - Telemetry


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11864)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25843)

## :bulb: Description
Don't show the keyboard when app is open from widgets and homepage is a customURL

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

