### PR TITLE
Refactor FXIOS-12008 #26132 - Zoom to remove logic from BVC and Tab

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -273,6 +273,8 @@
 		219935EC2B07110900E5966F /* TabTrayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219935EB2B07110900E5966F /* TabTrayModel.swift */; };
 		219935F12B07DFA200E5966F /* TabDisplayPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219935F02B07DFA200E5966F /* TabDisplayPanelTests.swift */; };
 		21996BAB2AE95AFC00E0D55F /* TabTrayPanelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21996BAA2AE95AFC00E0D55F /* TabTrayPanelType.swift */; };
+		2199A1D22DB80B6C00DC84BD /* ZoomPageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2199A1D12DB80B6C00DC84BD /* ZoomPageManagerTests.swift */; };
+		2199A1D42DB8389000DC84BD /* MockZoomStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2199A1D32DB8389000DC84BD /* MockZoomStore.swift */; };
 		219A0FD52ACC8506009A6D1A /* InactiveTabsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A0FD42ACC8506009A6D1A /* InactiveTabsCell.swift */; };
 		219A0FD72ACC8C03009A6D1A /* InactiveTabsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A0FD62ACC8C03009A6D1A /* InactiveTabsHeaderView.swift */; };
 		219A0FD92ACC8C0F009A6D1A /* InactiveTabsFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A0FD82ACC8C0F009A6D1A /* InactiveTabsFooterView.swift */; };
@@ -2746,6 +2748,8 @@
 		219935EB2B07110900E5966F /* TabTrayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayModel.swift; sourceTree = "<group>"; };
 		219935F02B07DFA200E5966F /* TabDisplayPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayPanelTests.swift; sourceTree = "<group>"; };
 		21996BAA2AE95AFC00E0D55F /* TabTrayPanelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayPanelType.swift; sourceTree = "<group>"; };
+		2199A1D12DB80B6C00DC84BD /* ZoomPageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomPageManagerTests.swift; sourceTree = "<group>"; };
+		2199A1D32DB8389000DC84BD /* MockZoomStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockZoomStore.swift; sourceTree = "<group>"; };
 		219A0FD42ACC8506009A6D1A /* InactiveTabsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabsCell.swift; sourceTree = "<group>"; };
 		219A0FD62ACC8C03009A6D1A /* InactiveTabsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabsHeaderView.swift; sourceTree = "<group>"; };
 		219A0FD82ACC8C0F009A6D1A /* InactiveTabsFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabsFooterView.swift; sourceTree = "<group>"; };
@@ -13590,6 +13594,7 @@
 		C889D7D22858C85200121E1D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				2199A1D32DB8389000DC84BD /* MockZoomStore.swift */,
 				0B7B05422D64C08F007FD7AC /* MockURLProtocol.swift */,
 				0B7B05402D64C087007FD7AC /* MockURLResponse.swift */,
 				0B7B053E2D64C022007FD7AC /* MockTabWebView.swift */,
@@ -14994,6 +14999,7 @@
 				0ECB6B672CCFE663006A7C82 /* DateGroupedTableDataTests.swift */,
 				0B7B053C2D647D00007FD7AC /* TemporaryDocumentTests.swift */,
 				21AE78512D8B54B8002FDC9E /* WebviewViewControllerTests.swift */,
+				2199A1D12DB80B6C00DC84BD /* ZoomPageManagerTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -17961,6 +17967,7 @@
 				39AF317429DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift in Sources */,
 				E14C78962C105488002AD3C7 /* AddressToolbarContainerModelTests.swift in Sources */,
 				C2A72A6B2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift in Sources */,
+				2199A1D42DB8389000DC84BD /* MockZoomStore.swift in Sources */,
 				C706CBEF2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift in Sources */,
 				E19B38B128A3E69300D8C541 /* WallpaperCollectionAvailabilityTests.swift in Sources */,
 				81DAB2F32C88F14400F4BE98 /* MainMenuCoordinatorTests.swift in Sources */,
@@ -18244,6 +18251,7 @@
 				C88012232A40E38D00F4D1D6 /* IntroViewControllerTests.swift in Sources */,
 				E16E1C9628BFB2E600EE2EF5 /* WallpaperSettingsViewModelTests.swift in Sources */,
 				8A9D31602D13506400171502 /* MockParentFolderSelector.swift in Sources */,
+				2199A1D22DB80B6C00DC84BD /* ZoomPageManagerTests.swift in Sources */,
 				E1463D042982D0240074E16E /* NotificationManagerTests.swift in Sources */,
 				8AA0A6682CAC747500AC7EB3 /* HomepageDiffableDataSourceTests.swift in Sources */,
 				3B61CD591F2A750800D38DE1 /* PocketFeedTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		2178A6A4291455F7002EC290 /* ReaderModeFontSizeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A6A3291455F7002EC290 /* ReaderModeFontSizeButton.swift */; };
 		217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AEF75284666D4004EED37 /* IntroViewModelTests.swift */; };
 		219588942D6E519F00B8715E /* AutofillPasswordSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219588932D6E519F00B8715E /* AutofillPasswordSetting.swift */; };
+		219638EC2DBFBC56007C3893 /* ZoomLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219638EB2DBFBC56007C3893 /* ZoomLevel.swift */; };
 		2197DF8A287624BF00215624 /* LibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2197DF89287624BF00215624 /* LibraryViewModelTests.swift */; };
 		219914052AF963F900153598 /* TabTrayAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219914042AF963F900153598 /* TabTrayAction.swift */; };
 		219935E72B05447C00E5966F /* TabDisplayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219935E62B05447C00E5966F /* TabDisplayModel.swift */; };
@@ -2741,6 +2742,7 @@
 		217AEF75284666D4004EED37 /* IntroViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModelTests.swift; sourceTree = "<group>"; };
 		2194437EA9B44A00EDC037FA /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/FindInPage.strings"; sourceTree = "<group>"; };
 		219588932D6E519F00B8715E /* AutofillPasswordSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillPasswordSetting.swift; sourceTree = "<group>"; };
+		219638EB2DBFBC56007C3893 /* ZoomLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomLevel.swift; sourceTree = "<group>"; };
 		2197DF89287624BF00215624 /* LibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModelTests.swift; sourceTree = "<group>"; };
 		219914042AF963F900153598 /* TabTrayAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayAction.swift; sourceTree = "<group>"; };
 		219935E62B05447C00E5966F /* TabDisplayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayModel.swift; sourceTree = "<group>"; };
@@ -10755,6 +10757,7 @@
 		2142B12B2D9F1284003AA82F /* Zoom */ = {
 			isa = PBXGroup;
 			children = (
+				219638EB2DBFBC56007C3893 /* ZoomLevel.swift */,
 				2142B1292D9F1284003AA82F /* ZoomPageBar.swift */,
 				2142B12A2D9F1284003AA82F /* ZoomPageManager.swift */,
 			);
@@ -17042,6 +17045,7 @@
 				2137785D297F1F2800D01309 /* DownloadedFile.swift in Sources */,
 				1DCEC4142D83B7EB00129966 /* ASSearchEngineIconDataFetcher.swift in Sources */,
 				745DAB301CDAAFAA00D44181 /* RecentlyClosedTabsPanel.swift in Sources */,
+				219638EC2DBFBC56007C3893 /* ZoomLevel.swift in Sources */,
 				D0B9483D22A18B78002F4AA1 /* TextFieldTableViewCell.swift in Sources */,
 				8A454D322CB8170D009436D9 /* PocketManager.swift in Sources */,
 				80967F802D0A36890057F0C7 /* RecordedNimbusContext.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
@@ -339,28 +339,28 @@ extension BrowserViewController {
 
     // MARK: Zoom
 
+    // TODO: YRD test if gainFocus is enough or we need to set the tab
     @objc
     func zoomIn() {
-        // TODO: YRD test if gainFocus is enought or we need to set the tab
-        if !contentContainer.hasAnyHomepage {
-            _ = zoomManager.zoomIn()
-        }
+        guard contentContainer.hasAnyHomepage else { return }
+
+        let zoomValue = zoomManager.zoomIn()
+        zoomPageBar?.updateZoomLabel(zoomValue: zoomValue)
     }
 
     @objc
     func zoomOut() {
-        // TODO: YRD test if gainFocus is enought or we need to set the tab
-        if !contentContainer.hasAnyHomepage {
-            _ = zoomManager.zoomOut()
-        }
+        guard contentContainer.hasAnyHomepage else { return }
+    
+        let zoomValue = zoomManager.zoomOut()
+        zoomPageBar?.updateZoomLabel(zoomValue: zoomValue)
     }
 
     @objc
     func resetZoom() {
-        // TODO: YRD test if gainFocus is enought or we need to set the tab
-        if !contentContainer.hasAnyHomepage {
-            zoomManager.resetZoom()
-        }
+        guard contentContainer.hasAnyHomepage else { return }
+
+        zoomManager.resetZoom()
     }
 
     // MARK: - KeyCommands

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
@@ -339,7 +339,6 @@ extension BrowserViewController {
 
     // MARK: Zoom
 
-    // TODO: YRD test if gainFocus is enough or we need to set the tab
     @objc
     func zoomIn() {
         guard contentContainer.hasAnyHomepage else { return }
@@ -351,7 +350,7 @@ extension BrowserViewController {
     @objc
     func zoomOut() {
         guard contentContainer.hasAnyHomepage else { return }
-    
+
         let zoomValue = zoomManager.zoomOut()
         zoomPageBar?.updateZoomLabel(zoomValue: zoomValue)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
@@ -341,28 +341,25 @@ extension BrowserViewController {
 
     @objc
     func zoomIn() {
-        guard let currentTab = tabManager.selectedTab else { return }
-
+        // TODO: YRD test if gainFocus is enought or we need to set the tab
         if !contentContainer.hasAnyHomepage {
-            currentTab.zoomIn()
+            _ = zoomManager.zoomIn()
         }
     }
 
     @objc
     func zoomOut() {
-        guard let currentTab = tabManager.selectedTab else { return }
-
+        // TODO: YRD test if gainFocus is enought or we need to set the tab
         if !contentContainer.hasAnyHomepage {
-            currentTab.zoomOut()
+            _ = zoomManager.zoomOut()
         }
     }
 
     @objc
     func resetZoom() {
-        guard let currentTab = tabManager.selectedTab else { return }
-
+        // TODO: YRD test if gainFocus is enought or we need to set the tab
         if !contentContainer.hasAnyHomepage {
-            currentTab.resetZoom()
+            zoomManager.resetZoom()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -424,7 +424,7 @@ extension BrowserViewController: WKNavigationDelegate {
             decisionHandler(.cancel)
             return
         }
-        updateZoomPageBarVisibility(visible: false)
+
         if tab == tabManager.selectedTab,
            navigationAction.navigationType == .linkActivated,
            !tab.adsTelemetryUrlList.isEmpty {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
@@ -64,16 +64,15 @@ extension BrowserViewController: ZoomPageBarDelegate {
     }
 
     func zoomPageHandleExitReaderMode() {
-        zoomManager.updatePageZoom()
+        zoomManager.setZoomAfterLeavingReaderMode()
     }
 
-    // TODO: YRD Move to manager keep only the update zoom value for the bar
+    // The zoom level was updated on another iPad window, but the host matches
+    // this window's selected tab, so we need to ensure we update also.
     func updateForZoomChangedInOtherIPadWindow(zoom: DomainZoomLevel) {
         guard let tab = tabManager.selectedTab,
               tab.pageZoom != zoom.zoomLevel else { return }
 
-        // The zoom level was updated on another iPad window, but the host matches
-        // this window's selected tab, so we need to ensure we update also.
         zoomManager.updateZoomChangedInOtherWindow()
         zoomPageBar?.updateZoomLabel(zoomValue: zoomManager.getZoomValue())
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
@@ -12,9 +12,7 @@ extension BrowserViewController: ZoomPageBarDelegate {
     }
 
     private func setupZoomPageBar() {
-        guard let tab = tabManager.selectedTab else { return }
-
-        let zoomPageBar = ZoomPageBar(tab: tab)
+        let zoomPageBar = ZoomPageBar(zoomManager: zoomManager)
         self.zoomPageBar = zoomPageBar
         scrollController.zoomPageBar = zoomPageBar
         zoomPageBar.delegate = self
@@ -61,42 +59,28 @@ extension BrowserViewController: ZoomPageBarDelegate {
     }
 
     func zoomPageHandleEnterReaderMode() {
-        guard let tab = tabManager.selectedTab else { return }
         updateZoomPageBarVisibility(visible: false)
-        tab.resetZoom()
+        zoomManager.resetZoom()
     }
 
     func zoomPageHandleExitReaderMode() {
-        guard let tab = tabManager.selectedTab else { return }
-        tab.setZoomLevelforDomain()
+        zoomManager.updatePageZoom()
     }
 
+    // TODO: YRD Move to manager keep only the update zoom value for the bar
     func updateForZoomChangedInOtherIPadWindow(zoom: DomainZoomLevel) {
         guard let tab = tabManager.selectedTab,
-              let currentHost = tab.url?.host,
-              currentHost.caseInsensitiveCompare(zoom.host) == .orderedSame,
               tab.pageZoom != zoom.zoomLevel else { return }
 
         // The zoom level was updated on another iPad window, but the host matches
         // this window's selected tab, so we need to ensure we update also.
-        if tab.pageZoom < zoom.zoomLevel { tab.zoomIn() } else { tab.zoomOut() }
-        zoomPageBar?.updateZoomLabel()
+        zoomManager.updateZoomChangedInOtherWindow()
+        zoomPageBar?.updateZoomLabel(zoomValue: zoomManager.getZoomValue())
     }
 
     // MARK: - ZoomPageBarDelegate
 
-    func didChangeZoomLevel() {
-        saveZoomLevel()
-    }
-
     func zoomPageDidPressClose() {
         updateZoomPageBarVisibility(visible: false)
-    }
-
-    private func saveZoomLevel() {
-        guard let tab = tabManager.selectedTab, let host = tab.url?.host else { return }
-
-        let zoomPageManager = ZoomPageManager(windowUUID: tab.windowUUID)
-        zoomPageManager.saveZoomLevel(for: host, zoomLevel: tab.pageZoom)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
@@ -60,7 +60,7 @@ extension BrowserViewController: ZoomPageBarDelegate {
 
     func zoomPageHandleEnterReaderMode() {
         updateZoomPageBarVisibility(visible: false)
-        zoomManager.resetZoom()
+        zoomManager.resetZoom(shouldSave: false)
     }
 
     func zoomPageHandleExitReaderMode() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
@@ -74,7 +74,7 @@ extension BrowserViewController: ZoomPageBarDelegate {
               tab.pageZoom != zoom.zoomLevel else { return }
 
         zoomManager.updateZoomChangedInOtherWindow()
-        zoomPageBar?.updateZoomLabel(zoomValue: zoomManager.getZoomValue())
+        zoomPageBar?.updateZoomLabel(zoomValue: zoomManager.getZoomLevel())
     }
 
     // MARK: - ZoomPageBarDelegate

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -92,7 +92,6 @@ class BrowserViewController: UIViewController,
     var notificationCenter: NotificationProtocol
     var themeObserver: NSObjectProtocol?
     var logger: Logger
-    // TODO: YRD - update to use dependency helper
     var zoomManager: ZoomPageManager
 
     // MARK: Optional UI elements

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2339,6 +2339,7 @@ class BrowserViewController: UIViewController,
             presentRefreshLongPressAction(from: button)
         case .tabTray:
             // TODO: FXIOS-11248 Use NavigationBrowserAction instead of GeneralBrowserAction to open tab tray
+            updateZoomPageBarVisibility(visible: false)
             focusOnTabSegment()
         case .share:
             // User tapped the Share button in the toolbar

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -92,6 +92,8 @@ class BrowserViewController: UIViewController,
     var notificationCenter: NotificationProtocol
     var themeObserver: NSObjectProtocol?
     var logger: Logger
+    // TODO: YRD - update to use dependency helper
+    var zoomManager: ZoomPageManager
 
     // MARK: Optional UI elements
 
@@ -336,6 +338,7 @@ class BrowserViewController: UIViewController,
         self.appAuthenticator = appAuthenticator
         self.bookmarksSaver = DefaultBookmarksSaver(profile: profile)
         self.bookmarksHandler = profile.places
+        self.zoomManager = ZoomPageManager(windowUUID: tabManager.windowUUID)
 
         super.init(nibName: nil, bundle: nil)
         didInit()

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomLevel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomLevel.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+enum ZoomLevel: CGFloat, CaseIterable {
+    case fiftyPercent = 0.5
+    case seventyFivePercent = 0.75
+    case ninetyPercent = 0.9
+    case oneHundredPercent = 1.0
+    case oneHundredTenPercent = 1.10
+    case oneHundredTwentyFivePercent = 1.25
+    case oneHundredFiftyPercent = 1.5
+    case oneHundredSeventyFivePercent = 1.75
+    case twoHundred = 2.0
+
+    /// Returns the next higher zoom level based on the given current zoom level.
+    /// If the current level is at or above the upper zoom limit (`ZoomConstants.upperZoomLimit`),
+    /// it will return the same level without change.
+    /// 
+    /// - Parameter level: The current zoom level as a `CGFloat`.
+    /// - Returns: The next zoom level as a `CGFloat`, or the current level if already at the maximum limit.
+    static func getNewZoomInLevel(for level: CGFloat) -> CGFloat {
+        let zoomLevels = self.allCases
+
+        guard let currentLevel = zoomLevels.first(where: { $0.rawValue == level }),
+              let currentIndex = zoomLevels.firstIndex(of: currentLevel),
+              level < ZoomConstants.upperZoomLimit else { return level }
+
+        return zoomLevels[currentIndex + 1].rawValue
+    }
+
+    /// Returns the next lower zoom level based on the given current zoom level.
+    /// If the current level is at or below the lower zoom limit (`ZoomConstants.lowerZoomLimit`),
+    /// it will return the same level without change.
+    ///
+    /// - Parameter level: The current zoom level as a `CGFloat`.
+    /// - Returns: The previous zoom level as a `CGFloat`, or the current level if already at the minimum limit.
+    static func getNewZoomOutLevel(for level: CGFloat) -> CGFloat {
+        let zoomLevels = self.allCases
+
+        guard let currentLevel = zoomLevels.first(where: { $0.rawValue == level }),
+              let currentIndex = zoomLevels.firstIndex(of: currentLevel),
+              level > ZoomConstants.lowerZoomLimit else { return level }
+
+        return zoomLevels[currentIndex - 1].rawValue
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -10,7 +10,6 @@ import Shared
 
 protocol ZoomPageBarDelegate: AnyObject {
     func zoomPageDidPressClose()
-    func didChangeZoomLevel()
 }
 
 final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
@@ -40,7 +39,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     private var stepperCompactConstraints = [NSLayoutConstraint]()
     private var stepperDefaultConstraints = [NSLayoutConstraint]()
     private var gradientViewHeightConstraint = NSLayoutConstraint()
-    private let tab: Tab
+    private let zoomManager: ZoomPageManager
 
     // MARK: - UI Elements
 
@@ -97,8 +96,8 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
 
     // MARK: - Initializers
 
-    init(tab: Tab) {
-        self.tab = tab
+    init(zoomManager: ZoomPageManager) {
+        self.zoomManager = zoomManager
         super.init(frame: .zero)
 
         setupViews()
@@ -122,8 +121,9 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         gestureRecognizer.addTarget(self, action: #selector(didPressReset))
         zoomLevel.addGestureRecognizer(gestureRecognizer)
 
-        updateZoomLabel()
-        checkPageZoomLimits()
+        let zoomValue = zoomManager.getZoomValue()
+        updateZoomLabel(zoomValue: zoomValue)
+        updateZoomButtonEnabled(zoomValue: zoomValue)
 
         [zoomOutButton, leftSeparator, zoomLevel, rightSeparator, zoomInButton].forEach {
             stepperContainer.addArrangedSubview($0)
@@ -213,25 +213,17 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         gradient.frame = gradientView.bounds
     }
 
-    func updateZoomLabel() {
-        zoomLevel.text = NumberFormatter.localizedString(from: NSNumber(value: tab.pageZoom), number: .percent)
-        zoomLevel.isEnabled = tab.pageZoom == 1.0 ? false : true
-        gestureRecognizer.isEnabled = !(tab.pageZoom == 1.0)
+    func updateZoomLabel(zoomValue: CGFloat) {
+        zoomLevel.text = NumberFormatter.localizedString(from: NSNumber(value: zoomValue), number: .percent)
+        zoomLevel.isEnabled = zoomValue == ZoomConstants.defaultZoomLimit ? false : true
+        gestureRecognizer.isEnabled = !(zoomValue == ZoomConstants.defaultZoomLimit)
         zoomLevel.accessibilityLabel = String(format: .LegacyAppMenu.ZoomPageCurrentZoomLevelAccessibilityLabel,
                                               zoomLevel.text ?? "")
     }
 
-    private func enableZoomButtons() {
-        zoomInButton.isEnabled = true
-        zoomOutButton.isEnabled = true
-    }
-
-    private func checkPageZoomLimits() {
-        if tab.pageZoom <= ZoomConstants.lowerZoomLimit {
-            zoomOutButton.isEnabled = false
-        } else if tab.pageZoom >= ZoomConstants.upperZoomLimit {
-            zoomInButton.isEnabled = false
-        } else { enableZoomButtons() }
+    private func updateZoomButtonEnabled(zoomValue: CGFloat) {
+        zoomInButton.isEnabled = zoomValue < ZoomConstants.upperZoomLimit
+        zoomOutButton.isEnabled = zoomValue > ZoomConstants.lowerZoomLimit
     }
 
     private func updateStepperConstraintsBasedOnSizeClass() {
@@ -255,33 +247,24 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
 
     @objc
     private func didPressZoomIn(_ sender: UIButton) {
-        tab.zoomIn()
-        updateZoomLabel()
-        delegate?.didChangeZoomLevel()
-        zoomOutButton.isEnabled = true
-        if tab.pageZoom >= ZoomConstants.upperZoomLimit {
-            zoomInButton.isEnabled = false
-        }
+        let zoomValue = zoomManager.zoomIn()
+        updateZoomLabel(zoomValue: zoomValue)
+        updateZoomButtonEnabled(zoomValue: zoomValue)
     }
 
     @objc
     private func didPressZoomOut(_ sender: UIButton) {
-        tab.zoomOut()
-        updateZoomLabel()
-        delegate?.didChangeZoomLevel()
-        zoomInButton.isEnabled = true
-        if tab.pageZoom <= ZoomConstants.lowerZoomLimit {
-            zoomOutButton.isEnabled = false
-        }
+        let zoomValue = zoomManager.zoomOut()
+        updateZoomLabel(zoomValue: zoomValue)
+        updateZoomButtonEnabled(zoomValue: zoomValue)
     }
 
     @objc
     private func didPressReset(_ recognizer: UITapGestureRecognizer) {
         if recognizer.state == .ended {
-            tab.resetZoom()
-            updateZoomLabel()
-            delegate?.didChangeZoomLevel()
-            enableZoomButtons()
+            zoomManager.resetZoom()
+            updateZoomLabel(zoomValue: ZoomConstants.defaultZoomLimit)
+            updateZoomButtonEnabled(zoomValue: ZoomConstants.defaultZoomLimit)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -121,7 +121,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         gestureRecognizer.addTarget(self, action: #selector(didPressReset))
         zoomLevel.addGestureRecognizer(gestureRecognizer)
 
-        let zoomValue = zoomManager.getZoomValue()
+        let zoomValue = zoomManager.getZoomLevel()
         updateZoomLabel(zoomValue: zoomValue)
         updateZoomButtonEnabled(zoomValue: zoomValue)
 

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -60,7 +60,6 @@ class ZoomPageManager: TabEventHandler {
         }
     }
 
-    // Check if guard is returning the proper thing
     func zoomOut() -> CGFloat {
         guard let tab = tab,
               let host = tab.url?.host,
@@ -89,7 +88,9 @@ class ZoomPageManager: TabEventHandler {
         }
     }
 
-    /// shouldSave: Only false when entering Reader mode where zoom reset is neccessary but we don't persist the value
+    /// Reset zoom level for a given host and saves new value
+    /// - Parameters:
+    ///   - shouldSave: Only false when entering reader mode where zoom resets but we don't persist the value
     func resetZoom(shouldSave: Bool = true) {
         guard let tab, let host = tab.url?.host else { return }
 

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -73,8 +73,6 @@ class ZoomPageManager: TabEventHandler {
     // Regular step is 0.25 except for the cases close to regular zoom
     // where we provide smaller step
     private func getNewZoomOutValue(value: CGFloat) -> CGFloat {
-        guard value > ZoomConstants.lowerZoomLimit else { return value}
-
         switch value {
         case 0.9:
             return 0.75
@@ -92,6 +90,37 @@ class ZoomPageManager: TabEventHandler {
     func resetZoom() {
         tab?.pageZoom = ZoomConstants.defaultZoomLimit
     }
+
+    func updatePageZoom() {
+        guard let tab,
+              let host = tab.url?.host,
+              let domainZoomLevel = ZoomLevelStore.shared.findZoomLevel(forDomain: host) else { return }
+
+        tab.pageZoom = domainZoomLevel.zoomLevel
+    }
+
+    func setZoomAfterLeavingReaderMode() {
+        guard let host = decodeReaderModeHost(),
+              let domainZoomLevel = ZoomLevelStore.shared.findZoomLevel(forDomain: host)
+        else { return }
+
+        tab?.pageZoom = domainZoomLevel.zoomLevel
+    }
+
+    private func decodeReaderModeHost() -> String? {
+        guard let tab,
+              tab.readerModeAvailableOrActive,
+              let host = tab.url?.decodeReaderModeURL?.host else { return nil }
+        return host
+    }
+
+    func updatePageZoomFromOtherWindow(zoomLevel: CGFloat) {
+        print("YRD --- update zoom level for window \(windowUUID) level \(zoomLevel)")
+
+        tab?.pageZoom = zoomLevel
+    }
+
+    // MARK: - Store level
 
     /// Saves the zoom level for a given host and notifies other windows of the change
     /// - Parameters:

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -33,58 +33,22 @@ class ZoomPageManager: TabEventHandler {
 
     func zoomIn() -> CGFloat {
         guard let tab = tab,
-              let host = tab.url?.host,
-              tab.pageZoom < ZoomConstants.upperZoomLimit else { return ZoomConstants.upperZoomLimit}
+              let host = tab.url?.host else { return ZoomConstants.defaultZoomLimit}
 
-        let newZoom = getNewZoomInLevel(level: tab.pageZoom)
+        let newZoom = ZoomLevel.getNewZoomInLevel(for: tab.pageZoom)
         tab.pageZoom = newZoom
         saveZoomLevel(for: host, zoomLevel: newZoom)
         return newZoom
-    }
-
-    // Regular step is 0.25 except for the cases close to regular zoom
-    // where we provide smaller step
-    private func getNewZoomInLevel(level: CGFloat) -> CGFloat {
-        switch level {
-        case 0.75:
-            return 0.9
-        case 0.9:
-            return 1.0
-        case 1.0:
-            return 1.10
-        case 1.10:
-            return 1.25
-        default:
-            return level + 0.25
-        }
     }
 
     func zoomOut() -> CGFloat {
         guard let tab = tab,
-              let host = tab.url?.host,
-              tab.pageZoom > ZoomConstants.lowerZoomLimit else { return ZoomConstants.lowerZoomLimit}
+              let host = tab.url?.host else { return ZoomConstants.defaultZoomLimit}
 
-        let newZoom = getNewZoomOutLevel(level: tab.pageZoom)
+        let newZoom = ZoomLevel.getNewZoomOutLevel(for: tab.pageZoom)
         tab.pageZoom = newZoom
         saveZoomLevel(for: host, zoomLevel: newZoom)
         return newZoom
-    }
-
-    // Regular step is 0.25 except for the cases close to regular zoom
-    // where we provide smaller step
-    private func getNewZoomOutLevel(level: CGFloat) -> CGFloat {
-        switch level {
-        case 0.9:
-            return 0.75
-        case 1.0:
-            return 0.9
-        case 1.10:
-            return 1.0
-        case 1.25:
-            return 1.10
-        default:
-            return level - 0.25
-        }
     }
 
     /// Reset zoom level for a given host and saves new value

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -22,7 +22,7 @@ class ZoomPageManager: TabEventHandler {
          zoomStore: ZoomLevelStorage = ZoomLevelStore.shared) {
         self.windowUUID = windowUUID
         self.zoomStore = zoomStore
-        register(self, forTabEvents: .didGainFocus)
+        register(self, forTabEvents: .didGainFocus, .didChangeURL)
     }
 
     func getZoomLevel() -> CGFloat {
@@ -115,6 +115,14 @@ class ZoomPageManager: TabEventHandler {
 
     func tabDidGainFocus(_ tab: Tab) {
         self.tab = tab
+        if tab.pageZoom != getZoomLevel() {
+            updatePageZoom()
+        }
+    }
+
+    func tab(_ tab: Tab, didChangeURL url: URL) {
+        guard tab == self.tab else { return }
+
         if tab.pageZoom != getZoomLevel() {
             updatePageZoom()
         }

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -25,19 +25,18 @@ class ZoomPageManager: TabEventHandler {
         register(self, forTabEvents: .didGainFocus)
     }
 
-    func getZoomValue() -> CGFloat {
+    func getZoomLevel() -> CGFloat {
         guard let tab else { return ZoomConstants.defaultZoomLimit}
 
         return getZoomLevel(for: tab.url?.host)
     }
 
-    // Check if guard is returning the proper thing
     func zoomIn() -> CGFloat {
         guard let tab = tab,
               let host = tab.url?.host,
               tab.pageZoom < ZoomConstants.upperZoomLimit else { return ZoomConstants.upperZoomLimit}
 
-        let newZoom = getNewZoomInValue(value: tab.pageZoom)
+        let newZoom = getNewZoomInLevel(level: tab.pageZoom)
         tab.pageZoom = newZoom
         saveZoomLevel(for: host, zoomLevel: newZoom)
         return newZoom
@@ -45,8 +44,8 @@ class ZoomPageManager: TabEventHandler {
 
     // Regular step is 0.25 except for the cases close to regular zoom
     // where we provide smaller step
-    private func getNewZoomInValue(value: CGFloat) -> CGFloat {
-        switch value {
+    private func getNewZoomInLevel(level: CGFloat) -> CGFloat {
+        switch level {
         case 0.75:
             return 0.9
         case 0.9:
@@ -56,7 +55,7 @@ class ZoomPageManager: TabEventHandler {
         case 1.10:
             return 1.25
         default:
-            return value + 0.25
+            return level + 0.25
         }
     }
 
@@ -65,7 +64,7 @@ class ZoomPageManager: TabEventHandler {
               let host = tab.url?.host,
               tab.pageZoom > ZoomConstants.lowerZoomLimit else { return ZoomConstants.lowerZoomLimit}
 
-        let newZoom = getNewZoomOutValue(value: tab.pageZoom)
+        let newZoom = getNewZoomOutLevel(level: tab.pageZoom)
         tab.pageZoom = newZoom
         saveZoomLevel(for: host, zoomLevel: newZoom)
         return newZoom
@@ -73,8 +72,8 @@ class ZoomPageManager: TabEventHandler {
 
     // Regular step is 0.25 except for the cases close to regular zoom
     // where we provide smaller step
-    private func getNewZoomOutValue(value: CGFloat) -> CGFloat {
-        switch value {
+    private func getNewZoomOutLevel(level: CGFloat) -> CGFloat {
+        switch level {
         case 0.9:
             return 0.75
         case 1.0:
@@ -84,7 +83,7 @@ class ZoomPageManager: TabEventHandler {
         case 1.25:
             return 1.10
         default:
-            return value - 0.25
+            return level - 0.25
         }
     }
 
@@ -105,7 +104,7 @@ class ZoomPageManager: TabEventHandler {
     }
 
     func updateZoomChangedInOtherWindow() {
-        tab?.pageZoom = getZoomValue()
+        tab?.pageZoom = getZoomLevel()
     }
 
     func setZoomAfterLeavingReaderMode() {
@@ -152,7 +151,7 @@ class ZoomPageManager: TabEventHandler {
 
     func tabDidGainFocus(_ tab: Tab) {
         self.tab = tab
-        if tab.pageZoom != getZoomValue() {
+        if tab.pageZoom != getZoomLevel() {
             updatePageZoom()
         }
     }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -403,7 +403,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         return false
     }
 
-    fileprivate(set) var pageZoom: CGFloat = 1.0 {
+    var pageZoom: CGFloat = 1.0 {
         didSet {
             webView?.setValue(pageZoom, forKey: "viewScale")
         }
@@ -432,7 +432,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     }
 
     var profile: Profile
-    var zoomPageManager: ZoomPageManager
 
     /// Returns true if this tab is considered inactive (has not been executed for more than a specific number of days).
     /// Note: When `FasterInactiveTabsOverride` is enabled, tabs become inactive very quickly for testing purposes.
@@ -480,7 +479,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         self.lastExecutedTime = tabCreatedTime.toTimestamp()
         self.firstCreatedTime = tabCreatedTime.toTimestamp()
         self.logger = logger
-        self.zoomPageManager = ZoomPageManager(windowUUID: windowUUID)
         super.init()
         self.isPrivate = isPrivate
 
@@ -880,28 +878,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         }
 
         return .none
-    }
-
-    // MARK: - Zoom
-
-    @objc
-    func zoomIn() {
-        let newValue = zoomPageManager.zoomIn(value: pageZoom)
-        pageZoom = newValue
-    }
-
-    @objc
-    func zoomOut() {
-        let newValue = zoomPageManager.zoomOut(value: pageZoom)
-        pageZoom = newValue
-    }
-
-    func resetZoom() {
-        pageZoom = 1.0
-    }
-
-    func setZoomLevelforDomain() {
-        pageZoom = zoomPageManager.setZoomLevelforDomain(for: url?.host)
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -924,7 +924,6 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
         if let tab = selectedTab {
             TabEvent.post(.didGainFocus, for: tab)
-            tab.setZoomLevelforDomain()
         }
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .tab)
 

--- a/firefox-ios/Storage/ZoomLevelStore.swift
+++ b/firefox-ios/Storage/ZoomLevelStore.swift
@@ -15,7 +15,12 @@ public struct DomainZoomLevel: Codable, Equatable {
     }
 }
 
-public class ZoomLevelStore {
+public protocol ZoomLevelStorage {
+    func save(_ domainZoomLevel: DomainZoomLevel, completion: (() -> Void)?)
+    func findZoomLevel(forDomain host: String) -> DomainZoomLevel?
+}
+
+public class ZoomLevelStore: ZoomLevelStorage {
     public static let shared = ZoomLevelStore()
 
     private(set) var domainZoomLevels = [DomainZoomLevel]()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockZoomStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockZoomStore.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Storage
+
+final class MockZoomStore: ZoomLevelStorage {
+    var store = [DomainZoomLevel]()
+    var saveCalledCount = 0
+    var findZoomLevelCalledCount = 0
+
+    func save(_ domainZoomLevel: DomainZoomLevel, completion: (() -> Void)?) {
+        saveCalledCount += 1
+        store.append(domainZoomLevel)
+    }
+
+    func findZoomLevel(forDomain host: String) -> DomainZoomLevel? {
+        findZoomLevelCalledCount += 1
+        return store.first { $0.host == host }
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ZoomPageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ZoomPageManagerTests.swift
@@ -1,0 +1,145 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Storage
+import XCTest
+
+@testable import Client
+
+class ZoomPageManagerTests: XCTestCase {
+    private var profile: MockProfile!
+    private var zoomStore: MockZoomStore!
+    private let windowUUID: WindowUUID = .XCTestDefaultUUID
+
+    override func setUp() {
+        super.setUp()
+        self.profile = MockProfile()
+        self.zoomStore = MockZoomStore()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        self.profile = nil
+        self.zoomStore = nil
+    }
+
+    func testTabNil_AfterInit() {
+        let subject = createSubject()
+        XCTAssertNil(subject.tab)
+    }
+
+    func testTabNotNil_WhenTabGainFocus() {
+        let subject = createSubject()
+        let tab = createTab()
+        subject.tabDidGainFocus(tab)
+
+        XCTAssertNotNil(subject.tab)
+    }
+
+    func testTabZoomChange_WhenZoomInIsCalled() {
+        let subject = createSubject()
+        let tab = createTab()
+        subject.tabDidGainFocus(tab)
+        let newZoom = subject.zoomIn()
+        let expectedZoom = 1.1
+
+        XCTAssertEqual(newZoom, expectedZoom)
+        XCTAssertEqual(tab.pageZoom, expectedZoom)
+    }
+
+    func testTabZoomChange_WhenZoomOutIsCalled() {
+        let subject = createSubject()
+        let tab = createTab()
+        subject.tabDidGainFocus(tab)
+        let newZoom = subject.zoomOut()
+        let expectedZoom = 0.9
+
+        XCTAssertEqual(newZoom, expectedZoom)
+        XCTAssertEqual(tab.pageZoom, expectedZoom)
+    }
+
+    func testTabZoomReset_WhenResetZoomIsCalled() {
+        let subject = createSubject()
+        let tab = createTab()
+        subject.tabDidGainFocus(tab)
+        let newZoom = subject.zoomOut()
+        let expectedZoom = 0.9
+
+        XCTAssertEqual(newZoom, expectedZoom)
+        XCTAssertEqual(tab.pageZoom, expectedZoom)
+    }
+
+    func testTabZoomDoesntChange_WhenZoomInIsCalledForUpperLimit() {
+        let subject = createSubject()
+        let domainZoomLevel = DomainZoomLevel(host: "www.website.com",
+                                              zoomLevel: ZoomConstants.upperZoomLimit)
+        zoomStore.save(domainZoomLevel, completion: nil)
+        let tab = createTab()
+        subject.tabDidGainFocus(tab)
+        let newZoom = subject.zoomIn()
+        let expectedZoom = ZoomConstants.upperZoomLimit
+
+        XCTAssertEqual(newZoom, expectedZoom)
+        XCTAssertEqual(tab.pageZoom, expectedZoom)
+    }
+
+    func testTabZoomDoesntChange_WhenZoomOutIsCalledForLowerLimit() {
+        let subject = createSubject()
+        let domainZoomLevel = DomainZoomLevel(host: "www.website.com",
+                                              zoomLevel: ZoomConstants.lowerZoomLimit)
+        zoomStore.save(domainZoomLevel, completion: nil)
+        let tab = createTab()
+        subject.tabDidGainFocus(tab)
+        let newZoom = subject.zoomOut()
+        let expectedZoom = ZoomConstants.lowerZoomLimit
+
+        XCTAssertEqual(newZoom, expectedZoom)
+        XCTAssertEqual(tab.pageZoom, expectedZoom)
+    }
+
+    func testZoomStoreSaved_WhenZoomInIsCalled() {
+        let subject = createSubject()
+        let tab = createTab()
+        subject.tabDidGainFocus(tab)
+        _ = subject.zoomIn()
+
+        XCTAssertEqual(zoomStore.saveCalledCount, 1)
+    }
+
+    func testZoomStoreSavedWhenZoomResetIsCalled() {
+        let subject = createSubject()
+        let tab = createTab()
+        subject.tabDidGainFocus(tab)
+        subject.resetZoom()
+
+        XCTAssertEqual(zoomStore.saveCalledCount, 1)
+    }
+
+    func testFindZoomStore_WhenZoomInIsCalled() {
+        let subject = createSubject()
+        let tab = createTab()
+        subject.tabDidGainFocus(tab)
+
+        // When the tab is set we check if there is zoom level and set it
+        XCTAssertEqual(zoomStore.findZoomLevelCalledCount, 1)
+    }
+
+    // MARK: - Private
+    private func createSubject() -> ZoomPageManager {
+        let subject = ZoomPageManager(windowUUID: .XCTestDefaultUUID,
+                                      zoomStore: zoomStore)
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+
+    func createTab() -> Tab {
+        let tab = Tab(profile: profile, windowUUID: windowUUID)
+
+        guard let url = URL(string: "http://www.website.com") else { return tab }
+
+        tab.url = url
+        return tab
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ZoomPageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ZoomPageManagerTests.swift
@@ -64,10 +64,9 @@ class ZoomPageManagerTests: XCTestCase {
         let subject = createSubject()
         let tab = createTab()
         subject.tabDidGainFocus(tab)
-        let newZoom = subject.zoomOut()
-        let expectedZoom = 0.9
+        subject.resetZoom()
+        let expectedZoom = ZoomConstants.defaultZoomLimit
 
-        XCTAssertEqual(newZoom, expectedZoom)
         XCTAssertEqual(tab.pageZoom, expectedZoom)
     }
 
@@ -108,7 +107,7 @@ class ZoomPageManagerTests: XCTestCase {
         XCTAssertEqual(zoomStore.saveCalledCount, 1)
     }
 
-    func testZoomStoreSavedWhenZoomResetIsCalled() {
+    func testZoomStoreSaved_WhenZoomResetIsCalled() {
         let subject = createSubject()
         let tab = createTab()
         subject.tabDidGainFocus(tab)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12008)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26132)

## :bulb: Description
- Remove `Tab` from `ZoomPageBar`
- Remove zoom logic from BrowserViewController and Tab related to saving and loading zoom levels
- Fixes bugs related to reader mode
- `ZoomPageManager` holds a Tab reference and updates zoom based on user action. Save and load zoom levels into the storage
- Add unit test

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

