### PR TITLE
Refactor FXIOS-11521 [Homepage] fix time out on jump back in tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
@@ -140,7 +140,11 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
     private func loadNewData(for subject: JumpBackInDataAdaptorImplementation) async {
         let delegate = MockJumpBackInDelegate()
         await subject.setDelegate(delegate: delegate)
-        await delegate.waitForNewData()
+        let expectation = XCTestExpectation(description: "Wait for didLoadNewData to be called")
+        delegate.didLoadNewDataHandler = {
+            expectation.fulfill()
+        }
+        await fulfillment(of: [expectation], timeout: 10.0)
     }
 
     private func createTab(profile: MockProfile, urlString: String? = "www.website.com") -> Tab {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockJumpBackInDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockJumpBackInDelegate.swift
@@ -6,18 +6,11 @@ import XCTest
 @testable import Client
 
 final class MockJumpBackInDelegate: JumpBackInDelegate {
-    private var continuation: CheckedContinuation<Void, Never>?
-    var didLoadNewDataCount = 0
+    var didLoadNewDataCalled = 0
+    var didLoadNewDataHandler: (() -> Void)?
 
     func didLoadNewData() {
-        didLoadNewDataCount += 1
-        continuation?.resume()
-        continuation = nil
-    }
-
-    func waitForNewData() async {
-        await withCheckedContinuation { continuation in
-            self.continuation = continuation
-        }
+        didLoadNewDataCalled += 1
+        didLoadNewDataHandler?()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11521)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25079)

## :bulb: Description
Refactor how we are waiting for loading data completion. The jump back adaptor implementation in general is not great to write isolated and testable code. So there may still be flaky tests (haven't dived too closely), but this should at least fix the issue of the tests being timing out instead of failing gracefully. Added an arbitrary 10 seconds for now. 

These tests should eventually be removed once we move over to the homepage rebuild project. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
