### PR TITLE
Refactor FXIOS-11958 [Splash screen] Disable in developer builds

### DIFF
--- a/firefox-ios/nimbus-features/splashScreenFeature.yaml
+++ b/firefox-ios/nimbus-features/splashScreenFeature.yaml
@@ -20,5 +20,5 @@ features:
           maximum_duration_ms: 0
       - channel: developer
         value:
-          enabled: true
+          enabled: false
           maximum_duration_ms: 6000


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11958)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26006)

## :bulb: Description
We're keeping the flag since some work is coming at some point on this feature, but discussed so we remove the build delay in Developer builds.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

