### PR TITLE
Bugfix FXIOS-11847 [Tab Tray UI Experiment] Fix glitch when navigating from tab tray to webpage

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
@@ -159,9 +159,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         context.containerView.addSubview(backgroundView)
         context.containerView.addSubview(bvcSnapshot)
         context.containerView.addSubview(tabSnapshot)
-        print(finalFrame)
-        print(destinationController.view.frame)
-        print("hi")
+
         destinationController.view.frame = finalFrame
         destinationController.view.setNeedsLayout()
         destinationController.view.layoutIfNeeded()
@@ -285,9 +283,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             if let cell = cv.cellForItem(at: indexPath) as? ExperimentTabCell {
                 tabCell = cell
                 tabSnapshot.frame = cv.convert(cell.frame, to: view)
-                print(tabSnapshot.frame)
-                print(toVCSnapshot.frame)
-                print("hi")
                 toVCSnapshot.frame = tabSnapshot.frame
 
                 tabSnapshot.setNeedsLayout()
@@ -301,9 +296,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             cv.transform = .init(scaleX: 1.2, y: 1.2)
             cv.alpha = 0.5
 
-            print(webView.frame)
-            let relativeFrame = webView.convert(webView.bounds, to: browserVC.view)
-            tabSnapshot.frame = relativeFrame
+            tabSnapshot.frame = webView.convert(webView.bounds, to: browserVC.view)
             tabSnapshot.layer.cornerRadius = 0
             toVCSnapshot.frame = finalFrame
             toVCSnapshot.layer.cornerRadius = 0

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
@@ -159,7 +159,9 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         context.containerView.addSubview(backgroundView)
         context.containerView.addSubview(bvcSnapshot)
         context.containerView.addSubview(tabSnapshot)
-
+        print(finalFrame)
+        print(destinationController.view.frame)
+        print("hi")
         destinationController.view.frame = finalFrame
         destinationController.view.setNeedsLayout()
         destinationController.view.layoutIfNeeded()
@@ -283,6 +285,9 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             if let cell = cv.cellForItem(at: indexPath) as? ExperimentTabCell {
                 tabCell = cell
                 tabSnapshot.frame = cv.convert(cell.frame, to: view)
+                print(tabSnapshot.frame)
+                print(toVCSnapshot.frame)
+                print("hi")
                 toVCSnapshot.frame = tabSnapshot.frame
 
                 tabSnapshot.setNeedsLayout()
@@ -296,7 +301,9 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             cv.transform = .init(scaleX: 1.2, y: 1.2)
             cv.alpha = 0.5
 
-            tabSnapshot.frame = webView.frame
+            print(webView.frame)
+            let relativeFrame = webView.convert(webView.bounds, to: browserVC.view)
+            tabSnapshot.frame = relativeFrame
             tabSnapshot.layer.cornerRadius = 0
             toVCSnapshot.frame = finalFrame
             toVCSnapshot.layer.cornerRadius = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11847)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25819)

## :bulb: Description
Fix glitch when navigating from tab tray to webpage, the frame needed to be adjusted while dismissing the tab tray so that the webView frame position was relative to the BrowserVC

TODO:
There's still some issues with homepage presentation and dismissal, I will be addressing those next as part of
[this ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11850)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

