### PR TITLE
Move Screenshot taking to app forground

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -561,9 +561,7 @@ class BrowserViewController: UIViewController,
         if self.presentedViewController as? PhotonActionSheet != nil {
             self.presentedViewController?.dismiss(animated: true, completion: nil)
         }
-        if let tab = tabManager.selectedTab, let screenshotHelper {
-            screenshotHelper.takeScreenshot(tab, windowUUID: windowUUID)
-        }
+
         // Formerly these calls were run during AppDelegate.didEnterBackground(), but we have
         // individual TabManager instances for each BVC, so we perform these here instead.
         tabManager.preserveTabs()
@@ -640,6 +638,9 @@ class BrowserViewController: UIViewController,
         }
 
         dismissModalsIfStartAtHome()
+        if let tab = tabManager.selectedTab, let screenshotHelper {
+            screenshotHelper.takeScreenshot(tab, windowUUID: windowUUID)
+        }
     }
 
     private func dismissModalsIfStartAtHome() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -639,7 +639,7 @@ class BrowserViewController: UIViewController,
 
         dismissModalsIfStartAtHome()
         if let tab = tabManager.selectedTab, let screenshotHelper {
-            screenshotHelper.takeScreenshot(tab, windowUUID: windowUUID)
+            screenshotHelper.takeScreenshot(tab)
         }
     }
 
@@ -1109,7 +1109,7 @@ class BrowserViewController: UIViewController,
 
     func willNavigateAway(from tab: Tab?) {
         if let tab {
-            screenshotHelper?.takeScreenshot(tab, windowUUID: windowUUID)
+            screenshotHelper?.takeScreenshot(tab)
         }
     }
 
@@ -2960,7 +2960,7 @@ class BrowserViewController: UIViewController,
                 // Issue created: https://github.com/mozilla-mobile/firefox-ios/issues/7003
                 let delayedTimeInterval = DispatchTimeInterval.milliseconds(500)
                 DispatchQueue.main.asyncAfter(deadline: .now() + delayedTimeInterval) {
-                    self.screenshotHelper?.takeScreenshot(tab, windowUUID: self.windowUUID)
+                    self.screenshotHelper?.takeScreenshot(tab)
                     if webView.superview == self.view {
                         webView.removeFromSuperview()
                     }

--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -22,7 +22,7 @@ class ScreenshotHelper {
     /// Takes a screenshot of the WebView to be displayed on the tab view page
     /// If taking a screenshot of the home page, uses our custom screenshot `UIView` extension function
     /// If taking a screenshot of a website, uses apple's `takeSnapshot` function
-    func takeScreenshot(_ tab: Tab, windowUUID: WindowUUID) {
+    func takeScreenshot(_ tab: Tab) {
         guard let webView = tab.webView else {
             logger.log("Tab Snapshot Error",
                        level: .debug,
@@ -47,7 +47,7 @@ class ScreenshotHelper {
                 tab.setScreenshot(screenshot)
                 store.dispatch(
                     ScreenshotAction(
-                        windowUUID: windowUUID,
+                        windowUUID: tab.windowUUID,
                         tab: tab,
                         actionType:
                             ScreenshotActionType.screenshotTaken
@@ -62,7 +62,7 @@ class ScreenshotHelper {
                 tab.setScreenshot(screenshot)
                 store.dispatch(
                     ScreenshotAction(
-                        windowUUID: windowUUID,
+                        windowUUID: tab.windowUUID,
                         tab: tab,
                         actionType:
                             ScreenshotActionType.screenshotTaken
@@ -81,7 +81,7 @@ class ScreenshotHelper {
                     tab.setScreenshot(image)
                     store.dispatch(
                         ScreenshotAction(
-                            windowUUID: windowUUID,
+                            windowUUID: tab.windowUUID,
                             tab: tab,
                             actionType:
                                 ScreenshotActionType.screenshotTaken

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -108,7 +108,7 @@ final class AddressBarPanGestureHandler: NSObject {
 
         // Check if the new tab index is within bounds.
         if newTabIndex >= 0 && newTabIndex < tabs.count {
-            screenshotHelper?.takeScreenshot(tabs[index], windowUUID: windowUUID)
+            screenshotHelper?.takeScreenshot(tabs[index])
             webPagePreview.setScreenshot(tabs[safe: newTabIndex]?.screenshot)
         } else {
             webPagePreview.isHidden = true


### PR DESCRIPTION

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
There is [a crash ](https://mozilla.sentry.io/issues/6546377026/?referrer=slack) in 137.2 around screenshots. This crash is confusing because it seems like sometimes when the app is moved in to the background there is a crash when we try to save the screenshot. This is due to an assertion failure on line 132 of the `WindowManagerImplementation` 
```
guard let tabManager = window(for: windowUUID)?.tabManager else {
            assertionFailure("Tab Manager unavailable for requested UUID: \(windowUUID). This is a client error.")
            logger.log("No tab manager for window UUID.", level: .fatal, category: .window)
            return windows.first!.value.tabManager!
        }
```
This is a half heart-ed effort to fix this issue by just moving the code that snaps the screenshot to the foreground. It seems to do handle the same edge cases for taking screenshots. 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

