### PR TITLE
Bugfix FXIOS-11809 [Blueprint Download Manager] Avoid automatic throttling of live activity updates

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -160,7 +160,6 @@
 		1D3822E92BAB99250046BC5E /* UIView+ThemeUUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3822E82BAB99250046BC5E /* UIView+ThemeUUIDIdentifiable.swift */; };
 		1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */; };
 		1D4D79462BF2F4E7007C6796 /* SimpleTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E69EAF254D064E00B591C2 /* SimpleTab.swift */; };
-		1D4D79472BF2F4FD007C6796 /* GCDThrottler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D95015270238500079D39D /* GCDThrottler.swift */; };
 		1D558A582BED7ECB001EF527 /* MockWindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D558A562BED7ECB001EF527 /* MockWindowManager.swift */; };
 		1D558A5A2BEE7D07001EF527 /* WindowSimpleTabsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D558A592BEE7D07001EF527 /* WindowSimpleTabsCoordinator.swift */; };
 		1D5CBF492B17E3CB0001D033 /* NotificationPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */; };
@@ -17970,7 +17969,6 @@
 				ED07C0F52CCB020B006C0627 /* SearchEngineSelectionMiddlewareTests.swift in Sources */,
 				C8DF92F72A14101500AA7B05 /* OnboardingViewControllerProtocolTests.swift in Sources */,
 				8A4EA0D92C01127C00E4E4F1 /* MicrosurveyMockModel.swift in Sources */,
-				1D4D79472BF2F4FD007C6796 /* GCDThrottler.swift in Sources */,
 				6A3E5D8A283831D1001E706E /* DownloadQueueTests.swift in Sources */,
 				8AEF41642D15EE1D0013925D /* MockTopSitesManager.swift in Sources */,
 				8AE80BB62891AEA100BC12EA /* MockDispatchGroup.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		0E6C1E252C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6C1E242C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift */; };
 		0E77DF0F2CB8220000B80BA1 /* GeneratedPasswordStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E77DF0E2CB8220000B80BA1 /* GeneratedPasswordStorage.swift */; };
 		0E9702742CC2F2FB00C357B7 /* PasswordGeneratorTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E12A3162CC2EE8C0037F8EE /* PasswordGeneratorTelemetryTests.swift */; };
+		0EBD66922DBFE41000A78532 /* ConcurrencyThrottler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBD66912DBFE40100A78532 /* ConcurrencyThrottler.swift */; };
 		0EC57CE32CA31C5B002E3F04 /* PasswordGeneratorViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57CE22CA31C5B002E3F04 /* PasswordGeneratorViewControllerTests.swift */; };
 		0EC57CE52CA31E59002E3F04 /* PasswordGeneratorStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57CE42CA31E59002E3F04 /* PasswordGeneratorStateTests.swift */; };
 		0EC57D082CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57D072CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift */; };
@@ -159,6 +160,7 @@
 		1D3822E92BAB99250046BC5E /* UIView+ThemeUUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3822E82BAB99250046BC5E /* UIView+ThemeUUIDIdentifiable.swift */; };
 		1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */; };
 		1D4D79462BF2F4E7007C6796 /* SimpleTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E69EAF254D064E00B591C2 /* SimpleTab.swift */; };
+		1D4D79472BF2F4FD007C6796 /* GCDThrottler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D95015270238500079D39D /* GCDThrottler.swift */; };
 		1D558A582BED7ECB001EF527 /* MockWindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D558A562BED7ECB001EF527 /* MockWindowManager.swift */; };
 		1D558A5A2BEE7D07001EF527 /* WindowSimpleTabsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D558A592BEE7D07001EF527 /* WindowSimpleTabsCoordinator.swift */; };
 		1D5CBF492B17E3CB0001D033 /* NotificationPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */; };
@@ -1092,7 +1094,7 @@
 		8AC976C22DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC976C12DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift */; };
 		8AC976C32DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC976C12DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift */; };
 		8ACA8F74291987AE00D3075D /* AccountSyncHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */; };
-		8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */; };
+		8ACA8F7629198D6400D3075D /* GCDThrottlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F7529198D6400D3075D /* GCDThrottlerTests.swift */; };
 		8ACE9BFB2A54A010001E7A73 /* ExpandButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */; };
 		8AD0110D2CB42FE700368BF3 /* HeaderState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD0110C2CB42FE700368BF3 /* HeaderState.swift */; };
 		8AD08D1527E9198E00B8E907 /* TabsTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */; };
@@ -1243,7 +1245,7 @@
 		96A5F73829928B3700234E5F /* GeneralizedImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A5F73729928B3700234E5F /* GeneralizedImageFetcher.swift */; };
 		96AF8C1C29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AF8C1B29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift */; };
 		96C11E9B2864C2DD00840E7C /* DependencyHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C11E9A2864C2DD00840E7C /* DependencyHelper.swift */; };
-		96D95016270238500079D39D /* Throttler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D95015270238500079D39D /* Throttler.swift */; };
+		96D95016270238500079D39D /* GCDThrottler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D95015270238500079D39D /* GCDThrottler.swift */; };
 		96EB6C3827D821B800A9D159 /* HistoryPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EB6C3727D821B800A9D159 /* HistoryPanelViewModel.swift */; };
 		96EB6C3E27D9266500A9D159 /* HistoryActionables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EB6C3D27D9266500A9D159 /* HistoryActionables.swift */; };
 		96F8DA49280452CA00E53239 /* GleanPlumbContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F8DA48280452CA00E53239 /* GleanPlumbContextProvider.swift */; };
@@ -2502,6 +2504,7 @@
 		0E9C4C2A8B5EAD7878B8ECA3 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Search.strings; sourceTree = "<group>"; };
 		0EA04BBB85CC8DBC434F724C /* hy-AM */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hy-AM"; path = "hy-AM.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		0EA243A6B20C0E8141C03888 /* pa-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pa-IN"; path = "pa-IN.lproj/LoginManager.strings"; sourceTree = "<group>"; };
+		0EBD66912DBFE40100A78532 /* ConcurrencyThrottler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrencyThrottler.swift; sourceTree = "<group>"; };
 		0EC57CE22CA31C5B002E3F04 /* PasswordGeneratorViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorViewControllerTests.swift; sourceTree = "<group>"; };
 		0EC57CE42CA31E59002E3F04 /* PasswordGeneratorStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorStateTests.swift; sourceTree = "<group>"; };
 		0EC57D072CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorHeaderView.swift; sourceTree = "<group>"; };
@@ -8338,7 +8341,7 @@
 		8AC884202D5261FC0033ABF5 /* CrashTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashTrackerTests.swift; sourceTree = "<group>"; };
 		8AC976C12DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlaggedTestBase.swift; sourceTree = "<group>"; };
 		8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSyncHandlerTests.swift; sourceTree = "<group>"; };
-		8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrottlerTests.swift; sourceTree = "<group>"; };
+		8ACA8F7529198D6400D3075D /* GCDThrottlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GCDThrottlerTests.swift; sourceTree = "<group>"; };
 		8ACD3B972BA8EA8300E73E9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandButtonState.swift; sourceTree = "<group>"; };
 		8AD0110C2CB42FE700368BF3 /* HeaderState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderState.swift; sourceTree = "<group>"; };
@@ -8606,7 +8609,7 @@
 		96AF8C1B29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardInputFieldHelperTests.swift; sourceTree = "<group>"; };
 		96B14F71BAAD012EA8852135 /* ne-NP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ne-NP"; path = "ne-NP.lproj/LoginManager.strings"; sourceTree = "<group>"; };
 		96C11E9A2864C2DD00840E7C /* DependencyHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyHelper.swift; sourceTree = "<group>"; };
-		96D95015270238500079D39D /* Throttler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throttler.swift; sourceTree = "<group>"; };
+		96D95015270238500079D39D /* GCDThrottler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GCDThrottler.swift; sourceTree = "<group>"; };
 		96EB6C3727D821B800A9D159 /* HistoryPanelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryPanelViewModel.swift; sourceTree = "<group>"; };
 		96EB6C3D27D9266500A9D159 /* HistoryActionables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryActionables.swift; sourceTree = "<group>"; };
 		96F8DA48280452CA00E53239 /* GleanPlumbContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbContextProvider.swift; sourceTree = "<group>"; };
@@ -12052,7 +12055,7 @@
 				961D6B822995AF84001B9CF1 /* GeneralizedImageFetcherTests.swift */,
 				C8E78BDC27F4A1E700C48BAA /* HistoryDeletionUtilityTests.swift */,
 				8A1E3BE128CBACD7003388C4 /* SponsoredContentFilterUtilityTests.swift */,
-				8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */,
+				8ACA8F7529198D6400D3075D /* GCDThrottlerTests.swift */,
 				8AA8389C2CA2FEFC003FA256 /* StoreTestUtility.swift */,
 			);
 			path = Utils;
@@ -14571,6 +14574,7 @@
 		E65075551E37F714006961AC /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				0EBD66912DBFE40100A78532 /* ConcurrencyThrottler.swift */,
 				ED80541A2DAD966B00484080 /* ContinuationsChecker.swift */,
 				0E4AF8602D763E9D002E4238 /* DownloadLiveActivityUtil.swift */,
 				5AD3B67D2CF665AE00AFA1FE /* UIApplicationInterface.swift */,
@@ -14583,7 +14587,7 @@
 				8A1E3BDE28CBA81E003388C4 /* SponsoredContentFilterUtility.swift */,
 				E650755A1E37F747006961AC /* Swizzling.h */,
 				E650755B1E37F747006961AC /* Swizzling.m */,
-				96D95015270238500079D39D /* Throttler.swift */,
+				96D95015270238500079D39D /* GCDThrottler.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -17023,7 +17027,7 @@
 				EB1C84BF212EFFBF001489DF /* BrowserViewController+ReaderMode.swift in Sources */,
 				AB2AC6662BD15E6300022AAB /* CertificatesHandler.swift in Sources */,
 				81020C922BB5AFA2007B8481 /* OnboardingMultipleChoiceButtonView.swift in Sources */,
-				96D95016270238500079D39D /* Throttler.swift in Sources */,
+				96D95016270238500079D39D /* GCDThrottler.swift in Sources */,
 				8A4593C92BF7BECA002758DE /* MicrosurveyTableHeaderView.swift in Sources */,
 				8A93080B27C01AD60052167D /* SingleActionViewModel.swift in Sources */,
 				ABB184EB2CB807B300F0689D /* CertificatesModel.swift in Sources */,
@@ -17504,6 +17508,7 @@
 				8A454D2C2CB81153009436D9 /* PocketStandardCell.swift in Sources */,
 				AB9CBC042C53B64C00102610 /* TrackingProtectionModel.swift in Sources */,
 				C8DC90C52A066B6A0008832B /* MarkupTokenizingUtility.swift in Sources */,
+				0EBD66922DBFE41000A78532 /* ConcurrencyThrottler.swift in Sources */,
 				EBC4869D2195F58300CDA48D /* ErrorPageHelper.swift in Sources */,
 				C84655E8288739CB00861B4A /* WallpaperCollectionAvailability.swift in Sources */,
 				8A454D462CB9C83F009436D9 /* TopSitesMiddleware.swift in Sources */,
@@ -17965,6 +17970,7 @@
 				ED07C0F52CCB020B006C0627 /* SearchEngineSelectionMiddlewareTests.swift in Sources */,
 				C8DF92F72A14101500AA7B05 /* OnboardingViewControllerProtocolTests.swift in Sources */,
 				8A4EA0D92C01127C00E4E4F1 /* MicrosurveyMockModel.swift in Sources */,
+				1D4D79472BF2F4FD007C6796 /* GCDThrottler.swift in Sources */,
 				6A3E5D8A283831D1001E706E /* DownloadQueueTests.swift in Sources */,
 				8AEF41642D15EE1D0013925D /* MockTopSitesManager.swift in Sources */,
 				8AE80BB62891AEA100BC12EA /* MockDispatchGroup.swift in Sources */,
@@ -18084,7 +18090,7 @@
 				967EDABF29D769A10089208D /* CreditCardInputFieldTests.swift in Sources */,
 				61E637852D03615D00E95B63 /* LabelButtonHeaderViewTests.swift in Sources */,
 				21F2A2D42B0D194A00626AEC /* TabsPanelStateTests.swift in Sources */,
-				8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */,
+				8ACA8F7629198D6400D3075D /* GCDThrottlerTests.swift in Sources */,
 				217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */,
 				8A09BCC32D22F1BE00CFDF60 /* ContextMenuCoordinatorTests.swift in Sources */,
 				0B7CF8872CAC1C4E00DC02F8 /* DefaultFolderHierarchyFetcherTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -62,7 +62,7 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
 
     private func shouldUpdateLiveActivity() -> Bool {
         let currentTime = Date()
-        
+
         guard currentTime.timeIntervalSince(lastUpdateTime) >= UX.updateCooldown else {return false}
         lastUpdateTime = currentTime
         return true

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -11,7 +11,7 @@ import Shared
 @available(iOS 17, *)
 class DownloadLiveActivityWrapper: DownloadProgressDelegate {
     private struct UX {
-        static let updateCooldown: Double = 0.75 // Update Cooldown in Seconds
+        static let updateCooldown = 0.75 // Update Cooldown in Seconds
     }
 
     enum DurationToDismissal: UInt64 {

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -19,7 +19,7 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
         case delayed = 3_000_000_000 // Milliseconds to dismissal
     }
 
-    let throttler = Throttler(seconds: UX.updateCooldown)
+    let throttler = ConcurrencyThrottler(seconds: UX.updateCooldown)
 
     var downloadLiveActivity: Activity<DownloadLiveActivityAttributes>?
 

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -21,8 +21,6 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
 
     let throttler = Throttler(seconds: UX.updateCooldown)
 
-    private var lastUpdateTime = Date.distantPast
-
     var downloadLiveActivity: Activity<DownloadLiveActivityAttributes>?
 
     var downloadProgressManager: DownloadProgressManager
@@ -53,9 +51,9 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
     }
 
     func end(durationToDismissal: DurationToDismissal) {
-        let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
-        let contentState = DownloadLiveActivityAttributes.ContentState(downloads: downloadsStates)
         Task {
+            let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
+            let contentState = DownloadLiveActivityAttributes.ContentState(downloads: downloadsStates)
             await update()
             try await Task.sleep(nanoseconds: durationToDismissal.rawValue)
             await downloadLiveActivity?.end(using: contentState, dismissalPolicy: .immediate)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -77,7 +77,7 @@ final class HomepageViewController: UIViewController,
          toastContainer: UIView,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          logger: Logger = DefaultLogger.shared,
-         throttler: ThrottleProtocol = Throttler(seconds: 0.5)
+         throttler: ThrottleProtocol = GCDThrottler(seconds: 0.5)
     ) {
         self.windowUUID = windowUUID
         self.themeManager = themeManager

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -46,7 +46,7 @@ class LegacyHomepageViewController:
     private var collectionView: UICollectionView?
     private var lastContentOffsetY: CGFloat = 0
     private var logger: Logger
-    private let viewWillAppearEventThrottler = Throttler(seconds: 0.5)
+    private let viewWillAppearEventThrottler = GCDThrottler(seconds: 0.5)
 
     var windowUUID: WindowUUID { return tabManager.windowUUID }
     var currentWindowUUID: UUID? { return windowUUID }

--- a/firefox-ios/Client/TabManagement/WindowSimpleTabsCoordinator.swift
+++ b/firefox-ios/Client/TabManagement/WindowSimpleTabsCoordinator.swift
@@ -13,7 +13,7 @@ final class WindowSimpleTabsCoordinator {
     private struct Timing {
         static let throttleDelay = 1.0
     }
-    private let throttler = Throttler(seconds: Timing.throttleDelay)
+    private let throttler = GCDThrottler(seconds: Timing.throttleDelay)
 
     func saveSimpleTabs(for providers: [WindowSimpleTabsProvider]) {
         throttler.throttle {

--- a/firefox-ios/Client/Utils/ConcurrencyThrottler.swift
+++ b/firefox-ios/Client/Utils/ConcurrencyThrottler.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import Foundation
+
+class ConcurrencyThrottler: ThrottleProtocol {
+    private var lastUpdateTime = Date.distantPast
+    private var delay: Double
+
+    init(
+        seconds delay: Double = 0.35
+    ) {
+        self.delay = delay
+    }
+
+    func throttle(completion: @escaping () -> Void) {
+        let currentTime = Date()
+
+        guard lastUpdateTime.timeIntervalSinceNow < -delay else { return }
+        lastUpdateTime = currentTime
+
+        Task {
+            await MainActor.run {
+                completion()
+            }
+        }
+    }
+}

--- a/firefox-ios/Client/Utils/GCDThrottler.swift
+++ b/firefox-ios/Client/Utils/GCDThrottler.swift
@@ -11,7 +11,7 @@ protocol ThrottleProtocol {
 
 /// For any work that needs to be delayed, you can wrap it inside a throttler
 /// and specify the delay time, in seconds, and queue.
-class Throttler: ThrottleProtocol {
+class GCDThrottler: ThrottleProtocol {
     private let defaultDelay = 0.35
 
     private let threshold: Double

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -313,7 +313,7 @@ struct DownloadLiveActivity: Widget {
     }
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: DownloadLiveActivityAttributes.self) { liveDownload in
-            lockScreenView(liveDownload: liveDownload)
+            lockScreenView(liveDownload: liveDownload).transition(.identity)
         } dynamicIsland: { liveDownload in
             DynamicIsland {
                 leadingExpandedRegion(liveDownload: liveDownload)

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -313,7 +313,7 @@ struct DownloadLiveActivity: Widget {
     }
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: DownloadLiveActivityAttributes.self) { liveDownload in
-            lockScreenView(liveDownload: liveDownload).transition(.identity)
+            lockScreenView(liveDownload: liveDownload)
         } dynamicIsland: { liveDownload in
             DynamicIsland {
                 leadingExpandedRegion(liveDownload: liveDownload)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/GCDThrottlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/GCDThrottlerTests.swift
@@ -6,14 +6,14 @@ import XCTest
 
 @testable import Client
 
-class ThrottlerTests: XCTestCase {
+class GCDThrottlerTests: XCTestCase {
     struct Timing {
         static let veryLongDelay: Double = 100_000
         static let defaultTestMaxWaitTime: Double = 2
     }
 
     private var testQueue: DispatchQueue!
-    private var throttler: Throttler!
+    private var throttler: GCDThrottler!
     private var expectation: XCTestExpectation!
     private var testValue = 0
 
@@ -73,7 +73,7 @@ class ThrottlerTests: XCTestCase {
     private func prepareTest(timeout: Double) {
         testValue = 0
         expectation = XCTestExpectation(description: "Throttle value expectation")
-        throttler = Throttler(seconds: timeout, on: testQueue)
+        throttler = GCDThrottler(seconds: timeout, on: testQueue)
     }
 
     private func expect(value expected: Int) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11809)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25753)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Try downloading a large enough file beforehand, you'll notice that in the beginning updates in the live activity happen rather quickly, but are later throttled
- Now, we implement our own throttling to ensure a reasonable amount of updates happen per second

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

