### PR TITLE
Refactor FXIOS-11838 [Unit Tests] flaky test testMetadataTracker_whenInitializedFirstTime_fetchesFreshData

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperMetadataUtility.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperMetadataUtility.swift
@@ -26,16 +26,19 @@ class WallpaperMetadataUtility {
 
     private let userDefaults: UserDefaultsInterface
     private let networkingModule: WallpaperNetworking
+    private let storageUtility: WallpaperStorageProtocol
     private var logger: Logger
 
     // MARK: - Initializers
     init(
         with networkingModule: WallpaperNetworking,
         and userDefaults: UserDefaultsInterface = UserDefaults.standard,
+        storageUtility: WallpaperStorageProtocol = WallpaperStorageUtility(),
         logger: Logger = DefaultLogger.shared
     ) {
         self.networkingModule = networkingModule
         self.userDefaults = userDefaults
+        self.storageUtility = storageUtility
         self.logger = logger
     }
 
@@ -89,7 +92,6 @@ class WallpaperMetadataUtility {
 
     private func oldMetadataIsDifferentThanNew(_ metadata: WallpaperMetadata) -> Bool {
         do {
-            let storageUtility = WallpaperStorageUtility()
             guard let oldMetadata = try storageUtility.fetchMetadata() else { return true }
 
             if oldMetadata.collections == metadata.collections { return false }

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperStorageUtility.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperStorageUtility.swift
@@ -14,9 +14,11 @@ enum WallpaperStorageError: Error {
     case cannotFindWallpaperDirectory
     case cannotFindThumbnailDirectory
 }
-
+protocol WallpaperStorageProtocol {
+    func fetchMetadata() throws -> WallpaperMetadata?
+}
 /// Responsible for writing or deleting wallpaper data to/from memory.
-struct WallpaperStorageUtility: WallpaperMetadataCodableProtocol {
+struct WallpaperStorageUtility: WallpaperMetadataCodableProtocol, WallpaperStorageProtocol {
     private var userDefaults: UserDefaultsInterface
     private var fileManager: FileManagerInterface
     private var logger: Logger

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/TestDataAndTestDataProviders/Protocols/WallpaperMetadataTestProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/TestDataAndTestDataProviders/Protocols/WallpaperMetadataTestProvider.swift
@@ -26,6 +26,7 @@ extension WallpaperMetadataTestProvider {
         case .noLocales: return getNoLocalesMetadata()
         case .availabilityStart: return getAvailabilityStartMetadata()
         case .availabilityEnd: return getAvailabilityEndMetadata()
+        case .newUpdates: return getNewUpdatesMetadata()
         default:
             fatalError("No such expected data exists")
         }
@@ -173,6 +174,28 @@ extension WallpaperMetadataTestProvider {
                         end: endDate),
                     wallpapers: [
                         Wallpaper(id: "beachVibes",
+                                  textColor: textColor,
+                                  cardColor: textColor,
+                                  logoTextColor: textColor)
+                    ],
+                description: nil,
+                heading: nil)
+            ])
+    }
+
+    private func getNewUpdatesMetadata() -> WallpaperMetadata {
+        return WallpaperMetadata(
+            lastUpdated: lastUpdatedDate,
+            collections: [
+                WallpaperCollection(
+                    id: "firefox",
+                    learnMoreURL: learnMoreURL,
+                    availableLocales: ["en-US", "es-US", "en-CA", "fr-CA"],
+                    availability: WallpaperCollectionAvailability(
+                        start: startDate,
+                        end: endDate),
+                    wallpapers: [
+                        Wallpaper(id: "northenLightsUpdates",
                                   textColor: textColor,
                                   cardColor: textColor,
                                   logoTextColor: textColor)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11838)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25801)

## :bulb: Description
- Fix `testMetadataTracker_whenInitializedFirstTime_fetchesFreshData` failing after running 2nd + more times. 
- This is because we were relying on the `WallpaperStorageUtility` directly instead of mocking it and it was returning the same metadata instead of a new one. So added `newUpdates` metadata to be distinct from `goodData`
- Running repeatedly seems to fix the issue; will monitor in future workflows

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

