### PR TITLE
FXIOS-11990 #26100 Remove extension method

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/URLExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/URLExtension.swift
@@ -5,13 +5,6 @@
 import Foundation
 
 extension URL {
-    /// Temporary init that will be removed with the update to XCode 15 where this URL API is available
-    public init?(string: String, invalidCharacters: Bool) {
-        // FXIOS-8107: Removed 'encodingInvalidCharacters' init for
-        // compatibility reasons that is available for iOS 17+ only
-        self.init(string: string)
-    }
-
     /// Returns a shorter displayable string for a domain
     /// E.g., https://m.foo.com/bar/baz?noo=abc#123  => foo
     /// https://accounts.foo.com/bar/baz?noo=abc#123  => accounts.foo

--- a/BrowserKit/Sources/Shared/Extensions/String+Extension.swift
+++ b/BrowserKit/Sources/Shared/Extensions/String+Extension.swift
@@ -20,8 +20,7 @@ public extension String {
         // Let's escape | for them.
         // We'd love to use one of the more sophisticated CFURL* or NSString.* functions, but
         // none seem to be quite suitable.
-        return URL(string: self, invalidCharacters: false) ??
-               URL(string: self.stringWithAdditionalEscaping, invalidCharacters: false)
+        return URL(string: self) ?? URL(string: self.stringWithAdditionalEscaping)
     }
 
     // MARK: - Hashing & Encoding

--- a/BrowserKit/Sources/Shared/InternalURL.swift
+++ b/BrowserKit/Sources/Shared/InternalURL.swift
@@ -95,7 +95,7 @@ public struct InternalURL {
 
     public var extractedUrlParam: URL? {
         if let nestedUrl = url.getQuery()[InternalURL.Param.url.rawValue]?.unescape() {
-            return URL(string: nestedUrl, invalidCharacters: false)
+            return URL(string: nestedUrl)
         }
         return nil
     }
@@ -114,7 +114,7 @@ public struct InternalURL {
     /// Return the path after "about/" in the URI.
     public var aboutComponent: String? {
         let aboutPath = "/about/"
-        guard let url = URL(string: stripAuthorization, invalidCharacters: false) else { return nil }
+        guard let url = URL(string: stripAuthorization) else { return nil }
 
         if url.path.hasPrefix(aboutPath) {
             return String(url.path.dropFirst(aboutPath.count))

--- a/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
@@ -61,7 +61,7 @@ public class FaviconImageView: UIImageView, SiteImageView {
 
     func setURL(_ viewModel: FaviconImageViewModel) {
         guard let siteURLString = viewModel.siteURLString,
-              let siteURL = URL(string: siteURLString, invalidCharacters: false),
+              let siteURL = URL(string: siteURLString),
               canMakeRequest(with: siteURLString)
         else { return }
 

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
@@ -32,7 +32,7 @@ actor DefaultFaviconURLCache: FaviconURLCache {
 
     func getURLFromCache(cacheKey: String) async throws -> URL {
         guard let favicon = urlCache[cacheKey],
-              let url = URL(string: favicon.faviconURL, invalidCharacters: false)
+              let url = URL(string: favicon.faviconURL)
         else { throw SiteImageError.noURLInCache }
 
         // Update the element in the cache so it's time to expire is reset

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/FaviconURLFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/FaviconURLFetcher.swift
@@ -47,7 +47,7 @@ struct DefaultFaviconURLFetcher: FaviconURLFetcher {
             if let refresh = meta["http-equiv"], refresh == "Refresh",
                let content = meta["content"],
                let index = content.range(of: "URL="),
-               let url = URL(string: String(content[index.upperBound...]), invalidCharacters: false) {
+               let url = URL(string: String(content[index.upperBound...])) {
                 reloadURL = url
             }
         }

--- a/BrowserKit/Sources/SiteImageView/HeroImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageView.swift
@@ -75,7 +75,7 @@ public class HeroImageView: UIView, SiteImageView {
 
     func setURL(_ siteURLString: String, type: SiteImageType) {
         guard canMakeRequest(with: siteURLString),
-              let siteURL = URL(string: siteURLString, invalidCharacters: false) else {
+              let siteURL = URL(string: siteURLString) else {
             return
         }
 

--- a/BrowserKit/Sources/WebEngine/Utilities/URLFormatter.swift
+++ b/BrowserKit/Sources/WebEngine/Utilities/URLFormatter.swift
@@ -30,8 +30,8 @@ public class DefaultURLFormatter: URLFormatter {
 
     public func getURL(entry: String) -> URL? {
         // If it's an Internal URL no formatting should happen
-        if let url = URL(string: entry, invalidCharacters: false), WKInternalURL.isValid(url: url) {
-            return URL(string: entry, invalidCharacters: false)
+        if let url = URL(string: entry), WKInternalURL.isValid(url: url) {
+            return URL(string: entry)
         }
 
         // If the entry is `localhost` then navigate to it
@@ -60,7 +60,7 @@ public class DefaultURLFormatter: URLFormatter {
     // Handle the entry if it has a scheme, make sure it's safe before browsing to it
     private func handleWithScheme(with entry: String) -> URL? {
         // Check if the URL includes a scheme
-        guard let url = URL(string: entry, invalidCharacters: false),
+        guard let url = URL(string: entry),
               url.scheme != nil,
               entry.range(of: "\\b:[0-9]{1,5}", options: .regularExpression) == nil else {
             return nil
@@ -78,7 +78,7 @@ public class DefaultURLFormatter: URLFormatter {
         // Only allow this URL if it's safe
         let browsingContext = BrowsingContext(type: .internalNavigation, url: url)
         if securityManager.canNavigateWith(browsingContext: browsingContext) == .allowed {
-            return URL(string: entry, invalidCharacters: false)
+            return URL(string: entry)
         } else {
             return nil
         }
@@ -116,7 +116,7 @@ public class DefaultURLFormatter: URLFormatter {
         let finalURL = escapedURL.hasPrefix("http://") || escapedURL.hasPrefix("https://") ? escapedURL : "http://\(escapedURL)"
 
         // If there is a host, return this formatted as a URL
-        if let url = URL(string: finalURL, invalidCharacters: false), url.host != nil {
+        if let url = URL(string: finalURL), url.host != nil {
             return url
         }
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/Extension/URLExtension.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Extension/URLExtension.swift
@@ -26,7 +26,7 @@ public extension URL {
                let queryItems = components.queryItems {
                 if let queryItem = queryItems.first(where: { $0.name == "url" }),
                    let value = queryItem.value {
-                    return URL(string: value, invalidCharacters: false)?.safeEncodedUrl
+                    return URL(string: value)?.safeEncodedUrl
                 }
             }
         }
@@ -35,7 +35,7 @@ public extension URL {
 
     func encodeReaderModeURL(_ baseReaderModeURL: String) -> URL? {
         if let encodedURL = absoluteString.addingPercentEncoding(withAllowedCharacters: .alphanumerics) {
-            if let aboutReaderURL = URL(string: "\(baseReaderModeURL)?url=\(encodedURL)", invalidCharacters: false) {
+            if let aboutReaderURL = URL(string: "\(baseReaderModeURL)?url=\(encodedURL)") {
                 return aboutReaderURL
             }
         }

--- a/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalURL.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalURL.swift
@@ -92,7 +92,7 @@ final class WKInternalURL: InternalURL {
 
     private var extractedUrlParam: URL? {
         if let nestedUrl = url.getQuery()[WKInternalURL.Param.url.rawValue]?.removingPercentEncoding {
-            return URL(string: nestedUrl, invalidCharacters: false)
+            return URL(string: nestedUrl)
         }
         return nil
     }

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/WKReaderModeHandlers.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/WKReaderModeHandlers.swift
@@ -48,7 +48,7 @@ struct WKReaderModeHandlers: WKReaderModeHandlersProtocol {
             resource: "page-exists"
         ) { (request: GCDWebServerRequest?) -> GCDWebServerResponse? in
             guard let stringURL = request?.query?["url"],
-                  let url = URL(string: stringURL, invalidCharacters: false) else {
+                  let url = URL(string: stringURL) else {
                 return GCDWebServerResponse(statusCode: 500)
             }
 
@@ -63,7 +63,7 @@ struct WKReaderModeHandlers: WKReaderModeHandlersProtocol {
             resource: "page"
         ) { (request: GCDWebServerRequest?) -> GCDWebServerResponse? in
             if let url = request?.query?["url"] {
-                if let url = URL(string: url, invalidCharacters: false), url.isWebPage() {
+                if let url = URL(string: url), url.isWebPage() {
                     do {
                         let readabilityResult = try readerModeCache.get(url)
                         guard let response = generateHtmlFor(

--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -178,7 +178,7 @@ final class RouteBuilder: FeatureFlaggable {
         if userActivity.activityType == CSSearchableItemActionType {
             guard let userInfo = userActivity.userInfo,
                   let urlString = userInfo[CSSearchableItemActivityIdentifier] as? String,
-                  let url = URL(string: urlString, invalidCharacters: false)
+                  let url = URL(string: urlString)
             else {
                 return nil
             }

--- a/firefox-ios/Client/Coordinators/Router/URLScanner.swift
+++ b/firefox-ios/Client/Coordinators/Router/URLScanner.swift
@@ -40,7 +40,7 @@ struct URLScanner {
         guard let scheme = urlComponents.scheme, urlSchemes.contains(scheme) else { return nil }
         self.scheme = scheme
         self.host = urlComponents.host ?? ""
-        self.components = URL(string: urlComponents.path, invalidCharacters: false)?.pathComponents ?? []
+        self.components = URL(string: urlComponents.path)?.pathComponents ?? []
         self.queries = urlComponents.queryItems ?? []
     }
 

--- a/firefox-ios/Client/Experiments/Settings/ExperimentsSettingsViewController.swift
+++ b/firefox-ios/Client/Experiments/Settings/ExperimentsSettingsViewController.swift
@@ -86,7 +86,7 @@ class ExperimentsSettingsViewController: UIViewController {
     private func loadRemoteExperiments(sender: AnyObject) {
         guard
             let text = experimentsView.customRemoteSettingsTextField.text,
-            let url = URL(string: text, invalidCharacters: false),
+            let url = URL(string: text),
             let data = try? String(contentsOf: url)
             else { return }
 

--- a/firefox-ios/Client/Extensions/UIPasteboard+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIPasteboard+Extension.swift
@@ -24,7 +24,7 @@ extension UIPasteboard {
 
     private var syncURL: URL? {
         return UIPasteboard.general.string.flatMap {
-            guard let url = URL(string: $0, invalidCharacters: false),
+            guard let url = URL(string: $0),
                     url.isWebPage()
             else { return nil }
             return url

--- a/firefox-ios/Client/Frontend/Accessors/HomePageAccessors.swift
+++ b/firefox-ios/Client/Frontend/Accessors/HomePageAccessors.swift
@@ -15,7 +15,7 @@ class NewTabHomePageAccessors {
     static func getHomePage(_ prefs: Prefs) -> URL? {
         let string = prefs.stringForKey(PrefsKeys.NewTabCustomUrlPrefKey) ?? getDefaultHomePageString(prefs)
         guard let urlString = string else { return nil }
-        return URL(string: urlString, invalidCharacters: false)
+        return URL(string: urlString)
     }
 
     static func getDefaultHomePageString(_ prefs: Prefs) -> String? {
@@ -27,6 +27,6 @@ class HomeButtonHomePageAccessors {
     static func getHomePage(_ prefs: Prefs) -> URL? {
         let string = prefs.stringForKey(PrefsKeys.HomeButtonHomePageURL)
         guard let urlString = string else { return nil }
-        return URL(string: urlString, invalidCharacters: false)
+        return URL(string: urlString)
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
@@ -49,7 +49,7 @@ struct LoginAutofillView: View {
     LoginAutofillView(
         windowUUID: .XCTestDefaultUUID,
         viewModel: LoginListViewModel(
-            tabURL: URL(string: "http://www.example.com", invalidCharacters: false)!,
+            tabURL: URL(string: "http://www.example.com")!,
             field: FocusFieldType.username,
             loginStorage: MockLoginStorage(),
             logger: MockLogger(),

--- a/firefox-ios/Client/Frontend/Autofill/LoginListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginListView.swift
@@ -54,7 +54,7 @@ struct LoginListView_Previews: PreviewProvider {
         LoginListView(
             windowUUID: .XCTestDefaultUUID,
             viewModel: LoginListViewModel(
-                tabURL: URL(string: "http://www.example.com", invalidCharacters: false)!,
+                tabURL: URL(string: "http://www.example.com")!,
                 field: FocusFieldType.username,
                 loginStorage: MockLoginStorage(),
                 logger: MockLogger(),

--- a/firefox-ios/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -108,7 +108,7 @@ class BackForwardTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     func configure(viewModel: BackForwardCellViewModel, theme: Theme) {
         self.viewModel = viewModel
 
-        if let url = URL(string: viewModel.site.url, invalidCharacters: false),
+        if let url = URL(string: viewModel.site.url),
            InternalURL(url)?.isAboutHomeURL == true {
             faviconView.manuallySetImage(UIImage(named: ImageIdentifiers.firefoxFavicon) ?? UIImage())
         } else {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2256,7 +2256,7 @@ class BrowserViewController: UIViewController,
                let range = urlString.range(of: "%s") {
                 urlString.replaceSubrange(range, with: escapedQuery)
 
-                if let url = URL(string: urlString, invalidCharacters: false) {
+                if let url = URL(string: urlString) {
                     self.finishEditingAndSubmit(url, visitType: VisitType.typed, forTab: currentTab)
                     return
                 }
@@ -3403,7 +3403,7 @@ class BrowserViewController: UIViewController,
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }
         case .some(.phoneNumber(let phoneNumber)):
-            if let url = URL(string: "tel:\(phoneNumber)", invalidCharacters: false) {
+            if let url = URL(string: "tel:\(phoneNumber)") {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             } else {
                 defaultAction()

--- a/firefox-ios/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -101,7 +101,7 @@ class ClipboardBarDisplayHandler: NSObject {
             return true
         }
 
-        if let url = URL(string: clipboardURL, invalidCharacters: false),
+        if let url = URL(string: clipboardURL),
            tabManager?.getTabForURL(url) != nil {
             return true
         }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -223,7 +223,7 @@ final class MainMenuMiddleware {
 
         var iconURL: URL?
         if let str = rustAccount.userProfile?.avatarUrl,
-           let url = URL(string: str, invalidCharacters: false) {
+           let url = URL(string: str) {
             iconURL = url
         }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -542,7 +542,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
         var iconURL: URL?
         if let str = rustAccount.userProfile?.avatarUrl,
-            let url = URL(string: str, invalidCharacters: false) {
+            let url = URL(string: str) {
             iconURL = url
         }
         let iconType: PhotonActionSheetIconType = needsReAuth ? .Image : .URL

--- a/firefox-ios/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -94,7 +94,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
     }
 
     func canOpenMailScheme(_ scheme: String) -> Bool {
-        if let url = URL(string: scheme, invalidCharacters: false) {
+        if let url = URL(string: scheme) {
             return UIApplication.shared.canOpenURL(url)
         }
         return false

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -461,20 +461,20 @@ class SearchViewController: SiteTableViewController,
         case .history:
             let site = viewModel.historySites[indexPath.row]
             searchTelemetry?.selectedResult = .history
-            if let url = URL(string: site.url, invalidCharacters: false) {
+            if let url = URL(string: site.url) {
                 selectedIndexPath = indexPath
                 searchDelegate?.searchViewController(self, didSelectURL: url, searchTerm: nil)
             }
         case .bookmarks:
             let site = viewModel.bookmarkSites[indexPath.row]
             searchTelemetry?.selectedResult = .bookmark
-            if let url = URL(string: site.url, invalidCharacters: false) {
+            if let url = URL(string: site.url) {
                 selectedIndexPath = indexPath
                 searchDelegate?.searchViewController(self, didSelectURL: url, searchTerm: nil)
             }
         case .searchHighlights:
             if let urlString = viewModel.searchHighlights[indexPath.row].urlString,
-                let url = URL(string: urlString, invalidCharacters: false) {
+                let url = URL(string: urlString) {
                 searchTelemetry?.selectedResult = .searchHistory
                 selectedIndexPath = indexPath
                 searchDelegate?.searchViewController(self, didSelectURL: url, searchTerm: nil)

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -159,7 +159,7 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
     private func isSearchURLForEngine(_ url: URL?) -> Bool {
         guard let urlHost = url?.shortDisplayString,
               let queryEndIndex = searchTemplate.range(of: "?")?.lowerBound,
-              let templateURL = URL(string: String(searchTemplate[..<queryEndIndex]), invalidCharacters: false)
+              let templateURL = URL(string: String(searchTemplate[..<queryEndIndex]))
         else { return false }
         return urlHost == templateURL.shortDisplayString
     }
@@ -178,7 +178,7 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
             ) {
                 let urlString = encodedSearchTemplate
                     .replacingOccurrences(of: searchTermComponent, with: escapedQuery, options: .literal, range: nil)
-                return URL(string: urlString, invalidCharacters: false)
+                return URL(string: urlString)
             }
         }
 

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchParser.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchParser.swift
@@ -128,7 +128,7 @@ class OpenSearchParser {
 
         let uiImage: UIImage
         if let imageElement = largestImageElement,
-            let imageURL = URL(string: imageElement.stringValue, invalidCharacters: false),
+            let imageURL = URL(string: imageElement.stringValue),
             let imageData = try? Data(contentsOf: imageURL),
             let image = UIImage(data: imageData) {
             uiImage = image

--- a/firefox-ios/Client/Frontend/Browser/URIFixup.swift
+++ b/firefox-ios/Client/Frontend/Browser/URIFixup.swift
@@ -8,9 +8,9 @@ import Shared
 
 class URIFixup {
     static func getURL(_ entry: String) -> URL? {
-        if let url = URL(string: entry, invalidCharacters: false),
+        if let url = URL(string: entry),
             InternalURL.isValid(url: url) {
-            return URL(string: entry, invalidCharacters: false)
+            return URL(string: entry)
         }
 
         let trimmed = entry.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -49,7 +49,7 @@ class URIFixup {
             string = replaceHashMarks(url: string)
         }
 
-        guard let url = URL(string: string, invalidCharacters: false) else { return nil }
+        guard let url = URL(string: string) else { return nil }
 
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         if AppConstants.punyCode {

--- a/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
+++ b/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
@@ -13,7 +13,7 @@ private let searchLimit = 1000
 
 extension HistoryHighlight {
     var urlFromString: URL? {
-        return URL(string: url, invalidCharacters: false)
+        return URL(string: url)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/HomePanelType.swift
+++ b/firefox-ios/Client/Frontend/Home/HomePanelType.swift
@@ -9,7 +9,7 @@ enum HomePanelType: Int {
     case topSites = 0
 
     var internalUrl: URL {
-        let aboutUrl = URL(string: "\(InternalURL.baseUrl)/\(AboutHomeHandler.path)", invalidCharacters: false)!
+        let aboutUrl = URL(string: "\(InternalURL.baseUrl)/\(AboutHomeHandler.path)")!
         return URL(string: "#panel=\(self.rawValue)", relativeTo: aboutUrl)!
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -268,7 +268,7 @@ struct ContextMenuState {
             iconString: StandardImageIdentifiers.Large.share,
             allowIconScaling: true,
             tapHandler: { _ in
-                guard let url = URL(string: siteURL, invalidCharacters: false) else {
+                guard let url = URL(string: siteURL) else {
                     self.logger.log(
                         "Unable to retrieve URL for \(siteURL), return early",
                         level: .warning,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -149,7 +149,7 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
 
         switch topSite.type {
         case .sponsoredSite(let siteInfo):
-            if let url = URL(string: siteInfo.imageURL, invalidCharacters: false) {
+            if let url = URL(string: siteInfo.imageURL) {
                 imageResource = .remoteURL(url: url)
             }
         case .pinnedSite, .suggestedSite:

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -253,7 +253,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol,
                                      iconString: StandardImageIdentifiers.Large.share,
                                      allowIconScaling: true,
                                      tapHandler: { _ in
-            guard let url = URL(string: site.url, invalidCharacters: false) else { return }
+            guard let url = URL(string: site.url) else { return }
 
             self.browserNavigationHandler?.showShareSheet(
                 shareType: .site(url: url),

--- a/firefox-ios/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -149,7 +149,7 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
 
         switch topSite.type {
         case .sponsoredSite(let siteInfo):
-            if let url = URL(string: siteInfo.imageURL, invalidCharacters: false) {
+            if let url = URL(string: siteInfo.imageURL) {
                 imageResource = .remoteURL(url: url)
             }
         case .pinnedSite, .suggestedSite:

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
@@ -103,8 +103,8 @@ class ContileProvider: ContileProviderInterface, URLCaching, FeatureFlaggable {
 
     private var resourceEndpoint: URL? {
         if featureFlags.isCoreFeatureEnabled(.useStagingContileAPI) {
-            return URL(string: ContileProvider.contileStagingResourceEndpoint, invalidCharacters: false)
+            return URL(string: ContileProvider.contileStagingResourceEndpoint)
         }
-        return URL(string: ContileProvider.contileProdResourceEndpoint, invalidCharacters: false)
+        return URL(string: ContileProvider.contileProdResourceEndpoint)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsProvider.swift
@@ -157,8 +157,8 @@ class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, FeatureFlagga
 
     private var resourceEndpoint: URL? {
         if featureFlags.isCoreFeatureEnabled(.useStagingContileAPI) {
-            return URL(string: UnifiedAdsProvider.stagingResourceEndpoint, invalidCharacters: false)
+            return URL(string: UnifiedAdsProvider.stagingResourceEndpoint)
         }
-        return URL(string: UnifiedAdsProvider.prodResourceEndpoint, invalidCharacters: false)
+        return URL(string: UnifiedAdsProvider.prodResourceEndpoint)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/WallpaperCollection.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/WallpaperCollection.swift
@@ -40,7 +40,7 @@ struct WallpaperCollection: Codable, Equatable {
 
     var learnMoreUrl: URL? {
         guard let urlString = learnMoreURLString else { return nil }
-        return URL(string: urlString, invalidCharacters: false)
+        return URL(string: urlString)
     }
 
     /// Wallpaper collections availability:

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -491,7 +491,7 @@ final class BookmarksViewController: SiteTableViewController,
 
         updatePanelState(newState: .bookmarks(state: .inFolder))
         if let itemData = bookmarkCell as? BookmarkItemData,
-           let url = URL(string: itemData.url, invalidCharacters: false) {
+           let url = URL(string: itemData.url) {
             libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .bookmark)
         } else {
             guard let folder = bookmarkCell as? FxBookmarkNode else { return }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
@@ -341,7 +341,7 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
     }
 
     private func isBookmarkItemURLValid() -> Bool {
-        let url = URL(string: bookmarkItemURL ?? "", invalidCharacters: false)
+        let url = URL(string: bookmarkItemURL ?? "")
         return url?.schemeIsValid == true && url?.host != nil
     }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
@@ -393,7 +393,7 @@ class LegacyBookmarksPanel: SiteTableViewController,
 
         updatePanelState(newState: .bookmarks(state: .inFolder))
         if let itemData = bookmarkCell as? BookmarkItemData,
-           let url = URL(string: itemData.url, invalidCharacters: false) {
+           let url = URL(string: itemData.url) {
             libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .bookmark)
         } else {
             guard let folder = bookmarkCell as? FxBookmarkNode else { return }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
@@ -186,7 +186,7 @@ class SearchGroupedItemsViewController: UIViewController, UITableViewDelegate, T
     }
 
     private func handleSiteItemTapped(site: Site) {
-        guard let url = URL(string: site.url, invalidCharacters: false) else {
+        guard let url = URL(string: site.url) else {
             logger.log("Couldn't navigate to site",
                        level: .warning,
                        category: .library)

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -690,7 +690,7 @@ extension HistoryPanel: UITableViewDelegate {
     }
 
     private func handleSiteItemTapped(site: Site) {
-        guard let url = URL(string: site.url, invalidCharacters: false) else {
+        guard let url = URL(string: site.url) else {
             self.logger.log("Couldn't navigate to site",
                             level: .warning,
                             category: .library)

--- a/firefox-ios/Client/Frontend/Library/LibraryPanelContextMenu.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryPanelContextMenu.swift
@@ -49,7 +49,7 @@ extension LibraryPanelContextMenu {
         for site: Site,
         recentlyClosedPanelDelegate: RecentlyClosedPanelDelegate?
     ) -> [PhotonRowActions]? {
-        guard let siteURL = URL(string: site.url, invalidCharacters: false) else { return nil }
+        guard let siteURL = URL(string: site.url) else { return nil }
 
         let openInNewTabAction = SingleActionViewModel(
             title: .OpenInNewTabContextMenuTitle,
@@ -72,7 +72,7 @@ extension LibraryPanelContextMenu {
         for site: Site,
         libraryPanelDelegate: LibraryPanelDelegate?
     ) -> [PhotonRowActions]? {
-        guard let siteURL = URL(string: site.url, invalidCharacters: false) else { return nil }
+        guard let siteURL = URL(string: site.url) else { return nil }
 
         let openInNewTabAction = SingleActionViewModel(title: .OpenInNewTabContextMenuTitle,
                                                        iconString: StandardImageIdentifiers.Large.plus) { _ in
@@ -92,7 +92,7 @@ extension LibraryPanelContextMenu {
         return SingleActionViewModel(
             title: .ShareContextMenuTitle,
             iconString: StandardImageIdentifiers.Large.share) { _ in
-                guard let siteURL = URL(string: site.url, invalidCharacters: false) else { return }
+                guard let siteURL = URL(string: site.url) else { return }
                 delegate?.shareLibraryItem(url: siteURL, sourceView: sourceView)
         }.items
     }

--- a/firefox-ios/Client/Frontend/Library/Reader/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Reader/ReaderPanel.swift
@@ -360,7 +360,7 @@ class ReadingListPanel: UITableViewController,
         }
         if let record = records?[indexPath.row] {
             cell.title = record.title
-            cell.url = URL(string: record.url, invalidCharacters: false)!
+            cell.url = URL(string: record.url)!
             cell.unread = record.unread
             cell.applyTheme(theme: currentTheme())
         }
@@ -404,7 +404,7 @@ class ReadingListPanel: UITableViewController,
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
         if let record = records?[indexPath.row],
-            let url = URL(string: record.url, invalidCharacters: false),
+            let url = URL(string: record.url),
             let encodedURL = url.encodeReaderModeURL(WebServer.sharedInstance.baseReaderModeURL()) {
             // Mark the item as read
             profile.readingList.updateRecord(record, unread: false)
@@ -511,7 +511,7 @@ extension ReadingListPanel: UITableViewDragDelegate {
         at indexPath: IndexPath
     ) -> [UIDragItem] {
         guard let site = getSiteDetails(for: indexPath),
-              let url = URL(string: site.url, invalidCharacters: false),
+              let url = URL(string: site.url),
               let itemProvider = NSItemProvider(contentsOf: url)
         else { return [] }
 

--- a/firefox-ios/Client/Frontend/PasswordManagement/BreachAlertsClient.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/BreachAlertsClient.swift
@@ -34,7 +34,7 @@ class BreachAlertsClient: BreachAlertsClientProtocol {
 
     /// Makes a header-only request to an endpoint and hands off the endpoint's etag to a completion handler.
     func fetchEtag(endpoint: Endpoint, profile: Profile, completion: @escaping (_ etag: String?) -> Void) {
-        guard let url = URL(string: endpoint.rawValue, invalidCharacters: false) else { return }
+        guard let url = URL(string: endpoint.rawValue) else { return }
         var request = URLRequest(url: url)
         request.httpMethod = "HEAD"
 
@@ -59,7 +59,7 @@ class BreachAlertsClient: BreachAlertsClientProtocol {
 
     /// Makes a network request to an endpoint and hands off the result to a completion handler.
     func fetchData(endpoint: Endpoint, profile: Profile, completion: @escaping (_ result: Maybe<Data>) -> Void) {
-        guard let url = URL(string: endpoint.rawValue, invalidCharacters: false) else { return }
+        guard let url = URL(string: endpoint.rawValue) else { return }
 
         dataTask?.cancel()
         dataTask = URLSession.sharedMPTCP.dataTask(with: url) { data, response, error in

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -40,7 +40,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
             resource: "page-exists"
         ) { (request: GCDWebServerRequest?) -> GCDWebServerResponse? in
             guard let stringURL = request?.query?["url"],
-                  let url = URL(string: stringURL, invalidCharacters: false) else {
+                  let url = URL(string: stringURL) else {
                 return GCDWebServerResponse(statusCode: 500)
             }
 
@@ -55,7 +55,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
             resource: "page"
         ) { (request: GCDWebServerRequest?) -> GCDWebServerResponse? in
             if let url = request?.query?["url"] {
-                if let url = URL(string: url, invalidCharacters: false), url.isWebPage() {
+                if let url = URL(string: url), url.isWebPage() {
                     do {
                         let readabilityResult = try readerModeCache.get(url)
                         guard let response = generateHtmlFor(readabilityResult: readabilityResult,

--- a/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -91,7 +91,7 @@ class CustomSearchViewController: SettingsTableViewController {
     func createEngine(query: String, name: String) async throws -> OpenSearchEngine {
         guard let template = getSearchTemplate(withString: query),
               let encodedTemplate = template.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed),
-              let url = URL(string: encodedTemplate, invalidCharacters: false),
+              let url = URL(string: encodedTemplate),
               url.isWebPage()
         else {
             throw CustomSearchError(.FormInput)
@@ -149,7 +149,7 @@ class CustomSearchViewController: SettingsTableViewController {
     override func generateSettings() -> [SettingSection] {
         func URLFromString(_ string: String?) -> URL? {
             guard let string = string else { return nil }
-            return URL(string: string, invalidCharacters: false)
+            return URL(string: string)
         }
 
         let titleField = CustomSearchEngineTextView(

--- a/firefox-ios/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
@@ -88,7 +88,7 @@ class AccountStatusSetting: WithAccountSetting {
                 .tinted(withColor: theme.colors.iconPrimary)
 
             guard let str = RustFirefoxAccounts.shared.userProfile?.avatarUrl,
-                  let actionIconUrl = URL(string: str, invalidCharacters: false)
+                  let actionIconUrl = URL(string: str)
             else { return }
 
             GeneralizedImageFetcher().getImageFor(url: actionIconUrl) { image in

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -507,7 +507,7 @@ class WebPageSetting: StringPrefSetting {
         guard let string = string, !string.isEmpty else {
             return true
         }
-        return URL(string: string, invalidCharacters: false)?.isWebPage() ?? false
+        return URL(string: string)?.isWebPage() ?? false
     }
 }
 

--- a/firefox-ios/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
@@ -46,13 +46,13 @@ extension ContextMenuHelper: TabContentScript {
         var linkURL: URL?
         if let urlString = data["link"] as? String,
                 let escapedURLString = urlString.addingPercentEncoding(withAllowedCharacters: .URLAllowed) {
-            linkURL = URL(string: escapedURLString, invalidCharacters: false)
+            linkURL = URL(string: escapedURLString)
         }
 
         var imageURL: URL?
         if let urlString = data["image"] as? String,
                 let escapedURLString = urlString.addingPercentEncoding(withAllowedCharacters: .URLAllowed) {
-            imageURL = URL(string: escapedURLString, invalidCharacters: false)
+            imageURL = URL(string: escapedURLString)
         }
 
         if linkURL != nil || imageURL != nil {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
@@ -43,7 +43,7 @@ class DownloadContentScript: TabContentScript {
         guard url.scheme == "blob" else {
             return false
         }
-        blobUrlForDownload = URL(string: safeUrl, invalidCharacters: false)
+        blobUrlForDownload = URL(string: safeUrl)
         tab.webView?.evaluateJavascriptInDefaultContentWorld(
             "window.__firefox__.download('\(safeUrl)', '\(UserScriptManager.appIdToken)')"
         )
@@ -57,7 +57,7 @@ class DownloadContentScript: TabContentScript {
     ) {
         guard let dictionary = message.body as? [String: Any?],
               let _url = dictionary["url"] as? String,
-              let url = URL(string: _url, invalidCharacters: false),
+              let url = URL(string: _url),
               let mimeType = dictionary["mimeType"] as? String,
               let size = dictionary["size"] as? Int64,
               let base64String = dictionary["base64String"] as? String,

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -76,7 +76,7 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
     }
 
     private func getOrigin(_ uriString: String, allowJS: Bool = false) -> String? {
-        guard let uri = URL(string: uriString, invalidCharacters: false),
+        guard let uri = URL(string: uriString),
               let scheme = uri.scheme, !scheme.isEmpty,
               let host = uri.host
         else {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -800,7 +800,7 @@ extension URLBarView: TabLocationViewDelegate {
         // Make sure to use the result from urlBarDisplayTextForURL as it is responsible
         // for extracting out search terms when on a search page
         if let text = locationText,
-            let url = URL(string: text, invalidCharacters: false),
+            let url = URL(string: text),
             let host = url.host,
             AppConstants.punyCode {
             overlayText = url.absoluteString.replacingOccurrences(of: host, with: host.asciiHostToUTF8())

--- a/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -205,10 +205,8 @@ extension SiteTableViewController: UITableViewDragDelegate {
     ) -> [UIDragItem] {
         guard let panelVC = self as? LibraryPanelContextMenu,
               let site = panelVC.getSiteDetails(for: indexPath),
-              let url = URL(
-                string: site.url,
-                invalidCharacters: false
-              ), let itemProvider = NSItemProvider(contentsOf: url)
+              let url = URL(string: site.url),
+              let itemProvider = NSItemProvider(contentsOf: url)
         else { return [] }
 
         // Telemetry is being sent to legacy, need to add it to metrics.yml

--- a/firefox-ios/Client/Helpers/UserActivityHandler.swift
+++ b/firefox-ios/Client/Helpers/UserActivityHandler.swift
@@ -71,7 +71,7 @@ extension UserActivityHandler: TabEventHandler {
     }
 
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {
-        guard let url = URL(string: metadata.siteURL, invalidCharacters: false) else { return }
+        guard let url = URL(string: metadata.siteURL) else { return }
 
         setUserActivityForTab(tab, url: url)
     }

--- a/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -184,7 +184,7 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
         from cardLink: NimbusOnboardingLink?
     ) -> OnboardingLinkInfoModel? {
         guard let cardLink = cardLink,
-              let url = URL(string: cardLink.url, invalidCharacters: false)
+              let url = URL(string: cardLink.url)
         else { return nil }
 
         return OnboardingLinkInfoModel(title: cardLink.title, url: url)

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -166,13 +166,13 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
             return url
         }
         if let string = pageMetadata?.siteURL,
-           let siteURL = URL(string: string, invalidCharacters: false) {
+           let siteURL = URL(string: string) {
             // If the canonical URL from the page metadata doesn't contain the
             // "#" fragment, check if the tab's URL has a fragment and if so,
             // append it to the canonical URL.
             if siteURL.fragment == nil,
                let fragment = self.url?.fragment,
-               let siteURLWithFragment = URL(string: "\(string)#\(fragment)", invalidCharacters: false) {
+               let siteURLWithFragment = URL(string: "\(string)#\(fragment)") {
                 return siteURLWithFragment
             }
 
@@ -285,7 +285,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         didSet {
             guard let url = url,
                   let faviconURLString = faviconURL,
-                  let faviconUrl = URL(string: faviconURLString, invalidCharacters: false)
+                  let faviconUrl = URL(string: faviconURLString)
             else { return }
             faviconHelper.cacheFaviconURL(
                 siteURL: url,
@@ -301,7 +301,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
                 url = sourceURL
             }
             if let _url = url, let internalUrl = InternalURL(_url), internalUrl.isAuthorized {
-                url = URL(string: internalUrl.stripAuthorization, invalidCharacters: false)
+                url = URL(string: internalUrl.stripAuthorization)
             }
         }
     }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -726,7 +726,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
             newTab = addTab(flushToDisk: false, zombie: true, isPrivate: tabData.isPrivate)
         }
 
-        newTab.url = URL(string: tabData.siteUrl, invalidCharacters: false)
+        newTab.url = URL(string: tabData.siteUrl)
         newTab.lastTitle = tabData.title
         newTab.tabUUID = tabData.id.uuidString
         newTab.screenshotUUID = tabData.id

--- a/firefox-ios/Extensions/NotificationService/NotificationService.swift
+++ b/firefox-ios/Extensions/NotificationService/NotificationService.swift
@@ -201,7 +201,7 @@ class SyncDataDisplay {
 
     func displayNewSentTabNotification(tab: [String: String]) {
         if let urlString = tab[NotificationSentTabs.Payload.urlKey],
-            let url = URL(string: urlString, invalidCharacters: false),
+            let url = URL(string: urlString),
             url.isWebPage(),
             let title = tab[NotificationSentTabs.Payload.titleKey] {
             let tab = [

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -534,7 +534,7 @@ extension ShareViewController {
             return "firefox://open-url?url=\(encoded)"
         }
 
-        guard let url = URL(string: firefoxUrl(url), invalidCharacters: false) else { return }
+        guard let url = URL(string: firefoxUrl(url)) else { return }
         var responder = self as UIResponder?
         let selectorOpenURL = sel_registerName("openURL:")
         while let current = responder {

--- a/firefox-ios/Providers/Pocket/Model/PocketFeedStory.swift
+++ b/firefox-ios/Providers/Pocket/Model/PocketFeedStory.swift
@@ -29,8 +29,8 @@ struct PocketFeedStory {
                       return nil
                   }
 
-            guard let url = URL(string: urlS, invalidCharacters: false),
-                  let imageURL = URL(string: imageURLS, invalidCharacters: false)
+            guard let url = URL(string: urlS),
+                  let imageURL = URL(string: imageURLS)
             else { return nil }
 
             return PocketFeedStory(

--- a/firefox-ios/Providers/Pocket/PocketProvider.swift
+++ b/firefox-ios/Providers/Pocket/PocketProvider.swift
@@ -127,10 +127,7 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
             params.append(URLQueryItem(name: "consumer_key", value: pocketKey))
         }
 
-        guard let feedURL = URL(
-            string: pocketGlobalFeed,
-            invalidCharacters: false
-        )?.withQueryParams(params) else { return nil }
+        guard let feedURL = URL(string: pocketGlobalFeed)?.withQueryParams(params) else { return nil }
 
         return URLRequest(url: feedURL, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: 5)
     }

--- a/firefox-ios/Providers/TopSitesProvider.swift
+++ b/firefox-ios/Providers/TopSitesProvider.swift
@@ -126,7 +126,7 @@ private extension TopSitesProviderImplementation {
         // How sites are merged together. We compare against the url's base domain.
         // Example m.youtube.com is compared against `youtube.com`
         let unionOnURL = { (site: Site) -> String in
-            return URL(string: site.url, invalidCharacters: false)?.normalizedHost ?? ""
+            return URL(string: site.url)?.normalizedHost ?? ""
         }
 
         // Fetch the default sites
@@ -144,7 +144,7 @@ private extension TopSitesProviderImplementation {
             if case SiteType.pinnedSite = site.type {
                 return site
             }
-            let domain = URL(string: site.url, invalidCharacters: false)?.shortDisplayString
+            let domain = URL(string: site.url)?.shortDisplayString
             return defaultSites.first(where: { $0.title.lowercased() == domain }) ?? site
         }
 

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -416,7 +416,7 @@ extension FxAWebViewModel {
         // The app handles this event fully in native UI.
         let redirectUrl = RustFirefoxAccounts.redirectURL
         if let navigationURL = navigationURL {
-            let expectedRedirectURL = URL(string: redirectUrl, invalidCharacters: false)!
+            let expectedRedirectURL = URL(string: redirectUrl)!
             if navigationURL.scheme == expectedRedirectURL.scheme
                 && navigationURL.host == expectedRedirectURL.host
                 && navigationURL.path == expectedRedirectURL.path {

--- a/firefox-ios/RustFxA/RustFirefoxAccounts.swift
+++ b/firefox-ios/RustFxA/RustFirefoxAccounts.swift
@@ -196,7 +196,7 @@ open class RustFirefoxAccounts {
     private func update() {
         guard let accountManager = RustFirefoxAccounts.shared.accountManager else { return}
         let avatarUrl = accountManager.accountProfile()?.avatar
-        if let str = avatarUrl, let url = URL(string: str, invalidCharacters: false) {
+        if let str = avatarUrl, let url = URL(string: str) {
             avatar = Avatar(url: url)
         }
 

--- a/firefox-ios/Storage/ExtensionUtils.swift
+++ b/firefox-ios/Storage/ExtensionUtils.swift
@@ -101,7 +101,7 @@ public struct ExtensionUtils {
             if !text.hasPrefix("http") {
                 text = "http://" + text
             }
-            let url = URL(string: text, invalidCharacters: false)
+            let url = URL(string: text)
             return url?.publicSuffix != nil ? url : nil
         }
 

--- a/firefox-ios/Storage/Rust/RustRemoteTabs.swift
+++ b/firefox-ios/Storage/Rust/RustRemoteTabs.swift
@@ -361,12 +361,9 @@ internal class RemoteTabsCommandQueue {
 
 public extension RemoteTabRecord {
     func toRemoteTab(client: RemoteClient) -> RemoteTab? {
-        guard let url = Foundation.URL(string: self.urlHistory[0], invalidCharacters: false) else { return nil }
+        guard let url = Foundation.URL(string: self.urlHistory[0]) else { return nil }
         let history = self.urlHistory[1...].map { url in
-            Foundation.URL(
-                string: url,
-                invalidCharacters: false
-            )
+            Foundation.URL(string: url)
         }.compactMap { $0 }
         let icon = self.icon != nil ? Foundation.URL(fileURLWithPath: self.icon ?? "") : nil
 

--- a/firefox-ios/Storage/SQL/SQLitePinnedSites.swift
+++ b/firefox-ios/Storage/SQL/SQLitePinnedSites.swift
@@ -18,7 +18,7 @@ public func isIgnoredURL(_ url: URL) -> Bool {
 }
 
 public func isIgnoredURL(_ url: String) -> Bool {
-    if let url = URL(string: url, invalidCharacters: false) {
+    if let url = URL(string: url) {
         return isIgnoredURL(url)
     }
 

--- a/firefox-ios/Storage/Sharing.swift
+++ b/firefox-ios/Storage/Sharing.swift
@@ -17,6 +17,6 @@ public struct ShareItem: Equatable {
 
     // We only support sharing HTTP and HTTPS URLs, as well as data URIs.
     public var isShareable: Bool {
-        return URL(string: url, invalidCharacters: false)?.isWebPage() ?? false
+        return URL(string: url)?.isWebPage() ?? false
     }
 }

--- a/firefox-ios/Storage/Sites/Site.swift
+++ b/firefox-ios/Storage/Sites/Site.swift
@@ -32,15 +32,15 @@ public struct Site: Identifiable, Hashable, Equatable, Codable, CustomStringConv
     public var tileURL: URL {
         switch type {
         case .suggestedSite:
-            return URL(string: url, invalidCharacters: false) ?? URL(string: "about:blank")!
+            return URL(string: url) ?? URL(string: "about:blank")!
         default:
-            return URL(string: url, invalidCharacters: false)?.domainURL ?? URL(string: "about:blank")!
+            return URL(string: url)?.domainURL ?? URL(string: "about:blank")!
         }
     }
 
     /// Gets the second level domain (i.e. `http://www.example.com/` --> `example`).
     public var secondLevelDomain: String? {
-        return URL(string: url, invalidCharacters: false)?.host?.components(separatedBy: ".").suffix(2).first
+        return URL(string: url)?.host?.components(separatedBy: ".").suffix(2).first
     }
 
     public var faviconImageCacheKey: String {

--- a/firefox-ios/WidgetKit/Helpers.swift
+++ b/firefox-ios/WidgetKit/Helpers.swift
@@ -13,5 +13,5 @@ var scheme: String {
 
 func linkToContainingApp(_ urlSuffix: String = "", query: String) -> URL {
     let urlString = "\(scheme)://\(query)\(urlSuffix)"
-    return URL(string: urlString, invalidCharacters: false)!
+    return URL(string: urlString)!
 }

--- a/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -133,7 +133,7 @@ struct OpenTabsView: View {
 
     private func linkToContainingApp(_ urlSuffix: String = "", query: String) -> URL {
         let urlString = "\(scheme)://\(query)\(urlSuffix)"
-        return URL(string: urlString, invalidCharacters: false)!
+        return URL(string: urlString)!
     }
 }
 

--- a/firefox-ios/WidgetKit/TopSites/TopSitesWidget.swift
+++ b/firefox-ios/WidgetKit/TopSites/TopSitesWidget.swift
@@ -99,6 +99,6 @@ struct TopSitesView: View {
 
     private func linkToContainingApp(_ urlSuffix: String = "", query: String) -> URL {
         let urlString = "\(scheme)://\(query)\(urlSuffix)"
-        return URL(string: urlString, invalidCharacters: false)!
+        return URL(string: urlString)!
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppSendTabDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppSendTabDelegateTests.swift
@@ -24,7 +24,7 @@ final class AppFxACommandsTests: XCTestCase {
 
     func testOpenSendTabs_inactiveState_doesntCallDeeplink() {
         applicationStateProvider.applicationState = .inactive
-        let url = URL(string: "https://mozilla.com", invalidCharacters: false)!
+        let url = URL(string: "https://mozilla.com")!
         let subject = createSubject()
         subject.openSendTabs(for: [url])
 
@@ -33,7 +33,7 @@ final class AppFxACommandsTests: XCTestCase {
 
     func testOpenSendTabs_backgroundState_doesntCallDeeplink() {
         applicationStateProvider.applicationState = .background
-        let url = URL(string: "https://mozilla.com", invalidCharacters: false)!
+        let url = URL(string: "https://mozilla.com")!
         let subject = createSubject()
         subject.openSendTabs(for: [url])
 
@@ -41,7 +41,7 @@ final class AppFxACommandsTests: XCTestCase {
     }
 
     func testOpenSendTabs_activeWithOneURL_callsDeeplink() {
-        let url = URL(string: "https://mozilla.com", invalidCharacters: false)!
+        let url = URL(string: "https://mozilla.com")!
         let subject = createSubject()
         subject.openSendTabs(for: [url])
 
@@ -51,7 +51,7 @@ final class AppFxACommandsTests: XCTestCase {
     }
 
     func testOpenSendTabs_activeWithMultipleURLs_callsDeeplink() {
-        let url = URL(string: "https://mozilla.com", invalidCharacters: false)!
+        let url = URL(string: "https://mozilla.com")!
         let subject = createSubject()
         subject.openSendTabs(for: [url, url, url])
 
@@ -60,7 +60,7 @@ final class AppFxACommandsTests: XCTestCase {
 
     // MARK: - Close Remote Tabs Tests
     func testCloseSendTabs_activeWithOneURL_callsDeeplink() async {
-        let url = URL(string: "https://mozilla.com", invalidCharacters: false)!
+        let url = URL(string: "https://mozilla.com")!
         let subject = createSubject()
         let expectation = XCTestExpectation(description: "Close tabs called")
         subject.closeTabs(for: [url])
@@ -72,9 +72,9 @@ final class AppFxACommandsTests: XCTestCase {
     }
 
     func testCloseSendTabs_activeWithMultipleURLs_callsDeeplink() async {
-        let url1 = URL(string: "https://example.com", invalidCharacters: false)!
-        let url2 = URL(string: "https://example.com/1", invalidCharacters: false)!
-        let url3 = URL(string: "https://example.com/2", invalidCharacters: false)!
+        let url1 = URL(string: "https://example.com")!
+        let url2 = URL(string: "https://example.com/1")!
+        let url3 = URL(string: "https://example.com/2")!
         let subject = createSubject()
         let expectation = XCTestExpectation(description: "Close tabs called multiple times")
         subject.closeTabs(for: [url1, url2, url3])

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -721,7 +721,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         return reducer(
             state,
             ToolbarAction(
-                url: URL(string: "http://mozilla.com", invalidCharacters: false),
+                url: URL(string: "http://mozilla.com"),
                 isPrivate: false,
                 isShowingNavigationToolbar: isShowingNavigationToolbar,
                 canGoBack: true,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/NavigationBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/NavigationBarStateTests.swift
@@ -195,7 +195,7 @@ final class NavigationBarStateTests: XCTestCase, StoreTestUtility {
         return reducer(
             state,
             ToolbarAction(
-                url: URL(string: "http://mozilla.com", invalidCharacters: false),
+                url: URL(string: "http://mozilla.com"),
                 isPrivate: false,
                 isShowingNavigationToolbar: true,
                 canGoBack: true,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
@@ -516,7 +516,7 @@ final class ToolbarStateTests: XCTestCase, StoreTestUtility {
         return reducer(
             state,
             ToolbarAction(
-                url: URL(string: "http://mozilla.com", invalidCharacters: false),
+                url: URL(string: "http://mozilla.com"),
                 isPrivate: false,
                 isShowingNavigationToolbar: true,
                 canGoBack: true,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11990)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26100)

## :bulb: Description
Looked at that code while reviewing https://github.com/mozilla-mobile/firefox-ios/pull/25191. This PR here removes the `URL.init?(string: String, invalidCharacters: Bool)` extension method since there's no check anymore for iOS 17+ under the hood. `invalidCharacters` is always false and never `true` in the codebase, and since that parameter was never used anyway it seems since 121.2, might as well remove the method entirely. Let me know if that's fine!

The method was added in [FXIOS-7463](https://mozilla-hub.atlassian.net/browse/FXIOS-7463) and removed in [FXIOS-8107](https://mozilla-hub.atlassian.net/browse/FXIOS-8107)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

