### PR TITLE
Bugfix FXIOS-11787 ⁃ [FF shortcuts widget] - A Google page is opened when tapping on open copied link without previously copying any link

### DIFF
--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -92,8 +92,7 @@ final class RouteBuilder: FeatureFlaggable {
 
             case .widgetSmallQuickLinkOpenCopied, .widgetMediumQuickLinkOpenCopied:
                 // Widget Quick links - medium - open copied url
-                if !UIPasteboard.general.hasURLs {
-                    let searchText = UIPasteboard.general.string ?? ""
+                if !UIPasteboard.general.hasURLs, let searchText = UIPasteboard.general.string {
                     return .searchQuery(query: searchText, isPrivate: isPrivate)
                 } else {
                     let url = UIPasteboard.general.url


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11787)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25702)

## :bulb: Description
Use .search instead of .searchQuery if pasteBoard string is empty

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

