### PR TITLE
Remove FXIOS-11882 ⁃ Remove "Show Link Previews" setting

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -30,7 +30,6 @@ public struct PrefsKeys {
     public static let KeyDefaultBrowserCardShowType = "defaultBrowserCardShowType"
     public static let DidDismissDefaultBrowserMessage = "DidDismissDefaultBrowserCard"
     public static let KeyDidShowDefaultBrowserOnboarding = "didShowDefaultBrowserOnboarding"
-    public static let ContextMenuShowLinkPreviews = "showLinkPreviews"
     public static let ShowClipboardBar = "showClipboardBar"
     public static let BlockOpeningExternalApps = "blockOpeningExternalApps"
     public static let NewTabCustomUrlPrefKey = "HomePageURLPref"

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -217,8 +217,6 @@ extension BrowserViewController: WKUIDelegate {
 
     private func contextMenuPreviewProvider(for url: URL, webView: WKWebView) -> UIContextMenuContentPreviewProvider? {
         let provider: UIContextMenuContentPreviewProvider = {
-            guard self.profile.prefs.boolForKey(PrefsKeys.ContextMenuShowLinkPreviews) ?? true else { return nil }
-
             let previewViewController = UIViewController()
             previewViewController.view.isUserInteractionEnabled = false
             let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)

--- a/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
@@ -75,17 +75,7 @@ class BrowsingSettingsViewController: SettingsTableViewController, FeatureFlagga
                 statusText: String(format: .SettingsOfferClipboardBarStatus, AppName.shortName.rawValue)
             )
 
-            let showLinksPreviewSettings = BoolSetting(
-                prefs: profile.prefs,
-                theme: theme,
-                prefKey: PrefsKeys.ContextMenuShowLinkPreviews,
-                defaultValue: true,
-                titleText: .SettingsShowLinkPreviewsTitle,
-                statusText: .SettingsShowLinkPreviewsStatus
-            )
-
-            linksSettings += [offerToOpenCopiedLinksSettings,
-                              showLinksPreviewSettings]
+            linksSettings += [offerToOpenCopiedLinksSettings]
 
             let blockOpeningExternalAppsSettings = BoolSetting(
                 prefs: profile.prefs,

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -3879,20 +3879,6 @@ extension String {
         comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349. %@ is for the app name.")
 }
 
-// MARK: - Link Previews
-extension String {
-    public static let SettingsShowLinkPreviewsTitle = MZLocalizedString(
-        key: "Settings.ShowLinkPreviews.Title",
-        tableName: nil,
-        value: "Show Link Previews",
-        comment: "Title of setting to enable link previews when long-pressing links.")
-    public static let SettingsShowLinkPreviewsStatus = MZLocalizedString(
-        key: "Settings.ShowLinkPreviews.StatusV2",
-        tableName: nil,
-        value: "When long-pressing links",
-        comment: "Description displayed under the ”Show Link Previews” option")
-}
-
 // MARK: - Block Opening External Apps
 extension String {
     public static let SettingsBlockOpeningExternalAppsTitle = MZLocalizedString(
@@ -8196,6 +8182,16 @@ extension String {
                 tableName: nil,
                 value: "Last month",
                 comment: "This label is meant to signify the section containing a group of items from the past thirty days.")
+            public static let SettingsShowLinkPreviewsTitle = MZLocalizedString(
+                key: "Settings.ShowLinkPreviews.Title",
+                tableName: nil,
+                value: "Show Link Previews",
+                comment: "Title of setting to enable link previews when long-pressing links.")
+            public static let SettingsShowLinkPreviewsStatus = MZLocalizedString(
+                key: "Settings.ShowLinkPreviews.StatusV2",
+                tableName: nil,
+                value: "When long-pressing links",
+                comment: "Description displayed under the ”Show Link Previews” option")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11882)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25897)

## :bulb: Description
Removed boolean option, for Show Link Previews, in Settings

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

