### PR TITLE
Refactor FXIOS-12145 - [Toolbar - Swipe Tabs Animation] - Adjust the height of the address bar for tab preview

### DIFF
--- a/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
@@ -10,8 +10,9 @@ final class TabWebViewPreview: UIView, Notifiable, ThemeApplicable {
     private struct UX {
         static let addressBarCornerRadius: CGFloat = 8
         static let addressBarBorderHeight: CGFloat = 1
-        static let addressBarHeight: CGFloat = 43
-        static let addressBarMaxHeight: CGFloat = 53
+        static let addressBarHeight: CGFloat = 44
+        static let addressBarMaxHeight: CGFloat = 54
+        static let edgePadding: CGFloat = 7
         static let addressBarOnTopLayoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
         static let addressBarOnBottomLayoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 4, right: 16)
     }
@@ -48,7 +49,7 @@ final class TabWebViewPreview: UIView, Notifiable, ThemeApplicable {
 
     // MARK: - Layout
     private func setupLayout() {
-        addSubviews(webPageScreenshotImageView, addressBarBorderView, topStackView, bottomStackView)
+        addSubviews(webPageScreenshotImageView, topStackView, bottomStackView, addressBarBorderView)
 
         addressBarHeightConstraint = skeletonAddressBar.heightAnchor
             .constraint(equalToConstant: UX.addressBarHeight)
@@ -98,7 +99,7 @@ final class TabWebViewPreview: UIView, Notifiable, ThemeApplicable {
             bottomStackView.addArrangedSubview(skeletonAddressBar)
             webViewTopConstraint = webPageScreenshotImageView.topAnchor.constraint(equalTo: topAnchor)
             addressBarBorderViewTopBottomConstraint = addressBarBorderView.bottomAnchor.constraint(
-                equalTo: bottomStackView.topAnchor
+                equalTo: skeletonAddressBar.topAnchor, constant: -UX.edgePadding
             )
             webViewBottomConstraint = webPageScreenshotImageView.bottomAnchor.constraint(
                 equalTo: addressBarBorderView.topAnchor
@@ -107,7 +108,7 @@ final class TabWebViewPreview: UIView, Notifiable, ThemeApplicable {
             topStackView.addArrangedSubview(skeletonAddressBar)
             webViewTopConstraint = webPageScreenshotImageView.topAnchor.constraint(equalTo: topStackView.bottomAnchor)
             addressBarBorderViewTopBottomConstraint = addressBarBorderView.topAnchor.constraint(
-                equalTo: topStackView.bottomAnchor
+                equalTo: skeletonAddressBar.bottomAnchor, constant: UX.edgePadding
             )
             webViewBottomConstraint = webPageScreenshotImageView.bottomAnchor.constraint(equalTo: bottomAnchor)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12145)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26417)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
There can be seen when the swiping is done that there's a readjustment in height of the address bar.

BEFORE:

https://github.com/user-attachments/assets/3432739a-bd0f-4c3e-95c9-f4af4f98bb1b

AFTER:

https://github.com/user-attachments/assets/bf231a49-85c1-436f-b8cd-32bd92fc1d1e

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
