### PR TITLE
Refactor FXIOS-11747-11659 [Tab tray UI experiment] Disable those toasts when experiment is turned ON

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -321,7 +321,11 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             if let tab = self.tabManager.selectedTab {
                 self.tabManager.removeTabWithCompletion(tab.tabUUID) {
                     self.updateTabCountUsingTabManager(self.tabManager)
-                    self.showToast(message: .TabsTray.CloseTabsToast.SingleTabTitle, toastAction: .closeTab)
+
+                    if !self.featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
+                        || UIDevice.current.userInterfaceIdiom == .pad {
+                        self.showToast(message: .TabsTray.CloseTabsToast.SingleTabTitle, toastAction: .closeTab)
+                    }
                 }
             }
         }.items

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -443,11 +443,13 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
                                                                              withUserData: userData,
                                                                              toApplication: .shared)
 
-        // The Tab Tray uses a "SimpleToast", so the urlString will go unused
-        let toastAction = TabPanelMiddlewareAction(toastType: .addBookmark(urlString: shareItem.url),
-                                                   windowUUID: uuid,
-                                                   actionType: TabPanelMiddlewareActionType.showToast)
-        store.dispatch(toastAction)
+        if !isTabTrayUIExperimentsEnabled {
+            // The Tab Tray uses a "SimpleToast", so the urlString will go unused
+            let toastAction = TabPanelMiddlewareAction(toastType: .addBookmark(urlString: shareItem.url),
+                                                       windowUUID: uuid,
+                                                       actionType: TabPanelMiddlewareActionType.showToast)
+            store.dispatch(toastAction)
+        }
 
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .add,
@@ -699,10 +701,13 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     private func copyURL(tabID: TabUUID, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         UIPasteboard.general.url = tabManager.getTabForUUID(uuid: tabID)?.canonicalURL
-        let toastAction = TabPanelMiddlewareAction(toastType: .copyURL,
-                                                   windowUUID: uuid,
-                                                   actionType: TabPanelMiddlewareActionType.showToast)
-        store.dispatch(toastAction)
+
+        if !isTabTrayUIExperimentsEnabled {
+            let toastAction = TabPanelMiddlewareAction(toastType: .copyURL,
+                                                       windowUUID: uuid,
+                                                       actionType: TabPanelMiddlewareActionType.showToast)
+            store.dispatch(toastAction)
+        }
     }
 
     private func tabPeekCloseTab(with tabID: TabUUID, uuid: WindowUUID, isPrivate: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11747)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25619)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11659)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25413)

## :bulb: Description
Disable those toasts when experiment is turned ON, but ensure on iPad we see the toasts all the time.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

