### PR TITLE
Refactor FXIOS-12134[Homepage] Enable homepage rebuild and felt privacy on beta

### DIFF
--- a/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
+++ b/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
@@ -15,8 +15,8 @@ features:
     defaults:
       - channel: beta
         value:
-          simplified-ui-enabled: false
-          felt-deletion-enabled: false
+          simplified-ui-enabled: true
+          felt-deletion-enabled: true
       - channel: developer
         value:
           simplified-ui-enabled: true

--- a/firefox-ios/nimbus-features/homepageRebuildFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRebuildFeature.yaml
@@ -12,7 +12,7 @@ features:
     defaults:
       - channel: beta
         value:
-          enabled: false
+          enabled: true
       - channel: developer
         value:
           enabled: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12134)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26397)

## :bulb: Description
- Enable the homepage rebuild and felt privacy (simplified UI and felt deletion) feature flags on beta by default

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
