### PR TITLE
Bugfix FXIOS-11898 Enable ToS by default in Firefox iOS 138+

### DIFF
--- a/firefox-ios/nimbus-features/tosFeature.yaml
+++ b/firefox-ios/nimbus-features/tosFeature.yaml
@@ -8,11 +8,11 @@ features:
         description: >
             Enables the feature
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:
-          status: false
+          status: true
       - channel: developer
         value:
-          status: false
+          status: true

--- a/firefox-ios/nimbus-features/tosFeature.yaml
+++ b/firefox-ios/nimbus-features/tosFeature.yaml
@@ -15,4 +15,4 @@ features:
           status: true
       - channel: developer
         value:
-          status: true
+          status: false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11898)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25952)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Enable tos for all channels.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

