### PR TITLE
Bugfix FXIOS-12045 Enable testOpenTabsInSearchSuggestions

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -290,7 +290,6 @@ class SearchTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2306989
     // Smoketest
     // [FXIOS-12045] Currently failing on multiple PRs; needs investigation.
-    /*
     func testOpenTabsInSearchSuggestions() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Test fails intermittently for iOS 15")
@@ -309,7 +308,6 @@ class SearchTests: BaseTestCase {
         waitForTabsButton()
         validateSearchSuggestionText(typeText: "localhost")
     }
-     */
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306886
     // SmokeTest

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -34,7 +34,7 @@ class SearchTests: BaseTestCase {
         typeOnSearchBar(text: typeText)
 
         // In the search suggestion, "text" should be displayed
-        let predicate = NSPredicate(format: "label CONTAINS[c] %@", "http://localhost:")
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", "localhost")
         let elementQuery = app.staticTexts.containing(predicate)
         mozWaitForElementToExist(elementQuery.element)
     }
@@ -289,7 +289,6 @@ class SearchTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306989
     // Smoketest
-    // [FXIOS-12045] Currently failing on multiple PRs; needs investigation.
     func testOpenTabsInSearchSuggestions() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Test fails intermittently for iOS 15")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12045)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26237)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

`testOpenTabsInSearchSuggestions()` is re-enabled. The label for the search suggestions now does not require "https://".

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

