### PR TITLE
Bugfix FXIOS-11784 Fixed Pass book rendering hang

### DIFF
--- a/firefox-ios/Client/Protocols/Presenter.swift
+++ b/firefox-ios/Client/Protocols/Presenter.swift
@@ -6,12 +6,14 @@ import Foundation
 
 /// Protocol to present a view controller
 protocol Presenter {
+    @MainActor
     func present(_ viewControllerToPresent: UIViewController,
                  animated flag: Bool,
                  completion: (() -> Void)?)
 }
 
-extension Presenter {
+ extension Presenter {
+    @MainActor
     func present(_ viewControllerToPresent: UIViewController,
                  animated flag: Bool,
                  completion: (() -> Void)? = nil) {

--- a/firefox-ios/Client/Protocols/Presenter.swift
+++ b/firefox-ios/Client/Protocols/Presenter.swift
@@ -12,7 +12,7 @@ protocol Presenter {
                  completion: (() -> Void)?)
 }
 
- extension Presenter {
+extension Presenter {
     @MainActor
     func present(_ viewControllerToPresent: UIViewController,
                  animated flag: Bool,


### PR DESCRIPTION
Updated Open pass method logic with async/await to prevent hang and moved presenter logic to main actor.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11784)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25697)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

