### PR TITLE
Add FXIOS-11962 [Logins] new verification logic

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -12,6 +12,7 @@ public struct PrefsKeys {
 
     // Global sync state for rust sync manager
     public static let RustSyncManagerPersistedState = "rustSyncManagerPersistedStateKey"
+    public static let LoginsHaveBeenVerified = "loginsHaveBeenVerified"
 
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
     public static let KeyDefaultHomePageURL = "KeyDefaultHomePageURL"

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -28,12 +28,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         .value()
         .rustKeychainEnabled
 
+    private let loginsVerificationEnabled = FxNimbus.shared
+        .features
+        .loginsVerification
+        .value()
+        .loginsVerificationEnabled
+
     lazy var profile: Profile = BrowserProfile(
         localName: "profile",
         fxaCommandsDelegate: UIApplication.shared.fxaCommandsDelegate,
         creditCardAutofillEnabled: creditCardAutofillStatus,
-        rustKeychainEnabled: rustKeychainEnabled
-    )
+        rustKeychainEnabled: rustKeychainEnabled,
+        loginsVerificationEnabled: loginsVerificationEnabled)
 
     lazy var themeManager: ThemeManager = DefaultThemeManager(
         sharedContainerIdentifier: AppInfo.sharedContainerIdentifier,

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -29,6 +29,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case menuRefactor
     case menuRefactorHint
     case microsurvey
+    case loginsVerificationEnabled
     case nativeErrorPage
     case noInternetConnectionErrorPage
     case pdfRefactor
@@ -64,6 +65,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .feltPrivacySimplifiedUI,
                 .menuRefactor,
                 .microsurvey,
+                .loginsVerificationEnabled,
                 .nativeErrorPage,
                 .noInternetConnectionErrorPage,
                 .sentFromFirefox,
@@ -122,6 +124,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .microsurvey,
                 .menuRefactor,
                 .menuRefactorHint,
+                .loginsVerificationEnabled,
                 .nativeErrorPage,
                 .noInternetConnectionErrorPage,
                 .pdfRefactor,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -81,6 +81,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
+                    with: .loginsVerificationEnabled,
+                    titleText: format(string: "Enable Logins Verification"),
+                    statusText: format(string: "Toggle to enable logins verification")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .trackingProtectionRefactor,
                     titleText: format(string: "Enable New Tracking Protection"),
                     statusText: format(string: "Toggle to use the new tracking protection")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -65,6 +65,9 @@ final class NimbusFeatureFlagLayer {
         case .microsurvey:
             return checkMicrosurveyFeature(from: nimbus)
 
+        case .loginsVerificationEnabled:
+            return checkLoginsVerificationFeature(from: nimbus)
+
         case .nativeErrorPage:
             return checkNativeErrorPageFeature(from: nimbus)
 
@@ -381,6 +384,10 @@ final class NimbusFeatureFlagLayer {
         let config = nimbus.features.microsurveyFeature.value()
 
         return config.enabled
+    }
+
+    private func checkLoginsVerificationFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.loginsVerification.value().loginsVerificationEnabled
     }
 
     private func checkNativeErrorPageFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -232,6 +232,7 @@ open class BrowserProfile: Profile {
         }
     }()
     private var rustKeychainEnabled = false
+    private var loginsVerificationEnabled = false
     fileprivate let name: String
     fileprivate let keychain: RustKeychain
     fileprivate let legacyKeychain: MZKeychainWrapper
@@ -261,6 +262,7 @@ open class BrowserProfile: Profile {
          fxaCommandsDelegate: FxACommandsDelegate? = nil,
          creditCardAutofillEnabled: Bool = false,
          rustKeychainEnabled: Bool = false,
+         loginsVerificationEnabled: Bool = false,
          clear: Bool = false,
          logger: Logger = DefaultLogger.shared) {
         logger.log("Initing profile \(localName) on thread \(Thread.current).",
@@ -269,6 +271,7 @@ open class BrowserProfile: Profile {
         self.name = localName
         self.files = ProfileFileAccessor(localName: localName)
         self.rustKeychainEnabled = rustKeychainEnabled
+        self.loginsVerificationEnabled = loginsVerificationEnabled
         self.keychain = KeychainManager.shared
         self.legacyKeychain = KeychainManager.legacyShared
         self.logger = logger
@@ -322,7 +325,8 @@ open class BrowserProfile: Profile {
         // because opening them can trigger events to which the SyncManager listens.
         self.syncManager = RustSyncManager(profile: self,
                                            creditCardAutofillEnabled: creditCardAutofillEnabled,
-                                           rustKeychainEnabled: rustKeychainEnabled)
+                                           rustKeychainEnabled: rustKeychainEnabled,
+                                           loginsVerificationEnabled: loginsVerificationEnabled)
 
         let notificationCenter = NotificationCenter.default
 

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -37,6 +37,7 @@ public class RustSyncManager: NSObject, SyncManager {
     private var notificationCenter: NotificationProtocol
     var creditCardAutofillEnabled = false
     var rustKeychainEnabled = false
+    var loginsVerificationEnabled = false
 
     let fifteenMinutesInterval = TimeInterval(60 * 15)
 
@@ -70,6 +71,7 @@ public class RustSyncManager: NSObject, SyncManager {
     init(profile: BrowserProfile,
          creditCardAutofillEnabled: Bool = false,
          rustKeychainEnabled: Bool = false,
+         loginsVerificationEnabled: Bool = false,
          logger: Logger = DefaultLogger.shared,
          notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.profile = profile
@@ -80,6 +82,7 @@ public class RustSyncManager: NSObject, SyncManager {
         super.init()
         self.creditCardAutofillEnabled = creditCardAutofillEnabled
         self.rustKeychainEnabled = rustKeychainEnabled
+        self.loginsVerificationEnabled = loginsVerificationEnabled
     }
 
     @objc
@@ -355,6 +358,22 @@ public class RustSyncManager: NSObject, SyncManager {
         public let description = "Failed to get token server endpoint url."
     }
 
+    func shouldSyncLogins(completion: @escaping (Bool) -> Void) {
+        if !(self.prefs.boolForKey(PrefsKeys.LoginsHaveBeenVerified) ?? false) {
+            // We should only sync logins when the verification step has completed successfully.
+            // Otherwise logins could exist in the database that can't be decrypted and would
+            // prevent logins from syncing if they are not removed.
+
+            self.profile?.logins.verifyLogins { successfullyVerified in
+                self.prefs.setBool(successfullyVerified, forKey: PrefsKeys.LoginsHaveBeenVerified)
+                completion(successfullyVerified)
+            }
+        } else {
+            // Successful logins verification already occurred so login syncing can proceed
+            completion(true)
+        }
+    }
+
     private func registerSyncEngines(engines: [RustSyncManagerAPI.TogglableEngine],
                                      loginKey: String?,
                                      creditCardKey: String?,
@@ -371,9 +390,18 @@ public class RustSyncManager: NSObject, SyncManager {
                  self.profile?.tabs.registerWithSyncManager()
                  rustEngines.append(engine.rawValue)
              case .passwords:
-                 if loginKey != nil {
-                     self.profile?.logins.registerWithSyncManager()
-                     rustEngines.append(engine.rawValue)
+                 if loginsVerificationEnabled {
+                     self.shouldSyncLogins { shouldSync in
+                         if shouldSync, loginKey != nil {
+                             self.profile?.logins.registerWithSyncManager()
+                             rustEngines.append(engine.rawValue)
+                         }
+                     }
+                 } else {
+                     if loginKey != nil {
+                          self.profile?.logins.registerWithSyncManager()
+                          rustEngines.append(engine.rawValue)
+                      }
                  }
              case .creditcards:
                  if self.creditCardAutofillEnabled {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -31,6 +31,227 @@ class RustSyncManagerTests: XCTestCase {
         profile = MockBrowserProfile(localName: "RustSyncManagerTests")
         rustSyncManager = RustSyncManager(profile: profile,
                                           creditCardAutofillEnabled: true,
+                                          loginsVerificationEnabled: true,
+                                          logger: MockLogger(),
+                                          notificationCenter: MockNotificationCenter())
+        rustSyncManager.syncManagerAPI = RustSyncManagerAPI()
+        profile.syncManager = rustSyncManager
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        rustSyncManager = nil
+        UserDefaults.standard.removeObject(forKey: "fxa.cwts.declinedSyncEngines")
+        profile.prefs.removeObjectForKey(Keys.bookmarksStateChangedPrefKey)
+        profile.prefs.removeObjectForKey(Keys.bookmarksEnabledPrefKey)
+        profile.prefs.removeObjectForKey(Keys.creditcardsStateChangedPrefKey)
+        profile.prefs.removeObjectForKey(Keys.creditcardsEnabledPrefKey)
+        profile.prefs.removeObjectForKey(Keys.historyStateChangedPrefKey)
+        profile.prefs.removeObjectForKey(Keys.historyEnabledPrefKey)
+        profile.prefs.removeObjectForKey(Keys.passwordsStateChangedPrefKey)
+        profile.prefs.removeObjectForKey(Keys.passwordsEnabledPrefKey)
+        profile.prefs.removeObjectForKey(Keys.tabsStateChangedPrefKey)
+        profile.prefs.removeObjectForKey(Keys.tabsEnabledPrefKey)
+        profile.prefs.removeObjectForKey(Keys.addressesEnabledPrefKey)
+        profile.prefs.removeObjectForKey(Keys.addressesStateChangedPrefKey)
+
+        profile = nil
+    }
+
+    func testGetEnginesAndKeys() {
+        let engines: [RustSyncManagerAPI.TogglableEngine] = [
+            .bookmarks,
+            .creditcards,
+            .history,
+            .passwords,
+            .tabs,
+            .addresses
+        ]
+
+        rustSyncManager.getEnginesAndKeys(engines: engines) { (engines, keys) in
+            XCTAssertEqual(engines.count, 6)
+
+            XCTAssertTrue(engines.contains("bookmarks"))
+            XCTAssertTrue(engines.contains("history"))
+            XCTAssertTrue(engines.contains("passwords"))
+            XCTAssertTrue(engines.contains("tabs"))
+            XCTAssertTrue(engines.contains("addresses"))
+            XCTAssertFalse(keys.isEmpty)
+
+            XCTAssertEqual(keys.count, 2)
+            XCTAssertNotNil(keys["creditcards"])
+            XCTAssertNotNil(keys["passwords"])
+        }
+    }
+
+    // Temp. Disabled: https://mozilla-hub.atlassian.net/browse/FXIOS-7505
+    func testGetEnginesAndKeysWithNoKey() {
+        rustSyncManager.getEnginesAndKeys(engines: [.tabs]) { (engines, keys) in
+            XCTAssertEqual(engines.count, 1)
+            XCTAssertTrue(engines.contains("tabs"))
+            XCTAssertTrue(keys.isEmpty)
+        }
+    }
+
+    func testGetEngineEnablementChangesForAccountWithNewAccount() {
+        let declinedEngines = ["tabs", "creditcards"]
+        UserDefaults.standard.set(declinedEngines, forKey: "fxa.cwts.declinedSyncEngines")
+        let changes = rustSyncManager.getEngineEnablementChangesForAccount()
+        XCTAssertFalse(changes["tabs"]!)
+        XCTAssertFalse(changes["creditcards"]!)
+    }
+
+    func testGetEngineEnablementChangesForAccountWithNoChanges() {
+        let changes = rustSyncManager.getEngineEnablementChangesForAccount()
+        XCTAssertTrue(changes.isEmpty)
+    }
+
+    func testGetEngineEnablementChangesForAccountWithNoRecentChanges() {
+        profile.prefs.setBool(true, forKey: Keys.bookmarksEnabledPrefKey)
+
+        let changes = rustSyncManager.getEngineEnablementChangesForAccount()
+        XCTAssertTrue(changes.isEmpty)
+    }
+
+    func testGetEngineEnablementChangesForAccountWithRecentChanges() {
+        profile.prefs.setBool(true, forKey: Keys.bookmarksStateChangedPrefKey)
+        profile.prefs.setBool(true, forKey: Keys.bookmarksEnabledPrefKey)
+        profile.prefs.setBool(true, forKey: Keys.creditcardsStateChangedPrefKey)
+        profile.prefs.setBool(false, forKey: Keys.creditcardsEnabledPrefKey)
+
+        let changes = rustSyncManager.getEngineEnablementChangesForAccount()
+        XCTAssertTrue(changes["bookmarks"]!)
+        XCTAssertFalse(changes["creditcards"]!)
+    }
+
+    // Temp. Disabled: https://mozilla-hub.atlassian.net/browse/FXIOS-7505
+    func testUpdateEnginePrefs_bookmarksEnabled() throws {
+        profile.prefs.setBool(true, forKey: Keys.bookmarksEnabledPrefKey)
+        profile.prefs.setBool(true, forKey: Keys.bookmarksStateChangedPrefKey)
+
+        let declined = ["bookmarks", "creditcards", "passwords"]
+        rustSyncManager.updateEnginePrefs(declined: declined)
+
+        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.bookmarksEnabledPrefKey))
+        XCTAssertFalse(key)
+        XCTAssertNil(profile.prefs.boolForKey(Keys.bookmarksStateChangedPrefKey))
+    }
+
+    func testUpdateEnginePrefs_creditCardEnabled() throws {
+        profile.prefs.setBool(true, forKey: Keys.creditcardsEnabledPrefKey)
+        profile.prefs.setBool(true, forKey: Keys.creditcardsStateChangedPrefKey)
+
+        let declined = ["bookmarks", "creditcards", "passwords"]
+        rustSyncManager.updateEnginePrefs(declined: declined)
+
+        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.creditcardsEnabledPrefKey))
+        XCTAssertFalse(key)
+        XCTAssertNil(profile.prefs.boolForKey(Keys.creditcardsStateChangedPrefKey))
+    }
+
+    func testUpdateEnginePrefs_historyEnabled() throws {
+        profile.prefs.setBool(true, forKey: Keys.historyEnabledPrefKey)
+        profile.prefs.setBool(false, forKey: Keys.historyStateChangedPrefKey)
+
+        let declined = ["bookmarks", "creditcards", "passwords"]
+        rustSyncManager.updateEnginePrefs(declined: declined)
+
+        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.historyEnabledPrefKey))
+        XCTAssertTrue(key)
+        XCTAssertNil(profile.prefs.boolForKey(Keys.historyStateChangedPrefKey))
+    }
+
+    func testUpdateEnginePrefs_passwordsEnabled() throws {
+        profile.prefs.setBool(false, forKey: Keys.passwordsEnabledPrefKey)
+        profile.prefs.setBool(false, forKey: Keys.passwordsStateChangedPrefKey)
+
+        let declined = ["bookmarks", "creditcards", "passwords"]
+        rustSyncManager.updateEnginePrefs(declined: declined)
+
+        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.passwordsEnabledPrefKey))
+        XCTAssertFalse(key)
+        XCTAssertNil(profile.prefs.boolForKey(Keys.passwordsStateChangedPrefKey))
+    }
+
+    func testUpdateEnginePrefs_tabsEnabled() throws {
+        profile.prefs.setBool(false, forKey: Keys.tabsEnabledPrefKey)
+        profile.prefs.setBool(true, forKey: Keys.tabsStateChangedPrefKey)
+
+        let declined = ["bookmarks", "creditcards", "passwords"]
+        rustSyncManager.updateEnginePrefs(declined: declined)
+
+        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.tabsEnabledPrefKey))
+        XCTAssertTrue(key)
+        XCTAssertNil(profile.prefs.boolForKey(Keys.tabsStateChangedPrefKey))
+    }
+
+    // FXIOS-8331: Disable History Highlight tests while FXIOS-8059 (Epic) is in progress
+    // FXIOS-8367: Added a ticket to enable these tests when we re-enable history highlights
+    func testUpdateEnginePrefs_addressesEnabled() throws {
+        profile.prefs.setBool(true, forKey: Keys.addressesEnabledPrefKey)
+        profile.prefs.setBool(true, forKey: Keys.addressesStateChangedPrefKey)
+
+        let declined = ["bookmarks", "creditcards", "passwords"]
+        rustSyncManager.updateEnginePrefs(declined: declined)
+
+        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.addressesEnabledPrefKey))
+        XCTAssertTrue(key)
+        XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
+    }
+
+    // FXIOS-8331: Disable History Highlight tests while FXIOS-8059 (Epic) is in progress
+    // FXIOS-8367: Added a ticket to enable these tests when we re-enable history highlights
+    func testUpdateEnginePrefs_addressesDisabled() throws {
+        profile.prefs.setBool(false, forKey: Keys.addressesEnabledPrefKey)
+        profile.prefs.setBool(false, forKey: Keys.addressesStateChangedPrefKey)
+
+        let declined = ["bookmarks", "addresses", "passwords"]
+        rustSyncManager.updateEnginePrefs(declined: declined)
+
+        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.addressesEnabledPrefKey))
+        XCTAssertFalse(key)
+        XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
+    }
+
+    func test_applicationDidBecomeActive_updateSignInPrefs() throws {
+        rustSyncManager.applicationDidBecomeActive()
+        let value = try XCTUnwrap(profile.prefs.boolForKey(PrefsKeys.Sync.signedInFxaAccount))
+        XCTAssertFalse(value)
+    }
+
+    func test_onRemovedAccount_updatePrefs() throws {
+        _ = rustSyncManager.onRemovedAccount()
+        let signedInStatus = try XCTUnwrap(profile.prefs.boolForKey(PrefsKeys.Sync.signedInFxaAccount))
+        let syncedDevicesCount = try XCTUnwrap(profile.prefs.intForKey(PrefsKeys.Sync.numberOfSyncedDevices))
+        XCTAssertFalse(signedInStatus)
+        XCTAssertEqual(syncedDevicesCount, 0)
+    }
+}
+
+class LegacyRustSyncManagerTests: XCTestCase {
+    struct Keys {
+        static let bookmarksStateChangedPrefKey = "sync.engine.bookmarks.enabledStateChanged"
+        static let bookmarksEnabledPrefKey = "sync.engine.bookmarks.enabled"
+        static let creditcardsStateChangedPrefKey = "sync.engine.creditcards.enabledStateChanged"
+        static let creditcardsEnabledPrefKey = "sync.engine.creditcards.enabled"
+        static let addressesStateChangedPrefKey = "sync.engine.addresses.enabledStateChanged"
+        static let addressesEnabledPrefKey = "sync.engine.addresses.enabled"
+        static let historyStateChangedPrefKey = "sync.engine.history.enabledStateChanged"
+        static let historyEnabledPrefKey = "sync.engine.history.enabled"
+        static let passwordsStateChangedPrefKey = "sync.engine.passwords.enabledStateChanged"
+        static let passwordsEnabledPrefKey = "sync.engine.passwords.enabled"
+        static let tabsStateChangedPrefKey = "sync.engine.tabs.enabledStateChanged"
+        static let tabsEnabledPrefKey = "sync.engine.tabs.enabled"
+    }
+
+    private var rustSyncManager: RustSyncManager!
+    private var profile: MockBrowserProfile!
+
+    override func setUp() {
+        super.setUp()
+        profile = MockBrowserProfile(localName: "RustSyncManagerTests")
+        rustSyncManager = RustSyncManager(profile: profile,
+                                          creditCardAutofillEnabled: true,
                                           logger: MockLogger(),
                                           notificationCenter: MockNotificationCenter())
         rustSyncManager.syncManagerAPI = RustSyncManagerAPI()

--- a/firefox-ios/nimbus-features/loginsVerificationEnabled.yaml
+++ b/firefox-ios/nimbus-features/loginsVerificationEnabled.yaml
@@ -1,0 +1,20 @@
+# The configuration for the logins verifiction feature
+features:
+  logins-verification:
+    description: >
+      Feature that enables the logins verification logic.
+    variables:
+      logins-verification-enabled:
+        description: >
+          Whether the logins verification logic is enabled. When enabled, an attempt will be made to decrypt all
+          stored logins when sync is enabled. If a login cannot be decrypted, it will be locally deleted to unblock
+          syncing.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          logins-verification-enabled: false
+      - channel: developer
+        value:
+          logins-verification-enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -29,6 +29,7 @@ include:
   - nimbus-features/menuRefactorFeature.yaml
   - nimbus-features/messagingFeature.yaml
   - nimbus-features/microsurveyFeature.yaml
+  - nimbus-features/loginsVerificationEnabled.yaml
   - nimbus-features/nativeErrorPageFeature.yaml
   - nimbus-features/newAppearanceMenu.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11962)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26018)

## :bulb: Description
In order to unblock login sync users who cannot sync because some of their records can't be decrypted, this verification logic is being introduced. Once per user, before a login sync, the verification logic will check if all stored logins can be decrypted. Any logins that cannot be decrypted will be _*locally*_ deleted. This local deletion will potentially restore the record during the next successful login sync if the record was previously synced in the past. Also, this logic is being introduced with a Nimbus feature flag to mitigate risk.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

