### PR TITLE
Bugfix FXIOS-11907 Firefox Focus is recognized as outdated by some websites

### DIFF
--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -160,7 +160,7 @@ class LegacyWebViewController: UIViewController, LegacyWebController {
         // Focus on iPad, which means there could be some edge cases right now.
 
         if UIDevice.current.userInterfaceIdiom == .pad {
-            configuration.applicationNameForUserAgent = "Version/15.0 Safari/605.1.15"
+            configuration.applicationNameForUserAgent = "Version/16.0 Safari/605.1.15"
         } else {
             configuration.applicationNameForUserAgent = "FxiOS/\(AppInfo.majorVersion) Mobile/15E148 Version/16.0"
         }

--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -7,7 +7,6 @@ import WebKit
 import PassKit
 import Combine
 import Glean
-import Shared
 
 protocol LegacyBrowserState {
     var url: URL? { get }

--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -154,6 +154,18 @@ class LegacyWebViewController: UIViewController, LegacyWebController {
         configuration.allowsInlineMediaPlayback = true
         configuration.ignoresViewportScaleLimits = true
 
+        // For consistency we set our user agent similar to Firefox iOS.
+        //
+        // Important to note that this UA change only applies when the webview is created initially or
+        // when people hit the erase session button. The UA is not changed when you change the width of
+        // Focus on iPad, which means there could be some edge cases right now.
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            configuration.applicationNameForUserAgent = "Version/15.0 Safari/605.1.15"
+        } else {
+            configuration.applicationNameForUserAgent = "FxiOS/\(AppInfo.majorVersion) Mobile/15E148 Version/15.0"
+        }
+
         if #available(iOS 15.0, *) {
             configuration.upgradeKnownHostsToHTTPS = true
         }
@@ -165,7 +177,6 @@ class LegacyWebViewController: UIViewController, LegacyWebController {
         browserView.scrollView.delegate = self
         browserView.navigationDelegate = self
         browserView.uiDelegate = self
-        browserView.customUserAgent = UserAgent.mobileUserAgent()
 
         progressObserver = browserView.observe(\WKWebView.estimatedProgress) { (webView, value) in
             self.delegate?.webController(self, didUpdateEstimatedProgress: webView.estimatedProgress)

--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -162,7 +162,7 @@ class LegacyWebViewController: UIViewController, LegacyWebController {
         if UIDevice.current.userInterfaceIdiom == .pad {
             configuration.applicationNameForUserAgent = "Version/15.0 Safari/605.1.15"
         } else {
-            configuration.applicationNameForUserAgent = "FxiOS/\(AppInfo.majorVersion) Mobile/15E148 Version/15.0"
+            configuration.applicationNameForUserAgent = "FxiOS/\(AppInfo.majorVersion) Mobile/15E148 Version/16.0"
         }
 
         if #available(iOS 15.0, *) {

--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -7,6 +7,7 @@ import WebKit
 import PassKit
 import Combine
 import Glean
+import Shared
 
 protocol LegacyBrowserState {
     var url: URL? { get }
@@ -153,18 +154,6 @@ class LegacyWebViewController: UIViewController, LegacyWebController {
         configuration.allowsInlineMediaPlayback = true
         configuration.ignoresViewportScaleLimits = true
 
-        // For consistency we set our user agent similar to Firefox iOS.
-        //
-        // Important to note that this UA change only applies when the webview is created initially or
-        // when people hit the erase session button. The UA is not changed when you change the width of
-        // Focus on iPad, which means there could be some edge cases right now.
-
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            configuration.applicationNameForUserAgent = "Version/13.1 Safari/605.1.15"
-        } else {
-            configuration.applicationNameForUserAgent = "FxiOS/\(AppInfo.majorVersion) Mobile/15E148 Version/15.0"
-        }
-
         if #available(iOS 15.0, *) {
             configuration.upgradeKnownHostsToHTTPS = true
         }
@@ -176,6 +165,7 @@ class LegacyWebViewController: UIViewController, LegacyWebController {
         browserView.scrollView.delegate = self
         browserView.navigationDelegate = self
         browserView.uiDelegate = self
+        browserView.customUserAgent = UserAgent.mobileUserAgent()
 
         progressObserver = browserView.observe(\WKWebView.estimatedProgress) { (webView, value) in
             self.delegate?.webController(self, didUpdateEstimatedProgress: webView.estimatedProgress)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11907)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25976)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I ended up using the user agent generated for Firefox from BrowserKit.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

