### PR TITLE
Add FXIOS-11210 [Blueprint Download Manager] Stop Downloads via Live Activity

### DIFF
--- a/BrowserKit/Sources/Shared/NotificationConstants.swift
+++ b/BrowserKit/Sources/Shared/NotificationConstants.swift
@@ -67,6 +67,8 @@ extension Notification.Name {
 
     public static let ShowHomepage = Notification.Name("ShowHomepage")
 
+    public static let StopDownloads = Notification.Name("StopDownloads")
+
     public static let TabsTrayDidClose = Notification.Name("TabsTrayDidClose")
 
     public static let TabsTrayDidSelectHomeTab = Notification.Name("TabsTrayDidSelectHomeTab")

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		0BF802E62CFF0951005633E5 /* Shared in Frameworks */ = {isa = PBXBuildFile; productRef = 0BF802E52CFF0951005633E5 /* Shared */; };
 		0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */; };
 		0E12A3152CC2D8410037F8EE /* PasswordGeneratorTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E12A3142CC2D8410037F8EE /* PasswordGeneratorTelemetry.swift */; };
+		0E1488232DAD99DA008978C4 /* DownloadLiveActivityIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECAA5F22DAD737700E27780 /* DownloadLiveActivityIntent.swift */; };
 		0E2E01DA2D77810D000BDBCF /* DownloadLiveActivityWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2E01D92D77810D000BDBCF /* DownloadLiveActivityWrapper.swift */; };
 		0E456F152C541CB300EE93BF /* PasswordGeneratorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E456F142C541CB300EE93BF /* PasswordGeneratorViewController.swift */; };
 		0E4AF8612D763EB0002E4238 /* DownloadLiveActivityUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AF8602D763E9D002E4238 /* DownloadLiveActivityUtil.swift */; };
@@ -130,6 +131,7 @@
 		0EC57CE52CA31E59002E3F04 /* PasswordGeneratorStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57CE42CA31E59002E3F04 /* PasswordGeneratorStateTests.swift */; };
 		0EC57D082CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57D072CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift */; };
 		0EC57D0A2CA6FCC5002E3F04 /* PasswordGeneratorPasswordFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57D092CA6FCC5002E3F04 /* PasswordGeneratorPasswordFieldView.swift */; };
+		0ECAA5F32DAD737700E27780 /* DownloadLiveActivityIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECAA5F22DAD737700E27780 /* DownloadLiveActivityIntent.swift */; };
 		0ECB6B6D2CCFF718006A7C82 /* DateGroupedTableDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECB6B672CCFE663006A7C82 /* DateGroupedTableDataTests.swift */; };
 		158241282820698B00956B39 /* RustRemoteTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158241272820698B00956B39 /* RustRemoteTabsTests.swift */; };
 		15DE98FD27FCED4F00F1ECDB /* RustRemoteTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DE98FC27FCED4F00F1ECDB /* RustRemoteTabs.swift */; };
@@ -2499,6 +2501,7 @@
 		0EC57CE42CA31E59002E3F04 /* PasswordGeneratorStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorStateTests.swift; sourceTree = "<group>"; };
 		0EC57D072CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorHeaderView.swift; sourceTree = "<group>"; };
 		0EC57D092CA6FCC5002E3F04 /* PasswordGeneratorPasswordFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorPasswordFieldView.swift; sourceTree = "<group>"; };
+		0ECAA5F22DAD737700E27780 /* DownloadLiveActivityIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadLiveActivityIntent.swift; sourceTree = "<group>"; };
 		0ECB6B672CCFE663006A7C82 /* DateGroupedTableDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateGroupedTableDataTests.swift; sourceTree = "<group>"; };
 		0EEE4B2AA4EEEF77B6F992F7 /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		0F894AD0807E49799E2534E6 /* nn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nn; path = nn.lproj/Today.strings; sourceTree = "<group>"; };
@@ -10794,6 +10797,7 @@
 				D04D1B852097859B0074B35F /* DownloadToast.swift */,
 				0E4AF8642D764046002E4238 /* DownloadProgressManager.swift */,
 				0E2E01D92D77810D000BDBCF /* DownloadLiveActivityWrapper.swift */,
+				0ECAA5F22DAD737700E27780 /* DownloadLiveActivityIntent.swift */,
 			);
 			path = DownloadHelper;
 			sourceTree = "<group>";
@@ -16512,6 +16516,7 @@
 				DA9FD88624E213CD00168D1E /* Helpers.swift in Sources */,
 				1DF426CF251BDF6A0086386A /* photon-colors.swift in Sources */,
 				E1B18C782B5FFFA9009CD968 /* UIView+extension.swift in Sources */,
+				0E1488232DAD99DA008978C4 /* DownloadLiveActivityIntent.swift in Sources */,
 				4392FB5C252EC51E00AD3D23 /* PrivilegedRequest.swift in Sources */,
 				1D06AE6A24FEE8D6000B092B /* TabProvider.swift in Sources */,
 				DA9FD88424E213B500168D1E /* SmallQuickLink.swift in Sources */,
@@ -17795,6 +17800,7 @@
 				8A83B7482A264FB7002FF9AC /* LibraryCoordinator.swift in Sources */,
 				E1CD81C2290C62A600124B27 /* HostingTableViewCell.swift in Sources */,
 				8AA020EF2B9A37E500771DE0 /* NimbusSplashScreenFeatureLayer.swift in Sources */,
+				0ECAA5F32DAD737700E27780 /* DownloadLiveActivityIntent.swift in Sources */,
 				E13C072D2C2189B80087E404 /* ToolbarActionConfiguration.swift in Sources */,
 				43175DB826B87D2C00C41C31 /* AdsTelemetryHelper.swift in Sources */,
 				E58368AA287D632F0087A449 /* StoryProvider.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -50,7 +50,7 @@ extension BrowserViewController: DownloadQueueDelegate {
         }
     }
 
-    private func stopDownload(buttonPressed: Bool) {
+    func stopDownload(buttonPressed: Bool) {
         // When this toast is dismissed, be sure to clear this so that any
         // subsequent downloads cause a new toast to be created.
         self.downloadToast = nil

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -25,10 +25,10 @@ extension BrowserViewController: DownloadQueueDelegate {
         let downloadProgressManager = DownloadProgressManager(downloads: [download])
         self.downloadProgressManager = downloadProgressManager
 
-        if #available(iOS 16.2, *),
+        if #available(iOS 17, *),
             featureFlags.isFeatureEnabled(.downloadLiveActivities, checking: .buildOnly),
             tabManager.selectedTab?.isPrivate == false {
-            let downloadLiveActivityWrapper = DownloadLiveActivityWrapper(downloadProgressManager: downloadProgressManager)
+            let downloadLiveActivityWrapper = DownloadLiveActivityWrapper(downloadProgressManager: downloadProgressManager, windowUUID: windowUUID.uuidString)
             downloadProgressManager.addDelegate(delegate: downloadLiveActivityWrapper)
             self.downloadLiveActivityWrapper = downloadLiveActivityWrapper
             guard downloadLiveActivityWrapper.start() else {
@@ -40,7 +40,7 @@ extension BrowserViewController: DownloadQueueDelegate {
     }
 
     private func dismissDownloadLiveActivity() {
-        if #available(iOS 16.2, *),
+        if #available(iOS 17, *),
            featureFlags.isFeatureEnabled(.downloadLiveActivities, checking: .buildOnly),
             let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
             downloadLiveActivityWrapper.end(durationToDismissal: .none)
@@ -92,7 +92,7 @@ extension BrowserViewController: DownloadQueueDelegate {
 
         DispatchQueue.main.async { [weak self] in
             downloadToast.dismiss(false)
-            if #available(iOS 16.2, *), let downloadLiveActivityWrapper = self?.downloadLiveActivityWrapper {
+            if #available(iOS 17, *), let downloadLiveActivityWrapper = self?.downloadLiveActivityWrapper {
                 downloadLiveActivityWrapper.end(durationToDismissal: .delayed)
                 self?.downloadLiveActivityWrapper = nil
             }
@@ -111,7 +111,7 @@ extension BrowserViewController: DownloadQueueDelegate {
         // We only care about download errors specific to our window's downloads
         DispatchQueue.main.async {
             downloadToast.dismiss(false)
-            if #available(iOS 16.2, *),
+            if #available(iOS 17, *),
                let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
                 downloadLiveActivityWrapper.end(durationToDismissal: .delayed)
                 self.downloadLiveActivityWrapper = nil
@@ -160,4 +160,5 @@ extension BrowserViewController: DownloadQueueDelegate {
                   afterWaiting: UX.downloadToastDelay,
                   duration: UX.downloadToastDuration)
     }
+
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -28,7 +28,9 @@ extension BrowserViewController: DownloadQueueDelegate {
         if #available(iOS 17, *),
             featureFlags.isFeatureEnabled(.downloadLiveActivities, checking: .buildOnly),
             tabManager.selectedTab?.isPrivate == false {
-            let downloadLiveActivityWrapper = DownloadLiveActivityWrapper(downloadProgressManager: downloadProgressManager, windowUUID: windowUUID.uuidString)
+            let downloadLiveActivityWrapper = DownloadLiveActivityWrapper(
+                downloadProgressManager: downloadProgressManager,
+                windowUUID: windowUUID.uuidString)
             downloadProgressManager.addDelegate(delegate: downloadLiveActivityWrapper)
             self.downloadLiveActivityWrapper = downloadLiveActivityWrapper
             guard downloadLiveActivityWrapper.start() else {
@@ -160,5 +162,4 @@ extension BrowserViewController: DownloadQueueDelegate {
                   afterWaiting: UX.downloadToastDelay,
                   duration: UX.downloadToastDuration)
     }
-
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -117,7 +117,7 @@ class BrowserViewController: UIViewController,
 
     private var _downloadLiveActivityWrapper: Any?
 
-    @available(iOS 16.2, *)
+    @available(iOS 17, *)
     var downloadLiveActivityWrapper: DownloadLiveActivityWrapper? {
         get {
             return _downloadLiveActivityWrapper as? DownloadLiveActivityWrapper
@@ -919,6 +919,16 @@ class BrowserViewController: UIViewController,
             name: .RemoteTabNotificationTapped,
             object: nil
         )
+        _ = notificationCenter.addObserver(name: UserDefaults.didChangeNotification, queue: .main) {_ in
+            print("Stopped UUID: \(UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.string(forKey: "stopDownload") ?? "not working")")
+            print("window UUID: \(self.windowUUID.uuidString)")
+            guard UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.string(forKey: "stopDownload") == self.windowUUID.uuidString else{
+                return
+            }
+            self.downloadToast?.dismiss(true)
+            self.stopDownload(buttonPressed: true)
+            UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.set(nil, forKey: "stopDownload")
+        }
     }
 
     private func switchToolbarIfNeeded() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -919,10 +919,19 @@ class BrowserViewController: UIViewController,
             name: .RemoteTabNotificationTapped,
             object: nil
         )
-        _ = notificationCenter.addObserver(name: UserDefaults.didChangeNotification, queue: .main) {_ in
-            print("Stopped UUID: \(UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.string(forKey: "stopDownload") ?? "not working")")
-            print("window UUID: \(self.windowUUID.uuidString)")
-            guard UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.string(forKey: "stopDownload") == self.windowUUID.uuidString else{
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(onStopDownloadChanged),
+            name: UserDefaults.didChangeNotification,
+            object: nil
+        )
+    }
+
+    @objc
+    private func onStopDownloadChanged() {
+        ensureMainThread {
+            guard UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?
+                .string(forKey: "stopDownload") == self.windowUUID.uuidString else {
                 return
             }
             self.downloadToast?.dismiss(true)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -921,22 +921,19 @@ class BrowserViewController: UIViewController,
         )
         notificationCenter.addObserver(
             self,
-            selector: #selector(onStopDownloadChanged),
-            name: UserDefaults.didChangeNotification,
+            selector: #selector(onStopDownloads(_:)),
+            name: .StopDownloads,
             object: nil
         )
     }
 
     @objc
-    private func onStopDownloadChanged() {
+    private func onStopDownloads(_ notification: Notification) {
         ensureMainThread {
-            guard UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?
-                .string(forKey: "stopDownload") == self.windowUUID.uuidString else {
-                return
-            }
+            guard let notiWindowUUID = notification.userInfo?["windowUUID"] as? String,
+                  notiWindowUUID == self.windowUUID.uuidString else {return}
             self.downloadToast?.dismiss(true)
             self.stopDownload(buttonPressed: true)
-            UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.set(nil, forKey: "stopDownload")
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityIntent.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityIntent.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import AppIntents
+import Common
+
+@available(iOS 17.0, *)
+struct DownloadLiveActivityIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "Stop Downloads"
+    
+    @Parameter(title: "WindowUUID")
+    var windowUUID: String
+
+    func perform() async throws -> some IntentResult {
+        UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.set(windowUUID, forKey: "stopDownload")
+
+        return .result()
+    }
+}
+
+

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityIntent.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityIntent.swift
@@ -14,7 +14,9 @@ struct DownloadLiveActivityIntent: LiveActivityIntent {
     var windowUUID: String
 
     func perform() async throws -> some IntentResult {
-        UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.set(windowUUID, forKey: "stopDownload")
+        NotificationCenter.default.post(name: Notification.Name.StopDownloads,
+                                        object: self,
+                                        userInfo: ["windowUUID": windowUUID])
 
         return .result()
     }

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityIntent.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityIntent.swift
@@ -9,7 +9,7 @@ import Common
 @available(iOS 17.0, *)
 struct DownloadLiveActivityIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Stop Downloads"
-    
+
     @Parameter(title: "WindowUUID")
     var windowUUID: String
 
@@ -19,5 +19,3 @@ struct DownloadLiveActivityIntent: LiveActivityIntent {
         return .result()
     }
 }
-
-

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -8,7 +8,7 @@ import ActivityKit
 import Common
 import Shared
 
-@available(iOS 16.2, *)
+@available(iOS 17, *)
 class DownloadLiveActivityWrapper: DownloadProgressDelegate {
     enum DurationToDismissal: Double {
         case none = 0
@@ -17,13 +17,16 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
     var downloadLiveActivity: Activity<DownloadLiveActivityAttributes>?
 
     var downloadProgressManager: DownloadProgressManager
+    
+    let windowUUID: String
 
-    init(downloadProgressManager: DownloadProgressManager) {
+    init(downloadProgressManager: DownloadProgressManager, windowUUID: String) {
         self.downloadProgressManager = downloadProgressManager
+        self.windowUUID = windowUUID
     }
 
     func start() -> Bool {
-        let attributes = DownloadLiveActivityAttributes()
+        let attributes = DownloadLiveActivityAttributes(windowUUID: windowUUID)
 
         let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
         let contentState = DownloadLiveActivityAttributes.ContentState(downloads: downloadsStates)

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -61,10 +61,10 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
     }
 
     func updateCombinedBytesDownloaded(value: Int64) {
-//        update()
+        update()
     }
 
     func updateCombinedTotalBytesExpected(value: Int64?) {
-//        update()
+        update()
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -17,7 +17,7 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
     var downloadLiveActivity: Activity<DownloadLiveActivityAttributes>?
 
     var downloadProgressManager: DownloadProgressManager
-    
+
     let windowUUID: String
 
     init(downloadProgressManager: DownloadProgressManager, windowUUID: String) {
@@ -61,10 +61,10 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
     }
 
     func updateCombinedBytesDownloaded(value: Int64) {
-        update()
+//        update()
     }
 
     func updateCombinedTotalBytesExpected(value: Int64?) {
-        update()
+//        update()
     }
 }

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -172,7 +172,6 @@ struct DownloadLiveActivity: Widget {
                 }
                 .padding()
             }
-        
     }
 
     private func lockScreenTexts(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>) -> some View {
@@ -289,7 +288,8 @@ struct DownloadLiveActivity: Widget {
           Button(intent: intent) {
               ZStack {
                   Circle()
-                      .stroke(UX.DynamicIsland.circleStrokeColor, lineWidth: DownloadLiveActivity.UX.DynamicIsland.progressWidth)
+                      .stroke(UX.DynamicIsland.circleStrokeColor,
+                              lineWidth: DownloadLiveActivity.UX.DynamicIsland.progressWidth)
                       .frame(width: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize,
                              height: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize)
                   Circle()
@@ -315,7 +315,7 @@ struct DownloadLiveActivity: Widget {
                                   bottom: DownloadLiveActivity.UX.DynamicIsland.iconBottomPadding,
                                   trailing: DownloadLiveActivity.UX.DynamicIsland.iconRightPadding))
           }.buttonStyle(.plain)
-          }
+      }
     }
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: DownloadLiveActivityAttributes.self) { liveDownload in

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -144,10 +144,12 @@ struct DownloadLiveActivity: Widget {
         }
     }
     private func lockScreenView (liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>) -> some View {
+        let intent = DownloadLiveActivityIntent()
+        intent.windowUUID = liveDownload.attributes.windowUUID
         return
             ZStack {
                 Rectangle()
-                                .widgetURL(URL(string: URL.mozInternalScheme + "://deep-link?url=/homepanel/downloads"))
+                    .widgetURL(URL(string: URL.mozInternalScheme + "://deep-link?url=/homepanel/downloads"))
                     .foregroundStyle(LinearGradient(
                         gradient: Gradient(colors: [UX.LockScreen.gradient1, UX.LockScreen.gradient2]),
                         startPoint: .topLeading,
@@ -161,11 +163,6 @@ struct DownloadLiveActivity: Widget {
                     }
                     lockScreenTexts(liveDownload: liveDownload)
                     Spacer()
-                    let intent: DownloadLiveActivityIntent = {
-                        let intent = DownloadLiveActivityIntent()
-                        intent.windowUUID = liveDownload.attributes.windowUUID
-                        return intent
-                    }()
                     Button(intent: intent) {
                         lockScreenDownloadProgress(liveDownload: liveDownload)
                     }.buttonStyle(.plain)
@@ -197,7 +194,7 @@ struct DownloadLiveActivity: Widget {
     private func lockScreenDownloadProgress(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>) -> some View {
         let totalCompletion = liveDownload.state.completedDownloads == liveDownload.state.downloads.count
         let circleProgressPercentage = min(
-          liveDownload.state.containsOnlyEncodedFiles ? 1.0 : liveDownload.state.totalProgress, 1.0
+            liveDownload.state.containsOnlyEncodedFiles ? 1.0 : liveDownload.state.totalProgress, 1.0
         )
         return ZStack {
             Circle()
@@ -220,102 +217,99 @@ struct DownloadLiveActivity: Widget {
 
     private func leadingExpandedRegion(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>)
     -> DynamicIslandExpandedRegion<some View> {
-      DynamicIslandExpandedRegion(.leading) {
-        ZStack {
-            RoundedRectangle(cornerRadius: DownloadLiveActivity.UX.DynamicIsland.iconEdgeRounding)
-            .fill(DownloadLiveActivity.UX.DynamicIsland.widgetColours)
-            .frame(width: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize,
-                   height: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize)
-          Image(DownloadLiveActivity.UX.firefoxIcon)
-            .resizable()
-            .scaledToFit()
-            .frame(width: DownloadLiveActivity.UX.DynamicIsland.firefoxIconSize,
-                   height: DownloadLiveActivity.UX.DynamicIsland.firefoxIconSize)
-        }.padding(EdgeInsets(top: DownloadLiveActivity.UX.DynamicIsland.iconTopPadding,
-                             leading: DownloadLiveActivity.UX.DynamicIsland.iconLeftPadding,
-                             bottom: DownloadLiveActivity.UX.DynamicIsland.iconBottomPadding,
-                             trailing: DownloadLiveActivity.UX.DynamicIsland.iconRightPadding))
-      }
+        DynamicIslandExpandedRegion(.leading) {
+            ZStack {
+                RoundedRectangle(cornerRadius: DownloadLiveActivity.UX.DynamicIsland.iconEdgeRounding)
+                    .fill(DownloadLiveActivity.UX.DynamicIsland.widgetColours)
+                    .frame(width: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize,
+                           height: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize)
+                Image(DownloadLiveActivity.UX.firefoxIcon)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: DownloadLiveActivity.UX.DynamicIsland.firefoxIconSize,
+                           height: DownloadLiveActivity.UX.DynamicIsland.firefoxIconSize)
+            }.padding(EdgeInsets(top: DownloadLiveActivity.UX.DynamicIsland.iconTopPadding,
+                                 leading: DownloadLiveActivity.UX.DynamicIsland.iconLeftPadding,
+                                 bottom: DownloadLiveActivity.UX.DynamicIsland.iconBottomPadding,
+                                 trailing: DownloadLiveActivity.UX.DynamicIsland.iconRightPadding))
+        }
     }
     private func centerExpandedRegion(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>)
     -> DynamicIslandExpandedRegion<some View> {
-      DynamicIslandExpandedRegion(.center) {
-          Text(liveDownload.state.downloads.count == 1 ?
-               String(format: .LiveActivity.Downloads.FileNameText, liveDownload.state.downloads[0].fileName) :
-                  String(format: .LiveActivity.Downloads.FileCountText, String(liveDownload.state.downloads.count)))
-          .font(.headline)
-          .frame(maxWidth: .infinity,
-                 alignment: .leading)
-          .padding(EdgeInsets(top: liveDownload.state.containsOnlyEncodedFiles ?
-                              DownloadLiveActivity.UX.DynamicIsland.wordsTopPaddingNoSubtitle :
-                              DownloadLiveActivity.UX.DynamicIsland.wordsTopPadding,
-                              leading: DownloadLiveActivity.UX.DynamicIsland.wordsLeftPadding,
-                              bottom: DownloadLiveActivity.UX.DynamicIsland.wordsBottomPadding,
-                              trailing: DownloadLiveActivity.UX.DynamicIsland.wordsRightPadding))
-        let bytesDownloaded = ByteCountFormatter.string(
-          fromByteCount: liveDownload.state.totalBytesDownloaded,
-          countStyle: .file
-        )
-        let bytesExpected = ByteCountFormatter.string(
-          fromByteCount: liveDownload.state.totalBytesExpected,
-          countStyle: .file
-        )
-        if !liveDownload.state.containsOnlyEncodedFiles {
-          Text(String(format: .LiveActivity.Downloads.FileProgressText, bytesDownloaded, bytesExpected))
-            .font(.subheadline)
-            .foregroundColor(DownloadLiveActivity.UX.DynamicIsland.widgetColours)
+        DynamicIslandExpandedRegion(.center) {
+            Text(liveDownload.state.downloads.count == 1 ?
+                 String(format: .LiveActivity.Downloads.FileNameText, liveDownload.state.downloads[0].fileName) :
+                    String(format: .LiveActivity.Downloads.FileCountText, String(liveDownload.state.downloads.count)))
+            .font(.headline)
             .frame(maxWidth: .infinity,
                    alignment: .leading)
-            .padding(EdgeInsets(top: DownloadLiveActivity.UX.DynamicIsland.wordsTopPadding,
+            .padding(EdgeInsets(top: liveDownload.state.containsOnlyEncodedFiles ?
+                                DownloadLiveActivity.UX.DynamicIsland.wordsTopPaddingNoSubtitle :
+                                    DownloadLiveActivity.UX.DynamicIsland.wordsTopPadding,
                                 leading: DownloadLiveActivity.UX.DynamicIsland.wordsLeftPadding,
                                 bottom: DownloadLiveActivity.UX.DynamicIsland.wordsBottomPadding,
                                 trailing: DownloadLiveActivity.UX.DynamicIsland.wordsRightPadding))
-            .contentTransition(.identity)
+            let bytesDownloaded = ByteCountFormatter.string(
+                fromByteCount: liveDownload.state.totalBytesDownloaded,
+                countStyle: .file
+            )
+            let bytesExpected = ByteCountFormatter.string(
+                fromByteCount: liveDownload.state.totalBytesExpected,
+                countStyle: .file
+            )
+            if !liveDownload.state.containsOnlyEncodedFiles {
+                Text(String(format: .LiveActivity.Downloads.FileProgressText, bytesDownloaded, bytesExpected))
+                    .font(.subheadline)
+                    .foregroundColor(DownloadLiveActivity.UX.DynamicIsland.widgetColours)
+                    .frame(maxWidth: .infinity,
+                           alignment: .leading)
+                    .padding(EdgeInsets(top: DownloadLiveActivity.UX.DynamicIsland.wordsTopPadding,
+                                        leading: DownloadLiveActivity.UX.DynamicIsland.wordsLeftPadding,
+                                        bottom: DownloadLiveActivity.UX.DynamicIsland.wordsBottomPadding,
+                                        trailing: DownloadLiveActivity.UX.DynamicIsland.wordsRightPadding))
+                    .contentTransition(.identity)
+            }
         }
-      }
     }
     private func trailingExpandedRegion(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>)
     -> DynamicIslandExpandedRegion<some View> {
-      let circleProgressPercentage = min(
-        liveDownload.state.containsOnlyEncodedFiles ? 1.0 : liveDownload.state.totalProgress, 1.0
-      )
-      return DynamicIslandExpandedRegion(.trailing) {
-          let intent: DownloadLiveActivityIntent = {
-              let intent = DownloadLiveActivityIntent()
-              intent.windowUUID = liveDownload.attributes.windowUUID
-              return intent
-          }()
-          Button(intent: intent) {
-              ZStack {
-                  Circle()
-                      .stroke(UX.DynamicIsland.circleStrokeColor,
-                              lineWidth: DownloadLiveActivity.UX.DynamicIsland.progressWidth)
-                      .frame(width: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize,
-                             height: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize)
-                  Circle()
-                      .trim(from: 0.0, to: circleProgressPercentage)
-                      .stroke(style: StrokeStyle(lineWidth: DownloadLiveActivity.UX.DynamicIsland.progressWidth))
-                      .rotationEffect(.degrees(DownloadLiveActivity.UX.DynamicIsland.rotation))
-                      .animation(.linear, value: 0.5)
-                  Image(
-                    liveDownload.state.completedDownloads == liveDownload.state.downloads.count
-                    ? DownloadLiveActivity.UX.checkmarkIcon
-                    : DownloadLiveActivity.UX.mediaStopIcon
-                  )
-                  .renderingMode(.template)
-                  .resizable()
-                  .scaledToFit()
-                  .foregroundStyle(DownloadLiveActivity.UX.DynamicIsland.widgetColours)
-                  .frame(width: DownloadLiveActivity.UX.DynamicIsland.stateIconSize,
-                         height: DownloadLiveActivity.UX.DynamicIsland.stateIconSize)
-              }.frame(width: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize,
-                      height: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize)
-              .padding(EdgeInsets(top: DownloadLiveActivity.UX.DynamicIsland.iconTopPadding,
-                                  leading: DownloadLiveActivity.UX.DynamicIsland.iconLeftPadding,
-                                  bottom: DownloadLiveActivity.UX.DynamicIsland.iconBottomPadding,
-                                  trailing: DownloadLiveActivity.UX.DynamicIsland.iconRightPadding))
-          }.buttonStyle(.plain)
-      }
+        let circleProgressPercentage = min(
+            liveDownload.state.containsOnlyEncodedFiles ? 1.0 : liveDownload.state.totalProgress, 1.0
+        )
+        let intent = DownloadLiveActivityIntent()
+        intent.windowUUID = liveDownload.attributes.windowUUID
+        return DynamicIslandExpandedRegion(.trailing) {
+            Button(intent: intent) {
+                ZStack {
+                    Circle()
+                        .stroke(UX.DynamicIsland.circleStrokeColor,
+                                lineWidth: DownloadLiveActivity.UX.DynamicIsland.progressWidth)
+                        .frame(width: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize,
+                               height: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize)
+                    Circle()
+                        .trim(from: 0.0, to: circleProgressPercentage)
+                        .stroke(style: StrokeStyle(lineWidth: DownloadLiveActivity.UX.DynamicIsland.progressWidth))
+                        .rotationEffect(.degrees(DownloadLiveActivity.UX.DynamicIsland.rotation))
+                        .animation(.linear, value: 0.5)
+                    Image(
+                        liveDownload.state.completedDownloads == liveDownload.state.downloads.count
+                        ? DownloadLiveActivity.UX.checkmarkIcon
+                        : DownloadLiveActivity.UX.mediaStopIcon
+                    )
+                    .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(DownloadLiveActivity.UX.DynamicIsland.widgetColours)
+                    .frame(width: DownloadLiveActivity.UX.DynamicIsland.stateIconSize,
+                           height: DownloadLiveActivity.UX.DynamicIsland.stateIconSize)
+                }.frame(width: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize,
+                        height: DownloadLiveActivity.UX.DynamicIsland.iconFrameSize)
+                .padding(EdgeInsets(top: DownloadLiveActivity.UX.DynamicIsland.iconTopPadding,
+                                    leading: DownloadLiveActivity.UX.DynamicIsland.iconLeftPadding,
+                                    bottom: DownloadLiveActivity.UX.DynamicIsland.iconBottomPadding,
+                                    trailing: DownloadLiveActivity.UX.DynamicIsland.iconRightPadding))
+            }.buttonStyle(.plain)
+        }
     }
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: DownloadLiveActivityAttributes.self) { liveDownload in
@@ -335,7 +329,7 @@ struct DownloadLiveActivity: Widget {
                     .padding([.leading, .trailing], 2)
             } compactTrailing: {
                 let circleProgressPercentage = min(
-                  liveDownload.state.containsOnlyEncodedFiles ? 1.0 : liveDownload.state.totalProgress, 1.0
+                    liveDownload.state.containsOnlyEncodedFiles ? 1.0 : liveDownload.state.totalProgress, 1.0
                 )
                 ZStack {
                     Circle()

--- a/firefox-ios/WidgetKit/WidgetKit.swift
+++ b/firefox-ios/WidgetKit/WidgetKit.swift
@@ -13,7 +13,7 @@ struct FirefoxWidgets: WidgetBundle {
         SearchQuickLinksWidget()
         OpenTabsWidget()
         TopSitesWidget()
-        if #available(iOS 16.2, *) {
+        if #available(iOS 17, *) {
             DownloadLiveActivity()
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadProgressManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadProgressManagerTests.swift
@@ -53,7 +53,7 @@ class DownloadProgressManagerTests: XCTestCase {
         XCTAssertEqual(mockDelegate.totalBytesExpectedParameter, 40)
     }
 
-    @available(iOS 16.2, *)
+    @available(iOS 17, *)
     func testMemoryLeaks() {
         let download = MockDownload()
         let downloadProgressManager = createSubject(downloads: [download])

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadProgressManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadProgressManagerTests.swift
@@ -58,7 +58,7 @@ class DownloadProgressManagerTests: XCTestCase {
         let download = MockDownload()
         let downloadProgressManager = createSubject(downloads: [download])
         var downloadLiveActivity: DownloadLiveActivityWrapper? = DownloadLiveActivityWrapper(
-            downloadProgressManager: downloadProgressManager)
+            downloadProgressManager: downloadProgressManager, windowUUID: WindowUUID.XCTestDefaultUUID.uuidString)
         var downloadToast: DownloadToast? = DownloadToast(
             downloadProgressManager: downloadProgressManager,
             theme: LightTheme(),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11210)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24401)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- When creating a live activity we pass the current `windowUUID` to it as an attribute. 
- We have set up a live activity intent to respond to a click of the stop button in the live activity. This intent takes the `windowUUID` mentioned in the last line to determine which window to cancel downloads for. The intent also updates the `stopDownload` shared userdefault mentioned in the next line.
- Designated a `UserDefault` shared value to hold the `windowUUID` of the window that requested download cancellation.
- Each window observes `UserDefaults` and checks if the `stopDownload` value is equal to the current current `windowUUID`. If this is the case, the downloads for this window will be stopped.

- The reason for the use of `UserDefaults` is that from what I understand, the app intent has no access to the client process. This means the way to indicate to the client that it has to stop the download is to update a shared value that client is observing.

Todo Still:
- Improve the naming for the userdefault
- Ensure that the app group that I'm using is ideal

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

