### PR TITLE
Add FXIOS-11208 [Blueprint Download Manager] Downloads Initiated From Private Tabs Dismiss the Live Activity

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -15,7 +15,7 @@ extension BrowserViewController: DownloadQueueDelegate {
         guard download.mimeType != MIMEType.Passbook else { return }
 
         if let downloadProgressManager = self.downloadProgressManager {
-            if tabManager.selectedTab?.isPrivate == true && self.downloadLiveActivityWrapper != nil {
+            if tabManager.selectedTab?.isPrivate == true {
                 dismissDownloadLiveActivity()
             }
             downloadProgressManager.addDownload(download)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11208)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24399)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- If a set of downloads is in progress, and one of the tabs from which a download was initiated was a private tab, dismiss the live activity. `downloadProgressManager` being defined corresponds with some set of downloads being in progress. In this case, dismiss if any newly added downloads were initiated by a private tab.
- If there are no downloads in progress -- `downloadProgressManager` is nil -- check that the tab initiating the download is not private before showing the live activity.
- This covers what to do if the live activity is not started and if it is in progress :)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

