### PR TITLE
Add FXIOS-12044 [UI tests] Generic base test classes to add experiment data to launch arguments

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1086,6 +1086,8 @@
 		8AC8841D2D525F7B0033ABF5 /* CrashTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC8841C2D525EFF0033ABF5 /* CrashTracker.swift */; };
 		8AC8841F2D5261170033ABF5 /* MockCrashTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC8841E2D5261170033ABF5 /* MockCrashTracker.swift */; };
 		8AC884212D5262070033ABF5 /* CrashTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC884202D5261FC0033ABF5 /* CrashTrackerTests.swift */; };
+		8AC976C22DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC976C12DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift */; };
+		8AC976C32DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC976C12DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift */; };
 		8ACA8F74291987AE00D3075D /* AccountSyncHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */; };
 		8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */; };
 		8ACE9BFB2A54A010001E7A73 /* ExpandButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */; };
@@ -8328,6 +8330,7 @@
 		8AC8841C2D525EFF0033ABF5 /* CrashTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashTracker.swift; sourceTree = "<group>"; };
 		8AC8841E2D5261170033ABF5 /* MockCrashTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCrashTracker.swift; sourceTree = "<group>"; };
 		8AC884202D5261FC0033ABF5 /* CrashTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashTrackerTests.swift; sourceTree = "<group>"; };
+		8AC976C12DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlaggedTestBase.swift; sourceTree = "<group>"; };
 		8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSyncHandlerTests.swift; sourceTree = "<group>"; };
 		8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrottlerTests.swift; sourceTree = "<group>"; };
 		8ACD3B972BA8EA8300E73E9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -11340,6 +11343,7 @@
 		3BF4B8DA1D38493300493393 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				8AC976C12DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift */,
 				5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */,
 				3BF4B8E81D38497A00493393 /* BaseTestCase.swift */,
 				39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */,
@@ -16743,6 +16747,7 @@
 				E1AF27362A13BDFE00CE5991 /* EngagementNotificationTests.swift in Sources */,
 				78F28FC02CB81FDF00DA862E /* InactiveTabsTest.swift in Sources */,
 				2C473BD0209778900008C853 /* DownloadsTests.swift in Sources */,
+				8AC976C22DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift in Sources */,
 				39C261CC2018DE21009D97BD /* FxScreenGraphTests.swift in Sources */,
 				787EDD852943EE75002B93AE /* JumpBackInTests.swift in Sources */,
 				B15058812AA0A878008B7382 /* OpeningScreenTests.swift in Sources */,
@@ -16788,6 +16793,7 @@
 				E40AFC541DD0E93300DA5651 /* L10nPermissionStringsSnapshotTests.swift in Sources */,
 				E40AFC6C1DD128DA00DA5651 /* L10nSuite1SnapshotTests.swift in Sources */,
 				D437C4FD25FF5A3E00316F2C /* L10nMktSuiteSnapshotTests.swift in Sources */,
+				8AC976C32DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift in Sources */,
 				E40AFC651DD0F25500DA5651 /* L10nBaseSnapshotTests.swift in Sources */,
 				391B4FFF1F9767F50094F841 /* FxScreenGraph.swift in Sources */,
 				8A9F0B5727C59E1700FE09AE /* ImageIdentifiers.swift in Sources */,

--- a/firefox-ios/Client/Nimbus/TestData/reportSiteIssueOff.json
+++ b/firefox-ios/Client/Nimbus/TestData/reportSiteIssueOff.json
@@ -1,5 +1,5 @@
 {
-  "report-site-issue": {
-      "status": false
+    "report-site-issue": {
+        "status": false
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -80,6 +80,10 @@ class BaseTestCase: XCTestCase {
         userState = navigator.userState
     }
 
+    func setUpExperimentVariables() {
+        /// To be overriden to setup experiment variables for `FeatureFlaggedTestSuite`
+    }
+
     func setUpApp() {
         setUpLaunchArguments()
         if ProcessInfo.processInfo.environment["EXPERIMENT_NAME"] != nil {
@@ -100,6 +104,7 @@ class BaseTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
+        setUpExperimentVariables()
         setUpApp()
         setUpScreenGraph()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -80,9 +80,8 @@ class BaseTestCase: XCTestCase {
         userState = navigator.userState
     }
 
-    func setUpExperimentVariables() {
-        /// To be overriden to setup experiment variables for `FeatureFlaggedTestSuite`
-    }
+    /// To be overriden to setup experiment variables for `FeatureFlaggedTestSuite`
+    func setUpExperimentVariables() {}
 
     func setUpApp() {
         setUpLaunchArguments()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FeatureFlaggedTestBase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FeatureFlaggedTestBase.swift
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+
+/// Provides utilities to enable experiments and feature flags for specific test cases within a test class.
+///
+/// See also:
+/// https://github.com/mozilla-mobile/firefox-ios/wiki/Automated-UI-Tests#experiments--feature-flags
+class FeatureFlaggedTestBase: BaseTestCase {
+    override func setUpApp() {
+        // Important: `app.launch()` must be called explicitly in each test case.
+        setUpLaunchArguments()
+    }
+
+    /// Adds experiment data and feature flag information to the app's launch arguments.
+    ///
+    /// - Parameters:
+    ///   - jsonFileName: The name of the JSON file containing experiment configurations.
+    ///   - featureName: The feature name as defined in the Nimbus feature YAML file,
+    ///                  written in kebab-case under the `features:` section.
+    func addLaunchArgument(jsonFileName: String, featureName: String) {
+        var launchArgs = app.launchArguments
+        launchArgs.append("\(LaunchArguments.LoadExperiment)\(jsonFileName)")
+        launchArgs.append("\(LaunchArguments.ExperimentFeatureName)\(featureName)")
+        app.launchArguments = launchArgs
+    }
+}
+
+/// Provides utilities to enable experiments and feature flags for an entire test class.
+/// Use this when *all* tests in the class require the same experiment and feature flag.
+///
+/// See also:
+/// https://github.com/mozilla-mobile/firefox-ios/wiki/Automated-UI-Tests#experiments--feature-flags
+class FeatureFlaggedTestSuite: FeatureFlaggedTestBase {
+    /// Set these variables inside the `setUpExperimentVariables()` method.
+    var jsonFileName: String!
+    var featureName: String!
+
+    override func setUpApp() {
+        addLaunchArgument(jsonFileName: jsonFileName, featureName: featureName)
+        app.launch()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReportSiteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReportSiteTests.swift
@@ -6,11 +6,7 @@ import Common
 import XCTest
 import Shared
 
-class ReportSiteTests: BaseTestCase {
-    override func setUpApp() {
-        setUpLaunchArguments()
-    }
-
+class ReportSiteTests: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2831278
     func testReportSiteIssueOn() {
         launchAndGoToMenu()
@@ -19,9 +15,8 @@ class ReportSiteTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2831279
     func testReportSiteIssueOff() {
-        var launchArgs = app.launchArguments + ["\(LaunchArguments.LoadExperiment)reportSiteIssueOff"]
-        launchArgs = launchArgs + ["\(LaunchArguments.ExperimentFeatureName)general-app-features"]
-        app.launchArguments = launchArgs
+        addLaunchArgument(jsonFileName: "reportSiteIssueOff",
+                          featureName: "general-app-features")
 
         launchAndGoToMenu()
         mozWaitForElementToNotExist(app.tables.cells[AccessibilityIdentifiers.MainMenu.reportBrokenSite])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12044)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26235)

## :bulb: Description
This PR aims at providing a generic way to add experiment data to launch arguments. We already have a way to do so exemplified with `reportSiteIssue`, but this is trying to improve it a little bit. I then want to use those to reenable UI tests for the tab tray UI experiment.

If this is approved, I'll document the changes under [the proper documentation page](https://github.com/mozilla-mobile/firefox-ios/wiki/Automated-UI-Tests#experiments--feature-flags). 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
