### PR TITLE
Build: FXIOS-11506 Don't run the decision task on github release publication

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -110,7 +110,6 @@ tasks:
               || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
               || (tasks_for == "github-push" && short_head_branch == "main")
               || (tasks_for == "github-push" && short_head_branch[:8] == "release/")
-              || (tasks_for == "github-release" && releaseAction == "published")
             then:
                 taskId:
                     $if: 'tasks_for != "action"'


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11506)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25045)

## :bulb: Description

We don't use that and it is later assumed that only 4 things can trigger the decision task:

- cronjobs
- actions
- pushes to branches
- pushes to pull requests

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

