### PR TITLE
Bugfix FXIOS-3820 #10114 ⁃ [iPad] No way to stop address/tab bar from auto hiding

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -51,46 +51,47 @@ class TabScrollController: NSObject,
         }
     }
 
-    // Top toolbar
+    // Top toolbar UI and Constraints
     weak var header: BaseAlphaStackView?
-    // Bottom toolbar UI containers
+    var headerTopConstraint: Constraint?
+
+    // Bottom toolbar UI and Constraints
     weak var overKeyboardContainer: BaseAlphaStackView?
     weak var bottomContainer: BaseAlphaStackView?
+    var overKeyboardContainerConstraint: Constraint?
+    var bottomContainerConstraint: Constraint?
 
     weak var zoomPageBar: ZoomPageBar?
     private var observedScrollViews = WeakList<UIScrollView>()
 
-    var overKeyboardContainerConstraint: Constraint?
-    var bottomContainerConstraint: Constraint?
-    var headerTopConstraint: Constraint?
-
     private var lastPanTranslation: CGFloat = 0
     private var lastContentOffsetY: CGFloat = 0
     private var scrollDirection: ScrollDirection = .down
-    var toolbarState: ToolbarState = .visible
-
+    private var toolbarState: ToolbarState = .visible
     let deviceType: UIUserInterfaceIdiom
 
     private let windowUUID: WindowUUID
     private let logger: Logger
 
     private var toolbarsShowing: Bool {
-        return toolbarState == .visible
+        let bottomShowing = overKeyboardContainerOffset == 0 && bottomContainerOffset == 0
+        return isBottomSearchBar ? bottomShowing : headerTopOffset == 0
     }
 
     private var isZoomedOut = false
     private var lastZoomedScale: CGFloat = 0
     private var isUserZoom = false
 
-    // Top Toolbar constraints
+    // Top Toolbar offset updates related constraints
     private var headerTopOffset: CGFloat = 0 {
         didSet {
             headerTopConstraint?.update(offset: headerTopOffset)
             header?.superview?.setNeedsLayout()
         }
     }
+    private var headerHeight: CGFloat { header?.frame.height ?? 0 }
 
-    // Bottom toolbar constraints
+    // Bottom toolbar offset updates related constraints
     private var overKeyboardContainerOffset: CGFloat = 0 {
         didSet {
             overKeyboardContainerConstraint?.update(offset: overKeyboardContainerOffset)
@@ -103,6 +104,17 @@ class TabScrollController: NSObject,
             bottomContainerConstraint?.update(offset: bottomContainerOffset)
             bottomContainer?.superview?.setNeedsLayout()
         }
+    }
+
+    // Over keyboard content and bottom content
+    private var overKeyboardScrollHeight: CGFloat {
+        let overKeyboardHeight = overKeyboardContainer?.frame.height ?? 0
+        return overKeyboardHeight
+    }
+
+    private var bottomContainerScrollHeight: CGFloat {
+        let bottomContainerHeight = bottomContainer?.frame.height ?? 0
+        return bottomContainerHeight
     }
 
     private lazy var panGesture: UIPanGestureRecognizer = {
@@ -118,7 +130,6 @@ class TabScrollController: NSObject,
     private var scrollView: UIScrollView? { return tab?.webView?.scrollView }
     var contentOffset: CGPoint { return scrollView?.contentOffset ?? .zero }
     private var scrollViewHeight: CGFloat { return scrollView?.frame.height ?? 0 }
-    private var topScrollHeight: CGFloat { header?.frame.height ?? 0 }
     private var contentSize: CGSize { return scrollView?.contentSize ?? .zero }
     private var contentOffsetBeforeAnimation = CGPoint.zero
     private var isAnimatingToolbar = false
@@ -128,17 +139,6 @@ class TabScrollController: NSObject,
     var notificationCenter: any NotificationProtocol
     var currentWindowUUID: WindowUUID? {
         return windowUUID
-    }
-
-    // Over keyboard content and bottom content
-    private var overKeyboardScrollHeight: CGFloat {
-        let overKeyboardHeight = overKeyboardContainer?.frame.height ?? 0
-        return overKeyboardHeight
-    }
-
-    private var bottomContainerScrollHeight: CGFloat {
-        let bottomContainerHeight = bottomContainer?.frame.height ?? 0
-        return bottomContainerHeight
     }
 
     // Settings option to avoid hiding Tab and Address bar on iPad
@@ -227,13 +227,8 @@ class TabScrollController: NSObject,
             setScrollDirection(delta)
 
             lastPanTranslation = translation.y
-            if checkRubberbandingForDelta(delta) && isAbleToScroll {
-                let bottomIsNotRubberbanding = contentOffset.y + scrollViewHeight < contentSize.height
-                let topIsRubberbanding = contentOffset.y <= 0
-
-                if shouldAllowScroll(with: topIsRubberbanding, and: bottomIsNotRubberbanding) {
-                    scrollWithDelta(delta)
-                }
+            if checkRubberbanding() && isAbleToScroll {
+                scrollWithDelta(delta)
                 updateToolbarState()
             }
         }
@@ -276,7 +271,7 @@ class TabScrollController: NSObject,
         animateToolbarsWithOffsets(
             animated,
             duration: actualDuration,
-            headerOffset: -topScrollHeight,
+            headerOffset: -headerHeight,
             bottomContainerOffset: bottomContainerScrollHeight,
             overKeyboardOffset: overKeyboardScrollHeight,
             alpha: 0,
@@ -370,7 +365,7 @@ private extension TabScrollController {
         if isBottomSearchBar {
             durationRatio = abs(overKeyboardContainerOffset / overKeyboardScrollHeight)
         } else {
-            durationRatio = abs(headerTopOffset / topScrollHeight)
+            durationRatio = abs(headerTopOffset / headerHeight)
         }
         return durationRatio
     }
@@ -380,9 +375,22 @@ private extension TabScrollController {
         if isBottomSearchBar {
             durationRatio = abs((overKeyboardScrollHeight + overKeyboardContainerOffset) / overKeyboardScrollHeight)
         } else {
-            durationRatio = abs((topScrollHeight + headerTopOffset) / topScrollHeight)
+            durationRatio = abs((headerHeight + headerTopOffset) / headerHeight)
         }
         return durationRatio
+    }
+
+    var isTopRubberbanding: Bool {
+        return contentOffset.y <= 0
+    }
+
+    var isBottomRubberbanding: Bool {
+        return contentOffset.y + scrollViewHeight > contentSize.height
+    }
+
+    // If scrollview contenSize is bigger than scrollview height scroll is enabled
+    var hasScrollableContent: Bool {
+        return scrollViewHeight < contentSize.height
     }
 
     // Scroll alpha is only for header views since status bar has an overlay
@@ -393,7 +401,7 @@ private extension TabScrollController {
            isBottomSearchBar {
             return 1 - abs(overKeyboardContainerOffset / overKeyboardScrollHeight)
         }
-        return 1 - abs(headerTopOffset / topScrollHeight)
+        return 1 - abs(headerTopOffset / headerHeight)
     }
 
     @objc
@@ -414,20 +422,24 @@ private extension TabScrollController {
     /// Returns true if scroll has reach the bottom
     ///
     /// 1. If the content is scrollable (taller than the view).
-    ///
     /// 2. The user has scrolled to (or beyond) the bottom.
     func scrollReachBottom() -> Bool {
-        guard let scrollView = scrollView else { return false }
-
         let contentIsScrollable = contentSize.height > scrollViewHeight
         let isMaxContentOffset = contentOffset.y > (contentSize.height - scrollViewHeight)
-        
+
         return isMaxContentOffset && contentIsScrollable
     }
 
-    func shouldAllowScroll(with topIsRubberbanding: Bool,
-                           and bottomIsNotRubberbanding: Bool) -> Bool {
-        return (toolbarState != .collapsed || topIsRubberbanding) && bottomIsNotRubberbanding
+    /// Determines whether a given scroll would cause rubberbanding behavior.
+    /// Rubberbanding typically occurs when the user scrolls past the content bounds
+    ///
+    /// - Scrolling upwards while already scrolled past the bottom of the content, and has scrollable content
+    /// - Scrolling beyond the top boundary (`contentOffset.y < delta`)
+    ///
+    /// - Returns: `true` if the scroll delta is allowed without rubberbanding; otherwise, `false`.
+    func checkRubberbanding() -> Bool {
+        return !((scrollDirection == .up && isBottomRubberbanding && hasScrollableContent) ||
+                isTopRubberbanding)
     }
 
     /// Updates the state of the toolbar based on the scroll positions of various UI components.
@@ -442,10 +454,14 @@ private extension TabScrollController {
     /// - `.visible`: Toolbars are currently showing (`toolbarsShowing == true`).
     /// - `.animating`: In transition or partially visible state.
     func updateToolbarState() {
+        // bottom containers are collapsedd
         let bottomContainerCollapsed = bottomContainerOffset == bottomContainerScrollHeight
         let overKeyboardContainerCollapsed = overKeyboardContainerOffset == overKeyboardScrollHeight
 
-        if headerTopOffset == -topScrollHeight && bottomContainerCollapsed && overKeyboardContainerCollapsed {
+        // top container
+        let headerContainerIsCollapesed = headerTopOffset == -headerHeight
+
+        if headerContainerIsCollapesed && (bottomContainerCollapsed && overKeyboardContainerCollapsed) {
             setToolbarState(state: .collapsed)
         } else if toolbarsShowing {
             setToolbarState(state: .visible)
@@ -460,28 +476,9 @@ private extension TabScrollController {
         toolbarState = state
     }
 
-    /// Determines whether a given scroll delta would cause rubberbanding behavior.
-    ///
-    /// Rubberbanding typically occurs when the user scrolls past the content bounds,
-    /// causing a stretch or bounce effect. This function checks two conditions where
-    /// rubberbanding might occur:
-    ///
-    /// - Scrolling upwards (`delta < 0`) while already scrolled past the bottom of the content,
-    ///   and the scroll view is shorter than the content.
-    /// - Scrolling beyond the top boundary (`contentOffset.y < delta`)
-    ///
-    /// Returns `false` if rubberbanding would occur; `true` if the delta is within valid bounds.
-    ///
-    /// - Parameter delta: The proposed change in scroll position (positive or negative).
-    /// - Returns: `true` if the scroll delta is allowed without rubberbanding; otherwise, `false`.
-    func checkRubberbandingForDelta(_ delta: CGFloat) -> Bool {
-        return !((delta < 0 && contentOffset.y + scrollViewHeight > contentSize.height &&
-                scrollViewHeight < contentSize.height) ||
-                contentOffset.y < delta)
-    }
-
     /// Handles synchronized scrolling of the header, bottom container, and over-keyboard container
     /// in response to a vertical scroll delta.
+    /// Updates all containers offset based in scrolling delta 
     ///
     /// This function performs the following actions:
     /// 1. Verifies that scrolling is necessary (i.e., content height exceeds the scroll view height).
@@ -494,35 +491,35 @@ private extension TabScrollController {
     /// - Parameter delta: The amount by which to scroll, where a positive delta scrolls down and
     ///   a negative delta scrolls up.
     func scrollWithDelta(_ delta: CGFloat) {
-        guard scrollViewHeight < contentSize.height else { return }
+        guard hasScrollableContent else { return }
 
         let updatedOffset = headerTopOffset - delta
-        headerTopOffset = clamp(updatedOffset, min: -topScrollHeight, max: 0)
+        headerTopOffset = clamp(offset: updatedOffset, min: -headerHeight, max: 0)
         if isHeaderDisplayedForGivenOffset(headerTopOffset) {
             scrollView?.contentOffset = CGPoint(x: contentOffset.x, y: contentOffset.y - delta)
         }
 
         let bottomUpdatedOffset = bottomContainerOffset + delta
-        bottomContainerOffset = clamp(bottomUpdatedOffset, min: 0, max: bottomContainerScrollHeight)
+        bottomContainerOffset = clamp(offset: bottomUpdatedOffset, min: 0, max: bottomContainerScrollHeight)
 
         let overKeyboardUpdatedOffset = overKeyboardContainerOffset + delta
-        overKeyboardContainerOffset = clamp(overKeyboardUpdatedOffset, min: 0, max: overKeyboardScrollHeight)
+        overKeyboardContainerOffset = clamp(offset: overKeyboardUpdatedOffset, min: 0, max: overKeyboardScrollHeight)
 
         header?.updateAlphaForSubviews(scrollAlpha)
         zoomPageBar?.updateAlphaForSubviews(scrollAlpha)
     }
 
     func isHeaderDisplayedForGivenOffset(_ offset: CGFloat) -> Bool {
-        return offset > -topScrollHeight && offset < 0
+        return offset > -headerHeight && offset < 0
     }
 
-    func clamp(_ y: CGFloat, min: CGFloat, max: CGFloat) -> CGFloat {
-        if y >= max {
+    func clamp(offset: CGFloat, min: CGFloat, max: CGFloat) -> CGFloat {
+        if offset >= max {
             return max
-        } else if y <= min {
+        } else if offset <= min {
             return min
         }
-        return y
+        return offset
     }
 
     /// Animates toolbar components (header, bottom container, and over-keyboard container)
@@ -564,7 +561,7 @@ private extension TabScrollController {
     }
 
     func shouldAdjustScrollForToolbarShow(currentOffset: CGFloat, targetOffset: CGFloat) -> Bool {
-        return currentOffset == -topScrollHeight && targetOffset == 0
+        return currentOffset == -headerHeight && targetOffset == 0
     }
 
     func buildToolbarAnimationBlock(isShownFromHidden: Bool,
@@ -578,7 +575,7 @@ private extension TabScrollController {
             if isShownFromHidden {
                 scrollView.contentOffset = CGPoint(
                     x: self.contentOffsetBeforeAnimation.x,
-                    y: self.contentOffsetBeforeAnimation.y + self.topScrollHeight
+                    y: self.contentOffsetBeforeAnimation.y + self.headerHeight
                 )
             }
 
@@ -636,11 +633,18 @@ extension TabScrollController: UIScrollViewDelegate {
         lastContentOffsetY = scrollView.contentOffset.y
     }
 
+    /// Decelerate is true the scrolling movement will continue
+    /// If the value is false, scrolling stops immediately upon touch-up.
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        guard let tab, !tabIsLoading(), !scrollReachBottom(), isAbleToScroll  else { return }
+        guard let tab,
+              !tabIsLoading(),
+              !scrollReachBottom(),
+              isAbleToScroll  else { return }
 
         tab.shouldScrollToTop = false
 
+        // Change toolbar status if scrolling will continue decelerate == true
+        // scrolling will stops decelerate == false but we are still animating
         if decelerate || (toolbarState == .animating && !decelerate) {
             if scrollDirection == .up, !tab.isFindInPageMode {
                 showToolbars(animated: true)
@@ -665,14 +669,12 @@ extension TabScrollController: UIScrollViewDelegate {
         guard isAnimatingToolbar else { return }
 
         if contentOffsetBeforeAnimation.y - scrollView.contentOffset.y > UX.abruptScrollEventOffset {
-            setOffset(y: contentOffsetBeforeAnimation.y + topScrollHeight, for: scrollView)
+            setOffset(y: contentOffsetBeforeAnimation.y + headerHeight, for: scrollView)
             contentOffsetBeforeAnimation.y = 0
         }
     }
 
-    // Send action to show new toolbar border which is only visible on scroll, due to a design choice.
-    
-    /// Sends a scroll action to update the toolbar border visibility based on scroll position changes.
+    /// Sends a scroll action to update the new toolbar border visibility based on scroll position changes.
     ///
     /// This function detects when the scroll view crosses the vertical `y = 0` threshold —
     /// either from scrolling into the top of the content or pulling past the top (overscroll).

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -398,13 +398,18 @@ private extension TabScrollController {
         return tab?.loading ?? true
     }
 
-    func isBouncingAtBottom() -> Bool {
+    /// Returns true if scroll has reach the bottom
+    ///
+    /// 1. If the content is scrollable (taller than the view).
+    ///
+    /// 2. The user has scrolled to (or beyond) the bottom.
+    func scrollReachBottom() -> Bool {
         guard let scrollView = scrollView else { return false }
 
-        let yOffsetCheck = contentOffset.y > (contentSize.height - scrollView.frame.size.height)
-        let heightCheck = contentSize.height > scrollView.frame.size.height
-
-        return yOffsetCheck && heightCheck
+        let contentIsScrollable = contentSize.height > scrollViewHeight
+        let isMaxContentOffset = contentOffset.y > (contentSize.height - scrollViewHeight)
+        
+        return isMaxContentOffset && contentIsScrollable
     }
 
     func shouldAllowScroll(with topIsRubberbanding: Bool,
@@ -619,7 +624,7 @@ extension TabScrollController: UIScrollViewDelegate {
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        guard !tabIsLoading(), !isBouncingAtBottom(), isAbleToScroll, let tab else { return }
+        guard let tab, !tabIsLoading(), !scrollReachBottom(), isAbleToScroll  else { return }
 
         tab.shouldScrollToTop = false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3820)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/10114)

## :bulb: Description
The goal of the PR is to improve the show/hide toolbar behaviour both for iPhone and iPad. Adds documentation and helps readability to understand all the related logic. Renamed variables and functions to reflect responsibilities and usage

Create computed variables for complicated mathematical checks like:  
```
   if isBottomRubberbanding {
   }
```
versus 
```
   if contentOffset.y + scrollViewHeight > contentSize.height: Bool {
   }
```


Changes in behaviour:

- Remove duplicated rubberband logic in `handlePan` that constrained the logic of show/hide toolbar
- Removed `animating` from ToolbarState and replaced usage with `isAnimatingToolbar`
- In `scrollViewDidEndDragging` add logic to avoid show/hiding toolbar when FindInPage is enabled. This logic was already present in the class buy only working partially for bottom toolbar.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

