### PR TITLE
Refactor FXIOS-11880 [UX Fundamentals] Shorten URL display name in context menu title

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -214,7 +214,7 @@ extension BrowserViewController: WKUIDelegate {
                                         image: elements.image,
                                         currentTab: currentTab,
                                         webView: webView)
-            return UIMenu(title: url.absoluteString, children: actions)
+            return UIMenu(title: url.normalizedHost ?? url.absoluteString, children: actions)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -15,7 +15,7 @@ let website_2 = [
     "label": "Example",
     "value": "example",
     "link": "More information...",
-    "moreLinkLongPressUrl": "http://www.iana.org/domains/example",
+    "moreLinkLongPressUrl": "iana.org",
     "moreLinkLongPressInfo": "iana"
 ]
 let popUpTestUrl = path(forTestPage: "test-popup-blocker.html")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11880)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25895)

## :bulb: Description
- Display the normalized host URL (Subdomain + Domain + TLD) in context menu titles

### 📸 Screenshots

| Before | After |
| ------------- | ------------- |
| <img width="559" alt="Screenshot 2025-04-17 at 4 14 36 PM" src="https://github.com/user-attachments/assets/778cb710-241f-4357-bdcd-64dc2345d25a" />  | <img width="559" alt="Screenshot 2025-04-17 at 4 16 06 PM" src="https://github.com/user-attachments/assets/c5336c5b-dfbb-432d-88df-260afd7a3c57" /> |
| <img width="559" alt="Screenshot 2025-04-17 at 4 14 45 PM" src="https://github.com/user-attachments/assets/15c49dfa-255b-44df-9231-8da43a416c85" /> | <img width="559" alt="Screenshot 2025-04-17 at 4 13 04 PM" src="https://github.com/user-attachments/assets/511dd8a4-0559-482a-90ab-da1b5510807e" /> | 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

