### PR TITLE
Add FXIOS-11868 [App Icon 2025] Auto-enable the app icon selection feature on all channels

### DIFF
--- a/firefox-ios/nimbus-features/appIconSelectionFeature.yaml
+++ b/firefox-ios/nimbus-features/appIconSelectionFeature.yaml
@@ -1,4 +1,4 @@
-# The configuration for the sentFromFirefoxFeature feature
+# The configuration for the appIconSelection feature
 features:
   app-icon-selection-feature:
     description: >
@@ -8,11 +8,4 @@ features:
         description: >
           Controls whether users see the setting to customize their app icon in Settings.
         type: Boolean
-        default: false
-    defaults:
-      - channel: beta
-        value:
-          enabled: false
-      - channel: developer
-        value:
-          enabled: true
+        default: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11868)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25857)

## :bulb: Description
Since the enrolment has been going well for the app icon selection feature, we have been asked to do a full default-on rollout of this feature in the next weekly release.

The feature flag will be cleaned up in v138: FXIOS-11645

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

