### PR TITLE
Remove FXIOS-3820 #10114 ⁃ [UX Fundamentals] iPad settings for No way to stop address/tab bar from auto hiding

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -112,7 +112,6 @@ public struct PrefsKeys {
         public static let SponsoredShortcuts = "SponsoredShortcutsUserPrefsKey"
         public static let StartAtHome = "StartAtHomeUserPrefsKey"
         public static let TopSiteSection = "TopSitesUserPrefsKey"
-        public static let TabsAndAddressBarAutoHide = "TabsAndAddressBarAutoHidePrefsKey"
     }
 
     // Firefox contextual hint

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -98,7 +98,6 @@ class TabScrollController: NSObject,
         }
     }
 
-    // Over keyboard content and bottom content
     private var overKeyboardScrollHeight: CGFloat {
         let overKeyboardHeight = overKeyboardContainer?.frame.height ?? 0
         return overKeyboardHeight
@@ -131,17 +130,6 @@ class TabScrollController: NSObject,
     var notificationCenter: any NotificationProtocol
     var currentWindowUUID: WindowUUID? {
         return windowUUID
-    }
-
-    // Over keyboard content and bottom content
-    private var overKeyboardScrollHeight: CGFloat {
-        let overKeyboardHeight = overKeyboardContainer?.frame.height ?? 0
-        return overKeyboardHeight
-    }
-
-    private var bottomContainerScrollHeight: CGFloat {
-        let bottomContainerHeight = bottomContainer?.frame.height ?? 0
-        return bottomContainerHeight
     }
 
     // If scrollview contentSize height is bigger that device height plus delta

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -7,13 +7,8 @@ import SnapKit
 import Shared
 import Common
 
-protocol ScrollToHideToolbar: AnyObject {
-    var isScrollToHideToolbarEnabled: Bool { get }
-}
-
 class TabScrollController: NSObject,
                            SearchBarLocationProvider,
-                           ScrollToHideToolbar,
                            Themeable {
     private struct UX {
         static let abruptScrollEventOffset: CGFloat = 200
@@ -67,7 +62,6 @@ class TabScrollController: NSObject,
     private var lastContentOffsetY: CGFloat = 0
     private var scrollDirection: ScrollDirection = .down
     var toolbarState: ToolbarState = .visible
-    let deviceType: UIUserInterfaceIdiom
 
     private let windowUUID: WindowUUID
     private let logger: Logger
@@ -139,19 +133,22 @@ class TabScrollController: NSObject,
         return windowUUID
     }
 
-    // Settings option to avoid hiding Tab and Address bar on iPad
-    var isScrollToHideToolbarEnabled: Bool {
-        guard deviceType == .pad,
-              let prefs = tab?.profile.prefs else { return true }
+    // Over keyboard content and bottom content
+    private var overKeyboardScrollHeight: CGFloat {
+        let overKeyboardHeight = overKeyboardContainer?.frame.height ?? 0
+        return overKeyboardHeight
+    }
 
-        return prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide) ?? true
+    private var bottomContainerScrollHeight: CGFloat {
+        let bottomContainerHeight = bottomContainer?.frame.height ?? 0
+        return bottomContainerHeight
     }
 
     // If scrollview contentSize height is bigger that device height plus delta
     // New settings to disable bar autohide only for iPad
     var isAbleToScroll: Bool {
         return (UIScreen.main.bounds.size.height + 2 * UIConstants.ToolbarHeight) <
-            contentSize.height && isScrollToHideToolbarEnabled
+            contentSize.height
     }
 
     deinit {
@@ -164,13 +161,11 @@ class TabScrollController: NSObject,
     init(windowUUID: WindowUUID,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
-         logger: Logger = DefaultLogger.shared,
-         deviceType: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+         logger: Logger = DefaultLogger.shared) {
         self.themeManager = themeManager
         self.windowUUID = windowUUID
         self.notificationCenter = notificationCenter
         self.logger = logger
-        self.deviceType = deviceType
         super.init()
         setupNotifications()
     }

--- a/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
@@ -36,19 +36,6 @@ class BrowsingSettingsViewController: SettingsTableViewController, FeatureFlagga
     override func generateSettings() -> [SettingSection] {
         var settings = [SettingSection]()
 
-        // Setting only available for iPad
-        if let profile, UIDevice.current.userInterfaceIdiom == .pad {
-            var generalSettings = [Setting]()
-            let toolbarHide = BoolSetting(prefs: profile.prefs,
-                                          theme: themeManager.getCurrentTheme(for: windowUUID),
-                                          prefKey: PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide,
-                                          defaultValue: true,
-                                          titleText: .Settings.General.ScrollToHideTabAndAddressBar.Title)
-            generalSettings.append(toolbarHide)
-            settings.append(SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle),
-                                           children: generalSettings))
-        }
-
         if featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildOnly)
             && !featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly) {
             let inactiveTabsSetting = BoolSetting(with: .inactiveTabs,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
@@ -34,33 +34,6 @@ final class TabScrollControllerTests: XCTestCase {
         super.tearDown()
     }
 
-    func testIsAbleToScrollTrue_ForIpadWhenAutoHideSettingIsEnabled() {
-        let subject = createSubject()
-        setupTabScroll(with: subject)
-        mockProfile.prefs.setBool(true,
-                                  forKey: PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide)
-
-        XCTAssertTrue(subject.isAbleToScroll)
-    }
-
-    func testIsAbleToScrollTrue_ForIpadWhenAutoHideSettingIsDisabled() {
-        let subject = createSubject(deviceType: .pad)
-        setupTabScroll(with: subject)
-        mockProfile.prefs.setBool(false,
-                                  forKey: PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide)
-
-        XCTAssertFalse(subject.isAbleToScroll)
-    }
-
-    func testIsAbleToScrollTrue_WhenDeviceisIphone() {
-        let subject = createSubject()
-        setupTabScroll(with: subject)
-        mockProfile.prefs.setBool(false,
-                                  forKey: PrefsKeys.UserFeatureFlagPrefs.TabsAndAddressBarAutoHide)
-
-        XCTAssertTrue(subject.isAbleToScroll)
-    }
-
     func testHandlePan_ScrollingUp() {
         let subject = createSubject()
         setupTabScroll(with: subject)
@@ -171,9 +144,8 @@ final class TabScrollControllerTests: XCTestCase {
         subject.header = header
     }
 
-    private func createSubject(deviceType: UIUserInterfaceIdiom = .phone) -> TabScrollController {
-        let subject = TabScrollController(windowUUID: .XCTestDefaultUUID,
-                                          deviceType: deviceType)
+    private func createSubject() -> TabScrollController {
+        let subject = TabScrollController(windowUUID: .XCTestDefaultUUID)
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3820)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/10114)

## :bulb: Description
After talking with UX we will remove the previously added setting and focus on fixing TabScrollController behaviour a first PR with improvements is already merged and we are waiting for feedback
- Remove settings to stop the behaviour to hide the toolbar on iPad

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

