### PR TITLE
Refactor FXIOS-12087 [Address Autofill] Enable address autofill by default for FR, DE and GB

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressUtility/AddressLocaleFeatureValidator.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressUtility/AddressLocaleFeatureValidator.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 struct AddressLocaleFeatureValidator {
-    static let supportedRegions = ["CA", "US"]
+    static let supportedRegions = ["CA", "US", "FR", "DE", "GB"]
 
     static func isValidRegion(locale: Locale = Locale.current) -> Bool {
         guard let regionCode = locale.regionCode else {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressLocaleFeatureValidatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressLocaleFeatureValidatorTests.swift
@@ -24,11 +24,35 @@ class AddressLocaleFeatureValidatorTests: XCTestCase {
         )
     }
 
-    func testInvalidRegionFR() {
+    func testValidRegionFR() {
         let locale = Locale(identifier: "fr_FR")
+        XCTAssertTrue(
+            AddressLocaleFeatureValidator.isValidRegion(locale: locale),
+            "Valid region for FR"
+        )
+    }
+
+    func testValidRegionDE() {
+        let locale = Locale(identifier: "de_DE")
+        XCTAssertTrue(
+            AddressLocaleFeatureValidator.isValidRegion(locale: locale),
+            "Valid region for DE"
+        )
+    }
+
+    func testValidRegionGB() {
+        let locale = Locale(identifier: "en_GB")
+        XCTAssertTrue(
+            AddressLocaleFeatureValidator.isValidRegion(locale: locale),
+            "Valid region for GB"
+        )
+    }
+
+    func testInvalidRegionMA() {
+        let locale = Locale(identifier: "fr_MA")
         XCTAssertFalse(
             AddressLocaleFeatureValidator.isValidRegion(locale: locale),
-            "Invalid region for FR"
+            "Invalid region for MA"
         )
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12087)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26306)

## :bulb: Description
This PR:
- Enables address autofill by default for **FR, DE and GB**

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
