### PR TITLE
Bugifx [Toolbar Experiment] FXIOS-11888  Correct color for pull refresh, Update padding browser address toolbar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -18,7 +18,8 @@ public class BrowserAddressToolbar: UIView,
                                     LocationViewDelegate,
                                     UIDragInteractionDelegate {
     private enum UX {
-        static let verticalEdgeSpace: CGFloat = 8
+        static let topEdgeSpace: CGFloat = 8
+        static let bottomEdgeSpace: CGFloat = 4
         static let horizontalSpace: CGFloat = 8
         static let borderHeight: CGFloat = 1
         static let actionSpacing: CGFloat = 0
@@ -203,9 +204,9 @@ public class BrowserAddressToolbar: UIView,
         NSLayoutConstraint.activate([
             toolbarContainerView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
             toolbarContainerView.topAnchor.constraint(equalTo: toolbarTopBorderView.topAnchor,
-                                                      constant: UX.verticalEdgeSpace),
+                                                      constant: UX.topEdgeSpace),
             toolbarContainerView.bottomAnchor.constraint(equalTo: toolbarBottomBorderView.bottomAnchor,
-                                                         constant: -UX.verticalEdgeSpace),
+                                                         constant: -UX.bottomEdgeSpace),
             toolbarContainerView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
 
             toolbarTopBorderView.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarLayoutStyle.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarLayoutStyle.swift
@@ -10,7 +10,7 @@ enum ToolbarLayoutStyle: String {
     /// share button is displayed in the address toolbar.
     case version1
 
-    static func style(from type: ToolbarLayoutType?) -> ToolbarLayoutStyle? {
+    static func style(from type: ToolbarLayoutType?) -> ToolbarLayoutStyle {
         guard let type else { return .baseline }
         switch type {
         case .baseline: return .baseline

--- a/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
@@ -44,6 +44,9 @@ class PullRefreshView: UIView,
     private var isIpad: Bool {
         return traitCollection.userInterfaceIdiom == .pad && traitCollection.horizontalSizeClass == .regular
     }
+    private var toolbarLayoutStyle: ToolbarLayoutStyle {
+        return .style(from: FxNimbus.shared.features.toolbarRefactorFeature.value().layout)
+    }
 
     init(parentScrollView: UIScrollView?,
          isPortraitOrientation: Bool,
@@ -228,7 +231,7 @@ class PullRefreshView: UIView,
 
     func applyTheme(theme: any Theme) {
         currentTheme = theme
-        backgroundColor = theme.colors.layer1
+        backgroundColor = toolbarLayoutStyle == .version1 ? theme.colors.layer3 : theme.colors.layer1
         progressView.tintColor = theme.colors.iconPrimary
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11888)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25926)

## :bulb: Description
Correct color for `PullRefresh` with toolbar version1. Update `BrowserAddressToolbar` bottom padding as per design.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

