### PR TITLE
Refactor FXIOS-11638 [Tab tray UI experiment] Disable animation of tab tray UI experiment on iPad

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -968,7 +968,8 @@ class BrowserCoordinator: BaseCoordinator,
         }
 
         if featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly) &&
-            featureFlags.isFeatureEnabled(.tabAnimation, checking: .buildOnly) {
+            featureFlags.isFeatureEnabled(.tabAnimation, checking: .buildOnly) &&
+            UIDevice.current.userInterfaceIdiom != .pad {
             guard let tabTrayVC = tabTrayCoordinator.tabTrayViewController else { return }
             present(navigationController, customTransition: tabTrayVC, style: modalPresentationStyle)
         } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11638)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25350)

## :bulb: Description
Only bring this change to `main` since [the experiment](https://experimenter.services.mozilla.com/nimbus/tab-tray-rapid-ui-experiment/summary) is not targeting iPad anyway, but for the sake of consistency let's do this change still.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

