### PR TITLE
FXIOS-11164 Remove redundant privacy notice link from Set as Default Browser onboarding card

### DIFF
--- a/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
@@ -38,9 +38,6 @@ features:
               title: Onboarding/Onboarding.Welcome.Title.TreatementA.v120
               body: Onboarding/Onboarding.Welcome.Description.TreatementA.v120
               image: welcome-globe
-              link:
-                title: Onboarding/Onboarding.Welcome.Link.Action.v114
-                url: "https://www.mozilla.org/privacy/firefox/"
               buttons:
                 primary:
                   title: Onboarding/Onboarding.Welcome.ActionTreatementA.v114


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11164)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Follow-up to [FXIOS-11898](https://mozilla-hub.atlassian.net/browse/FXIOS-11898) the privacy link is redundant.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)



[FXIOS-11898]: https://mozilla-hub.atlassian.net/browse/FXIOS-11898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ