### PR TITLE
Refactor FXIOS-25005 [Homepage] relocate notification observers to middleware

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -56,7 +56,7 @@ class RemoteTabsPanelMiddleware {
     private func resolveHomepageActions(action: Action, state: AppState) {
         switch action.actionType {
         case HomepageActionType.viewWillAppear,
-            JumpBackInActionType.fetchRemoteTabs,
+            HomepageMiddlewareActionType.jumpBackInRemoteTabsUpdated,
             TabTrayActionType.dismissTabTray,
             TopTabsActionType.didTapNewTab,
             TopTabsActionType.didTapCloseTab:

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -909,7 +909,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     private func resolveHomepageActions(with action: Action) {
         switch action.actionType {
         case HomepageActionType.viewWillAppear,
-            JumpBackInActionType.fetchLocalTabs,
+            HomepageMiddlewareActionType.jumpBackInLocalTabsUpdated,
             TopTabsActionType.didTapNewTab,
             TopTabsActionType.didTapCloseTab:
             dispatchRecentlyAccessedTabs(action: action)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksAction.swift
@@ -22,7 +22,6 @@ final class BookmarksAction: Action {
 }
 
 enum BookmarksActionType: ActionType {
-    case fetchBookmarks
     case toggleShowSectionSetting
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksMiddleware.swift
@@ -18,7 +18,7 @@ final class BookmarksMiddleware {
         let windowUUID = action.windowUUID
 
         switch action.actionType {
-        case HomepageActionType.initialize, BookmarksActionType.fetchBookmarks:
+        case HomepageActionType.initialize, HomepageMiddlewareActionType.bookmarksUpdated:
             self.handleInitializeBookmarksAction(windowUUID: windowUUID)
         default:
            break

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -14,7 +14,6 @@ final class HomepageViewController: UIViewController,
                                     FeatureFlaggable,
                                     ContentContainable,
                                     Themeable,
-                                    Notifiable,
                                     StoreSubscriber {
     // MARK: - Typealiases
     typealias SubscriberStateType = HomepageState
@@ -110,17 +109,6 @@ final class HomepageViewController: UIViewController,
 
         homepageState = HomepageState(windowUUID: windowUUID)
         super.init(nibName: nil, bundle: nil)
-
-        setupNotifications(forObserver: self, observing: [
-            UIApplication.didBecomeActiveNotification,
-            .FirefoxAccountChanged,
-            .PrivateDataClearedHistory,
-            .ProfileDidFinishSyncing,
-            .TopSitesUpdated,
-            .DefaultSearchEngineUpdated,
-            .BookmarksUpdated,
-            .RustPlacesOpened
-        ])
 
         subscribeToRedux()
     }
@@ -996,57 +984,5 @@ final class HomepageViewController: UIViewController,
         traitCollection: UITraitCollection
     ) -> UIModalPresentationStyle {
         .none
-    }
-
-    // MARK: - Notifiable
-    func handleNotifications(_ notification: Notification) {
-        switch notification.name {
-        case UIApplication.willEnterForegroundNotification:
-            store.dispatch(
-                PocketAction(
-                    windowUUID: self.windowUUID,
-                    actionType: PocketActionType.enteredForeground
-                )
-            )
-        case .PrivateDataClearedHistory,
-                .TopSitesUpdated,
-                .DefaultSearchEngineUpdated:
-            dispatchActionToFetchTopSites()
-        case .BookmarksUpdated, .RustPlacesOpened:
-            store.dispatch(
-                BookmarksAction(
-                    windowUUID: self.windowUUID,
-                    actionType: BookmarksActionType.fetchBookmarks
-                )
-            )
-        case .ProfileDidFinishSyncing, .FirefoxAccountChanged:
-            dispatchActionToFetchTopSites()
-            dispatchActionToFetchTabs()
-        default: break
-        }
-    }
-
-    private func dispatchActionToFetchTopSites() {
-        store.dispatch(
-            TopSitesAction(
-                windowUUID: self.windowUUID,
-                actionType: TopSitesActionType.fetchTopSites
-            )
-        )
-    }
-
-    private func dispatchActionToFetchTabs() {
-        store.dispatch(
-            JumpBackInAction(
-                windowUUID: self.windowUUID,
-                actionType: JumpBackInActionType.fetchLocalTabs
-            )
-        )
-        store.dispatch(
-            JumpBackInAction(
-                windowUUID: self.windowUUID,
-                actionType: JumpBackInActionType.fetchRemoteTabs
-            )
-        )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInAction.swift
@@ -22,8 +22,6 @@ final class JumpBackInAction: Action {
 }
 
 enum JumpBackInActionType: ActionType {
-    case fetchLocalTabs
-    case fetchRemoteTabs
     case tapOnCell
     case toggleShowSectionSetting
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketAction.swift
@@ -31,7 +31,6 @@ final class PocketAction: Action {
 }
 
 enum PocketActionType: ActionType {
-    case enteredForeground
     case toggleShowSectionSetting
     case tapOnHomepagePocketCell
     case viewedSection

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketMiddleware.swift
@@ -23,7 +23,7 @@ final class PocketMiddleware {
     lazy var pocketSectionProvider: Middleware<AppState> = { state, action in
         switch action.actionType {
         case HomepageActionType.initialize,
-            PocketActionType.enteredForeground:
+            HomepageMiddlewareActionType.enteredForeground:
             self.getPocketDataAndUpdateState(for: action)
         case PocketActionType.tapOnHomepagePocketCell:
             self.sendOpenPocketItemTelemetry(for: action)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -44,3 +44,11 @@ enum HomepageActionType: ActionType {
     case embeddedHomepage
     case sectionSeen
 }
+
+enum HomepageMiddlewareActionType: ActionType {
+    case topSitesUpdated
+    case jumpBackInLocalTabsUpdated
+    case jumpBackInRemoteTabsUpdated
+    case bookmarksUpdated
+    case enteredForeground
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesAction.swift
@@ -34,7 +34,6 @@ final class TopSitesAction: Action {
 }
 
 enum TopSitesActionType: ActionType {
-    case fetchTopSites
     case updatedNumberOfRows
     case toggleShowSectionSetting
     case toggleShowSponsoredSettings

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -49,17 +49,13 @@ final class TopSitesMiddleware: FeatureFlaggable {
 
     lazy var topSitesProvider: Middleware<AppState> = { state, action in
         switch action.actionType {
-        case HomepageActionType.initialize:
+        case HomepageActionType.initialize,
+            HomepageMiddlewareActionType.topSitesUpdated,
+            TopSitesActionType.toggleShowSponsoredSettings:
             self.getTopSitesDataAndUpdateState(for: action)
 
         case TopSitesActionType.topSitesSeen:
             self.handleSponsoredImpressionTracking(for: action)
-
-        case TopSitesActionType.fetchTopSites:
-            self.getTopSitesDataAndUpdateState(for: action)
-
-        case TopSitesActionType.toggleShowSponsoredSettings:
-            self.getTopSitesDataAndUpdateState(for: action)
 
         case TopSitesActionType.tapOnHomepageTopSitesCell:
             self.handleOpenTopSitesItemTelemetry(for: action)

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -78,7 +78,7 @@ let middlewares = [
     NativeErrorPageMiddleware().nativeErrorPageProvider,
     WallpaperMiddleware().wallpaperProvider,
     BookmarksMiddleware().bookmarksProvider,
-    HomepageMiddleware().homepageProvider
+    HomepageMiddleware(notificationCenter: NotificationCenter.default).homepageProvider
 ]
 
 // In order for us to mock and test the middlewares easier,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -138,10 +138,10 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         subject.tabManager(tabManager, didSelectedTabChange: testTab, previousTab: testTab, isRestoring: false)
         wait(for: [expectation])
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions[2] as? GeneralBrowserAction)
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions[3] as? GeneralBrowserAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? GeneralBrowserActionType)
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 5)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 6)
         XCTAssertEqual(actionType, GeneralBrowserActionType.didSelectedTabChangeToHomepage)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -47,31 +47,13 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         let sut = createSubject()
 
         XCTAssertEqual(mockThemeManager?.getCurrentThemeCallCount, 0)
-        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 8)
-        XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
-                                                           .FirefoxAccountChanged,
-                                                           .PrivateDataClearedHistory,
-                                                           .ProfileDidFinishSyncing,
-                                                           .TopSitesUpdated,
-                                                           .DefaultSearchEngineUpdated,
-                                                           .BookmarksUpdated,
-                                                           .RustPlacesOpened
-        ])
+        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 0)
 
         sut.loadViewIfNeeded()
 
         XCTAssertEqual(mockThemeManager?.getCurrentThemeCallCount, 1)
-        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 9)
-        XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
-                                                           .FirefoxAccountChanged,
-                                                           .PrivateDataClearedHistory,
-                                                           .ProfileDidFinishSyncing,
-                                                           .TopSitesUpdated,
-                                                           .DefaultSearchEngineUpdated,
-                                                           .BookmarksUpdated,
-                                                           .RustPlacesOpened,
-                                                           .ThemeDidChange
-        ])
+        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 1)
+        XCTAssertEqual(mockNotificationCenter?.observers, [.ThemeDidChange])
     }
 
     // MARK: - Deinit State

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/BookmarksMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/BookmarksMiddlewareTests.swift
@@ -46,6 +46,30 @@ final class BookmarksMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
     }
 
+    func test_homepageMiddlewareAction_getBookmarksData() throws {
+        let subject = createSubject()
+
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageMiddlewareActionType.bookmarksUpdated
+        )
+        let expectation = XCTestExpectation(description: "Homepage action initialize dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.bookmarksProvider(AppState(), action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? BookmarksAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? BookmarksMiddlewareActionType)
+
+        XCTAssertEqual(actionType, BookmarksMiddlewareActionType.initialize)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+    }
+
     // MARK: - Helpers
     private func createSubject() -> BookmarksMiddleware {
         return BookmarksMiddleware(profile: mockProfile)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
@@ -11,10 +11,12 @@ import XCTest
 final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockGleanWrapper: MockGleanWrapper!
     var mockStore: MockStoreForMiddleware<AppState>!
+    var mockNotificationCenter: MockNotificationCenter!
 
     override func setUp() {
         super.setUp()
         mockGleanWrapper = MockGleanWrapper()
+        mockNotificationCenter = MockNotificationCenter()
         DependencyHelperMock().bootstrapDependencies()
         setupStore()
     }
@@ -22,8 +24,24 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
     override func tearDown() {
         DependencyHelperMock().reset()
         mockGleanWrapper = nil
+        mockNotificationCenter = nil
         resetStore()
         super.tearDown()
+    }
+
+    func test_init_setsUpNotifications() {
+        _ = createSubject()
+
+        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 8)
+        XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
+                                                           .FirefoxAccountChanged,
+                                                           .PrivateDataClearedHistory,
+                                                           .ProfileDidFinishSyncing,
+                                                           .TopSitesUpdated,
+                                                           .DefaultSearchEngineUpdated,
+                                                           .BookmarksUpdated,
+                                                           .RustPlacesOpened
+        ])
     }
 
     func test_viewWillAppearAction_sendsTelemetryData() throws {
@@ -217,7 +235,8 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         return HomepageMiddleware(
             homepageTelemetry: HomepageTelemetry(
                 gleanWrapper: mockGleanWrapper
-            )
+            ),
+            notificationCenter: mockNotificationCenter
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
@@ -51,7 +51,10 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
 
     func test_enterForegroundAction_getPocketData() throws {
         let subject = createSubject(pocketManager: pocketManager)
-        let action = PocketAction(windowUUID: .XCTestDefaultUUID, actionType: PocketActionType.enteredForeground)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageMiddlewareActionType.enteredForeground
+        )
 
         let expectation = XCTestExpectation(description: "Pocket action entered foreground dispatched")
         mockStore.dispatchCalled = {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
@@ -117,9 +117,9 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
     func test_fetchTopSitesAction_returnsTopSitesSection() throws {
         let subject = createSubject(topSitesManager: mockTopSitesManager)
-        let action = TopSitesAction(
+        let action = HomepageAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: TopSitesActionType.fetchTopSites
+            actionType: HomepageMiddlewareActionType.topSitesUpdated
         )
 
         let expectation = XCTestExpectation(description: "All top sites middleware actions are dispatched")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
@@ -11,14 +11,17 @@ import XCTest
 final class TopSitesManagerTests: XCTestCase {
     private var profile: MockProfile?
     private var dispatchQueue: MockDispatchQueue?
+    private var mockNotificationCenter: MockNotificationCenter?
     override func setUp() {
         super.setUp()
         profile = MockProfile()
         dispatchQueue = MockDispatchQueue()
+        mockNotificationCenter = MockNotificationCenter()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
     }
 
     override func tearDown() {
+        mockNotificationCenter = nil
         dispatchQueue = nil
         profile = nil
         super.tearDown()
@@ -415,7 +418,7 @@ final class TopSitesManagerTests: XCTestCase {
             topSiteHistoryManager: topSiteHistoryManager,
             searchEnginesManager: searchEngineManager,
             dispatchQueue: mockQueue,
-            notification: MockNotificationCenter(),
+            notification: try XCTUnwrap(mockNotificationCenter),
             maxTopSites: maxCount
         )
         trackForMemoryLeaks(subject, file: file, line: line)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabsMiddlewareTests.swift
@@ -27,11 +27,11 @@ final class RemoteTabsMiddlewareTests: XCTestCase, StoreTestUtility {
         super.tearDown()
     }
 
-    func test_jumpBackInAction_returnsMostRecentTab() throws {
+    func test_homepageMiddlewareAction_returnsMostRecentTab() throws {
         let subject = createSubject()
-        let action = JumpBackInAction(
+        let action = HomepageAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: JumpBackInActionType.fetchRemoteTabs
+            actionType: HomepageMiddlewareActionType.jumpBackInRemoteTabsUpdated
         )
 
         let expectation = XCTestExpectation(description: "Most recent tab should be returned")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -86,11 +86,11 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
     }
 
-    func test_jumpBackInAction_returnsRecentTabs() throws {
+    func test_homepageAction_returnsRecentTabs() throws {
         let subject = createSubject()
         let action = JumpBackInAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: JumpBackInActionType.fetchLocalTabs
+            actionType: HomepageMiddlewareActionType.jumpBackInLocalTabsUpdated
         )
 
         let expectation = XCTestExpectation(description: "Recent tabs should be returned")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11491)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25005)

## :bulb: Description
Move observing notifications and dispatching actions to `HomepageMiddleware` instead of `HomepageViewController`. Replace old actions with new actions in `HomepageMiddlewareActionType`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

