### PR TITLE
Bugfix FXIOS-XXXX - [A11y] - VoiceOver reading Homepage elements in search suggestions

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1724,6 +1724,12 @@ class BrowserViewController: UIViewController,
         ])
 
         searchController.didMove(toParent: self)
+
+        // We need to hide the Homepage content
+        // from accessibility, otherwise it will
+        // be read by VoiceOver when reading in the
+        // Search Controller
+        contentContainer.accessibilityElementsHidden = true
     }
 
     func hideSearchController() {
@@ -1735,6 +1741,8 @@ class BrowserViewController: UIViewController,
 
         keyboardBackdrop?.removeFromSuperview()
         keyboardBackdrop = nil
+
+        contentContainer.accessibilityElementsHidden = false
     }
 
     func destroySearchController() {
@@ -1743,6 +1751,8 @@ class BrowserViewController: UIViewController,
         searchController = nil
         searchSessionState = nil
         searchLoader = nil
+
+        contentContainer.accessibilityElementsHidden = false
     }
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25783)

## :bulb: Description

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/13af3d81-5cec-40ad-93b0-548a623353cf) | ![after](https://github.com/user-attachments/assets/04010969-aa05-4f21-b53c-e1d6d63a9f19) |

VoiceOver was reading the contents from the Homepage after finishing reading the suggestion list. This happens on iPads and iPhones.

Due to how the search controller is presented, the contents from the homepage are still in the accessibility tree. I added the method to hide them when the search is being presented, and once it ends, unhide the elements.


PS: Looks like some tests are failing for the homepage. I ran the tests before and after the changes, and it is the same tests are failing. I ran `A11ySearchTest` and other tests, but maybe I'm missing something.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

