### PR TITLE
Refactor FXIOS-11896 #25949 [WebEngine] Make config public

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalSchemeHandler.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalSchemeHandler.swift
@@ -23,7 +23,7 @@ public protocol SchemeHandler: WKURLSchemeHandler {
 public class WKInternalSchemeHandler: NSObject, SchemeHandler {
     public let scheme = "internal"
 
-    public override init() {}
+    override public init() {}
 
     static func response(forUrl url: URL) -> URLResponse {
         return URLResponse(url: url, mimeType: "text/html", expectedContentLength: -1, textEncodingName: "utf-8")

--- a/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalSchemeHandler.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalSchemeHandler.swift
@@ -15,9 +15,15 @@ protocol WKInternalSchemeResponse {
     func response(forRequest: URLRequest) -> (URLResponse, Data)?
 }
 
+public protocol SchemeHandler: WKURLSchemeHandler {
+    var scheme: String { get }
+}
+
 /// Will load resources with URL schemes that WebKit doesn’t handle like homepage and error page.
-class WKInternalSchemeHandler: NSObject, WKURLSchemeHandler {
-    public static let scheme = "internal"
+public class WKInternalSchemeHandler: NSObject, SchemeHandler {
+    public let scheme = "internal"
+
+    public override init() {}
 
     static func response(forUrl url: URL) -> URLResponse {
         return URLResponse(url: url, mimeType: "text/html", expectedContentLength: -1, textEncodingName: "utf-8")
@@ -27,7 +33,7 @@ class WKInternalSchemeHandler: NSObject, WKURLSchemeHandler {
     // responder["about/home"] is used for 'internal://local/about/home'
     static var responders = [String: WKInternalSchemeResponse]()
 
-    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+    public func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
         guard let url = urlSchemeTask.request.url else {
             urlSchemeTask.didFailWithError(WKInternalPageSchemeHandlerError.badURL)
             return
@@ -56,5 +62,5 @@ class WKInternalSchemeHandler: NSObject, WKURLSchemeHandler {
         urlSchemeTask.didFinish()
     }
 
-    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {}
+    public func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {}
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/WKReaderModeHandlers.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/WKReaderModeHandlers.swift
@@ -17,6 +17,20 @@ public struct ReaderModeConfiguration {
     var loadOriginalText: String
     var readerModeErrorText: String
     var cachedReaderModeStyle: [String: Any]?
+
+    public init(
+        loadingText: String,
+        loadingFailedText: String,
+        loadOriginalText: String,
+        readerModeErrorText: String,
+        cachedReaderModeStyle: [String : Any]? = nil
+    ) {
+        self.loadingText = loadingText
+        self.loadingFailedText = loadingFailedText
+        self.loadOriginalText = loadOriginalText
+        self.readerModeErrorText = readerModeErrorText
+        self.cachedReaderModeStyle = cachedReaderModeStyle
+    }
 }
 
 struct WKReaderModeHandlers: WKReaderModeHandlersProtocol {

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/WKReaderModeHandlers.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/WKReaderModeHandlers.swift
@@ -23,7 +23,7 @@ public struct ReaderModeConfiguration {
         loadingFailedText: String,
         loadOriginalText: String,
         readerModeErrorText: String,
-        cachedReaderModeStyle: [String : Any]? = nil
+        cachedReaderModeStyle: [String: Any]? = nil
     ) {
         self.loadingText = loadingText
         self.loadingFailedText = loadingFailedText

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
@@ -11,6 +11,7 @@ public class WKEngine: Engine {
     private let userScriptManager: WKUserScriptManager
     private let webServerUtil: WKWebServerUtil
     private let engineDependencies: EngineDependencies
+    private let configProvider: WKEngineConfigurationProvider
 
     public static func factory(engineDependencies: EngineDependencies) -> WKEngine {
         return WKEngine(engineDependencies: engineDependencies)
@@ -19,10 +20,12 @@ public class WKEngine: Engine {
     init(userScriptManager: WKUserScriptManager = DefaultUserScriptManager(),
          webServerUtil: WKWebServerUtil = DefaultWKWebServerUtil(),
          sourceTimerFactory: DispatchSourceTimerFactory = DefaultDispatchSourceTimerFactory(),
+         configProvider: WKEngineConfigurationProvider = DefaultWKEngineConfigurationProvider(),
          engineDependencies: EngineDependencies) {
         self.userScriptManager = userScriptManager
         self.webServerUtil = webServerUtil
         self.sourceTimerFactory = sourceTimerFactory
+        self.configProvider = configProvider
         self.engineDependencies = engineDependencies
 
         InternalUtil().setUpInternalHandlers()
@@ -33,9 +36,8 @@ public class WKEngine: Engine {
     }
 
     public func createSession(dependencies: EngineSessionDependencies) throws -> EngineSession {
-        let configProvider = DefaultWKEngineConfigurationProvider(parameters: dependencies.webviewParameters)
         guard let session = WKEngineSession(userScriptManager: userScriptManager,
-                                            telemetryProxy: dependencies.telemetryProxy,
+                                            dependencies: dependencies,
                                             configurationProvider: configProvider) else {
             throw EngineError.sessionNotCreated
         }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfiguration.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfiguration.swift
@@ -7,6 +7,8 @@ import WebKit
 
 /// Abstraction on top of `WKWebViewConfiguration` and the `WKUserContentController`
 public protocol WKEngineConfiguration {
+    var webViewConfiguration: WKWebViewConfiguration { get set }
+
     func addUserScript(_ userScript: WKUserScript)
     func addInDefaultContentWorld(scriptMessageHandler: WKScriptMessageHandler, name: String)
     func addInPageContentWorld(scriptMessageHandler: WKScriptMessageHandler, name: String)

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfiguration.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfiguration.swift
@@ -6,7 +6,7 @@ import Foundation
 import WebKit
 
 /// Abstraction on top of `WKWebViewConfiguration` and the `WKUserContentController`
-protocol WKEngineConfiguration {
+public protocol WKEngineConfiguration {
     func addUserScript(_ userScript: WKUserScript)
     func addInDefaultContentWorld(scriptMessageHandler: WKScriptMessageHandler, name: String)
     func addInPageContentWorld(scriptMessageHandler: WKScriptMessageHandler, name: String)

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
@@ -41,6 +41,8 @@ public struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvide
     private static let normalSessionsProcessPool = WKProcessPool()
     private static let privateSessionsProcessPool = WKProcessPool()
 
+    public init() {}
+
     public func createConfiguration(parameters: WKWebviewParameters) -> WKEngineConfiguration {
         let configuration = WKWebViewConfiguration()
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -49,7 +49,7 @@ class WKEngineSession: NSObject,
     }
 
     init?(userScriptManager: WKUserScriptManager,
-          telemetryProxy: EngineTelemetryProxy? = nil,
+          dependencies: EngineSessionDependencies,
           configurationProvider: WKEngineConfigurationProvider,
           webViewProvider: WKWebViewProvider = DefaultWKWebViewProvider(),
           logger: Logger = DefaultLogger.shared,
@@ -59,7 +59,8 @@ class WKEngineSession: NSObject,
           metadataFetcher: MetadataFetcherHelper = DefaultMetadataFetcherHelper(),
           navigationHandler: DefaultNavigationHandler = DefaultNavigationHandler(),
           uiHandler: WKUIHandler = DefaultUIHandler()) {
-        guard let webView = webViewProvider.createWebview(configurationProvider: configurationProvider) else {
+        guard let webView = webViewProvider.createWebview(configurationProvider: configurationProvider,
+                                                          parameters: dependencies.webviewParameters) else {
             logger.log("WKEngineWebView creation failed on configuration",
                        level: .fatal,
                        category: .webview)
@@ -74,7 +75,7 @@ class WKEngineSession: NSObject,
         self.navigationHandler = navigationHandler
         self.uiHandler = uiHandler
         self.scriptResponder = scriptResponder
-        self.telemetryProxy = telemetryProxy
+        self.telemetryProxy = dependencies.telemetryProxy
         super.init()
 
         self.metadataFetcher.delegate = self

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -41,7 +41,7 @@ protocol WKEngineWebView: UIView {
     @available(iOS 16.4, *)
     var isInspectable: Bool { get set }
 
-    init?(frame: CGRect, configurationProvider: WKEngineConfigurationProvider)
+    init?(frame: CGRect, configurationProvider: WKEngineConfigurationProvider, parameters: WKWebviewParameters)
 
     @discardableResult
     func load(_ request: URLRequest) -> WKNavigation?
@@ -120,7 +120,6 @@ extension WKEngineWebView {
     }
 }
 
-// TODO: FXIOS-7897 #17642 Handle WKEngineWebView AccessoryViewProvider
 final class DefaultWKEngineWebView: WKWebView, WKEngineWebView, MenuHelperWebViewInterface, ThemeApplicable {
     var engineScrollView: WKScrollView?
     var engineConfiguration: WKEngineConfiguration
@@ -150,8 +149,10 @@ final class DefaultWKEngineWebView: WKWebView, WKEngineWebView, MenuHelperWebVie
         return self.backForwardList.currentItem
     }
 
-    required init?(frame: CGRect, configurationProvider: WKEngineConfigurationProvider) {
-        let configuration = configurationProvider.createConfiguration()
+    required init?(frame: CGRect,
+                   configurationProvider: WKEngineConfigurationProvider,
+                   parameters: WKWebviewParameters) {
+        let configuration = configurationProvider.createConfiguration(parameters: parameters)
         self.engineConfiguration = configuration
         guard let configuration = configuration as? DefaultEngineConfiguration else { return nil }
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKWebViewProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKWebViewProvider.swift
@@ -9,7 +9,8 @@ import WebKit
 /// Abstraction that allow us to create a `WKWebView` object through
 /// the usage of a configuration provider and an webview abstraction.
 protocol WKWebViewProvider {
-    func createWebview(configurationProvider: WKEngineConfigurationProvider) -> WKEngineWebView?
+    func createWebview(configurationProvider: WKEngineConfigurationProvider,
+                       parameters: WKWebviewParameters) -> WKEngineWebView?
 }
 
 struct DefaultWKWebViewProvider: WKWebViewProvider {
@@ -19,9 +20,11 @@ struct DefaultWKWebViewProvider: WKWebViewProvider {
         self.logger = logger
     }
 
-    func createWebview(configurationProvider: WKEngineConfigurationProvider) -> WKEngineWebView? {
+    func createWebview(configurationProvider: WKEngineConfigurationProvider,
+                       parameters: WKWebviewParameters) -> WKEngineWebView? {
         guard let webView = DefaultWKEngineWebView(frame: .zero,
-                                                   configurationProvider: configurationProvider) else {
+                                                   configurationProvider: configurationProvider,
+                                                   parameters: parameters) else {
             logger.log("WKEngineWebView creation failed on configuration",
                        level: .fatal,
                        category: .webview)

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineConfiguration.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineConfiguration.swift
@@ -7,6 +7,11 @@ import WebKit
 @testable import WebEngine
 
 class MockWKEngineConfiguration: WKEngineConfiguration {
+    var webViewConfiguration: WKWebViewConfiguration
+    init(webViewConfiguration: WKWebViewConfiguration) {
+        self.webViewConfiguration = webViewConfiguration
+    }
+
     var scriptNameAdded: String?
     var addUserScriptCalled = 0
     var addInDefaultContentWorldCalled = 0

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineConfigurationProvider.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineConfigurationProvider.swift
@@ -3,10 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import WebKit
 @testable import WebEngine
 
 struct MockWKEngineConfigurationProvider: WKEngineConfigurationProvider {
-    func createConfiguration() -> WKEngineConfiguration {
-        return MockWKEngineConfiguration()
+    func createConfiguration(parameters: WKWebviewParameters) -> WKEngineConfiguration {
+        return MockWKEngineConfiguration(webViewConfiguration: WKWebViewConfiguration())
     }
 }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineSession.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineSession.swift
@@ -14,7 +14,7 @@ class MockWKEngineSession: WKEngineSession {
 
     init() {
         super.init(userScriptManager: MockWKUserScriptManager(),
-                   telemetryProxy: mockTelemetryProxy,
+                   dependencies: DefaultTestDependencies().sessionDependencies,
                    configurationProvider: MockWKEngineConfigurationProvider(),
                    webViewProvider: webviewProvider,
                    contentScriptManager: MockWKContentScriptManager())!

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineSession.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineSession.swift
@@ -13,8 +13,9 @@ class MockWKEngineSession: WKEngineSession {
     var callJavascriptMethodCalled = 0
 
     init() {
+        let defaultDependencies =  DefaultTestDependencies(mockTelemetryProxy: mockTelemetryProxy)
         super.init(userScriptManager: MockWKUserScriptManager(),
-                   dependencies: DefaultTestDependencies().sessionDependencies,
+                   dependencies: defaultDependencies.sessionDependencies,
                    configurationProvider: MockWKEngineConfigurationProvider(),
                    webViewProvider: webviewProvider,
                    contentScriptManager: MockWKContentScriptManager())!

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -52,8 +52,9 @@ class MockWKEngineWebView: UIView, WKEngineWebView {
     var loadFileReadAccessURL: URL?
 
     required init?(frame: CGRect,
-                   configurationProvider: WKEngineConfigurationProvider) {
-        self.engineConfiguration = configurationProvider.createConfiguration()
+                   configurationProvider: WKEngineConfigurationProvider,
+                   parameters: WKWebviewParameters) {
+        self.engineConfiguration = configurationProvider.createConfiguration(parameters: parameters)
         super.init(frame: frame)
     }
 

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKWebViewProvider.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKWebViewProvider.swift
@@ -9,8 +9,11 @@ import Foundation
 class MockWKWebViewProvider: WKWebViewProvider {
     var webView: MockWKEngineWebView!
 
-    func createWebview(configurationProvider: WKEngineConfigurationProvider) -> WKEngineWebView? {
-        let webView = MockWKEngineWebView(frame: .zero, configurationProvider: configurationProvider)
+    func createWebview(configurationProvider: WKEngineConfigurationProvider,
+                       parameters: WKWebviewParameters) -> WKEngineWebView? {
+        let webView = MockWKEngineWebView(frame: .zero,
+                                          configurationProvider: configurationProvider,
+                                          parameters: parameters)
         self.webView = webView
         return webView
     }

--- a/BrowserKit/Tests/WebEngineTests/Utilities/DefaultTestDependencies.swift
+++ b/BrowserKit/Tests/WebEngineTests/Utilities/DefaultTestDependencies.swift
@@ -5,11 +5,18 @@
 @testable import WebEngine
 
 struct DefaultTestDependencies {
+    var mockTelemetryProxy: MockEngineTelemetryProxy
     var webviewParameters = WKWebviewParameters(blockPopups: true,
                                                 isPrivate: true,
                                                 autoPlay: .all,
                                                 schemeHandler: WKInternalSchemeHandler())
+
+    init(mockTelemetryProxy: MockEngineTelemetryProxy = MockEngineTelemetryProxy()) {
+        self.mockTelemetryProxy = mockTelemetryProxy
+    }
+
     var sessionDependencies: EngineSessionDependencies {
-        return EngineSessionDependencies(webviewParameters: webviewParameters)
+        return EngineSessionDependencies(webviewParameters: webviewParameters,
+                                         telemetryProxy: mockTelemetryProxy)
     }
 }

--- a/BrowserKit/Tests/WebEngineTests/Utilities/DefaultTestDependencies.swift
+++ b/BrowserKit/Tests/WebEngineTests/Utilities/DefaultTestDependencies.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import WebEngine
+
+struct DefaultTestDependencies {
+    var webviewParameters = WKWebviewParameters(blockPopups: true,
+                                                isPrivate: true,
+                                                autoPlay: .all,
+                                                schemeHandler: WKInternalSchemeHandler())
+    var sessionDependencies: EngineSessionDependencies {
+        return EngineSessionDependencies(webviewParameters: webviewParameters)
+    }
+}

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -631,6 +631,7 @@ final class WKEngineSessionTests: XCTestCase {
                        line: UInt = #line,
                        uiHandler: WKUIHandler = DefaultUIHandler()) -> WKEngineSession? {
         guard let subject = WKEngineSession(userScriptManager: userScriptManager,
+                                            dependencies: DefaultTestDependencies().sessionDependencies,
                                             configurationProvider: configurationProvider,
                                             webViewProvider: webViewProvider,
                                             contentScriptManager: contentScriptManager,

--- a/BrowserKit/Tests/WebEngineTests/WKEngineTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineTests.swift
@@ -32,10 +32,7 @@ final class WKEngineTests: XCTestCase {
 
     func testCreateSessionThenCreatesSession() throws {
         let subject = createSubject()
-
-        let params = WKWebviewParameters(blockPopups: true, isPrivate: false)
-        let dependencies = EngineSessionDependencies(webviewParameters: params)
-        let session = try XCTUnwrap(subject.createSession(dependencies: dependencies))
+        let session = try XCTUnwrap(subject.createSession(dependencies: DefaultTestDependencies().sessionDependencies))
         XCTAssertNotNil(session)
     }
 

--- a/BrowserKit/Tests/WebEngineTests/WKEngineViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineViewTests.swift
@@ -12,6 +12,7 @@ final class WKEngineViewTests: XCTestCase {
     override func setUp() {
         super.setUp()
         engineSession = WKEngineSession(userScriptManager: MockWKUserScriptManager(),
+                                        dependencies: DefaultTestDependencies().sessionDependencies,
                                         configurationProvider: MockWKEngineConfigurationProvider(),
                                         webViewProvider: MockWKWebViewProvider(),
                                         contentScriptManager: MockWKContentScriptManager(),
@@ -34,6 +35,7 @@ final class WKEngineViewTests: XCTestCase {
     func testRemoveSetsIsActiveFalse() {
         let subject = createSubject()
         let newEngineSession = WKEngineSession(userScriptManager: MockWKUserScriptManager(),
+                                               dependencies: DefaultTestDependencies().sessionDependencies,
                                                configurationProvider: MockWKEngineConfigurationProvider(),
                                                webViewProvider: MockWKWebViewProvider(),
                                                contentScriptManager: MockWKContentScriptManager(),

--- a/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
@@ -175,10 +175,14 @@ final class WKEngineWebViewTests: XCTestCase {
 
     func createSubject(file: StaticString = #file,
                        line: UInt = #line) -> DefaultWKEngineWebView {
-        let parameters = WKWebviewParameters(blockPopups: true, isPrivate: false)
-        let configuration = DefaultWKEngineConfigurationProvider(parameters: parameters)
+        let parameters = WKWebviewParameters(blockPopups: true,
+                                             isPrivate: false,
+                                             autoPlay: .all,
+                                             schemeHandler: WKInternalSchemeHandler())
+        let configuration = DefaultWKEngineConfigurationProvider()
         let subject = DefaultWKEngineWebView(frame: .zero,
-                                             configurationProvider: configuration)!
+                                             configurationProvider: configuration,
+                                             parameters: parameters)!
         subject.delegate = delegate
         trackForMemoryLeaks(subject, file: file, line: line)
 

--- a/BrowserKit/Tests/WebEngineTests/WKUserScriptManagerTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKUserScriptManagerTests.swift
@@ -14,7 +14,8 @@ final class WKUserScriptManagerTests: XCTestCase {
 
     func testInjectUserScriptThenScriptsAreAddedInWebView() {
         let webview = MockWKEngineWebView(frame: .zero,
-                                          configurationProvider: MockWKEngineConfigurationProvider())!
+                                          configurationProvider: MockWKEngineConfigurationProvider(),
+                                          parameters: DefaultTestDependencies().webviewParameters)!
         let subject = createSubject()
 
         subject.injectUserScriptsIntoWebView(webview)

--- a/SampleBrowser/SampleBrowser/AppDelegate.swift
+++ b/SampleBrowser/SampleBrowser/AppDelegate.swift
@@ -15,10 +15,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate, Notifiable {
     )
 
     lazy var engineProvider: EngineProvider = {
-        let parameters = WKWebviewParameters(blockPopups: false, isPrivate: false)
-        let dependencies = EngineSessionDependencies(webviewParameters: parameters,
-                                                     telemetryProxy: TelemetryHandler())
-        return EngineProvider(sessionDependencies: dependencies)!
+        let parameters = WKWebviewParameters(blockPopups: false,
+                                             isPrivate: false,
+                                             autoPlay: .all,
+                                             schemeHandler: WKInternalSchemeHandler())
+        let sessionDependencies = EngineSessionDependencies(webviewParameters: parameters,
+                                                            telemetryProxy: TelemetryHandler())
+
+        let readerModeConfig = ReaderModeConfiguration(loadingText: "Loading",
+                                                       loadingFailedText: "Loading failed",
+                                                       loadOriginalText: "Loading",
+                                                       readerModeErrorText: "Error")
+        let engineDependencies = EngineDependencies(readerModeConfiguration: readerModeConfig)
+        let engine = WKEngine.factory(engineDependencies: engineDependencies)
+        return EngineProvider(engine: engine, sessionDependencies: sessionDependencies)!
     }()
 
     func application(

--- a/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
+++ b/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
@@ -9,9 +9,9 @@ struct EngineProvider {
     private var engine: Engine
     // We only have one session and one view in the SampleBrowser so this code is very simple
     private(set) var session: EngineSession
-    let view: EngineView
+    private(set) var view: EngineView
 
-    init?(engine: Engine = WKEngine.factory(),
+    init?(engine: Engine,
           sessionDependencies: EngineSessionDependencies) {
         self.engine = engine
 

--- a/SampleBrowser/SampleBrowser/Model/RootViewControllerModel.swift
+++ b/SampleBrowser/SampleBrowser/Model/RootViewControllerModel.swift
@@ -127,7 +127,8 @@ class RootViewControllerModel {
             isPrivate: false,
             locationViewConfiguration: locationViewConfig,
             navigationActions: [],
-            pageActions: pageActions,
+            leadingPageActions: pageActions,
+            trailingPageActions: pageActions,
             browserActions: browserActions)
     }
 }

--- a/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainer.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainer.swift
@@ -27,6 +27,7 @@ class AddressToolbarContainer: UIView, ThemeApplicable {
                    toolbarDelegate: AddressToolbarDelegate) {
         compactToolbar.configure(
             config: model.state,
+            toolbarPosition: .top,
             toolbarDelegate: toolbarDelegate,
             leadingSpace: 0,
             trailingSpace: 0,
@@ -35,6 +36,7 @@ class AddressToolbarContainer: UIView, ThemeApplicable {
         )
         regularToolbar.configure(
             config: model.state,
+            toolbarPosition: .top,
             toolbarDelegate: toolbarDelegate,
             leadingSpace: 0,
             trailingSpace: 0,

--- a/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainerModel.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainerModel.swift
@@ -12,7 +12,8 @@ struct AddressToolbarContainerModel {
     let isPrivate: Bool
     let locationViewConfiguration: LocationViewConfiguration
     let navigationActions: [ToolbarElement]
-    let pageActions: [ToolbarElement]
+    let leadingPageActions: [ToolbarElement]
+    let trailingPageActions: [ToolbarElement]
     let browserActions: [ToolbarElement]
     var manager: ToolbarManager = DefaultToolbarManager()
 
@@ -20,7 +21,8 @@ struct AddressToolbarContainerModel {
         return AddressToolbarConfiguration(
             locationViewConfiguration: locationViewConfiguration,
             navigationActions: navigationActions,
-            pageActions: pageActions,
+            leadingPageActions: leadingPageActions,
+            trailingPageActions: trailingPageActions,
             browserActions: browserActions,
             borderPosition: borderPosition,
             uxConfiguration: AddressToolbarUXConfiguration.default,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4140,7 +4140,7 @@ extension BrowserViewController: TabManagerDelegate {
             topTabsDidChangeTab()
         }
 
-       /// If the selectedTab is showing an error page trigger a reload
+        /// If the selectedTab is showing an error page trigger a reload
         if let url = selectedTab.url, let internalUrl = InternalURL(url), internalUrl.isErrorPage {
             needsReload = true
         }

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import WebKit
+import WebEngine
 
 enum InternalPageSchemeHandlerError: Error {
     case badURL
@@ -15,7 +16,8 @@ protocol InternalSchemeResponse {
     func response(forRequest: URLRequest, useOldErrorPage: Bool) -> (URLResponse, Data)?
 }
 
-class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
+class InternalSchemeHandler: NSObject, SchemeHandler {
+    public let scheme = "internal"
     private var shouldUseOldErrorPage = false
 
     static func response(forUrl url: URL) -> URLResponse {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11896)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25949)

## :bulb: Description
Of course this turned out to imply a bit more change than what I initially thought 😄 
- We can now use `DefaultWKEngineConfigurationProvider` in `Firefox iOS` to create a `WKWebviewConfiguration`
- I double checked to ensure the `DefaultWKEngineConfigurationProvider` creates the same configuration as in production today. This meant I needed to do an extra couple of changes.
- Other `WebEngine` changes are so the code still works as expected in there.
- I went to adjust the `SampleBrowser` project too, some changes were needed due to unrelated PR for that project to build, so including this here out of simplicity.

## Sample usage code
This is the `makeWebviewConfig` replacement. `WKWebviewParameters` should use the proper `Prefs` of course.

```
    // We should have one configuration provider at most per window
    let configurationProvider = DefaultWKEngineConfigurationProvider()
    private lazy var configuration: WKWebViewConfiguration = {
        let parameters = WKWebviewParameters(blockPopups: true,
                                             isPrivate: true,
                                             autoPlay: .all,
                                             schemeHandler: InternalSchemeHandler())
        let config = configurationProvider.createConfiguration(parameters: parameters)
        return config.webViewConfiguration
    }()
```

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

