### PR TITLE
Add FXIOS-11999 [Address Bar Menu] P3. Add nimbus flag

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1322,12 +1322,13 @@
 		B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */; };
 		BA03AE592D41715900C7FA7B /* MockMZKeychainWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA03AE582D41714B00C7FA7B /* MockMZKeychainWrapper.swift */; };
 		BA1237BA2DAE55EA00BB6333 /* NightModeAllFramesAtDocumentStart.js in Resources */ = {isa = PBXBuildFile; fileRef = BA1237B72DAE54BB00BB6333 /* NightModeAllFramesAtDocumentStart.js */; };
+		BA1237BC2DAE608100BB6333 /* GenericSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1237BB2DAE607B00BB6333 /* GenericSectionView.swift */; };
+		BA1237BF2DAE675B00BB6333 /* GenericImageOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1237BE2DAE675400BB6333 /* GenericImageOption.swift */; };
 		BA1C68BA2B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1C68B92B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift */; };
 		BA1C68BC2B7ED153000D9397 /* MockWebKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */; };
 		BA4BB99A2D7F374C006BD137 /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BB9992D7F3743006BD137 /* AppearanceSettingsView.swift */; };
 		BA4BB99E2D7FB38B006BD137 /* ThemeSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BB99D2D7FB382006BD137 /* ThemeSelectionView.swift */; };
 		BA4BB9A02D7FB3C9006BD137 /* ThemeOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BB99F2D7FB3C3006BD137 /* ThemeOptionView.swift */; };
-		BA4BB9A22D7FE961006BD137 /* GenericSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BB9A12D7FE952006BD137 /* GenericSectionView.swift */; };
 		BA4BB9A42D7FF754006BD137 /* DarkModeToggleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BB9A32D7FF74D006BD137 /* DarkModeToggleView.swift */; };
 		BA7A14842C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7A14832C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift */; };
 		BA8E197F2BF2FB1900590B5F /* AddressFormManager.js in Resources */ = {isa = PBXBuildFile; fileRef = BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */; };
@@ -8935,13 +8936,14 @@
 		BA03AE582D41714B00C7FA7B /* MockMZKeychainWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMZKeychainWrapper.swift; sourceTree = "<group>"; };
 		BA05405089CFDC6097258640 /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/3DTouchActions.strings"; sourceTree = "<group>"; };
 		BA1237B72DAE54BB00BB6333 /* NightModeAllFramesAtDocumentStart.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = NightModeAllFramesAtDocumentStart.js; sourceTree = "<group>"; };
+		BA1237BB2DAE607B00BB6333 /* GenericSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericSectionView.swift; sourceTree = "<group>"; };
+		BA1237BE2DAE675400BB6333 /* GenericImageOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericImageOption.swift; sourceTree = "<group>"; };
 		BA1C68B92B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKFrameInfoExtensionsTest.swift; sourceTree = "<group>"; };
 		BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebKit.swift; sourceTree = "<group>"; };
 		BA354251BD3FFF63A161E385 /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		BA4BB9992D7F3743006BD137 /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		BA4BB99D2D7FB382006BD137 /* ThemeSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSelectionView.swift; sourceTree = "<group>"; };
 		BA4BB99F2D7FB3C3006BD137 /* ThemeOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeOptionView.swift; sourceTree = "<group>"; };
-		BA4BB9A12D7FE952006BD137 /* GenericSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericSectionView.swift; sourceTree = "<group>"; };
 		BA4BB9A32D7FF74D006BD137 /* DarkModeToggleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeToggleView.swift; sourceTree = "<group>"; };
 		BA7A14832C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAddressWebViewManager.swift; sourceTree = "<group>"; };
 		BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AddressFormManager.js; sourceTree = "<group>"; };
@@ -13291,8 +13293,9 @@
 		BA4BB9962D7F371F006BD137 /* AppearanceSettings */ = {
 			isa = PBXGroup;
 			children = (
+				BA1237BE2DAE675400BB6333 /* GenericImageOption.swift */,
+				BA1237BB2DAE607B00BB6333 /* GenericSectionView.swift */,
 				BA4BB9A32D7FF74D006BD137 /* DarkModeToggleView.swift */,
-				BA4BB9A12D7FE952006BD137 /* GenericSectionView.swift */,
 				BA4BB99F2D7FB3C3006BD137 /* ThemeOptionView.swift */,
 				BA4BB99D2D7FB382006BD137 /* ThemeSelectionView.swift */,
 				BA4BB9992D7F3743006BD137 /* AppearanceSettingsView.swift */,
@@ -16998,7 +17001,6 @@
 				8A855C032D1EE9EF00C1A2F3 /* ContextMenuCoordinator.swift in Sources */,
 				EB9A179D20E69A7F00B12184 /* LegacyTheme.swift in Sources */,
 				8A2DAD4B2CC02AA00067ECD0 /* LabelButtonHeaderView.swift in Sources */,
-				BA4BB9A22D7FE961006BD137 /* GenericSectionView.swift in Sources */,
 				C825E9832832A425006CB811 /* NimbusSearchBarLayer.swift in Sources */,
 				8AF347DE2CADD1B200624036 /* HomepageState.swift in Sources */,
 				C8DC90C92A0675E70008832B /* MarkupParsingUtility.swift in Sources */,
@@ -17656,6 +17658,7 @@
 				8ADC2A1D2A33999800543DAA /* VersionSetting.swift in Sources */,
 				8ADAE41E2A33A0E2007BF926 /* ShowIntroductionSetting.swift in Sources */,
 				8AF10D8F29D774090086351D /* SceneSetupHelper.swift in Sources */,
+				BA1237BC2DAE608100BB6333 /* GenericSectionView.swift in Sources */,
 				C4E398601D22C409004E89BA /* TopTabsLayout.swift in Sources */,
 				5A2918CB2B522338002B197E /* GeneralBrowserAction.swift in Sources */,
 				8A5D1CC12A30DCA4005AD35C /* SettingDisclosureUtility.swift in Sources */,
@@ -17901,6 +17904,7 @@
 				8AD40FCA27BADC4B00672675 /* ReaderModeButton.swift in Sources */,
 				8A3EF7FB2A2FCF9D00796E3A /* ForceCrashSetting.swift in Sources */,
 				2178A6A4291455F7002EC290 /* ReaderModeFontSizeButton.swift in Sources */,
+				BA1237BF2DAE675B00BB6333 /* GenericImageOption.swift in Sources */,
 				BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */,
 				BCFF93F22AAF9688005B5B71 /* FirefoxSuggestSettings.swift in Sources */,
 				BCFF93F42AAF9879005B5B71 /* FirefoxSuggestSettingsViewController.swift in Sources */,

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -12,6 +12,7 @@ import UIKit
 enum NimbusFeatureFlagID: String, CaseIterable {
     case addressAutofillEdit
     case appearanceMenu
+    case addressBarMenu
     case bookmarksRefactor
     case bottomSearchBar
     case contextualHintForToolbar
@@ -59,6 +60,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     var debugKey: String? {
         switch self {
         case    .appearanceMenu,
+                .addressBarMenu,
                 .bookmarksRefactor,
                 .deeplinkOptimizationRefactor,
                 .homepageRebuild,
@@ -113,6 +115,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.SentFromFirefox
         // Cases where users do not have the option to manipulate a setting.
         case .appearanceMenu,
+                .addressBarMenu,
                 .contextualHintForToolbar,
                 .bookmarksRefactor,
                 .addressAutofillEdit,

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/GenericImageOption.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/GenericImageOption.swift
@@ -1,0 +1,81 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+
+/// A view that represents a selectable option with an image and a radio button.
+struct GenericImageOption: View {
+    private struct UX {
+        static let optionWidth: CGFloat = 60
+        static let optionHeight: CGFloat = 100
+        static let cornerRadius: CGFloat = 12
+        static let spacing: CGFloat = 8
+
+        static let selectedBorderWidth: CGFloat = 3
+        static let unselectedBorderWidth: CGFloat = 1
+
+        static let selectedBorderColor = Color.blue
+        static let unselectedBorderColor = Color.gray
+
+        static let textColor = Color.primary
+
+        static let radioSize: CGFloat = 22
+    }
+
+    // Properties
+    let isSelected: Bool
+    let onSelected: (() -> Void)?
+    let label: String
+    let imageName: String
+
+    var body: some View {
+        VStack(spacing: UX.spacing) {
+            selectableOptionVisual
+            selectableOptionLabel
+            selectableOptionRadioButton
+        }
+        .onTapGesture {
+            onSelected?()
+        }
+        .accessibilityElement()
+        .accessibilityLabel("\(label)")
+        .accessibilityValue("\(isSelected ? 1 : 0)")
+        .accessibilityAddTraits([.isButton])
+        .accessibilityAction {
+            onSelected?()
+        }
+    }
+
+    private var selectableOptionVisual: some View {
+        RoundedRectangle(cornerRadius: UX.cornerRadius)
+            .stroke(isSelected ? UX.selectedBorderColor : UX.unselectedBorderColor,
+                    lineWidth: isSelected ? UX.selectedBorderWidth : UX.unselectedBorderWidth)
+            .background(
+                Image(imageName)
+                    .resizable()
+                    .scaledToFill()
+                    // Accessibility label is on the parent view on the whole ThemeOptionView
+                    .accessibility(hidden: true)
+                    .clipShape(RoundedRectangle(cornerRadius: UX.cornerRadius))
+            )
+            .frame(width: UX.optionWidth, height: UX.optionHeight)
+    }
+
+    /// The text label displaying the theme option's name.
+    private var selectableOptionLabel: some View {
+        Text(label)
+            .font(.caption)
+            .foregroundColor(UX.textColor)
+    }
+
+    /// The radio button image indicating selection state.
+    private var selectableOptionRadioButton: some View {
+        Image(isSelected ? ImageIdentifiers.radioButtonSelected : ImageIdentifiers.radioButtonNotSelected)
+            .resizable()
+            .scaledToFit()
+            .frame(width: UX.radioSize, height: UX.radioSize)
+            // Accessibility label is on the parent view on the whole ThemeOptionView
+            .accessibilityHidden(true)
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/ThemeOptionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/ThemeOptionView.swift
@@ -3,96 +3,33 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
+import Common
 
 /// A view that represents a selectable theme option.
 struct ThemeOptionView: View {
-    private struct UX {
-        static let optionWidth: CGFloat = 60
-        static let optionHeight: CGFloat = 100
-        static let cornerRadius: CGFloat = 12
-        static let spacing: CGFloat = 8
-
-        static let selectedBorderWidth: CGFloat = 3
-        static let unselectedBorderWidth: CGFloat = 1
-
-        static let selectedBorderColor = Color.blue
-        static let unselectedBorderColor = Color.gray
-
-        static let textColor = Color.primary
-
-        static let radioSize: CGFloat = 22
-    }
-
     let theme: ThemeSelectionView.ThemeOption
-
     /// A flag indicating whether this option is currently selected.
     let isSelected: Bool
-
     /// Callback executed when a new theme option is selected.
     let onSelected: (() -> Void)?
 
     var body: some View {
-        VStack(spacing: UX.spacing) {
-            themeOptionVisual
-            themeOptionLabel
-            themeOptionRadioButton
-        }
-        .onTapGesture {
-            onSelected?()
-        }
-        .accessibilityElement()
-        .accessibilityLabel("\(theme.rawValue)")
-        .accessibilityValue("\(isSelected ? 1 : 0)")
-        .accessibilityAddTraits([.isButton])
-        .accessibilityAction {
-            onSelected?()
-        }
+        GenericImageOption(
+            isSelected: isSelected,
+            onSelected: onSelected,
+            label: theme.rawValue,
+            imageName: imageName(for: theme)
+        )
     }
 
-    /// The visual representation of the theme option (rounded rectangle with background image).
-    private var themeOptionVisual: some View {
-        RoundedRectangle(cornerRadius: UX.cornerRadius)
-            .stroke(isSelected ? UX.selectedBorderColor : UX.unselectedBorderColor,
-                    lineWidth: isSelected ? UX.selectedBorderWidth : UX.unselectedBorderWidth)
-            .background(
-                themeOptionBackground(for: theme)
-                    .clipShape(RoundedRectangle(cornerRadius: UX.cornerRadius))
-            )
-            .frame(width: UX.optionWidth, height: UX.optionHeight)
-    }
-
-    /// The text label displaying the theme option's name.
-    private var themeOptionLabel: some View {
-        Text(theme.rawValue)
-            .font(.caption)
-            .foregroundColor(UX.textColor)
-    }
-
-    /// The radio button image indicating selection state.
-    private var themeOptionRadioButton: some View {
-        Image(isSelected ? ImageIdentifiers.radioButtonSelected : ImageIdentifiers.radioButtonNotSelected)
-            .resizable()
-            .scaledToFit()
-            .frame(width: UX.radioSize, height: UX.radioSize)
-            // Accessibility label is on the parent view on the whole ThemeOptionView
-            .accessibilityHidden(true)
-    }
-
-    func themeOptionBackground(for themeOption: ThemeSelectionView.ThemeOption) -> some View {
-        let imageName: String
+    func imageName(for themeOption: ThemeSelectionView.ThemeOption) -> String {
         switch themeOption {
         case .automatic:
-            imageName = ImageIdentifiers.Appearance.automaticBrowserThemeGradient
+            return ImageIdentifiers.Appearance.automaticBrowserThemeGradient
         case .light:
-            imageName = ImageIdentifiers.Appearance.lightBrowserThemeGradient
+            return ImageIdentifiers.Appearance.lightBrowserThemeGradient
         case .dark:
-            imageName = ImageIdentifiers.Appearance.darkBrowserThemeGradient
+            return ImageIdentifiers.Appearance.darkBrowserThemeGradient
         }
-
-        return Image(imageName)
-            .resizable()
-            .scaledToFill()
-            // Accessibility label is on the parent view on the whole ThemeOptionView
-            .accessibility(hidden: true)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -27,6 +27,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
             title: nil,
             children: [
                 FeatureFlagsBoolSetting(
+                    with: .addressBarMenu,
+                    titleText: format(string: "Enable New AddressBar Menu"),
+                    statusText: format(string: "Toggle to show the new address bar menu")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .appearanceMenu,
                     titleText: format(string: "Enable New Appearance Menu"),
                     statusText: format(string: "Toggle to show the new apperance menu")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -16,6 +16,9 @@ final class NimbusFeatureFlagLayer {
         case .appearanceMenu:
             return checkAppearanceMenuFeature(from: nimbus)
 
+        case .addressBarMenu:
+            return checkAddressBarMenuFeature(from: nimbus)
+
         case .bookmarksRefactor:
             return checkBookmarksRefactor(from: nimbus)
 
@@ -351,6 +354,11 @@ final class NimbusFeatureFlagLayer {
 
     private func checkAppearanceMenuFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.appearanceMenuFeature.value()
+        return config.status
+    }
+
+    private func checkAddressBarMenuFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.addressBarMenuFeature.value()
         return config.status
     }
 

--- a/firefox-ios/nimbus-features/newAddressBarMenu.yaml
+++ b/firefox-ios/nimbus-features/newAddressBarMenu.yaml
@@ -1,0 +1,17 @@
+# The configuration for the new address menu entry
+features:
+  address-bar-menu-feature:
+    description: >
+      This property determines if we show the new address bar menu entry or the toolbar menu in settings
+    variables:
+      status:
+        description: If true, we will show the new address bar menu entry
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          status: false
+      - channel: developer
+        value:
+          status: false

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -32,6 +32,7 @@ include:
   - nimbus-features/loginsVerificationEnabled.yaml
   - nimbus-features/nativeErrorPageFeature.yaml
   - nimbus-features/newAppearanceMenu.yaml
+  - nimbus-features/newAddressBarMenu.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml
   - nimbus-features/pdfRefactorFeature.yaml
   - nimbus-features/ratingPromptFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11999)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26113)

⚠️ NOTE: This a PR in a stack of PRs to make reviewing easier
- https://github.com/mozilla-mobile/firefox-ios/pull/26115
- https://github.com/mozilla-mobile/firefox-ios/pull/26116
- ➡️ https://github.com/mozilla-mobile/firefox-ios/pull/26117
- https://github.com/mozilla-mobile/firefox-ios/pull/26118

## :bulb: Description
This PR:
- Adds nimbus flag and debug toggle for turning on/off new address bar menu.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

