### PR TITLE
Remove FXIOS-11965 Remove unused code from ContextualHintViewProvider

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
@@ -15,7 +15,6 @@ public class ContextualHintView: UIView, ThemeApplicable {
         static let closeButtonTop: CGFloat = 23
         static let closeButtonBottom: CGFloat = 12
         static let closeButtonInsets = NSDirectionalEdgeInsets(top: 0, leading: 7.5, bottom: 15, trailing: 7.5)
-        static let actionButtonInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
         static let stackViewLeading: CGFloat = 16
         static let stackViewTopArrowTopConstraint: CGFloat = 16
         static let stackViewBottomArrowTopConstraint: CGFloat = 5
@@ -48,12 +47,6 @@ public class ContextualHintView: UIView, ThemeApplicable {
         label.adjustsFontForContentSizeCategory = true
     }
 
-    private lazy var actionButton: LinkButton = .build { button in
-        button.titleLabel?.textAlignment = .left
-        button.titleLabel?.numberOfLines = 0
-        button.addTarget(self, action: #selector(self.didTapActionButton), for: .touchUpInside)
-    }
-
     private lazy var stackView: UIStackView = .build { stack in
         stack.backgroundColor = .clear
         stack.distribution = .fillProportionally
@@ -84,13 +77,6 @@ public class ContextualHintView: UIView, ThemeApplicable {
     public func configure(viewModel: ContextualHintViewModel) {
         self.viewModel = viewModel
 
-        let actionButtonViewModel = LinkButtonViewModel(
-            title: viewModel.actionButtonTitle,
-            a11yIdentifier: viewModel.actionButtonA11yId,
-            contentInsets: UX.actionButtonInsets
-        )
-        actionButton.configure(viewModel: actionButtonViewModel)
-
         closeButton.accessibilityLabel = viewModel.closeButtonA11yLabel
         descriptionLabel.text = viewModel.description
 
@@ -107,7 +93,6 @@ public class ContextualHintView: UIView, ThemeApplicable {
             stackView.addArrangedSubview(titleLabel)
         }
         stackView.addArrangedSubview(descriptionLabel)
-        if viewModel.isActionType { stackView.addArrangedSubview(actionButton) }
 
         setupConstraints()
     }
@@ -156,32 +141,10 @@ public class ContextualHintView: UIView, ThemeApplicable {
         viewModel?.closeButtonAction?(sender)
     }
 
-    @objc
-    private func didTapActionButton(sender: UIButton) {
-        viewModel?.actionButtonAction?(sender)
-    }
-
     public func applyTheme(theme: Theme) {
         closeButton.tintColor = theme.colors.textOnDark
         titleLabel.textColor = theme.colors.textOnDark
         descriptionLabel.textColor = theme.colors.textOnDark
         gradient.colors = theme.colors.layerGradient.cgColors
-
-        guard let viewModel else { return }
-
-        if viewModel.isActionType {
-            let textAttributes: [NSAttributedString.Key: Any] = [
-                .font: FXFontStyles.Regular.body.scaledFont(),
-                .foregroundColor: theme.colors.textOnDark,
-                .underlineStyle: NSUnderlineStyle.single.rawValue
-            ]
-
-            let attributeString = NSMutableAttributedString(
-                string: viewModel.actionButtonTitle,
-                attributes: textAttributes
-            )
-
-            actionButton.setAttributedTitle(attributeString, for: .normal)
-        }
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintViewModel.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintViewModel.swift
@@ -6,7 +6,6 @@ import UIKit
 
 /// The view model used to configure a `ContextualHintView`
 public struct ContextualHintViewModel {
-    public var isActionType: Bool
     public var actionButtonTitle: String
     public var title: String
     public var description: String
@@ -17,14 +16,12 @@ public struct ContextualHintViewModel {
     public var closeButtonAction: ((UIButton) -> Void)?
     public var actionButtonAction: ((UIButton) -> Void)?
 
-    public init(isActionType: Bool,
-                actionButtonTitle: String,
+    public init(actionButtonTitle: String,
                 title: String,
                 description: String,
                 arrowDirection: UIPopoverArrowDirection,
                 closeButtonA11yLabel: String,
                 actionButtonA11yId: String) {
-        self.isActionType = isActionType
         self.actionButtonTitle = actionButtonTitle
         self.title = title
         self.description = description

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -207,7 +207,6 @@ class MainMenuViewController: UIViewController,
 
     private func setupHintView() {
         var viewModel = ContextualHintViewModel(
-            isActionType: viewProvider.isActionType,
             actionButtonTitle: viewProvider.getCopyFor(.action),
             title: viewProvider.getCopyFor(.title),
             description: viewProvider.getCopyFor(.description),

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewController.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewController.swift
@@ -163,7 +163,6 @@ class ContextualHintViewController: UIViewController,
         if delegate == nil { presentationController?.delegate = self }
 
         var viewModel = ContextualHintViewModel(
-            isActionType: viewProvider.isActionType,
             actionButtonTitle: viewProvider.getCopyFor(.action),
             title: viewProvider.getCopyFor(.title),
             description: viewProvider.getCopyFor(.description),

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewProvider.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewProvider.swift
@@ -113,10 +113,6 @@ class ContextualHintViewProvider: ContextualHintPrefsKeysProvider, SearchBarLoca
         return copyProvider.getCopyFor(copyType, of: hintType)
     }
 
-    var isActionType: Bool {
-        return false
-    }
-
     // MARK: - Telemetry
     func sendTelemetryEvent(for eventType: CFRTelemetryEvent) {
         let hintTypeExtra = hintType == .toolbarLocation ? getToolbarLocation() : hintType.rawValue

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintViewProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintViewProviderTests.swift
@@ -28,7 +28,6 @@ class ContextualHintViewProviderTests: XCTestCase {
     func test_dataClearanceConfiguration() {
         let subject = ContextualHintViewProvider(forHintType: .dataClearance, with: profile)
         XCTAssertTrue(subject.shouldPresentContextualHint())
-        XCTAssertFalse(subject.isActionType)
     }
 
     func test_markContextualHintPresented_setPrefsTrue() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11965)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26033)

## :bulb: Description
Removes unused code from ContextualHintViewProvider.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

