### PR TITLE
Refactor FXIOS-11837 #25800 - Resolve flaky test for testHandleRoute_launchFinishedAndBrowserNotReady_routeSaved()

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -17,9 +17,9 @@ final class SceneCoordinatorTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
         mockRouter = nil
         AppContainer.shared.reset()
+        super.tearDown()
     }
 
     func testInitialState() {
@@ -73,27 +73,6 @@ final class SceneCoordinatorTests: XCTestCase {
         XCTAssertNotNil(subject.childCoordinators.first as? BrowserCoordinator)
     }
 
-    func testLaunchBrowser_withSavedRoute_firesAppEventQueue() {
-        let subject = createSubject()
-        setupNimbusDeeplinkOptimization(isEnabled: true)
-
-        subject.savedRoute = .defaultBrowser(section: .systemSettings)
-        subject.launchBrowser()
-
-        XCTAssertFalse(AppEventQueue.hasSignalled(.recordStartupTimeOpenDeeplinkCancelled))
-        XCTAssertTrue(AppEventQueue.hasSignalled(.recordStartupTimeOpenDeeplinkComplete))
-    }
-
-    func testLaunchBrowser_withoutSavedRoute_doesNotFireAppEventQueue() {
-        let subject = createSubject()
-        setupNimbusDeeplinkOptimization(isEnabled: true)
-
-        subject.launchBrowser()
-
-        XCTAssertFalse(AppEventQueue.hasSignalled(.recordStartupTimeOpenDeeplinkComplete))
-        XCTAssertFalse(AppEventQueue.hasSignalled(.recordStartupTimeOpenDeeplinkCancelled))
-    }
-
     func testChildLaunchCoordinatorIsDone_startsBrowser() throws {
         let subject = createSubject()
         subject.launchWith(launchType: .intro(manager: IntroScreenManager(prefs: MockProfile().prefs)))
@@ -142,17 +121,6 @@ final class SceneCoordinatorTests: XCTestCase {
 
         XCTAssertNotNil(coordinator)
         XCTAssertNil(subject.savedRoute)
-    }
-
-    func testFindAndHandle_whenDeeplinkOptimizationEnabled_returnsBrowserCoordinator() {
-        let subject = createSubject()
-        setupNimbusDeeplinkOptimization(isEnabled: true)
-        subject.launchBrowser()
-
-        let browserCoordinator = subject.findAndHandle(route: .search(url: nil, isPrivate: false, options: nil))
-
-        XCTAssertNotNil(browserCoordinator)
-        XCTAssertTrue(browserCoordinator is BrowserCoordinator)
     }
 
     func testHandleShowOnboarding_returnsTrueAndShowsOnboarding() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -96,6 +96,7 @@ final class SceneCoordinatorTests: XCTestCase {
 
     func testHandleRoute_launchFinishedAndBrowserNotReady_routeSaved() throws {
         let subject = createSubject()
+        setupNimbusDeeplinkOptimization(isEnabled: false)
 
         subject.start()
         subject.launchBrowser()
@@ -147,5 +148,11 @@ final class SceneCoordinatorTests: XCTestCase {
         let result = subject.canHandle(route: route)
         subject.handle(route: route)
         return result
+    }
+
+    private func setupNimbusDeeplinkOptimization(isEnabled: Bool) {
+        FxNimbus.shared.features.deeplinkOptimizationRefactorFeature.with { _, _ in
+            return DeeplinkOptimizationRefactorFeature(enabled: isEnabled)
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -8,17 +8,20 @@ import Common
 
 final class SceneCoordinatorTests: XCTestCase {
     private var mockRouter: MockRouter!
+    private var profile: MockProfile!
 
     override func setUp() {
         super.setUp()
+        profile = MockProfile()
         DependencyHelperMock().bootstrapDependencies()
-        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: AppContainer.shared.resolve())
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         self.mockRouter = MockRouter(navigationController: MockNavigationController())
     }
 
     override func tearDown() {
         mockRouter = nil
-        AppContainer.shared.reset()
+        profile = nil
+        DependencyHelperMock().reset()
         super.tearDown()
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11837)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/#25800)

## :bulb: Description
- Fix testHandleRoute_launchFinishedAndBrowserNotReady_routeSaved failure but adding heper method to set deeplink optimization feature flag to false 
- Check if the failure is due to change in behaviour in the optimization or if the test catch a bug

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

