### PR TITLE
Bugfix FXIOS-11904 - [Toolbar - Swipe Tabs Animation] - The UI becomes unresponsive in a specific case

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1045,7 +1045,7 @@ class BrowserViewController: UIViewController,
 
     func addSubviews() {
         view.addSubviews(contentStackView)
-        view.addSubview(webPagePreview)
+        if isSwipingTabsEnabled { contentStackView.addSubview(webPagePreview) }
 
         contentStackView.addArrangedSubview(contentContainer)
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -82,6 +82,9 @@ final class AddressBarPanGestureHandler: NSObject {
             originalPosition = contentContainer.frame.origin
             // Set the initial position of webPagePreview with the offset
             webPagePreview.frame.origin.x = calculateX(width: originalPosition.x)
+            // Set to true to deactivate Auto Layout because we manipulate the rect of
+            // the view directly and want to avoid conflicts such as flickering.
+            webPagePreview.translatesAutoresizingMaskIntoConstraints = true
         case .changed:
             updateWebPagePreview(translation: translation, index: index, tabs: tabs)
         case .ended:
@@ -141,6 +144,8 @@ final class AddressBarPanGestureHandler: NSObject {
         }) { [self] _ in
             // Hide the webPagePreview after the animation.
             webPagePreview.isHidden = true
+            // Reactivate Auto Layout after the animation.
+            webPagePreview.translatesAutoresizingMaskIntoConstraints = false
             if shouldCompleteTransition && isValidIndex {
                 // Reset the positions and select the new tab if the transition was completed.
                 contentContainer.frame.origin.x = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11904)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25971)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Fix flickering and UI freeze.
## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

