### PR TITLE
Add FXIOS-11791 [Dark Reader] Use dark reader to handle reader mode theming

### DIFF
--- a/BrowserKit/Sources/Common/ReaderMode/ReaderModeFontType.swift
+++ b/BrowserKit/Sources/Common/ReaderMode/ReaderModeFontType.swift
@@ -27,8 +27,11 @@ public enum ReaderModeFontType: String {
         }
     }
 
-    public func isSameFamily(_ font: ReaderModeFontType) -> Bool {
-        return FontFamily.families.contains(where: { $0.contains(font) && $0.contains(self) })
+    public func attributes() -> [String: String] {
+        [
+            "fontType": rawValue.contains("serif") ? "serif" : "sans-serif",
+            "fontWeight": rawValue.contains("bold") ? "bold" : "normal"
+        ]
     }
 }
 

--- a/BrowserKit/Sources/Common/ReaderMode/ReaderModeFontType.swift
+++ b/BrowserKit/Sources/Common/ReaderMode/ReaderModeFontType.swift
@@ -11,6 +11,24 @@ public enum ReaderModeFontType: String {
     case sansSerif = "sans-serif"
     case sansSerifBold = "sans-serif-bold"
 
+    public var fontFamily: String {
+        switch self {
+        case .serif, .serifBold:
+            return "serif"
+        case .sansSerif, .sansSerifBold:
+            return "sans-serif"
+        }
+    }
+
+    public var fontWeight: String {
+        switch self {
+        case .serifBold, .sansSerifBold:
+            return "bold"
+        default:
+            return "normal"
+        }
+    }
+
     public init(type: String) {
         let font = ReaderModeFontType(rawValue: type)
         let isBoldFontEnabled = UIAccessibility.isBoldTextEnabled
@@ -33,8 +51,8 @@ public enum ReaderModeFontType: String {
 
     public func attributes() -> [String: String] {
         [
-            "fontType": rawValue.contains("serif") ? "serif" : "sans-serif",
-            "fontWeight": rawValue.contains("bold") ? "bold" : "normal"
+            "fontType": fontFamily,
+            "fontWeight": fontWeight
         ]
     }
 }

--- a/BrowserKit/Sources/Common/ReaderMode/ReaderModeFontType.swift
+++ b/BrowserKit/Sources/Common/ReaderMode/ReaderModeFontType.swift
@@ -27,6 +27,10 @@ public enum ReaderModeFontType: String {
         }
     }
 
+    public func isSameFamily(_ font: ReaderModeFontType) -> Bool {
+        return FontFamily.families.contains(where: { $0.contains(font) && $0.contains(self) })
+    }
+
     public func attributes() -> [String: String] {
         [
             "fontType": rawValue.contains("serif") ? "serif" : "sans-serif",

--- a/BrowserKit/Sources/Common/ReaderMode/ReaderModeStyle.swift
+++ b/BrowserKit/Sources/Common/ReaderMode/ReaderModeStyle.swift
@@ -18,7 +18,13 @@ public struct ReaderModeStyle {
 
     /// Encode the style to a dictionary that can be stored in the profile
     public func encodeAsDictionary() -> [String: Any] {
-        return ["theme": theme.rawValue, "fontType": fontType.rawValue, "fontSize": fontSize.rawValue]
+        let fontAttributes = fontType.attributes()
+        return [
+            "theme": theme.rawValue,
+            "fontType": fontAttributes["fontType"],
+            "fontWeight": fontAttributes["fontWeight"],
+            "fontSize": fontSize.rawValue
+        ]
     }
 
     public init(windowUUID: WindowUUID?,

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -116,8 +116,14 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
               let response = GCDWebServerDataResponse(html: html) else { return nil }
         // Apply a Content Security Policy that disallows everything except images from
         // anywhere and fonts and css from our internal server
-        response.setValue("default-src 'none'; img-src *; style-src http://localhost:* '\(ReaderModeStyleHash)'; font-src http://localhost:*",
-                          forAdditionalHeader: "Content-Security-Policy")
+        let csp = """
+            default-src 'none';
+            img-src *;
+            style-src 'unsafe-inline' http://localhost:*;
+            font-src http://localhost:*;
+            script-src 'unsafe-inline' http://localhost:*;
+        """
+        response.setValue(scp, forAdditionalHeader: "Content-Security-Policy")
         return response
     }
 

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -13,8 +13,6 @@ protocol ReaderModeHandlersProtocol {
 }
 
 struct ReaderModeHandlers: ReaderModeHandlersProtocol {
-    static let ReaderModeStyleHash = "sha256-L2W8+0446ay9/L1oMrgucknQXag570zwgQrHwE68qbQ="
-
     static var readerModeCache: ReaderModeCache = DiskReaderModeCache.shared
 
     func register(_ webServer: WebServerProtocol, profile: Profile) {
@@ -114,8 +112,11 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
             initialStyle: readerModeStyle
         ),
               let response = GCDWebServerDataResponse(html: html) else { return nil }
-        // Apply a Content Security Policy that disallows everything except images from
-        // anywhere and fonts and css from our internal server
+        // Apply a Content Security Policy that disallows everything except:
+        // - images from anywhere
+        // - styles including inline styles from our internal server
+        // - scripts including inline scripts from our internal server
+        // - fonts our internal server
         let csp = """
             default-src 'none';
             img-src *;

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -123,7 +123,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
             font-src http://localhost:*;
             script-src 'unsafe-inline' http://localhost:*;
         """
-        response.setValue(scp, forAdditionalHeader: "Content-Security-Policy")
+        response.setValue(csp, forAdditionalHeader: "Content-Security-Policy")
         return response
     }
 

--- a/firefox-ios/Client/Frontend/Reader/Resources/Reader.css
+++ b/firefox-ios/Client/Frontend/Reader/Resources/Reader.css
@@ -40,36 +40,7 @@ body {
   font-family: -apple-system, sans-serif;
 }
 
-.light {
-  background-color: #ffffff;
-  color: #15141a;
-}
-
-.dark {
-  background-color: #333333;
-  color: #fbfbfe;
-}
-
-.sepia {
-    background-color: #fff4de;
-    color: #15141a;
-}
-
-.sans-serif {
-  font-family: -apple-system, sans-serif;
-}
-
-.sans-serif-bold {
-  font-family: -apple-system, sans-serif;
-  font-weight: bold;
-}
-
-.serif {
-  font-family: new-york;
-}
-
-.serif-bold {
-    font-family: new-york;
+.bold {
     font-weight: bold;
 }
 

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentEnd/FindInPage.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentEnd/FindInPage.js
@@ -15,10 +15,6 @@ const HIGHLIGHT_CLASS_NAME_ACTIVE = "__firefox__find-highlight-active";
 const HIGHLIGHT_COLOR = "#ffde49";
 const HIGHLIGHT_COLOR_ACTIVE = "#f19750";
 
-// IMPORTANT!!!: If this CSS is ever changed, the sha256-base64
-// hash in Client/Frontend/Reader/ReaderModeHandlers.swift will
-// also need updated. The value of `ReaderModeStyleHash` in that
-// file represents the sha256-base64 hash of the `HIGHLIGHT_CSS`.
 const HIGHLIGHT_CSS =
 `.${HIGHLIGHT_CLASS_NAME} {
   color: #000;

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderMode.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderMode.js
@@ -5,11 +5,11 @@
 
 "use strict";
 import { isProbablyReaderable, Readability } from "@mozilla/readability";
+import {setStyle} from "./ReaderModeStyles.js";
 
 const DEBUG = false;
 
 var readabilityResult = null;
-var currentStyle = null;
 
 const readerModeURL = /^http:\/\/localhost:\d+\/reader-mode\/page/;
 
@@ -101,38 +101,6 @@ function checkReadability() {
 // can simply return the results we already have.
 function readerize() {
   return readabilityResult;
-}
-
-// TODO: The following code only makes sense in about:reader context. It may be a good idea to move
-// it out of this file and into for example a Reader.js.
-
-function setStyle(style) {
-  // Configure the theme (light, dark)
-  if (currentStyle && currentStyle.theme) {
-    document.body.classList.remove(currentStyle.theme);
-  }
-  if (style && style.theme) {
-    document.body.classList.add(style.theme);
-  }
-
-  // Configure the font size (1-5)
-  if (currentStyle && currentStyle.fontSize) {
-    document.body.classList.remove("font-size" + currentStyle.fontSize);
-  }
-  if (style && style.fontSize) {
-    document.body.classList.add("font-size" + style.fontSize);
-  }
-
-  // Configure the font type
-  if (currentStyle && currentStyle.fontType) {
-    document.body.classList.remove(currentStyle.fontType);
-  }
-  if (style && style.fontType) {
-    document.body.classList.add(style.fontType);
-  }
-
-  // Remember the style
-  currentStyle = style;
 }
 
 function updateImageMargins() {

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderModeStyles.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderModeStyles.js
@@ -1,0 +1,59 @@
+import { enable as enableDarkReader, setFetchMethod } from "darkreader";
+
+// Needed in order for dark reader to handle CORS properly
+// This tells dark reader to use the global window.fetch.
+setFetchMethod(window.fetch);
+
+const THEME_CLASSES = ["light", "dark", "sepia"];
+const FONT_TYPES = {
+  "sans-serif": "-apple-system, sans-serif",
+  serif: "new-york",
+};
+const DEFAULT_DR_CONFIGS = {
+  light: {
+    mode: 0,
+    brightness: 100,
+    contrast: 100,
+    sepia: 0,
+    lightSchemeBackgroundColor: "#ffffff",
+    lightSchemeTextColor: "#15141a",
+  },
+  dark: {
+    mode: 1,
+    brightness: 100,
+    contrast: 100,
+    sepia: 0,
+  },
+  sepia: {
+    mode: 0,
+    brightness: 100,
+    contrast: 100,
+    sepia: 20,
+    lightSchemeBackgroundColor: "#fff4de",
+    lightSchemeTextColor: "#15141a",
+  },
+};
+
+const applyFontConfig = (style) => {
+  // Font Sizes (1–13)
+  for (let i = 1; i <= 13; i++) {
+    document.body.classList.toggle(`font-size${i}`, style?.fontSize === i);
+  }
+
+  document.body.classList.toggle("bold", style?.fontWeight === "bold");
+  return {
+    ...DEFAULT_DR_CONFIGS[style?.theme],
+    useFont: true,
+    fontFamily: FONT_TYPES[style?.fontType],
+  };
+};
+
+export const setStyle = (style) => {
+  // Remove all theme classes
+  THEME_CLASSES.forEach((theme) => {
+    document.body.classList.toggle(theme, theme === style?.theme);
+  });
+  // Apply new dark reader config with font setup
+  const config = applyFontConfig(style);
+  enableDarkReader(config);
+};

--- a/focus-ios/Blockzilla/FindInPage.js
+++ b/focus-ios/Blockzilla/FindInPage.js
@@ -36,10 +36,6 @@ const HIGHLIGHT_CLASS_NAME_ACTIVE = "__firefox__find-highlight-active";
 const HIGHLIGHT_COLOR = "#ffde49";
 const HIGHLIGHT_COLOR_ACTIVE = "#f19750";
 
-// IMPORTANT!!!: If this CSS is ever changed, the sha256-base64
-// hash in Client/Frontend/Reader/ReaderModeHandlers.swift will
-// also need updated. The value of `ReaderModeStyleHash` in that
-// file represents the sha256-base64 hash of the `HIGHLIGHT_CSS`.
 const HIGHLIGHT_CSS =
 `.${HIGHLIGHT_CLASS_NAME} {
   color: #000;


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11791)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25709)

## :bulb: Description
This PR:
- Removes extra logic for switching styles in reader mode.
- Adds `ReaderModeStyles` script that defers to dark reader for styling.
- Updates csp to allow inline scripts and styles to run ( Needed for Dark Reader to run properly) 


https://github.com/user-attachments/assets/b7ffc222-13f5-4ed0-ad9c-c3f32e16cd28


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

