### PR TITLE
Bugfix FXIOS-11909 ⁃ [Homepage rebuilt] Disabling "Shortcuts" does not remove them from homepage on iOS 16

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -283,13 +283,6 @@ extension HomePageSettingViewController {
             let areShortcutsOn = profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.TopSiteSection) ?? true
             typealias Shortcuts = String.Settings.Homepage.Shortcuts
             let status: String = areShortcutsOn ? Shortcuts.ToggleOn : Shortcuts.ToggleOff
-            store.dispatch(
-                TopSitesAction(
-                    isEnabled: areShortcutsOn,
-                    windowUUID: self.windowUUID,
-                    actionType: TopSitesActionType.toggleShowSectionSetting
-                )
-            )
             return NSAttributedString(string: String(format: status))
         }
 

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -38,7 +38,15 @@ class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlagga
                     prefKey: PrefsKeys.UserFeatureFlagPrefs.TopSiteSection,
                     defaultValue: true,
                     titleText: .Settings.Homepage.Shortcuts.ShortcutsToggle
-                ),
+                ) { isOn in
+                    store.dispatch(
+                        TopSitesAction(
+                            isEnabled: isOn,
+                            windowUUID: self.windowUUID,
+                            actionType: TopSitesActionType.toggleShowSectionSetting
+                        )
+                    )
+                },
                 BoolSetting(
                     prefs: profile.prefs,
                     theme: themeManager.getCurrentTheme(for: windowUUID),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11909)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25978)

## :bulb: Description
Dispatch an action when toggle shortcuts 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

