### PR TITLE
Bugfix FXIOS-11447 ⁃ Unnecessary bar above the on-screen keyboard when activating an input field

### DIFF
--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -36,6 +36,10 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
     var savedLoginsClosure: (() -> Void)?
     var useStrongPasswordClosure: (() -> Void)?
 
+    var hasAccessoryView: Bool {
+        return currentAccessoryView != nil
+    }
+
     // MARK: - UI Elements
     private let toolbar: UIToolbar = .build {
         $0.sizeToFit()

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -1055,8 +1055,12 @@ extension Tab: TabWebViewDelegate {
 
     func tabWebViewShouldShowAccessoryView(_ tabWebView: TabWebView) -> Bool {
         // Hide the default WKWebView accessory view panel for PDF documents and
-        // there is no accessory view to display
-        return mimeType != MIMEType.PDF && tabWebView.accessoryView.hasAccessoryView
+        // there is no accessory view to display (but only for iPad cases)
+        let isPDF = mimeType == MIMEType.PDF
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            return !isPDF && tabWebView.accessoryView.hasAccessoryView
+        }
+        return !isPDF
     }
 }
 

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -1054,8 +1054,9 @@ extension Tab: TabWebViewDelegate {
     }
 
     func tabWebViewShouldShowAccessoryView(_ tabWebView: TabWebView) -> Bool {
-        // Hide the default WKWebView accessory view panel for PDF documents
-        return mimeType != MIMEType.PDF
+        // Hide the default WKWebView accessory view panel for PDF documents and
+        // there is no accessory view to display
+        return mimeType != MIMEType.PDF && tabWebView.accessoryView.hasAccessoryView
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11447)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24915)

## :bulb: Description
Don't display accessoryView when currentAccessoryView is nil

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

