### PR TITLE
 Bugfix FXIOS-11833 #25796 ⁃ User report: cookies unavailable after updating to iOS 18.4

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -202,10 +202,13 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
 
         // Use shared pool for regular mode, isolated pool for private mode
-        configuration.processPool = isPrivate ? WKProcessPool() : defaultProcessPool
-        configuration.websiteDataStore = isPrivate
-                ? WKWebsiteDataStore.nonPersistent()
-                : WKWebsiteDataStore.default()
+        if isPrivate {
+            configuration.processPool = WKProcessPool()
+            configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        } else {
+            configuration.processPool = defaultProcessPool
+            configuration.websiteDataStore = WKWebsiteDataStore.default()
+        }
 
         configuration.setURLSchemeHandler(InternalSchemeHandler(), forURLScheme: InternalURL.scheme)
         return configuration


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11833)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25796)

## :bulb: Description
Use shared pool for regular mode to lower the risk of losing cookies
Apple documentation [WKProcessPool](https://developer.apple.com/documentation/webkit/wkprocesspool)

```If your app creates multiple web views, assign the same [WKProcessPool](https://developer.apple.com/documentation/webkit/wkprocesspool) object to web views that may safely share a process space. Instantiate an instance of this class and assign it to the [processPool](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/processpool) property of each web view’s [WKWebViewConfiguration](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration) object.```

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

