### PR TITLE
Bugfix FXIOS-11976 - [A11y] - VoiceOver reading hidden elements

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -85,6 +85,7 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
 
         isUserInteractionEnabled = false
         isAccessibilityElement = false
+        accessibilityElementsHidden = true
         normalBackgroundColor = .clear
         highlightedBackgroundColor = .clear
         foregroundColor = .clear

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
@@ -76,7 +76,7 @@ class OnboardingTests: BaseTestCase {
         XCTAssertTrue(app.staticTexts["\(rootA11yId)TitleLabel"].exists)
         XCTAssertTrue(app.staticTexts["\(rootA11yId)DescriptionLabel"].exists)
         XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
-        XCTAssertTrue(app.buttons["\(rootA11yId)SecondaryButton"].exists)
+        XCTAssertFalse(app.buttons["\(rootA11yId)SecondaryButton"].exists)
 
         // Swipe to the fifth screen
         app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
@@ -86,7 +86,7 @@ class OnboardingTests: BaseTestCase {
         XCTAssertTrue(app.staticTexts["\(rootA11yId)TitleLabel"].exists)
         XCTAssertTrue(app.staticTexts["\(rootA11yId)DescriptionLabel"].exists)
         XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
-        XCTAssertTrue(app.buttons["\(rootA11yId)SecondaryButton"].exists)
+        XCTAssertFalse(app.buttons["\(rootA11yId)SecondaryButton"].exists)
 
         // Finish onboarding
         app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
@@ -144,7 +144,7 @@ class OnboardingTests: BaseTestCase {
         XCTAssertTrue(app.staticTexts["\(rootA11yId)TitleLabel"].exists)
         XCTAssertTrue(app.staticTexts["\(rootA11yId)DescriptionLabel"].exists)
         XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
-        XCTAssertTrue(app.buttons["\(rootA11yId)SecondaryButton"].exists)
+        XCTAssertFalse(app.buttons["\(rootA11yId)SecondaryButton"].exists)
 
         // Swipe to the fifth screen
         app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
@@ -154,7 +154,7 @@ class OnboardingTests: BaseTestCase {
         XCTAssertTrue(app.staticTexts["\(rootA11yId)TitleLabel"].exists)
         XCTAssertTrue(app.staticTexts["\(rootA11yId)DescriptionLabel"].exists)
         XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
-        XCTAssertTrue(app.buttons["\(rootA11yId)SecondaryButton"].exists)
+        XCTAssertFalse(app.buttons["\(rootA11yId)SecondaryButton"].exists)
 
         // Finish onboarding
         let topSites = app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11976)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26060)

## :bulb: Description
| Before | After |
|--------|--------|
| ![accessibility_1](https://github.com/user-attachments/assets/8f8ab0ac-084b-4100-9e31-211116a0a046) | ![accessibility_2](https://github.com/user-attachments/assets/61cf3ee1-0039-4689-9dc8-0c9ab1d1cacf) | 

When hiding the `SecondaryRoundedButton`, VoiceOver still recognized the element. Using the hidden elements to remove the button and all of its children from accessibility solves the problem when it's hidden.

This is easily reproduced in the Onboarding flow.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

