### PR TITLE
Bugfix FXIOS-11984 ⁃ Jump back in section is visible on private homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -360,13 +360,15 @@ class LegacyHomepageViewController:
 
     // MARK: - Helpers
 
-    /// Configure isZeroSearch
+    /// Configure isZeroSearch & isPrivate
     /// - Parameter isZeroSearch: IsZeroSearch is true when the homepage is created from the tab tray, a long press
     /// on the tab bar to open a new tab or by pressing the home page button on the tab bar. Inline is false when
     /// it's the zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
     /// This needs to be set properly for telemetry and the contextual pop overs that appears on homepage
+    /// We need also to set isPrivate value when this configure method is being called
     func configure(isZeroSearch: Bool) {
         viewModel.isZeroSearch = isZeroSearch
+        viewModel.isPrivate = currentTab?.isPrivate ?? false
     }
 
     /// On iPhone, we call reloadOnRotation when the trait collection has changed, to ensure calculation is


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11984)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26076)

## :bulb: Description
Don't display JumpBackIn section for private mode

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

