### PR TITLE
Bugfix FXIOS-11949 Web link context menus showing incorrect actions

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/ContextMenu.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/ContextMenu.js
@@ -7,7 +7,7 @@
 
 // Ensure this module only gets included once. This is
 // required for user scripts injected into all frames.
-window.__firefox__.includeOnce("ContextMenu", function() {
+
   function sendMessage(evt) {
     var target = evt.target;
 
@@ -40,6 +40,5 @@ window.__firefox__.includeOnce("ContextMenu", function() {
     }
   }
 
-  window.addEventListener("touchstart", sendMessage, true);
-  window.addEventListener("mousedown", sendMessage, true);
-});
+  window.addEventListener("touchstart", sendMessage);
+  window.addEventListener("mousedown", sendMessage);


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11949)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25994)

## :bulb: Description
- Show firefox-related context menu actions instead of default webkit safari-related context menu actions

### 📝 Discussion
- The `ContextMenu` script was not correctly being injected into all frames

### 📸 Screenshots

| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 16 - 2025-04-10 at 13 04 30](https://github.com/user-attachments/assets/a608f290-09c7-4eb8-9623-5b792d4667a5) | ![Simulator Screenshot - iPhone 16 - 2025-04-10 at 13 16 36](https://github.com/user-attachments/assets/339eeae1-7cb2-471f-9299-bc0b50d37dcb) |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

