### PR TITLE
Bugfix MTE-4457 Shorten timeout to 40 min

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1718,7 +1718,7 @@ workflows:
             ls /Users/vagrant/git/DerivedData/Build/Products
             ls /Users/vagrant/git/DerivedData
     - xcode-test-without-building@0:
-        timeout: 6000
+        timeout: 2400
         inputs:
         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.2
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData"'


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4457)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The job `Firebase_Unit_Test` got stuck at a particular test. The old timeout was 1.5 hours.
Example workflow: https://app.bitrise.io/build/d3ff349e-df8e-4932-9212-a7c76308a4f8

If the test did not get stuck, the workflow would take just under 35 minutes. Let me set the timeout of the step to 40 minutes.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

