### PR TITLE
Fix FXIOS-11506 [Release Automation] Use the bitrise app title to detect staging build promotions

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2161,7 +2161,7 @@ workflows:
             envman add --key BITRISE_SCHEME --value FirefoxStaging
             envman add --key EXPORT_METHOD --value development
         run_if: |-
-          {{enveq "BITRISE_APP_SLUG" "staging-firefox-ios"}}
+          {{enveq "BITRISE_APP_TITLE" "staging-firefox-ios"}}
     - script@1.2.1:
         inputs:
         - content: |-
@@ -2173,7 +2173,7 @@ workflows:
             cd -
         title: Set xcodeproj code_sign_identity
         run_if: |-
-          {{enveq "BITRISE_APP_SLUG" "firefox-ios"}}
+          {{enveq "BITRISE_APP_TITLE" "firefox-ios"}}
     - script@1.2.1:
         title: NPM, ContentBlockerGen
         inputs:
@@ -2267,7 +2267,7 @@ workflows:
     - script@1.2.1:
         title: Upload Firefox Prod Beta Symbols
         run_if: |-
-          {{enveq "BITRISE_APP_SLUG" "firefox-ios"}}
+          {{enveq "BITRISE_APP_TITLE" "firefox-ios"}}
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -2277,7 +2277,7 @@ workflows:
     - deploy-to-itunesconnect-application-loader@1:
         title: Deploy to AppStoreConnect
         run_if: |-
-          {{enveq "BITRISE_APP_SLUG" "firefox-ios"}}
+          {{enveq "BITRISE_APP_TITLE" "firefox-ios"}}
         inputs:
         - connection: 'off'
         - app_password: "$APPLE_ACCOUNT_PW"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11506)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25045)

## :bulb: Description

In 6464e3c3f6833ffc4144ef6a773cc830c413d217 we misunderstood what the app slug was and changed the way staging was detected to that quite late in the process. Turns out the app slug is the unique identifier for the app (a UUID), not the application name itself which means that those `run_if` were never evaluated as `true`.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
