### PR TITLE
Bugfix MTE-4493 Workaround for iOS 16: warm up simulator before running tests

### DIFF
--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -64,9 +64,7 @@ jobs:
           else
             echo "Install iOS ${{ matrix.ios_version }} runtime"
             sudo xcodes runtimes install "iOS ${{ matrix.ios_version }}"
-            xcrun simctl create "${{ matrix.ios_simulator }}" ${{ matrix.device_type }} ${{ matrix.runtime }}
           fi
-          xcrun simctl boot "${{ matrix.ios_simulator }}"
       - name: Build Focus
         id: compile
         run: |

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -25,11 +25,11 @@ jobs:
             device_type: ""
             runtime: ""
           - ios_version: 16.4
-            ios_simulator: iPhone 14
+            ios_simulator: iPhone 14 iOS 16.4
             device_type: com.apple.CoreSimulator.SimDeviceType.iPhone-14
             runtime: com.apple.CoreSimulator.SimRuntime.iOS-16-4
           - ios_version: 15.5
-            ios_simulator: iPhone 13
+            ios_simulator: iPhone 13 iOS 15.5
             device_type: com.apple.CoreSimulator.SimDeviceType.iPhone-13
             runtime: com.apple.CoreSimulator.SimRuntime.iOS-15-5"
     steps:

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -20,16 +20,16 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          #- ios_version: 17.5
-          #  ios_simulator: iPhone 15
-          #  device_type: ""
-          #  runtime: ""
+          - ios_version: 17.5
+            ios_simulator: iPhone 15
+            device_type: ""
+            runtime: ""
           - ios_version: 16.4
-            ios_simulator: iPhone 14 iOS 16.4
+            ios_simulator: iPhone 14
             device_type: com.apple.CoreSimulator.SimDeviceType.iPhone-14
             runtime: com.apple.CoreSimulator.SimRuntime.iOS-16-4
           - ios_version: 15.5
-            ios_simulator: iPhone 13 iOS 15.5
+            ios_simulator: iPhone 13
             device_type: com.apple.CoreSimulator.SimDeviceType.iPhone-13
             runtime: com.apple.CoreSimulator.SimRuntime.iOS-15-5
     steps:
@@ -66,7 +66,6 @@ jobs:
             sudo xcodes runtimes install "iOS ${{ matrix.ios_version }}"
             xcrun simctl create "${{ matrix.ios_simulator }}" ${{ matrix.device_type }} ${{ matrix.runtime }}
           fi
-          xcrun simctl list devices iphone
           xcrun simctl boot "${{ matrix.ios_simulator }}"
       - name: Build Focus
         id: compile
@@ -91,7 +90,7 @@ jobs:
             -derivedDataPath ~/DerivedData \
             -destination 'platform=iOS Simulator,arch=arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan SmokeTest \
-            -only-testing:XCUITest/SettingTest/testCheckSetting | xcpretty _0.3.0_
+            -only-testing:XCUITest/CopyPasteTest/testPastenGo | xcpretty _0.3.0_
           xcodebuild \
             test-without-building \
             -scheme ${{ env.xcodebuild_scheme }} \

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -23,7 +23,7 @@ jobs:
           - ios_version: 17.5
             ios_simulator: iPhone 15
           - ios_version: 16.4
-            ios_simulator: iPhone 14
+            ios_simulator: iPhone 14 Pro Max
           - ios_version: 15.5
             ios_simulator: iPhone 13
     steps:

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -83,6 +83,15 @@ jobs:
         id: run-smoketests
         run: |
           xcrun simctl list devices iphone
+          # "warmup" the simulator by running one test. It's ok this attempt fails
+          xcodebuild \
+            test-without-building \
+            -scheme ${{ env.xcodebuild_scheme }} \
+            -target ${{ env.xcodebuild_target }} \
+            -derivedDataPath ~/DerivedData \
+            -destination 'platform=iOS Simulator,arch=arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
+            -testPlan SmokeTests \
+            -only-testing:XCUITest/SettingTest/testCheckSetting && exit ${PIPESTATUS[0]}
           xcodebuild \
             test-without-building \
             -scheme ${{ env.xcodebuild_scheme }} \

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -22,10 +22,16 @@ jobs:
         include:
           - ios_version: 17.5
             ios_simulator: iPhone 15
+            device_type: ""
+            runtime: ""
           - ios_version: 16.4
             ios_simulator: iPhone 14
+            device_type: com.apple.CoreSimulator.SimDeviceType.iPhone-14
+            runtime: com.apple.CoreSimulator.SimRuntime.iOS-16-4
           - ios_version: 15.5
             ios_simulator: iPhone 13
+            device_type: com.apple.CoreSimulator.SimDeviceType.iPhone-13
+            runtime: com.apple.CoreSimulator.SimRuntime.iOS-15-5"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4.1.7
@@ -58,6 +64,7 @@ jobs:
           else
             echo "Install iOS ${{ matrix.ios_version }} runtime"
             sudo xcodes runtimes install "iOS ${{ matrix.ios_version }}"
+            xcrun simctl create "${{ matrix.ios_simulator }}" ${{ matrix.device_type }} ${{ matrix.runtime }}
           fi
           xcrun simctl list devices iphone
           xcrun simctl boot "${{ matrix.ios_simulator }}"

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -76,7 +76,7 @@ jobs:
             -scheme ${{ env.xcodebuild_scheme }} \
             -target ${{ env.xcodebuild_target }} \
             -derivedDataPath ~/DerivedData \
-            -destination 'platform=iOS Simulator,arch:arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
+            -destination 'platform=iOS Simulator,arch=arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ARCH="arm64"
         working-directory:  ${{ env.browser }}
       - name: Run smoke tests
@@ -88,7 +88,7 @@ jobs:
             -scheme ${{ env.xcodebuild_scheme }} \
             -target ${{ env.xcodebuild_target }} \
             -derivedDataPath ~/DerivedData \
-            -destination 'platform=iOS Simulator,arch:arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
+            -destination 'platform=iOS Simulator,arch=arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan SmokeTest \
             -resultBundlePath ${{ env.test_results_directory }}/results-smoketests \
             | tee xcodebuild-smoketests.log | xcpretty _0.3.0_ -r junit --output ./junit-smoketests.xml && exit ${PIPESTATUS[0]}
@@ -102,7 +102,7 @@ jobs:
             -scheme ${{ env.xcodebuild_scheme }} \
             -target ${{ env.xcodebuild_target }} \
             -derivedDataPath ~/DerivedData \
-            -destination 'platform=iOS Simulator,arch:arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
+            -destination 'platform=iOS Simulator,arch=arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan FullFunctionalTests \
             -resultBundlePath ${{ env.test_results_directory }}/results-fullfunctionaltests \
             | tee xcodebuild-fullfunctionaltests.log | xcpretty _0.3.0_ -r junit --output ./junit-fullfunctionaltests.xml && exit ${PIPESTATUS[0]}

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -60,6 +60,7 @@ jobs:
             sudo xcodes runtimes install "iOS ${{ matrix.ios_version }}"
           fi
           xcrun simctl list devices iphone
+          xcrun simctl boot "${{ matrix.ios_simulator }}"
       - name: Build Focus
         id: compile
         run: |

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -90,7 +90,7 @@ jobs:
             -target ${{ env.xcodebuild_target }} \
             -derivedDataPath ~/DerivedData \
             -destination 'platform=iOS Simulator,arch=arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
-            -testPlan SmokeTests \
+            -testPlan SmokeTest \
             -only-testing:XCUITest/SettingTest/testCheckSetting && exit ${PIPESTATUS[0]}
           xcodebuild \
             test-without-building \

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -22,16 +22,10 @@ jobs:
         include:
           - ios_version: 17.5
             ios_simulator: iPhone 15
-            device_type: ""
-            runtime: ""
           - ios_version: 16.4
             ios_simulator: iPhone 14
-            device_type: com.apple.CoreSimulator.SimDeviceType.iPhone-14
-            runtime: com.apple.CoreSimulator.SimRuntime.iOS-16-4
           - ios_version: 15.5
             ios_simulator: iPhone 13
-            device_type: com.apple.CoreSimulator.SimDeviceType.iPhone-13
-            runtime: com.apple.CoreSimulator.SimRuntime.iOS-15-5
     steps:
       - name: Check out source code
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -91,7 +91,7 @@ jobs:
             -derivedDataPath ~/DerivedData \
             -destination 'platform=iOS Simulator,arch=arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan SmokeTest \
-            -only-testing:XCUITest/SettingTest/testCheckSetting && exit ${PIPESTATUS[0]}
+            -only-testing:XCUITest/SettingTest/testCheckSetting | xcpretty _0.3.0_
           xcodebuild \
             test-without-building \
             -scheme ${{ env.xcodebuild_scheme }} \

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -23,7 +23,7 @@ jobs:
           - ios_version: 17.5
             ios_simulator: iPhone 15
           - ios_version: 16.4
-            ios_simulator: iPhone 14 Pro Max
+            ios_simulator: iPhone 14
           - ios_version: 15.5
             ios_simulator: iPhone 13
     steps:

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -31,7 +31,7 @@ jobs:
           - ios_version: 15.5
             ios_simulator: iPhone 13 iOS 15.5
             device_type: com.apple.CoreSimulator.SimDeviceType.iPhone-13
-            runtime: com.apple.CoreSimulator.SimRuntime.iOS-15-5"
+            runtime: com.apple.CoreSimulator.SimRuntime.iOS-15-5
     steps:
       - name: Check out source code
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -20,10 +20,10 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - ios_version: 17.5
-            ios_simulator: iPhone 15
-            device_type: ""
-            runtime: ""
+          #- ios_version: 17.5
+          #  ios_simulator: iPhone 15
+          #  device_type: ""
+          #  runtime: ""
           - ios_version: 16.4
             ios_simulator: iPhone 14 iOS 16.4
             device_type: com.apple.CoreSimulator.SimDeviceType.iPhone-14

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -76,18 +76,19 @@ jobs:
             -scheme ${{ env.xcodebuild_scheme }} \
             -target ${{ env.xcodebuild_target }} \
             -derivedDataPath ~/DerivedData \
-            -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
+            -destination 'platform=iOS Simulator,arch:arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ARCH="arm64"
         working-directory:  ${{ env.browser }}
       - name: Run smoke tests
         id: run-smoketests
         run: |
+          xcrun simctl list devices iphone
           xcodebuild \
             test-without-building \
             -scheme ${{ env.xcodebuild_scheme }} \
             -target ${{ env.xcodebuild_target }} \
             -derivedDataPath ~/DerivedData \
-            -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
+            -destination 'platform=iOS Simulator,arch:arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan SmokeTest \
             -resultBundlePath ${{ env.test_results_directory }}/results-smoketests \
             | tee xcodebuild-smoketests.log | xcpretty _0.3.0_ -r junit --output ./junit-smoketests.xml && exit ${PIPESTATUS[0]}
@@ -101,7 +102,7 @@ jobs:
             -scheme ${{ env.xcodebuild_scheme }} \
             -target ${{ env.xcodebuild_target }} \
             -derivedDataPath ~/DerivedData \
-            -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
+            -destination 'platform=iOS Simulator,arch:arm64,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan FullFunctionalTests \
             -resultBundlePath ${{ env.test_results_directory }}/results-fullfunctionaltests \
             | tee xcodebuild-fullfunctionaltests.log | xcpretty _0.3.0_ -r junit --output ./junit-fullfunctionaltests.xml && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4493)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
iOS 16 simulator does not start randomly. I have tried the following to ensure the app is loaded to the simulator:
* Specify `arch=arm64` when identifying the simulator
* Invoke `xcodebuild` to run one test to "warm up" the simulator before running the smoke tests and full functional tests.

Github Actions: https://github.com/mozilla-mobile/firefox-ios/actions/runs/14425593891

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

