### PR TITLE
Add FXIOS-11067 [Password Manager] P1. Add feature flag for updated password manager scripts

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -54,6 +54,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case trackingProtectionRefactor
     case revertUnsafeContinuationsRefactor
     case useRustKeychain
+    case updatedPasswordManager
 
     // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`. Add in alphabetical order.
     var debugKey: String? {
@@ -78,7 +79,8 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .downloadLiveActivities,
                 .unifiedAds,
                 .unifiedSearch,
-                .useRustKeychain:
+                .useRustKeychain,
+                .updatedPasswordManager:
             return rawValue + PrefsKeys.FeatureFlags.DebugSuffixKey
         default:
             return nil
@@ -150,7 +152,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .tosFeature,
                 .trackingProtectionRefactor,
                 .revertUnsafeContinuationsRefactor,
-                .useRustKeychain:
+                .useRustKeychain,
+                .updatedPasswordManager:
             return nil
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -165,6 +165,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
+                    with: .updatedPasswordManager,
+                    titleText: format(string: "Enable Updated Password Manager"),
+                    statusText: format(string: "Toggle to enable updated password manager")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .sentFromFirefox,
                     titleText: format(string: "Enable Sent from Firefox"),
                     statusText: format(string: "Toggle to enable Sent from Firefox to append text to WhatsApp shares")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -136,6 +136,9 @@ final class NimbusFeatureFlagLayer {
 
         case .useRustKeychain:
             return checkUseRustKeychainFeature(from: nimbus)
+
+        case .updatedPasswordManager:
+            return checkUpdatedPasswordManagerFeature(from: nimbus)
         }
     }
 
@@ -408,5 +411,10 @@ final class NimbusFeatureFlagLayer {
 
     private func checkUseRustKeychainFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.rustKeychainRefactor.value().rustKeychainEnabled
+    }
+
+    private func checkUpdatedPasswordManagerFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.updatedPasswordManagerFeature.value()
+        return config.status
     }
 }

--- a/firefox-ios/nimbus-features/updatedPasswordManager.yaml
+++ b/firefox-ios/nimbus-features/updatedPasswordManager.yaml
@@ -1,0 +1,17 @@
+# The configuration for the updated password manager scripts
+features:
+  updated-password-manager-feature:
+    description: >
+      This property determines if we use the updated password manager or the legacy one.
+    variables:
+      status:
+        description: If true, firefox will use the  the updated password manager.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          status: false
+      - channel: developer
+        value:
+          status: false

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -49,3 +49,4 @@ include:
   - nimbus-features/trackingProtectionRefactor.yaml
   - nimbus-features/revertUnsafeContinuationsRefactor.yaml
   - nimbus-features/unifiedAds.yaml
+  - nimbus-features/updatedPasswordManager.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11067)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24133)

⚠️ NOTE: This a PR in a stack of PRs to make reviewing easier
- ➡️ https://github.com/mozilla-mobile/firefox-ios/pull/26162
- https://github.com/mozilla-mobile/firefox-ios/pull/26163
- https://github.com/mozilla-mobile/firefox-ios/pull/26164

## :bulb: Description
This PR:
- Adds `updatedPasswordManager` nimbus flag for controlling the updated password manager rollout.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

