### PR TITLE
Add FXIOS-11390 [WebEngine] Introducing strict concurrency into WebEngine (part 1)

### DIFF
--- a/BrowserKit/Sources/WebEngine/Engine.swift
+++ b/BrowserKit/Sources/WebEngine/Engine.swift
@@ -14,7 +14,7 @@ public protocol Engine {
     /// Creates a new engine session.
     /// - Parameter dependencies: Pass in the required session dependencies on creation
     /// - Returns: The created `EngineSession`
-    func createSession(dependencies: EngineSessionDependencies) throws -> EngineSession
+    func createSession(dependencies: EngineSessionDependencies) async throws -> EngineSession
 
     /// Warm the `Engine` whenever we move the application to foreground
     func warmEngine()

--- a/BrowserKit/Sources/WebEngine/Engine.swift
+++ b/BrowserKit/Sources/WebEngine/Engine.swift
@@ -14,7 +14,8 @@ public protocol Engine {
     /// Creates a new engine session.
     /// - Parameter dependencies: Pass in the required session dependencies on creation
     /// - Returns: The created `EngineSession`
-    func createSession(dependencies: EngineSessionDependencies) async throws -> EngineSession
+    @MainActor
+    func createSession(dependencies: EngineSessionDependencies) throws -> EngineSession
 
     /// Warm the `Engine` whenever we move the application to foreground
     func warmEngine()

--- a/BrowserKit/Sources/WebEngine/WKWebview/Internal/InternalUtil.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Internal/InternalUtil.swift
@@ -6,6 +6,7 @@ import Foundation
 
 /// Used to setup internal scheme handlers
 struct InternalUtil {
+    @MainActor
     func setUpInternalHandlers() {
         let responders: [(String, WKInternalSchemeResponse)] =
              [(WKAboutHomeHandler.path, WKAboutHomeHandler()),

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKUserScriptManager.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKUserScriptManager.swift
@@ -7,9 +7,10 @@ import Foundation
 
 /// Manager used to inject scripts at document start or end inside a WKEngineWebView
 protocol WKUserScriptManager {
-    func injectUserScriptsIntoWebView(_ webView: WKEngineWebView)
+    func injectUserScriptsIntoWebView(_ webView: WKEngineWebView) async
 }
 
+@MainActor
 class DefaultUserScriptManager: WKUserScriptManager {
     // Scripts can use this to verify the application (not JS on the web) is calling into them
     private let appIdToken = UUID().uuidString
@@ -26,7 +27,7 @@ class DefaultUserScriptManager: WKUserScriptManager {
         injectUserScripts()
     }
 
-    func injectUserScriptsIntoWebView(_ webView: WKEngineWebView) {
+    func injectUserScriptsIntoWebView(_ webView: WKEngineWebView) async {
         // Remove any previously-added user scripts to prevent the same script from being injected twice
         webView.engineConfiguration.removeAllUserScripts()
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKUserScriptManager.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKUserScriptManager.swift
@@ -6,11 +6,11 @@ import WebKit
 import Foundation
 
 /// Manager used to inject scripts at document start or end inside a WKEngineWebView
+@MainActor
 protocol WKUserScriptManager {
-    func injectUserScriptsIntoWebView(_ webView: WKEngineWebView) async
+    func injectUserScriptsIntoWebView(_ webView: WKEngineWebView)
 }
 
-@MainActor
 class DefaultUserScriptManager: WKUserScriptManager {
     // Scripts can use this to verify the application (not JS on the web) is calling into them
     private let appIdToken = UUID().uuidString
@@ -27,7 +27,7 @@ class DefaultUserScriptManager: WKUserScriptManager {
         injectUserScripts()
     }
 
-    func injectUserScriptsIntoWebView(_ webView: WKEngineWebView) async {
+    func injectUserScriptsIntoWebView(_ webView: WKEngineWebView) {
         // Remove any previously-added user scripts to prevent the same script from being injected twice
         webView.engineConfiguration.removeAllUserScripts()
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
@@ -5,7 +5,7 @@
 import Common
 import Foundation
 
-public class WKEngine: @preconcurrency Engine {
+public class WKEngine: Engine {
     private let sourceTimerFactory: DispatchSourceTimerFactory
     private var shutdownWebServerTimer: DispatchSourceInterface?
     private let userScriptManager: WKUserScriptManager
@@ -40,7 +40,6 @@ public class WKEngine: @preconcurrency Engine {
         await InternalUtil().setUpInternalHandlers()
     }
 
-    @MainActor
     public func createView() -> EngineView {
         return WKEngineView(frame: .zero)
     }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
@@ -13,6 +13,7 @@ public class WKEngine: Engine {
     private let engineDependencies: EngineDependencies
     private let configProvider: WKEngineConfigurationProvider
 
+    // TODO: With Swift 6 we can use default params in the init
     @MainActor
     public static func factory(engineDependencies: EngineDependencies) -> WKEngine {
         let configProvider = DefaultWKEngineConfigurationProvider()

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
@@ -42,6 +42,7 @@ public protocol WKEngineConfigurationProvider {
 }
 
 /// FXIOS-11986 - This will be internal when the WebEngine is fully integrated in Firefox iOS
+@MainActor
 public struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvider {
     private static let normalSessionsProcessPool = WKProcessPool()
     private static let privateSessionsProcessPool = WKProcessPool()

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
@@ -37,12 +37,12 @@ public struct WKWebViewParameters {
 
 /// Provider to get a configured `WKEngineConfiguration`
 /// Only one configuration provider per application should exists.
+@MainActor
 public protocol WKEngineConfigurationProvider {
     func createConfiguration(parameters: WKWebViewParameters) -> WKEngineConfiguration
 }
 
 /// FXIOS-11986 - This will be internal when the WebEngine is fully integrated in Firefox iOS
-@MainActor
 public struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvider {
     private static let normalSessionsProcessPool = WKProcessPool()
     private static let privateSessionsProcessPool = WKProcessPool()

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -34,7 +34,7 @@ class WKEngineSession: NSObject,
     weak var fullscreenDelegate: FullscreenDelegate?
 
     private(set) var webView: WKEngineWebView
-    var sessionData: WKEngineSessionData
+    var sessionData = WKEngineSessionData()
 
     private var scriptResponder: EngineSessionScriptResponder
     private var logger: Logger
@@ -49,6 +49,7 @@ class WKEngineSession: NSObject,
         }
     }
 
+    // TODO: With Swift 6 we can use default params in the init
     @MainActor
     public static func sessionFactory(
         userScriptManager: WKUserScriptManager,
@@ -57,7 +58,6 @@ class WKEngineSession: NSObject,
     ) -> WKEngineSession? {
         let webViewProvider = DefaultWKWebViewProvider()
         let logger = DefaultLogger.shared
-        let sessionData = WKEngineSessionData()
         let contentScriptManager = DefaultContentScriptManager()
         let scriptResponder = EngineSessionScriptResponder()
         let metadataFetcher = DefaultMetadataFetcherHelper()
@@ -70,7 +70,6 @@ class WKEngineSession: NSObject,
             configurationProvider: configurationProvider,
             webViewProvider: webViewProvider,
             logger: logger,
-            sessionData: sessionData,
             contentScriptManager: contentScriptManager,
             scriptResponder: scriptResponder,
             metadataFetcher: metadataFetcher,
@@ -85,7 +84,6 @@ class WKEngineSession: NSObject,
           configurationProvider: WKEngineConfigurationProvider,
           webViewProvider: WKWebViewProvider,
           logger: Logger = DefaultLogger.shared,
-          sessionData: WKEngineSessionData,
           contentScriptManager: WKContentScriptManager,
           scriptResponder: EngineSessionScriptResponder,
           metadataFetcher: MetadataFetcherHelper,
@@ -101,7 +99,6 @@ class WKEngineSession: NSObject,
 
         self.webView = webView
         self.logger = logger
-        self.sessionData = sessionData
         self.contentScriptManager = contentScriptManager
         self.metadataFetcher = metadataFetcher
         self.navigationHandler = navigationHandler

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineView.swift
@@ -5,7 +5,6 @@
 import Common
 import UIKit
 
-@MainActor
 class WKEngineView: UIView, EngineView, FullscreenDelegate {
     private var session: WKEngineSession?
     private var logger: Logger

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineView.swift
@@ -5,6 +5,7 @@
 import Common
 import UIKit
 
+@MainActor
 class WKEngineView: UIView, EngineView, FullscreenDelegate {
     private var session: WKEngineSession?
     private var logger: Logger

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -163,7 +163,6 @@ final class DefaultWKEngineWebView: WKWebView,
                    parameters: WKWebViewParameters) {
         let configuration = configurationProvider.createConfiguration(parameters: parameters)
         self.engineConfiguration = configuration
-        guard let configuration = configuration as? DefaultEngineConfiguration else { return nil }
         pullRefreshViewType = parameters.pullRefreshType
         super.init(frame: frame, configuration: configuration.webViewConfiguration)
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKWebViewProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKWebViewProvider.swift
@@ -13,6 +13,7 @@ protocol WKWebViewProvider {
                        parameters: WKWebViewParameters) -> WKEngineWebView?
 }
 
+@MainActor
 struct DefaultWKWebViewProvider: WKWebViewProvider {
     private var logger: Logger
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKWebViewProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKWebViewProvider.swift
@@ -8,12 +8,12 @@ import WebKit
 
 /// Abstraction that allow us to create a `WKWebView` object through
 /// the usage of a configuration provider and an webview abstraction.
+@MainActor
 protocol WKWebViewProvider {
     func createWebview(configurationProvider: WKEngineConfigurationProvider,
                        parameters: WKWebViewParameters) -> WKEngineWebView?
 }
 
-@MainActor
 struct DefaultWKWebViewProvider: WKWebViewProvider {
     private var logger: Logger
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKWebServerUtil.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKWebServerUtil.swift
@@ -10,15 +10,15 @@ protocol WKWebServerUtil {
 }
 
 class DefaultWKWebServerUtil: WKWebServerUtil {
-    private var readerModeHander: WKReaderModeHandlersProtocol
+    private var readerModeHandler: WKReaderModeHandlersProtocol
     private var webServer: WKEngineWebServerProtocol
     private let logger: Logger
 
     init(webServer: WKEngineWebServerProtocol,
-         readerModeHander: WKReaderModeHandlersProtocol = WKReaderModeHandlers(),
+         readerModeHandler: WKReaderModeHandlersProtocol = WKReaderModeHandlers(),
          logger: Logger = DefaultLogger.shared) {
         self.webServer = webServer
-        self.readerModeHander = readerModeHander
+        self.readerModeHandler = readerModeHandler
         self.logger = logger
     }
 
@@ -32,7 +32,7 @@ class DefaultWKWebServerUtil: WKWebServerUtil {
     func setUpWebServer(readerModeConfiguration: ReaderModeConfiguration) {
         guard !webServer.isRunning else { return }
 
-        readerModeHander.register(webServer, readerModeConfiguration: readerModeConfiguration)
+        readerModeHandler.register(webServer, readerModeConfiguration: readerModeConfiguration)
 
         if AppConstants.isRunningTest {
             webServer.addTestHandler()

--- a/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKWebServerUtil.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKWebServerUtil.swift
@@ -22,6 +22,7 @@ class DefaultWKWebServerUtil: WKWebServerUtil {
         self.logger = logger
     }
 
+    // TODO: With Swift 6 we can use default params in the init
     @MainActor
     static func factory() -> DefaultWKWebServerUtil {
         let webServer = WKEngineWebServer.shared

--- a/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKWebServerUtil.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKWebServerUtil.swift
@@ -22,8 +22,9 @@ class DefaultWKWebServerUtil: WKWebServerUtil {
         self.logger = logger
     }
 
-    static func make() async -> DefaultWKWebServerUtil {
-        let webServer = await MainActor.run { WKEngineWebServer.shared }
+    @MainActor
+    static func factory() -> DefaultWKWebServerUtil {
+        let webServer = WKEngineWebServer.shared
         return DefaultWKWebServerUtil(webServer: webServer)
     }
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKWebServerUtil.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKWebServerUtil.swift
@@ -14,12 +14,17 @@ class DefaultWKWebServerUtil: WKWebServerUtil {
     private var webServer: WKEngineWebServerProtocol
     private let logger: Logger
 
-    init(webServer: WKEngineWebServerProtocol = WKEngineWebServer.shared,
+    init(webServer: WKEngineWebServerProtocol,
          readerModeHander: WKReaderModeHandlersProtocol = WKReaderModeHandlers(),
          logger: Logger = DefaultLogger.shared) {
         self.webServer = webServer
         self.readerModeHander = readerModeHander
         self.logger = logger
+    }
+
+    static func make() async -> DefaultWKWebServerUtil {
+        let webServer = await MainActor.run { WKEngineWebServer.shared }
+        return DefaultWKWebServerUtil(webServer: webServer)
     }
 
     func setUpWebServer(readerModeConfiguration: ReaderModeConfiguration) {

--- a/BrowserKit/Tests/WebEngineTests/EngineSessionScriptResponderTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/EngineSessionScriptResponderTests.swift
@@ -9,9 +9,9 @@ import XCTest
 class EngineSessionScriptResponderTests: XCTestCase {
     private var session: MockWKEngineSession!
 
-    override func setUp() {
-        super.setUp()
-        session = MockWKEngineSession()
+    override func setUp() async throws {
+        try await super.setUp()
+        session = await MockWKEngineSession()
     }
 
     override func tearDown() {

--- a/BrowserKit/Tests/WebEngineTests/MetadataFetcherHelperTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/MetadataFetcherHelperTests.swift
@@ -40,7 +40,6 @@ final class MetadataFetcherHelperTests: XCTestCase {
         XCTAssertEqual(metadataDelegate.didLoadPageMetadataCalled, 0)
     }
 
-    // laurie
     @MainActor
     func testFetchFromSessionGivenErrorThenPageMetadataNil() async {
         let subject = createSubject()

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineSession.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineSession.swift
@@ -8,17 +8,22 @@ import WebKit
 
 @available(iOS 16.0, *)
 class MockWKEngineSession: WKEngineSession {
-    let webviewProvider = MockWKWebViewProvider()
+    let webviewProvider: MockWKWebViewProvider!
     let mockTelemetryProxy = MockEngineTelemetryProxy()
     var callJavascriptMethodCalled = 0
 
-    init() {
+    init() async {
+        self.webviewProvider = await MockWKWebViewProvider()
         let defaultDependencies =  DefaultTestDependencies(mockTelemetryProxy: mockTelemetryProxy)
-        super.init(userScriptManager: MockWKUserScriptManager(),
-                   dependencies: defaultDependencies.sessionDependencies,
-                   configurationProvider: MockWKEngineConfigurationProvider(),
-                   webViewProvider: webviewProvider,
-                   contentScriptManager: MockWKContentScriptManager())!
+        await super.init(userScriptManager: MockWKUserScriptManager(),
+                         dependencies: defaultDependencies.sessionDependencies,
+                         configurationProvider: MockWKEngineConfigurationProvider(),
+                         webViewProvider: webviewProvider,
+                         contentScriptManager: MockWKContentScriptManager(),
+                         scriptResponder: EngineSessionScriptResponder(),
+                         metadataFetcher: DefaultMetadataFetcherHelper(),
+                         navigationHandler: DefaultNavigationHandler(),
+                         uiHandler: DefaultUIHandler())!
     }
 
     override func callJavascriptMethod(_ method: String, scope: String?) {

--- a/BrowserKit/Tests/WebEngineTests/WKContentScriptManagerTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKContentScriptManagerTests.swift
@@ -89,9 +89,9 @@ final class WKContentScriptManagerTests: XCTestCase {
         await subject.addContentScript(script,
                                        name: MockWKContentScript.name(),
                                        forSession: session)
-        
+
         await subject.uninstall(session: session)
-        
+
         XCTAssertEqual(script.scriptMessageHandlerNamesCalled, 2)
         XCTAssertEqual(script.prepareForDeinitCalled, 1)
     }

--- a/BrowserKit/Tests/WebEngineTests/WKContentScriptManagerTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKContentScriptManagerTests.swift
@@ -19,9 +19,10 @@ final class WKContentScriptManagerTests: XCTestCase {
         script = nil
     }
 
-    func testAddContentGivenAddedTwiceThenOnlyAddOnce() {
+    @MainActor
+    func testAddContentGivenAddedTwiceThenOnlyAddOnce() async {
         let subject = createSubject()
-        let session = MockWKEngineSession()
+        let session = await MockWKEngineSession()
 
         subject.addContentScript(script,
                                  name: MockWKContentScript.name(),
@@ -33,13 +34,13 @@ final class WKContentScriptManagerTests: XCTestCase {
         XCTAssertEqual(subject.scripts.count, 1)
     }
 
-    func testAddContentGivenAddedThenCallsMessageHandlers() {
+    func testAddContentGivenAddedThenCallsMessageHandlers() async {
         let subject = createSubject()
-        let session = MockWKEngineSession()
+        let session = await MockWKEngineSession()
 
-        subject.addContentScript(script,
-                                 name: MockWKContentScript.name(),
-                                 forSession: session)
+        await subject.addContentScript(script,
+                                       name: MockWKContentScript.name(),
+                                       forSession: session)
 
         XCTAssertEqual(script.scriptMessageHandlerNamesCalled, 1)
         guard let config = session.webView.engineConfiguration as? MockWKEngineConfiguration else {
@@ -50,9 +51,10 @@ final class WKContentScriptManagerTests: XCTestCase {
         XCTAssertEqual(config.scriptNameAdded, "MockWKContentScriptHandler")
     }
 
-    func testAddContentToPageGivenAddedTwiceThenOnlyAddOnce() {
+    @MainActor
+    func testAddContentToPageGivenAddedTwiceThenOnlyAddOnce() async {
         let subject = createSubject()
-        let session = MockWKEngineSession()
+        let session = await MockWKEngineSession()
 
         subject.addContentScriptToPage(script,
                                        name: MockWKContentScript.name(),
@@ -64,13 +66,13 @@ final class WKContentScriptManagerTests: XCTestCase {
         XCTAssertEqual(subject.scripts.count, 1)
     }
 
-    func testAddContentToPageGivenAddedThenCallsMessageHandlers() {
+    func testAddContentToPageGivenAddedThenCallsMessageHandlers() async {
         let subject = createSubject()
-        let session = MockWKEngineSession()
+        let session = await MockWKEngineSession()
 
-        subject.addContentScriptToPage(script,
-                                       name: MockWKContentScript.name(),
-                                       forSession: session)
+        await subject.addContentScriptToPage(script,
+                                             name: MockWKContentScript.name(),
+                                             forSession: session)
 
         XCTAssertEqual(script.scriptMessageHandlerNamesCalled, 1)
         guard let config = session.webView.engineConfiguration as? MockWKEngineConfiguration else {
@@ -81,15 +83,15 @@ final class WKContentScriptManagerTests: XCTestCase {
         XCTAssertEqual(config.scriptNameAdded, "MockWKContentScriptHandler")
     }
 
-    func testUninstallGivenAScriptThenCallsDeinitAndMessageHandlerNames() {
+    func testUninstallGivenAScriptThenCallsDeinitAndMessageHandlerNames() async {
         let subject = createSubject()
-        let session = MockWKEngineSession()
-        subject.addContentScript(script,
-                                 name: MockWKContentScript.name(),
-                                 forSession: session)
-
-        subject.uninstall(session: session)
-
+        let session = await MockWKEngineSession()
+        await subject.addContentScript(script,
+                                       name: MockWKContentScript.name(),
+                                       forSession: session)
+        
+        await subject.uninstall(session: session)
+        
         XCTAssertEqual(script.scriptMessageHandlerNamesCalled, 2)
         XCTAssertEqual(script.prepareForDeinitCalled, 1)
     }

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -6,6 +6,7 @@ import XCTest
 @testable import WebEngine
 import WebKit
 
+@MainActor
 @available(iOS 16.0, *)
 final class WKEngineSessionTests: XCTestCase {
     private var configurationProvider: MockWKEngineConfigurationProvider!
@@ -605,7 +606,7 @@ final class WKEngineSessionTests: XCTestCase {
 
     func createSubject(file: StaticString = #file,
                        line: UInt = #line,
-                       uiHandler: WKUIHandler = DefaultUIHandler()) -> WKEngineSession? {
+                       uiHandler: WKUIHandler? = nil) -> WKEngineSession? {
         guard let subject = WKEngineSession(userScriptManager: userScriptManager,
                                             dependencies: DefaultTestDependencies().sessionDependencies,
                                             configurationProvider: configurationProvider,
@@ -613,7 +614,8 @@ final class WKEngineSessionTests: XCTestCase {
                                             contentScriptManager: contentScriptManager,
                                             scriptResponder: scriptResponder,
                                             metadataFetcher: metadataFetcher,
-                                            uiHandler: uiHandler) else {
+                                            navigationHandler: DefaultNavigationHandler(),
+                                            uiHandler: uiHandler ?? DefaultUIHandler()) else {
             return nil
         }
 

--- a/BrowserKit/Tests/WebEngineTests/WKEngineTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineTests.swift
@@ -25,6 +25,7 @@ final class WKEngineTests: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testCreateViewThenCreatesView() async {
         let subject = await createSubject()
         XCTAssertNotNil(subject.createView())

--- a/BrowserKit/Tests/WebEngineTests/WKEngineViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineViewTests.swift
@@ -9,14 +9,9 @@ import XCTest
 final class WKEngineViewTests: XCTestCase {
     private var engineSession: WKEngineSession!
 
-    override func setUp() {
-        super.setUp()
-        engineSession = WKEngineSession(userScriptManager: MockWKUserScriptManager(),
-                                        dependencies: DefaultTestDependencies().sessionDependencies,
-                                        configurationProvider: MockWKEngineConfigurationProvider(),
-                                        webViewProvider: MockWKWebViewProvider(),
-                                        contentScriptManager: MockWKContentScriptManager(),
-                                        metadataFetcher: MockMetadataFetcherHelper())
+    override func setUp() async throws {
+        try await super.setUp()
+        engineSession = await MockWKEngineSession()
     }
 
     override func tearDown() {
@@ -32,14 +27,10 @@ final class WKEngineViewTests: XCTestCase {
         XCTAssertTrue(engineSession.isActive)
     }
 
-    func testRemoveSetsIsActiveFalse() {
+    @MainActor
+    func testRemoveSetsIsActiveFalse() async {
         let subject = createSubject()
-        let newEngineSession = WKEngineSession(userScriptManager: MockWKUserScriptManager(),
-                                               dependencies: DefaultTestDependencies().sessionDependencies,
-                                               configurationProvider: MockWKEngineConfigurationProvider(),
-                                               webViewProvider: MockWKWebViewProvider(),
-                                               contentScriptManager: MockWKContentScriptManager(),
-                                               metadataFetcher: MockMetadataFetcherHelper())!
+        let newEngineSession = await MockWKEngineSession()
 
         subject.render(session: engineSession)
         subject.render(session: newEngineSession)

--- a/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
@@ -20,6 +20,7 @@ final class WKEngineWebViewTests: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testNoLeaks() {
         let subject = createSubject()
         subject.close()
@@ -28,6 +29,7 @@ final class WKEngineWebViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
 
+    @MainActor
     func testLoad_callsObservers() {
         let subject = createSubject()
         let loadingExpectation = expectation(that: \WKWebView.isLoading, on: subject) { _, change in
@@ -83,6 +85,7 @@ final class WKEngineWebViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
 
+    @MainActor
     func testLoad_callsBeginRefreshing_onUIRefreshControl() throws {
         let subject = createSubject(pullRefreshViewType: MockUIRefreshControl.self)
         let pullRefresh = try XCTUnwrap(subject.scrollView.refreshControl as? MockUIRefreshControl)
@@ -94,6 +97,7 @@ final class WKEngineWebViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
 
+    @MainActor
     func testInit_setupsPullRefresh() throws {
         let subject = createSubject()
 
@@ -107,6 +111,7 @@ final class WKEngineWebViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
 
+    @MainActor
     func testInit_withUIRefreshControl_setupsCorrectlyPullRefresh() {
         let subject = createSubject(pullRefreshViewType: UIRefreshControl.self)
 
@@ -114,6 +119,7 @@ final class WKEngineWebViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
 
+    @MainActor
     func testScrollWillBeginZooming_removesPullRefresh() {
         let subject = createSubject()
 
@@ -124,6 +130,7 @@ final class WKEngineWebViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
 
+    @MainActor
     func testScrollDidEndZooming_setupsPullRefresh() {
         let subject = createSubject()
 
@@ -137,6 +144,7 @@ final class WKEngineWebViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
 
+    @MainActor
     func testScrollDidEndZooming_doesntSetupPullRefreshAgain() {
         let subject = createSubject()
 
@@ -149,6 +157,7 @@ final class WKEngineWebViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
 
+    @MainActor
     func testTriggerPullRefresh_callsDelegate() throws {
         let subject = createSubject()
         let pullRefresh = try XCTUnwrap(subject.scrollView.subviews.first { $0 is EnginePullRefreshView }
@@ -160,6 +169,7 @@ final class WKEngineWebViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
 
+    @MainActor
     func testCurrentHistoryItemSetAfterVisitingPage() {
         let subject = createSubject()
         let testURL = URL(string: "https://www.example.com/")!
@@ -179,6 +189,7 @@ final class WKEngineWebViewTests: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
+    @MainActor
     func testGetBackHistoryList() {
         let subject = createSubject()
 
@@ -189,6 +200,7 @@ final class WKEngineWebViewTests: XCTestCase {
         XCTAssertEqual(subject.backList().count, 2)
     }
 
+    @MainActor
     func testGetForwardHistoryList() {
         let subject = createSubject()
 
@@ -250,6 +262,7 @@ final class WKEngineWebViewTests: XCTestCase {
         wait(for: [expectation3], timeout: 10)
     }
 
+    @MainActor
     func createSubject(pullRefreshViewType: EnginePullRefreshViewType = MockEnginePullRefreshView.self,
                        file: StaticString = #file,
                        line: UInt = #line) -> DefaultWKEngineWebView {

--- a/BrowserKit/Tests/WebEngineTests/WKInternalSchemeHandlerTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKInternalSchemeHandlerTests.swift
@@ -37,6 +37,7 @@ final class WKInternalSchemeHandlerTests: XCTestCase {
         XCTAssertEqual(error, WKInternalPageSchemeHandlerError.noResponder)
     }
 
+    @MainActor
     func testSchemeStartIsCalledWithPrivilegedURLWithWrongResponder() throws {
         InternalUtil().setUpInternalHandlers()
         let subject = createSubject()

--- a/BrowserKit/Tests/WebEngineTests/WKUserScriptManagerTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKUserScriptManagerTests.swift
@@ -7,27 +7,29 @@ import XCTest
 
 @available(iOS 16.0, *)
 final class WKUserScriptManagerTests: XCTestCase {
-    func testInitThenAddsUserScripts() {
-        let subject = createSubject()
-        XCTAssertEqual(subject.compiledUserScripts.count, 8)
+    func testInitThenAddsUserScripts() async {
+        let subject = await createSubject()
+
+        let userScripts = await subject.compiledUserScripts
+        XCTAssertEqual(userScripts.count, 8)
     }
 
-    func testInjectUserScriptThenScriptsAreAddedInWebView() {
-        let webview = MockWKEngineWebView(frame: .zero,
-                                          configurationProvider: MockWKEngineConfigurationProvider(),
-                                          parameters: DefaultTestDependencies().webviewParameters)!
-        let subject = createSubject()
+    func testInjectUserScriptThenScriptsAreAddedInWebView() async {
+        let webview = await MockWKEngineWebView(frame: .zero,
+                                                configurationProvider: MockWKEngineConfigurationProvider(),
+                                                parameters: DefaultTestDependencies().webviewParameters)!
+        let subject = await createSubject()
 
-        subject.injectUserScriptsIntoWebView(webview)
-        guard let config = webview.engineConfiguration as? MockWKEngineConfiguration else {
+        await subject.injectUserScriptsIntoWebView(webview)
+        guard let config = await webview.engineConfiguration as? MockWKEngineConfiguration else {
             XCTFail("Failed to cast webview engine configuration to MockWKEngineConfiguration")
             return
         }
         XCTAssertEqual(config.addUserScriptCalled, 8)
     }
 
-    func createSubject() -> DefaultUserScriptManager {
-        let subject = DefaultUserScriptManager(scriptProvider: MockUserScriptProvider())
+    func createSubject() async -> DefaultUserScriptManager {
+        let subject = await DefaultUserScriptManager(scriptProvider: MockUserScriptProvider())
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/SampleBrowser/SampleBrowser.xcodeproj/project.pbxproj
+++ b/SampleBrowser/SampleBrowser.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		8ADF72C92B73DB9700530E7A /* AllFramesAtDocumentEnd.js in Resources */ = {isa = PBXBuildFile; fileRef = 8ADF72C42B73DB9700530E7A /* AllFramesAtDocumentEnd.js */; };
 		8ADF72CA2B73DB9700530E7A /* MainFrameAtDocumentEnd.js in Resources */ = {isa = PBXBuildFile; fileRef = 8ADF72C52B73DB9700530E7A /* MainFrameAtDocumentEnd.js */; };
 		8AEBDD712B69A8C300FE9192 /* AppLaunchUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEBDD702B69A8C300FE9192 /* AppLaunchUtil.swift */; };
+		8AF6DABC2DAF21E20074C496 /* EngineDependencyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF6DABB2DAF21E20074C496 /* EngineDependencyManager.swift */; };
+		8AF6DABE2DAF24770074C496 /* EngineProviderManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF6DABD2DAF24770074C496 /* EngineProviderManager.swift */; };
 		E132973C2BA9E71B0095FF61 /* ToolbarKit in Frameworks */ = {isa = PBXBuildFile; productRef = E132973B2BA9E71B0095FF61 /* ToolbarKit */; };
 		E1A58CC52BC3FF8F004009F1 /* AddressToolbarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A58CC42BC3FF8F004009F1 /* AddressToolbarContainer.swift */; };
 		E1C525C62BCFF77900073A6D /* RootViewControllerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C525C52BCFF77900073A6D /* RootViewControllerModel.swift */; };
@@ -98,6 +100,8 @@
 		8ADF72C42B73DB9700530E7A /* AllFramesAtDocumentEnd.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = AllFramesAtDocumentEnd.js; sourceTree = "<group>"; };
 		8ADF72C52B73DB9700530E7A /* MainFrameAtDocumentEnd.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = MainFrameAtDocumentEnd.js; sourceTree = "<group>"; };
 		8AEBDD702B69A8C300FE9192 /* AppLaunchUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchUtil.swift; sourceTree = "<group>"; };
+		8AF6DABB2DAF21E20074C496 /* EngineDependencyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineDependencyManager.swift; sourceTree = "<group>"; };
+		8AF6DABD2DAF24770074C496 /* EngineProviderManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineProviderManager.swift; sourceTree = "<group>"; };
 		E1A58CC42BC3FF8F004009F1 /* AddressToolbarContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressToolbarContainer.swift; sourceTree = "<group>"; };
 		E1C525C52BCFF77900073A6D /* RootViewControllerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewControllerModel.swift; sourceTree = "<group>"; };
 		E1CF5D1B2BC82F9E00F2287F /* AddressToolbarContainerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressToolbarContainerModel.swift; sourceTree = "<group>"; };
@@ -129,8 +133,10 @@
 		8A0F44692B56EDC000438589 /* Engine */ = {
 			isa = PBXGroup;
 			children = (
-				8ADF72C02B73D6F600530E7A /* Scripts */,
+				8AF6DABD2DAF24770074C496 /* EngineProviderManager.swift */,
+				8AF6DABB2DAF21E20074C496 /* EngineDependencyManager.swift */,
 				8A0F446A2B56EDC900438589 /* EngineProvider.swift */,
+				8ADF72C02B73D6F600530E7A /* Scripts */,
 			);
 			path = Engine;
 			sourceTree = "<group>";
@@ -394,6 +400,7 @@
 			files = (
 				8A0F447B2B56FD8300438589 /* SearchDataProviderProtocol.swift in Sources */,
 				8A4602222B0FE55300FFD17F /* UIViewController+Extension.swift in Sources */,
+				8AF6DABE2DAF24770074C496 /* EngineProviderManager.swift in Sources */,
 				8A0F44712B56FD3600438589 /* SearchViewController.swift in Sources */,
 				8A3DB3352B5AD47500F89705 /* SettingsType.swift in Sources */,
 				8A0F44832B56FE1300438589 /* UIAlertController+Error.swift in Sources */,
@@ -413,6 +420,7 @@
 				8A3DB32F2B5AD3D400F89705 /* SettingsCell.swift in Sources */,
 				8A0F44792B56FD6E00438589 /* SuggestionCellViewModel.swift in Sources */,
 				8A3DB32D2B5AD3C700F89705 /* SettingsViewController.swift in Sources */,
+				8AF6DABC2DAF21E20074C496 /* EngineDependencyManager.swift in Sources */,
 				8AEBDD712B69A8C300FE9192 /* AppLaunchUtil.swift in Sources */,
 				E1F816B32BCEC4A80043E2E0 /* NavigationToolbarContainerModel.swift in Sources */,
 				8A0F44732B56FD4500438589 /* SuggestionViewController.swift in Sources */,

--- a/SampleBrowser/SampleBrowser/AppDelegate.swift
+++ b/SampleBrowser/SampleBrowser/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, Notifiable {
         _ application: UIApplication,
         willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        Task { @MainActor in
+        Task {
             self.engineProvider = await EngineProviderManager.shared.getProvider()
             engineProvider?.warmEngine()
         }

--- a/SampleBrowser/SampleBrowser/Dependency/DependencyHelper.swift
+++ b/SampleBrowser/SampleBrowser/Dependency/DependencyHelper.swift
@@ -15,9 +15,6 @@ class DependencyHelper {
         let themeManager: ThemeManager = appDelegate.themeManager
         AppContainer.shared.register(service: themeManager)
 
-        let engineProvider = appDelegate.engineProvider
-        AppContainer.shared.register(service: engineProvider)
-
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }

--- a/SampleBrowser/SampleBrowser/Engine/EngineDependencyManager.swift
+++ b/SampleBrowser/SampleBrowser/Engine/EngineDependencyManager.swift
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import WebEngine
+
+class EngineDependencyManager {
+    let sessionDependencies: EngineSessionDependencies
+    let engineDependencies: EngineDependencies
+    let telemetryHandler = TelemetryHandler()
+
+    init() {
+        let parameters = WKWebviewParameters(blockPopups: false,
+                                             isPrivate: false,
+                                             autoPlay: .all,
+                                             schemeHandler: WKInternalSchemeHandler())
+        self.sessionDependencies = EngineSessionDependencies(webviewParameters: parameters,
+                                                             telemetryProxy: telemetryHandler)
+
+        let readerModeConfig = ReaderModeConfiguration(loadingText: "Loading",
+                                                       loadingFailedText: "Loading failed",
+                                                       loadOriginalText: "Loading",
+                                                       readerModeErrorText: "Error")
+        self.engineDependencies = EngineDependencies(readerModeConfiguration: readerModeConfig)
+    }
+}

--- a/SampleBrowser/SampleBrowser/Engine/EngineDependencyManager.swift
+++ b/SampleBrowser/SampleBrowser/Engine/EngineDependencyManager.swift
@@ -10,10 +10,11 @@ class EngineDependencyManager {
     let telemetryHandler = TelemetryHandler()
 
     init() {
-        let parameters = WKWebviewParameters(blockPopups: false,
+        let parameters = WKWebViewParameters(blockPopups: false,
                                              isPrivate: false,
                                              autoPlay: .all,
-                                             schemeHandler: WKInternalSchemeHandler())
+                                             schemeHandler: WKInternalSchemeHandler(),
+                                             pullRefreshType: PullRefreshView.self)
         self.sessionDependencies = EngineSessionDependencies(webviewParameters: parameters,
                                                              telemetryProxy: telemetryHandler)
 

--- a/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
+++ b/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
@@ -5,6 +5,7 @@
 import Foundation
 import WebEngine
 
+@MainActor
 struct EngineProvider {
     private var engine: Engine
     // We only have one session and one view in the SampleBrowser so this code is very simple
@@ -12,7 +13,7 @@ struct EngineProvider {
     private(set) var view: EngineView
 
     init?(dependencyManager: EngineDependencyManager) async {
-        self.engine = await WKEngine.factory(engineDependencies: dependencyManager.engineDependencies)
+        self.engine = WKEngine.factory(engineDependencies: dependencyManager.engineDependencies)
 
         do {
             session = try await engine.createSession(dependencies: dependencyManager.sessionDependencies)

--- a/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
+++ b/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
@@ -11,12 +11,11 @@ struct EngineProvider {
     private(set) var session: EngineSession
     private(set) var view: EngineView
 
-    init?(engine: Engine,
-          sessionDependencies: EngineSessionDependencies) {
-        self.engine = engine
+    init?(dependencyManager: EngineDependencyManager) async {
+        self.engine = await WKEngine.factory(engineDependencies: dependencyManager.engineDependencies)
 
         do {
-            session = try engine.createSession(dependencies: sessionDependencies)
+            session = try await engine.createSession(dependencies: dependencyManager.sessionDependencies)
         } catch {
             return nil
         }

--- a/SampleBrowser/SampleBrowser/Engine/EngineProviderManager.swift
+++ b/SampleBrowser/SampleBrowser/Engine/EngineProviderManager.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/// The `EngineProviderManager` ensures only one engine can exists per application
+actor EngineProviderManager {
+    static let shared = EngineProviderManager()
+
+    private var dependencyManager = EngineDependencyManager()
+    private var engineProvider: EngineProvider?
+
+    func getProvider() async -> EngineProvider {
+        if let existing = engineProvider {
+            return existing
+        }
+
+        guard let provider = await EngineProvider(dependencyManager: dependencyManager) else {
+            fatalError("No engine provider could be created, this is a fatal error")
+        }
+        self.engineProvider = provider
+        return provider
+    }
+}

--- a/SampleBrowser/SampleBrowser/SceneDelegate.swift
+++ b/SampleBrowser/SampleBrowser/SceneDelegate.swift
@@ -13,15 +13,27 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                willConnectTo session: UISceneSession,
                options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        let windowUUID = UUID()
-        let baseViewController = RootViewController(windowUUID: windowUUID)
-        window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = baseViewController
-        window?.makeKeyAndVisible()
 
-        guard let window else { return }
-        let themeManager: ThemeManager = AppContainer.shared.resolve()
-        themeManager.setWindow(window, for: windowUUID)
-        themeManager.setSystemTheme(isOn: true)
+        let tempVC = UIViewController()
+        tempVC.view.backgroundColor = .systemBackground
+
+        let window = UIWindow(windowScene: windowScene)
+        self.window = window
+        window.rootViewController = tempVC
+        window.makeKeyAndVisible()
+
+        Task {
+            let engineProvider = await EngineProviderManager.shared.getProvider()
+            let windowUUID = UUID()
+            let rootVC = RootViewController(engineProvider: engineProvider, windowUUID: windowUUID)
+
+            await MainActor.run {
+                window.rootViewController = rootVC
+
+                let themeManager: ThemeManager = AppContainer.shared.resolve()
+                themeManager.setWindow(window, for: windowUUID)
+                themeManager.setSystemTheme(isOn: true)
+            }
+        }
     }
 }

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -18,6 +18,7 @@ class BrowserViewController: UIViewController,
                              EngineSessionDelegate {
     weak var navigationDelegate: NavigationDelegate?
     private lazy var progressView: UIProgressView = .build { _ in }
+    private var engineProvider: EngineProvider
     private var engineSession: EngineSession
     private var engineView: EngineView
     private let urlFormatter: URLFormatter
@@ -25,8 +26,9 @@ class BrowserViewController: UIViewController,
 
     // MARK: - Init
 
-    init(engineProvider: EngineProvider = AppContainer.shared.resolve(),
+    init(engineProvider: EngineProvider,
          urlFormatter: URLFormatter = DefaultURLFormatter()) {
+        self.engineProvider = engineProvider
         self.engineSession = engineProvider.session
         self.engineView = engineProvider.view
         self.urlFormatter = urlFormatter
@@ -233,8 +235,7 @@ class BrowserViewController: UIViewController,
         guard let url = linkURL else { return nil }
 
         let previewProvider: UIContextMenuContentPreviewProvider = {
-            let previewEngineProvider: EngineProvider = AppContainer.shared.resolve()
-            let previewVC = BrowserViewController(engineProvider: previewEngineProvider)
+            let previewVC = BrowserViewController(engineProvider: self.engineProvider)
 
             let context = BrowsingContext(type: .internalNavigation, url: url)
             if let browserURL = BrowserURL(browsingContext: context) {

--- a/SampleBrowser/SampleBrowser/UI/RootViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/RootViewController.swift
@@ -37,7 +37,7 @@ class RootViewController: UIViewController,
     private var model = RootViewControllerModel()
 
     // MARK: - Init
-    init(engineProvider: EngineProvider = AppContainer.shared.resolve(),
+    init(engineProvider: EngineProvider,
          windowUUID: UUID?,
          themeManager: ThemeManager = AppContainer.shared.resolve()) {
         self.browserVC = BrowserViewController(engineProvider: engineProvider)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11390)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24791)

## :bulb: Description
This is the first step toward adopting strict concurrency and main actor isolation in the `WebEngine`. This started as a "let's ensure we create a webview configuration on the main thread", but then making this one change had a chain of repercussion so here I am!

### Question
I realized I was relying on default initializer parameters in many places, but it turns out that's not very compatible with strict concurrency — unless I’m misunderstanding the `Main actor-isolated default value in a nonisolated context` error. To fix this, I switched to a factory pattern to support async initialization instead. Let me know if there’s a cleaner way to handle this!

### More to come
I was trying to get this in a good enough working state so we can start discussing the changes in here, but as you can see with the screenshot, there will be more changes (maybe we can do them in another PR since this code is not used yet). I also need to adjust unit tests before this can be merged.

![Screenshot 2025-04-15 at 8 33 51 PM](https://github.com/user-attachments/assets/e56c2b47-d088-4626-821e-2f59d8ad25dc)

 Once this is done we'll also need to enable ` .unsafeFlags(["-strict-concurrency=complete"])` under the `Package.swift` for the `WebEngine`.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

