### PR TITLE
Refactor FXIOS-7301 - Remove 2 closure_body_length violation from DownloadLiveActivity.swift and TrackingProtectionViewController.swift, and decrease threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,8 +103,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 45
-  error: 45
+  warning: 43
+  error: 43
 
 file_header:
   required_string: |

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -191,6 +191,28 @@ struct DownloadLiveActivity: Widget {
             .padding()
         }
     }
+
+    private func texts(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>) -> some View {
+        let bytesCompleted = liveDownload.state.totalBytesDownloaded
+        let bytesExpected = liveDownload.state.totalBytesExpected
+        let mbCompleted = ByteCountFormatter.string(fromByteCount: bytesCompleted, countStyle: .file)
+        let mbExpected = ByteCountFormatter.string(fromByteCount: bytesExpected, countStyle: .file)
+        let subtitle = String(format: .LiveActivity.Downloads.FileProgressText, mbCompleted, mbExpected)
+
+        return VStack(alignment: .leading, spacing: UX.LockScreen.verticalSpacing) {
+            Text(liveDownload.state.downloads.count == 1 ?
+                 String(format: .LiveActivity.Downloads.FileNameText, liveDownload.state.downloads[0].fileName) :
+                    String(format: .LiveActivity.Downloads.FileCountText,
+                           String(liveDownload.state.downloads.count)))
+            .font(.system(size: UX.LockScreen.titleFont, weight: .bold))
+            .foregroundColor(UX.LockScreen.labelColor)
+            Text(subtitle).font(.system(size: UX.LockScreen.subtitleFont))
+                .opacity(0.8)
+                .foregroundColor(UX.LockScreen.labelColor)
+                .contentTransition(.identity)
+        }
+    }
+
     private func leadingExpandedRegion
     (liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>)
     -> DynamicIslandExpandedRegion<some View> {

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -137,11 +137,6 @@ struct DownloadLiveActivity: Widget {
         }
     }
     private func lockScreenView (liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>) -> some View {
-        let bytesCompleted = liveDownload.state.totalBytesDownloaded
-        let bytesExpected = liveDownload.state.totalBytesExpected
-        let mbCompleted = ByteCountFormatter.string(fromByteCount: bytesCompleted, countStyle: .file)
-        let mbExpected = ByteCountFormatter.string(fromByteCount: bytesExpected, countStyle: .file)
-        let subtitle = String(format: .LiveActivity.Downloads.FileProgressText, mbCompleted, mbExpected)
         let totalCompletion = liveDownload.state.completedDownloads == liveDownload.state.downloads.count
         return ZStack {
             Rectangle()
@@ -157,18 +152,7 @@ struct DownloadLiveActivity: Widget {
                         .scaledToFit()
                         .frame(width: UX.LockScreen.iconSize, height: UX.LockScreen.iconSize)
                 }
-                VStack(alignment: .leading, spacing: UX.LockScreen.verticalSpacing) {
-                    Text(liveDownload.state.downloads.count == 1 ?
-                         String(format: .LiveActivity.Downloads.FileNameText, liveDownload.state.downloads[0].fileName) :
-                            String(format: .LiveActivity.Downloads.FileCountText,
-                                   String(liveDownload.state.downloads.count)))
-                        .font(.system(size: UX.LockScreen.titleFont, weight: .bold))
-                        .foregroundColor(UX.LockScreen.labelColor)
-                    Text(subtitle).font(.system(size: UX.LockScreen.subtitleFont))
-                        .opacity(0.8)
-                        .foregroundColor(UX.LockScreen.labelColor)
-                        .contentTransition(.identity)
-                }
+                lockScreenTexts(liveDownload: liveDownload)
                 Spacer()
                 ZStack {
                     Circle()

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -197,6 +197,28 @@ struct DownloadLiveActivity: Widget {
         }
     }
 
+    private func lockScreenDownloadProgress(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>) -> some View {
+        let totalCompletion = liveDownload.state.completedDownloads == liveDownload.state.downloads.count
+
+        return ZStack {
+            Circle()
+                .stroke(lineWidth: UX.LockScreen.circleWidth)
+                .foregroundColor(UX.LockScreen.labelColor)
+                .opacity(0.3)
+            Circle()
+                .trim(from: 0.0, to: min(liveDownload.state.totalProgress, 1.0))
+                .stroke(style: StrokeStyle(lineWidth: UX.LockScreen.circleWidth))
+                .rotationEffect(.degrees(270))
+                .animation(.linear, value: UX.LockScreen.circleAnimation)
+                .foregroundColor(UX.LockScreen.labelColor)
+            Image(totalCompletion ? UX.checkmarkIcon : UX.mediaStopIcon)
+                .renderingMode(.template)
+                .frame(width: UX.LockScreen.progressIconSize, height: UX.LockScreen.progressIconSize)
+                .foregroundStyle(UX.LockScreen.labelColor)
+        }
+        .frame(width: UX.LockScreen.circleRadius, height: UX.LockScreen.circleRadius)
+    }
+
     private func leadingExpandedRegion
     (liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>)
     -> DynamicIslandExpandedRegion<some View> {

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -137,7 +137,6 @@ struct DownloadLiveActivity: Widget {
         }
     }
     private func lockScreenView (liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>) -> some View {
-        let totalCompletion = liveDownload.state.completedDownloads == liveDownload.state.downloads.count
         return ZStack {
             Rectangle()
                 .widgetURL(URL(string: URL.mozInternalScheme + "://deep-link?url=/homepanel/downloads"))
@@ -154,23 +153,7 @@ struct DownloadLiveActivity: Widget {
                 }
                 lockScreenTexts(liveDownload: liveDownload)
                 Spacer()
-                ZStack {
-                    Circle()
-                        .stroke(lineWidth: UX.LockScreen.circleWidth)
-                        .foregroundColor(UX.LockScreen.labelColor)
-                        .opacity(0.3)
-                    Circle()
-                        .trim(from: 0.0, to: min(liveDownload.state.totalProgress, 1.0))
-                        .stroke(style: StrokeStyle(lineWidth: UX.LockScreen.circleWidth))
-                        .rotationEffect(.degrees(270))
-                        .animation(.linear, value: UX.LockScreen.circleAnimation)
-                        .foregroundColor(UX.LockScreen.labelColor)
-                    Image(totalCompletion ? UX.checkmarkIcon : UX.mediaStopIcon)
-                        .renderingMode(.template)
-                        .frame(width: UX.LockScreen.progressIconSize, height: UX.LockScreen.progressIconSize)
-                        .foregroundStyle(UX.LockScreen.labelColor)
-                }
-                .frame(width: UX.LockScreen.circleRadius, height: UX.LockScreen.circleRadius)
+                lockScreenDownloadProgress(liveDownload: liveDownload)
             }
             .padding()
         }

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -192,7 +192,7 @@ struct DownloadLiveActivity: Widget {
         }
     }
 
-    private func texts(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>) -> some View {
+    private func lockScreenTexts(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>) -> some View {
         let bytesCompleted = liveDownload.state.totalBytesDownloaded
         let bytesExpected = liveDownload.state.totalBytesExpected
         let mbCompleted = ByteCountFormatter.string(fromByteCount: bytesCompleted, countStyle: .file)

--- a/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -134,7 +134,7 @@ class TrackingProtectionViewController: UIViewController {
                 let cell = SwitchTableViewCell(item: blockOtherItem, reuseIdentifier: "SwitchTableViewCell")
                 cell.valueChanged.sink { [unowned self] isOn in
                     if isOn {
-                        let alertController = createAlertController(cell: cell)
+                        let alertController = createAlertControllerToShowContentBlockingWarning(cell: cell)
                         self.present(alertController, animated: true, completion: nil)
                     } else {
                         self.blockOtherItem.settingsValue = isOn
@@ -155,7 +155,7 @@ class TrackingProtectionViewController: UIViewController {
         )
     ]
 
-    private func createAlertController(cell: SwitchTableViewCell) -> UIAlertController {
+    private func createAlertControllerToShowContentBlockingWarning(cell: SwitchTableViewCell) -> UIAlertController {
         let alertController = UIAlertController(title: nil, message: UIConstants.strings.settingsBlockOtherMessage, preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: UIConstants.strings.settingsBlockOtherNo, style: .default) { [unowned self] _ in
             // TODO: Make sure to reset the toggle

--- a/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -134,7 +134,7 @@ class TrackingProtectionViewController: UIViewController {
                 let cell = SwitchTableViewCell(item: blockOtherItem, reuseIdentifier: "SwitchTableViewCell")
                 cell.valueChanged.sink { [unowned self] isOn in
                     if isOn {
-                        let alertController = createAlertControllerToShowContentBlockingWarning(cell: cell)
+                        let alertController = self.createAlertControllerToShowContentBlockingWarning(cell: cell)
                         self.present(alertController, animated: true, completion: nil)
                     } else {
                         self.blockOtherItem.settingsValue = isOn

--- a/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -134,7 +134,7 @@ class TrackingProtectionViewController: UIViewController {
                 let cell = SwitchTableViewCell(item: blockOtherItem, reuseIdentifier: "SwitchTableViewCell")
                 cell.valueChanged.sink { [unowned self] isOn in
                     if isOn {
-                        let alertController = self.createAlertControllerToShowContentBlockingWarning(cell: cell)
+                        let alertController = self.createAlertControllerForCell(cell: cell)
                         self.present(alertController, animated: true, completion: nil)
                     } else {
                         self.blockOtherItem.settingsValue = isOn
@@ -155,7 +155,7 @@ class TrackingProtectionViewController: UIViewController {
         )
     ]
 
-    private func createAlertControllerToShowContentBlockingWarning(cell: SwitchTableViewCell) -> UIAlertController {
+    private func createAlertControllerForCell(cell: SwitchTableViewCell) -> UIAlertController {
         let alertController = UIAlertController(title: nil, message: UIConstants.strings.settingsBlockOtherMessage, preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: UIConstants.strings.settingsBlockOtherNo, style: .default) { [unowned self] _ in
             // TODO: Make sure to reset the toggle

--- a/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -155,38 +155,6 @@ class TrackingProtectionViewController: UIViewController {
         )
     ]
 
-    private func createAlertControllerForCell(_ cell: SwitchTableViewCell) -> UIAlertController {
-        let alertController = UIAlertController(title: nil, message: UIConstants.strings.settingsBlockOtherMessage, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: UIConstants.strings.settingsBlockOtherNo, style: .default) { [unowned self] _ in
-            // TODO: Make sure to reset the toggle
-            cell.isOn = false
-            self.blockOtherItem.settingsValue = false
-            self.updateTelemetry(self.blockOtherItem.settingsKey, false)
-            GleanMetrics
-                .TrackingProtection
-                .trackerSettingChanged
-                .record(.init(
-                    isEnabled: false,
-                    sourceOfChange: self.sourceOfChange,
-                    trackerChanged: self.blockOtherItem.settingsKey.trackerChanged
-                ))
-        })
-        alertController.addAction(UIAlertAction(title: UIConstants.strings.settingsBlockOtherYes, style: .destructive) { [unowned self] _ in
-            self.blockOtherItem.settingsValue = true
-            self.updateTelemetry(self.blockOtherItem.settingsKey, true)
-            GleanMetrics
-                .TrackingProtection
-                .trackerSettingChanged
-                .record(.init(
-                    isEnabled: true,
-                    sourceOfChange: self.sourceOfChange,
-                    trackerChanged: self.blockOtherItem.settingsKey.trackerChanged
-                ))
-        })
-
-        return alertController
-    }
-
     lazy var statsSectionItems = [
         SectionItem(
             configureCell: { [unowned self] _, _ in
@@ -383,6 +351,38 @@ class TrackingProtectionViewController: UIViewController {
         GleanMetrics.TrackingProtection.hasEverChangedEtp.set(true)
 
         delegate?.trackingProtectionDidToggleProtection(enabled: isOn)
+    }
+
+    private func createAlertControllerForCell(_ cell: SwitchTableViewCell) -> UIAlertController {
+        let alertController = UIAlertController(title: nil, message: UIConstants.strings.settingsBlockOtherMessage, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: UIConstants.strings.settingsBlockOtherNo, style: .default) { [unowned self] _ in
+            // TODO: Make sure to reset the toggle
+            cell.isOn = false
+            self.blockOtherItem.settingsValue = false
+            self.updateTelemetry(self.blockOtherItem.settingsKey, false)
+            GleanMetrics
+                .TrackingProtection
+                .trackerSettingChanged
+                .record(.init(
+                    isEnabled: false,
+                    sourceOfChange: self.sourceOfChange,
+                    trackerChanged: self.blockOtherItem.settingsKey.trackerChanged
+                ))
+        })
+        alertController.addAction(UIAlertAction(title: UIConstants.strings.settingsBlockOtherYes, style: .destructive) { [unowned self] _ in
+            self.blockOtherItem.settingsValue = true
+            self.updateTelemetry(self.blockOtherItem.settingsKey, true)
+            GleanMetrics
+                .TrackingProtection
+                .trackerSettingChanged
+                .record(.init(
+                    isEnabled: true,
+                    sourceOfChange: self.sourceOfChange,
+                    trackerChanged: self.blockOtherItem.settingsKey.trackerChanged
+                ))
+        })
+
+        return alertController
     }
 }
 

--- a/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -181,6 +181,38 @@ class TrackingProtectionViewController: UIViewController {
         )
     ]
 
+    private func createAlertController(cell: SwitchTableViewCell) -> UIAlertController {
+        let alertController = UIAlertController(title: nil, message: UIConstants.strings.settingsBlockOtherMessage, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: UIConstants.strings.settingsBlockOtherNo, style: .default) { [unowned self] _ in
+            // TODO: Make sure to reset the toggle
+            cell.isOn = false
+            self.blockOtherItem.settingsValue = false
+            self.updateTelemetry(self.blockOtherItem.settingsKey, false)
+            GleanMetrics
+                .TrackingProtection
+                .trackerSettingChanged
+                .record(.init(
+                    isEnabled: false,
+                    sourceOfChange: self.sourceOfChange,
+                    trackerChanged: self.blockOtherItem.settingsKey.trackerChanged
+                ))
+        })
+        alertController.addAction(UIAlertAction(title: UIConstants.strings.settingsBlockOtherYes, style: .destructive) { [unowned self] _ in
+            self.blockOtherItem.settingsValue = true
+            self.updateTelemetry(self.blockOtherItem.settingsKey, true)
+            GleanMetrics
+                .TrackingProtection
+                .trackerSettingChanged
+                .record(.init(
+                    isEnabled: true,
+                    sourceOfChange: self.sourceOfChange,
+                    trackerChanged: self.blockOtherItem.settingsKey.trackerChanged
+                ))
+        })
+
+        return alertController
+    }
+
     lazy var statsSectionItems = [
         SectionItem(
             configureCell: { [unowned self] _, _ in

--- a/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -134,7 +134,7 @@ class TrackingProtectionViewController: UIViewController {
                 let cell = SwitchTableViewCell(item: blockOtherItem, reuseIdentifier: "SwitchTableViewCell")
                 cell.valueChanged.sink { [unowned self] isOn in
                     if isOn {
-                        let alertController = self.createAlertControllerForCell(cell: cell)
+                        let alertController = self.createAlertControllerForCell(cell)
                         self.present(alertController, animated: true, completion: nil)
                     } else {
                         self.blockOtherItem.settingsValue = isOn
@@ -155,7 +155,7 @@ class TrackingProtectionViewController: UIViewController {
         )
     ]
 
-    private func createAlertControllerForCell(cell: SwitchTableViewCell) -> UIAlertController {
+    private func createAlertControllerForCell(_ cell: SwitchTableViewCell) -> UIAlertController {
         let alertController = UIAlertController(title: nil, message: UIConstants.strings.settingsBlockOtherMessage, preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: UIConstants.strings.settingsBlockOtherNo, style: .default) { [unowned self] _ in
             // TODO: Make sure to reset the toggle

--- a/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
+++ b/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionViewController.swift
@@ -134,33 +134,7 @@ class TrackingProtectionViewController: UIViewController {
                 let cell = SwitchTableViewCell(item: blockOtherItem, reuseIdentifier: "SwitchTableViewCell")
                 cell.valueChanged.sink { [unowned self] isOn in
                     if isOn {
-                        let alertController = UIAlertController(title: nil, message: UIConstants.strings.settingsBlockOtherMessage, preferredStyle: .alert)
-                        alertController.addAction(UIAlertAction(title: UIConstants.strings.settingsBlockOtherNo, style: .default) { [unowned self] _ in
-                            // TODO: Make sure to reset the toggle
-                            cell.isOn = false
-                            self.blockOtherItem.settingsValue = false
-                            self.updateTelemetry(self.blockOtherItem.settingsKey, false)
-                            GleanMetrics
-                                .TrackingProtection
-                                .trackerSettingChanged
-                                .record(.init(
-                                    isEnabled: false,
-                                    sourceOfChange: self.sourceOfChange,
-                                    trackerChanged: self.blockOtherItem.settingsKey.trackerChanged
-                                ))
-                        })
-                        alertController.addAction(UIAlertAction(title: UIConstants.strings.settingsBlockOtherYes, style: .destructive) { [unowned self] _ in
-                            self.blockOtherItem.settingsValue = true
-                            self.updateTelemetry(self.blockOtherItem.settingsKey, true)
-                            GleanMetrics
-                                .TrackingProtection
-                                .trackerSettingChanged
-                                .record(.init(
-                                    isEnabled: true,
-                                    sourceOfChange: self.sourceOfChange,
-                                    trackerChanged: self.blockOtherItem.settingsKey.trackerChanged
-                                ))
-                        })
+                        let alertController = createAlertController(cell: cell)
                         self.present(alertController, animated: true, completion: nil)
                     } else {
                         self.blockOtherItem.settingsValue = isOn


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 2 `closure_body_length` violations from the `DownloadLiveActivity.swift` file (Firefox), and from the `TrackingProtectionViewController.swift` file (Focus). Also, this PR decrease threshold to 43.

An interesting observation is that I cannot see the lock screen live activity updating in real-time during downloads. This behavior also occurs on the main branch. Is this normal, or could it be a limitation of the iOS simulator? I made several tests to download large files and monitor updates in both the dynamic island and the lock screen.

Here’s an example for reference. When I tried downloading a large file, my objective was to monitor updates on the lock screen. However, the download progress bar didn’t update as expected during the process. Interestingly, only at the end did the lock screen live activity update and then disappear.

https://github.com/user-attachments/assets/5f5ea0c1-91f4-4812-bd74-47e6a6a0fa79

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

