### PR TITLE
Refactor FXIOS-7301 - Remove 2 closure_body_length violations from MainMenuMiddleware.swift (Firefox) and InternalTelemetrySettingsView.swift (Focus)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,8 +103,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 43
-  error: 43
+  warning: 42
+  error: 42
 
 file_header:
   required_string: |

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -170,61 +170,6 @@ final class MainMenuMiddleware {
         }
     }
 
-    private func handleMainMenuDetailsActionType(action: MainMenuAction, isHomepage: Bool) -> Bool {
-        guard let mainMenuDetailsActionType = action.actionType as? MainMenuDetailsActionType else {
-            return false
-        }
-
-        switch mainMenuDetailsActionType {
-        case .tapZoom:
-            telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
-            return true
-
-        case .tapReportBrokenSite:
-            telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
-            return true
-
-        case .tapAddToBookmarks:
-            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
-            return true
-
-        case .tapEditBookmark:
-            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
-            return true
-
-        case .tapAddToShortcuts:
-            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
-            return true
-
-        case .tapRemoveFromShortcuts:
-            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
-            return true
-
-        case .tapAddToReadingList:
-            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
-            return true
-
-        case .tapRemoveFromReadingList:
-            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
-            return true
-
-        case .tapToggleNightMode:
-            handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
-            return true
-
-        case .tapBackToMainMenu:
-            handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
-            return true
-
-        case .tapDismissView:
-            telemetry.closeButtonTapped(isHomepage: isHomepage)
-            return true
-
-        @unknown default:
-            return false
-        }
-    }
-
     private func handleTapNavigateToDestinationAction(action: MainMenuAction, isHomepage: Bool) {
         guard let destination = action.navigationDestination?.destination else { return }
         handleTelemetryFor(for: destination,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -59,11 +59,7 @@ final class MainMenuMiddleware {
                                           mainMenuActionType: actionType,
                                           isHomepage: isHomepage)
         }
-
-        if let actionType = action.actionType as? GeneralBrowserActionType {
-            self.handleGeneralBrowserActionType(action: action, generalBrowserActionType: actionType)
-        }
-
+        if self.handleGeneralBrowserActionType(action: action) { return }
         if self.handleMainMenuDetailsActionType(action: action, isHomepage: isHomepage) { return }
     }
 
@@ -97,13 +93,18 @@ final class MainMenuMiddleware {
         }
     }
 
-    private func handleGeneralBrowserActionType(action: MainMenuAction, generalBrowserActionType: GeneralBrowserActionType) {
+    private func handleGeneralBrowserActionType(action: MainMenuAction) -> Bool {
+        guard let generalBrowserActionType = action.actionType as? GeneralBrowserActionType else {
+            return false
+        }
+
         switch generalBrowserActionType {
         case .showReaderMode:
             handleShowReaderModeAction(action: action)
+            return true
 
         default:
-            break
+            return false
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -116,45 +116,6 @@ final class MainMenuMiddleware {
         }
     }
 
-    private func handleMainMenuAction(action: MainMenuAction, isHomepage: Bool) -> Bool {
-        guard let mainMenuActionType = action.actionType as? MainMenuActionType else {
-            return false
-        }
-
-        switch mainMenuActionType {
-        case .tapNavigateToDestination:
-            handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
-            return true
-
-        case .tapShowDetailsView:
-            handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
-            return true
-
-        case .tapToggleUserAgent:
-            handleTapToggleUserAgentAction(action: action, isHomepage: isHomepage)
-            return true
-
-        case .tapCloseMenu:
-            telemetry.closeButtonTapped(isHomepage: isHomepage)
-            return true
-
-        case .didInstantiateView:
-            handleDidInstantiateViewAction(action: action)
-            return true
-
-        case .viewDidLoad:
-            handleViewDidLoadAction(action: action)
-            return true
-
-        case .menuDismissed:
-            telemetry.menuDismissed(isHomepage: isHomepage)
-            return true
-
-        default:
-            return false
-        }
-    }
-
     private func handleTapNavigateToDestinationAction(action: MainMenuAction, isHomepage: Bool) {
         guard let destination = action.navigationDestination?.destination else { return }
         handleTelemetryFor(for: destination,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -59,7 +59,11 @@ final class MainMenuMiddleware {
                                           mainMenuActionType: actionType,
                                           isHomepage: isHomepage)
         }
-        if self.handleGeneralBrowserActionType(action: action) { return }
+
+        if let actionType = action.actionType as? GeneralBrowserActionType {
+            self.handleGeneralBrowserActionType(action: action, generalBrowserActionType: actionType)
+        }
+
         if self.handleMainMenuDetailsActionType(action: action, isHomepage: isHomepage) { return }
     }
 
@@ -93,18 +97,13 @@ final class MainMenuMiddleware {
         }
     }
 
-    private func handleGeneralBrowserActionType(action: MainMenuAction) -> Bool {
-        guard let generalBrowserActionType = action.actionType as? GeneralBrowserActionType else {
-            return false
-        }
-
+    private func handleGeneralBrowserActionType(action: MainMenuAction, generalBrowserActionType: GeneralBrowserActionType) {
         switch generalBrowserActionType {
         case .showReaderMode:
             handleShowReaderModeAction(action: action)
-            return true
 
         default:
-            return false
+            break
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -60,61 +60,61 @@ final class MainMenuMiddleware {
     private func handleMainMenuActions(action: MainMenuAction, isHomepage: Bool) {
         switch action.actionType {
         case MainMenuActionType.tapNavigateToDestination:
-            self.handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
+            handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
 
         case MainMenuActionType.tapShowDetailsView:
-            self.handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
+            handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
 
         case MainMenuActionType.tapToggleUserAgent:
-            self.handleTapToggleUserAgentAction(action: action, isHomepage: isHomepage)
+            handleTapToggleUserAgentAction(action: action, isHomepage: isHomepage)
 
         case MainMenuActionType.tapCloseMenu:
-            self.telemetry.closeButtonTapped(isHomepage: isHomepage)
+            telemetry.closeButtonTapped(isHomepage: isHomepage)
 
         case GeneralBrowserActionType.showReaderMode:
-            self.handleShowReaderModeAction(action: action)
+            handleShowReaderModeAction(action: action)
 
         case MainMenuActionType.didInstantiateView:
-            self.handleDidInstantiateViewAction(action: action)
+            handleDidInstantiateViewAction(action: action)
 
         case MainMenuActionType.viewDidLoad:
-            self.handleViewDidLoadAction(action: action)
+            handleViewDidLoadAction(action: action)
 
         case MainMenuActionType.menuDismissed:
-            self.telemetry.menuDismissed(isHomepage: isHomepage)
+            telemetry.menuDismissed(isHomepage: isHomepage)
 
         case MainMenuDetailsActionType.tapZoom:
-            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
+            telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
 
         case MainMenuDetailsActionType.tapReportBrokenSite:
-            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
+            telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
 
         case MainMenuDetailsActionType.tapAddToBookmarks:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
 
         case MainMenuDetailsActionType.tapEditBookmark:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
 
         case MainMenuDetailsActionType.tapAddToShortcuts:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
 
         case MainMenuDetailsActionType.tapRemoveFromShortcuts:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
 
         case MainMenuDetailsActionType.tapAddToReadingList:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
 
         case MainMenuDetailsActionType.tapRemoveFromReadingList:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
 
         case MainMenuDetailsActionType.tapToggleNightMode:
-            self.handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
+            handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
 
         case MainMenuDetailsActionType.tapBackToMainMenu:
-            self.handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
+            handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
 
         case MainMenuDetailsActionType.tapDismissView:
-            self.telemetry.closeButtonTapped(isHomepage: isHomepage)
+            telemetry.closeButtonTapped(isHomepage: isHomepage)
 
         default: break
         }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -54,47 +54,42 @@ final class MainMenuMiddleware {
         guard let action = action as? MainMenuAction else { return }
         let isHomepage = action.telemetryInfo?.isHomepage ?? false
 
-        if self.handleMainMenuActionType(action: action, isHomepage: isHomepage) { return }
+        if let actionType = action.actionType as? MainMenuActionType {
+            self.handleMainMenuActionType(action: action,
+                                          mainMenuActionType: actionType,
+                                          isHomepage: isHomepage)
+        }
         if self.handleGeneralBrowserActionType(action: action) { return }
         if self.handleMainMenuDetailsActionType(action: action, isHomepage: isHomepage) { return }
     }
 
-    private func handleMainMenuActionType(action: MainMenuAction, isHomepage: Bool) -> Bool {
-        guard let mainMenuActionType = action.actionType as? MainMenuActionType else {
-            return false
-        }
-
+    private func handleMainMenuActionType(action: MainMenuAction,
+                                          mainMenuActionType: MainMenuActionType,
+                                          isHomepage: Bool) {
         switch mainMenuActionType {
         case .tapNavigateToDestination:
             handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
-            return true
 
         case .tapShowDetailsView:
             handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
-            return true
 
         case .tapToggleUserAgent:
             handleTapToggleUserAgentAction(action: action, isHomepage: isHomepage)
-            return true
 
         case .tapCloseMenu:
             telemetry.closeButtonTapped(isHomepage: isHomepage)
-            return true
 
         case .didInstantiateView:
             handleDidInstantiateViewAction(action: action)
-            return true
 
         case .viewDidLoad:
             handleViewDidLoadAction(action: action)
-            return true
 
         case .menuDismissed:
             telemetry.menuDismissed(isHomepage: isHomepage)
-            return true
 
         default:
-            return false
+            break
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -54,8 +54,6 @@ final class MainMenuMiddleware {
         guard let action = action as? MainMenuAction else { return }
         let isHomepage = action.telemetryInfo?.isHomepage ?? false
 
-        if self.handleMainMenuActionType(action: action, isHomepage: isHomepage) { return }
-
         switch action.actionType {
         case MainMenuActionType.tapNavigateToDestination:
             self.handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -54,42 +54,47 @@ final class MainMenuMiddleware {
         guard let action = action as? MainMenuAction else { return }
         let isHomepage = action.telemetryInfo?.isHomepage ?? false
 
-        if let actionType = action.actionType as? MainMenuActionType {
-            self.handleMainMenuActionType(action: action,
-                                          mainMenuActionType: actionType,
-                                          isHomepage: isHomepage)
-        }
+        if self.handleMainMenuActionType(action: action, isHomepage: isHomepage) { return }
         if self.handleGeneralBrowserActionType(action: action) { return }
         if self.handleMainMenuDetailsActionType(action: action, isHomepage: isHomepage) { return }
     }
 
-    private func handleMainMenuActionType(action: MainMenuAction,
-                                          mainMenuActionType: MainMenuActionType,
-                                          isHomepage: Bool) {
+    private func handleMainMenuActionType(action: MainMenuAction, isHomepage: Bool) -> Bool {
+        guard let mainMenuActionType = action.actionType as? MainMenuActionType else {
+            return false
+        }
+
         switch mainMenuActionType {
         case .tapNavigateToDestination:
             handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
+            return true
 
         case .tapShowDetailsView:
             handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
+            return true
 
         case .tapToggleUserAgent:
             handleTapToggleUserAgentAction(action: action, isHomepage: isHomepage)
+            return true
 
         case .tapCloseMenu:
             telemetry.closeButtonTapped(isHomepage: isHomepage)
+            return true
 
         case .didInstantiateView:
             handleDidInstantiateViewAction(action: action)
+            return true
 
         case .viewDidLoad:
             handleViewDidLoadAction(action: action)
+            return true
 
         case .menuDismissed:
             telemetry.menuDismissed(isHomepage: isHomepage)
+            return true
 
         default:
-            break
+            return false
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -116,6 +116,45 @@ final class MainMenuMiddleware {
         }
     }
 
+    private func handleMainMenuAction(action: MainMenuAction, isHomepage: Bool) -> Bool {
+        guard let mainMenuActionType = action.actionType as? MainMenuActionType else {
+            return false
+        }
+
+        switch mainMenuActionType {
+        case .tapNavigateToDestination:
+            handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
+            return true
+
+        case .tapShowDetailsView:
+            handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
+            return true
+
+        case .tapToggleUserAgent:
+            handleTapToggleUserAgentAction(action: action, isHomepage: isHomepage)
+            return true
+
+        case .tapCloseMenu:
+            telemetry.closeButtonTapped(isHomepage: isHomepage)
+            return true
+
+        case .didInstantiateView:
+            handleDidInstantiateViewAction(action: action)
+            return true
+
+        case .viewDidLoad:
+            handleViewDidLoadAction(action: action)
+            return true
+
+        case .menuDismissed:
+            telemetry.menuDismissed(isHomepage: isHomepage)
+            return true
+
+        default:
+            return false
+        }
+    }
+
     private func handleTapNavigateToDestinationAction(action: MainMenuAction, isHomepage: Bool) {
         guard let destination = action.navigationDestination?.destination else { return }
         handleTelemetryFor(for: destination,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -116,7 +116,7 @@ final class MainMenuMiddleware {
         }
     }
 
-    private func handleMainMenuActionType(action: MainMenuAction, isHomepage: Bool) -> Bool {
+    private func handleMainMenuAction(action: MainMenuAction, isHomepage: Bool) -> Bool {
         guard let mainMenuActionType = action.actionType as? MainMenuActionType else {
             return false
         }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -64,11 +64,7 @@ final class MainMenuMiddleware {
             self.handleGeneralBrowserActionType(action: action, generalBrowserActionType: actionType)
         }
 
-        if let actionType = action.actionType as? MainMenuDetailsActionType {
-            self.handleMainMenuDetailsActionType(action: action,
-                                                 mainMenuDetailsActionType: actionType,
-                                                 isHomepage: isHomepage)
-        }
+        if self.handleMainMenuDetailsActionType(action: action, isHomepage: isHomepage) { return }
     }
 
     private func handleMainMenuActionType(action: MainMenuAction,
@@ -111,45 +107,58 @@ final class MainMenuMiddleware {
         }
     }
 
-    private func handleMainMenuDetailsActionType(action: MainMenuAction,
-                                                 mainMenuDetailsActionType: MainMenuDetailsActionType,
-                                                 isHomepage: Bool) {
+    private func handleMainMenuDetailsActionType(action: MainMenuAction, isHomepage: Bool) -> Bool {
+        guard let mainMenuDetailsActionType = action.actionType as? MainMenuDetailsActionType else {
+            return false
+        }
+
         switch mainMenuDetailsActionType {
         case .tapZoom:
             telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
+            return true
 
         case .tapReportBrokenSite:
             telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
+            return true
 
         case .tapAddToBookmarks:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
+            return true
 
         case .tapEditBookmark:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
+            return true
 
         case .tapAddToShortcuts:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
+            return true
 
         case .tapRemoveFromShortcuts:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
+            return true
 
         case .tapAddToReadingList:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
+            return true
 
         case .tapRemoveFromReadingList:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
+            return true
 
         case .tapToggleNightMode:
             handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
+            return true
 
         case .tapBackToMainMenu:
             handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
+            return true
 
         case .tapDismissView:
             telemetry.closeButtonTapped(isHomepage: isHomepage)
+            return true
 
         @unknown default:
-            break
+            return false
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -54,6 +54,8 @@ final class MainMenuMiddleware {
         guard let action = action as? MainMenuAction else { return }
         let isHomepage = action.telemetryInfo?.isHomepage ?? false
 
+        if self.handleMainMenuActionType(action: action, isHomepage: isHomepage) { return }
+
         switch action.actionType {
         case MainMenuActionType.tapNavigateToDestination:
             self.handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -54,66 +54,7 @@ final class MainMenuMiddleware {
         guard let action = action as? MainMenuAction else { return }
         let isHomepage = action.telemetryInfo?.isHomepage ?? false
 
-        switch action.actionType {
-        case MainMenuActionType.tapNavigateToDestination:
-            self.handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
-
-        case MainMenuActionType.tapShowDetailsView:
-            self.handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
-
-        case MainMenuActionType.tapToggleUserAgent:
-            self.handleTapToggleUserAgentAction(action: action, isHomepage: isHomepage)
-
-        case MainMenuActionType.tapCloseMenu:
-            self.telemetry.closeButtonTapped(isHomepage: isHomepage)
-
-        case GeneralBrowserActionType.showReaderMode:
-            self.handleShowReaderModeAction(action: action)
-
-        case MainMenuActionType.didInstantiateView:
-            self.handleDidInstantiateViewAction(action: action)
-
-        case MainMenuActionType.viewDidLoad:
-            self.handleViewDidLoadAction(action: action)
-
-        case MainMenuActionType.menuDismissed:
-            self.telemetry.menuDismissed(isHomepage: isHomepage)
-
-        case MainMenuDetailsActionType.tapZoom:
-            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
-
-        case MainMenuDetailsActionType.tapReportBrokenSite:
-            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
-
-        case MainMenuDetailsActionType.tapAddToBookmarks:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
-
-        case MainMenuDetailsActionType.tapEditBookmark:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
-
-        case MainMenuDetailsActionType.tapAddToShortcuts:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
-
-        case MainMenuDetailsActionType.tapRemoveFromShortcuts:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
-
-        case MainMenuDetailsActionType.tapAddToReadingList:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
-
-        case MainMenuDetailsActionType.tapRemoveFromReadingList:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
-
-        case MainMenuDetailsActionType.tapToggleNightMode:
-            self.handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
-
-        case MainMenuDetailsActionType.tapBackToMainMenu:
-            self.handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
-
-        case MainMenuDetailsActionType.tapDismissView:
-            self.telemetry.closeButtonTapped(isHomepage: isHomepage)
-
-        default: break
-        }
+        self.handleMainMenuActions(action: action, isHomepage: isHomepage)
     }
     
     private func handleMainMenuActions(action: MainMenuAction, isHomepage: Bool) {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -155,21 +155,6 @@ final class MainMenuMiddleware {
         }
     }
 
-    private func handleGeneralBrowserActionType(action: MainMenuAction) -> Bool {
-        guard let generalBrowserActionType = action.actionType as? GeneralBrowserActionType else {
-            return false
-        }
-
-        switch generalBrowserActionType {
-        case .showReaderMode:
-            handleShowReaderModeAction(action: action)
-            return true
-
-        default:
-            return false
-        }
-    }
-
     private func handleTapNavigateToDestinationAction(action: MainMenuAction, isHomepage: Bool) {
         guard let destination = action.navigationDestination?.destination else { return }
         handleTelemetryFor(for: destination,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -56,7 +56,7 @@ final class MainMenuMiddleware {
 
         self.handleMainMenuActions(action: action, isHomepage: isHomepage)
     }
-    
+
     private func handleMainMenuActions(action: MainMenuAction, isHomepage: Bool) {
         switch action.actionType {
         case MainMenuActionType.tapNavigateToDestination:

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -55,6 +55,7 @@ final class MainMenuMiddleware {
         let isHomepage = action.telemetryInfo?.isHomepage ?? false
 
         if self.handleMainMenuActionType(action: action, isHomepage: isHomepage) { return }
+        if self.handleGeneralBrowserActionType(action: action) { return }
 
         switch action.actionType {
         case MainMenuActionType.tapNavigateToDestination:

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -170,6 +170,61 @@ final class MainMenuMiddleware {
         }
     }
 
+    private func handleMainMenuDetailsActionType(action: MainMenuAction, isHomepage: Bool) -> Bool {
+        guard let mainMenuDetailsActionType = action.actionType as? MainMenuDetailsActionType else {
+            return false
+        }
+
+        switch mainMenuDetailsActionType {
+        case .tapZoom:
+            telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
+            return true
+
+        case .tapReportBrokenSite:
+            telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
+            return true
+
+        case .tapAddToBookmarks:
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
+            return true
+
+        case .tapEditBookmark:
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
+            return true
+
+        case .tapAddToShortcuts:
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
+            return true
+
+        case .tapRemoveFromShortcuts:
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
+            return true
+
+        case .tapAddToReadingList:
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
+            return true
+
+        case .tapRemoveFromReadingList:
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
+            return true
+
+        case .tapToggleNightMode:
+            handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
+            return true
+
+        case .tapBackToMainMenu:
+            handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
+            return true
+
+        case .tapDismissView:
+            telemetry.closeButtonTapped(isHomepage: isHomepage)
+            return true
+
+        @unknown default:
+            return false
+        }
+    }
+
     private func handleTapNavigateToDestinationAction(action: MainMenuAction, isHomepage: Bool) {
         guard let destination = action.navigationDestination?.destination else { return }
         handleTelemetryFor(for: destination,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -155,6 +155,21 @@ final class MainMenuMiddleware {
         }
     }
 
+    private func handleGeneralBrowserActionType(action: MainMenuAction) -> Bool {
+        guard let generalBrowserActionType = action.actionType as? GeneralBrowserActionType else {
+            return false
+        }
+
+        switch generalBrowserActionType {
+        case .showReaderMode:
+            handleShowReaderModeAction(action: action)
+            return true
+
+        default:
+            return false
+        }
+    }
+
     private func handleTapNavigateToDestinationAction(action: MainMenuAction, isHomepage: Bool) {
         guard let destination = action.navigationDestination?.destination else { return }
         handleTelemetryFor(for: destination,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -115,6 +115,69 @@ final class MainMenuMiddleware {
         default: break
         }
     }
+    
+    private func handleMainMenuActions(action: MainMenuAction, isHomepage: Bool) {
+        switch action.actionType {
+        case MainMenuActionType.tapNavigateToDestination:
+            self.handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
+
+        case MainMenuActionType.tapShowDetailsView:
+            self.handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
+
+        case MainMenuActionType.tapToggleUserAgent:
+            self.handleTapToggleUserAgentAction(action: action, isHomepage: isHomepage)
+
+        case MainMenuActionType.tapCloseMenu:
+            self.telemetry.closeButtonTapped(isHomepage: isHomepage)
+
+        case GeneralBrowserActionType.showReaderMode:
+            self.handleShowReaderModeAction(action: action)
+
+        case MainMenuActionType.didInstantiateView:
+            self.handleDidInstantiateViewAction(action: action)
+
+        case MainMenuActionType.viewDidLoad:
+            self.handleViewDidLoadAction(action: action)
+
+        case MainMenuActionType.menuDismissed:
+            self.telemetry.menuDismissed(isHomepage: isHomepage)
+
+        case MainMenuDetailsActionType.tapZoom:
+            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
+
+        case MainMenuDetailsActionType.tapReportBrokenSite:
+            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
+
+        case MainMenuDetailsActionType.tapAddToBookmarks:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
+
+        case MainMenuDetailsActionType.tapEditBookmark:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
+
+        case MainMenuDetailsActionType.tapAddToShortcuts:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
+
+        case MainMenuDetailsActionType.tapRemoveFromShortcuts:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
+
+        case MainMenuDetailsActionType.tapAddToReadingList:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
+
+        case MainMenuDetailsActionType.tapRemoveFromReadingList:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
+
+        case MainMenuDetailsActionType.tapToggleNightMode:
+            self.handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
+
+        case MainMenuDetailsActionType.tapBackToMainMenu:
+            self.handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
+
+        case MainMenuDetailsActionType.tapDismissView:
+            self.telemetry.closeButtonTapped(isHomepage: isHomepage)
+
+        default: break
+        }
+    }
 
     private func handleTapNavigateToDestinationAction(action: MainMenuAction, isHomepage: Bool) {
         guard let destination = action.navigationDestination?.destination else { return }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -56,7 +56,6 @@ final class MainMenuMiddleware {
 
         if self.handleMainMenuActionType(action: action, isHomepage: isHomepage) { return }
         if self.handleGeneralBrowserActionType(action: action) { return }
-        if self.handleMainMenuDetailsActionType(action: action, isHomepage: isHomepage) { return }
 
         switch action.actionType {
         case MainMenuActionType.tapNavigateToDestination:

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -116,7 +116,7 @@ final class MainMenuMiddleware {
         }
     }
 
-    private func handleMainMenuAction(action: MainMenuAction, isHomepage: Bool) -> Bool {
+    private func handleMainMenuActionType(action: MainMenuAction, isHomepage: Bool) -> Bool {
         guard let mainMenuActionType = action.actionType as? MainMenuActionType else {
             return false
         }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -55,7 +55,6 @@ final class MainMenuMiddleware {
         let isHomepage = action.telemetryInfo?.isHomepage ?? false
 
         if self.handleMainMenuActionType(action: action, isHomepage: isHomepage) { return }
-        if self.handleGeneralBrowserActionType(action: action) { return }
 
         switch action.actionType {
         case MainMenuActionType.tapNavigateToDestination:

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -64,7 +64,11 @@ final class MainMenuMiddleware {
             self.handleGeneralBrowserActionType(action: action, generalBrowserActionType: actionType)
         }
 
-        if self.handleMainMenuDetailsActionType(action: action, isHomepage: isHomepage) { return }
+        if let actionType = action.actionType as? MainMenuDetailsActionType {
+            self.handleMainMenuDetailsActionType(action: action,
+                                                 mainMenuDetailsActionType: actionType,
+                                                 isHomepage: isHomepage)
+        }
     }
 
     private func handleMainMenuActionType(action: MainMenuAction,
@@ -107,58 +111,45 @@ final class MainMenuMiddleware {
         }
     }
 
-    private func handleMainMenuDetailsActionType(action: MainMenuAction, isHomepage: Bool) -> Bool {
-        guard let mainMenuDetailsActionType = action.actionType as? MainMenuDetailsActionType else {
-            return false
-        }
-
+    private func handleMainMenuDetailsActionType(action: MainMenuAction,
+                                                 mainMenuDetailsActionType: MainMenuDetailsActionType,
+                                                 isHomepage: Bool) {
         switch mainMenuDetailsActionType {
         case .tapZoom:
             telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
-            return true
 
         case .tapReportBrokenSite:
             telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
-            return true
 
         case .tapAddToBookmarks:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
-            return true
 
         case .tapEditBookmark:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
-            return true
 
         case .tapAddToShortcuts:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
-            return true
 
         case .tapRemoveFromShortcuts:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
-            return true
 
         case .tapAddToReadingList:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
-            return true
 
         case .tapRemoveFromReadingList:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
-            return true
 
         case .tapToggleNightMode:
             handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
-            return true
 
         case .tapBackToMainMenu:
             handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
-            return true
 
         case .tapDismissView:
             telemetry.closeButtonTapped(isHomepage: isHomepage)
-            return true
 
         @unknown default:
-            return false
+            break
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -57,67 +57,6 @@ final class MainMenuMiddleware {
         if self.handleMainMenuActionType(action: action, isHomepage: isHomepage) { return }
         if self.handleGeneralBrowserActionType(action: action) { return }
         if self.handleMainMenuDetailsActionType(action: action, isHomepage: isHomepage) { return }
-
-        switch action.actionType {
-        case MainMenuActionType.tapNavigateToDestination:
-            self.handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
-
-        case MainMenuActionType.tapShowDetailsView:
-            self.handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
-
-        case MainMenuActionType.tapToggleUserAgent:
-            self.handleTapToggleUserAgentAction(action: action, isHomepage: isHomepage)
-
-        case MainMenuActionType.tapCloseMenu:
-            self.telemetry.closeButtonTapped(isHomepage: isHomepage)
-
-        case GeneralBrowserActionType.showReaderMode:
-            self.handleShowReaderModeAction(action: action)
-
-        case MainMenuActionType.didInstantiateView:
-            self.handleDidInstantiateViewAction(action: action)
-
-        case MainMenuActionType.viewDidLoad:
-            self.handleViewDidLoadAction(action: action)
-
-        case MainMenuActionType.menuDismissed:
-            self.telemetry.menuDismissed(isHomepage: isHomepage)
-
-        case MainMenuDetailsActionType.tapZoom:
-            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
-
-        case MainMenuDetailsActionType.tapReportBrokenSite:
-            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
-
-        case MainMenuDetailsActionType.tapAddToBookmarks:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
-
-        case MainMenuDetailsActionType.tapEditBookmark:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
-
-        case MainMenuDetailsActionType.tapAddToShortcuts:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
-
-        case MainMenuDetailsActionType.tapRemoveFromShortcuts:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
-
-        case MainMenuDetailsActionType.tapAddToReadingList:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
-
-        case MainMenuDetailsActionType.tapRemoveFromReadingList:
-            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
-
-        case MainMenuDetailsActionType.tapToggleNightMode:
-            self.handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
-
-        case MainMenuDetailsActionType.tapBackToMainMenu:
-            self.handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
-
-        case MainMenuDetailsActionType.tapDismissView:
-            self.telemetry.closeButtonTapped(isHomepage: isHomepage)
-
-        default: break
-        }
     }
 
     private func handleMainMenuActionType(action: MainMenuAction, isHomepage: Bool) -> Bool {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -57,6 +57,67 @@ final class MainMenuMiddleware {
         if self.handleMainMenuActionType(action: action, isHomepage: isHomepage) { return }
         if self.handleGeneralBrowserActionType(action: action) { return }
         if self.handleMainMenuDetailsActionType(action: action, isHomepage: isHomepage) { return }
+
+        switch action.actionType {
+        case MainMenuActionType.tapNavigateToDestination:
+            self.handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
+
+        case MainMenuActionType.tapShowDetailsView:
+            self.handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
+
+        case MainMenuActionType.tapToggleUserAgent:
+            self.handleTapToggleUserAgentAction(action: action, isHomepage: isHomepage)
+
+        case MainMenuActionType.tapCloseMenu:
+            self.telemetry.closeButtonTapped(isHomepage: isHomepage)
+
+        case GeneralBrowserActionType.showReaderMode:
+            self.handleShowReaderModeAction(action: action)
+
+        case MainMenuActionType.didInstantiateView:
+            self.handleDidInstantiateViewAction(action: action)
+
+        case MainMenuActionType.viewDidLoad:
+            self.handleViewDidLoadAction(action: action)
+
+        case MainMenuActionType.menuDismissed:
+            self.telemetry.menuDismissed(isHomepage: isHomepage)
+
+        case MainMenuDetailsActionType.tapZoom:
+            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
+
+        case MainMenuDetailsActionType.tapReportBrokenSite:
+            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
+
+        case MainMenuDetailsActionType.tapAddToBookmarks:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
+
+        case MainMenuDetailsActionType.tapEditBookmark:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
+
+        case MainMenuDetailsActionType.tapAddToShortcuts:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
+
+        case MainMenuDetailsActionType.tapRemoveFromShortcuts:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
+
+        case MainMenuDetailsActionType.tapAddToReadingList:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
+
+        case MainMenuDetailsActionType.tapRemoveFromReadingList:
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
+
+        case MainMenuDetailsActionType.tapToggleNightMode:
+            self.handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
+
+        case MainMenuDetailsActionType.tapBackToMainMenu:
+            self.handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
+
+        case MainMenuDetailsActionType.tapDismissView:
+            self.telemetry.closeButtonTapped(isHomepage: isHomepage)
+
+        default: break
+        }
     }
 
     private func handleMainMenuActionType(action: MainMenuAction, isHomepage: Bool) -> Bool {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -56,6 +56,7 @@ final class MainMenuMiddleware {
 
         if self.handleMainMenuActionType(action: action, isHomepage: isHomepage) { return }
         if self.handleGeneralBrowserActionType(action: action) { return }
+        if self.handleMainMenuDetailsActionType(action: action, isHomepage: isHomepage) { return }
 
         switch action.actionType {
         case MainMenuActionType.tapNavigateToDestination:

--- a/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
+++ b/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
@@ -56,13 +56,7 @@ extension InternalTelemetrySettingsView: View {
     var body: some View {
         Form {
             if #available(iOS 14, *) {
-                SwiftUI.Section(header: Text(verbatim: "Logging")) {
-                    Toggle(isOn: $internalSettings.gleanLogPingsToConsole) {
-                        VStack(alignment: .leading) {
-                            Text(verbatim: "Log Pings to Console")
-                        }
-                    }.onChange(of: internalSettings.gleanLogPingsToConsole, perform: changeLogPingsToConsole)
-                }
+                loggingSection
 
                 SwiftUI.Section(header: Text(verbatim: "Debug View")) {
                     Toggle(isOn: $internalSettings.gleanEnableDebugView) {

--- a/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
+++ b/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
@@ -112,6 +112,30 @@ extension InternalTelemetrySettingsView: View {
             }.onChange(of: internalSettings.gleanLogPingsToConsole, perform: changeLogPingsToConsole)
         }
     }
+
+    private var debugViewSection: some View {
+        return SwiftUI.Section(header: Text(verbatim: "Debug View")) {
+            Toggle(isOn: $internalSettings.gleanEnableDebugView) {
+                VStack(alignment: .leading) {
+                    Text(verbatim: "Enable Debug View")
+                    Text(verbatim: "Requires app restart").font(.caption)
+                }
+            }.disabled(internalSettings.gleanDebugViewTag.isEmpty)
+
+            VStack(alignment: .leading) {
+                TextField("Debug View Tag", text: $internalSettings.gleanDebugViewTag)
+                    .onChange(of: internalSettings.gleanDebugViewTag, perform: changeDebugViewTag)
+            }
+
+            Button(action: { UIApplication.shared.open(GleanDebugViewURL) }) {
+                Text(verbatim: "Open Debug View (In Default Browser)")
+            }
+
+            Button(action: { UIPasteboard.general.url = GleanDebugViewURL }) {
+                Text(verbatim: "Copy Debug View Link")
+            }
+        }
+    }
 }
 
 struct InternalTelemetrySettingsView_Previews: PreviewProvider {

--- a/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
+++ b/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
@@ -60,23 +60,7 @@ extension InternalTelemetrySettingsView: View {
 
                 debugViewSection
 
-                SwiftUI.Section {
-                    Button(action: { sendPendingEventPings() }) {
-                        Text(verbatim: "Send Pending Event Pings")
-                    }
-
-                    Button(action: { sendPendingBaselinePings() }) {
-                        Text(verbatim: "Send Baseline Event Pings")
-                    }
-
-                    Button(action: { sendPendingMetricsPings() }) {
-                        Text(verbatim: "Send Metrics Event Pings")
-                    }
-
-                    Button(action: { sendPendingDeletionRequestPings() }) {
-                        Text(verbatim: "Send Deletion Request Event Pings")
-                    }
-                }
+                eventPingsSection
             } else {
                 Text(verbatim: "Internal Telemetry Settings are only available on iOS 14 and newer.")
             }

--- a/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
+++ b/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
@@ -108,6 +108,16 @@ extension InternalTelemetrySettingsView: View {
             }
         }.navigationBarTitle(Text(verbatim: "Telemetry"))
     }
+
+    private var loggingSection: some View {
+        return SwiftUI.Section(header: Text(verbatim: "Logging")) {
+            Toggle(isOn: $internalSettings.gleanLogPingsToConsole) {
+                VStack(alignment: .leading) {
+                    Text(verbatim: "Log Pings to Console")
+                }
+            }.onChange(of: internalSettings.gleanLogPingsToConsole, perform: changeLogPingsToConsole)
+        }
+    }
 }
 
 struct InternalTelemetrySettingsView_Previews: PreviewProvider {

--- a/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
+++ b/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
@@ -116,6 +116,26 @@ extension InternalTelemetrySettingsView: View {
             }
         }
     }
+
+    private var eventPingsSection: some View {
+        return SwiftUI.Section {
+            Button(action: { sendPendingEventPings() }) {
+                Text(verbatim: "Send Pending Event Pings")
+            }
+
+            Button(action: { sendPendingBaselinePings() }) {
+                Text(verbatim: "Send Baseline Event Pings")
+            }
+
+            Button(action: { sendPendingMetricsPings() }) {
+                Text(verbatim: "Send Metrics Event Pings")
+            }
+
+            Button(action: { sendPendingDeletionRequestPings() }) {
+                Text(verbatim: "Send Deletion Request Event Pings")
+            }
+        }
+    }
 }
 
 struct InternalTelemetrySettingsView_Previews: PreviewProvider {

--- a/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
+++ b/focus-ios/Blockzilla/InternalSettings/InternalTelemetrySettingsView.swift
@@ -58,27 +58,7 @@ extension InternalTelemetrySettingsView: View {
             if #available(iOS 14, *) {
                 loggingSection
 
-                SwiftUI.Section(header: Text(verbatim: "Debug View")) {
-                    Toggle(isOn: $internalSettings.gleanEnableDebugView) {
-                        VStack(alignment: .leading) {
-                            Text(verbatim: "Enable Debug View")
-                            Text(verbatim: "Requires app restart").font(.caption)
-                        }
-                    }.disabled(internalSettings.gleanDebugViewTag.isEmpty)
-
-                    VStack(alignment: .leading) {
-                        TextField("Debug View Tag", text: $internalSettings.gleanDebugViewTag)
-                            .onChange(of: internalSettings.gleanDebugViewTag, perform: changeDebugViewTag)
-                    }
-
-                    Button(action: { UIApplication.shared.open(GleanDebugViewURL) }) {
-                        Text(verbatim: "Open Debug View (In Default Browser)")
-                    }
-
-                    Button(action: { UIPasteboard.general.url = GleanDebugViewURL }) {
-                        Text(verbatim: "Copy Debug View Link")
-                    }
-                }
+                debugViewSection
 
                 SwiftUI.Section {
                     Button(action: { sendPendingEventPings() }) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 2 `closure_body_length` violations from the `MainMenuMiddleware.swift` (Firefox) and `InternalTelemetrySettingsView.swift` (Focus). Also, it decreases the threshold to 42.

~The most controversial change in this PR is in the `MainMenuMiddleware.swift` file. In this file, I changed the `mainMenuProvider` property, splitting it into separated functions. I created three new functions, each one based on the `ActionType`: `MainMenuActionType`, `GeneralBrowserActionType`, and `MainMenuDetailsActionType`. To the last one, I needed to add the `@unknown` keyword, because all option already available into switch case statement.~

I've changed the strategy, so I just discard the paragraph above, and I made  a comment bellow explaining this.

Please, feel free to give me suggestions about how can we improve this.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

