### PR TITLE
Bugfix FXIOS-11968 [Tab tray UI experiment] Change the tab selector title to "Sync"

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
@@ -28,7 +28,7 @@ enum TabTrayPanelType: Int, CaseIterable {
         case .privateTabs:
             return String.TabTraySegmentedControlTitlesPrivateTabs
         case .syncedTabs:
-            return String.TabTraySegmentedControlTitlesSyncedTabs
+            return String.Settings.Notifications.SyncNotificationsTitle
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11968)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26043)

## :bulb: Description
Reusing another string for now so we can get this in 138.1, then we'll have proper translations with v139 with [this task](https://mozilla-hub.atlassian.net/browse/FXIOS-12133).

## :movie_camera: Screenshot

<details>
<summary>"Sync" instead of "Synced"</summary>

![Simulator Screenshot - iPhone 16 - 2025-04-30 at 10 55 21](https://github.com/user-attachments/assets/add5fea2-f8d1-42e6-8d88-2d0b623efdae)

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
