### PR TITLE
Refactor FXIOS-11799 [Profile] Decouple SearchEnginesManager from Profile

### DIFF
--- a/BrowserKit/Sources/Common/DependencyInjection/AppContainer.swift
+++ b/BrowserKit/Sources/Common/DependencyInjection/AppContainer.swift
@@ -16,8 +16,12 @@ public class AppContainer: ServiceProvider {
 
     /// Any services needed by the client can be resolved by calling this.
     public func resolve<T>() -> T {
+        resolve(T.self)
+    }
+
+    public func resolve<T>(_ type: T.Type) -> T {
         do {
-            guard let service = try container.resolve(T.self) as? T else {
+            guard let service = try container.resolve(type) as? T else {
                 fatalError("Failed to cast resolved service to type \(T.self)")
             }
             return service

--- a/BrowserKit/Sources/Common/DependencyInjection/ServiceProvider.swift
+++ b/BrowserKit/Sources/Common/DependencyInjection/ServiceProvider.swift
@@ -18,6 +18,7 @@ import Dip
 /// to resolve services.
 public protocol ServiceProvider {
     func resolve<T>() -> T
+    func resolve<T>(_ type: T.Type) -> T
     func register<T>(service: T)
     func bootstrap()
     func reset()

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -97,7 +97,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         // Then setup dependency container as it's needed for everything else
         DependencyHelper().bootstrapDependencies()
 
-        appLaunchUtil = AppLaunchUtil(profile: profile, searchEnginesManager: searchEnginesManager)
+        appLaunchUtil = AppLaunchUtil(profile: profile)
         appLaunchUtil?.setUpPreLaunchDependencies()
 
         // Set up a web server that serves us static content.

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -34,6 +34,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         rustKeychainEnabled: rustKeychainEnabled,
         loginsVerificationEnabled: loginsVerificationEnabled)
 
+    lazy var searchEnginesManager = SearchEnginesManager(
+        prefs: profile.prefs,
+        files: profile.files
+    )
+
     lazy var themeManager: ThemeManager = DefaultThemeManager(
         sharedContainerIdentifier: AppInfo.sharedContainerIdentifier,
         isNewAppearanceMenuOnClosure: { self.featureFlags.isFeatureEnabled(.appearanceMenu, checking: .buildOnly) }
@@ -92,7 +97,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         // Then setup dependency container as it's needed for everything else
         DependencyHelper().bootstrapDependencies()
 
-        appLaunchUtil = AppLaunchUtil(profile: profile)
+        appLaunchUtil = AppLaunchUtil(profile: profile, searchEnginesManager: searchEnginesManager)
         appLaunchUtil?.setUpPreLaunchDependencies()
 
         // Set up a web server that serves us static content.

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -19,7 +19,7 @@ final class AppLaunchUtil {
 
     init(
         logger: Logger = DefaultLogger.shared,
-        profile: Profile,
+        profile: Profile
     ) {
         self.logger = logger
         self.profile = profile

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -14,15 +14,18 @@ class AppLaunchUtil {
     private var logger: Logger
 //    private var adjustHelper: AdjustHelper
     private var profile: Profile
+    private let searchEnginesManager: SearchEnginesManager
     private let introScreenManager: IntroScreenManager
     private let termsOfServiceManager: TermsOfServiceManager
 
     init(
         logger: Logger = DefaultLogger.shared,
-        profile: Profile
+        profile: Profile,
+        searchEnginesManager: SearchEnginesManager
     ) {
         self.logger = logger
         self.profile = profile
+        self.searchEnginesManager = searchEnginesManager
 //        self.adjustHelper = AdjustHelper(profile: profile)
         self.introScreenManager = IntroScreenManager(prefs: profile.prefs)
         self.termsOfServiceManager = TermsOfServiceManager(prefs: profile.prefs)
@@ -52,7 +55,7 @@ class AppLaunchUtil {
             let isTermsOfServiceAccepted = termsOfServiceManager.isAccepted || !introScreenManager.shouldShowIntroScreen
             logger.setup(sendCrashReports: sendCrashReports && isTermsOfServiceAccepted)
             if isTermsOfServiceAccepted {
-                TelemetryWrapper.shared.setup(profile: profile)
+                TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
                 TelemetryWrapper.shared.recordStartUpTelemetry()
             } else {
                 // If ToS are not accepted, we still need to setup the Contextual Identifier for
@@ -61,7 +64,7 @@ class AppLaunchUtil {
             }
         } else {
             logger.setup(sendCrashReports: sendCrashReports)
-            TelemetryWrapper.shared.setup(profile: profile)
+            TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
             TelemetryWrapper.shared.recordStartUpTelemetry()
         }
 

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -10,22 +10,19 @@ import Account
 import Glean
 import MozillaAppServices
 
-class AppLaunchUtil {
+final class AppLaunchUtil {
     private var logger: Logger
 //    private var adjustHelper: AdjustHelper
     private var profile: Profile
-    private let searchEnginesManager: SearchEnginesManagerProvider
     private let introScreenManager: IntroScreenManager
     private let termsOfServiceManager: TermsOfServiceManager
 
     init(
         logger: Logger = DefaultLogger.shared,
         profile: Profile,
-        searchEnginesManager: SearchEnginesManagerProvider
     ) {
         self.logger = logger
         self.profile = profile
-        self.searchEnginesManager = searchEnginesManager
 //        self.adjustHelper = AdjustHelper(profile: profile)
         self.introScreenManager = IntroScreenManager(prefs: profile.prefs)
         self.termsOfServiceManager = TermsOfServiceManager(prefs: profile.prefs)
@@ -55,7 +52,7 @@ class AppLaunchUtil {
             let isTermsOfServiceAccepted = termsOfServiceManager.isAccepted || !introScreenManager.shouldShowIntroScreen
             logger.setup(sendCrashReports: sendCrashReports && isTermsOfServiceAccepted)
             if isTermsOfServiceAccepted {
-                TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
+                TelemetryWrapper.shared.setup(profile: profile)
                 TelemetryWrapper.shared.recordStartUpTelemetry()
             } else {
                 // If ToS are not accepted, we still need to setup the Contextual Identifier for
@@ -64,7 +61,7 @@ class AppLaunchUtil {
             }
         } else {
             logger.setup(sendCrashReports: sendCrashReports)
-            TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
+            TelemetryWrapper.shared.setup(profile: profile)
             TelemetryWrapper.shared.recordStartUpTelemetry()
         }
 

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -14,14 +14,14 @@ class AppLaunchUtil {
     private var logger: Logger
 //    private var adjustHelper: AdjustHelper
     private var profile: Profile
-    private let searchEnginesManager: SearchEnginesManager
+    private let searchEnginesManager: SearchEnginesManagerProvider
     private let introScreenManager: IntroScreenManager
     private let termsOfServiceManager: TermsOfServiceManager
 
     init(
         logger: Logger = DefaultLogger.shared,
         profile: Profile,
-        searchEnginesManager: SearchEnginesManager
+        searchEnginesManager: SearchEnginesManagerProvider
     ) {
         self.logger = logger
         self.profile = profile

--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -15,11 +15,7 @@ class DependencyHelper {
         let profile: Profile = appDelegate.profile
         AppContainer.shared.register(service: profile)
 
-        let searchEnginesManager = appDelegate.searchEnginesManager
-        AppContainer.shared.register(service: searchEnginesManager)
-
-        let searchEnginesManagerProvider: SearchEnginesManagerProvider = searchEnginesManager
-        AppContainer.shared.register(service: searchEnginesManagerProvider)
+        AppContainer.shared.register(service: appDelegate.searchEnginesManager as SearchEnginesManagerProvider)
 
         let diskImageStore: DiskImageStore =
         DefaultDiskImageStore(files: profile.files,

--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -18,6 +18,9 @@ class DependencyHelper {
         let searchEnginesManager = appDelegate.searchEnginesManager
         AppContainer.shared.register(service: searchEnginesManager)
 
+        let searchEnginesManagerProvider: SearchEnginesManagerProvider = searchEnginesManager
+        AppContainer.shared.register(service: searchEnginesManagerProvider)
+
         let diskImageStore: DiskImageStore =
         DefaultDiskImageStore(files: profile.files,
                               namespace: TabManagerConstants.tabScreenshotNamespace,

--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -15,6 +15,9 @@ class DependencyHelper {
         let profile: Profile = appDelegate.profile
         AppContainer.shared.register(service: profile)
 
+        let searchEnginesManager = appDelegate.searchEnginesManager
+        AppContainer.shared.register(service: searchEnginesManager)
+
         let diskImageStore: DiskImageStore =
         DefaultDiskImageStore(files: profile.files,
                               namespace: TabManagerConstants.tabScreenshotNamespace,

--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -15,7 +15,7 @@ class DependencyHelper {
         let profile: Profile = appDelegate.profile
         AppContainer.shared.register(service: profile)
 
-        AppContainer.shared.register(service: appDelegate.searchEnginesManager as SearchEnginesManagerProvider)
+        AppContainer.shared.register(service: appDelegate.searchEnginesManager)
 
         let diskImageStore: DiskImageStore =
         DefaultDiskImageStore(files: profile.files,

--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -17,7 +17,7 @@ class LaunchCoordinator: BaseCoordinator,
                          QRCodeNavigationHandler,
                          ParentCoordinatorDelegate {
     private let profile: Profile
-    private let searchEnginesManager: SearchEnginesManager
+    private let searchEnginesManager: SearchEnginesManagerProvider
     private let isIphone: Bool
     let windowUUID: WindowUUID
     weak var parentCoordinator: LaunchCoordinatorDelegate?
@@ -25,7 +25,7 @@ class LaunchCoordinator: BaseCoordinator,
     init(router: Router,
          windowUUID: WindowUUID,
          profile: Profile = AppContainer.shared.resolve(),
-         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
+         searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(),
          isIphone: Bool = UIDevice.current.userInterfaceIdiom == .phone) {
         self.profile = profile
         self.isIphone = isIphone

--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -17,6 +17,7 @@ class LaunchCoordinator: BaseCoordinator,
                          QRCodeNavigationHandler,
                          ParentCoordinatorDelegate {
     private let profile: Profile
+    private let searchEnginesManager: SearchEnginesManager
     private let isIphone: Bool
     let windowUUID: WindowUUID
     weak var parentCoordinator: LaunchCoordinatorDelegate?
@@ -24,10 +25,12 @@ class LaunchCoordinator: BaseCoordinator,
     init(router: Router,
          windowUUID: WindowUUID,
          profile: Profile = AppContainer.shared.resolve(),
+         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
          isIphone: Bool = UIDevice.current.userInterfaceIdiom == .phone) {
         self.profile = profile
         self.isIphone = isIphone
         self.windowUUID = windowUUID
+        self.searchEnginesManager = searchEnginesManager
         super.init(router: router)
     }
 
@@ -65,7 +68,7 @@ class LaunchCoordinator: BaseCoordinator,
             self.profile.prefs.setBool(sendCrashReports, forKey: AppConstants.prefSendCrashReports)
             self.logger.setup(sendCrashReports: sendCrashReports)
 
-            TelemetryWrapper.shared.setup(profile: profile)
+            TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
             TelemetryWrapper.shared.recordStartUpTelemetry()
 
             self.parentCoordinator?.didFinishTermsOfService(from: self)

--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -12,12 +12,11 @@ protocol LaunchCoordinatorDelegate: AnyObject {
 }
 
 // Manages different types of onboarding that gets shown at the launch of the application
-class LaunchCoordinator: BaseCoordinator,
-                         SurveySurfaceViewControllerDelegate,
-                         QRCodeNavigationHandler,
-                         ParentCoordinatorDelegate {
+final class LaunchCoordinator: BaseCoordinator,
+                               SurveySurfaceViewControllerDelegate,
+                               QRCodeNavigationHandler,
+                               ParentCoordinatorDelegate {
     private let profile: Profile
-    private let searchEnginesManager: SearchEnginesManagerProvider
     private let isIphone: Bool
     let windowUUID: WindowUUID
     weak var parentCoordinator: LaunchCoordinatorDelegate?
@@ -25,12 +24,10 @@ class LaunchCoordinator: BaseCoordinator,
     init(router: Router,
          windowUUID: WindowUUID,
          profile: Profile = AppContainer.shared.resolve(),
-         searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(),
          isIphone: Bool = UIDevice.current.userInterfaceIdiom == .phone) {
         self.profile = profile
         self.isIphone = isIphone
         self.windowUUID = windowUUID
-        self.searchEnginesManager = searchEnginesManager
         super.init(router: router)
     }
 
@@ -68,7 +65,7 @@ class LaunchCoordinator: BaseCoordinator,
             self.profile.prefs.setBool(sendCrashReports, forKey: AppConstants.prefSendCrashReports)
             self.logger.setup(sendCrashReports: sendCrashReports)
 
-            TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
+            TelemetryWrapper.shared.setup(profile: profile)
             TelemetryWrapper.shared.recordStartUpTelemetry()
 
             self.parentCoordinator?.didFinishTermsOfService(from: self)

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -13,24 +13,23 @@ protocol SettingsCoordinatorDelegate: AnyObject {
     func didFinishSettings(from coordinator: SettingsCoordinator)
 }
 
-class SettingsCoordinator: BaseCoordinator,
-                           SettingsDelegate,
-                           SettingsFlowDelegate,
-                           GeneralSettingsDelegate,
-                           PrivacySettingsDelegate,
-                           PasswordManagerCoordinatorDelegate,
-                           AccountSettingsDelegate,
-                           AboutSettingsDelegate,
-                           ParentCoordinatorDelegate,
-                           QRCodeNavigationHandler,
-                           BrowsingSettingsDelegate {
+final class SettingsCoordinator: BaseCoordinator,
+                                 SettingsDelegate,
+                                 SettingsFlowDelegate,
+                                 GeneralSettingsDelegate,
+                                 PrivacySettingsDelegate,
+                                 PasswordManagerCoordinatorDelegate,
+                                 AccountSettingsDelegate,
+                                 AboutSettingsDelegate,
+                                 ParentCoordinatorDelegate,
+                                 QRCodeNavigationHandler,
+                                 BrowsingSettingsDelegate {
     var settingsViewController: AppSettingsScreen?
     private let wallpaperManager: WallpaperManagerInterface
     private let profile: Profile
     private let tabManager: TabManager
     private let themeManager: ThemeManager
     private let gleanUsageReportingMetricsService: GleanUsageReportingMetricsService
-    private let searchEnginesManager: SearchEnginesManagerProvider
     weak var parentCoordinator: SettingsCoordinatorDelegate?
     private var windowUUID: WindowUUID { return tabManager.windowUUID }
     private let settingsTelemetry: SettingsTelemetry
@@ -42,8 +41,7 @@ class SettingsCoordinator: BaseCoordinator,
         tabManager: TabManager,
         themeManager: ThemeManager = AppContainer.shared.resolve(),
         gleanUsageReportingMetricsService: GleanUsageReportingMetricsService = AppContainer.shared.resolve(),
-        gleanWrapper: GleanWrapper = DefaultGleanWrapper(),
-        searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve()
+        gleanWrapper: GleanWrapper = DefaultGleanWrapper()
     ) {
         self.wallpaperManager = wallpaperManager
         self.profile = profile
@@ -51,7 +49,6 @@ class SettingsCoordinator: BaseCoordinator,
         self.themeManager = themeManager
         self.gleanUsageReportingMetricsService = gleanUsageReportingMetricsService
         self.settingsTelemetry = SettingsTelemetry(gleanWrapper: gleanWrapper)
-        self.searchEnginesManager = searchEnginesManager
         super.init(router: router)
 
         // It's important we initialize AppSettingsTableViewController with a settingsDelegate and parentCoordinator
@@ -133,10 +130,8 @@ class SettingsCoordinator: BaseCoordinator,
             return viewController
 
         case .search:
-            guard let searchEnginesManager = searchEnginesManager as? SearchEnginesManager else { return nil }
             let viewController = SearchSettingsTableViewController(
                 profile: profile,
-                searchEnginesManager: searchEnginesManager,
                 windowUUID: windowUUID
             )
             return viewController
@@ -373,10 +368,8 @@ class SettingsCoordinator: BaseCoordinator,
     }
 
     func pressedSearchEngine() {
-        guard let searchEnginesManager = searchEnginesManager as? SearchEnginesManager else { return }
         let viewController = SearchSettingsTableViewController(
             profile: profile,
-            searchEnginesManager: searchEnginesManager,
             windowUUID: windowUUID
         )
         router.push(viewController)

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -30,7 +30,7 @@ class SettingsCoordinator: BaseCoordinator,
     private let tabManager: TabManager
     private let themeManager: ThemeManager
     private let gleanUsageReportingMetricsService: GleanUsageReportingMetricsService
-    private let searchEnginesManager: SearchEnginesManager
+    private let searchEnginesManager: SearchEnginesManagerProvider
     weak var parentCoordinator: SettingsCoordinatorDelegate?
     private var windowUUID: WindowUUID { return tabManager.windowUUID }
     private let settingsTelemetry: SettingsTelemetry
@@ -43,7 +43,7 @@ class SettingsCoordinator: BaseCoordinator,
         themeManager: ThemeManager = AppContainer.shared.resolve(),
         gleanUsageReportingMetricsService: GleanUsageReportingMetricsService = AppContainer.shared.resolve(),
         gleanWrapper: GleanWrapper = DefaultGleanWrapper(),
-        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve()
+        searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve()
     ) {
         self.wallpaperManager = wallpaperManager
         self.profile = profile
@@ -133,6 +133,7 @@ class SettingsCoordinator: BaseCoordinator,
             return viewController
 
         case .search:
+            guard let searchEnginesManager = searchEnginesManager as? SearchEnginesManager else { return nil }
             let viewController = SearchSettingsTableViewController(
                 profile: profile,
                 searchEnginesManager: searchEnginesManager,
@@ -372,6 +373,7 @@ class SettingsCoordinator: BaseCoordinator,
     }
 
     func pressedSearchEngine() {
+        guard let searchEnginesManager = searchEnginesManager as? SearchEnginesManager else { return }
         let viewController = SearchSettingsTableViewController(
             profile: profile,
             searchEnginesManager: searchEnginesManager,

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -30,6 +30,7 @@ class SettingsCoordinator: BaseCoordinator,
     private let tabManager: TabManager
     private let themeManager: ThemeManager
     private let gleanUsageReportingMetricsService: GleanUsageReportingMetricsService
+    private let searchEnginesManager: SearchEnginesManager
     weak var parentCoordinator: SettingsCoordinatorDelegate?
     private var windowUUID: WindowUUID { return tabManager.windowUUID }
     private let settingsTelemetry: SettingsTelemetry
@@ -41,7 +42,8 @@ class SettingsCoordinator: BaseCoordinator,
         tabManager: TabManager,
         themeManager: ThemeManager = AppContainer.shared.resolve(),
         gleanUsageReportingMetricsService: GleanUsageReportingMetricsService = AppContainer.shared.resolve(),
-        gleanWrapper: GleanWrapper = DefaultGleanWrapper()
+        gleanWrapper: GleanWrapper = DefaultGleanWrapper(),
+        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve()
     ) {
         self.wallpaperManager = wallpaperManager
         self.profile = profile
@@ -49,6 +51,7 @@ class SettingsCoordinator: BaseCoordinator,
         self.themeManager = themeManager
         self.gleanUsageReportingMetricsService = gleanUsageReportingMetricsService
         self.settingsTelemetry = SettingsTelemetry(gleanWrapper: gleanWrapper)
+        self.searchEnginesManager = searchEnginesManager
         super.init(router: router)
 
         // It's important we initialize AppSettingsTableViewController with a settingsDelegate and parentCoordinator
@@ -130,7 +133,11 @@ class SettingsCoordinator: BaseCoordinator,
             return viewController
 
         case .search:
-            let viewController = SearchSettingsTableViewController(profile: profile, windowUUID: windowUUID)
+            let viewController = SearchSettingsTableViewController(
+                profile: profile,
+                searchEnginesManager: searchEnginesManager,
+                windowUUID: windowUUID
+            )
             return viewController
 
         case .clearPrivateData:
@@ -176,6 +183,7 @@ class SettingsCoordinator: BaseCoordinator,
             contentBlockerVC.settingsDelegate = self
             contentBlockerVC.profile = profile
             contentBlockerVC.tabManager = tabManager
+            contentBlockerVC.searchEnginesManager = searchEnginesManager
             return contentBlockerVC
 
         case .browser:
@@ -314,6 +322,7 @@ class SettingsCoordinator: BaseCoordinator,
         viewController.settingsDelegate = self
         viewController.profile = profile
         viewController.tabManager = tabManager
+        viewController.searchEnginesManager = searchEnginesManager
         router.push(viewController)
     }
 
@@ -365,7 +374,11 @@ class SettingsCoordinator: BaseCoordinator,
     }
 
     func pressedSearchEngine() {
-        let viewController = SearchSettingsTableViewController(profile: profile, windowUUID: windowUUID)
+        let viewController = SearchSettingsTableViewController(
+            profile: profile,
+            searchEnginesManager: searchEnginesManager,
+            windowUUID: windowUUID
+        )
         router.push(viewController)
     }
 

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -183,7 +183,6 @@ class SettingsCoordinator: BaseCoordinator,
             contentBlockerVC.settingsDelegate = self
             contentBlockerVC.profile = profile
             contentBlockerVC.tabManager = tabManager
-            contentBlockerVC.searchEnginesManager = searchEnginesManager
             return contentBlockerVC
 
         case .browser:
@@ -322,7 +321,6 @@ class SettingsCoordinator: BaseCoordinator,
         viewController.settingsDelegate = self
         viewController.profile = profile
         viewController.tabManager = tabManager
-        viewController.searchEnginesManager = searchEnginesManager
         router.push(viewController)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -89,7 +89,7 @@ extension BrowserViewController: URLBarDelegate {
         if let url = searchURL, InternalURL.isValid(url: url) {
             searchURL = url
         }
-        if let query = profile.searchEnginesManager.queryForSearchURL(searchURL as URL?) {
+        if let query = searchEnginesManager.queryForSearchURL(searchURL as URL?) {
             return (query, true)
         } else {
             return (url?.absoluteString, false)
@@ -138,7 +138,7 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func submitSearchText(_ text: String, forTab tab: Tab) {
-        guard let engine = profile.searchEnginesManager.defaultEngine,
+        guard let engine = searchEnginesManager.defaultEngine,
               let searchURL = engine.searchURLForQuery(text)
         else {
             DefaultLogger.shared.log("Error handling URL entry: \"\(text)\".", level: .warning, category: .tabs)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -89,8 +89,7 @@ extension BrowserViewController: URLBarDelegate {
         if let url = searchURL, InternalURL.isValid(url: url) {
             searchURL = url
         }
-        if let searchEnginesManager = searchEnginesManager as? SearchEnginesManager,
-           let query = searchEnginesManager.queryForSearchURL(searchURL as URL?) {
+        if let query = searchEnginesManager.queryForSearchURL(searchURL as URL?) {
             return (query, true)
         } else {
             return (url?.absoluteString, false)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -89,7 +89,8 @@ extension BrowserViewController: URLBarDelegate {
         if let url = searchURL, InternalURL.isValid(url: url) {
             searchURL = url
         }
-        if let query = searchEnginesManager.queryForSearchURL(searchURL as URL?) {
+        if let searchEnginesManager = searchEnginesManager as? SearchEnginesManager,
+           let query = searchEnginesManager.queryForSearchURL(searchURL as URL?) {
             return (query, true)
         } else {
             return (url?.absoluteString, false)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -281,6 +281,7 @@ class BrowserViewController: UIViewController,
     let ratingPromptManager: RatingPromptManager
     private var browserViewControllerState: BrowserViewControllerState?
     var appAuthenticator: AppAuthenticationProtocol
+    let searchEnginesManager: SearchEnginesManager
     private var keyboardState: KeyboardState?
 
     // Tracking navigation items to record history types.
@@ -325,7 +326,8 @@ class BrowserViewController: UIViewController,
         notificationCenter: NotificationProtocol = NotificationCenter.default,
         downloadQueue: DownloadQueue = AppContainer.shared.resolve(),
         logger: Logger = DefaultLogger.shared,
-        appAuthenticator: AppAuthenticationProtocol = AppAuthenticator()
+        appAuthenticator: AppAuthenticationProtocol = AppAuthenticator(),
+        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve()
     ) {
         self.profile = profile
         self.tabManager = tabManager
@@ -336,6 +338,7 @@ class BrowserViewController: UIViewController,
         self.downloadQueue = downloadQueue
         self.logger = logger
         self.appAuthenticator = appAuthenticator
+        self.searchEnginesManager = searchEnginesManager
         self.bookmarksSaver = DefaultBookmarksSaver(profile: profile)
         self.bookmarksHandler = profile.places
         self.zoomManager = ZoomPageManager(windowUUID: tabManager.windowUUID)
@@ -985,7 +988,7 @@ class BrowserViewController: UIViewController,
     private func createLegacyUrlBar() {
         guard !isToolbarRefactorEnabled else { return }
 
-        let urlBar = URLBarView(profile: profile, windowUUID: windowUUID)
+        let urlBar = URLBarView(profile: profile, searchEnginesManager: searchEnginesManager, windowUUID: windowUUID)
         urlBar.translatesAutoresizingMaskIntoConstraints = false
         urlBar.delegate = self
         urlBar.tabToolbarDelegate = self
@@ -1003,6 +1006,7 @@ class BrowserViewController: UIViewController,
         addressToolbarContainer.configure(
             windowUUID: windowUUID,
             profile: profile,
+            searchEnginesManager: searchEnginesManager,
             delegate: self,
             isUnifiedSearchEnabled: isUnifiedSearchEnabled
         )
@@ -1690,12 +1694,12 @@ class BrowserViewController: UIViewController,
         let searchViewModel = SearchViewModel(isPrivate: isPrivate,
                                               isBottomSearchBar: isBottomSearchBar,
                                               profile: profile,
-                                              model: profile.searchEnginesManager,
+                                              model: searchEnginesManager,
                                               tabManager: tabManager)
         let searchController = SearchViewController(profile: profile,
                                                     viewModel: searchViewModel,
                                                     tabManager: tabManager)
-        searchViewModel.searchEnginesManager = profile.searchEnginesManager
+        searchViewModel.searchEnginesManager = searchEnginesManager
         searchController.searchDelegate = self
 
         let searchLoader = SearchLoader(
@@ -2889,7 +2893,7 @@ class BrowserViewController: UIViewController,
     func openSearchNewTab(isPrivate: Bool = false, _ text: String) {
         popToBVC()
 
-        guard let engine = profile.searchEnginesManager.defaultEngine,
+        guard let engine = searchEnginesManager.defaultEngine,
               let searchURL = engine.searchURLForQuery(text)
         else {
             DefaultLogger.shared.log("Error handling URL entry: \"\(text)\".", level: .warning, category: .tabs)
@@ -3215,7 +3219,7 @@ class BrowserViewController: UIViewController,
             .searchScreenState
             .showSearchSugestionsView ?? false
 
-        let isSettingEnabled = profile.searchEnginesManager.shouldShowPrivateModeSearchSuggestions
+        let isSettingEnabled = searchEnginesManager.shouldShowPrivateModeSearchSuggestions
 
         return featureFlagEnabled && !alwaysShowSearchSuggestionsView && !isSettingEnabled
     }
@@ -3861,7 +3865,11 @@ extension BrowserViewController: SearchViewControllerDelegate {
     }
 
     func presentSearchSettingsController() {
-        let searchSettingsTableViewController = SearchSettingsTableViewController(profile: profile, windowUUID: windowUUID)
+        let searchSettingsTableViewController = SearchSettingsTableViewController(
+            profile: profile,
+            searchEnginesManager: searchEnginesManager,
+            windowUUID: windowUUID
+        )
         let navController = ModalSettingsNavigationController(rootViewController: searchSettingsTableViewController)
         self.present(navController, animated: true, completion: nil)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -281,7 +281,7 @@ class BrowserViewController: UIViewController,
     let ratingPromptManager: RatingPromptManager
     private var browserViewControllerState: BrowserViewControllerState?
     var appAuthenticator: AppAuthenticationProtocol
-    let searchEnginesManager: SearchEnginesManagerProvider
+    let searchEnginesManager: SearchEnginesManager
     private var keyboardState: KeyboardState?
 
     // Tracking navigation items to record history types.
@@ -327,7 +327,7 @@ class BrowserViewController: UIViewController,
         downloadQueue: DownloadQueue = AppContainer.shared.resolve(),
         logger: Logger = DefaultLogger.shared,
         appAuthenticator: AppAuthenticationProtocol = AppAuthenticator(),
-        searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve()
+        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve()
     ) {
         self.profile = profile
         self.tabManager = tabManager
@@ -988,7 +988,7 @@ class BrowserViewController: UIViewController,
     private func createLegacyUrlBar() {
         guard !isToolbarRefactorEnabled else { return }
 
-        let urlBar = URLBarView(profile: profile, searchEnginesManager: searchEnginesManager, windowUUID: windowUUID)
+        let urlBar = URLBarView(profile: profile, windowUUID: windowUUID)
         urlBar.translatesAutoresizingMaskIntoConstraints = false
         urlBar.delegate = self
         urlBar.tabToolbarDelegate = self
@@ -1688,8 +1688,7 @@ class BrowserViewController: UIViewController,
     }
 
     fileprivate func createSearchControllerIfNeeded() {
-        guard self.searchController == nil,
-              let searchEnginesManager = searchEnginesManager as? SearchEnginesManager else { return }
+        guard self.searchController == nil else { return }
 
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         let searchViewModel = SearchViewModel(isPrivate: isPrivate,
@@ -3220,8 +3219,7 @@ class BrowserViewController: UIViewController,
             .searchScreenState
             .showSearchSugestionsView ?? false
 
-        let isSettingEnabled = (searchEnginesManager as? SearchEnginesManager)?
-            .shouldShowPrivateModeSearchSuggestions ?? false
+        let isSettingEnabled = searchEnginesManager.shouldShowPrivateModeSearchSuggestions
 
         return featureFlagEnabled && !alwaysShowSearchSuggestionsView && !isSettingEnabled
     }
@@ -3867,7 +3865,6 @@ extension BrowserViewController: SearchViewControllerDelegate {
     }
 
     func presentSearchSettingsController() {
-        guard let searchEnginesManager = searchEnginesManager as? SearchEnginesManager else { return }
         let searchSettingsTableViewController = SearchSettingsTableViewController(
             profile: profile,
             searchEnginesManager: searchEnginesManager,

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -8,10 +8,10 @@ import Redux
 final class SearchEngineSelectionMiddleware {
     private let profile: Profile
     private let logger: Logger
-    private let searchEnginesManager: SearchEnginesManager
+    private let searchEnginesManager: SearchEnginesManagerProvider
 
     init(profile: Profile = AppContainer.shared.resolve(),
-         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
+         searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.logger = logger

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -8,14 +8,14 @@ import Redux
 final class SearchEngineSelectionMiddleware {
     private let profile: Profile
     private let logger: Logger
-    private let searchEnginesManager: SearchEnginesManagerProvider
+    private let searchEnginesManager: SearchEnginesManager
 
     init(profile: Profile = AppContainer.shared.resolve(),
-         searchEnginesManager: SearchEnginesManagerProvider? = nil,
+         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.logger = logger
-        self.searchEnginesManager = searchEnginesManager ?? profile.searchEnginesManager
+        self.searchEnginesManager = searchEnginesManager
     }
 
     lazy var searchEngineSelectionProvider: Middleware<AppState> = { [self] state, action in

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -11,7 +11,7 @@ final class SearchEngineSelectionMiddleware {
     private let searchEnginesManager: SearchEnginesManagerProvider
 
     init(profile: Profile = AppContainer.shared.resolve(),
-         searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(),
+         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.logger = logger

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -11,7 +11,7 @@ final class SearchEngineSelectionMiddleware {
     private let searchEnginesManager: SearchEnginesManagerProvider
 
     init(profile: Profile = AppContainer.shared.resolve(),
-         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
+         searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(SearchEnginesManager.self),
          logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.logger = logger

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -7,9 +7,10 @@ import Common
 import Shared
 import Storage
 
-protocol SearchEnginesManagerProvider {
+protocol SearchEnginesManagerProvider: AnyObject {
     var defaultEngine: OpenSearchEngine? { get }
     var orderedEngines: [OpenSearchEngine] { get }
+    var delegate: SearchEngineDelegate? { get set }
     func getOrderedEngines(completion: @escaping SearchEngineCompletion)
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -38,7 +38,6 @@ final class AddressToolbarContainer: UIView,
 
     private var windowUUID: WindowUUID?
     private var profile: Profile?
-    private var searchEnginesManager: SearchEnginesManagerProvider?
     private var model: AddressToolbarContainerModel?
     private(set) weak var delegate: AddressToolbarContainerDelegate?
 
@@ -130,7 +129,6 @@ final class AddressToolbarContainer: UIView,
     ) {
         self.windowUUID = windowUUID
         self.profile = profile
-        self.searchEnginesManager = searchEnginesManager
         self.delegate = delegate
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
         subscribeToRedux()
@@ -200,10 +198,9 @@ final class AddressToolbarContainer: UIView,
     }
 
     private func updateModel(toolbarState: ToolbarState) {
-        guard let windowUUID, let profile, let searchEnginesManager else { return }
+        guard let windowUUID, let profile else { return }
         let newModel = AddressToolbarContainerModel(state: toolbarState,
                                                     profile: profile,
-                                                    searchEnginesManager: searchEnginesManager,
                                                     windowUUID: windowUUID)
 
         shouldDisplayCompact = newModel.shouldDisplayCompact

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -38,6 +38,7 @@ final class AddressToolbarContainer: UIView,
 
     private var windowUUID: WindowUUID?
     private var profile: Profile?
+    private var searchEnginesManager: SearchEnginesManager?
     private var model: AddressToolbarContainerModel?
     private(set) weak var delegate: AddressToolbarContainerDelegate?
 
@@ -123,11 +124,13 @@ final class AddressToolbarContainer: UIView,
     func configure(
         windowUUID: WindowUUID,
         profile: Profile,
+        searchEnginesManager: SearchEnginesManager,
         delegate: AddressToolbarContainerDelegate,
         isUnifiedSearchEnabled: Bool
     ) {
         self.windowUUID = windowUUID
         self.profile = profile
+        self.searchEnginesManager = searchEnginesManager
         self.delegate = delegate
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
         subscribeToRedux()
@@ -197,9 +200,10 @@ final class AddressToolbarContainer: UIView,
     }
 
     private func updateModel(toolbarState: ToolbarState) {
-        guard let windowUUID, let profile else { return }
+        guard let windowUUID, let profile, let searchEnginesManager else { return }
         let newModel = AddressToolbarContainerModel(state: toolbarState,
                                                     profile: profile,
+                                                    searchEnginesManager: searchEnginesManager,
                                                     windowUUID: windowUUID)
 
         shouldDisplayCompact = newModel.shouldDisplayCompact

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -38,7 +38,7 @@ final class AddressToolbarContainer: UIView,
 
     private var windowUUID: WindowUUID?
     private var profile: Profile?
-    private var searchEnginesManager: SearchEnginesManager?
+    private var searchEnginesManager: SearchEnginesManagerProvider?
     private var model: AddressToolbarContainerModel?
     private(set) weak var delegate: AddressToolbarContainerDelegate?
 
@@ -124,7 +124,7 @@ final class AddressToolbarContainer: UIView,
     func configure(
         windowUUID: WindowUUID,
         profile: Profile,
-        searchEnginesManager: SearchEnginesManager,
+        searchEnginesManager: SearchEnginesManagerProvider,
         delegate: AddressToolbarContainerDelegate,
         isUnifiedSearchEnabled: Bool
     ) {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import ToolbarKit
 import Shared
 
@@ -93,7 +94,12 @@ final class AddressToolbarContainerModel: Equatable {
             shouldAnimate: shouldAnimate)
     }
 
-    init(state: ToolbarState, profile: Profile, searchEnginesManager: SearchEnginesManagerProvider, windowUUID: UUID) {
+    init(
+        state: ToolbarState,
+        profile: Profile,
+        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
+        windowUUID: UUID
+    ) {
         self.borderPosition = state.addressToolbar.borderPosition
         self.navigationActions = AddressToolbarContainerModel.mapActions(state.addressToolbar.navigationActions,
                                                                          isShowingTopTabs: state.isShowingTopTabs,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -16,7 +16,7 @@ final class AddressToolbarContainerModel: Equatable {
     let borderPosition: AddressToolbarBorderPosition?
     let searchEngineName: String
     let searchEngineImage: UIImage
-    let searchEnginesManager: SearchEnginesManagerProvider
+    let searchEnginesManager: SearchEnginesManager
     let lockIconImageName: String?
     let lockIconNeedsTheming: Bool
     let safeListedURLImageName: String?
@@ -34,7 +34,7 @@ final class AddressToolbarContainerModel: Equatable {
     let windowUUID: UUID
 
     var addressToolbarConfig: AddressToolbarConfiguration {
-        let term = searchTerm ?? searchTermFromURL(url, searchEnginesManager: searchEnginesManager)
+        let term = searchTerm ?? searchTermFromURL(url)
         let isVersionLayout = toolbarLayoutStyle == .version1 || toolbarLayoutStyle == .version2
         let uxConfiguration: AddressToolbarUXConfiguration = if isVersionLayout {
             .experiment
@@ -138,17 +138,14 @@ final class AddressToolbarContainerModel: Equatable {
         self.toolbarLayoutStyle = state.toolbarLayout
     }
 
-    func searchTermFromURL(_ url: URL?, searchEnginesManager: SearchEnginesManagerProvider) -> String? {
+    func searchTermFromURL(_ url: URL?) -> String? {
         var searchURL: URL? = url
 
         if let url = searchURL, InternalURL.isValid(url: url) {
             searchURL = url
         }
 
-        guard
-            let searchEnginesManager = searchEnginesManager as? SearchEnginesManager,
-            let query = searchEnginesManager.queryForSearchURL(searchURL) else { return nil }
-        return query
+        return searchEnginesManager.queryForSearchURL(searchURL)
     }
 
     private static func mapActions(_ actions: [ToolbarActionConfiguration],

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -93,7 +93,7 @@ final class AddressToolbarContainerModel: Equatable {
             shouldAnimate: shouldAnimate)
     }
 
-    init(state: ToolbarState, profile: Profile, windowUUID: UUID) {
+    init(state: ToolbarState, profile: Profile, searchEnginesManager: SearchEnginesManager, windowUUID: UUID) {
         self.borderPosition = state.addressToolbar.borderPosition
         self.navigationActions = AddressToolbarContainerModel.mapActions(state.addressToolbar.navigationActions,
                                                                          isShowingTopTabs: state.isShowingTopTabs,
@@ -110,12 +110,12 @@ final class AddressToolbarContainerModel: Equatable {
 
         // If the user has selected an alternative search engine, use that. Otherwise, use the default engine.
         let searchEngineModel = state.addressToolbar.alternativeSearchEngine
-                                ?? profile.searchEnginesManager.defaultEngine?.generateModel()
+                                ?? searchEnginesManager.defaultEngine?.generateModel()
 
         self.windowUUID = windowUUID
         self.searchEngineName = searchEngineModel?.name ?? ""
         self.searchEngineImage = searchEngineModel?.image ?? UIImage()
-        self.searchEnginesManager = profile.searchEnginesManager
+        self.searchEnginesManager = searchEnginesManager
         self.lockIconImageName = state.addressToolbar.lockIconImageName
         self.lockIconNeedsTheming = state.addressToolbar.lockIconNeedsTheming
         self.safeListedURLImageName = state.addressToolbar.safeListedURLImageName

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -15,7 +15,7 @@ final class AddressToolbarContainerModel: Equatable {
     let borderPosition: AddressToolbarBorderPosition?
     let searchEngineName: String
     let searchEngineImage: UIImage
-    let searchEnginesManager: SearchEnginesManager
+    let searchEnginesManager: SearchEnginesManagerProvider
     let lockIconImageName: String?
     let lockIconNeedsTheming: Bool
     let safeListedURLImageName: String?
@@ -93,7 +93,7 @@ final class AddressToolbarContainerModel: Equatable {
             shouldAnimate: shouldAnimate)
     }
 
-    init(state: ToolbarState, profile: Profile, searchEnginesManager: SearchEnginesManager, windowUUID: UUID) {
+    init(state: ToolbarState, profile: Profile, searchEnginesManager: SearchEnginesManagerProvider, windowUUID: UUID) {
         self.borderPosition = state.addressToolbar.borderPosition
         self.navigationActions = AddressToolbarContainerModel.mapActions(state.addressToolbar.navigationActions,
                                                                          isShowingTopTabs: state.isShowingTopTabs,
@@ -132,14 +132,16 @@ final class AddressToolbarContainerModel: Equatable {
         self.toolbarLayoutStyle = state.toolbarLayout
     }
 
-    func searchTermFromURL(_ url: URL?, searchEnginesManager: SearchEnginesManager) -> String? {
+    func searchTermFromURL(_ url: URL?, searchEnginesManager: SearchEnginesManagerProvider) -> String? {
         var searchURL: URL? = url
 
         if let url = searchURL, InternalURL.isValid(url: url) {
             searchURL = url
         }
 
-        guard let query = searchEnginesManager.queryForSearchURL(searchURL) else { return nil }
+        guard
+            let searchEnginesManager = searchEnginesManager as? SearchEnginesManager,
+            let query = searchEnginesManager.queryForSearchURL(searchURL) else { return nil }
         return query
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -29,6 +29,7 @@ final class TopSitesMiddleware: FeatureFlaggable {
         bookmarksTelemetry: BookmarksTelemetry = BookmarksTelemetry(),
         unifiedAdsTelemetry: UnifiedAdsCallbackTelemetry = DefaultUnifiedAdsCallbackTelemetry(),
         sponsoredTileTelemetry: SponsoredTileTelemetry = DefaultSponsoredTileTelemetry(),
+        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
         logger: Logger = DefaultLogger.shared
     ) {
         self.topSitesManager = topSitesManager ?? TopSitesManager(
@@ -37,7 +38,7 @@ final class TopSitesMiddleware: FeatureFlaggable {
                 prefs: profile.prefs
             ),
             topSiteHistoryManager: TopSiteHistoryManager(profile: profile),
-            searchEnginesManager: profile.searchEnginesManager
+            searchEnginesManager: searchEnginesManager
         )
         self.homepageTelemetry = homepageTelemetry
         self.bookmarksTelemetry = bookmarksTelemetry

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -29,7 +29,7 @@ final class TopSitesMiddleware: FeatureFlaggable {
         bookmarksTelemetry: BookmarksTelemetry = BookmarksTelemetry(),
         unifiedAdsTelemetry: UnifiedAdsCallbackTelemetry = DefaultUnifiedAdsCallbackTelemetry(),
         sponsoredTileTelemetry: SponsoredTileTelemetry = DefaultSponsoredTileTelemetry(),
-        searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(),
+        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
         logger: Logger = DefaultLogger.shared
     ) {
         self.topSitesManager = topSitesManager ?? TopSitesManager(

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -29,7 +29,7 @@ final class TopSitesMiddleware: FeatureFlaggable {
         bookmarksTelemetry: BookmarksTelemetry = BookmarksTelemetry(),
         unifiedAdsTelemetry: UnifiedAdsCallbackTelemetry = DefaultUnifiedAdsCallbackTelemetry(),
         sponsoredTileTelemetry: SponsoredTileTelemetry = DefaultSponsoredTileTelemetry(),
-        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
+        searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(),
         logger: Logger = DefaultLogger.shared
     ) {
         self.topSitesManager = topSitesManager ?? TopSitesManager(

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -40,7 +40,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
     private let contileProvider: ContileProviderInterface
     private let unifiedAdsProvider: UnifiedAdsProviderInterface
     private let dispatchGroup: DispatchGroupInterface
-    private let searchEnginesManager: SearchEnginesManager
+    private let searchEnginesManager: SearchEnginesManagerProvider
 
     // Pre-loading the data with a default number of tiles so we always show section when needed
     // If this isn't done, then no data will be found from the view model and section won't show
@@ -53,7 +53,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
          contileProvider: ContileProviderInterface = ContileProvider(),
          unifiedAdsProvider: UnifiedAdsProviderInterface = UnifiedAdsProvider(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
-         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
+         searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(),
          dispatchGroup: DispatchGroupInterface = DispatchGroup()
     ) {
         self.profile = profile

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -40,6 +40,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
     private let contileProvider: ContileProviderInterface
     private let unifiedAdsProvider: UnifiedAdsProviderInterface
     private let dispatchGroup: DispatchGroupInterface
+    private let searchEnginesManager: SearchEnginesManager
 
     // Pre-loading the data with a default number of tiles so we always show section when needed
     // If this isn't done, then no data will be found from the view model and section won't show
@@ -52,6 +53,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
          contileProvider: ContileProviderInterface = ContileProvider(),
          unifiedAdsProvider: UnifiedAdsProviderInterface = UnifiedAdsProvider(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
+         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
          dispatchGroup: DispatchGroupInterface = DispatchGroup()
     ) {
         self.profile = profile
@@ -60,6 +62,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
         self.contileProvider = contileProvider
         self.unifiedAdsProvider = unifiedAdsProvider
         self.notificationCenter = notificationCenter
+        self.searchEnginesManager = searchEnginesManager
         self.dispatchGroup = dispatchGroup
         topSiteHistoryManager.delegate = self
 
@@ -194,7 +197,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
         if sponsoredTileSpaces > 0 {
             sites.addSponsoredTiles(sponsoredTileSpaces: sponsoredTileSpaces,
                                     contiles: contiles,
-                                    defaultSearchEngine: profile.searchEnginesManager.defaultEngine)
+                                    defaultSearchEngine: searchEnginesManager.defaultEngine)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -53,7 +53,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
          contileProvider: ContileProviderInterface = ContileProvider(),
          unifiedAdsProvider: UnifiedAdsProviderInterface = UnifiedAdsProvider(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
-         searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(),
+         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
          dispatchGroup: DispatchGroupInterface = DispatchGroup()
     ) {
         self.profile = profile

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -13,6 +13,7 @@ protocol BookmarksFolderCell: BookmarksRefactorFeatureFlagProvider {
     func getViewModel() -> OneLineTableViewCellViewModel
 
     func didSelect(profile: Profile,
+                   searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
                    libraryPanelDelegate: LibraryPanelDelegate?,
                    navigationController: UINavigationController?,
@@ -44,6 +45,7 @@ extension BookmarkFolderData: BookmarksFolderCell {
     }
 
     func didSelect(profile: Profile,
+                   searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
                    libraryPanelDelegate: LibraryPanelDelegate?,
                    navigationController: UINavigationController?,
@@ -87,6 +89,7 @@ extension BookmarkItemData: BookmarksFolderCell {
     }
 
     func didSelect(profile: Profile,
+                   searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
                    libraryPanelDelegate: LibraryPanelDelegate?,
                    navigationController: UINavigationController?,
@@ -97,7 +100,7 @@ extension BookmarkItemData: BookmarksFolderCell {
         // (e.g., "http://foo.com/bar/?query=%s"), and this will get them the same behavior as if
         // they'd copied and pasted into the URL bar.
         // See BrowserViewController.urlBar:didSubmitText:.
-        guard let url = URIFixup.getURL(url) ?? profile.searchEnginesManager.defaultEngine?.searchURLForQuery(url) else {
+        guard let url = URIFixup.getURL(url) ?? searchEnginesManager.defaultEngine?.searchURLForQuery(url) else {
             logger.log("Invalid URL, and couldn't generate a search URL for it.",
                        level: .warning,
                        category: .library)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -13,7 +13,6 @@ protocol BookmarksFolderCell: BookmarksRefactorFeatureFlagProvider {
     func getViewModel() -> OneLineTableViewCellViewModel
 
     func didSelect(profile: Profile,
-                   searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
                    libraryPanelDelegate: LibraryPanelDelegate?,
                    navigationController: UINavigationController?,
@@ -45,7 +44,6 @@ extension BookmarkFolderData: BookmarksFolderCell {
     }
 
     func didSelect(profile: Profile,
-                   searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
                    libraryPanelDelegate: LibraryPanelDelegate?,
                    navigationController: UINavigationController?,
@@ -89,11 +87,11 @@ extension BookmarkItemData: BookmarksFolderCell {
     }
 
     func didSelect(profile: Profile,
-                   searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
                    libraryPanelDelegate: LibraryPanelDelegate?,
                    navigationController: UINavigationController?,
                    logger: Logger) {
+        let searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve()
         // If we can't get a real URL out of what should be a URL, we let the user's
         // default search engine give it a shot.
         // Typically we'll be in this state if the user has tapped a bookmarked search template

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -13,6 +13,7 @@ protocol BookmarksFolderCell: BookmarksRefactorFeatureFlagProvider {
     func getViewModel() -> OneLineTableViewCellViewModel
 
     func didSelect(profile: Profile,
+                   searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
                    libraryPanelDelegate: LibraryPanelDelegate?,
                    navigationController: UINavigationController?,
@@ -44,6 +45,7 @@ extension BookmarkFolderData: BookmarksFolderCell {
     }
 
     func didSelect(profile: Profile,
+                   searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
                    libraryPanelDelegate: LibraryPanelDelegate?,
                    navigationController: UINavigationController?,
@@ -87,11 +89,11 @@ extension BookmarkItemData: BookmarksFolderCell {
     }
 
     func didSelect(profile: Profile,
+                   searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
                    libraryPanelDelegate: LibraryPanelDelegate?,
                    navigationController: UINavigationController?,
                    logger: Logger) {
-        let searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve()
         // If we can't get a real URL out of what should be a URL, we let the user's
         // default search engine give it a shot.
         // Typically we'll be in this state if the user has tapped a bookmarked search template

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LocalDesktopFolder.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LocalDesktopFolder.swift
@@ -66,6 +66,7 @@ extension LocalDesktopFolder: BookmarksFolderCell {
     }
 
     func didSelect(profile: Profile,
+                   searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
                    libraryPanelDelegate: LibraryPanelDelegate?,
                    navigationController: UINavigationController?,

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LocalDesktopFolder.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LocalDesktopFolder.swift
@@ -66,7 +66,6 @@ extension LocalDesktopFolder: BookmarksFolderCell {
     }
 
     func didSelect(profile: Profile,
-                   searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
                    libraryPanelDelegate: LibraryPanelDelegate?,
                    navigationController: UINavigationController?,

--- a/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -34,6 +34,8 @@ class CustomSearchViewController: SettingsTableViewController {
         spinner.hidesWhenStopped = true
     }
 
+    var searchEnginesManager: SearchEnginesManager?
+
     init(windowUUID: WindowUUID,
          faviconFetcher: SiteImageHandler = DefaultSiteImageHandler.factory()) {
         self.faviconFetcher = faviconFetcher
@@ -67,23 +69,23 @@ class CustomSearchViewController: SettingsTableViewController {
         Task {
             do {
                 let engine = try await createEngine(query: trimmedQuery, name: trimmedTitle)
-                self.spinnerView.stopAnimating()
-                self.searchEnginesManager?.addSearchEngine(engine)
+                spinnerView.stopAnimating()
+                searchEnginesManager?.addSearchEngine(engine)
 
                 CATransaction.begin() // Use transaction to call callback after animation has been completed
-                CATransaction.setCompletionBlock(self.successCallback)
-                _ = self.navigationController?.popViewController(animated: true)
+                CATransaction.setCompletionBlock(successCallback)
+                _ = navigationController?.popViewController(animated: true)
                 CATransaction.commit()
             } catch {
-                self.spinnerView.stopAnimating()
+                spinnerView.stopAnimating()
                 let alert: UIAlertController
                 let error = error as? CustomSearchError
 
                 alert = (error?.reason == .DuplicateEngine) ?
                     ThirdPartySearchAlerts.duplicateCustomEngine() : ThirdPartySearchAlerts.incorrectCustomEngineForm()
 
-                self.navigationItem.rightBarButtonItem?.isEnabled = true
-                self.present(alert, animated: true, completion: nil)
+                navigationItem.rightBarButtonItem?.isEnabled = true
+                present(alert, animated: true, completion: nil)
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -68,7 +68,7 @@ class CustomSearchViewController: SettingsTableViewController {
             do {
                 let engine = try await createEngine(query: trimmedQuery, name: trimmedTitle)
                 self.spinnerView.stopAnimating()
-                self.profile?.searchEnginesManager.addSearchEngine(engine)
+                self.searchEnginesManager?.addSearchEngine(engine)
 
                 CATransaction.begin() // Use transaction to call callback after animation has been completed
                 CATransaction.setCompletionBlock(self.successCallback)
@@ -126,8 +126,8 @@ class CustomSearchViewController: SettingsTableViewController {
     }
 
     private func engineExists(name: String, template: String) -> Bool {
-        guard let profile else { return false }
-        return profile.searchEnginesManager.orderedEngines.contains { (engine) -> Bool in
+        guard let searchEnginesManager else { return false }
+        return searchEnginesManager.orderedEngines.contains { (engine) -> Bool in
             return engine.shortName == name || engine.searchTemplate == template
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -52,7 +52,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
     private let logger: Logger
     private let gleanUsageReportingMetricsService: GleanUsageReportingMetricsService
     private var hasAppearedBefore = false
-    private let searchEnginesManager: SearchEnginesManager
+    private let searchEnginesManager: SearchEnginesManagerProvider
 
     weak var parentCoordinator: SettingsFlowDelegate?
 
@@ -72,7 +72,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         appAuthenticator: AppAuthenticationProtocol = AppAuthenticator(),
         applicationHelper: ApplicationHelper = DefaultApplicationHelper(),
         logger: Logger = DefaultLogger.shared,
-        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve()
+        searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve()
     ) {
         self.appAuthenticator = appAuthenticator
         self.applicationHelper = applicationHelper

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -52,6 +52,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
     private let logger: Logger
     private let gleanUsageReportingMetricsService: GleanUsageReportingMetricsService
     private var hasAppearedBefore = false
+    private let searchEnginesManager: SearchEnginesManager
 
     weak var parentCoordinator: SettingsFlowDelegate?
 
@@ -70,12 +71,14 @@ class AppSettingsTableViewController: SettingsTableViewController,
         gleanUsageReportingMetricsService: GleanUsageReportingMetricsService,
         appAuthenticator: AppAuthenticationProtocol = AppAuthenticator(),
         applicationHelper: ApplicationHelper = DefaultApplicationHelper(),
-        logger: Logger = DefaultLogger.shared
+        logger: Logger = DefaultLogger.shared,
+        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve()
     ) {
         self.appAuthenticator = appAuthenticator
         self.applicationHelper = applicationHelper
         self.logger = logger
         self.gleanUsageReportingMetricsService = gleanUsageReportingMetricsService
+        self.searchEnginesManager = searchEnginesManager
 
         super.init(windowUUID: tabManager.windowUUID)
         self.profile = profile
@@ -318,7 +321,11 @@ class AppSettingsTableViewController: SettingsTableViewController,
     private func getGeneralSettings() -> [SettingSection] {
         var generalSettings: [Setting] = [
             BrowsingSetting(settings: self, settingsDelegate: parentCoordinator),
-            SearchSetting(settings: self, settingsDelegate: parentCoordinator),
+            SearchSetting(
+                settingsDelegate: parentCoordinator,
+                searchEnginesManager: searchEnginesManager,
+                theme: themeManager.getCurrentTheme(for: windowUUID)
+            ),
             NewTabPageSetting(settings: self, settingsDelegate: parentCoordinator),
             HomeSetting(settings: self, settingsDelegate: parentCoordinator),
             ThemeSetting(settings: self, settingsDelegate: parentCoordinator)

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -72,7 +72,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         appAuthenticator: AppAuthenticationProtocol = AppAuthenticator(),
         applicationHelper: ApplicationHelper = DefaultApplicationHelper(),
         logger: Logger = DefaultLogger.shared,
-        searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve()
+        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve()
     ) {
         self.appAuthenticator = appAuthenticator
         self.applicationHelper = applicationHelper

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
@@ -6,7 +6,7 @@ import Common
 import Foundation
 
 class SearchSetting: Setting {
-    private let searchEnginesManager: SearchEnginesManager
+    private let searchEnginesManager: SearchEnginesManagerProvider
     private weak var settingsDelegate: GeneralSettingsDelegate?
 
     override var accessoryView: UIImageView? {
@@ -27,7 +27,7 @@ class SearchSetting: Setting {
     }
 
     init(settingsDelegate: GeneralSettingsDelegate?,
-         searchEnginesManager: SearchEnginesManager,
+         searchEnginesManager: SearchEnginesManagerProvider,
          theme: Theme) {
         self.searchEnginesManager = searchEnginesManager
         self.settingsDelegate = settingsDelegate

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 class SearchSetting: Setting {
-    private let profile: Profile?
+    private let searchEnginesManager: SearchEnginesManager?
     private weak var settingsDelegate: GeneralSettingsDelegate?
 
     override var accessoryView: UIImageView? {
@@ -16,9 +16,9 @@ class SearchSetting: Setting {
     override var style: UITableViewCell.CellStyle { return .value1 }
 
     override var status: NSAttributedString? {
-        guard let profile else { return nil }
+        guard let searchEnginesManager else { return nil }
         return NSAttributedString(
-            string: profile.searchEnginesManager.defaultEngine?.shortName ?? ""
+            string: searchEnginesManager.defaultEngine?.shortName ?? ""
         )
     }
 
@@ -28,7 +28,7 @@ class SearchSetting: Setting {
 
     init(settings: SettingsTableViewController,
          settingsDelegate: GeneralSettingsDelegate?) {
-        self.profile = settings.profile
+        self.searchEnginesManager = settings.searchEnginesManager
         self.settingsDelegate = settingsDelegate
         let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
@@ -2,10 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 class SearchSetting: Setting {
-    private let searchEnginesManager: SearchEnginesManager?
+    private let searchEnginesManager: SearchEnginesManager
     private weak var settingsDelegate: GeneralSettingsDelegate?
 
     override var accessoryView: UIImageView? {
@@ -16,7 +17,6 @@ class SearchSetting: Setting {
     override var style: UITableViewCell.CellStyle { return .value1 }
 
     override var status: NSAttributedString? {
-        guard let searchEnginesManager else { return nil }
         return NSAttributedString(
             string: searchEnginesManager.defaultEngine?.shortName ?? ""
         )
@@ -26,11 +26,11 @@ class SearchSetting: Setting {
         return AccessibilityIdentifiers.Settings.Search.title
     }
 
-    init(settings: SettingsTableViewController,
-         settingsDelegate: GeneralSettingsDelegate?) {
-        self.searchEnginesManager = settings.searchEnginesManager
+    init(settingsDelegate: GeneralSettingsDelegate?,
+         searchEnginesManager: SearchEnginesManager,
+         theme: Theme) {
+        self.searchEnginesManager = searchEnginesManager
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .AppSettingsSearch,

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -82,11 +82,12 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     }
 
     init(profile: Profile,
+         searchEnginesManager: SearchEnginesManager,
          windowUUID: WindowUUID,
          logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.logger = logger
-        model = profile.searchEnginesManager
+        model = searchEnginesManager
 
         super.init(windowUUID: windowUUID)
     }

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -82,7 +82,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     }
 
     init(profile: Profile,
-         searchEnginesManager: SearchEnginesManager,
+         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
          windowUUID: WindowUUID,
          logger: Logger = DefaultLogger.shared) {
         self.profile = profile

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -824,6 +824,7 @@ class SettingsTableViewController: ThemedTableViewController {
 
     var profile: Profile?
     var tabManager: TabManager?
+    var searchEnginesManager: SearchEnginesManager?
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -824,7 +824,6 @@ class SettingsTableViewController: ThemedTableViewController {
 
     var profile: Profile?
     var tabManager: TabManager?
-    var searchEnginesManager: SearchEnginesManager?
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -88,7 +88,7 @@ class URLBarView: UIView,
     }
 
     var parent: UIStackView?
-    var searchEnginesManager: SearchEnginesManager?
+    let searchEnginesManager: SearchEnginesManager
     weak var delegate: URLBarDelegate?
     weak var tabToolbarDelegate: TabToolbarDelegate?
     var helper: TabToolbarHelper?
@@ -241,7 +241,7 @@ class URLBarView: UIView,
         imageMask: ImageIdentifiers.menuWarningMask
     )
 
-    init(profile: Profile, windowUUID: WindowUUID) {
+    init(profile: Profile, searchEnginesManager: SearchEnginesManager, windowUUID: WindowUUID) {
         self.profile = profile
         self.windowUUID = windowUUID
         self.searchEnginesManager = SearchEnginesManager(prefs: profile.prefs, files: profile.files)
@@ -254,7 +254,9 @@ class URLBarView: UIView,
     }
 
     func searchEnginesDidUpdate() {
-        let engineID = profile.searchEnginesManager.defaultEngine?.telemetryID ?? "unavailable"
+        let defaultEngine = searchEnginesManager.defaultEngine
+
+        let engineID = defaultEngine?.telemetryID ?? "unavailable"
         TelemetryWrapper.recordEvent(
             category: .information,
             method: .change,
@@ -263,11 +265,11 @@ class URLBarView: UIView,
             extras: [TelemetryWrapper.EventExtraKey.recordSearchEngineID.rawValue: engineID]
         )
 
-        self.searchIconImageView.image = profile.searchEnginesManager.defaultEngine?.image
-        self.searchIconImageView.largeContentTitle = profile.searchEnginesManager.defaultEngine?.shortName
+        self.searchIconImageView.image = defaultEngine?.image
+        self.searchIconImageView.largeContentTitle = defaultEngine?.shortName
         self.searchIconImageView.largeContentImage = nil
 
-        guard let name = profile.searchEnginesManager.defaultEngine?.shortName else { return }
+        guard let name = searchEnginesManager.defaultEngine?.shortName else { return }
         self.searchIconImageView.accessibilityLabel = String(format: .AddressToolbar.SearchEngineA11yLabel, name)
     }
 
@@ -293,7 +295,7 @@ class URLBarView: UIView,
             addSubview($0)
         }
 
-        profile.searchEnginesManager.delegate = self
+        searchEnginesManager.delegate = self
 
         privateModeBadge.add(toParent: self)
         warningMenuBadge.add(toParent: self)

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -241,7 +241,11 @@ class URLBarView: UIView,
         imageMask: ImageIdentifiers.menuWarningMask
     )
 
-    init(profile: Profile, searchEnginesManager: SearchEnginesManagerProvider, windowUUID: WindowUUID) {
+    init(
+        profile: Profile,
+        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
+        windowUUID: WindowUUID
+    ) {
         self.profile = profile
         self.windowUUID = windowUUID
         self.searchEnginesManager = searchEnginesManager

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -88,7 +88,7 @@ class URLBarView: UIView,
     }
 
     var parent: UIStackView?
-    let searchEnginesManager: SearchEnginesManager
+    let searchEnginesManager: SearchEnginesManagerProvider
     weak var delegate: URLBarDelegate?
     weak var tabToolbarDelegate: TabToolbarDelegate?
     var helper: TabToolbarHelper?
@@ -241,10 +241,10 @@ class URLBarView: UIView,
         imageMask: ImageIdentifiers.menuWarningMask
     )
 
-    init(profile: Profile, searchEnginesManager: SearchEnginesManager, windowUUID: WindowUUID) {
+    init(profile: Profile, searchEnginesManager: SearchEnginesManagerProvider, windowUUID: WindowUUID) {
         self.profile = profile
         self.windowUUID = windowUUID
-        self.searchEnginesManager = SearchEnginesManager(prefs: profile.prefs, files: profile.files)
+        self.searchEnginesManager = searchEnginesManager
         super.init(frame: CGRect())
         commonInit()
     }

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -82,7 +82,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         } catch {}
     }
 
-    func setup(profile: Profile, searchEnginesManager: SearchEnginesManagerProvider) {
+    func setup(profile: Profile) {
         migratePathComponentInDocumentsDirectory("MozTelemetry-Default-core", to: .cachesDirectory)
         migratePathComponentInDocumentsDirectory("MozTelemetry-Default-mobile-event", to: .cachesDirectory)
         migratePathComponentInDocumentsDirectory("eventArray-MozTelemetry-Default-mobile-event.json", to: .cachesDirectory)
@@ -90,10 +90,14 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         let sendUsageData = profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
 
         // Initialize Glean
-        initGlean(profile, searchEnginesManager: searchEnginesManager, sendUsageData: sendUsageData)
+        initGlean(profile, sendUsageData: sendUsageData)
     }
 
-    func initGlean(_ profile: Profile, searchEnginesManager: SearchEnginesManagerProvider, sendUsageData: Bool) {
+    func initGlean(
+        _ profile: Profile,
+        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
+        sendUsageData: Bool
+    ) {
         // Record default search engine setting to avoid sending a `null` value.
         // If there's no default search engine, (there's not, at this point), we will
         // send "unavailable" in order not to send `null`, but still differentiate

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -90,9 +90,6 @@ protocol Profile: AnyObject {
     var places: RustPlaces { get }
     var prefs: Prefs { get }
     var queue: TabQueue { get }
-    #if !MOZ_TARGET_NOTIFICATIONSERVICE && !MOZ_TARGET_SHARETO && !MOZ_TARGET_CREDENTIAL_PROVIDER
-    var searchEnginesManager: SearchEnginesManager { get }
-    #endif
     var files: FileAccessor { get }
     var pinnedSites: PinnedSites { get }
     var logins: RustLogins { get }
@@ -485,12 +482,6 @@ open class BrowserProfile: Profile {
     ).appendingPathComponent("autofill.db").path
 
     lazy var autofill = RustAutofill(databasePath: autofillDbPath, rustKeychainEnabled: rustKeychainEnabled)
-
-    #if !MOZ_TARGET_NOTIFICATIONSERVICE && !MOZ_TARGET_SHARETO && !MOZ_TARGET_CREDENTIAL_PROVIDER
-    lazy var searchEnginesManager: SearchEnginesManager = {
-        return SearchEnginesManager(prefs: self.prefs, files: self.files)
-    }()
-    #endif
 
     func makePrefs() -> Prefs {
         return NSUserDefaultsPrefs(prefix: self.localName())

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -25,7 +25,7 @@ class DependencyHelperMock {
             files: profile.files,
             engineProvider: MockSearchEngineProvider()
         )
-        AppContainer.shared.register(service: searchEnginesManager as SearchEnginesManagerProvider)
+        AppContainer.shared.register(service: searchEnginesManager)
 
         let diskImageStore: DiskImageStore = DefaultDiskImageStore(
             files: profile.files,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -25,10 +25,7 @@ class DependencyHelperMock {
             files: profile.files,
             engineProvider: MockSearchEngineProvider()
         )
-        AppContainer.shared.register(service: searchEnginesManager)
-
-        let searchEngineManagerProvider: SearchEnginesManagerProvider = searchEnginesManager
-        AppContainer.shared.register(service: searchEngineManagerProvider)
+        AppContainer.shared.register(service: searchEnginesManager as SearchEnginesManagerProvider)
 
         let diskImageStore: DiskImageStore = DefaultDiskImageStore(
             files: profile.files,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -20,6 +20,16 @@ class DependencyHelperMock {
         )
         AppContainer.shared.register(service: profile)
 
+        let searchEnginesManager = SearchEnginesManager(
+            prefs: profile.prefs,
+            files: profile.files,
+            engineProvider: MockSearchEngineProvider()
+        )
+        AppContainer.shared.register(service: searchEnginesManager)
+
+        let searchEngineManagerProvider: SearchEnginesManagerProvider = searchEnginesManager
+        AppContainer.shared.register(service: searchEngineManagerProvider)
+
         let diskImageStore: DiskImageStore = DefaultDiskImageStore(
             files: profile.files,
             namespace: TabManagerConstants.tabScreenshotNamespace,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
@@ -66,7 +66,7 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
     // MARK: - Helpers
 
     private func createSubject(mockSearchEnginesManager: SearchEnginesManagerProvider) -> SearchEngineSelectionMiddleware {
-        return SearchEngineSelectionMiddleware(profile: mockProfile, searchEnginesManager: mockSearchEnginesManager)
+        return SearchEngineSelectionMiddleware(profile: mockProfile)
     }
 
     private func getAction(for actionType: SearchEngineSelectionActionType) -> SearchEngineSelectionAction {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
@@ -66,7 +66,7 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
     // MARK: - Helpers
 
     private func createSubject(mockSearchEnginesManager: SearchEnginesManagerProvider) -> SearchEngineSelectionMiddleware {
-        return SearchEngineSelectionMiddleware(profile: mockProfile)
+        return SearchEngineSelectionMiddleware(profile: mockProfile, searchEnginesManager: mockSearchEnginesManager)
     }
 
     private func getAction(for actionType: SearchEngineSelectionActionType) -> SearchEngineSelectionAction {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/LegacyHomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/LegacyHomepageViewControllerTests.swift
@@ -9,25 +9,32 @@ import Common
 
 class LegacyHomepageViewControllerTests: XCTestCase {
     var profile: MockProfile!
+    var searchEnginesManager: SearchEnginesManager!
 
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
+        searchEnginesManager = SearchEnginesManager(
+            prefs: profile.prefs,
+            files: profile.files,
+            engineProvider: MockSearchEngineProvider()
+        )
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
     override func tearDown() {
-        super.tearDown()
         AppContainer.shared.reset()
         profile = nil
+        searchEnginesManager = nil
         Experiments.events.clearEvents()
+        super.tearDown()
     }
 
     func testHomepageViewController_simpleCreation_hasNoLeaks() {
         let tabManager = TabManagerImplementation(profile: profile,
                                                   uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
-        let urlBar = URLBarView(profile: profile, windowUUID: .XCTestDefaultUUID)
+        let urlBar = URLBarView(profile: profile, searchEnginesManager: searchEnginesManager, windowUUID: .XCTestDefaultUUID)
         let overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)
 
@@ -45,7 +52,7 @@ class LegacyHomepageViewControllerTests: XCTestCase {
         Experiments.events.clearEvents()
         let tabManager = TabManagerImplementation(profile: profile,
                                                   uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
-        let urlBar = URLBarView(profile: profile, windowUUID: .XCTestDefaultUUID)
+        let urlBar = URLBarView(profile: profile, searchEnginesManager: searchEnginesManager, windowUUID: .XCTestDefaultUUID)
         let overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/LegacyHomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/LegacyHomepageViewControllerTests.swift
@@ -9,24 +9,17 @@ import Common
 
 class LegacyHomepageViewControllerTests: XCTestCase {
     var profile: MockProfile!
-    var searchEnginesManager: SearchEnginesManager!
 
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        searchEnginesManager = SearchEnginesManager(
-            prefs: profile.prefs,
-            files: profile.files,
-            engineProvider: MockSearchEngineProvider()
-        )
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
     override func tearDown() {
         AppContainer.shared.reset()
         profile = nil
-        searchEnginesManager = nil
         Experiments.events.clearEvents()
         super.tearDown()
     }
@@ -34,7 +27,7 @@ class LegacyHomepageViewControllerTests: XCTestCase {
     func testHomepageViewController_simpleCreation_hasNoLeaks() {
         let tabManager = TabManagerImplementation(profile: profile,
                                                   uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
-        let urlBar = URLBarView(profile: profile, searchEnginesManager: searchEnginesManager, windowUUID: .XCTestDefaultUUID)
+        let urlBar = URLBarView(profile: profile, windowUUID: .XCTestDefaultUUID)
         let overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)
 
@@ -52,7 +45,7 @@ class LegacyHomepageViewControllerTests: XCTestCase {
         Experiments.events.clearEvents()
         let tabManager = TabManagerImplementation(profile: profile,
                                                   uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
-        let urlBar = URLBarView(profile: profile, searchEnginesManager: searchEnginesManager, windowUUID: .XCTestDefaultUUID)
+        let urlBar = URLBarView(profile: profile, windowUUID: .XCTestDefaultUUID)
         let overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     private var profile: MockProfile!
-    private var searchEnginesManager: SearchEnginesManagerProvider!
+    private var searchEnginesManager: SearchEnginesManager!
     private var contileProviderMock: ContileProviderMock!
     private var notificationCenter: MockNotificationCenter!
 
@@ -580,7 +580,7 @@ extension TopSitesDataAdaptorTests {
     }
 
     func add(searchEngine: OpenSearchEngine) {
-        (searchEnginesManager as? SearchEnginesManager)?.defaultEngine = searchEngine
+        searchEnginesManager.defaultEngine = searchEngine
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -10,6 +10,7 @@ import XCTest
 
 class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     private var profile: MockProfile!
+    private var searchEnginesManager: SearchEnginesManager!
     private var contileProviderMock: ContileProviderMock!
     private var notificationCenter: MockNotificationCenter!
 
@@ -19,6 +20,12 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         notificationCenter = MockNotificationCenter()
         profile = MockProfile(databasePrefix: "FxHomeTopSitesManagerTests")
         profile.reopen()
+
+        searchEnginesManager = SearchEnginesManager(
+            prefs: profile.prefs,
+            files: profile.files,
+            engineProvider: MockSearchEngineProvider()
+        )
 
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 
@@ -574,7 +581,7 @@ extension TopSitesDataAdaptorTests {
     }
 
     func add(searchEngine: OpenSearchEngine) {
-        profile.searchEnginesManager.defaultEngine = searchEngine
+        searchEnginesManager.defaultEngine = searchEngine
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -573,6 +573,7 @@ extension TopSitesDataAdaptorTests {
                                                         contileProvider: contileProviderMock,
                                                         unifiedAdsProvider: contileProviderMock,
                                                         notificationCenter: notificationCenter,
+                                                        searchEnginesManager: searchEnginesManager,
                                                         dispatchGroup: dispatchGroup)
 
         trackForMemoryLeaks(subject, file: file, line: line)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -4,28 +4,26 @@
 
 @testable import Client
 
+import Common
 import Shared
 import Storage
 import XCTest
 
 class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     private var profile: MockProfile!
-    private var searchEnginesManager: SearchEnginesManager!
+    private var searchEnginesManager: SearchEnginesManagerProvider!
     private var contileProviderMock: ContileProviderMock!
     private var notificationCenter: MockNotificationCenter!
 
     override func setUp() {
         super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
 
         notificationCenter = MockNotificationCenter()
         profile = MockProfile(databasePrefix: "FxHomeTopSitesManagerTests")
         profile.reopen()
 
-        searchEnginesManager = SearchEnginesManager(
-            prefs: profile.prefs,
-            files: profile.files,
-            engineProvider: MockSearchEngineProvider()
-        )
+        searchEnginesManager = AppContainer.shared.resolve()
 
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 
@@ -33,13 +31,14 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     }
 
     override func tearDown() {
-        super.tearDown()
-
         notificationCenter = nil
         contileProviderMock = nil
+        searchEnginesManager = nil
         profile.prefs.clearAll()
         profile.shutdown()
         profile = nil
+
+        super.tearDown()
     }
 
     func testData_whenNotLoaded() {
@@ -581,7 +580,7 @@ extension TopSitesDataAdaptorTests {
     }
 
     func add(searchEngine: OpenSearchEngine) {
-        searchEnginesManager.defaultEngine = searchEngine
+        (searchEnginesManager as? SearchEnginesManager)?.defaultEngine = searchEngine
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -23,7 +23,11 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         profile = MockProfile(databasePrefix: "FxHomeTopSitesManagerTests")
         profile.reopen()
 
-        searchEnginesManager = AppContainer.shared.resolve()
+        searchEnginesManager = SearchEnginesManager(
+            prefs: profile.prefs,
+            files: profile.files,
+            engineProvider: MockSearchEngineProvider()
+        )
 
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesViewModelTests.swift
@@ -14,15 +14,18 @@ class TopSitesViewModelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+
         self.profile = MockProfile(databasePrefix: "FxHomeTopSitesViewModelTests")
 
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
     override func tearDown() {
-        super.tearDown()
         self.profile.shutdown()
         self.profile = nil
+        DependencyHelperMock().reset()
+        super.tearDown()
     }
 
     func testDeletionOfSingleSuggestedSite() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
@@ -9,6 +9,8 @@ import Foundation
 class MockSearchEnginesManager: SearchEnginesManagerProvider {
     private let searchEngines: [OpenSearchEngine]
 
+    weak var delegate: (any SearchEngineDelegate)?
+
     var defaultEngine: OpenSearchEngine? {
         return searchEngines.first
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
@@ -176,10 +176,6 @@ open class MockProfile: Client.Profile {
         return CertStore()
     }()
 
-    public lazy var searchEnginesManager: SearchEnginesManager = {
-        return SearchEnginesManager(prefs: self.prefs, files: self.files, engineProvider: MockSearchEngineProvider())
-    }()
-
     public lazy var prefs: Prefs = {
         return MockProfilePrefs()
     }()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
@@ -43,8 +43,7 @@ class TelemetryContextualIdentifierTests: XCTestCase {
     }
 
     func testTelemetryWrapper_setsContextId() {
-        let profile = MockProfile()
-        TelemetryWrapper.shared.setup(profile: profile)
+        TelemetryWrapper.shared.setup(profile: MockProfile())
         XCTAssertNotNil(TelemetryContextualIdentifier.contextId)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
@@ -10,6 +10,7 @@ import XCTest
 class TelemetryContextualIdentifierTests: XCTestCase {
     override func setUp() {
         super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
         clearTest()
     }
 
@@ -43,12 +44,7 @@ class TelemetryContextualIdentifierTests: XCTestCase {
 
     func testTelemetryWrapper_setsContextId() {
         let profile = MockProfile()
-        let searchEnginesManager = SearchEnginesManager(
-            prefs: profile.prefs,
-            files: profile.files,
-            engineProvider: MockSearchEngineProvider()
-        )
-        TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
+        TelemetryWrapper.shared.setup(profile: profile)
         XCTAssertNotNil(TelemetryContextualIdentifier.contextId)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
@@ -42,7 +42,13 @@ class TelemetryContextualIdentifierTests: XCTestCase {
     }
 
     func testTelemetryWrapper_setsContextId() {
-        TelemetryWrapper.shared.setup(profile: MockProfile())
+        let profile = MockProfile()
+        let searchEnginesManager = SearchEnginesManager(
+            prefs: profile.prefs,
+            files: profile.files,
+            engineProvider: MockSearchEngineProvider()
+        )
+        TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
         XCTAssertNotNil(TelemetryContextualIdentifier.contextId)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -334,7 +334,12 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_backgroundWallpaperMetric_defaultBackgroundIsNotSent() {
         let profile = MockProfile()
-        TelemetryWrapper.shared.setup(profile: profile)
+        let searchEnginesManager = SearchEnginesManager(
+            prefs: profile.prefs,
+            files: profile.files,
+            engineProvider: MockSearchEngineProvider()
+        )
+        TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 
         let defaultWallpaper = Wallpaper(id: "fxDefault",
@@ -355,8 +360,13 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_backgroundWallpaperMetric_themedWallpaperIsSent() {
         let profile = MockProfile()
+        let searchEnginesManager = SearchEnginesManager(
+            prefs: profile.prefs,
+            files: profile.files,
+            engineProvider: MockSearchEngineProvider()
+        )
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
-        TelemetryWrapper.shared.setup(profile: profile)
+        TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
 
         let themedWallpaper = Wallpaper(id: "amethyst",
                                         textColor: nil,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -24,7 +24,7 @@ class TelemetryWrapperTests: XCTestCase {
         Glean.shared.resetGlean(clearStores: true)
         Experiments.events.clearEvents()
 
-        profile = AppContainer.shared.resolve()
+        profile = MockProfile()
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -13,7 +13,6 @@ class TelemetryWrapperTests: XCTestCase {
     typealias ValueKey = TelemetryWrapper.EventValue
 
     var profile: Profile!
-    var searchEnginesManager: SearchEnginesManagerProvider!
 
     override func setUp() {
         super.setUp()
@@ -26,14 +25,12 @@ class TelemetryWrapperTests: XCTestCase {
         Experiments.events.clearEvents()
 
         profile = AppContainer.shared.resolve()
-        searchEnginesManager = AppContainer.shared.resolve()
     }
 
     override func tearDown() {
         Experiments.events.clearEvents()
         DependencyHelperMock().reset()
         profile = nil
-        searchEnginesManager = nil
         super.tearDown()
     }
 
@@ -342,7 +339,7 @@ class TelemetryWrapperTests: XCTestCase {
     // MARK: Wallpapers
 
     func test_backgroundWallpaperMetric_defaultBackgroundIsNotSent() {
-        TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
+        TelemetryWrapper.shared.setup(profile: profile)
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 
         let defaultWallpaper = Wallpaper(id: "fxDefault",
@@ -363,7 +360,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_backgroundWallpaperMetric_themedWallpaperIsSent() {
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
-        TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
+        TelemetryWrapper.shared.setup(profile: profile)
 
         let themedWallpaper = Wallpaper(id: "amethyst",
                                         textColor: nil,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -4,12 +4,16 @@
 
 @testable import Client
 
+import Common
 import Glean
 import XCTest
 
 class TelemetryWrapperTests: XCTestCase {
     typealias ExtraKey = TelemetryWrapper.EventExtraKey
     typealias ValueKey = TelemetryWrapper.EventValue
+
+    var profile: Profile!
+    var searchEnginesManager: SearchEnginesManagerProvider!
 
     override func setUp() {
         super.setUp()
@@ -20,11 +24,16 @@ class TelemetryWrapperTests: XCTestCase {
         Glean.shared.registerPings(GleanMetrics.Pings.shared)
         Glean.shared.resetGlean(clearStores: true)
         Experiments.events.clearEvents()
+
+        profile = AppContainer.shared.resolve()
+        searchEnginesManager = AppContainer.shared.resolve()
     }
 
     override func tearDown() {
         Experiments.events.clearEvents()
         DependencyHelperMock().reset()
+        profile = nil
+        searchEnginesManager = nil
         super.tearDown()
     }
 
@@ -333,12 +342,6 @@ class TelemetryWrapperTests: XCTestCase {
     // MARK: Wallpapers
 
     func test_backgroundWallpaperMetric_defaultBackgroundIsNotSent() {
-        let profile = MockProfile()
-        let searchEnginesManager = SearchEnginesManager(
-            prefs: profile.prefs,
-            files: profile.files,
-            engineProvider: MockSearchEngineProvider()
-        )
         TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 
@@ -359,12 +362,6 @@ class TelemetryWrapperTests: XCTestCase {
     }
 
     func test_backgroundWallpaperMetric_themedWallpaperIsSent() {
-        let profile = MockProfile()
-        let searchEnginesManager = SearchEnginesManager(
-            prefs: profile.prefs,
-            files: profile.files,
-            engineProvider: MockSearchEngineProvider()
-        )
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         TelemetryWrapper.shared.setup(profile: profile, searchEnginesManager: searchEnginesManager)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -16,13 +16,7 @@ class AddressToolbarContainerModelTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
 
         mockProfile = MockProfile()
-
-        // The MockProfile creates a SearchEnginesManager with a `MockSearchEngineProvider`
-        searchEnginesManager = SearchEnginesManager(
-            prefs: mockProfile.prefs,
-            files: mockProfile.files,
-            engineProvider: MockSearchEngineProvider()
-        )
+        searchEnginesManager = AppContainer.shared.resolve()
     }
 
     override func tearDown() {
@@ -82,7 +76,6 @@ class AddressToolbarContainerModelTests: XCTestCase {
     private func createSubject(withState state: ToolbarState) -> AddressToolbarContainerModel {
         return AddressToolbarContainerModel(state: state,
                                             profile: mockProfile,
-                                            searchEnginesManager: searchEnginesManager,
                                             windowUUID: windowUUID)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -18,7 +18,11 @@ class AddressToolbarContainerModelTests: XCTestCase {
         mockProfile = MockProfile()
 
         // The MockProfile creates a SearchEnginesManager with a `MockSearchEngineProvider`
-        searchEnginesManager = mockProfile.searchEnginesManager
+        searchEnginesManager = SearchEnginesManager(
+            prefs: mockProfile.prefs,
+            files: mockProfile.files,
+            engineProvider: MockSearchEngineProvider()
+        )
     }
 
     override func tearDown() {
@@ -78,6 +82,7 @@ class AddressToolbarContainerModelTests: XCTestCase {
     private func createSubject(withState state: ToolbarState) -> AddressToolbarContainerModel {
         return AddressToolbarContainerModel(state: state,
                                             profile: mockProfile,
+                                            searchEnginesManager: searchEnginesManager,
                                             windowUUID: windowUUID)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -26,6 +26,7 @@ class AddressToolbarContainerModelTests: XCTestCase {
     override func tearDown() {
         mockProfile = nil
         searchEnginesManager = nil
+        DependencyHelperMock().reset()
         super.tearDown()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -27,14 +27,14 @@ class AddressToolbarContainerModelTests: XCTestCase {
 
     func testSearchWordFromURLWhenUrlIsNilThenSearchWordIsNil() {
         let viewModel = createSubject(withState: createBasicToolbarState())
-        XCTAssertNil(viewModel.searchTermFromURL(nil, searchEnginesManager: searchEnginesManager))
+        XCTAssertNil(viewModel.searchTermFromURL(nil))
     }
 
     func testSearchWordFromURLWhenUsingGoogleSearchThenSearchWordIsCorrect() {
         let viewModel = createSubject(withState: createBasicToolbarState())
         let searchTerm = "test"
         let url = URL(string: "http://firefox.com/find?q=\(searchTerm)")
-        let result = viewModel.searchTermFromURL(url, searchEnginesManager: searchEnginesManager)
+        let result = viewModel.searchTermFromURL(url)
         XCTAssertEqual(searchTerm, result)
     }
 
@@ -42,7 +42,7 @@ class AddressToolbarContainerModelTests: XCTestCase {
         let viewModel = createSubject(withState: createBasicToolbarState())
         let searchTerm = "test"
         let url = URL(string: "internal://local?q=\(searchTerm)")
-        XCTAssertNil(viewModel.searchTermFromURL(url, searchEnginesManager: searchEnginesManager))
+        XCTAssertNil(viewModel.searchTermFromURL(url))
     }
 
     func testUsesDefaultSearchEngine_WhenNoSearchEngineSelected() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 class AddressToolbarContainerModelTests: XCTestCase {
     private var mockProfile: MockProfile!
-    private var searchEnginesManager: SearchEnginesManager!
+    private var searchEnginesManager: SearchEnginesManagerProvider!
     private let windowUUID: WindowUUID = .XCTestDefaultUUID
 
     override func setUp() {
@@ -16,7 +16,11 @@ class AddressToolbarContainerModelTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
 
         mockProfile = MockProfile()
-        searchEnginesManager = AppContainer.shared.resolve()
+        searchEnginesManager = SearchEnginesManager(
+            prefs: mockProfile.prefs,
+            files: mockProfile.files,
+            engineProvider: MockSearchEngineProvider()
+        )
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -26,9 +26,9 @@ class AddressToolbarContainerModelTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
         mockProfile = nil
         searchEnginesManager = nil
+        super.tearDown()
     }
 
     func testSearchWordFromURLWhenUrlIsNilThenSearchWordIsNil() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11799)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25731)

## :bulb: Description
Decoupled `SearchEnginesManager` from Profile

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

