### PR TITLE
Bugfix FXIOS-11738 [Tab tray UI experiment] Make sure status bar is covered in remote tabs tray

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -21,7 +21,8 @@ class RemoteTabsPanel: UIViewController,
                        Themeable,
                        RemoteTabsClientAndTabsDataSourceDelegate,
                        RemoteTabsEmptyViewDelegate,
-                       StoreSubscriber {
+                       StoreSubscriber,
+                       FeatureFlaggable {
     typealias SubscriberStateType = RemoteTabsPanelState
 
     // MARK: - Properties
@@ -34,6 +35,12 @@ class RemoteTabsPanel: UIViewController,
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
     private let windowUUID: WindowUUID
+    private var isTabTrayUIExperimentsEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
+        && UIDevice.current.userInterfaceIdiom != .pad
+    }
+
+    private lazy var statusBarBackground: UIView = .build()
 
     // MARK: - Initializer
 
@@ -97,12 +104,28 @@ class RemoteTabsPanel: UIViewController,
         view.addSubview(tableViewController.view)
         tableViewController.didMove(toParent: self)
 
-        NSLayoutConstraint.activate([
-            tableViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            tableViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        if isTabTrayUIExperimentsEnabled {
+            view.addSubview(statusBarBackground)
+
+            NSLayoutConstraint.activate([
+                tableViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                tableViewController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                tableViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                tableViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+                statusBarBackground.topAnchor.constraint(equalTo: view.topAnchor),
+                statusBarBackground.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                statusBarBackground.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                statusBarBackground.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                tableViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                tableViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
+                tableViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                tableViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            ])
+        }
     }
 
     func applyTheme() {
@@ -110,6 +133,7 @@ class RemoteTabsPanel: UIViewController,
         view.backgroundColor = theme.colors.layer4
         tableViewController.tableView.backgroundColor =  theme.colors.layer3
         tableViewController.tableView.separatorColor = theme.colors.borderPrimary
+        statusBarBackground.backgroundColor = theme.colors.layer3
     }
 
     // MARK: - Redux


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11738)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25597)

## :bulb: Description
Make sure status bar is covered in remote tabs tray.

### 🎥 Screenshots
<details>
<summary>Dark mode</summary>

![Simulator Screenshot - iPhone 16 - 2025-04-08 at 21 54 09](https://github.com/user-attachments/assets/4ae0f687-e378-4462-ac4c-5f4594e789df)

</details>

<details>
<summary>Light mode</summary>

![Simulator Screenshot - iPhone 16 - 2025-04-08 at 21 57 04](https://github.com/user-attachments/assets/2291e44e-d0cf-40ce-83cb-b4af378ebc78)

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

