### PR TITLE
Refactor FXIOS-11017 [Feature flag] Turn on clean up history if needed in release

### DIFF
--- a/firefox-ios/nimbus-features/cleanupHistoryReenabled.yaml
+++ b/firefox-ios/nimbus-features/cleanupHistoryReenabled.yaml
@@ -8,7 +8,7 @@ features:
         description: >
           When true the cleanupHistoryIfNeeded will be run
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11017)

## :bulb: Description
Turn on in v139, experiment to turn it on will go on in v137-v138. Keeping the flag for now just in case, will delete in a couple of releases.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

