### PR TITLE
Bugfix FXIOS-11829 [New Toolbar experiment][iPad] The loading bar is not displayed when refreshing/loading a new webpage

### DIFF
--- a/firefox-ios/Client/Nimbus/NimbusSearchBarLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusSearchBarLayer.swift
@@ -8,18 +8,13 @@ final class NimbusSearchBarLayer {
     // MARK: - Public methods
     public func getDefaultPosition(from nimbus: FxNimbus = FxNimbus.shared) -> SearchBarPosition {
         let layout = nimbus.features.toolbarRefactorFeature.value().layout
-        switch layout {
-        // Set the address bar to the bottom for new users enrolled in `version1` toolbar experiment.
-        case .version1:
-            if UIDevice.current.userInterfaceIdiom != .pad {
-                return .bottom
-            } else {
-                let isAtBottom = nimbus.features.search.value().awesomeBar.position.isBottom
-                return isAtBottom ? .bottom : .top
-            }
-        default:
+
+        guard UIDevice.current.userInterfaceIdiom != .pad, layout == .version1 else {
             let isAtBottom = nimbus.features.search.value().awesomeBar.position.isBottom
             return isAtBottom ? .bottom : .top
         }
+
+        // Set the address bar to the bottom for new users enrolled in `version1` toolbar experiment.
+        return .bottom
     }
 }

--- a/firefox-ios/Client/Nimbus/NimbusSearchBarLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusSearchBarLayer.swift
@@ -10,7 +10,13 @@ final class NimbusSearchBarLayer {
         let layout = nimbus.features.toolbarRefactorFeature.value().layout
         switch layout {
         // Set the address bar to the bottom for new users enrolled in `version1` toolbar experiment.
-        case .version1: return .bottom
+        case .version1:
+            if UIDevice.current.userInterfaceIdiom != .pad {
+                return .bottom
+            } else {
+                let isAtBottom = nimbus.features.search.value().awesomeBar.position.isBottom
+                return isAtBottom ? .bottom : .top
+            }
         default:
             let isAtBottom = nimbus.features.search.value().awesomeBar.position.isBottom
             return isAtBottom ? .bottom : .top


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11829)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25787)

## :bulb: Description
We were forcing the toolbar position to bottom for the rapid UI experiment. This lead to the loading progress to be displayed in the wrong position. As we can't change the toolbar position on iPad, we will now only force the toolbar to bottom on iPhones.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

