### PR TITLE
Bugfix FXIOS-1066/FXIOS-10767 [Accessibility] Prevent toast voiceover announcements from being interrupted

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
@@ -73,7 +73,16 @@ struct SimpleToast: ThemeApplicable {
         animate(containerView)
 
         if UIAccessibility.isVoiceOverRunning {
-            UIAccessibility.post(notification: .announcement, argument: text)
+            let announcementString = NSMutableAttributedString(string: text)
+
+            // FXIOS-10766/10767 Prevents toast messages from being interrupted
+            if #available(iOS 17, *) {
+                let fullRange = NSRange(location: 0, length: announcementString.length)
+                announcementString.addAttribute(NSAttributedString.Key.accessibilitySpeechAnnouncementPriority,
+                                                value: UIAccessibilityPriority.high.rawValue,
+                                                range: fullRange)
+            }
+            UIAccessibility.post(notification: .announcement, argument: announcementString)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
- Prevents toast notification voiceover announcements from being interrupted by a switch in focus.

### 📝 Notes
- This is accomplished by using an `AttributedString` type and setting the `accessibilitySpeechAnnouncementPriority` attribute to `high`, making it uninterruptible. The [accessibilitySpeechAnnouncementPriority API](https://developer.apple.com/documentation/foundation/attributescopes/accessibilityattributes/accessibilityspeechannouncementpriority) is iOS 17+ 

### 🎥 Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/048160ec-f42e-40c7-aaa0-67d0d0ab5ab7

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/1fcd287a-03a9-4d74-a870-f1c13cefe7fb

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

