### PR TITLE
Add FXIOS-9666 [Accessibility] Add headings to homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
@@ -45,6 +45,7 @@ class LegacyLabelButtonHeaderView: UICollectionReusableView, ReusableCell {
         label.font = FXFontStyles.Bold.title3.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
+        label.accessibilityTraits.insert(.header)
     }
 
     private lazy var moreButton: ActionButton = .build { button in

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/HomepageMessageCardCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/HomepageMessageCardCell.swift
@@ -48,6 +48,7 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
         label.font = FXFontStyles.Regular.headline.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.titleLabel
+        label.accessibilityTraits.insert(.header)
     }
 
     private lazy var descriptionText: UILabel = .build { label in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9666)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21271)

## :bulb: Description
- Add the `header` accessibility trait to legacy homepage section titles (Bookmarks, jump back in, pocket stories) and homepage message card titles

### 📝 Notes:
- Header trait was added to microsurvey prompt title's in #21272 
- Header trait was added to homepage rebuild section titles in  #25631

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

