### PR TITLE
Fix MTE-4508 Tentative fix for entitlement smoketest errors

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1760,8 +1760,9 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -x
-            /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" Focus.entitlements
-            /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" Klar.entitlements
+            echo "Skip PlistBuddy for now"
+            # /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" Focus.entitlements
+            # /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" Klar.entitlements
     - script@1.2.1:
         title: Build for Testing Focus
         inputs:
@@ -2000,8 +2001,9 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -x
-            /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" focus-ios/Focus.entitlements
-            /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" focus-ios/Klar.entitlements
+            echo "Skip PlistBuddy command for now"
+            # /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" focus-ios/Focus.entitlements
+            # /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" focus-ios/Klar.entitlements
 
   # # Update the name change in Taskcluster files 
   # focus_l10n_build:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1760,8 +1760,8 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -x
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Focus.entitlements
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Klar.entitlements
+            /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" Focus.entitlements
+            /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" Klar.entitlements
     - script@1.2.1:
         title: Build for Testing Focus
         inputs:
@@ -2000,8 +2000,8 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -x
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" focus-ios/Focus.entitlements
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" focus-ios/Klar.entitlements
+            /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" focus-ios/Focus.entitlements
+            /usr/libexec/PlistBuddy -c "Set :com.apple.developer.web-browser bool true" focus-ios/Klar.entitlements
 
   # # Update the name change in Taskcluster files 
   # focus_l10n_build:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4508)

## :bulb: Description
This PR implements a tentative fix for this error

`+ echo 'Adding com.apple.developer.web-browser to entitlements'
Adding com.apple.developer.web-browser to entitlements
+ /usr/libexec/PlistBuddy -c 'Add :com.apple.developer.web-browser bool true' firefox-ios/Client/Entitlements/FennecApplication.entitlements
Add: ":com.apple.developer.web-browser" Entry Already Exists`

Now I use Set instead of Add, so if the key already exists the script updates it otherwise it creates a new one.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

