### PR TITLE
Refactor FXIOS-12052 [Unit Test] flaky top sites middleware tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
@@ -16,6 +16,8 @@ final class MockTopSitesManager: TopSitesManagerInterface {
     var pinTopSiteCalledCount = 0
     var unpinTopSiteCalledCount = 0
 
+    private let lock = NSLock()
+
     func getOtherSites() async -> [TopSiteConfiguration] {
         getOtherSitesCalledCount += 1
         return createSites(count: 15, subtitle: ": otherSites")
@@ -29,6 +31,11 @@ final class MockTopSitesManager: TopSitesManagerInterface {
     }
 
     func recalculateTopSites(otherSites: [TopSiteConfiguration], sponsoredSites: [Site]) -> [TopSiteConfiguration] {
+        // We add this lock because while it is okay for production code to not happen synchronously,
+        // we need a way to mock and confirm that this method has been called three times.
+        // Without the lock then we two threads simultaneously setting `recalculateTopSitesCalledCount` to 1.
+        lock.lock()
+        defer { lock.unlock() }
         recalculateTopSitesCalledCount += 1
         return createSites(subtitle: ": total top sites")
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12052)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26249)

## :bulb: Description
Address flaky tests related to top sites middleware. The issue here is how we created our mock and we needed to add a lock. There are other ways to address this, but decide to go with the lock because its the most straightforward, happy to discuss on alternatives.

The actual production code makes 2 calls to `recalculateTopSites` that operate on different threads. We are okay with this because there is eventually a third call that takes the more up to date value after those threads finish completion. Meanwhile, the mock was following the production code in calling the method on separate threads, causing a race condition and to write to `recalculateTopSites` at the same time.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

