### PR TITLE
Add FXIOS-11895 Add feature flag to test reverting unsafe continuations workaround for iOS 18.0 (beta?) users

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1928,7 +1928,7 @@
 		ED7A08DD2CF6749B0035EC8F /* ShareType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A08DC2CF6749B0035EC8F /* ShareType.swift */; };
 		ED7A08DF2CF674BA0035EC8F /* ShareTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A08DE2CF674BA0035EC8F /* ShareTab.swift */; };
 		ED7A08E12CF679CE0035EC8F /* MockShareTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A08E02CF679CE0035EC8F /* MockShareTab.swift */; };
-		ED80541B2DAD967000484080 /* ContinuationWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED80541A2DAD966B00484080 /* ContinuationWrapper.swift */; };
+		ED80541B2DAD967000484080 /* ContinuationsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED80541A2DAD966B00484080 /* ContinuationsChecker.swift */; };
 		ED8B49B92D6CF72700743444 /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8B49B82D6CF72700743444 /* AppIcon.swift */; };
 		ED9FD5DB2CEBB5EA00E906A3 /* SentFromFirefoxSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9FD5DA2CEBB5EA00E906A3 /* SentFromFirefoxSetting.swift */; };
 		EDADF77A2D70BD3E00C39295 /* AppIconSelectionTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDADF7792D70BD3E00C39295 /* AppIconSelectionTelemetry.swift */; };
@@ -10131,7 +10131,7 @@
 		ED7A08DC2CF6749B0035EC8F /* ShareType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareType.swift; sourceTree = "<group>"; };
 		ED7A08DE2CF674BA0035EC8F /* ShareTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTab.swift; sourceTree = "<group>"; };
 		ED7A08E02CF679CE0035EC8F /* MockShareTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShareTab.swift; sourceTree = "<group>"; };
-		ED80541A2DAD966B00484080 /* ContinuationWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuationWrapper.swift; sourceTree = "<group>"; };
+		ED80541A2DAD966B00484080 /* ContinuationsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuationsChecker.swift; sourceTree = "<group>"; };
 		ED84423D8666C751BBFC76AC /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Storage.strings; sourceTree = "<group>"; };
 		ED8B49B82D6CF72700743444 /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
 		ED9FD5DA2CEBB5EA00E906A3 /* SentFromFirefoxSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentFromFirefoxSetting.swift; sourceTree = "<group>"; };
@@ -14598,7 +14598,7 @@
 			isa = PBXGroup;
 			children = (
 				8ACF70542DA99E0F00D9C546 /* StopWatchTimer.swift */,
-				ED80541A2DAD966B00484080 /* ContinuationWrapper.swift */,
+				ED80541A2DAD966B00484080 /* ContinuationsChecker.swift */,
 				0E4AF8602D763E9D002E4238 /* DownloadLiveActivityUtil.swift */,
 				5AD3B67D2CF665AE00AFA1FE /* UIApplicationInterface.swift */,
 				5AD3B67B2CF65DE300AFA1FE /* LocaleInterface.swift */,
@@ -17827,7 +17827,7 @@
 				884CA7492344A301002E4711 /* TextContentDetector.swift in Sources */,
 				8A9F0B5627C595F300FE09AE /* ImageIdentifiers.swift in Sources */,
 				43A5643823CD1E1C00B6857D /* UpdateViewController.swift in Sources */,
-				ED80541B2DAD967000484080 /* ContinuationWrapper.swift in Sources */,
+				ED80541B2DAD967000484080 /* ContinuationsChecker.swift in Sources */,
 				ED28DAC92C45A95F00D2641C /* TabScrollBehaviorModel.swift in Sources */,
 				8AD248F12C0F735200500AB7 /* BehavioralTargetingEvent.swift in Sources */,
 				1D69FF8D27B17286001F660E /* HomeLogoHeaderCell.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1928,6 +1928,7 @@
 		ED7A08DD2CF6749B0035EC8F /* ShareType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A08DC2CF6749B0035EC8F /* ShareType.swift */; };
 		ED7A08DF2CF674BA0035EC8F /* ShareTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A08DE2CF674BA0035EC8F /* ShareTab.swift */; };
 		ED7A08E12CF679CE0035EC8F /* MockShareTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A08E02CF679CE0035EC8F /* MockShareTab.swift */; };
+		ED80541B2DAD967000484080 /* ContinuationWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED80541A2DAD966B00484080 /* ContinuationWrapper.swift */; };
 		ED8B49B92D6CF72700743444 /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8B49B82D6CF72700743444 /* AppIcon.swift */; };
 		ED9FD5DB2CEBB5EA00E906A3 /* SentFromFirefoxSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9FD5DA2CEBB5EA00E906A3 /* SentFromFirefoxSetting.swift */; };
 		EDADF77A2D70BD3E00C39295 /* AppIconSelectionTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDADF7792D70BD3E00C39295 /* AppIconSelectionTelemetry.swift */; };
@@ -10130,6 +10131,7 @@
 		ED7A08DC2CF6749B0035EC8F /* ShareType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareType.swift; sourceTree = "<group>"; };
 		ED7A08DE2CF674BA0035EC8F /* ShareTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTab.swift; sourceTree = "<group>"; };
 		ED7A08E02CF679CE0035EC8F /* MockShareTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShareTab.swift; sourceTree = "<group>"; };
+		ED80541A2DAD966B00484080 /* ContinuationWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuationWrapper.swift; sourceTree = "<group>"; };
 		ED84423D8666C751BBFC76AC /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Storage.strings; sourceTree = "<group>"; };
 		ED8B49B82D6CF72700743444 /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
 		ED9FD5DA2CEBB5EA00E906A3 /* SentFromFirefoxSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentFromFirefoxSetting.swift; sourceTree = "<group>"; };
@@ -14596,6 +14598,7 @@
 			isa = PBXGroup;
 			children = (
 				8ACF70542DA99E0F00D9C546 /* StopWatchTimer.swift */,
+				ED80541A2DAD966B00484080 /* ContinuationWrapper.swift */,
 				0E4AF8602D763E9D002E4238 /* DownloadLiveActivityUtil.swift */,
 				5AD3B67D2CF665AE00AFA1FE /* UIApplicationInterface.swift */,
 				5AD3B67B2CF65DE300AFA1FE /* LocaleInterface.swift */,
@@ -17824,6 +17827,7 @@
 				884CA7492344A301002E4711 /* TextContentDetector.swift in Sources */,
 				8A9F0B5627C595F300FE09AE /* ImageIdentifiers.swift in Sources */,
 				43A5643823CD1E1C00B6857D /* UpdateViewController.swift in Sources */,
+				ED80541B2DAD967000484080 /* ContinuationWrapper.swift in Sources */,
 				ED28DAC92C45A95F00D2641C /* TabScrollBehaviorModel.swift in Sources */,
 				8AD248F12C0F735200500AB7 /* BehavioralTargetingEvent.swift in Sources */,
 				1D69FF8D27B17286001F660E /* HomeLogoHeaderCell.swift in Sources */,

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -51,6 +51,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case toolbarNavigationHint
     case tosFeature
     case trackingProtectionRefactor
+    case revertUnsafeContinuationsRefactor
     case useRustKeychain
 
     // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`. Add in alphabetical order.
@@ -145,6 +146,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .toolbarNavigationHint,
                 .tosFeature,
                 .trackingProtectionRefactor,
+                .revertUnsafeContinuationsRefactor,
                 .useRustKeychain:
             return nil
         }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
@@ -127,7 +127,7 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
 
     private func countDesktopBookmarks() async -> Int? {
         // FXIOS-11895 Temporary test for reverting continuation workaround we put in place for iOS 18.0 (beta?) users
-        if ContinuationWrapper.shouldUseCheckedContinuation {
+        if ContinuationsChecker.shouldUseCheckedContinuation {
             return await withCheckedContinuation { continuation in
                 profile.places.countBookmarksInTrees(folderGuids: BookmarkRoots.DesktopRoots.map { $0 }) { result in
                     switch result {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
@@ -126,13 +126,27 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
     }
 
     private func countDesktopBookmarks() async -> Int? {
-        return await withUnsafeContinuation { continuation in
-            profile.places.countBookmarksInTrees(folderGuids: BookmarkRoots.DesktopRoots.map { $0 }) { result in
-                switch result {
-                case .success(let count):
-                    continuation.resume(returning: count)
-                case .failure:
-                    continuation.resume(returning: nil)
+        // FXIOS-11895 Temporary test for reverting continuation workaround we put in place for iOS 18.0 (beta?) users
+        if ContinuationWrapper.shouldUseCheckedContinuation {
+            return await withCheckedContinuation { continuation in
+                profile.places.countBookmarksInTrees(folderGuids: BookmarkRoots.DesktopRoots.map { $0 }) { result in
+                    switch result {
+                    case .success(let count):
+                        continuation.resume(returning: count)
+                    case .failure:
+                        continuation.resume(returning: nil)
+                    }
+                }
+            }
+        } else {
+            return await withUnsafeContinuation { continuation in
+                profile.places.countBookmarksInTrees(folderGuids: BookmarkRoots.DesktopRoots.map { $0 }) { result in
+                    switch result {
+                    case .success(let count):
+                        continuation.resume(returning: count)
+                    case .failure:
+                        continuation.resume(returning: nil)
+                    }
                 }
             }
         }

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -128,6 +128,9 @@ final class NimbusFeatureFlagLayer {
         case .trackingProtectionRefactor:
             return checkTrackingProtectionRefactor(from: nimbus)
 
+        case .revertUnsafeContinuationsRefactor:
+            return checkRevertUnsafeContinuationsRefactor(from: nimbus)
+
         case .useRustKeychain:
             return checkUseRustKeychainFeature(from: nimbus)
         }
@@ -389,6 +392,11 @@ final class NimbusFeatureFlagLayer {
 
     private func checkNICErrorPageFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.nativeErrorPageFeature.value().noInternetConnectionError
+    }
+
+    private func checkRevertUnsafeContinuationsRefactor(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.revertUnsafeContinuationsRefactor.value()
+        return config.enabled
     }
 
     private func checkUseRustKeychainFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Client/NotificationManager.swift
+++ b/firefox-ios/Client/NotificationManager.swift
@@ -114,10 +114,18 @@ class NotificationManager: NotificationManagerProtocol {
 
     // Determines if the user has allowed notifications
     func hasPermission() async -> Bool {
-        // NOTE: Testing "unsafe" variant of this method, see FXIOS-10832 for details.
-        await withUnsafeContinuation { continuation in
-            hasPermission { hasPermission in
-                continuation.resume(returning: hasPermission)
+        // FXIOS-11895 Temporary test for reverting continuation workaround we put in place for iOS 18.0 (beta?) users
+        if ContinuationWrapper.shouldUseCheckedContinuation {
+            await withCheckedContinuation { continuation in
+                hasPermission { hasPermission in
+                    continuation.resume(returning: hasPermission)
+                }
+            }
+        } else {
+            await withUnsafeContinuation { continuation in
+                hasPermission { hasPermission in
+                    continuation.resume(returning: hasPermission)
+                }
             }
         }
     }

--- a/firefox-ios/Client/NotificationManager.swift
+++ b/firefox-ios/Client/NotificationManager.swift
@@ -115,7 +115,7 @@ class NotificationManager: NotificationManagerProtocol {
     // Determines if the user has allowed notifications
     func hasPermission() async -> Bool {
         // FXIOS-11895 Temporary test for reverting continuation workaround we put in place for iOS 18.0 (beta?) users
-        if ContinuationWrapper.shouldUseCheckedContinuation {
+        if ContinuationsChecker.shouldUseCheckedContinuation {
             await withCheckedContinuation { continuation in
                 hasPermission { hasPermission in
                     continuation.resume(returning: hasPermission)

--- a/firefox-ios/Client/Utils/ContinuationWrapper.swift
+++ b/firefox-ios/Client/Utils/ContinuationWrapper.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/// In the future, we may wish to flesh out a wrapper for continuations. This will allow us to check for usage violations
+/// to log misuse rather than crash the app (FXIOS-11895).
+struct ContinuationWrapper {
+    // FXIOS-11895 Temporary test for reverting continuation workaround we put in place for iOS 18.0 (beta?) users
+    static var shouldUseCheckedContinuation: Bool {
+        let systemVersion = UIDevice.current.systemVersion
+        let isRevertUnsafeContinuationsRefactorEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(
+            .revertUnsafeContinuationsRefactor,
+            checking: .buildOnly
+        )
+
+        // iOS 18.0 saw crashes on checked versions of continuations (possibly only on beta iOS 18.0). We are experimenting
+        // here to see if crashes also occur for our official release iOS 18.0 users when we revert the workaround of using
+        // unsafe variants of continuations.
+        guard systemVersion != "18.0" else {
+            return isRevertUnsafeContinuationsRefactorEnabled
+        }
+
+        return true
+    }
+}

--- a/firefox-ios/Client/Utils/ContinuationsChecker.swift
+++ b/firefox-ios/Client/Utils/ContinuationsChecker.swift
@@ -4,8 +4,10 @@
 
 /// In the future, we may wish to flesh out a wrapper for continuations. This will allow us to check for usage violations
 /// to log misuse rather than crash the app (FXIOS-11895).
-struct ContinuationWrapper {
-    // FXIOS-11895 Temporary test for reverting continuation workaround we put in place for iOS 18.0 (beta?) users
+struct ContinuationsChecker {
+    /// Always returns true except for iOS 18.0 users who are not under an experiment to revert unsafe continuation usage
+    /// back to checked continuations.
+    /// FXIOS-11895 This is a temp. check for reverting a continuation workaround we put in place for iOS 18.0 (beta?) users
     static var shouldUseCheckedContinuation: Bool {
         let systemVersion = UIDevice.current.systemVersion
         let isRevertUnsafeContinuationsRefactorEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(

--- a/firefox-ios/nimbus-features/revertUnsafeContinuationsRefactor.yaml
+++ b/firefox-ios/nimbus-features/revertUnsafeContinuationsRefactor.yaml
@@ -1,0 +1,17 @@
+features:
+  revert-unsafe-continuations-refactor:
+    description: >
+      A feature flag to wrap reverting the unsafe continuations usage in the app. Unsafe continuations were used in response to an early 2025 incident when iOS 18.0 (possibly beta only) crashed on checked continuations (both regular and throwing).
+    variables:
+      enabled:
+        description: >
+          If true, revert unsafe continuations usage back to normal checked continuations usage.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: true
+      - channel: developer
+        value:
+          enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -46,4 +46,5 @@ include:
   - nimbus-features/toolbarRefactorFeature.yaml
   - nimbus-features/tosFeature.yaml
   - nimbus-features/trackingProtectionRefactor.yaml
+  - nimbus-features/revertUnsafeContinuationsRefactor.yaml
   - nimbus-features/unifiedAds.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11895)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25943)

## :bulb: Description
Added a feature flag for testing reverting our iOS 18.0 workaround for crashing continuations. More context available in the attached ticket.

Motivation: We want to test reverting the unsafe continuations workaround put in place a few months ago (which prevented crashes for iOS 18.0 users) just to see if only iOS 18.0 _beta_ users were affected, not official release users. This will help us decide on next steps with continuations.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

