### PR TITLE
Add FXIOS-11623 [UX Fundamentals] Nimbus flag for opening screen

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -83,6 +83,7 @@ public struct PrefsKeys {
         public static let InactiveTabs = "InactiveTabsUserPrefsKey"
         public static let SearchBarPosition = "SearchBarPositionUsersPrefsKey"
         public static let SentFromFirefox = "SentFromFirefoxUserPrefsKey"
+        public static let StartAtHome = "StartAtHomeUserPrefsKey"
     }
 
     public struct SearchSettings {

--- a/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
+++ b/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
@@ -87,12 +87,14 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
 
         switch featureID {
         case .searchBarPosition: return SearchBarPosition(rawValue: userSetting) as? T
+        case .startAtHome: return StartAtHome(rawValue: userSetting) as? T
         }
     }
 
     private func convertCustomIDToStandard(_ featureID: NimbusFeatureFlagWithCustomOptionsID) -> NimbusFeatureFlagID {
         switch featureID {
         case .searchBarPosition: return .bottomSearchBar
+        case .startAtHome: return .startAtHome
         }
     }
 
@@ -131,6 +133,10 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
         switch featureID {
         case .searchBarPosition:
             if let option = desiredState as? SearchBarPosition {
+                feature.setUserPreference(to: option.rawValue)
+            }
+        case .startAtHome:
+            if let option = desiredState as? StartAtHome {
                 feature.setUserPreference(to: option.rawValue)
             }
         }

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -38,6 +38,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case sentFromFirefox
     case sentFromFirefoxTreatmentA
     case splashScreen
+    case startAtHome
     case unifiedAds
     case unifiedSearch
     case tabAnimation
@@ -89,6 +90,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
 /// just an ON or OFF setting. These option must also be added to `NimbusFeatureFlagID`
 enum NimbusFeatureFlagWithCustomOptionsID {
     case searchBarPosition
+    case startAtHome
 }
 
 struct NimbusFlaggableFeature: HasNimbusSearchBar {
@@ -108,6 +110,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.InactiveTabs
         case .sentFromFirefox:
             return FlagKeys.SentFromFirefox
+        case .startAtHome:
+            return FlagKeys.StartAtHome
         // Cases where users do not have the option to manipulate a setting.
         case .appearanceMenu,
                 .addressBarMenu,
@@ -205,6 +209,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return nimbusSearchBar.getDefaultPosition().rawValue
         case .splashScreen:
             return nimbusSearchBar.getDefaultPosition().rawValue
+        case .startAtHome:
+            return FxNimbus.shared.features.startAtHomeFeature.value().setting.rawValue
         default: return nil
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -37,12 +37,10 @@ class StartAtHomeHelper: FeatureFlaggable {
 
     var startAtHomeSetting: StartAtHomeSetting {
         get {
-            if let prefs = prefs.stringForKey(PrefsKeys.UserFeatureFlagPrefs.StartAtHome) {
-                return StartAtHomeSetting(rawValue: prefs) ?? .afterFourHours
-            }
-            return .afterFourHours
+            let pref: StartAtHome = featureFlags.getCustomState(for: .startAtHome) ?? .afterFourHours
+            return StartAtHomeSetting(rawValue: pref.rawValue) ?? .afterFourHours
         }
-        set { prefs.setString(newValue.rawValue, forKey: PrefsKeys.UserFeatureFlagPrefs.StartAtHome) }
+        set { prefs.setString(newValue.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome) }
     }
 
     /// Determines whether the Start at Home feature is enabled, how long it has been since

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -203,18 +203,17 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
     }
 
     private func setupStartAtHomeSection() -> SettingSection {
-        let defaultSetting = StartAtHomeSetting.afterFourHours.rawValue
-        let prefsSetting = prefs.stringForKey(PrefsKeys.UserFeatureFlagPrefs.StartAtHome) ?? defaultSetting
-        currentStartAtHomeSetting = StartAtHomeSetting(rawValue: prefsSetting) ?? .afterFourHours
+        let pref: StartAtHome = featureFlags.getCustomState(for: .startAtHome) ?? .afterFourHours
+        currentStartAtHomeSetting = StartAtHomeSetting(rawValue: pref.rawValue) ?? .afterFourHours
 
         typealias a11y = AccessibilityIdentifiers.Settings.Homepage.StartAtHome
 
         let onOptionSelected: (Bool, StartAtHomeSetting) -> Void = { [weak self] state, option in
-            self?.prefs.setString(option.rawValue, forKey: PrefsKeys.UserFeatureFlagPrefs.StartAtHome)
+            self?.prefs.setString(option.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
             self?.tableView.reloadData()
 
             let extras = [
-                TelemetryWrapper.EventExtraKey.preference.rawValue: PrefsKeys.UserFeatureFlagPrefs.StartAtHome,
+                TelemetryWrapper.EventExtraKey.preference.rawValue: PrefsKeys.FeatureFlags.StartAtHome,
                 TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: option.rawValue
             ]
             TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: extras)

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -91,6 +91,9 @@ final class NimbusFeatureFlagLayer {
         case .splashScreen:
             return checkSplashScreenFeature(for: featureID, from: nimbus)
 
+        case .startAtHome:
+            return checkStartAtHomeFeature(for: featureID, from: nimbus) != .disabled
+
         case .toolbarRefactor:
             return checkToolbarRefactorFeature(from: nimbus)
 
@@ -278,6 +281,17 @@ final class NimbusFeatureFlagLayer {
         from nimbus: FxNimbus
     ) -> Bool {
         return nimbus.features.splashScreen.value().enabled
+    }
+
+    private func checkStartAtHomeFeature(for featureID: NimbusFeatureFlagID, from nimbus: FxNimbus) -> StartAtHome {
+        let config = nimbus.features.startAtHomeFeature.value()
+        let nimbusSetting = config.setting
+
+        switch nimbusSetting {
+        case .afterFourHours: return .afterFourHours
+        case .always: return .always
+        case .disabled: return .disabled
+        }
     }
 
     private func checkTabTrayFeature(for featureID: NimbusFeatureFlagID,

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -313,8 +313,8 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         let isPocketEnabled = isFeatureEnabled && PocketProvider.islocaleSupported(Locale.current.identifier)
         GleanMetrics.Preferences.pocket.set(isPocketEnabled)
 
-        let startAtHomeOption = prefs.stringForKey(PrefsKeys.UserFeatureFlagPrefs.StartAtHome) ?? StartAtHomeSetting.afterFourHours.rawValue
-        GleanMetrics.Preferences.openingScreen.set(startAtHomeOption)
+        let startAtHomeOption: StartAtHome = featureFlags.getCustomState(for: .startAtHome) ?? .afterFourHours
+        GleanMetrics.Preferences.openingScreen.set(startAtHomeOption.rawValue)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
@@ -21,6 +21,7 @@ class StartAtHomeHelperTests: XCTestCase {
                                               uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
 
         DependencyHelperMock().bootstrapDependencies()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
     override func tearDown() {

--- a/firefox-ios/nimbus-features/startAtHomeFeature.yaml
+++ b/firefox-ios/nimbus-features/startAtHomeFeature.yaml
@@ -1,0 +1,28 @@
+# The configuration for the open to last tab feature
+features:
+  start-at-home-feature:
+    description: This feature is for experimenting with opening screen
+    variables:
+      setting:
+        description: This property provides a default setting for the start at home feature
+        type: StartAtHome
+        default: disabled
+    defaults:
+      - channel: beta
+        value:
+          setting: disabled
+      - channel: developer
+        value: 
+          setting: disabled
+        
+# These different variants must match those of StartAtHomeSetting (including casing) in FlaggableFeatureOptions.swift
+enums:
+  StartAtHome:
+    description: The option for what screen to open the app to
+    variants:
+      afterFourHours:
+        description: Starts the app at the homepage after four hours of inactivity, otherwise starts the app at the most recently viewed tab.
+      always:
+        description: Starts the app at the homepage.
+      disabled:
+        description: Starts the app at the most recently viewed tab.

--- a/firefox-ios/nimbus-features/startAtHomeFeature.yaml
+++ b/firefox-ios/nimbus-features/startAtHomeFeature.yaml
@@ -6,14 +6,14 @@ features:
       setting:
         description: This property provides a default setting for the start at home feature
         type: StartAtHome
-        default: disabled
+        default: afterFourHours
     defaults:
       - channel: beta
         value:
-          setting: disabled
+          setting: afterFourHours
       - channel: developer
         value: 
-          setting: disabled
+          setting: afterFourHours
         
 # These different variants must match those of StartAtHomeSetting (including casing) in FlaggableFeatureOptions.swift
 enums:

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -41,6 +41,7 @@ include:
   - nimbus-features/sentFromFirefoxFeature.yaml
   - nimbus-features/splashScreenFeature.yaml
   - nimbus-features/spotlightSearchFeature.yaml
+  - nimbus-features/startAtHomeFeature.yaml
   - nimbus-features/tabTrayFeature.yaml
   - nimbus-features/tabTrayUIExperiments.yaml
   - nimbus-features/toolbarRefactorFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11623)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25310)

## :bulb: Description
- (Re)add the `start-at-home` feature flag for experimentation and check nimbus when utilizing the `StartAtHome` pref

### 📝 Notes
- [LegacyFeatureFlagManager::getCustomState](https://github.com/mozilla-mobile/firefox-ios/blob/8abf61257c74eae7efde912288c8cc6bde1891aa/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift#L81) should be used to query this flag as it has more than a binary option (instead of the more commonly used [LegacyFeatureFlagManager::isFeatureEnabled](https://github.com/mozilla-mobile/firefox-ios/blob/8abf61257c74eae7efde912288c8cc6bde1891aa/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift#L50))

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
