### PR TITLE
Bugfix FXIOS-12033 [SEC] Fix check for `{searchTerms}` in base URL

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineUtilities.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineUtilities.swift
@@ -50,7 +50,9 @@ struct ASSearchEngineUtilities {
         if let searchArg = searchURL.searchTermParamName, !searchURL.base.contains("{searchTerms}") {
             queryItems.append(URLQueryItem(name: searchArg, value: "{searchTerms}"))
         }
-        components.queryItems = queryItems
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
 
         return components.url?.absoluteString.removingPercentEncoding
     }

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineUtilities.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineUtilities.swift
@@ -46,8 +46,8 @@ struct ASSearchEngineUtilities {
             return URLQueryItem(name: $0.name, value: value)
         }
         // From API docs: "This may be skipped if `{searchTerm}` is included in the base."
-        if let searchArg = searchURL.searchTermParamName, !searchURL.base.contains("{searchTerm}") {
-            // Note: term vs terms is not a typo.
+        // Note: there is a typo in the docs, the value is searchTerms (plural).
+        if let searchArg = searchURL.searchTermParamName, !searchURL.base.contains("{searchTerms}") {
             queryItems.append(URLQueryItem(name: searchArg, value: "{searchTerms}"))
         }
         components.queryItems = queryItems

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/ASSearchEngineUtilitiesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/ASSearchEngineUtilitiesTests.swift
@@ -10,7 +10,7 @@ import WebKit
 import MozillaAppServices
 
 class ASSearchEngineUtilitiesTests: XCTestCase {
-    private let leo_eng_deu_engine =
+    private let leo_eng_deu_engine_no_search_params =
     SearchEngineDefinition(
         aliases: [],
         charset: "UTF-8",
@@ -25,6 +25,35 @@ class ASSearchEngineUtilitiesTests: XCTestCase {
                 base: "https://dict.leo.org/englisch-deutsch/{searchTerms}",
                 method: "GET",
                 params: [],
+                searchTermParamName: nil
+            ),
+            suggestions: nil,
+            trending: nil,
+            searchForm: nil
+        ),
+        orderHint: nil,
+        clickUrl: nil
+    )
+    private let leo_eng_deu_engine =
+    SearchEngineDefinition(
+        aliases: [],
+        charset: "UTF-8",
+        classification: .unknown,
+        identifier: "leo_ende_de",
+        name: "LEO Eng-Deu",
+        optional: false,
+        partnerCode: "",
+        telemetrySuffix: "",
+        urls: SearchEngineUrls(
+            search: SearchEngineUrl(
+                base: "https://dict.leo.org/englisch-deutsch/{searchTerms}",
+                method: "GET",
+                params: [SearchUrlParam(
+                    name: "foo",
+                    value: "bar",
+                    enterpriseValue: nil,
+                    experimentConfig: nil
+                )],
                 searchTermParamName: nil
             ),
             suggestions: nil,
@@ -127,11 +156,20 @@ class ASSearchEngineUtilitiesTests: XCTestCase {
     }
 
     func testSearchTermIncludedInBaseURL() {
-        let engine = leo_eng_deu_engine
+        let engine = leo_eng_deu_engine_no_search_params
 
         let result = ASSearchEngineUtilities.convertASSearchURLToOpenSearchURL(engine.urls.search,
                                                                                for: engine)
         let expected = "https://dict.leo.org/englisch-deutsch/{searchTerms}"
+        XCTAssertEqual(result, expected)
+    }
+
+    func testSearchTermIncludedInBaseURLAndParams() {
+        let engine = leo_eng_deu_engine
+
+        let result = ASSearchEngineUtilities.convertASSearchURLToOpenSearchURL(engine.urls.search,
+                                                                               for: engine)
+        let expected = "https://dict.leo.org/englisch-deutsch/{searchTerms}?foo=bar"
         XCTAssertEqual(result, expected)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/ASSearchEngineUtilitiesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/ASSearchEngineUtilitiesTests.swift
@@ -10,6 +10,30 @@ import WebKit
 import MozillaAppServices
 
 class ASSearchEngineUtilitiesTests: XCTestCase {
+    private let leo_eng_deu_engine =
+    SearchEngineDefinition(
+        aliases: [],
+        charset: "UTF-8",
+        classification: .unknown,
+        identifier: "leo_ende_de",
+        name: "LEO Eng-Deu",
+        optional: false,
+        partnerCode: "",
+        telemetrySuffix: "",
+        urls: SearchEngineUrls(
+            search: SearchEngineUrl(
+                base: "https://dict.leo.org/englisch-deutsch/{searchTerms}",
+                method: "GET",
+                params: [],
+                searchTermParamName: nil
+            ),
+            suggestions: nil,
+            trending: nil,
+            searchForm: nil
+        ),
+        orderHint: nil,
+        clickUrl: nil
+    )
     private let google_US_testEngine =
     SearchEngineDefinition(
         aliases: ["google"],
@@ -87,6 +111,27 @@ class ASSearchEngineUtilitiesTests: XCTestCase {
         let result = ASSearchEngineUtilities.convertASSearchURLToOpenSearchURL(engine.urls.suggestions,
                                                                                for: engine)
         let expected = "https://www.google.com/complete/search?client=firefox&q={searchTerms}"
+        XCTAssertEqual(result, expected)
+    }
+
+    func testEmptyPartnerCodeSearchURL() {
+        var engine = google_US_testEngine
+
+        // Force an empty partnerCode string:
+        engine.partnerCode = ""
+
+        let result = ASSearchEngineUtilities.convertASSearchURLToOpenSearchURL(engine.urls.search,
+                                                                               for: engine)
+        let expected = "https://www.google.com/search?client=&q={searchTerms}"
+        XCTAssertEqual(result, expected)
+    }
+
+    func testSearchTermIncludedInBaseURL() {
+        let engine = leo_eng_deu_engine
+
+        let result = ASSearchEngineUtilities.convertASSearchURLToOpenSearchURL(engine.urls.search,
+                                                                               for: engine)
+        let expected = "https://dict.leo.org/englisch-deutsch/{searchTerms}"
         XCTAssertEqual(result, expected)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12033)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26199)

## :bulb: Description

Fixes an issue with checks for `{searchTerm}` in the base URL of our AS-based search engines. It turns out the API headers did, in fact, contain a typo.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

