### PR TITLE
Bugfix FXIOS-12036 [Homepage] scroll to top on opening a new homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -295,10 +295,11 @@ final class HomepageViewController: UIViewController,
             state: state,
             jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
         )
-        // FXIOS-11523 - Trigger impression when user opens homepage view new tab
+        // FXIOS-11523 - Trigger impression when user opens homepage view new tab + scroll to top
         if homepageState.shouldTriggerImpression {
             alreadyTrackedItems.removeAll()
             trackVisibleItemImpressions()
+            scrollToTop()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -277,6 +277,29 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
     }
 
+    func test_newState_didSelectedTabChangeToHomepageAction_forScrollToTop_setsCollectionViewOffsetToZero() {
+        let mockStatusBarScrollDelegate = MockStatusBarScrollDelegate()
+        let subject = createSubject(statusBarScrollDelegate: mockStatusBarScrollDelegate)
+        let newState = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            GeneralBrowserAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: GeneralBrowserActionType.didSelectedTabChangeToHomepage
+            )
+        )
+
+        guard let collectionView = subject.view.subviews.first(where: {
+            $0 is UICollectionView
+        }) as? UICollectionView else {
+            XCTFail()
+            return
+        }
+
+        subject.newState(state: newState)
+
+        XCTAssertEqual(collectionView.contentOffset, .zero)
+    }
+
     private func createSubject(statusBarScrollDelegate: StatusBarScrollDelegate? = nil) -> HomepageViewController {
         let notificationCenter = MockNotificationCenter()
         let themeManager = MockThemeManager()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12036)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26209)

## :bulb: Description
Fix bug where homepage was not scrolling to top when opening a new homepage

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots

https://github.com/user-attachments/assets/ccd8c2eb-4119-49a1-921d-b4ac2a67f9d8