### PR TITLE
Bugfix FXIOS-11588 - Toolbar position persistance problems

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
@@ -367,8 +367,12 @@ extension IntroViewController: OnboardingCardDelegate {
             turnSystemTheme(on: true)
         case .toolbarBottom:
             featureFlags.set(feature: .searchBarPosition, to: SearchBarPosition.bottom)
+            let notificationObject = [PrefsKeys.FeatureFlags.SearchBarPosition: SearchBarPosition.bottom]
+            notificationCenter.post(name: .SearchBarPositionDidChange, withObject: notificationObject)
         case .toolbarTop:
             featureFlags.set(feature: .searchBarPosition, to: SearchBarPosition.top)
+            let notificationObject = [PrefsKeys.FeatureFlags.SearchBarPosition: SearchBarPosition.top]
+            notificationCenter.post(name: .SearchBarPositionDidChange, withObject: notificationObject)
         }
         viewModel.telemetryUtility.sendMultipleChoiceButtonActionTelemetry(
             from: cardName,

--- a/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceButtonView.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceButtonView.swift
@@ -99,6 +99,7 @@ class OnboardingMultipleChoiceButtonView: UIView, Themeable {
 
         setupLayout()
         updateUIForState()
+        handleButtonTapIfSelected()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -169,6 +170,14 @@ class OnboardingMultipleChoiceButtonView: UIView, Themeable {
             from: viewModel.presentingCardName
         )
         stateUpdateDelegate?.updateSelectedButton(to: viewModel.info.title)
+    }
+
+    private func handleButtonTapIfSelected() {
+        guard viewModel.isSelected else { return }
+        // Call `buttonTapped` immediately if the button is selected to ensure the user preference is saved.
+        // This avoids having two default cases between experiments, preventing scenarios where the toolbar
+        // is initially set to the bottom and then changes to the top after an experiment update.
+        buttonTapped()
     }
 
     // MARK: - Theme


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11588)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25232)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Save the onboarding selection in user preferences from the start to ensure consistent behavior when changing toolbar experiments.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

