### PR TITLE
Bugfix FXIOS-11997 [Tab Tray UI Experiment] Fix animation on URL bar by stopping keyboard coming up automatically

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -251,6 +251,11 @@ class BrowserViewController: UIViewController,
         return featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
     }
 
+    private var isTabTrayUIExperimentsEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
+        && UIDevice.current.userInterfaceIdiom != .pad
+    }
+
     var isUnifiedSearchEnabled: Bool {
         return featureFlags.isFeatureEnabled(.unifiedSearch, checking: .buildOnly)
     }
@@ -4395,6 +4400,11 @@ extension BrowserViewController: TabManagerDelegate {
             let count = selectedTab.isPrivate ? tabManager.privateTabs.count : tabManager.normalTabs.count
             if isToolbarRefactorEnabled {
                 updateToolbarTabCount(count)
+            } else if !isToolbarRefactorEnabled && isTabTrayUIExperimentsEnabled, let legacyUrlBar {
+                // In the case where the tab tray experiment is enabled but toolbar refactor is
+                // not we want to not animate tab counts so that the animation between tabTray and browserVC looks better
+                toolbar.updateTabCount(count, animated: false)
+                legacyUrlBar.updateTabCount(count, animated: !legacyUrlBar.inOverlayMode)
             } else if !isToolbarRefactorEnabled, let legacyUrlBar {
                 toolbar.updateTabCount(count, animated: animated)
                 legacyUrlBar.updateTabCount(count, animated: !legacyUrlBar.inOverlayMode)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -372,7 +372,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
                                           actionType: TabTrayActionType.dismissTabTray)
         store.dispatch(dismissAction)
 
-        if isTabTrayUIExperimentsEnabled == false {
+        if !isTabTrayUIExperimentsEnabled {
             let overlayAction = GeneralBrowserAction(showOverlay: showOverlay,
                                                      windowUUID: uuid,
                                                      actionType: GeneralBrowserActionType.showOverlay)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -372,10 +372,12 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
                                           actionType: TabTrayActionType.dismissTabTray)
         store.dispatch(dismissAction)
 
-        let overlayAction = GeneralBrowserAction(showOverlay: showOverlay,
-                                                 windowUUID: uuid,
-                                                 actionType: GeneralBrowserActionType.showOverlay)
-        store.dispatch(overlayAction)
+        if isTabTrayUIExperimentsEnabled == false {
+            let overlayAction = GeneralBrowserAction(showOverlay: showOverlay,
+                                                     windowUUID: uuid,
+                                                     actionType: GeneralBrowserActionType.showOverlay)
+            store.dispatch(overlayAction)
+        }
     }
 
     /// Move tab on `TabManager` array to support drag and drop

--- a/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
@@ -5,7 +5,9 @@
 import Foundation
 import Common
 
-class TabsButton: UIButton, ThemeApplicable {
+class TabsButton: UIButton,
+                  ThemeApplicable,
+                  FeatureFlaggable {
     struct UX {
         static let cornerRadius: CGFloat = 2
         static let titleFont: UIFont = FXFontStyles.Bold.caption2.systemFont()
@@ -34,6 +36,12 @@ class TabsButton: UIButton, ThemeApplicable {
 
     // Re-entrancy guard to ensure the function is complete before starting another animation.
     private var isUpdatingTabCount = false
+
+    private var isTabTrayUIExperimentsEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
+        && UIDevice.current.userInterfaceIdiom != .pad
+        && featureFlags.isFeatureEnabled(.tabAnimation, checking: .buildOnly)
+    }
 
     override var transform: CGAffineTransform {
         didSet {
@@ -173,7 +181,12 @@ class TabsButton: UIButton, ThemeApplicable {
             newTabsButton.centerYAnchor.constraint(equalTo: newTabsButton.centerYAnchor)
         ])
 
-        animateButton(newTabsButton: newTabsButton, animated: animated)
+        if isTabTrayUIExperimentsEnabled {
+            countLabel.text = countToBe
+            accessibilityValue = countToBe
+        } else {
+            animateButton(newTabsButton: newTabsButton, animated: animated)
+        }
     }
 
     private func animateButton(newTabsButton: TabsButton, animated: Bool) {

--- a/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
@@ -37,12 +37,6 @@ class TabsButton: UIButton,
     // Re-entrancy guard to ensure the function is complete before starting another animation.
     private var isUpdatingTabCount = false
 
-    private var isTabTrayUIExperimentsEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
-        && UIDevice.current.userInterfaceIdiom != .pad
-        && featureFlags.isFeatureEnabled(.tabAnimation, checking: .buildOnly)
-    }
-
     override var transform: CGAffineTransform {
         didSet {
             clonedTabsButton?.transform = transform
@@ -181,12 +175,7 @@ class TabsButton: UIButton,
             newTabsButton.centerYAnchor.constraint(equalTo: newTabsButton.centerYAnchor)
         ])
 
-        if isTabTrayUIExperimentsEnabled {
-            countLabel.text = countToBe
-            accessibilityValue = countToBe
-        } else {
-            animateButton(newTabsButton: newTabsButton, animated: animated)
-        }
+        animateButton(newTabsButton: newTabsButton, animated: animated)
     }
 
     private func animateButton(newTabsButton: TabsButton, animated: Bool) {

--- a/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Common
 
-class TabsButton: UIButton, ThemeApplicable{
+class TabsButton: UIButton, ThemeApplicable {
     struct UX {
         static let cornerRadius: CGFloat = 2
         static let titleFont: UIFont = FXFontStyles.Bold.caption2.systemFont()

--- a/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
@@ -5,9 +5,7 @@
 import Foundation
 import Common
 
-class TabsButton: UIButton,
-                  ThemeApplicable,
-                  FeatureFlaggable {
+class TabsButton: UIButton, ThemeApplicable{
     struct UX {
         static let cornerRadius: CGFloat = 2
         static let titleFont: UIFont = FXFontStyles.Bold.caption2.systemFont()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -160,7 +160,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].press(forDuration: 1)
         selectOptionFromContextMenu(option: "Pin")
         waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
+        // waitForExistence(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -161,7 +161,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         selectOptionFromContextMenu(option: "Pin")
         waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
         // waitForExistence(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
-        navigator.performAction(Action.CloseURLBarOpen)
+        // navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         navigator.goto(ClearPrivateDataSettings)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -160,8 +160,6 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].press(forDuration: 1)
         selectOptionFromContextMenu(option: "Pin")
         waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
-        // waitForExistence(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
-        // navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         navigator.goto(ClearPrivateDataSettings)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11997)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26111)

## :bulb: Description
Fix animation on URL bar by stopping keyboard coming up automatically when tab tray experiment is enabled.
As part of this I also disabled the update animation of the tab label on the legacy toolbar so it didn't look weird if tabTrayExperiments was enabled but not toolbarRefactor.

## :movie_camera: Demos
With new toolbar baseline
https://github.com/user-attachments/assets/7d9f7ad7-a496-4e29-9035-9539c1ea749c

With old toolbar with tab tray animation **enabled**
https://github.com/user-attachments/assets/a13b36e7-ca5c-4699-8a02-b3ca389bd778

With old toolbar with tab tray animation **disabled**
https://github.com/user-attachments/assets/47854a7c-7dab-431b-9046-beae94b7b6f6




## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
