### PR TITLE
Bugfix FXIOS-11850 [Tab Tray UI Experiment] Fix homepage animation double display and new tab screenshot being missing

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
@@ -303,13 +303,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
 
             let contentContainer = browserVC.contentContainer
             tabSnapshot.frame = contentContainer.convert(contentContainer.bounds, to: browserVC.view)
-            print("✨Tab snapshot frame✨")
-            print(tabSnapshot.frame)
             tabSnapshot.layer.cornerRadius = 0
-            print("🐣toVCSnapshot frame🐣")
-            print(toVCSnapshot.frame)
-            print("🍄‍🟫Final Frame🍄‍🟫")
-            print(finalFrame)
             toVCSnapshot.frame = finalFrame
             toVCSnapshot.layer.cornerRadius = 0
             backgroundView.alpha = 1

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
@@ -159,9 +159,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         context.containerView.addSubview(backgroundView)
         context.containerView.addSubview(bvcSnapshot)
         context.containerView.addSubview(tabSnapshot)
-        print(finalFrame)
-        print(destinationController.view.frame)
-        print("hi")
+
         destinationController.view.frame = finalFrame
         destinationController.view.setNeedsLayout()
         destinationController.view.layoutIfNeeded()
@@ -285,9 +283,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             if let cell = cv.cellForItem(at: indexPath) as? ExperimentTabCell {
                 tabCell = cell
                 tabSnapshot.frame = cv.convert(cell.frame, to: view)
-                print(tabSnapshot.frame)
-                print(toVCSnapshot.frame)
-                print("hi")
                 toVCSnapshot.frame = tabSnapshot.frame
 
                 tabSnapshot.setNeedsLayout()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
@@ -56,10 +56,9 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         tabSnapshot.layer.cornerCurve = .continuous
         tabSnapshot.clipsToBounds = true
         tabSnapshot.contentMode = .scaleAspectFill
-        tabSnapshot.frame = webView.frame
+        tabSnapshot.frame = webView.convert(webView.bounds, to: bvc.view)
 
         // Allow the UI to render to make the snapshotting code more performant
-
         DispatchQueue.main.async { [self] in
             runPresentationAnimation(
                 context: context,
@@ -296,6 +295,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             cv.transform = .init(scaleX: 1.2, y: 1.2)
             cv.alpha = 0.5
 
+            // SOPHIE - Fix for webview frame presentation
             tabSnapshot.frame = webView.convert(webView.bounds, to: browserVC.view)
             print("✨Tab snapshot frame✨")
             print(tabSnapshot.frame)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
@@ -297,7 +297,14 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             cv.alpha = 0.5
 
             tabSnapshot.frame = webView.convert(webView.bounds, to: browserVC.view)
+            toVCSnapshot.frame = tabSnapshot.convert(tabSnapshot.bounds, to: view)
+            print("✨Tab snapshot frame✨")
+            print(tabSnapshot.frame)
             tabSnapshot.layer.cornerRadius = 0
+            print("🐣toVCSnapshot frame🐣")
+            print(toVCSnapshot.frame)
+            print("🍄‍🟫Final Frame🍄‍🟫")
+            print(finalFrame)
             toVCSnapshot.frame = finalFrame
             toVCSnapshot.layer.cornerRadius = 0
             backgroundView.alpha = 1

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
@@ -297,7 +297,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             cv.alpha = 0.5
 
             tabSnapshot.frame = webView.convert(webView.bounds, to: browserVC.view)
-            toVCSnapshot.frame = tabSnapshot.convert(tabSnapshot.bounds, to: view)
             print("✨Tab snapshot frame✨")
             print(tabSnapshot.frame)
             tabSnapshot.layer.cornerRadius = 0

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
@@ -159,7 +159,9 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         context.containerView.addSubview(backgroundView)
         context.containerView.addSubview(bvcSnapshot)
         context.containerView.addSubview(tabSnapshot)
-
+        print(finalFrame)
+        print(destinationController.view.frame)
+        print("hi")
         destinationController.view.frame = finalFrame
         destinationController.view.setNeedsLayout()
         destinationController.view.layoutIfNeeded()
@@ -283,6 +285,9 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             if let cell = cv.cellForItem(at: indexPath) as? ExperimentTabCell {
                 tabCell = cell
                 tabSnapshot.frame = cv.convert(cell.frame, to: view)
+                print(tabSnapshot.frame)
+                print(toVCSnapshot.frame)
+                print("hi")
                 toVCSnapshot.frame = tabSnapshot.frame
 
                 tabSnapshot.setNeedsLayout()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
@@ -39,8 +39,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             return
         }
 
-        guard let selectedTab = bvc.tabManager.selectedTab,
-              let webView = selectedTab.webView
+        guard let selectedTab = bvc.tabManager.selectedTab
         else {
             logger.log("Attempted to present the tab tray without having a selected tab",
                        level: .warning,
@@ -52,13 +51,21 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         let finalFrame = context.finalFrame(for: destinationController)
 
         // Tab snapshot animates from web view container on BVC to the cell frame
-        let tabSnapshot = UIImageView(image: selectedTab.screenshot ?? .init())
+        var tempScreenshot = UIImage()
+        if selectedTab.screenshot == nil {
+            // When we first open a tab we do not have a screenshot before this animation runs
+            // We can fix this to run in a sequence where the tab has a snapshot by the time we get here
+            // if we roll out the .tabTrayUIExperiments fully
+            let contentView = bvc.contentContainer.contentView
+            tempScreenshot = contentView?.screenshot(quality: UIConstants.ActiveScreenshotQuality) ?? UIImage()
+        }
+        let tabSnapshot = UIImageView(image: selectedTab.screenshot ?? tempScreenshot)
         tabSnapshot.layer.cornerCurve = .continuous
         tabSnapshot.clipsToBounds = true
         tabSnapshot.contentMode = .scaleAspectFill
-        tabSnapshot.frame = webView.convert(webView.bounds, to: bvc.view)
+        let contentContainer = bvc.contentContainer
+        tabSnapshot.frame = contentContainer.convert(contentContainer.bounds, to: bvc.view)
 
-        // Allow the UI to render to make the snapshotting code more performant
         DispatchQueue.main.async { [self] in
             runPresentationAnimation(
                 context: context,
@@ -230,8 +237,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         selectedTab: Tab
     ) {
         guard let panel = currentPanel as? ThemedNavigationController,
-              let panelViewController = panel.viewControllers.first as? TabDisplayPanelViewController,
-              let webView = selectedTab.webView
+              let panelViewController = panel.viewControllers.first as? TabDisplayPanelViewController
         else {
             context.completeTransition(true)
             return
@@ -295,8 +301,8 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             cv.transform = .init(scaleX: 1.2, y: 1.2)
             cv.alpha = 0.5
 
-            // SOPHIE - Fix for webview frame presentation
-            tabSnapshot.frame = webView.convert(webView.bounds, to: browserVC.view)
+            let contentContainer = browserVC.contentContainer
+            tabSnapshot.frame = contentContainer.convert(contentContainer.bounds, to: browserVC.view)
             print("✨Tab snapshot frame✨")
             print(tabSnapshot.frame)
             tabSnapshot.layer.cornerRadius = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11850)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25822)

## :bulb: Description
In the case when the tab was first made where there was no tab screenshot on the selectedTab (because of timing of taking the screenshot) the animation looked awkward when transitioning from webpage to tab tray view. I've added a check to see if the screenshot is nil and it will take a temp screenshot in this one case.

The contentView on BVC is now what's being used instead of webView, this covers the cases for homepage use so that the animation no longer has duplication of views.

## Before 
https://github.com/user-attachments/assets/876bc26e-ca55-408f-bfcd-8361725b6a3f

## After
https://github.com/user-attachments/assets/7febd145-91d9-4cda-a9d4-b20ff201931d




## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

