### PR TITLE
Add FXIOS-12049 - [Toolbar - Swipe Tabs Animation] - Enable swiping for a specific case on homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4278,6 +4278,8 @@ extension BrowserViewController: KeyboardHelperDelegate {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidHideWithState state: KeyboardState) {
         tabManager.selectedTab?.setFindInPage(isBottomSearchBar: isBottomSearchBar,
                                               doesFindInPageBarExist: findInPageBar != nil)
+        guard isSwipingTabsEnabled else { return }
+        addressBarPanGestureHandler?.enablePanGestureOnHomepageIfNeeded()
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillChangeWithState state: KeyboardState) {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -60,12 +60,26 @@ final class AddressBarPanGestureHandler: NSObject {
         panGestureRecognizer?.isEnabled = true
     }
 
+    // MARK: - Pan Gesture Availability
     func enablePanGestureRecognizer() {
         panGestureRecognizer?.isEnabled = true
     }
 
     func disablePanGestureRecognizer() {
         panGestureRecognizer?.isEnabled = false
+    }
+
+    /// Enables swiping gesture in overlay mode when no URL or text is in the address bar,
+    /// such as after dismissing the keyboard on the homepage.
+    func enablePanGestureOnHomepageIfNeeded() {
+        let addressToolbarState = store.state.screenState(
+            ToolbarState.self,
+            for: .toolbar,
+            window: windowUUID
+        )?.addressToolbar
+        guard addressToolbarState?.didStartTyping == false,
+              addressToolbarState?.url == nil  else { return }
+        enablePanGestureRecognizer()
     }
 
     // MARK: - Pan Gesture Handling


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12049)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26245)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Swiping gesture is enabled when leaving overlay mode. However, there is a case where, if we are on the homepage in overlay mode and tap outside the keyboard, the keyboard gets dismissed, but we remain in overlay mode. In this scenario, there is no visible difference, and swiping remains disabled. We want to handle this case differently when there is no URL in the address bar and enable the swiping gesture.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

