### PR TITLE
Bugfix FXIOS-11972 [SEC] Fail safe for empty icon fetch

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
@@ -39,7 +39,12 @@ final class ASSearchEngineIconDataFetcher: ASSearchEngineIconDataFetcherProtocol
                                 completion: @escaping ([(SearchEngineDefinition, UIImage)]) -> Void) {
         // Reminder: client creation must happen before sync() or the sync won't pull data for that client's collection
         if SearchEngineFlagManager.temp_dbg_forceASSync { _ = try? service.sync() }
-        guard let client, let records = client.getRecords() else { completion([]); return }
+        guard let client, let records = client.getRecords() else {
+            // If we can't fetch icons, return the input engines list with blank icons
+            // This should never happen, but we need to make sure we handle it regardless
+            completion(engines.map { ($0, UIImage()) })
+            return
+        }
 
         logger.log("Fetched \(records.count) search icon records", level: .info, category: .remoteSettings)
         let iconRecords = records.map { ASSearchEngineIconRecord(record: $0) }

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
@@ -42,6 +42,9 @@ final class ASSearchEngineIconDataFetcher: ASSearchEngineIconDataFetcherProtocol
         guard let client, let records = client.getRecords() else {
             // If we can't fetch icons, return the input engines list with blank icons
             // This should never happen, but we need to make sure we handle it regardless
+            logger.log("Search engine icon fetch failed. Nil client or getRecords() was empty.",
+                       level: .warning,
+                       category: .remoteSettings)
             completion(engines.map { ($0, UIImage()) })
             return
         }

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsServiceSyncCoordinator.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsServiceSyncCoordinator.swift
@@ -44,7 +44,7 @@ final class RemoteSettingsServiceSyncCoordinator {
         // Don't perform sync immediately upon becoming active, give the app
         // some time to allow any other work or threads to take priority
         syncTimer?.invalidate()
-        syncTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { [weak self] _ in
+        syncTimer = Timer.scheduledTimer(withTimeInterval: 20.0, repeats: false) { [weak self] _ in
             self?.syncIfNeeded()
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11972)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26048)

## :bulb: Description

Fix issue where a failed icon records fetch would result in an empty search engine list. Also includes a minor change to bump up the delay for our Remote Settings sync(). 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

