### PR TITLE
Add FXIOS-7907 [WebEngine] Handle goToHistoryIndex in WKEngineSession

### DIFF
--- a/BrowserKit/Sources/WebEngine/EngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSession.swift
@@ -45,7 +45,7 @@ public protocol EngineSession: NSObject {
     /// - Parameter item: EngineSessionBackForwardListItem in the back forward list that
     /// you would like to navigate to.
     func goToHistory(item: EngineSessionBackForwardListItem)
-    
+
     /// Returns the current EngineSessionBackForwardListItem
     func currentHistoryItem() -> (EngineSessionBackForwardListItem)?
 

--- a/BrowserKit/Sources/WebEngine/EngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSession.swift
@@ -47,7 +47,7 @@ public protocol EngineSession: NSObject {
     func goToHistory(item: EngineSessionBackForwardListItem)
 
     /// Returns the current EngineSessionBackForwardListItem
-    func currentHistoryItem() -> (EngineSessionBackForwardListItem)?
+    func currentHistoryItem() -> EngineSessionBackForwardListItem?
 
     /// Returns the history backlist as a list of EngineSessionBackForwardListItems
     func getBackListItems() -> [EngineSessionBackForwardListItem]

--- a/BrowserKit/Sources/WebEngine/EngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSession.swift
@@ -41,11 +41,16 @@ public protocol EngineSession: NSObject {
     @available(iOS 16.0, *)
     func showFindInPage(withSearchText searchText: String?)
 
-    /// Navigates to the specified index in the history of this session. The current index of
-    /// this session's history  will be updated but the items within it will be unchanged.
-    /// Invalid index values are ignored.
+    /// Navigates to the specified history item
+    /// SessionBackForwardListItem
     /// - Parameter index: index the index of the session's history to navigate to
-    func goToHistory(index: Int)
+    func goToHistory(item: EngineSessionBackForwardListItem)
+
+    func currentHistoryItem() -> (EngineSessionBackForwardListItem)?
+
+    func getBackListItems() -> [EngineSessionBackForwardListItem]
+
+    func getForwardListItems() -> [EngineSessionBackForwardListItem]
 
     /// Restore a saved state; only data that is saved (history, scroll position, zoom, and form data)
     /// will be restored.

--- a/BrowserKit/Sources/WebEngine/EngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSession.swift
@@ -45,11 +45,14 @@ public protocol EngineSession: NSObject {
     /// - Parameter item: EngineSessionBackForwardListItem in the back forward list that
     /// you would like to navigate to.
     func goToHistory(item: EngineSessionBackForwardListItem)
-
+    
+    /// Returns the current EngineSessionBackForwardListItem
     func currentHistoryItem() -> (EngineSessionBackForwardListItem)?
 
+    /// Returns the history backlist as a list of EngineSessionBackForwardListItems
     func getBackListItems() -> [EngineSessionBackForwardListItem]
 
+    /// Returns the history forwardlist as a list of EngineSessionBackForwardListItems
     func getForwardListItems() -> [EngineSessionBackForwardListItem]
 
     /// Restore a saved state; only data that is saved (history, scroll position, zoom, and form data)

--- a/BrowserKit/Sources/WebEngine/EngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSession.swift
@@ -42,8 +42,8 @@ public protocol EngineSession: NSObject {
     func showFindInPage(withSearchText searchText: String?)
 
     /// Navigates to the specified history item
-    /// SessionBackForwardListItem
-    /// - Parameter index: index the index of the session's history to navigate to
+    /// - Parameter item: EngineSessionBackForwardListItem in the back forward list that
+    /// you would like to navigate to.
     func goToHistory(item: EngineSessionBackForwardListItem)
 
     func currentHistoryItem() -> (EngineSessionBackForwardListItem)?

--- a/BrowserKit/Sources/WebEngine/EngineSessionBackForwardListItem.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionBackForwardListItem.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import Foundation
+import WebKit
 
 public protocol EngineSessionBackForwardListItem {
     var url: URL { get }
@@ -10,3 +11,5 @@ public protocol EngineSessionBackForwardListItem {
 
     var initialURL: URL { get }
 }
+
+extension WKBackForwardListItem: EngineSessionBackForwardListItem {}

--- a/BrowserKit/Sources/WebEngine/EngineSessionBackForwardListItem.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionBackForwardListItem.swift
@@ -8,8 +8,6 @@ public protocol EngineSessionBackForwardListItem {
     var url: URL { get }
 
     var title: String? { get }
-
-    var initialURL: URL { get }
 }
 
 extension WKBackForwardListItem: EngineSessionBackForwardListItem {}

--- a/BrowserKit/Sources/WebEngine/EngineSessionBackForwardListItem.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionBackForwardListItem.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import Foundation
+
+public protocol EngineSessionBackForwardListItem {
+    var url: URL { get }
+
+    var title: String? { get }
+
+    var initialURL: URL { get }
+}

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKBackForwardListItem+EngineSessionBackForwardListItem.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKBackForwardListItem+EngineSessionBackForwardListItem.swift
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import WebKit
+
+extension WKBackForwardListItem: EngineSessionBackForwardListItem {}

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKBackForwardListItem+EngineSessionBackForwardListItem.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKBackForwardListItem+EngineSessionBackForwardListItem.swift
@@ -1,6 +1,0 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-import WebKit
-
-extension WKBackForwardListItem: EngineSessionBackForwardListItem {}

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -198,7 +198,7 @@ class WKEngineSession: NSObject,
                         category: .webview)
             return
         }
-        _ = webView.go(to: backForwardListItem)
+        webView.go(to: backForwardListItem)
     }
 
     func currentHistoryItem() -> (EngineSessionBackForwardListItem)? {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -188,8 +188,26 @@ class WKEngineSession: NSObject,
         }
     }
 
-    func goToHistory(index: Int) {
-        // TODO: FXIOS-7907 #17651 Handle goToHistoryIndex in WKEngineSession (equivalent to goToBackForwardListItem)
+    func goToHistory(item: EngineSessionBackForwardListItem) {
+        guard let backForwardListItem = item as? WKBackForwardListItem else {
+            logger.log("Going to an EngineSessionBackForwardListItem that is not of type WKBackForwardListItem in WKEngineSession is not permitted",
+                       level: .debug,
+                       category: .webview)
+            return
+        }
+        _ = webView.go(to: backForwardListItem)
+    }
+
+    func currentHistoryItem() -> (EngineSessionBackForwardListItem)? {
+        return webView.currentBackForwardListItem()
+    }
+
+    func getBackListItems() -> [EngineSessionBackForwardListItem] {
+        return webView.backList()
+    }
+
+    func getForwardListItems() -> [EngineSessionBackForwardListItem] {
+        return webView.forwardList()
     }
 
     func restore(state: Data) {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -190,9 +190,12 @@ class WKEngineSession: NSObject,
 
     func goToHistory(item: EngineSessionBackForwardListItem) {
         guard let backForwardListItem = item as? WKBackForwardListItem else {
-            logger.log("Going to an EngineSessionBackForwardListItem that is not of type WKBackForwardListItem in WKEngineSession is not permitted",
-                       level: .debug,
-                       category: .webview)
+            logger.log("""
+                        Going to an EngineSessionBackForwardListItem that is not of \
+                        type WKBackForwardListItem in WKEngineSession is not permitted
+                        """,
+                        level: .debug,
+                        category: .webview)
             return
         }
         _ = webView.go(to: backForwardListItem)

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -59,6 +59,14 @@ protocol WKEngineWebView: UIView {
 
     func goForward() -> WKNavigation?
 
+    func go(to item: WKBackForwardListItem) -> WKNavigation?
+
+    func currentBackForwardListItem() -> WKBackForwardListItem?
+
+    func backList() -> [WKBackForwardListItem]
+
+    func forwardList() -> [WKBackForwardListItem]
+
     func evaluateJavaScript(
         _ javaScript: String,
         in frame: WKFrameInfo?,
@@ -127,6 +135,18 @@ final class DefaultWKEngineWebView: WKWebView, WKEngineWebView, MenuHelperWebVie
             }
         }
         return super.inputAccessoryView
+    }
+
+    func backList() -> [WKBackForwardListItem] {
+        return self.backForwardList.backList
+    }
+
+    func forwardList() -> [WKBackForwardListItem] {
+        return self.backForwardList.forwardList
+    }
+
+    func currentBackForwardListItem() -> WKBackForwardListItem? {
+        return self.backForwardList.currentItem
     }
 
     required init?(frame: CGRect, configurationProvider: WKEngineConfigurationProvider) {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -59,6 +59,7 @@ protocol WKEngineWebView: UIView {
 
     func goForward() -> WKNavigation?
 
+    @discardableResult
     func go(to item: WKBackForwardListItem) -> WKNavigation?
 
     func currentBackForwardListItem() -> WKBackForwardListItem?

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -37,6 +37,10 @@ class MockWKEngineWebView: UIView, WKEngineWebView {
     var stopLoadingCalled = 0
     var goBackCalled = 0
     var goForwardCalled = 0
+    var goToCalled = 0
+    var getBackListCalled = 0
+    var getForwardListCalled = 0
+    var getCurrentBackForwardItemCalled = 0
     var removeAllUserScriptsCalled = 0
     var removeFromSuperviewCalled = 0
     var closeCalled = 0
@@ -86,6 +90,26 @@ class MockWKEngineWebView: UIView, WKEngineWebView {
 
     func goForward() -> WKNavigation? {
         goForwardCalled += 1
+        return nil
+    }
+
+    func go(to item: WKBackForwardListItem) -> WKNavigation? {
+        goToCalled += 1
+        return nil
+    }
+
+    func backList() -> [WKBackForwardListItem] {
+        getBackListCalled += 1
+        return []
+    }
+
+    func forwardList() -> [WKBackForwardListItem] {
+        getForwardListCalled += 1
+        return []
+    }
+
+    func currentBackForwardListItem() -> WKBackForwardListItem? {
+        getCurrentBackForwardItemCalled += 1
         return nil
     }
 

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebViewDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebViewDelegate.swift
@@ -8,6 +8,7 @@ import UIKit
 class MockWKEngineWebViewDelegate: WKEngineWebViewDelegate {
     var webViewPropertyChangedCalled = 0
     var lastWebViewPropertyChanged: WKEngineWebViewProperty?
+    var webViewPropertyChangedCallback: ((WKEngineWebViewProperty) -> Void)?
 
     func tabWebView(_ webView: WKEngineWebView, findInPageSelection: String) {}
 
@@ -20,5 +21,6 @@ class MockWKEngineWebViewDelegate: WKEngineWebViewDelegate {
     func webViewPropertyChanged(_ property: WKEngineWebViewProperty) {
         webViewPropertyChangedCalled += 1
         lastWebViewPropertyChanged = property
+        webViewPropertyChangedCallback?(property)
     }
 }

--- a/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
@@ -83,6 +83,96 @@ final class WKEngineWebViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
 
+    func testCurrentHistoryItemSetAfterVisitingPage() {
+        let subject = createSubject()
+        let testURL = URL(string: "https://www.example.com/")!
+
+        let expectation = expectation(description: "Wait for the decision handler to be called")
+
+        XCTAssertNil(subject.currentBackForwardListItem())
+        delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
+            guard webEngineViewProperty == .loading(false) else {return}
+            XCTAssertNotNil(subject.currentBackForwardListItem())
+            self.delegate.webViewPropertyChangedCallback = nil
+            expectation.fulfill()
+        }
+        
+        subject.load(URLRequest(url: testURL))
+
+        wait(for: [expectation])
+    }
+
+    func testGetBackHistoryList() {
+        let subject = createSubject()
+
+        XCTAssertEqual(subject.backList().count, 0)
+
+        createBackList(subject: subject)
+
+        XCTAssertEqual(subject.backList().count, 2)
+    }
+
+    func testGetForwardHistoryList() {
+        let subject = createSubject()
+
+        let expectation1 = expectation(description: "Wait for the decision handler to be called")
+        let expectation2 = expectation(description: "Wait for the decision handler to be called twice")
+
+        createBackList(subject: subject)
+
+        XCTAssertEqual(subject.forwardList().count, 0)
+
+        delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
+            guard webEngineViewProperty == .loading(false) else {return}
+            expectation1.fulfill()
+        }
+        subject.goBack()
+        wait(for: [expectation1])
+
+        delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
+            guard webEngineViewProperty == .loading(false) else {return}
+            XCTAssertEqual(subject.forwardList().count, 2)
+            self.delegate.webViewPropertyChangedCallback = nil
+            expectation2.fulfill()
+        }
+        subject.goBack()
+        wait(for: [expectation2])
+    }
+
+    func createBackList(subject: DefaultWKEngineWebView) {
+        let testURL1 = URL(string: "https://www.example.com/")!
+        let testURL2 = URL(string: "https://www.youtube.com/")!
+        let currentURL = URL(string: "https://www.google.com/")!
+
+        let expectation1 = expectation(description: "Wait for the decision handler to be called once")
+
+        let expectation2 = expectation(description: "Wait for the decision handler to be called twice")
+
+        let expectation3 = expectation(description: "Wait for the decision handler to be called three times")
+
+        delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
+            guard webEngineViewProperty == .loading(false) else {return}
+            expectation1.fulfill()
+        }
+        subject.load(URLRequest(url: testURL1))
+        wait(for: [expectation1])
+
+        delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
+            guard webEngineViewProperty == .loading(false) else {return}
+            expectation2.fulfill()
+        }
+        subject.load(URLRequest(url: testURL2))
+        wait(for: [expectation2])
+
+        delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
+            guard webEngineViewProperty == .loading(false) else {return}
+            self.delegate.webViewPropertyChangedCallback = nil
+            expectation3.fulfill()
+        }
+        subject.load(URLRequest(url: currentURL))
+        wait(for: [expectation3])
+    }
+
     func createSubject(file: StaticString = #file,
                        line: UInt = #line) -> DefaultWKEngineWebView {
         let parameters = WKWebviewParameters(blockPopups: true, isPrivate: false)

--- a/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
@@ -96,7 +96,7 @@ final class WKEngineWebViewTests: XCTestCase {
             self.delegate.webViewPropertyChangedCallback = nil
             expectation.fulfill()
         }
-        
+
         subject.load(URLRequest(url: testURL))
 
         wait(for: [expectation])

--- a/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
@@ -99,7 +99,7 @@ final class WKEngineWebViewTests: XCTestCase {
 
         subject.load(URLRequest(url: testURL))
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: 10)
     }
 
     func testGetBackHistoryList() {
@@ -127,7 +127,7 @@ final class WKEngineWebViewTests: XCTestCase {
             expectation1.fulfill()
         }
         subject.goBack()
-        wait(for: [expectation1])
+        wait(for: [expectation1], timeout: 10)
 
         delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
             guard webEngineViewProperty == .loading(false) else {return}
@@ -136,7 +136,7 @@ final class WKEngineWebViewTests: XCTestCase {
             expectation2.fulfill()
         }
         subject.goBack()
-        wait(for: [expectation2])
+        wait(for: [expectation2], timeout: 10)
     }
 
     func createBackList(subject: DefaultWKEngineWebView) {
@@ -155,14 +155,14 @@ final class WKEngineWebViewTests: XCTestCase {
             expectation1.fulfill()
         }
         subject.load(URLRequest(url: testURL1))
-        wait(for: [expectation1])
+        wait(for: [expectation1], timeout: 10)
 
         delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
             guard webEngineViewProperty == .loading(false) else {return}
             expectation2.fulfill()
         }
         subject.load(URLRequest(url: testURL2))
-        wait(for: [expectation2])
+        wait(for: [expectation2], timeout: 10)
 
         delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
             guard webEngineViewProperty == .loading(false) else {return}
@@ -170,7 +170,7 @@ final class WKEngineWebViewTests: XCTestCase {
             expectation3.fulfill()
         }
         subject.load(URLRequest(url: currentURL))
-        wait(for: [expectation3])
+        wait(for: [expectation3], timeout: 10)
     }
 
     func createSubject(file: StaticString = #file,

--- a/SampleBrowser/SampleBrowser/UI/Components/NavigationToolbarContainer.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/NavigationToolbarContainer.swift
@@ -61,7 +61,7 @@ class NavigationToolbarContainer: UIView,
     }
 
     func configure(_ model: NavigationToolbarContainerModel) {
-        toolbar.configure(config: model.state, toolbarDelegate: self)
+        toolbar.configure(config: model.state, isVersion1Layout: true, toolbarDelegate: self)
     }
 
     private func setupLayout() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7907)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17651)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Created an abstract `EngineSessionBackForwardListItem` that the user can use to keep track of history items
- Added the ability to go to and access history items in the `EngineSession`
- The `WKEngineSession` implements the `goToHistoryItem` method, only allowing `WKBackForwardListItems` to be the valid history item type
- Tested manually by temporarily changing the `goBack` and `goForward` methods in `BrowserViewController` (lines 95-101) to have the following implementation:
```
    func goBack() {
        engineSession.goToHistory(item: engineSession.getBackListItems().last!)
    }

    func goForward() {
        engineSession.goToHistory(item: engineSession.getForwardListItems().first!)
    }
```

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

