### PR TITLE
Bugfix MTE-4457 Enable Firefox_Unit_Tests to be shown on Bitrise insights

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1624,7 +1624,7 @@ workflows:
     steps:
     - cache-pull@2.7.2:
         is_always_run: true
-    - xcode-test@6.0.0:
+    - xcode-test@6.0.1:
         inputs:
         - project_path: firefox-ios/Client.xcodeproj
         - scheme: Fennec

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1629,11 +1629,13 @@ workflows:
     - cache-pull@2.7.2:
         is_always_run: true
     - xcode-test@6.0.1:
+        timeout: 3000
         inputs:
         - project_path: firefox-ios/Client.xcodeproj
         - scheme: Fennec
         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.2
         - test_plan: UnitTest
+        - maximum_test_repetitions: 20
     - deploy-to-bitrise-io@2.10.0: {}
   #
   # *****%*****%***** FOCUS WORKFLOWS *****%*****%*****

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2155,9 +2155,9 @@ app:
     BITRISE_DESTINATION: 'platform=iOS Simulator,name=Bitrise iOS default,OS=latest'
 
 
-pipeline_build_and_testtrigger_map:
+pipeline_build_and_test:
 - push_branch: main
-  pipeline: 
+  pipeline: pipeline_build_and_test
 - push_branch: epic-branch/*
   pipeline: pipeline_build_and_test
 - push_branch: release/*

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1635,6 +1635,7 @@ workflows:
         - scheme: Fennec
         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.2
         - test_plan: UnitTest
+        - test_repetition_mode: until_failure
         - maximum_test_repetitions: 20
     - deploy-to-bitrise-io@2.10.0: {}
   #

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1621,6 +1621,10 @@ workflows:
             python3 perfTestTransform.py
 
   Firefox_Unit_Tests:
+    before_run:
+    - 1_git_clone_and_post_clone
+    - 2_certificate_and_profile
+    - 3_provisioning_and_npm_installation
     steps:
     - cache-pull@2.7.2:
         is_always_run: true

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1626,8 +1626,6 @@ workflows:
     - 2_certificate_and_profile
     - 3_provisioning_and_npm_installation
     steps:
-    - cache-pull@2.7.2:
-        is_always_run: true
     - xcode-test@6.0.1:
         timeout: 3000
         inputs:
@@ -1636,7 +1634,7 @@ workflows:
         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.2
         - test_plan: UnitTest
         - test_repetition_mode: until_failure
-        - maximum_test_repetitions: 20
+        - maximum_test_repetitions: 10
     - deploy-to-bitrise-io@2.10.0: {}
   #
   # *****%*****%***** FOCUS WORKFLOWS *****%*****%*****

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1634,30 +1634,6 @@ workflows:
         - scheme: Fennec
         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.2
         - test_plan: UnitTest
-    - script@1.2.1:
-        is_always_run: true
-        title: Create perfherder data object
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            # debug log
-            set -x
-            # get dependency
-            cd ./test-fixtures && git clone https://github.com/clarmso/xcresult_extract.git
-
-            echo $BITRISE_XCRESULT_PATH
-            ls
-            ls $BITRISE_XCRESULT_PATH
-
-            cp -r $BITRISE_XCRESULT_PATH /Users/vagrant/Library/Developer/Xcode/DerivedData/**/Logs/Test/
-            echo "DerivedData/Client/Log/Tests"
-            ls /Users/vagrant/Library/Developer/Xcode/DerivedData
-            CLIENT_PATH=$(ls /Users/vagrant/Library/Developer/Xcode/DerivedData | grep 'Client-')
-            mv /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test/Test-Fennec.xcresult /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test/Test-Fennec-test.xcresult
-
-            ls /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test
     - deploy-to-bitrise-io@2.10.0: {}
   #
   # *****%*****%***** FOCUS WORKFLOWS *****%*****%*****
@@ -2155,7 +2131,7 @@ app:
     BITRISE_DESTINATION: 'platform=iOS Simulator,name=Bitrise iOS default,OS=latest'
 
 
-pipeline_build_and_test:
+trigger_map:
 - push_branch: main
   pipeline: pipeline_build_and_test
 - push_branch: epic-branch/*

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1627,7 +1627,6 @@ workflows:
     - xcode-test@6.0.0:
         inputs:
         - project_path: firefox-ios/Client.xcodeproj
-        - config: Fennec_Testing
         - scheme: Fennec
         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.2
         - test_plan: UnitTest

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1621,64 +1621,49 @@ workflows:
             python3 perfTestTransform.py
 
   Firefox_Unit_Tests:
-    before_run:
-    - 1_git_clone_and_post_clone
-    - 2_certificate_and_profile
-    - 3_provisioning_and_npm_installation
     steps:
-    - activate-ssh-key@4:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - restore-spm-cache@1:
+    - cache-pull@2.7.2:
         is_always_run: true
-    - script@1.1:
-        title: Build for Testing
+    - xcode-test@6.0.0:
         inputs:
-        - content: |
-            set -euxo pipefail
-            echo "-- build-for-testing --"
-            mkdir DerivedData
-
-            xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
-            xcodebuild "-project" "/Users/vagrant/git/firefox-ios/Client.xcodeproj" "-scheme" "Fennec" -configuration "Fennec_Testing" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 16,OS=18.2" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_fennec.log
-
-            ls /Users/vagrant/git/DerivedData/Build/Products
-            ls /Users/vagrant/git/DerivedData
-    - xcode-test-without-building@0:
-        timeout: 2400
-        inputs:
+        - project_path: firefox-ios/Client.xcodeproj
+        - config: Fennec_Testing
+        - scheme: Fennec
         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.2
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData"'
-        - xctestrun: "/Users/vagrant/git/DerivedData/Build/Products/Fennec_UnitTest_iphonesimulator18.2-arm64.xctestrun"
-        - test_repetition_mode: until_failure
-        - maximum_test_repetitions: 10
+        - test_plan: UnitTest
     - script@1.2.1:
-        title: Compress Derived Data
         is_always_run: true
+        title: Create perfherder data object
         inputs:
-        - content: |
-            set -euxo pipefail
-            ls /Users/vagrant/git/DerivedData
-            ls /Users/vagrant/git/DerivedData/Build/Products
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+            # get dependency
+            cd ./test-fixtures && git clone https://github.com/clarmso/xcresult_extract.git
 
-            echo "-- compress --"
-            # Add Fennec-iphonesimulator folder
-            # Add All .xctestrun files
-            # Add firefox-ios-test files and test plans
+            echo $BITRISE_XCRESULT_PATH
+            ls
+            ls $BITRISE_XCRESULT_PATH
 
-            exec zip -0 -qr "${BITRISE_SOURCE_DIR}/DerivedData.zip" \
-            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/" \
-            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Fennec-iphonesimulator/" \
-            "$BITRISE_SOURCE_DIR/firefox-ios/Client.xcodeproj" \
-            "$BITRISE_SOURCE_DIR/firefox-ios/firefox-ios-tests/" \
-            "$BITRISE_SOURCE_DIR/firefox-ios/Client/" \
-            "$BITRISE_SOURCE_DIR/xcodebuild.log"
-    - deploy-to-bitrise-io@2.10.0:
-        inputs:
-        - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"
-        - pipeline_intermediate_files: |-
-            $BITRISE_XCRESULT_PATH:BITRISE_XCRESULT_PATH
-            ${BITRISE_SOURCE_DIR}/DerivedData.zip:DERIVED_DATA_DIR
-        is_always_run: true
+            cp -r $BITRISE_XCRESULT_PATH /Users/vagrant/Library/Developer/Xcode/DerivedData/**/Logs/Test/
+            echo "DerivedData/Client/Log/Tests"
+            ls /Users/vagrant/Library/Developer/Xcode/DerivedData
+            CLIENT_PATH=$(ls /Users/vagrant/Library/Developer/Xcode/DerivedData | grep 'Client-')
+            mv /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test/Test-Fennec.xcresult /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test/Test-Fennec-test.xcresult
+
+            ls /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test
+
+            xcrun xcresulttool graph --path $BITRISE_XCRESULT_PATH --legacy
+            ls ..
+            python3 xcresult_extract/xcresult_extract.py -project ../Client.xcodeproj -scheme Fennec
+            cat data.txt
+            sed 's/.*=//;s/'\''/"/g' data.txt > test.json
+            cat test.json
+            python3 perfTestTransform.py
+    - deploy-to-bitrise-io@2.10.0: {}
   #
   # *****%*****%***** FOCUS WORKFLOWS *****%*****%*****
   # 
@@ -2175,9 +2160,9 @@ app:
     BITRISE_DESTINATION: 'platform=iOS Simulator,name=Bitrise iOS default,OS=latest'
 
 
-trigger_map:
+pipeline_build_and_testtrigger_map:
 - push_branch: main
-  pipeline: pipeline_build_and_test
+  pipeline: 
 - push_branch: epic-branch/*
   pipeline: pipeline_build_and_test
 - push_branch: release/*

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1658,14 +1658,6 @@ workflows:
             mv /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test/Test-Fennec.xcresult /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test/Test-Fennec-test.xcresult
 
             ls /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test
-
-            xcrun xcresulttool graph --path $BITRISE_XCRESULT_PATH --legacy
-            ls ..
-            python3 xcresult_extract/xcresult_extract.py -project ../Client.xcodeproj -scheme Fennec
-            cat data.txt
-            sed 's/.*=//;s/'\''/"/g' data.txt > test.json
-            cat test.json
-            python3 perfTestTransform.py
     - deploy-to-bitrise-io@2.10.0: {}
   #
   # *****%*****%***** FOCUS WORKFLOWS *****%*****%*****


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4457)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

The result of Firefox_Unit_Tests workflow is be shown on Bitrise Insights. I resolve the issue by the following:
* Use xcode-test step to run the unit tests so that all environment variables for reporting are set.
* Insert `deploy-to-bitrise-io`.
* Remove `Compress Derived Data`.
* Copy `before_run` and `cache-pull` from `Bitrise_Performance_Test` which has been reporting to insights successfully.

Bitrise workflow: https://app.bitrise.io/build/b76eb14a-2305-499e-9ead-8c42f26f3a3d
Test Reports: 
Bitrise insights: https://app.bitrise.io/insights/095364a9afb324b2/explore/tests?interval=daily&duration=P30D&tab=failure_rate&app_slug=6c06d3a40422d10f&workflow=Firefox_Unit_Tests

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

