### PR TITLE
Bugfix FXIOS-11980 - [Toolbar - Swipe Tabs Animation] - Textfield is cut off at the bottom of the screen

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1020,7 +1020,7 @@ class BrowserViewController: UIViewController,
 
     func addSubviews() {
         view.addSubviews(contentContainer)
-        view.addSubview(webPagePreview)
+        if isSwipingTabsEnabled { view.addSubview(webPagePreview) }
 
         view.addSubview(topTouchArea)
 
@@ -1262,25 +1262,6 @@ class BrowserViewController: UIViewController,
 
     // MARK: - Constraints
 
-    private var contentStackViewBottomConstraint: NSLayoutConstraint?
-
-    private func updateContentStackViewBottomConstraint() {
-        guard isSwipingTabsEnabled else {
-            contentStackViewBottomConstraint = contentContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-            contentStackViewBottomConstraint?.isActive = true
-            return
-        }
-        contentStackViewBottomConstraint?.isActive = false
-        if isBottomSearchBar {
-            contentStackViewBottomConstraint = contentContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        } else {
-            contentStackViewBottomConstraint = contentContainer.bottomAnchor.constraint(
-                equalTo: overKeyboardContainer.topAnchor
-            )
-        }
-        contentStackViewBottomConstraint?.isActive = true
-    }
-
     private func setupConstraints() {
         if !isToolbarRefactorEnabled {
             legacyUrlBar?.snp.makeConstraints { make in
@@ -1292,6 +1273,7 @@ class BrowserViewController: UIViewController,
             contentContainer.topAnchor.constraint(equalTo: header.bottomAnchor),
             contentContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            contentContainer.bottomAnchor.constraint(equalTo: overKeyboardContainer.topAnchor)
         ])
 
         if isSwipingTabsEnabled {
@@ -1302,7 +1284,6 @@ class BrowserViewController: UIViewController,
                 webPagePreview.bottomAnchor.constraint(equalTo: bottomContainer.topAnchor)
             ])
         }
-        updateContentStackViewBottomConstraint()
 
         updateHeaderConstraints()
     }
@@ -1366,7 +1347,6 @@ class BrowserViewController: UIViewController,
             adjustBottomSearchBarForKeyboard()
         }
 
-        updateContentStackViewBottomConstraint()
         super.updateViewConstraints()
     }
 

--- a/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
@@ -11,7 +11,6 @@ final class TabWebViewPreview: UIView, ThemeApplicable {
         static let addressBarCornerRadius: CGFloat = 8
         static let addressBarBorderHeight: CGFloat = 1
         static let addressBarHeight: CGFloat = 43
-        static let toolbarHeight: CGFloat = 48
         static let addressBarOnToplayoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
         static let addressBarOnBottomlayoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 4, right: 16)
     }

--- a/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
@@ -12,7 +12,8 @@ final class TabWebViewPreview: UIView, ThemeApplicable {
         static let addressBarBorderHeight: CGFloat = 1
         static let addressBarHeight: CGFloat = 43
         static let toolbarHeight: CGFloat = 48
-        static let layoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
+        static let addressBarOnToplayoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
+        static let addressBarOnBottomlayoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 4, right: 16)
     }
     // MARK: - UI Properties
     private lazy var webPageScreenshotImageView: UIImageView = .build()
@@ -33,6 +34,7 @@ final class TabWebViewPreview: UIView, ThemeApplicable {
     init() {
         super.init(frame: .zero)
         setupLayout()
+        setStackViewsLayoutMargins()
     }
 
     required init?(coder: NSCoder) {
@@ -85,8 +87,7 @@ final class TabWebViewPreview: UIView, ThemeApplicable {
                 equalTo: bottomStackView.topAnchor
             )
             webViewBottomConstraint = webPageScreenshotImageView.bottomAnchor.constraint(
-                equalTo: bottomAnchor,
-                constant: UX.toolbarHeight + UIConstants.BottomInset
+                equalTo: addressBarBorderView.topAnchor
             )
         case .top:
             topStackView.addArrangedSubview(skeletonAddressBar)
@@ -114,8 +115,12 @@ final class TabWebViewPreview: UIView, ThemeApplicable {
         return .build { stackView in
             stackView.axis = .vertical
             stackView.isLayoutMarginsRelativeArrangement = true
-            stackView.layoutMargins = UX.layoutMargins
         }
+    }
+
+    private func setStackViewsLayoutMargins() {
+        topStackView.layoutMargins = UX.addressBarOnToplayoutMargins
+        bottomStackView.layoutMargins = UX.addressBarOnBottomlayoutMargins
     }
 
     private func setStackViewsVisibility(by searchBarPosition: SearchBarPosition) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11980)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26069)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Revert `contentContainer` bottom constraint.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

