### PR TITLE
Refactor FXIOS-11845 [Tab tray UI experiment] Add blur on the tab close button

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -17,7 +17,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         static let subviewDefaultPadding: CGFloat = 6.0
         static let faviconSize = CGSize(width: 16, height: 16)
         static let fallbackFaviconSize = CGSize(width: 24, height: 24)
-        static let closeButtonSize: CGFloat = 32
+        static let closeButtonSize: CGFloat = 24
         static let textBoxHeight: CGFloat = 32
         static let closeButtonEdgeInset = NSDirectionalEdgeInsets(top: 12,
                                                                   leading: 12,
@@ -25,7 +25,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
                                                                   trailing: 12)
         static let closeButtonTop: CGFloat = 6
         static let closeButtonTrailing: CGFloat = 8
-        static let closeButtonOverlaySpacing: CGFloat = 16
+        static let closeButtonOverlaySpacing: CGFloat = 6
         static let tabViewFooterSpacing: CGFloat = 4
         static let shadowRadius: CGFloat = 4
         static let shadowOffset = CGSize(width: 0, height: 2)
@@ -83,13 +83,9 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     }
 
     private lazy var closeButton: UIButton = .build { button in
-        button.setImage(UIImage.templateImageNamed(ImageIdentifiers.badgeMask), for: [])
-        button.imageView?.contentMode = .scaleAspectFit
-        button.contentMode = .center
         var configuration = UIButton.Configuration.plain()
         configuration.contentInsets = UX.closeButtonEdgeInset
         button.configuration = configuration
-        button.alpha = 0.5
     }
 
     private lazy var closeButtonOverlay: UIImageView = .build { imageView in
@@ -106,6 +102,9 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             roundedRect: self.backgroundHolder.bounds,
             cornerRadius: self.backgroundHolder.layer.cornerRadius
         ).cgPath
+
+        closeButton.addBlurEffectWithClearBackgroundAndClipping(using: .systemUltraThinMaterialDark)
+        closeButton.layer.cornerRadius = closeButton.frame.height / 2
     }
 
     // MARK: - Initializer
@@ -137,6 +136,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) not yet supported") }
 
     // MARK: - Configuration
+
     func configure(with tabModel: TabModel, theme: Theme?, delegate: TabCellDelegate, a11yId: String) {
         self.tabModel = tabModel
         self.delegate = delegate
@@ -185,8 +185,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
 
     func applyTheme(theme: Theme) {
         backgroundHolder.backgroundColor = theme.colors.layer1
-        closeButton.tintColor = theme.colors.iconPrimary
-        closeButtonOverlay.tintColor = theme.colors.textInverted
+        closeButtonOverlay.tintColor = theme.colors.textOnDark
         titleText.textColor = theme.colors.textPrimary
         screenshotView.backgroundColor = theme.colors.layer1
         favicon.tintColor = theme.colors.textPrimary
@@ -265,6 +264,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         layer.shadowPath = nil
         layer.shadowOpacity = 0
         isHidden = false
+        closeButton.removeVisualEffectView()
     }
 
     // MARK: - Auto Layout


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11845)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25817)

## :bulb: Description
This PR is for the weekly release v138.1. It will improve the look of the X button in the tab tray UI experiment using a blur on the button background.

### 🎥 Screenshots
<details>
<summary>Light mode</summary>

![systemUltraThinMaterialDark - light mode](https://github.com/user-attachments/assets/972b8f18-40f8-4953-b467-6071b87b7040)


</details>

<details>
<summary>Dark mode</summary>

![systemUltraThinMaterialDark - dark mode](https://github.com/user-attachments/assets/7300d141-4158-462b-b0f1-bd58ee108209)

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

