### PR TITLE
Refactor FXIOS-12045 Temporarily disable `testOpenTabsInSearchSuggestions()`

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -289,6 +289,7 @@ class SearchTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306989
     // Smoketest
+    // [FXIOS-12045] Currently failing on multiple PRs; needs investigation.
     /*
     func testOpenTabsInSearchSuggestions() throws {
         if #unavailable(iOS 16) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -289,6 +289,7 @@ class SearchTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306989
     // Smoketest
+    /*
     func testOpenTabsInSearchSuggestions() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Test fails intermittently for iOS 15")
@@ -307,6 +308,7 @@ class SearchTests: BaseTestCase {
         waitForTabsButton()
         validateSearchSuggestionText(typeText: "localhost")
     }
+     */
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306886
     // SmokeTest


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12045)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26237)

## :bulb: Description

Disable failing UI test.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

