### PR TITLE
Add FXIOS-11522 [Homepage] general homepage impression event

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
@@ -13,6 +13,9 @@ final class HomepageMiddleware {
 
     lazy var homepageProvider: Middleware<AppState> = { state, action in
         switch action.actionType {
+        case HomepageActionType.viewWillAppear:
+            self.homepageTelemetry.sendHomepageImpressionEvent()
+
         case NavigationBrowserActionType.tapOnCustomizeHomepageButton:
             self.homepageTelemetry.sendItemTappedTelemetryEvent(for: .customizeHomepage)
 

--- a/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
@@ -40,6 +40,10 @@ struct HomepageTelemetry {
     }
 
     // MARK: - General
+    func sendHomepageImpressionEvent() {
+        gleanWrapper.recordEvent(for: GleanMetrics.Homepage.viewed)
+    }
+
     func sendItemTappedTelemetryEvent(for itemType: TappedItemType) {
         let itemNameExtra = GleanMetrics.Homepage.ItemTappedExtra(section: itemType.sectionName, type: itemType.rawValue)
         gleanWrapper.recordEvent(for: GleanMetrics.Homepage.itemTapped, extras: itemNameExtra)

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -2785,6 +2785,21 @@ firefox_home_page:
 
 # HomePage - General
 homepage:
+  viewed:
+    type: event
+    description: |
+      Records when the Firefox homepage is viewed.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/25082
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25923
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-07-01"
+    metadata:
+      tags:
+        - Homepage
+
   item_tapped:
     type: event
     description: |

--- a/firefox-ios/Client/tags.yaml
+++ b/firefox-ios/Client/tags.yaml
@@ -10,9 +10,6 @@
 
 ---
 $schema: moz://mozilla.org/schemas/glean/tags/1-0-0
-
-Homepage:
-  description: Corresponds to the homepage feature and all content that resides on the page.
   
 AppIconSelection:
   description: Corresponds to the feature where users can change their default app icon in the settings.
@@ -25,6 +22,9 @@ Library:
 
 HistoryPanel:
   description: Corresponds to the history panel of the library.
+
+Homepage:
+  description: Corresponds to the homepage feature and all content that resides on the page.
 
 Settings:
   description: Corresponds to all the options encompassed in the app's settings screens.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -181,6 +181,18 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertFalse(actionCalled.showiPadSetup ?? true)
     }
 
+    func test_viewWillAppear_triggersHomepageAction() throws {
+        let subject = createSubject()
+        subject.viewWillAppear(false)
+
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.first(where: { $0 is HomepageAction }) as? HomepageAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
+        XCTAssertEqual(actionType, HomepageActionType.viewWillAppear)
+        XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+    }
+
     private func createSubject(statusBarScrollDelegate: StatusBarScrollDelegate? = nil) -> HomepageViewController {
         let notificationCenter = MockNotificationCenter()
         let themeManager = MockThemeManager()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
@@ -26,6 +26,24 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         super.tearDown()
     }
 
+    func test_viewWillAppearAction_sendsTelemetryData() throws {
+        let subject = createSubject()
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.viewWillAppear
+        )
+
+        subject.homepageProvider(AppState(), action)
+
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents?[0] as? EventMetricType<NoExtras>)
+        let expectedMetricType = type(of: GleanMetrics.Homepage.viewed)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
     func test_tapOnCustomizeHomepageAction_sendTelemetryData() throws {
         let subject = createSubject()
         let action = NavigationBrowserAction(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11522)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25082)

## :bulb: Description
Add new homepage impression event. The cases in which the `viewWillAppear` gets triggered are:
- Navigate from webpage to homepage via home button
- Tap on search when on webpage and view homepage
- Previously seen homepage, navigate to webpage, and use back button to view homepage again

Note: We are postponing addressing this issue: https://mozilla-hub.atlassian.net/browse/FXIOS-11156. Also this impression is not sent when a modal appears / disappears above.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

