### PR TITLE
Fix MTE-4505 Remove some A11y tests from Full functional Test Plan

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -67,6 +67,8 @@
         "A11ySettingsTests\/testSettingToolbarPageAudit()",
         "A11ySettingsTests\/testTrackingProtectionAccessibilityReport()",
         "A11ySettingsTests\/testTrackingProtectionPageAudit()",
+        "A11yTabTrayTests",
+        "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
         "ActivityStreamTest\/testActivityStreamPages()",
         "ActivityStreamTest\/testDefaultSites()",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4505)

## :bulb: Description
This PR removes the A11yTabTrayTests from the Full Functional Test Plan.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

