### PR TITLE
Add FXIOS-11523 [Homepage] item impression event

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -60,7 +60,7 @@ final class HomepageDiffableDataSource:
             ]
         }
 
-        var telemetryTappedItemType: HomepageTelemetry.TappedItemType? {
+        var telemetryItemType: HomepageTelemetry.ItemType? {
             switch self {
             case .topSite:
                 return .topSite

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -848,7 +848,7 @@ final class HomepageViewController: UIViewController,
     }
 
     private func sendItemActionWithTelemetryExtras(item: HomepageItem, actionType: HomepageActionType) {
-        let telemetryExtras = HomepageTelemetryExtras(itemType: item.telemetryTappedItemType)
+        let telemetryExtras = HomepageTelemetryExtras(itemType: item.telemetryItemType)
         store.dispatch(
             HomepageAction(
                 telemetryExtras: telemetryExtras,
@@ -865,11 +865,7 @@ final class HomepageViewController: UIViewController,
         willDisplay cell: UICollectionViewCell,
         forItemAt indexPath: IndexPath
     ) {
-        guard let item = dataSource?.itemIdentifier(for: indexPath),
-              !alreadyTrackedItems.contains(item)
-        else {
-            return
-        }
+        guard let item = dataSource?.itemIdentifier(for: indexPath) else { return }
         handleTrackingItemImpression(with: item)
     }
 
@@ -885,16 +881,13 @@ final class HomepageViewController: UIViewController,
             return
         }
         for indexPath in collectionView.indexPathsForVisibleItems {
-            guard let item = dataSource?.itemIdentifier(for: indexPath),
-                  !alreadyTrackedItems.contains(item)
-            else {
-                continue
-            }
+            guard let item = dataSource?.itemIdentifier(for: indexPath) else { continue }
             handleTrackingItemImpression(with: item)
         }
     }
 
     private func handleTrackingItemImpression(with item: HomepageItem) {
+        guard !alreadyTrackedItems.contains(item) else { return }
         alreadyTrackedItems.insert(item)
         sendItemActionWithTelemetryExtras(item: item, actionType: HomepageActionType.itemSeen)
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -6,7 +6,7 @@ import Common
 import Redux
 
 struct HomepageTelemetryExtras {
-    let itemType: HomepageTelemetry.TappedItemType?
+    let itemType: HomepageTelemetry.ItemType?
 }
 
 final class HomepageAction: Action {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -38,4 +38,5 @@ enum HomepageActionType: ActionType {
     case viewWillAppear
     case didSelectItem
     case embeddedHomepage
+    case itemSeen
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
@@ -7,6 +7,7 @@ import Redux
 
 final class HomepageMiddleware {
     private let homepageTelemetry: HomepageTelemetry
+
     init(homepageTelemetry: HomepageTelemetry = HomepageTelemetry()) {
         self.homepageTelemetry = homepageTelemetry
     }
@@ -36,6 +37,12 @@ final class HomepageMiddleware {
                 return
             }
             self.homepageTelemetry.sendItemTappedTelemetryEvent(for: type)
+
+        case HomepageActionType.itemSeen:
+            guard let extras = (action as? HomepageAction)?.telemetryExtras, let type = extras.itemType else {
+                return
+            }
+            self.homepageTelemetry.sendItemImpressionTelemetryEvent(for: type)
 
         default:
             break

--- a/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
@@ -6,7 +6,7 @@ import Foundation
 import Glean
 
 struct HomepageTelemetry {
-    enum TappedItemType: String {
+    enum ItemType: String {
         case topSite = "top_site"
         case jumpBackInTab = "jump_back_in_tab"
         case jumpBackInSyncedTab = "jump_back_in_synced_tab"
@@ -44,12 +44,12 @@ struct HomepageTelemetry {
         gleanWrapper.recordEvent(for: GleanMetrics.Homepage.viewed)
     }
 
-    func sendItemTappedTelemetryEvent(for itemType: TappedItemType) {
+    func sendItemTappedTelemetryEvent(for itemType: ItemType) {
         let itemNameExtra = GleanMetrics.Homepage.ItemTappedExtra(section: itemType.sectionName, type: itemType.rawValue)
         gleanWrapper.recordEvent(for: GleanMetrics.Homepage.itemTapped, extras: itemNameExtra)
     }
 
-    func sendItemImpressionTelemetryEvent(for itemType: TappedItemType) {
+    func sendItemImpressionTelemetryEvent(for itemType: ItemType) {
         let itemNameExtra = GleanMetrics.Homepage.ItemViewedExtra(section: itemType.sectionName, type: itemType.rawValue)
         gleanWrapper.recordEvent(for: GleanMetrics.Homepage.itemViewed, extras: itemNameExtra)
     }

--- a/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
@@ -49,6 +49,11 @@ struct HomepageTelemetry {
         gleanWrapper.recordEvent(for: GleanMetrics.Homepage.itemTapped, extras: itemNameExtra)
     }
 
+    func sendItemImpressionTelemetryEvent(for itemType: TappedItemType) {
+        let itemNameExtra = GleanMetrics.Homepage.ItemViewedExtra(section: itemType.sectionName, type: itemType.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.Homepage.itemViewed, extras: itemNameExtra)
+    }
+
     // MARK: - Top Sites
     enum ContextMenuTelemetryActionType: String {
         case remove, unpin, pin, settings, sponsoredSupport

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -2389,7 +2389,7 @@ homepage:
   viewed:
     type: event
     description: |
-      Records when the Firefox homepage is viewed.
+      Records when the Firefox homepage is viewed. We consider a `view` to be if a user navigates to a new homepage whether through opening a new tab, navigating from a webpage, or after selecting the address bar. Seeing the homepage again after viewing a modal that is not full screen does not trigger a view.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/25082
     data_reviews:
@@ -2409,11 +2409,11 @@ homepage:
       section:
        type: string
        description: |
-        The section that the item belongs to on the homepage. This section name is found in `HomepageTelemetry.TappedItemType` under `sectionName`.
+        The section that the item belongs to on the homepage. This section name is found in `HomepageTelemetry.ItemType` under `sectionName`.
       type:
        type: string
        description: |
-        The type of item that was tapped on the homepage. This name is found in `HomepageTelemetry.TappedItemType`.
+        The type of item that was tapped on the homepage. This name is found in `HomepageTelemetry.ItemType`.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/25086
     data_reviews:
@@ -2428,16 +2428,16 @@ homepage:
   item_viewed:
     type: event
     description: |
-      Records when an item has been viewed on the homepage.
+      Records when an item has been viewed on the homepage. See `homepage.viewed` for more details on what is considered a homepage view. This event refers to an item has been scrolled to or seen on an homepage that has been viewed.
     extra_keys:
       section:
        type: string
        description: |
-        The section that the item belongs to on the homepage. This section name is found in `HomepageTelemetry.TappedItemType` under `sectionName`.
+        The section that the item belongs to on the homepage. This section name is found in `HomepageTelemetry.ItemType` under `sectionName`.
       type:
        type: string
        description: |
-        The type of item that was tapped on the homepage. This name is found in `HomepageTelemetry.TappedItemType`.
+        The type of item that was tapped on the homepage. This name is found in `HomepageTelemetry.ItemType`.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/25083
     data_reviews:

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -2425,6 +2425,31 @@ homepage:
       tags:
         - Homepage
 
+  item_viewed:
+    type: event
+    description: |
+      Records when an item has been viewed on the homepage.
+    extra_keys:
+      section:
+       type: string
+       description: |
+        The section that the item belongs to on the homepage. This section name is found in `HomepageTelemetry.TappedItemType` under `sectionName`.
+      type:
+       type: string
+       description: |
+        The type of item that was tapped on the homepage. This name is found in `HomepageTelemetry.TappedItemType`.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/25083
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/26144
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-07-01"
+    metadata:
+      tags:
+        - Homepage
+
+
 # Metrics related to the history panel of the library
 library:
   panel_pressed:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -193,6 +193,64 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
     }
 
+    func test_collectionDelegate_willDisplay_triggersHomepageAction() throws {
+        let subject = createSubject()
+        // Need to call loadViewIfNeeded and newState to populate the datasource
+        // used to check whether we should send dispatch action or not
+        subject.loadViewIfNeeded()
+        subject.newState(state: HomepageState(windowUUID: .XCTestDefaultUUID))
+
+        subject.collectionView(
+            UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout()),
+            willDisplay: UICollectionViewCell(),
+            forItemAt: IndexPath(item: 0, section: 0)
+        )
+
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.last(where: { $0 is HomepageAction }) as? HomepageAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
+        XCTAssertEqual(actionType, HomepageActionType.itemSeen)
+        XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+    }
+
+    func test_viewDidAppear_triggersHomepageAction() throws {
+        let subject = createSubject()
+        // Need to call loadViewIfNeeded and newState to populate the datasource
+        // used to check whether we should send dispatch action or not
+        // layoutIfNeeded() recalculates the collection view to have items
+        subject.loadViewIfNeeded()
+        subject.newState(state: HomepageState(windowUUID: .XCTestDefaultUUID))
+        subject.view.layoutIfNeeded()
+        subject.viewDidAppear(false)
+
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.last(where: { $0 is HomepageAction }) as? HomepageAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
+        XCTAssertEqual(actionType, HomepageActionType.itemSeen)
+        XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+    }
+
+    func test_scrollViewDidEndDecelerating_triggersHomepageAction() throws {
+        let subject = createSubject()
+        // Need to call loadViewIfNeeded and newState to populate the datasource
+        // used to check whether we should send dispatch action or not
+        // layoutIfNeeded() recalculates the collection view to have items
+        subject.loadViewIfNeeded()
+        subject.newState(state: HomepageState(windowUUID: .XCTestDefaultUUID))
+        subject.view.layoutIfNeeded()
+
+        subject.scrollViewDidEndDecelerating(UIScrollView())
+
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.last(where: { $0 is HomepageAction }) as? HomepageAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
+        XCTAssertEqual(actionType, HomepageActionType.itemSeen)
+        XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+    }
+
     private func createSubject(statusBarScrollDelegate: StatusBarScrollDelegate? = nil) -> HomepageViewController {
         let notificationCenter = MockNotificationCenter()
         let themeManager = MockThemeManager()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
@@ -174,6 +174,32 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(savedExtras.section, "top_sites")
     }
 
+    func test_itemSeenAction_sendTelemetryData() throws {
+        let subject = createSubject()
+        let action = HomepageAction(
+            telemetryExtras: HomepageTelemetryExtras(itemType: .topSite),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.itemSeen
+        )
+
+        subject.homepageProvider(AppState(), action)
+
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Homepage.ItemViewedExtra>
+        )
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras as? GleanMetrics.Homepage.ItemViewedExtra
+        )
+        let expectedMetricType = type(of: GleanMetrics.Homepage.itemViewed)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(savedExtras.type, "top_site")
+        XCTAssertEqual(savedExtras.section, "top_sites")
+    }
+
     // MARK: - Helpers
     private func createSubject() -> HomepageMiddleware {
         return HomepageMiddleware(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11523)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25083)

## :bulb: Description
Add item impression telemetry event. Currently, we only care about certain items being tapped, therefore the show all buttons are not being handled here.
- Added new event `item_viewed`
- Added new action `itemSeen`

Instead of using when the cell is configured like we did in legacy, we add a check to track impression in a couple of places, which is more aligned with the user viewing a cell.
- `viewDidAppear` - initial view
- `scrollViewDidEndDecelerating` - after users scrolls
- `collectionViewDelegate - willDisplay` - if a new cell is about to be viewed

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

