### PR TITLE
Bugfix FXIOS-11892 Web link context menu crash

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -156,7 +156,10 @@ extension BrowserViewController: WKUIDelegate {
                 name: ContextMenuHelper.name()
               ) as? ContextMenuHelper,
               let elements = contextHelper.elements
-        else { return }
+        else {
+            completionHandler(nil)
+            return
+        }
         completionHandler(contextMenuConfiguration(for: url, webView: webView, elements: elements))
         ContextMenuTelemetry().shown(origin: elements.image != nil ? .imageLink : .webLink)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11892)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25932)

## :bulb: Description
- Fix web link context menu crash by making sure to always call the completion handler in the `webView(_:contextMenuConfigurationForElement:completionHandler:)` delegate function

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

