### PR TITLE
Refactor MTE-4495 Use xcode 16.3 for Firefox iOS

### DIFF
--- a/.github/workflows/firefox-ios-publish-docc.yml
+++ b/.github/workflows/firefox-ios-publish-docc.yml
@@ -28,7 +28,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: macos-15
     env:
-      XCODE: '16.2'
+      XCODE: '16.3'
     steps:
       - name: Switch to Xcode ${{env.XCODE}}
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/focus-ios-l10n-linter.yml
+++ b/.github/workflows/focus-ios-l10n-linter.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 4
       matrix:
         xcode:
-          - "16.2"
+          - "16.3"
     steps:
       - name: Clone code repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Download [Firefox iOS](https://apps.apple.com/app/firefox-web-browser/id98980492
 <table>
   <tr>
     <th style="border: none;"><strong>Firefox iOS</strong></th>
-    <td style="border: none;"><img src="https://img.shields.io/badge/Xcode-16.2-blue?logo=Xcode&logoColor=white" alt="Firefox-iOS"></td>
+    <td style="border: none;"><img src="https://img.shields.io/badge/Xcode-16.3-blue?logo=Xcode&logoColor=white" alt="Firefox-iOS"></td>
     <td style="border: none;"><img src="https://img.shields.io/badge/Swift-5.6-red?logo=Swift&logoColor=white" alt="Firefox-iOS"></td>
     <td style="border: none;"><img src="https://img.shields.io/badge/iOS-15.0+-green?logo=apple&logoColor=white" alt="Firefox-iOS"></td>
     <th rowspan="2" style="border: none;">
@@ -21,7 +21,7 @@ Download [Firefox iOS](https://apps.apple.com/app/firefox-web-browser/id98980492
   </tr>
   <tr>
     <th style="border: none;"><strong>Focus iOS</strong></th>
-    <td style="border: none;"><img src="https://img.shields.io/badge/Xcode-16.2-blue?logo=Xcode&logoColor=white" alt="Focus-iOS"></td>
+    <td style="border: none;"><img src="https://img.shields.io/badge/Xcode-16.3-blue?logo=Xcode&logoColor=white" alt="Focus-iOS"></td>
     <td style="border: none;"><img src="https://img.shields.io/badge/Swift-5.6-red?logo=Swift&logoColor=white" alt="Focus-iOS"></td>
     <td style="border: none;"><img src="https://img.shields.io/badge/iOS-15.0+-green?logo=apple&logoColor=white" alt="Focus-iOS"></td>
   </tr>

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -52,6 +52,9 @@ workflows:
             echo "-- build-for-testing --"
             mkdir DerivedData
 
+            brew install xcodes
+            xcodes runtimes install "iOS 18.2"
+
             xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
             xcodebuild "-project" "/Users/vagrant/git/firefox-ios/Client.xcodeproj" "-scheme" "Fennec" -configuration "Fennec_Testing" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 16,OS=18.2" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_fennec.log
 
@@ -85,6 +88,9 @@ workflows:
             set -euxo pipefail
             echo "-- build-for-testing --"
             mkdir DerivedData
+
+            brew install xcodes
+            xcodes runtimes install "iOS 18.2"
 
             xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
             xcodebuild "-project" "/Users/vagrant/git/firefox-ios/Client.xcodeproj" "-scheme" "Fennec" -configuration "Fennec_Testing" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 16,OS=18.2" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_fennec.log
@@ -233,6 +239,12 @@ workflows:
     - decision_to_run_UI_Tests
     - firefox_pull_and_unzip_dependencies
     steps:
+    - script@1.2.1
+        title: Installer older iOS runtime
+        inputs:
+        - content: |-
+            brew install xcodes
+            xcodes runtimes install "iOS 18.2"
     - xcode-test-without-building@0.4.0:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         timeout: 1200
@@ -784,7 +796,7 @@ workflows:
     description: This Workflow is to build the app using latest xcode available in Bitrise
     meta:
       bitrise.io:
-        stack: osx-xcode-16.2.x
+        stack: osx-xcode-16.3.x
         machine_type_id: g2.mac.large
   L10nBuild:
     steps:
@@ -879,7 +891,7 @@ workflows:
       the rest of the builds
     meta:
       bitrise.io:
-        stack: osx-xcode-16.2.x
+        stack: osx-xcode-16.3.x
         machine_type_id: g2.mac.large
   L10nScreenshotsTests:
     steps:
@@ -924,7 +936,7 @@ workflows:
       This Workflow is to run L10n tests for all locales
     meta:
       bitrise.io:
-        stack: osx-xcode-16.2.x
+        stack: osx-xcode-16.3.x
         machine_type_id: g2.mac.large
   SPM_Deploy_Prod_Beta:
     before_run:
@@ -1566,7 +1578,7 @@ workflows:
 
             FIREBASE_TEST_RESULT=$($HOME/google-cloud-sdk/bin/gcloud firebase test ios run \
                 --test "$TARGET_ARCHIVE" \
-                --xcode-version=16.2 \
+                --xcode-version=16.3 \
                 --device model="$DEVICE_MODEL",version="$DEVICE_VERSION" \
                 --client-details=matrixLabel="Bitrise" \
                 --num-flaky-test-attempts=2 \
@@ -1724,6 +1736,10 @@ workflows:
             set -euxo pipefail
             echo "-- build-for-testing --"
             mkdir DerivedData
+
+            brew install xcodes
+            xcodes runtimes install "iOS 18.2"
+
             #xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
             xcodebuild "-project" "/Users/vagrant/git/focus-ios/Blockzilla.xcodeproj" "-scheme" "Focus" -configuration "FocusDebug" "CODE_SIGNING_ALLOWED=NO" "-destination" "platform=iOS Simulator,name=iPhone 16,OS=18.2" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
     - script@1.2.1:
@@ -1793,6 +1809,10 @@ workflows:
         - content: |
             #!/usr/bin/env bash
             set -ex
+
+            brew install xcodes
+            xcodes runtimes install "iOS 18.2"
+
             ls ./Users/vagrant/git/focus-ios/focus-ios-tests/XCUITest/
             ls ./Users/vagrant/git/DerivedData/Build/Products
             cp -r ./Users/vagrant/git/focus-ios/focus-ios-tests/XCUITest/* .
@@ -1824,6 +1844,10 @@ workflows:
         - content: |
             #!/usr/bin/env bash
             set -ex
+
+            brew install xcodes
+            xcodes runtimes install "iOS 18.2"
+
             ls ./Users/vagrant/git/focus-ios/Blockzilla.xcodeproj/
             cp -r ./Users/vagrant/git/focus-ios/Blockzilla.xcodeproj/* .
             mv ./Users/vagrant/git/* .
@@ -1852,6 +1876,10 @@ workflows:
         - content: |
             #!/usr/bin/env bash
             set -ex
+
+            brew install xcodes
+            xcodes runtimes install "iOS 18.2"
+
             ls ./Users/vagrant/git/focus-ios/Blockzilla.xcodeproj/
             cp -r ./Users/vagrant/git/focus-ios/Blockzilla.xcodeproj/* .
             mv ./Users/vagrant/git/* .
@@ -2253,5 +2281,5 @@ trigger_map:
 
 meta:
   bitrise.io:
-    stack: osx-xcode-16.2.x
+    stack: osx-xcode-16.3.x
     machine_type_id: g2.mac.large

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -239,7 +239,7 @@ workflows:
     - decision_to_run_UI_Tests
     - firefox_pull_and_unzip_dependencies
     steps:
-    - script@1.2.1
+    - script@1.2.1:
         title: Installer older iOS runtime
         inputs:
         - content: |-

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -5,6 +5,7 @@
 import MappaMundi
 import XCTest
 import Shared
+import Common
 
 let testPageBase = "http://www.example.com"
 let loremIpsumURL = "\(testPageBase)"

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -4,6 +4,7 @@
 
 import XCTest
 import Shared
+import Common
 
 class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     var noSkipIntroTest = ["testIntro"]

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11ySettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11ySettingsTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Testing
+import XCTest
 
 class A11ySettingsTests: BaseTestCase {
     func testSettingsMenuPageAudit() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import XCTest
 
 class AddressesTests: BaseTestCase {
     let addressSavedTxt = "Address Saved"

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -168,10 +168,10 @@ class BookmarksTests: BaseTestCase {
         if shouldSkipTest {
             throw XCTSkip("No longer possible to add manually a page as bookmarked")
         }
-        addNewBookmark()
-        // Verify that clicking on bookmark opens the website
-        app.tables["Bookmarks List"].cells.element(boundBy: 1).waitAndTap()
-        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
+//        addNewBookmark()
+//        // Verify that clicking on bookmark opens the website
+//        app.tables["Bookmarks List"].cells.element(boundBy: 1).waitAndTap()
+//        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306914
@@ -211,20 +211,20 @@ class BookmarksTests: BaseTestCase {
         if shouldSkipTest {
             throw XCTSkip("No longer possible to add manually a separator")
         }
-        navigator.goto(LibraryPanel_Bookmarks)
-        navigator.nowAt(MobileBookmarks)
-        navigator.performAction(Action.AddNewSeparator)
-        app.buttons["Done"].waitAndTap()
-        // There is one item plus the default Desktop Bookmarks folder
-        checkItemsInBookmarksList(items: 2)
-
-        // Remove it
-        navigator.nowAt(MobileBookmarks)
-        navigator.performAction(Action.RemoveItemMobileBookmarks)
-        mozWaitForElementToExist(app.buttons["Delete"])
-        navigator.performAction(Action.ConfirmRemoveItemMobileBookmarks)
-        // Verify that there are only 1 cell (desktop bookmark folder)
-        checkItemsInBookmarksList(items: 1)
+//        navigator.goto(LibraryPanel_Bookmarks)
+//        navigator.nowAt(MobileBookmarks)
+//        navigator.performAction(Action.AddNewSeparator)
+//        app.buttons["Done"].waitAndTap()
+//        // There is one item plus the default Desktop Bookmarks folder
+//        checkItemsInBookmarksList(items: 2)
+//
+//        // Remove it
+//        navigator.nowAt(MobileBookmarks)
+//        navigator.performAction(Action.RemoveItemMobileBookmarks)
+//        mozWaitForElementToExist(app.buttons["Delete"])
+//        navigator.performAction(Action.ConfirmRemoveItemMobileBookmarks)
+//        // Verify that there are only 1 cell (desktop bookmark folder)
+//        checkItemsInBookmarksList(items: 1)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306916
@@ -233,12 +233,12 @@ class BookmarksTests: BaseTestCase {
         if shouldSkipTest {
             throw XCTSkip("No longer possible to add manually a page as bookmarked")
         }
-        addNewBookmark()
-        // Remove by swiping
-        app.tables["Bookmarks List"].staticTexts["BBC"].swipeLeft()
-        app.buttons["Delete"].waitAndTap()
-        // Verify that there are only 1 cell (desktop bookmark folder)
-        checkItemsInBookmarksList(items: 1)
+//        addNewBookmark()
+//        // Remove by swiping
+//        app.tables["Bookmarks List"].staticTexts["BBC"].swipeLeft()
+//        app.buttons["Delete"].waitAndTap()
+//        // Verify that there are only 1 cell (desktop bookmark folder)
+//        checkItemsInBookmarksList(items: 1)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306917
@@ -247,13 +247,13 @@ class BookmarksTests: BaseTestCase {
         if shouldSkipTest {
             throw XCTSkip("No longer possible to add manually a page as bookmarked")
         }
-        addNewBookmark()
-        // Remove by long press and select option from context menu
-        app.tables.staticTexts.element(boundBy: 1).press(forDuration: 1)
-        mozWaitForElementToExist(app.tables["Context Menu"])
-        app.tables.otherElements["Remove Bookmark"].waitAndTap()
-        // Verify that there are only 1 cell (desktop bookmark folder)
-        checkItemsInBookmarksList(items: 1)
+//        addNewBookmark()
+//        // Remove by long press and select option from context menu
+//        app.tables.staticTexts.element(boundBy: 1).press(forDuration: 1)
+//        mozWaitForElementToExist(app.tables["Context Menu"])
+//        app.tables.otherElements["Remove Bookmark"].waitAndTap()
+//        // Verify that there are only 1 cell (desktop bookmark folder)
+//        checkItemsInBookmarksList(items: 1)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306908
@@ -338,18 +338,18 @@ class BookmarksTests: BaseTestCase {
         if shouldSkipTest {
             throw XCTSkip("Desktop folder is no longer available")
         }
-        // Verify that there are only 1 cell (desktop bookmark folder)
-        navigator.nowAt(NewTabScreen)
-        waitForTabsButton()
-        navigator.goto(LibraryPanel_Bookmarks)
-        // There is only one folder at the root of the bookmarks
-        mozWaitForElementToExist(app.tables["Bookmarks List"])
-        XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 0)
-
-        // There is only three folders inside the desktop bookmarks
-        app.tables["Bookmarks List"].cells.firstMatch.waitAndTap()
-        mozWaitForElementToExist(app.tables["Bookmarks List"])
-        XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 3)
+//        // Verify that there are only 1 cell (desktop bookmark folder)
+//        navigator.nowAt(NewTabScreen)
+//        waitForTabsButton()
+//        navigator.goto(LibraryPanel_Bookmarks)
+//        // There is only one folder at the root of the bookmarks
+//        mozWaitForElementToExist(app.tables["Bookmarks List"])
+//        XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 0)
+//
+//        // There is only three folders inside the desktop bookmarks
+//        app.tables["Bookmarks List"].cells.firstMatch.waitAndTap()
+//        mozWaitForElementToExist(app.tables["Bookmarks List"])
+//        XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 3)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306911

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import XCTest
 
 class MultiWindowTests: IpadOnlyTestCase {
     let dotMenu = springboard.buttons["top-affordance:org.mozilla.ios.Fennec"]

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarMenuTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import XCTest
 
 class ToolbarMenuTests: BaseTestCase {
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import XCTest
 
 class UrlBarTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2306888


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4495)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Let's use Xcode 16.3 to compile Firefox iOS.

Highlights:
* `import XCTest` is needed for `XCTSkip`
* The unreachable code generates an error.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

