### PR TITLE
Add FXIOS-11999 [Address Bar Menu] P4. Implement new address bar UI

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1352,6 +1352,8 @@
 		BA1237BA2DAE55EA00BB6333 /* NightModeAllFramesAtDocumentStart.js in Resources */ = {isa = PBXBuildFile; fileRef = BA1237B72DAE54BB00BB6333 /* NightModeAllFramesAtDocumentStart.js */; };
 		BA1237BC2DAE608100BB6333 /* GenericSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1237BB2DAE607B00BB6333 /* GenericSectionView.swift */; };
 		BA1237BF2DAE675B00BB6333 /* GenericImageOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1237BE2DAE675400BB6333 /* GenericImageOption.swift */; };
+		BA1237C12DAE6D2C00BB6333 /* AddressBarSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1237C02DAE6D2500BB6333 /* AddressBarSelectionView.swift */; };
+		BA1237C32DAE6D5700BB6333 /* AddressBarSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1237C22DAE6D5100BB6333 /* AddressBarSettingsView.swift */; };
 		BA1C68BA2B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1C68B92B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift */; };
 		BA1C68BC2B7ED153000D9397 /* MockWebKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */; };
 		BA4BB99A2D7F374C006BD137 /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BB9992D7F3743006BD137 /* AppearanceSettingsView.swift */; };
@@ -9015,6 +9017,8 @@
 		BA1237B72DAE54BB00BB6333 /* NightModeAllFramesAtDocumentStart.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = NightModeAllFramesAtDocumentStart.js; sourceTree = "<group>"; };
 		BA1237BB2DAE607B00BB6333 /* GenericSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericSectionView.swift; sourceTree = "<group>"; };
 		BA1237BE2DAE675400BB6333 /* GenericImageOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericImageOption.swift; sourceTree = "<group>"; };
+		BA1237C02DAE6D2500BB6333 /* AddressBarSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBarSelectionView.swift; sourceTree = "<group>"; };
+		BA1237C22DAE6D5100BB6333 /* AddressBarSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBarSettingsView.swift; sourceTree = "<group>"; };
 		BA1C68B92B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKFrameInfoExtensionsTest.swift; sourceTree = "<group>"; };
 		BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebKit.swift; sourceTree = "<group>"; };
 		BA354251BD3FFF63A161E385 /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
@@ -13411,6 +13415,8 @@
 			children = (
 				214099602DCBF4DB004881E1 /* Zoom */,
 				BA4BB9992D7F3743006BD137 /* AppearanceSettingsView.swift */,
+				BA1237C22DAE6D5100BB6333 /* AddressBarSettingsView.swift */,
+				BA1237C02DAE6D2500BB6333 /* AddressBarSelectionView.swift */,
 				BA1237BE2DAE675400BB6333 /* GenericImageOption.swift */,
 				BA4BB9A32D7FF74D006BD137 /* DarkModeToggleView.swift */,
 				BA4BB99F2D7FB3C3006BD137 /* ThemeOptionView.swift */,
@@ -17123,6 +17129,7 @@
 				8A19ACB02A329078001C2147 /* AutofillCreditCardSettings.swift in Sources */,
 				E1E5BE252A28F7BE00248F77 /* PasswordDetailViewControllerModel.swift in Sources */,
 				E1FE133129C22726002A65FF /* BackgroundFetchAndProcessingUtility.swift in Sources */,
+				BA1237C12DAE6D2C00BB6333 /* AddressBarSelectionView.swift in Sources */,
 				8A4EA0D12C010BE700E4E4F1 /* MicrosurveySurfaceManager.swift in Sources */,
 				8AD40FD527BB1C1000672675 /* LockButton.swift in Sources */,
 				5F130D2E2483508E00B0F7D0 /* FxAWebViewModel.swift in Sources */,
@@ -17415,6 +17422,7 @@
 				EBB8950C21939E4100EB91A0 /* FirefoxTabContentBlocker.swift in Sources */,
 				21618A632A422A3900A5189E /* ThemeMiddleware.swift in Sources */,
 				0E77DF0F2CB8220000B80BA1 /* GeneratedPasswordStorage.swift in Sources */,
+				BA1237C32DAE6D5700BB6333 /* AddressBarSettingsView.swift in Sources */,
 				219A0FDB2ACCCFFC009A6D1A /* InactiveTabsSectionManager.swift in Sources */,
 				B2981F8A2B71AD7A00132C1B /* AutofillAccessoryViewButtonItem.swift in Sources */,
 				63B213282CCA796D00A466DB /* NativeErrorPageAction.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -392,7 +392,10 @@ final class SettingsCoordinator: BaseCoordinator,
     func pressedToolbar() {
         let viewModel = SearchBarSettingsViewModel(prefs: profile.prefs)
         if LegacyFeatureFlagsManager.shared.isFeatureEnabled(.addressBarMenu, checking: .buildOnly) {
-            let viewController = UIHostingController(rootView: AddressBarSettingsView(windowUUID: windowUUID, viewModel: viewModel))
+            let viewController = UIHostingController(
+                rootView: AddressBarSettingsView(
+                windowUUID: windowUUID,
+                viewModel: viewModel))
             viewController.title = .Settings.AddressBar.AddressBarMenuTitle
             router.push(viewController)
         } else {

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -192,7 +192,9 @@ final class SettingsCoordinator: BaseCoordinator,
 
         case .toolbar:
             let viewModel = SearchBarSettingsViewModel(prefs: profile.prefs)
-            return SearchBarSettingsViewController(viewModel: viewModel, windowUUID: windowUUID)
+            return LegacyFeatureFlagsManager.shared.isFeatureEnabled(.addressBarMenu, checking: .buildOnly)
+               ? UIHostingController(rootView: AddressBarSettingsView(windowUUID: windowUUID, viewModel: viewModel))
+               : SearchBarSettingsViewController(viewModel: viewModel, windowUUID: windowUUID)
 
         case .topSites:
             let viewController = TopSitesSettingsViewController(windowUUID: windowUUID)
@@ -389,8 +391,14 @@ final class SettingsCoordinator: BaseCoordinator,
 
     func pressedToolbar() {
         let viewModel = SearchBarSettingsViewModel(prefs: profile.prefs)
-        let viewController = SearchBarSettingsViewController(viewModel: viewModel, windowUUID: windowUUID)
-        router.push(viewController)
+        if LegacyFeatureFlagsManager.shared.isFeatureEnabled(.addressBarMenu, checking: .buildOnly) {
+            let viewController = UIHostingController(rootView: AddressBarSettingsView(windowUUID: windowUUID, viewModel: viewModel))
+            viewController.title = .Settings.AddressBar.AddressBarMenuTitle
+            router.push(viewController)
+        } else {
+            let viewController = SearchBarSettingsViewController(viewModel: viewModel, windowUUID: windowUUID)
+            router.push(viewController)
+        }
     }
 
     func pressedTheme() {

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -13,7 +13,6 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case addressAutofillEdit
     case addressBarMenu
     case appearanceMenu
-    case addressBarMenu
     case bookmarksRefactor
     case bottomSearchBar
     case cleanupHistoryReenabled

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -13,6 +13,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case addressAutofillEdit
     case addressBarMenu
     case appearanceMenu
+    case addressBarMenu
     case bookmarksRefactor
     case bottomSearchBar
     case cleanupHistoryReenabled

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+import Common
+
+struct AddressBarSelectionView: View {
+    let theme: Theme?
+
+    @State var selectedAddressBarPostion: SearchBarPosition = .bottom
+
+    /// Callback executed when a new option is selected.
+    var onSelected: ((SearchBarPosition) -> Void)?
+
+    var backgroundColor: Color {
+        return Color(theme?.colors.layer2 ?? UIColor.clear)
+    }
+
+    private struct UX {
+        static let spacing: CGFloat = 36
+        static let sectionPadding: CGFloat = 16
+        static let dividerHeight: CGFloat = 0.7
+    }
+
+    var body: some View {
+        HStack(spacing: UX.spacing) {
+            ForEach(SearchBarPosition.allCases, id: \.label) { addressBarPosition in
+                GenericImageOption(
+                    isSelected: selectedAddressBarPostion == addressBarPosition,
+                    onSelected: {
+                        selectedAddressBarPostion = addressBarPosition
+                        onSelected?(selectedAddressBarPostion)
+                    },
+                    label: addressBarPosition.label,
+                    imageName: addressBarPosition.imageName
+                )
+            }
+        }
+        .padding(.vertical, UX.sectionPadding)
+        .frame(maxWidth: .infinity)
+        .background(backgroundColor)
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
@@ -8,7 +8,7 @@ import Common
 struct AddressBarSelectionView: View {
     let theme: Theme?
 
-    @State var selectedAddressBarPostion: SearchBarPosition = .bottom
+    @State var selectedAddressBarPosition: SearchBarPosition = .bottom
 
     /// Callback executed when a new option is selected.
     var onSelected: ((SearchBarPosition) -> Void)?
@@ -27,9 +27,9 @@ struct AddressBarSelectionView: View {
         HStack(spacing: UX.spacing) {
             ForEach(SearchBarPosition.allCases, id: \.label) { addressBarPosition in
                 GenericImageOption(
-                    isSelected: selectedAddressBarPostion == addressBarPosition,
+                    isSelected: selectedAddressBarPosition == addressBarPosition,
                     onSelected: {
-                        selectedAddressBarPostion = addressBarPosition
+                        selectedAddressBarPosition = addressBarPosition
                         onSelected?(selectedAddressBarPostion)
                     },
                     label: addressBarPosition.label,

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
@@ -30,7 +30,7 @@ struct AddressBarSelectionView: View {
                     isSelected: selectedAddressBarPosition == addressBarPosition,
                     onSelected: {
                         selectedAddressBarPosition = addressBarPosition
-                        onSelected?(selectedAddressBarPostion)
+                        onSelected?(selectedAddressBarPosition)
                     },
                     label: addressBarPosition.label,
                     imageName: addressBarPosition.imageName

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSettingsView.swift
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+import Common
+import Shared
+
+/// The main view displaying the settings for the address bar position menu.
+struct AddressBarSettingsView: View {
+    let windowUUID: WindowUUID
+    /// NOTE: To avoid duplication, the old view model is reused in the new address bar setting menu.
+    /// TODO(FXIOS-12000): Once the experiment is done, we can remove the old viewmodel and move it to here.
+    let viewModel: SearchBarSettingsViewModel
+
+    @Environment(\.themeManager)
+    var themeManager
+
+    @State private var currentTheme: Theme?
+
+    private var addressBarPosition: SearchBarPosition {
+        LegacyFeatureFlagsManager.shared.getCustomState(for: .searchBarPosition) ?? .bottom
+    }
+
+    private var viewBackground: Color {
+        return Color(currentTheme?.colors.layer1 ?? UIColor.clear)
+    }
+
+    private struct UX {
+        static let spacing: CGFloat = 24
+    }
+
+    var body: some View {
+        VStack {
+            GenericSectionView(theme: currentTheme, title: .Settings.AddressBar.AddressBarSectionTitle) {
+                AddressBarSelectionView(
+                    theme: currentTheme,
+                    selectedAddressBarPostion: addressBarPosition,
+                    onSelected: viewModel.saveSearchBarPosition)
+            }
+            Spacer()
+        }
+        .padding(.top, UX.spacing)
+        .frame(maxWidth: .infinity)
+        .background(viewBackground)
+        .onAppear {
+            currentTheme = themeManager.getCurrentTheme(for: windowUUID)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
+            currentTheme = themeManager.getCurrentTheme(for: windowUUID)
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSettingsView.swift
@@ -35,7 +35,7 @@ struct AddressBarSettingsView: View {
             GenericSectionView(theme: currentTheme, title: .Settings.AddressBar.AddressBarSectionTitle) {
                 AddressBarSelectionView(
                     theme: currentTheme,
-                    selectedAddressBarPostion: addressBarPosition,
+                    selectedAddressBarPosition: addressBarPosition,
                     onSelected: viewModel.saveSearchBarPosition)
             }
             Spacer()

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -29,7 +29,7 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
             children: [
                 FeatureFlagsBoolSetting(
                     with: .addressBarMenu,
-                    titleText: format(string: "AddressBar Menu"),
+                    titleText: format(string: "Enable New AddressBar Menu"),
                     statusText: format(string: "Toggle to show the new address bar menu")
                 ) { [weak self] _ in
                     self?.reloadView()

--- a/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -6,9 +6,10 @@ import Common
 import Foundation
 import Shared
 
-enum SearchBarPosition: String, FlaggableFeatureOptions {
-    case bottom
+enum SearchBarPosition: String, FlaggableFeatureOptions, CaseIterable {
     case top
+    case bottom
+
 
     var getLocalizedTitle: String {
         switch self {
@@ -16,6 +17,28 @@ enum SearchBarPosition: String, FlaggableFeatureOptions {
             return .Settings.Toolbar.Bottom
         case .top:
             return .Settings.Toolbar.Top
+        }
+    }
+
+    /// NOTE: To avoid duplication, this enum is reused in the new address bar setting menu.
+    /// TODO(FXIOS-12000): Once the experiment is done, we can move this enum closer to the new UI.
+    var label: String {
+        switch self {
+        case .top:
+            return .Settings.AddressBar.Top
+        case .bottom:
+            return .Settings.AddressBar.Bottom
+        }
+    }
+
+    /// NOTE: To avoid duplication, this enum is reused in the new address bar setting menu.
+    /// TODO(FXIOS-12000): Once the experiment is done, we can move this enum closer to the new UI and remove unused props.
+    var imageName: String {
+        switch self {
+        case .top:
+            return ImageIdentifiers.AddressBar.addressBarIllustrationTop
+        case .bottom:
+            return ImageIdentifiers.AddressBar.addressBarIllustrationBottom
         }
     }
 }
@@ -55,7 +78,6 @@ extension SearchBarLocationProvider {
 }
 
 final class SearchBarSettingsViewModel: FeatureFlaggable {
-    var title: String = .Settings.Toolbar.Toolbar
     weak var delegate: SearchBarPreferenceDelegate?
 
     private let prefs: Prefs
@@ -65,8 +87,16 @@ final class SearchBarSettingsViewModel: FeatureFlaggable {
         self.notificationCenter = notificationCenter
     }
 
+    var isNewAddressBarOn: Bool {
+        featureFlags.isFeatureEnabled(.addressBarMenu, checking: .buildOnly)
+    }
+
+    var title: String {
+        isNewAddressBarOn ? .Settings.AddressBar.AddressBarMenuTitle : .Settings.Toolbar.Toolbar
+    }
+
     var searchBarTitle: String {
-        searchBarPosition.getLocalizedTitle
+        isNewAddressBarOn ? "" : searchBarPosition.getLocalizedTitle
     }
 
     var searchBarPosition: SearchBarPosition {
@@ -97,7 +127,7 @@ final class SearchBarSettingsViewModel: FeatureFlaggable {
 }
 
 // MARK: Private
-private extension SearchBarSettingsViewModel {
+extension SearchBarSettingsViewModel {
     func saveSearchBarPosition(_ searchBarPosition: SearchBarPosition) {
         featureFlags.set(feature: .searchBarPosition, to: searchBarPosition)
         delegate?.didUpdateSearchBarPositionPreference()
@@ -107,7 +137,7 @@ private extension SearchBarSettingsViewModel {
         notificationCenter.post(name: .SearchBarPositionDidChange, withObject: notificationObject)
     }
 
-    func recordPreferenceChange(_ searchBarPosition: SearchBarPosition) {
+    private func recordPreferenceChange(_ searchBarPosition: SearchBarPosition) {
         let extras = [TelemetryWrapper.EventExtraKey.preference.rawValue: PrefsKeys.FeatureFlags.SearchBarPosition,
                       TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: searchBarPosition.rawValue]
         TelemetryWrapper.recordEvent(category: .action,

--- a/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -10,7 +10,6 @@ enum SearchBarPosition: String, FlaggableFeatureOptions, CaseIterable {
     case top
     case bottom
 
-
     var getLocalizedTitle: String {
         switch self {
         case .bottom:

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -31,6 +31,7 @@ include:
   - nimbus-features/nativeErrorPageFeature.yaml
   - nimbus-features/newAddressBarMenu.yaml
   - nimbus-features/newAppearanceMenu.yaml
+  - nimbus-features/newAddressBarMenu.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml
   - nimbus-features/pdfRefactorFeature.yaml
   - nimbus-features/ratingPromptFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11999)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26113)


⚠️ NOTE: This a PR in a stack of PRs to make reviewing easier
- https://github.com/mozilla-mobile/firefox-ios/pull/26115
- https://github.com/mozilla-mobile/firefox-ios/pull/26116
- https://github.com/mozilla-mobile/firefox-ios/pull/26117
- ➡️ https://github.com/mozilla-mobile/firefox-ios/pull/26118

## :bulb: Description
This PR:
- Adds new address bar UI and integrates it in the settings coordinator.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

