### PR TITLE
Bugfix FXIOS-11569 [Focus URIFixup] Always encode characters in valid URLs

### DIFF
--- a/focus-ios/Blockzilla/Utilities/URIFixup.swift
+++ b/focus-ios/Blockzilla/Utilities/URIFixup.swift
@@ -11,7 +11,7 @@ class URIFixup {
             return nil
         }
 
-        guard !trimmed.lowercased().hasPrefix("javascript:") else {
+        guard !escaped.lowercased().hasPrefix("javascript:") else {
             return nil
         }
 
@@ -19,7 +19,7 @@ class URIFixup {
         // If it starts with "file://", return nil, indicating that this function
         // does not handle local file URLs, resulting in a search
 
-        guard !trimmed.lowercased().hasPrefix("file:") else {
+        guard !escaped.lowercased().hasPrefix("file:") else {
             return nil
         }
 
@@ -27,12 +27,12 @@ class URIFixup {
         // all valid requests starting with "http://", "about:", etc.
         // Also check with a regular expression if there is a port in the url
         // this will be handle later in this function adding http prefix
-        if let url = URL(string: trimmed, invalidCharacters: false),
+        if let url = URL(string: escaped, invalidCharacters: false),
             url.scheme != nil,
-            trimmed.range(of: "\\b:[0-9]{1,5}", options: .regularExpression) == nil {
+            escaped.range(of: "\\b:[0-9]{1,5}", options: .regularExpression) == nil {
             // check for top-level domain if scheme is "http://" or "https://"
-            if trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://") {
-                if trimmed.contains(".") == false {
+            if escaped.hasPrefix("http://") || escaped.hasPrefix("https://") {
+                if escaped.contains(".") == false {
                     return nil
                 }
             }
@@ -43,19 +43,14 @@ class URIFixup {
         // make sure there's at least one "." in the host. This means
         // we'll allow single-word searches (e.g., "foo") at the expense
         // of breaking single-word hosts without a scheme (e.g., "localhost").
-        if trimmed.contains(".") == false {
+        if escaped.contains(".") == false {
             return nil
         }
 
-        if trimmed.contains(" ") == true {
-            return nil
-        }
-
-        // If the input url has a prefix http or https, don't append again
+        // If there is a "." but no http or https prefix, prepend "http://" and try again.
         let finalurl = escaped.hasPrefix("http://") || escaped.hasPrefix("https://") ? escaped : "http://\(escaped)"
 
-        // If there is a ".", prepend "http://" and try again. Since this
-        // is strictly an "http://" URL, we also require a host.
+        // Since this is strictly an "http://" URL, we also require a host.
         if let url = URL(string: finalurl, invalidCharacters: false), url.host != nil {
             return url
         }

--- a/focus-ios/Blockzilla/Utilities/URIFixup.swift
+++ b/focus-ios/Blockzilla/Utilities/URIFixup.swift
@@ -51,10 +51,16 @@ class URIFixup {
         let finalurl = escaped.hasPrefix("http://") || escaped.hasPrefix("https://") ? escaped : "http://\(escaped)"
 
         // Since this is strictly an "http://" URL, we also require a host.
-        if let url = URL(string: finalurl, invalidCharacters: false), url.host != nil {
-            return url
+        guard let url = URL(string: finalurl, invalidCharacters: false), url.host != nil else {
+            return nil
         }
 
-        return nil
+        // Check for malformed URLs
+        // (URL has less stringent checks than URLComponents pre- iOS 17)
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        return url
     }
 }

--- a/focus-ios/focus-ios-tests/ClientTests/URIFixupTests.swift
+++ b/focus-ios/focus-ios-tests/ClientTests/URIFixupTests.swift
@@ -23,6 +23,7 @@ class URIFixupTests: XCTestCase {
                                   "http://mozilla.org//fire_fire/",
                                   "http://mozilla.org//fire_fire_(firefox)",
                                   "http://mozilla.org//fire_fire_(firefox)_(browser)",
+                                  "http://mozilla.org/fire fire",
                                   "http://www.mozilla.org/wpstyle/?p=364",
                                   "http://www.mozilla.org/foo/?bar=baz&inga=42&quux",
                                   "http://✪gg.ff/123",
@@ -45,6 +46,7 @@ class URIFixupTests: XCTestCase {
                                   "http://code.mozilla.org/users/#&firefox=browser",
                                   "http://f.co",
                                   "http://moz.fir/?q=Test%20URL-encoded%20fire",
+                                  "http://moz.fir/?q=Test URL-unencoded fire",
                                   "http://مثال.إختبار",
                                   "http://王涵.王涵",
                                   "http://6662.net",
@@ -69,6 +71,13 @@ class URIFixupTests: XCTestCase {
 
             let httpsSchemeURL = $0.replacingOccurrences(of: "http", with: "https")
             XCTAssertNotNil(URIFixup.getURL(entry: httpsSchemeURL), "\(httpsSchemeURL) is not a valid URL")
+        }
+    }
+
+    func testValidURLsWithoutSchemes() {
+        httpSchemeURLs.forEach {
+            let noSchemeURL = $0.replacingOccurrences(of: "http://", with: "")
+            XCTAssertNotNil(URIFixup.getURL(entry: noSchemeURL), "\(noSchemeURL) is not a valid URL")
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11569)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25189)

## :bulb: Description
Encode spaces and other characters in otherwise-valid URLs using the default scheme instead of rejecting the URL entirely.

This PR replicates the same `URIFixup` changes from PR #25191 in the equivalent Firefox Focus file. I also expanded the unit tests to check that URLs without a scheme are handled correctly. I'm not experienced with this testing framework so please double check that the new function actually gets executed.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

