### PR TITLE
Bugfix FXIOS-11970 [Tab Tray Experiment] Fix blue border animation and animation oscillation

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import UIKit
 import Shared
@@ -182,6 +183,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         cv.reloadData()
         var tabCell: ExperimentTabCell?
         var cellFrame: CGRect?
+        let theme = currentTheme()
 
         if let indexPath = dataSource.indexPath(for: item) {
             // This is needed otherwise the collection views content offset is incorrect
@@ -190,8 +192,10 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             tabCell = cv.cellForItem(at: indexPath) as? ExperimentTabCell
             if let cell = tabCell {
                 cellFrame = cell.backgroundHolder.convert(cell.backgroundHolder.bounds, to: nil)
-                // Hide the cell that is being animated since we are making a copy of it to animate in
+                // Hide the cell and border that is being animated since we are making a copy of it to animate in
                 cell.isHidden = true
+                cell.backgroundHolder.layer.borderColor = theme.colors.borderPrimary.cgColor
+                cell.backgroundHolder.layer.borderWidth = ExperimentTabCell.UX.unselectedBorderWidth
                 cell.alpha = 0.0
             }
         }
@@ -218,13 +222,21 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
                 tabCell?.alpha = 1
             }.startAnimation()
         }
-        animator.addCompletion { _ in
+        animator.addCompletion { [weak self] _ in
             backgroundView.removeFromSuperview()
             tabSnapshot.removeFromSuperview()
             bvcSnapshot.removeFromSuperview()
+            self?.unhideCellBorder(tabCell: tabCell, isPrivate: selectedTab.isPrivate, theme: theme)
             context.completeTransition(true)
         }
         animator.startAnimation()
+    }
+
+    private func unhideCellBorder(tabCell: ExperimentTabCell?, isPrivate: Bool, theme: Theme) {
+        guard let tab = tabCell else { return }
+        let borderColor = isPrivate ? theme.colors.borderAccentPrivate : theme.colors.borderAccent
+        tab.backgroundHolder.layer.borderColor = borderColor.cgColor
+        tab.backgroundHolder.layer.borderWidth = ExperimentTabCell.UX.selectedBorderWidth
     }
 
     private func runDismissalAnimation(

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabAnimation.swift
@@ -202,7 +202,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
 
         cv.transform = .init(scaleX: 1.2, y: 1.2)
         cv.alpha = 0.5
-        let animator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 0.825) {
+        let animator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 1) {
             cv.transform = .identity
             cv.alpha = 1
             if let frame = cellFrame {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -534,7 +534,7 @@ class TabTrayViewController: UIViewController,
         return button
     }
 
-    private func currentTheme() -> Theme {
+    internal func currentTheme() -> Theme {
         return themeManager.getCurrentTheme(for: windowUUID)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11970)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26045)

## :bulb: Description
- Disable tab cell border at the beginning of presentation and enable it again at the end of presentation of the tab tray to avoid the flickering.
- set damping ratio to 1 on the animation to reduce oscillation after feedback from Andy

## Video
https://github.com/user-attachments/assets/5ed81382-1437-41aa-8330-1eb5b316f6bd

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

