### PR TITLE
Bugfix FXIOS-11843 [Tab Tray UI Experiment] Fix Tab Tray Selector Options Not Centered

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -107,7 +107,19 @@ class TabTrayViewController: UIViewController,
     }()
 
     private lazy var experimentSegmentControl: TabTraySelectorView = {
-        // Temporary offset of numbers to account for the different order in the experiment
+        let selectedIndex = experimentConvertSelectedIndex()
+        let selector = TabTraySelectorView(selectedIndex: selectedIndex, windowUUID: windowUUID)
+        selector.delegate = self
+        selector.items = [TabTrayPanelType.privateTabs.label,
+                          TabTrayPanelType.tabs.label,
+                          TabTrayPanelType.syncedTabs.label]
+
+        didSelectSection(panelType: tabTrayState.selectedPanel)
+        return selector
+    }()
+
+    private func experimentConvertSelectedIndex() -> Int {
+        // Temporary offset of numbers to account for the different order in the experiment - tabTrayUIExperiments
         // Order can be updated in TabTrayPanelType once the experiment is done
         var selectedIndex = 0
         switch tabTrayState.selectedPanel {
@@ -118,16 +130,8 @@ class TabTrayViewController: UIViewController,
         case .syncedTabs:
             selectedIndex = 2
         }
-
-        let selector = TabTraySelectorView(selectedIndex: selectedIndex, windowUUID: windowUUID)
-        selector.delegate = self
-        selector.items = [TabTrayPanelType.privateTabs.label,
-                          TabTrayPanelType.tabs.label,
-                          TabTrayPanelType.syncedTabs.label]
-
-        didSelectSection(panelType: tabTrayState.selectedPanel)
-        return selector
-    }()
+        return selectedIndex
+    }
 
     lazy var countLabel: UILabel = {
         let label = UILabel(frame: CGRect(width: 24, height: 24))
@@ -480,6 +484,7 @@ class TabTrayViewController: UIViewController,
         var toolbarItems: [UIBarButtonItem]
         if isTabTrayUIExperimentsEnabled {
             toolbarItems = isSyncTabsPanel ? experimentBottomToolbarItemsForSync : experimentBottomToolbarItems
+            experimentSegmentControl.scrollToItem(at: experimentConvertSelectedIndex(), animated: false)
         } else {
             toolbarItems = isSyncTabsPanel ? bottomToolbarItemsForSync : bottomToolbarItems
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11843)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25815)

## :bulb: Description
When the tab tray opens with the Tab Tray UI Experiments enabled, the selector options (tabs, private, synced) are now centered.

## Screenshot
![image](https://github.com/user-attachments/assets/d052bd5f-e0f9-4def-9cdc-75773afb6f0a)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

