### PR TITLE
Bugfix FXIOS-12007 [Tab tray UI experiment] Do not show toast in remote tabs when experiment is ON

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -173,6 +173,8 @@ class RemoteTabsTableViewController: UITableViewController,
     private func show(toast: Toast,
                       afterWaiting delay: DispatchTimeInterval = Toast.UX.toastDelayBefore,
                       duration: DispatchTimeInterval? = Toast.UX.toastDismissAfter) {
+        guard !isTabTrayUIExperimentsEnabled else { return }
+
         if let buttonToast = toast as? ButtonToast {
             self.buttonToast = buttonToast
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12007)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26125)

## :bulb: Description
Do not show "Tab Closed" toast in remote tabs when experiment is ON

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
