### PR TITLE
Bugix [Content Sharing opt] fix home page activity and File copy to clipboard message

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		0B7C1E951F6097AD006A8869 /* TrackingProtectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7C1E941F6097AD006A8869 /* TrackingProtectionTests.swift */; };
 		0B7CF8872CAC1C4E00DC02F8 /* DefaultFolderHierarchyFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7CF8862CAC1C4E00DC02F8 /* DefaultFolderHierarchyFetcherTests.swift */; };
 		0B7FC3D32CAE811F005C5CCE /* DefaultBookmarksSaverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7FC3D12CAE811B005C5CCE /* DefaultBookmarksSaverTests.swift */; };
+		0B81AFEC2DB1000C000AF70F /* HomePageActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B81AFEB2DB1000C000AF70F /* HomePageActivity.swift */; };
+		0B81AFEE2DB1036B000AF70F /* HomePageActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B81AFED2DB1036B000AF70F /* HomePageActivityTests.swift */; };
 		0B8A39EF2D3514C100853E47 /* EditBookmarkDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8A39EE2D3514C100853E47 /* EditBookmarkDiffableDataSource.swift */; };
 		0B8A39F12D351C2500853E47 /* EditBookmarkDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8A39F02D351C2500853E47 /* EditBookmarkDataSourceTests.swift */; };
 		0B8BF3702CA2D60B00E9812D /* BookmarksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8BF36F2CA2D60B00E9812D /* BookmarksViewController.swift */; };
@@ -2432,6 +2434,8 @@
 		0B7C1E941F6097AD006A8869 /* TrackingProtectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionTests.swift; sourceTree = "<group>"; };
 		0B7CF8862CAC1C4E00DC02F8 /* DefaultFolderHierarchyFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFolderHierarchyFetcherTests.swift; sourceTree = "<group>"; };
 		0B7FC3D12CAE811B005C5CCE /* DefaultBookmarksSaverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBookmarksSaverTests.swift; sourceTree = "<group>"; };
+		0B81AFEB2DB1000C000AF70F /* HomePageActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageActivity.swift; sourceTree = "<group>"; };
+		0B81AFED2DB1036B000AF70F /* HomePageActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageActivityTests.swift; sourceTree = "<group>"; };
 		0B8749EB891EE229EA88FEF3 /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		0B8A39EE2D3514C100853E47 /* EditBookmarkDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditBookmarkDiffableDataSource.swift; sourceTree = "<group>"; };
 		0B8A39F02D351C2500853E47 /* EditBookmarkDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditBookmarkDataSourceTests.swift; sourceTree = "<group>"; };
@@ -14025,6 +14029,7 @@
 				2128E27A292E624400FB91BE /* SendToDeviceActivity.swift */,
 				E1AFBAF8292EA0330065E35E /* SendToDeviceHelper.swift */,
 				D3972BF11C22412B00035B87 /* ShareManager.swift */,
+				0B81AFEB2DB1000C000AF70F /* HomePageActivity.swift */,
 				ED67B2952D0C921600BDC599 /* ShareTelemetry.swift */,
 				ED7A08DA2CF674730035EC8F /* ShareMessage.swift */,
 				ED7A08DC2CF6749B0035EC8F /* ShareType.swift */,
@@ -14820,6 +14825,7 @@
 				ED67B2932D0B80E200BDC599 /* TitleActivityItemProviderTests.swift */,
 				ED67B2912D0B79F000BDC599 /* TitleSubtitleActivityItemProviderTests.swift */,
 				ED33E3562D0A4CE9002265A7 /* URLActivityItemProviderTests.swift */,
+				0B81AFED2DB1036B000AF70F /* HomePageActivityTests.swift */,
 			);
 			path = Sharing;
 			sourceTree = "<group>";
@@ -17077,6 +17083,7 @@
 				C2D71B9B2A3850B4003DEC7A /* ThemedTableViewCellViewModel.swift in Sources */,
 				C869912F28917688007ACC5C /* WallpaperMetadataLoader.swift in Sources */,
 				8A6904802B97BBAE00E30047 /* SplashScreenAnimation.swift in Sources */,
+				0B81AFEC2DB1000C000AF70F /* HomePageActivity.swift in Sources */,
 				2137785D297F1F2800D01309 /* DownloadedFile.swift in Sources */,
 				1DCEC4142D83B7EB00129966 /* ASSearchEngineIconDataFetcher.swift in Sources */,
 				745DAB301CDAAFAA00D44181 /* RecentlyClosedTabsPanel.swift in Sources */,
@@ -18140,6 +18147,7 @@
 				8A8629E72880B7330096DDB1 /* LegacyBookmarksPanelTests.swift in Sources */,
 				61A1644A2CE7BE8A001D6058 /* WallpaperMiddlewareTests.swift in Sources */,
 				C8B394362A0ED55D00700E49 /* MockOnboardingCardDelegate.swift in Sources */,
+				0B81AFEE2DB1036B000AF70F /* HomePageActivityTests.swift in Sources */,
 				8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */,
 				8ABB15C92D5A4E3900A4635C /* RemoteTabsMiddlewareTests.swift in Sources */,
 				C787D8C32C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -102,7 +102,11 @@ class ShareSheetCoordinator: BaseCoordinator,
                 showSendToDevice(url: shareType.wrappedURL, relatedTab: nil)
             }
         case .copyToPasteboard:
-            showToast(text: .LegacyAppMenu.AppMenuCopyURLConfirmMessage)
+            if case .file = shareType {
+                showToast(text: .ShareFileCopiedToClipboard)
+            } else {
+                showToast(text: .LegacyAppMenu.AppMenuCopyURLConfirmMessage)
+            }
             dequeueNotShownJSAlert()
         default:
             dequeueNotShownJSAlert()

--- a/firefox-ios/Client/Frontend/Share/HomePageActivity.swift
+++ b/firefox-ios/Client/Frontend/Share/HomePageActivity.swift
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import WebKit
+
+/// The activity representing in the Share sheet the action to add a website to the iOS homepage.
+///
+/// - Note: the activity is a `WKWebView` cause the frameworks generates the add to home page activity only
+/// when passing a `WKWebView`. This `WKWebView` subclass gives the ability to modify the content of the activity,
+/// by modifying the title and/or the url.
+class HomePageActivity: WKWebView {
+    private let stubbedURL: URL?
+    private let stubbedTitle: String?
+
+    init(url: URL?, title: String?) {
+        if let internalURL = InternalURL(url) {
+            stubbedURL = internalURL.extractedUrlParam
+        } else {
+            stubbedURL = url
+        }
+        stubbedTitle = title
+        super.init(frame: .zero, configuration: .init())
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var url: URL? {
+        return stubbedURL
+    }
+
+    override var title: String? {
+        return stubbedTitle
+    }
+}

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -6,6 +6,7 @@ import Foundation
 import MobileCoreServices
 import WebKit
 import UniformTypeIdentifiers
+import Shared
 
 class ShareManager: NSObject, FeatureFlaggable {
     private struct ActivityIdentifiers {
@@ -115,9 +116,8 @@ class ShareManager: NSObject, FeatureFlaggable {
 
             // Add the webview for an option to add a website to the iOS home screen
             if #available(iOS 16.4, *), let webView = tab.webView {
-                // NOTE: You will not see "Add to Home Screen" option on debug builds. Possibly this is because of how the
-                // com.apple.developer.web-browser entitlement is applied...
-                activityItems.append(webView)
+                activityItems.append(HomePageActivity(url: webView.url,
+                                                      title: webView.title))
             }
 
             if let explicitShareMessage {

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -5401,6 +5401,11 @@ extension String {
         tableName: nil,
         value: "Add to Reading List",
         comment: "Action label on share extension to add page to the Firefox reading list.")
+    public static let ShareFileCopiedToClipboard = MZLocalizedString(
+        key: "ShareExtension.FileCopiedToClipboard.Title.v139",
+        tableName: "Share",
+        value: "File Copied To Clipboard",
+        comment: "The Toast message that appears when the user press copy on the share sheet with a file like a pdf")
     public static let ShareAddToReadingListDone = MZLocalizedString(
         key: "ShareExtension.AddToReadingListActionDone.Title",
         tableName: nil,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/HomePageActivityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/HomePageActivityTests.swift
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+import Shared
+@testable import Client
+
+final class HomePageActivityTests: XCTestCase {
+    func testInit_withOnlineURL_returnsSameURL() {
+        let urlString = "https://www.google.com"
+        let url = URL(string: urlString)!
+        let title = "test title"
+        let subject = createSubject(url: url, title: title)
+
+        XCTAssertEqual(subject.url, url)
+        XCTAssertEqual(subject.title, title)
+    }
+
+    func testInit_withLocalURL_returnsNilURL() {
+        let urlString = "internal://fennec.test"
+        let url = URL(string: urlString)!
+        let subject = createSubject(url: url)
+
+        // has to be nil since we try only to unwrap the url param from internal url
+        XCTAssertNil(subject.url)
+    }
+
+    func testInit_withLocalHostURL_returnsUnwrappedURLParameter() {
+        let innerUrl = "https//:www.google.com"
+        let urlString = "http://localhost:\(AppInfo.webserverPort)/?url=\(innerUrl)"
+        let url = URL(string: urlString)!
+        let subject = createSubject(url: url)
+
+        XCTAssertEqual(subject.url, URL(string: innerUrl))
+    }
+
+    private func createSubject(url: URL? = nil,
+                               title: String? = nil) -> HomePageActivity {
+        return HomePageActivity(url: url, title: title)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareManagerTests.swift
@@ -199,7 +199,7 @@ final class ShareManagerTests: XCTestCase {
 
         _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
@@ -244,7 +244,7 @@ final class ShareManagerTests: XCTestCase {
 
         _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
@@ -290,7 +290,7 @@ final class ShareManagerTests: XCTestCase {
 
         _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleSubtitleActivityItemProvider)
 
@@ -339,7 +339,7 @@ final class ShareManagerTests: XCTestCase {
         // The rest of the content should be unchanged from other tests:
         _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
@@ -389,7 +389,7 @@ final class ShareManagerTests: XCTestCase {
         // The rest of the content should be unchanged from other tests:
         _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
@@ -437,7 +437,7 @@ final class ShareManagerTests: XCTestCase {
         // The rest of the content should be unchanged from other tests:
         _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
@@ -485,7 +485,7 @@ final class ShareManagerTests: XCTestCase {
         // The rest of the content should be unchanged from other tests:
         _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
@@ -535,7 +535,7 @@ final class ShareManagerTests: XCTestCase {
         // The rest of the content should be unchanged from other tests:
         _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
@@ -592,7 +592,7 @@ final class ShareManagerTests: XCTestCase {
         // The rest of the content should be unchanged from other tests:
         _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
@@ -651,7 +651,7 @@ final class ShareManagerTests: XCTestCase {
         // The rest of the content should be unchanged from other tests:
         _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(


### PR DESCRIPTION
## :scroll: Tickets

## File copied to clipboard
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10960)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23938)


## Home page activity with localhost when reader mode active
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10961)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23940)

## :bulb: Description
Bugfix `Home page activity` showing localhost when sharing a tab in reader mode. Add correct label when copying a pdf to clipboard.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

