### PR TITLE
Bugfix FXIOS-11819 [New Toolbar experiment] [iPad] - 'X' Button to close tab is too large

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
@@ -57,7 +57,6 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFl
     let favicon: FaviconImageView = .build { _ in }
 
     let closeButton: UIButton = .build { button in
-        button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: [])
         button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: UX.verticalPadding,
                                                                       leading: UX.tabTitlePadding,
                                                                       bottom: UX.verticalPadding,
@@ -87,7 +86,14 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFl
                                                 self.titleText.text ?? "")
         closeButton.showsLargeContentViewer = true
         closeButton.largeContentTitle = .TopSitesRemoveButtonLargeContentTitle
-        closeButton.largeContentImage = UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross)
+
+        let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: tab.windowUUID)
+        if let toolbarState, toolbarState.toolbarLayout == .version1 {
+            closeButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Medium.cross), for: [])
+        } else {
+            closeButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: [])
+        }
+
         closeButton.scalesLargeContentImage = true
 
         let hideCloseButton = frame.width < UX.closeButtonThreshold && !selected

--- a/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
@@ -13,6 +13,7 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFl
         static let faviconSize: CGFloat = 20
         static let faviconCornerRadius: CGFloat = 2
         static let tabTitlePadding: CGFloat = 10
+        static let tabTitlePaddingVersion1: CGFloat = 14
         static let tabNudge: CGFloat = 1 // Nudge the favicon and close button by 1px
 
         // MARK: - Tab Appearance Constants
@@ -57,6 +58,7 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFl
     let favicon: FaviconImageView = .build { _ in }
 
     let closeButton: UIButton = .build { button in
+        button.configuration = .plain()
         button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: UX.verticalPadding,
                                                                       leading: UX.tabTitlePadding,
                                                                       bottom: UX.verticalPadding,
@@ -89,9 +91,13 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFl
 
         let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: tab.windowUUID)
         if let toolbarState, toolbarState.toolbarLayout == .version1 {
-            closeButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Medium.cross), for: [])
+            closeButton.configuration?.image = UIImage.templateImageNamed(StandardImageIdentifiers.Medium.cross)
+            closeButton.configuration?.contentInsets = NSDirectionalEdgeInsets(top: UX.verticalPadding,
+                                                                               leading: UX.tabTitlePaddingVersion1,
+                                                                               bottom: UX.verticalPadding,
+                                                                               trailing: UX.tabTitlePaddingVersion1)
         } else {
-            closeButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: [])
+            closeButton.configuration?.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross)
         }
 
         closeButton.scalesLargeContentImage = true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11819)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25773)

## :bulb: Description
Use a smaller close button for tabs when toolbar rapid experiment is enabled.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

<details>
<summary>📷 Screenshots</summary>

![Simulator Screenshot - iPad Air 11-inch (M2) - 2025-04-09 at 13 44 48](https://github.com/user-attachments/assets/361c5270-9391-4fba-b00e-f09101806d3b)

</details>