### PR TITLE
Add FXIOS-11897 [Webview telemetry] Add telemetry event for webview process terminated

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1369,6 +1369,11 @@ extension TabManagerImplementation: WKNavigationDelegate {
             // Only automatically attempt to reload the crashed
             // tab three times before giving up.
             if tab.consecutiveCrashes < 3 {
+                logger.log("The webview has crashed, trying to reload. Attempt number \(tab.consecutiveCrashes)",
+                           level: .warning,
+                           category: .webview)
+                tabsTelemetry.trackConsecutiveCrashTelemetry(attemptNumber: tab.consecutiveCrashes)
+
                 webView.reload()
             } else {
                 tab.consecutiveCrashes = 0

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1369,9 +1369,10 @@ extension TabManagerImplementation: WKNavigationDelegate {
             // Only automatically attempt to reload the crashed
             // tab three times before giving up.
             if tab.consecutiveCrashes < 3 {
-                logger.log("The webview has crashed, trying to reload. Attempt number \(tab.consecutiveCrashes)",
+                logger.log("The webview has crashed, trying to reload.",
                            level: .warning,
-                           category: .webview)
+                           category: .webview,
+                           extra: ["Attempt number": "\(tab.consecutiveCrashes)"])
                 tabsTelemetry.trackConsecutiveCrashTelemetry(attemptNumber: tab.consecutiveCrashes)
 
                 webView.reload()

--- a/firefox-ios/Client/Telemetry/TabsTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabsTelemetry.swift
@@ -10,6 +10,12 @@ final class TabsTelemetry {
     /// how long it takes to switch to a new tab
     private var tabSwitchTimerId: GleanTimerId?
 
+    private let gleanWrapper: GleanWrapper
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
     func startTabSwitchMeasurement() {
         tabSwitchTimerId = GleanMetrics.Tabs.tabSwitch.start()
     }
@@ -44,5 +50,11 @@ final class TabsTelemetry {
                                      method: .background,
                                      object: .tabInactiveQuantity,
                                      extras: inactiveExtra)
+    }
+
+    func trackConsecutiveCrashTelemetry(attemptNumber: UInt) {
+        let extras = GleanMetrics.Webview.ProcessDidTerminateExtra(consecutiveCrash: Int32(attemptNumber))
+        gleanWrapper.recordEvent(for: GleanMetrics.Webview.processDidTerminate,
+                                 extras: extras)
     }
 }

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -6099,6 +6099,22 @@ webview:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
+  process_did_terminate:
+    type: event
+    extra_keys:
+      consecutive_crash:
+        type: quantity
+        description: |
+          The number of consecutive times the webview has crashed.
+    description: |
+      Recorded when a webview process terminates and we attempt a reload of that webview.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/25951
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-10-01"
 
 fx_suggest:
   ping_type:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11897)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25951)

## :bulb: Description
Adding some new telemetry so we can determine if `consecutiveCrash` is needed and is used in production.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

