### PR TITLE
Refactor FXIOS-11844 [Tab tray UI experiment] Fix tab selector view isSelected when moving to background

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4281,7 +4281,7 @@ extension BrowserViewController: TabManagerDelegate {
         if let selectedTab = tabManager.selectedTab {
             let count = selectedTab.isPrivate ? tabManager.privateTabs.count : tabManager.normalTabs.count
             if isToolbarRefactorEnabled {
-               updateToolbarTabCount(count)
+                updateToolbarTabCount(count)
             } else if !isToolbarRefactorEnabled, let legacyUrlBar {
                 toolbar.updateTabCount(count, animated: animated)
                 legacyUrlBar.updateTabCount(count, animated: !legacyUrlBar.inOverlayMode)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorCell.swift
@@ -8,6 +8,8 @@ import Common
 final class TabTraySelectorCell: UICollectionViewCell,
                                  ReusableCell,
                                  ThemeApplicable {
+    /// `isSelected` property doesn't seem to be retained when we move to background so saving it here as well
+    private var isCellSelected = false
     private let label = UILabel()
     private let padding = UIEdgeInsets(
         top: TabTraySelectorUX.cellVerticalPadding,
@@ -41,6 +43,7 @@ final class TabTraySelectorCell: UICollectionViewCell,
     }
 
     func configure(title: String, selected: Bool, theme: Theme?, position: Int, total: Int) {
+        isCellSelected = selected
         isSelected = selected
         label.text = title
         label.font = selected ? FXFontStyles.Bold.body.scaledFont() : FXFontStyles.Regular.body.scaledFont()
@@ -55,6 +58,6 @@ final class TabTraySelectorCell: UICollectionViewCell,
 
     func applyTheme(theme: Theme) {
         label.textColor = theme.colors.textPrimary
-        contentView.backgroundColor = isSelected ? theme.colors.layer4 : .clear
+        contentView.backgroundColor = isCellSelected ? theme.colors.layer4 : .clear
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11844)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25816)

## :bulb: Description
Fix tab selector view `isSelected` when moving to background

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

