### PR TITLE
Bugfix MTE-4509 Intermittent issues in sync integration tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_tabs.js
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_tabs.js
@@ -14,7 +14,7 @@ var phases = { "phase1": "profile1" };
 // expected tabs state
 var tabs1 = [
     { uri: "https://example.com/",
-      profile: "Fennec (cso) on iOS"
+      profile: "Fennec (administrator) on iOS"
     }
 ];
 

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_tabs.js
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_tabs.js
@@ -14,7 +14,7 @@ var phases = { "phase1": "profile1" };
 // expected tabs state
 var tabs1 = [
     { uri: "https://example.com/",
-      profile: "Fennec (administrator) on iOS"
+      profile: "Fennec (cso) on iOS"
     }
 ];
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -181,7 +181,6 @@ class IntegrationTests: BaseTestCase {
 
         // Sign in with FxAccount
         signInFxAccounts()
-
         // Wait for initial sync to complete
         waitForInitialSyncComplete()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -59,11 +59,12 @@ class IntegrationTests: BaseTestCase {
             app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar],
             timeout: TIMEOUT_LONG
         )
-        mozWaitForElementToExist(app.staticTexts["Continue to your Mozilla account"], timeout: TIMEOUT_LONG)
         userState.fxaUsername = ProcessInfo.processInfo.environment["FXA_EMAIL"]!
         userState.fxaPassword = ProcessInfo.processInfo.environment["FXA_PASSWORD"]!
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField])
         navigator.performAction(Action.FxATypeEmail)
         navigator.performAction(Action.FxATapOnContinueButton)
+        mozWaitForElementToNotExist(app.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField])
         mozWaitForElementToExist(app.staticTexts["Enter your password"], timeout: TIMEOUT_LONG)
         navigator.performAction(Action.FxATypePasswordExistingAccount)
         navigator.performAction(Action.FxATapOnSignInButton)
@@ -75,6 +76,7 @@ class IntegrationTests: BaseTestCase {
     private func waitForInitialSyncComplete() {
         navigator.nowAt(BrowserTab)
         waitForTabsButton()
+        navigator.goto(BrowserTabMenu)
         navigator.goto(SettingsScreen)
         mozWaitForElementToExist(app.staticTexts["ACCOUNT"], timeout: TIMEOUT_LONG)
         mozWaitForElementToNotExist(app.staticTexts["Sync and Save Data"])
@@ -153,7 +155,7 @@ class IntegrationTests: BaseTestCase {
         mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"])
         XCTAssertEqual(
             app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as? String,
-            "Fennec (administrator) on iOS"
+            "Fennec (cso) on iOS"
         )
 
         // Sync again just to make sure to sync after new name is shown
@@ -177,8 +179,6 @@ class IntegrationTests: BaseTestCase {
         // Save the login
         app.buttons[AccessibilityIdentifiers.SaveLoginAlert.saveButton].waitAndTap()
 
-        // Sign in with FxAccount
-        signInFxAccounts()
         // Wait for initial sync to complete
         waitForInitialSyncComplete()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -155,7 +155,7 @@ class IntegrationTests: BaseTestCase {
         mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"])
         XCTAssertEqual(
             app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as? String,
-            "Fennec (cso) on iOS"
+            "Fennec (administrator) on iOS"
         )
 
         // Sync again just to make sure to sync after new name is shown

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -179,6 +179,9 @@ class IntegrationTests: BaseTestCase {
         // Save the login
         app.buttons[AccessibilityIdentifiers.SaveLoginAlert.saveButton].waitAndTap()
 
+        // Sign in with FxAccount
+        signInFxAccounts()
+
         // Wait for initial sync to complete
         waitForInitialSyncComplete()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4509)


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Sync Integration Tests fail intermittent because of the following issues unrelated to TPS:
* "Continue to your Mozilla account" banner on the sign-in page now contains an invisible white space character, so the `mozWait` now fails.
* In `waitForInitialSyncComplete()`, navigating directly to `SettingsScreen` may temporarily crash the app. Navigating to `BrowserTabMenu` first alleviates the issue.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

