### PR TITLE
Refactor FXIOS-11837 [Unit Test] Resolve fetchTopSitesAction tests

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
@@ -52,6 +52,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
     private let searchEnginesManager: SearchEnginesManagerProvider
     private let unifiedAdsProvider: UnifiedAdsProviderInterface
     private let dispatchQueue: DispatchQueueInterface
+    private let notification: NotificationProtocol
 
     private let maxTopSites: Int
     private let maxNumberOfSponsoredTile = 2
@@ -65,6 +66,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
         searchEnginesManager: SearchEnginesManagerProvider,
         logger: Logger = DefaultLogger.shared,
         dispatchQueue: DispatchQueueInterface = DispatchQueue.main,
+        notification: NotificationProtocol = NotificationCenter.default,
         maxTopSites: Int = 4 * 14 // Max rows * max tiles on the largest screen plus some padding
     ) {
         self.profile = profile
@@ -75,6 +77,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
         self.searchEnginesManager = searchEnginesManager
         self.logger = logger
         self.dispatchQueue = dispatchQueue
+        self.notification = notification
         self.maxTopSites = maxTopSites
     }
 
@@ -247,7 +250,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
         // We make sure to remove all history for URL so it doesn't show anymore in the
         // top sites, this is the approach that Android takes too.
         profile.places.deleteVisitsFor(url: site.url).uponQueue(.main) { [weak self] _ in
-            NotificationCenter.default.post(name: .TopSitesUpdated, object: self)
+            self?.notification.post(name: .TopSitesUpdated, withObject: self)
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
@@ -415,6 +415,7 @@ final class TopSitesManagerTests: XCTestCase {
             topSiteHistoryManager: topSiteHistoryManager,
             searchEnginesManager: searchEngineManager,
             dispatchQueue: mockQueue,
+            notification: MockNotificationCenter(),
             maxTopSites: maxCount
         )
         trackForMemoryLeaks(subject, file: file, line: line)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11837)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25800)

## :bulb: Description
Address issue with tests failing due to notification post causing other tests to fail. We should try to avoid using the concrete notification our unit tests. Basically the top sites manager test were impacting the middleware tests, because a notification was posted and then it was observed in the later tests. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

