### PR TITLE
Add FXIOS-11504 [Homepage] add isZeroSearch to state

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -147,17 +147,27 @@ class BrowserCoordinator: BaseCoordinator,
     ) {
         let homepageController = self.homepageViewController ?? HomepageViewController(
             windowUUID: windowUUID,
-            isZeroSearch: isZeroSearch,
             overlayManager: overlayManager,
             statusBarScrollDelegate: statusBarScrollDelegate,
             toastContainer: toastContainer
         )
+        dispatchActionForEmbeddingHomepage(with: isZeroSearch)
         guard browserViewController.embedContent(homepageController) else {
             logger.log("Unable to embed new homepage", level: .debug, category: .coordinator)
             return
         }
         self.homepageViewController = homepageController
         homepageController.scrollToTop()
+    }
+
+    private func dispatchActionForEmbeddingHomepage(with isZeroSearch: Bool) {
+        store.dispatch(
+            HomepageAction(
+                isZeroSearch: isZeroSearch,
+                windowUUID: windowUUID,
+                actionType: HomepageActionType.embeddedHomepage
+            )
+        )
     }
 
     func showPrivateHomepage(overlayManager: OverlayModeManager) {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -48,8 +48,6 @@ final class HomepageViewController: UIViewController,
 
     private let jumpBackInContextualHintViewController: ContextualHintViewController
     private let syncTabContextualHintViewController: ContextualHintViewController
-    // TODO: FXIOS-11504: Move this to state + add comments on what this is + why we use it
-    private let isZeroSearch: Bool
     private var homepageState: HomepageState
     private var lastContentOffsetY: CGFloat = 0
 
@@ -70,7 +68,6 @@ final class HomepageViewController: UIViewController,
     init(windowUUID: WindowUUID,
          profile: Profile = AppContainer.shared.resolve(),
          themeManager: ThemeManager = AppContainer.shared.resolve(),
-         isZeroSearch: Bool,
          overlayManager: OverlayModeManager,
          statusBarScrollDelegate: StatusBarScrollDelegate? = nil,
          toastContainer: UIView,
@@ -80,7 +77,6 @@ final class HomepageViewController: UIViewController,
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
-        self.isZeroSearch = isZeroSearch
         self.overlayManager = overlayManager
         self.statusBarScrollDelegate = statusBarScrollDelegate
         self.toastContainer = toastContainer
@@ -742,7 +738,7 @@ final class HomepageViewController: UIViewController,
     }
 
     private func dispatchOpenPocketAction(at index: Int, actionType: ActionType) {
-        let config = OpenPocketTelemetryConfig(isZeroSearch: isZeroSearch, position: index)
+        let config = OpenPocketTelemetryConfig(isZeroSearch: homepageState.isZeroSearch, position: index)
         store.dispatch(
             PocketAction(
                 telemetryConfig: config,
@@ -754,7 +750,7 @@ final class HomepageViewController: UIViewController,
 
     private func dispatchOpenTopSitesAction(at index: Int, tileType: String, urlString: String) {
         let config = TopSitesTelemetryConfig(
-            isZeroSearch: isZeroSearch,
+            isZeroSearch: homepageState.isZeroSearch,
             position: index,
             tileType: tileType,
             url: urlString
@@ -896,13 +892,13 @@ final class HomepageViewController: UIViewController,
             overlayState: overlayManager)
     }
 
-    private var canModalBePresented: Bool {
-        return presentedViewController == nil && isZeroSearch
+    private var canContextHintBePresented: Bool {
+        return presentedViewController == nil && homepageState.isZeroSearch
     }
 
     @objc
     private func presentContextualHint(with contextualHintViewController: ContextualHintViewController) {
-        guard canModalBePresented else { return }
+        guard canContextHintBePresented else { return }
         contextualHintViewController.isPresenting = true
         present(contextualHintViewController, animated: true, completion: nil)
         UIAccessibility.post(notification: .layoutChanged, argument: contextualHintViewController)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -13,17 +13,20 @@ final class HomepageAction: Action {
     let showiPadSetup: Bool?
     let numberOfTopSitesPerRow: Int?
     let telemetryExtras: HomepageTelemetryExtras?
+    let isZeroSearch: Bool?
 
     init(
         numberOfTopSitesPerRow: Int? = nil,
         showiPadSetup: Bool? = nil,
         telemetryExtras: HomepageTelemetryExtras? = nil,
+        isZeroSearch: Bool? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
         self.numberOfTopSitesPerRow = numberOfTopSitesPerRow
         self.showiPadSetup = showiPadSetup
         self.telemetryExtras = telemetryExtras
+        self.isZeroSearch = isZeroSearch
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
@@ -34,4 +37,5 @@ enum HomepageActionType: ActionType {
     case viewWillTransition
     case viewWillAppear
     case didSelectItem
+    case embeddedHomepage
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -49,7 +49,6 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
-            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )
@@ -61,7 +60,6 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
-            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )
@@ -139,7 +137,6 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
-            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )
@@ -201,7 +198,6 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
-            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )
@@ -244,7 +240,6 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
-            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )
@@ -278,7 +273,6 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
-            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -202,7 +202,6 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         let homepageViewController = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
             themeManager: themeManager,
-            isZeroSearch: true,
             overlayManager: mockOverlayManager,
             statusBarScrollDelegate: statusBarScrollDelegate,
             toastContainer: UIView(),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
@@ -25,6 +25,7 @@ final class HomepageStateTests: XCTestCase {
 
         XCTAssertFalse(initialState.headerState.isPrivate)
         XCTAssertFalse(initialState.headerState.showiPadSetup)
+        XCTAssertFalse(initialState.isZeroSearch)
     }
 
     func test_initializeAction_returnsExpectedState() {
@@ -43,6 +44,41 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertFalse(newState.headerState.isPrivate)
         XCTAssertTrue(newState.headerState.showiPadSetup)
+        XCTAssertFalse(newState.isZeroSearch)
+    }
+
+    func test_embeddedHomepageAction_withTrueZeroSearch_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = homepageReducer()
+
+        let newState = reducer(
+            initialState,
+            HomepageAction(
+                isZeroSearch: true,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.embeddedHomepage
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertTrue(newState.isZeroSearch)
+    }
+
+    func test_embeddedHomepageAction_withFalseZeroSearch_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = homepageReducer()
+
+        let newState = reducer(
+            initialState,
+            HomepageAction(
+                isZeroSearch: false,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.embeddedHomepage
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(newState.isZeroSearch)
     }
 
     // MARK: - Private


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11504)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR is to add `isZeroSearch` as a property to the state instead of injecting it directly in the init to follow our Redux pattern. Also add some clarifying comments. It seems `isZeroSearch` may have lost its true meaning a long the way. To avoid increasing effort for the homepage rebuild, will create a separate follow up ticket to address this. For new homepage telemetry, we are not concern with this value as we should be determining the flow from actions taken before reaching the homepage.

As of this PR,
`isZeroSearch` is true, when:
- Load webpage -> tap on home button -> view homepage
- Add new tab from tab tray -> view homepage (search URL is selected)
- Long pressing on tab tray to open new tab -> view homepage (search URL is selected)
- Adding new tab via menu -> view homepage (search URL is selected)

`isZeroSearch` is false, when:
- Load webpage -> select on URL -> homepage appears 

<details>
<summary>My assumption of `isZeroSearch` is this view:</summary>

![image](https://github.com/user-attachments/assets/23a48ce1-8b9b-45c6-8354-caf884336c29)

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

