### PR TITLE
Refactor MTE-4464 Use Xcode 16.3 for Focus iOS

### DIFF
--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -6,7 +6,7 @@ on:
 
 env:
     browser: focus-ios
-    xcode_version: 16.2
+    xcode_version: 16.3
     xcodebuild_scheme: Focus
     xcodebuild_target: XCUITest
     test_results_directory: /Users/runner/tmp

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -7,8 +7,8 @@ on:
 
 env:
     browser: focus-ios
-    xcode_version: 16.2
-    ios_version: 18.2
+    xcode_version: 16.3
+    ios_version: 18.3.1
     ios_simulator_default: iPhone 16
     xcodebuild_scheme: Focus
     xcodebuild_target: XCUITest
@@ -29,6 +29,7 @@ jobs:
                 xcodebuild -version
                 ./checkout.sh
                 ./bootstrap.sh --force
+                sudo xcodes runtimes install "iOS ${{ env.ios_version }}"
             - name: Compile source code
               id: compile
               run: |


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4464)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

I have used Xcode 16.3 and iOS 18.3.1 simulators for Focus full functional and smoke tests.

Focus iOS: https://github.com/mozilla-mobile/firefox-ios/actions/runs/14347855493
Focus iOS 15, 16, 17: https://github.com/mozilla-mobile/firefox-ios/actions/runs/14347853144

*Not in this PR*
* iOS 18.4, which is bundled with Xcode 16.3, is not used because of an error upon launching the app: https://github.com/mozilla-mobile/firefox-ios/issues/25699
* L10n screenshots tests aren't using Xcode 16.3 yet. I could not have `fastlane` to use a version of iOS that isn't bundled with Xcode 16.3.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

