### PR TITLE
Add FXIOS-12085 [App Icon 2025] Add new localization strings for hand-drawn app icon alternatives

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2238,7 +2238,7 @@ extension String {
                 key: "Settings.AppIconSelection.AppIconNames.ContributorCredit.Subtitle.v139",
                 tableName: "AppIconSelection",
                 value: "Created by %@",
-                comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the subtitle shown on alternative app icons added by contributors which credit them for their design work. The parameter specifies the creator's name, @ handle, or other personal identifier.")
+                comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the subtitle shown on alternative app icons added by contributors which credit them for their design work. The parameter %@ specifies the creator's name, @ handle, or other personal identifier.")
 
             public struct Errors {
                 public static let SelectErrorMessage = MZLocalizedString(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2234,6 +2234,12 @@ extension String {
                 value: "App Icon",
                 comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the title displayed at the top of the screen.")
 
+            public static let ContributorCreditSubtitle = MZLocalizedString(
+                key: "Settings.AppIconSelection.AppIconNames.ContributorCredit.Subtitle.v139",
+                tableName: "AppIconSelection",
+                value: "Created by %@",
+                comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the subtitle shown on alternative app icons added by contributors which credit them for their design work. The parameter specifies the creator's name, @ handle, or other personal identifier.")
+
             public struct Errors {
                 public static let SelectErrorMessage = MZLocalizedString(
                     key: "Settings.AppIconSelection.Errors.SelectErrorMessage.v136",
@@ -2255,6 +2261,24 @@ extension String {
                     value: "Default",
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the default Firefox for iOS icon.")
 
+                public static let Light = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Light.Title.v139",
+                    tableName: "AppIconSelection",
+                    value: "Light",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox for iOS icon with a white background.")
+
+                public static let Dark = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Dark.Title.v139",
+                    tableName: "AppIconSelection",
+                    value: "Dark",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox for iOS icon with a black background.")
+
+                public static let SystemAuto = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.SystemAuto.Title.v139",
+                    tableName: "AppIconSelection",
+                    value: "System Auto",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox for iOS icon which automatically adjusts the white/black background according to the iOS system light/dark themes.")
+
                 public static let DarkPurple = MZLocalizedString(
                     key: "Settings.AppIconSelection.AppIconNames.DarkPurple.Title.v136",
                     tableName: "AppIconSelection",
@@ -2266,6 +2290,12 @@ extension String {
                     tableName: "AppIconSelection",
                     value: "Blue",
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox icon with a blue background.")
+
+                public static let Cute = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Cute.Title.v139",
+                    tableName: "AppIconSelection",
+                    value: "Cute",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a cute cartoony fox artwork app icon.")
 
                 public static let Cyan = MZLocalizedString(
                     key: "Settings.AppIconSelection.AppIconNames.Cyan.Title.v137",
@@ -2290,6 +2320,12 @@ extension String {
                     tableName: "AppIconSelection",
                     value: "Lazy",
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the artsy Firefox for iOS icon of a funny fox lying on top of a globe.")
+
+                public static let Minimal = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Minimal.Title.v139",
+                    tableName: "AppIconSelection",
+                    value: "Minimal",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a minimal version of the Firefox for iOS app icon which flattens and simplifies the default icon.")
 
                 public static let Orange = MZLocalizedString(
                     key: "Settings.AppIconSelection.AppIconNames.Orange.Title.v137",
@@ -2327,11 +2363,17 @@ extension String {
                     value: "Red",
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox icon with a red background.")
 
-                public static let Retro = MZLocalizedString(
-                    key: "Settings.AppIconSelection.AppIconNames.Retro.Title.v136",
+                public static let Retro2004 = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Retro2004.Title.v139",
                     tableName: "AppIconSelection",
-                    value: "Retro",
-                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a retro version of the regular Firefox for iOS app icon.")
+                    value: "Retro 2004",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a retro version of the regular Firefox for iOS app icon which was default in the year 2004.")
+
+                public static let Retro2017 = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Retro2017.Title.v139",
+                    tableName: "AppIconSelection",
+                    value: "Retro 2017",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a retro version of the regular Firefox for iOS app icon which was default in the year 2017.")
 
                 public static let Yellow = MZLocalizedString(
                     key: "Settings.AppIconSelection.AppIconNames.Yellow.Title.v137",
@@ -2386,6 +2428,15 @@ extension String {
                     tableName: "AppIconSelection",
                     value: "Northern Lights",
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox for iOS app icon with a background gradient of black fading to blue fading to green.")
+
+                /// Names and subtitles for approved icons added by contributors.
+                struct ContributorIconNames {
+                    public static let Momo = MZLocalizedString(
+                        key: "Settings.AppIconSelection.AppIconNames.Momo.Title.v139",
+                        tableName: "AppIconSelection",
+                        value: "Momo",
+                        comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a hand-drawn version of the Firefox for iOS app icon of a cartoony fox resting on a globe.")
+                }
             }
 
             public struct Accessibility {

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2235,7 +2235,7 @@ extension String {
                 comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the title displayed at the top of the screen.")
 
             public static let ContributorCreditSubtitle = MZLocalizedString(
-                key: "Settings.AppIconSelection.AppIconNames.ContributorCredit.Subtitle.v139",
+                key: "Settings.AppIconSelection.ContributorCredit.Subtitle.v139",
                 tableName: "AppIconSelection",
                 value: "Created by %@",
                 comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the subtitle shown on alternative app icons added by contributors which credit them for their design work. The parameter %@ specifies the creator's name, @ handle, or other personal identifier.")
@@ -2430,9 +2430,9 @@ extension String {
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox for iOS app icon with a background gradient of black fading to blue fading to green.")
 
                 /// Names and subtitles for approved icons added by contributors.
-                struct ContributorIconNames {
+                struct FromContributors {
                     public static let Momo = MZLocalizedString(
-                        key: "Settings.AppIconSelection.AppIconNames.Momo.Title.v139",
+                        key: "Settings.AppIconSelection.AppIconNames.FromContributors.Momo.Title.v139",
                         tableName: "AppIconSelection",
                         value: "Momo",
                         comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a hand-drawn version of the Firefox for iOS app icon of a cartoony fox resting on a globe.")

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2240,6 +2240,33 @@ extension String {
                 value: "Created by %@",
                 comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the subtitle shown on alternative app icons added by contributors which credit them for their design work. The parameter %@ specifies the creator's name, @ handle, or other personal identifier.")
 
+            /// Names for the groupings of app icons on the App Icon Selection screen
+            public struct SectionNames {
+                public static let Basics = MZLocalizedString(
+                    key: "Settings.AppIconSelection.SectionNames.Basics.Title.v139",
+                    tableName: "AppIconSelection",
+                    value: "Basics",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the section heading shown for the basic variants of the app icon like the default, white, black, and legacy options.")
+
+                public static let Colors = MZLocalizedString(
+                    key: "Settings.AppIconSelection.SectionNames.Colors.Title.v139",
+                    tableName: "AppIconSelection",
+                    value: "Colors",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the section heading shown for the solid color background variants of the app icon, all of which apply different colored backgrounds (like blue, pink, or orange) to the regular app icon.")
+
+                public static let Gradients = MZLocalizedString(
+                    key: "Settings.AppIconSelection.SectionNames.Gradients.Title.v139",
+                    tableName: "AppIconSelection",
+                    value: "Gradients",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the section heading shown for the gradient color background variants of the app icon, all of which apply different gradient color backgrounds (like blue fading to yellow or black fading to purple) to the regular app icon.")
+
+                public static let More = MZLocalizedString(
+                    key: "Settings.AppIconSelection.SectionNames.More.Title.v139",
+                    tableName: "AppIconSelection",
+                    value: "More",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the section heading shown for all other miscellaneous variants of the app icon (like hand drawn or retro versions).")
+            }
+
             public struct Errors {
                 public static let SelectErrorMessage = MZLocalizedString(
                     key: "Settings.AppIconSelection.Errors.SelectErrorMessage.v136",
@@ -2276,8 +2303,8 @@ extension String {
                 public static let SystemAuto = MZLocalizedString(
                     key: "Settings.AppIconSelection.AppIconNames.SystemAuto.Title.v139",
                     tableName: "AppIconSelection",
-                    value: "System Auto",
-                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox for iOS icon which automatically adjusts the white/black background according to the iOS system light/dark themes.")
+                    value: "System Theme",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox for iOS icon which automatically adjusts the white/black background according to the iOS 18+ system light/dark/tinted home screen themes.")
 
                 public static let DarkPurple = MZLocalizedString(
                     key: "Settings.AppIconSelection.AppIconNames.DarkPurple.Title.v136",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12085)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26302)

## :bulb: Description
Add new localization strings for hand-drawn app icon alternatives.

Final (maybe this time?) Icon Names:
<img width="525" alt="Screenshot 2025-04-25 at 11 57 21 AM" src="https://github.com/user-attachments/assets/e9afe0fc-c82a-48f9-aff9-1f2d6904c68a" />

**Special Note**: I was able to rename the preexisting "Retro" string since that icon is not currently present in the app, so the old string was never surfaced to the user yet.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

