### PR TITLE
Bugfix FXIOS-11967 [Tab Tray UI Experiment] tabs count

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -32,7 +32,7 @@ final class TabTraySelectorView: UIView,
     var items: [String] = [] {
         didSet {
             collectionView.reloadData()
-            scrollToItem(at: selectedIndex, animated: false)
+            scrollToCenter()
         }
     }
 
@@ -99,9 +99,11 @@ final class TabTraySelectorView: UIView,
     }
 
     // MARK: - Public Methods
-    func scrollToItem(at index: Int, animated: Bool) {
-        let indexPath = IndexPath(item: index, section: 0)
-        collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: animated)
+    func scrollToCenter() {
+        // Force it to always be centered on the center item,
+        // temporary until this component is replaced with a simpler one
+        let indexPath = IndexPath(item: 1, section: 0)
+        collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
     }
 
     // MARK: - UICollectionViewDataSource
@@ -131,7 +133,7 @@ final class TabTraySelectorView: UIView,
         guard selectedIndex != newIndex else { return }
         selectedIndex = newIndex
         collectionView.reloadData()
-        scrollToItem(at: selectedIndex, animated: true)
+        scrollToCenter()
 
         var panelType: TabTrayPanelType = .tabs
         if selectedIndex == 0 {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -289,6 +289,10 @@ class TabTrayViewController: UIViewController,
             || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {
             updateLayout()
         }
+
+        if isTabTrayUIExperimentsEnabled {
+            experimentSegmentControl.scrollToCenter()
+        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -488,7 +492,7 @@ class TabTrayViewController: UIViewController,
         var toolbarItems: [UIBarButtonItem]
         if isTabTrayUIExperimentsEnabled {
             toolbarItems = isSyncTabsPanel ? experimentBottomToolbarItemsForSync : experimentBottomToolbarItems
-            experimentSegmentControl.scrollToItem(at: experimentConvertSelectedIndex(), animated: false)
+            experimentSegmentControl.scrollToCenter()
         } else {
             toolbarItems = isSyncTabsPanel ? bottomToolbarItemsForSync : bottomToolbarItems
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -291,7 +291,10 @@ class TabTrayViewController: UIViewController,
         }
 
         if isTabTrayUIExperimentsEnabled {
-            experimentSegmentControl.scrollToCenter()
+            // Needs to execute the layout pass after the orientation has changed
+            DispatchQueue.main.async {
+                self.experimentSegmentControl.scrollToCenter()
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -112,7 +112,7 @@ class TabTrayViewController: UIViewController,
                                            theme: themeManager.getCurrentTheme(for: windowUUID))
         selector.delegate = self
         selector.items = [TabTrayPanelType.privateTabs.label,
-                          TabTrayPanelType.tabs.label,
+                          "0 \(TabTrayPanelType.tabs.label)",
                           TabTrayPanelType.syncedTabs.label]
 
         didSelectSection(panelType: tabTrayState.selectedPanel)
@@ -378,6 +378,9 @@ class TabTrayViewController: UIViewController,
         countLabel.text = count
         segmentedControl.setImage(TabTrayPanelType.tabs.image!.overlayWith(image: countLabel),
                                   forSegmentAt: 0)
+        if isTabTrayUIExperimentsEnabled {
+            experimentSegmentControl.items[1] = "\(count) \(TabTrayPanelType.tabs.label)"
+        }
     }
 
     // MARK: Themeable


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-26042)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/11967)

## :bulb: Description
Add count to tabs label.
Pin the selectors to the center. Temporary fix for the weekly release. Will be removing the collection view in a follow up PR.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

