### PR TITLE
Bugfix FXIOS-12097 [Felt Privacy - Simplified UI] private mode header theme

### DIFF
--- a/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
@@ -91,7 +91,8 @@ class StatusBarOverlay: UIView,
         // Status bar height can be 0 on iPhone in landscape mode.
         guard isBottomSearchBar,
               let statusBarHeight: CGFloat = statusBarFrame?.height,
-              statusBarHeight > 0
+              statusBarHeight > 0,
+              savedIsHomepage ?? false
         else {
             scrollOffset = 1
             return

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -114,7 +114,13 @@ extension HomeLogoHeaderCell: ThemeApplicable {
     func applyTheme(theme: Theme) {
         // TODO: FXIOS-10851 This can be moved to the new homescreen wallpaper fetching redux
         let wallpaperManager = WallpaperManager()
-        if let logoTextColor = wallpaperManager.currentWallpaper.logoTextColor {
+        let browserViewType = store.state.screenState(
+            BrowserViewControllerState.self,
+            for: .browserViewController,
+            window: currentWindowUUID
+        )?.browserViewType
+
+        if let logoTextColor = wallpaperManager.currentWallpaper.logoTextColor, browserViewType != .privateHomepage {
             logoTextImage.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoText)
                 .withRenderingMode(.alwaysTemplate)
             logoTextImage.tintColor = logoTextColor

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -85,10 +85,10 @@ final class PrivateHomepageViewController:
         return messageCard
     }()
 
-    private lazy var homepageHeaderCell: LegacyHomepageHeaderCell = {
-        let header = LegacyHomepageHeaderCell()
+    private lazy var homepageHeaderCell: HomepageHeaderCell = {
+        let header = HomepageHeaderCell()
         header.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
-        header.configure(with: headerViewModel)
+        header.configure(headerState: HeaderState(windowUUID: windowUUID))
         return header
     }()
 
@@ -125,7 +125,7 @@ final class PrivateHomepageViewController:
         updateConstraintsForMultitasking()
         if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass
             || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {
-            homepageHeaderCell.configure(with: headerViewModel)
+            homepageHeaderCell.configure(headerState: HeaderState(windowUUID: windowUUID))
         }
         applyTheme()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12097)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26322)

## :bulb: Description
Fix header theme due to wallpaper configuration and add check for only when browser type is not private theme.

## :movie_camera: Demos
https://github.com/user-attachments/assets/f5d9ea78-e2e3-43dc-ada2-38c5dc3b0cf4

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
