### PR TITLE
Add FXIOS-12103 [Translations] Fetch model files from RS

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1320,6 +1320,7 @@
 		BA4BB9A42D7FF754006BD137 /* DarkModeToggleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BB9A32D7FF74D006BD137 /* DarkModeToggleView.swift */; };
 		BA7A14842C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7A14832C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift */; };
 		BA8E197F2BF2FB1900590B5F /* AddressFormManager.js in Resources */ = {isa = PBXBuildFile; fileRef = BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */; };
+		BACE70062DC110CA00E6102C /* ASTranslationModelsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE70052DC110C700E6102C /* ASTranslationModelsFetcher.swift */; };
 		BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
 		BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */; };
@@ -8932,6 +8933,7 @@
 		BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AddressFormManager.js; sourceTree = "<group>"; };
 		BA904A3B89BC820A7A802D55 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/Storage.strings"; sourceTree = "<group>"; };
 		BAA64356B54F1CD258764620 /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/FindInPage.strings; sourceTree = "<group>"; };
+		BACE70052DC110C700E6102C /* ASTranslationModelsFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTranslationModelsFetcher.swift; sourceTree = "<group>"; };
 		BAF14FEC94CB9DA4E08BA60C /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Storage.strings; sourceTree = "<group>"; };
 		BAF74394B38CDAE36910B788 /* eu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/Shared.strings; sourceTree = "<group>"; };
 		BAFB47EE839E6EE784CA9C34 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
@@ -10716,6 +10718,7 @@
 		1DCEC3EF2D5C1BA700129966 /* Application Services */ = {
 			isa = PBXGroup;
 			children = (
+				BACE70052DC110C700E6102C /* ASTranslationModelsFetcher.swift */,
 				1D05C9822D9CCF690081540C /* RemoteSettingsServiceSyncCoordinator.swift */,
 				1DCEC40F2D822F1500129966 /* ASRemoteSettingsCollection.swift */,
 				1DCEC3F12D5D1FDD00129966 /* ASSearchEngineSelector.swift */,
@@ -16975,6 +16978,7 @@
 				E12BD0B028AC3A7E0029AAF0 /* UIEdgeInsets+Extension.swift in Sources */,
 				C2D80BE72AADE38100CDF7A9 /* CredentialAutofillCoordinator.swift in Sources */,
 				5A96FB622D97076200917B12 /* CenterSnappingFlowLayout.swift in Sources */,
+				BACE70062DC110CA00E6102C /* ASTranslationModelsFetcher.swift in Sources */,
 				8A62B15D2CED408B0045F46E /* ContextMenuState.swift in Sources */,
 				C8BE692729BA2FBB0015C4A2 /* SurveySurfaceInfoModel.swift in Sources */,
 				D0152245229855A8009DE753 /* OneLineTableViewCell.swift in Sources */,

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASRemoteSettingsCollection.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASRemoteSettingsCollection.swift
@@ -8,6 +8,8 @@ import Common
 /// Defines a specific Remote Settings collection fetched through Application Services
 enum ASRemoteSettingsCollection: String {
     case searchEngineIcons = "search-config-icons"
+    case translationsModels = "translations-models"
+    case translationsWasm = "translations-wasm"
 }
 
 extension ASRemoteSettingsCollection {

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
@@ -15,12 +15,12 @@ struct TranslatorFieldsRecord: Codable {
 /// For more context, See schema in
 /// https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/translations-models/records
 struct ModelFieldsRecord: Codable {
-  let fileType: String
-  let fromLang: String
+    let fileType: String
+    let fromLang: String
     let toLang: String
-  let version: String
-  let name: String
-  let schema: Int64
+    let version: String
+    let name: String
+    let schema: Int64
 }
 
 struct TranslationRecord: Codable {
@@ -71,9 +71,7 @@ final class ASTranslationModelsFetcher: TranslationModelsFetching {
 
     /// Decodes a RemoteSettingsRecord into a specific type.
     private func decodeRecord<T: Codable>(_ record: RemoteSettingsRecord) -> T? {
-        guard
-            let data = record.fields.data(using: .utf8)
-        else { return nil }
+        guard let data = record.fields.data(using: .utf8) else { return nil }
         return try? decoder.decode(T.self, from: data)
     }
 

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
@@ -1,0 +1,132 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MozillaAppServices
+import Common
+
+/// For more context, See schema in
+/// https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/translations-wasm/records
+struct TranslatorFieldsRecord: Codable {
+  let name: String
+  let version: String
+}
+
+/// For more context, See schema in
+/// https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/translations-models/records
+struct ModelFieldsRecord: Codable {
+  let fileType: String
+  let fromLang: String
+    let toLang: String
+  let version: String
+  let name: String
+  let schema: Int64
+}
+
+struct TranslationRecord: Codable {
+    let fileType: String?
+    let fromLang: String?
+    let name: String
+    let schema: Int64?
+    let toLang: String?
+    let version: String
+}
+
+protocol TranslationModelsFetching {
+    func fetchTranslatorWASM() -> Data?
+    func fetchModels(from sourceLang: String, to targetLang: String) -> Data?
+}
+
+final class ASTranslationModelsFetcher: TranslationModelsFetching {
+    static let shared = ASTranslationModelsFetcher()
+    // Pin versions to avoid using unsupported models
+    private enum Constants {
+        static let translatorVersion = "2.0"
+        static let modelsVersion = "1.0"
+        static let translatorName = "bergamot-translator"
+    }
+
+    private let service: RemoteSettingsService
+    private let modelsClient: RemoteSettingsClient?
+    private let translatorsClient: RemoteSettingsClient?
+    private let logger: Logger
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+
+    init?(logger: Logger = DefaultLogger.shared) {
+        let profile: Profile = AppContainer.shared.resolve()
+        guard let service = profile.remoteSettingsService else {
+            logger.log("Remote Settings service unavailable.", level: .warning, category: .remoteSettings)
+            return nil
+        }
+        self.service = service
+        self.modelsClient = ASRemoteSettingsCollection.translationsModels.makeClient()
+        self.translatorsClient = ASRemoteSettingsCollection.translationsWasm.makeClient()
+        self.logger = logger
+    }
+
+    /// Decodes a RemoteSettingsRecord into a specific type.
+    private func decodeRecord<T: Codable>(_ record: RemoteSettingsRecord) -> T? {
+        guard
+            let data = record.fields.data(using: .utf8)
+        else { return nil }
+        return try? decoder.decode(T.self, from: data)
+    }
+
+    /// Fetches the wasm binary for the translator that matches the pinned version.
+    func fetchTranslatorWASM() -> Data? {
+        guard let records = translatorsClient?.getRecords() else {
+            logger.log("No translator records found", level: .warning, category: .remoteSettings)
+            return nil
+        }
+
+        let matchingRecord = records.first { record in
+            guard let fields: TranslatorFieldsRecord = decodeRecord(record) else { return false }
+            return fields.name == Constants.translatorName &&
+                fields.version == Constants.translatorVersion
+        }
+
+        return matchingRecord.flatMap { record in try? translatorsClient?.getAttachment(record: record) }
+    }
+
+    /// Fetches the translation model files for a given language pair matching the pinned version.
+    func fetchModels(from sourceLang: String, to targetLang: String) -> Data? {
+        guard let records = modelsClient?.getRecords() else {
+            logger.log("No model records found.", level: .warning, category: .remoteSettings)
+            return nil
+        }
+
+        var languageModelFiles = [String: Any]()
+
+        for record in records {
+            guard
+                let fields: ModelFieldsRecord = decodeRecord(record),
+                fields.fromLang == sourceLang,
+                fields.toLang == targetLang,
+                fields.version == Constants.modelsVersion
+            else { continue }
+
+            guard let attachment = try? modelsClient?.getAttachment(record: record) else {
+                logger.log("Cannot fetch model attachment.", level: .warning, category: .remoteSettings)
+                return nil
+            }
+
+            languageModelFiles[fields.fileType] = [
+                "buffer": attachment.base64EncodedString(),
+                "record": [
+                    "fromLang": fields.fromLang,
+                    "toLang": fields.toLang,
+                    "fileType": fields.fileType,
+                    "version": fields.version,
+                    "name": fields.name,
+                ]
+            ]
+        }
+
+        return try? JSONSerialization.data(withJSONObject: ["languageModelFiles": languageModelFiles])
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12103)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26349)

## :bulb: Description
This PR:
- Adds `ASTranslationModelsFetcher` with two methods to fetch translator and model files from RS.
- Adds `translations-models, translations-wasm` to `ASRemoteSettingsCollection`

⚠️ **NOTE** The collections haven’t been added to AS yet; I’ll add them in [FXIOS-12105](https://mozilla-hub.atlassian.net/browse/FXIOS-12105)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)


[FXIOS-12105]: https://mozilla-hub.atlassian.net/browse/FXIOS-12105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ