### PR TITLE
Add FXIOS-12133 [Tab tray UI experiment] New tab tray experiment strings

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -8,12 +8,12 @@ import UIKit
 class PrivateModeButton: ToggleButton, PrivateModeUI {
     override init(frame: CGRect) {
         super.init(frame: frame)
-        accessibilityLabel = .TabTrayToggleAccessibilityLabel
+        accessibilityLabel = .TabsTray.TabTrayToggleAccessibilityLabel
         let maskImage = UIImage(named: StandardImageIdentifiers.Large.privateMode)?
             .withRenderingMode(.alwaysTemplate)
         setImage(maskImage, for: [])
         showsLargeContentViewer = true
-        largeContentTitle = .TabTrayToggleAccessibilityLabel
+        largeContentTitle = .TabsTray.TabTrayToggleAccessibilityLabel
         largeContentImage = maskImage
     }
 
@@ -28,7 +28,7 @@ class PrivateModeButton: ToggleButton, PrivateModeUI {
         tintColor = isPrivate ? colors.iconOnColor : colors.iconPrimary
         imageView?.tintColor = tintColor
 
-        accessibilityValue = isSelected ? .TabTrayToggleAccessibilityValueOn : .TabTrayToggleAccessibilityValueOff
+        accessibilityValue = isSelected ? .TabsTray.TabTrayToggleAccessibilityValueOn : .TabsTray.TabTrayToggleAccessibilityValueOff
     }
 
     override func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -28,7 +28,11 @@ class PrivateModeButton: ToggleButton, PrivateModeUI {
         tintColor = isPrivate ? colors.iconOnColor : colors.iconPrimary
         imageView?.tintColor = tintColor
 
-        accessibilityValue = isSelected ? .TabsTray.TabTrayToggleAccessibilityValueOn : .TabsTray.TabTrayToggleAccessibilityValueOff
+        if isSelected {
+            accessibilityValue = .TabsTray.TabTrayToggleAccessibilityValueOn
+        } else {
+            accessibilityValue = .TabsTray.TabTrayToggleAccessibilityValueOff
+        }
     }
 
     override func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
@@ -24,11 +24,11 @@ enum TabTrayPanelType: Int, CaseIterable {
     var label: String {
         switch self {
         case .tabs:
-            return .TabsTray.TabTraySegmentedControlTitlesTabs
+            return .TabsTray.TabsSelectorNormalTabsTitle
         case .privateTabs:
-            return .TabsTray.TabTraySegmentedControlTitlesPrivateTabs
+            return .TabsTray.TabsSelectorPrivateTabsTitle
         case .syncedTabs:
-            return String.Settings.Notifications.SyncNotificationsTitle
+            return .TabsTray.TabsSelectorSyncedTabsTitle
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
@@ -13,9 +13,9 @@ enum TabTrayPanelType: Int, CaseIterable {
     var navTitle: String {
         switch self {
         case .tabs:
-            return .TabTrayV2Title
+            return .TabsTray.TabTrayV2Title
         case .privateTabs:
-            return .TabTrayPrivateBrowsingTitle
+            return .TabsTray.TabTrayPrivateBrowsingTitle
         case .syncedTabs:
             return .LegacyAppMenu.AppMenuSyncedTabsTitleString
         }
@@ -24,9 +24,9 @@ enum TabTrayPanelType: Int, CaseIterable {
     var label: String {
         switch self {
         case .tabs:
-            return String.TabTraySegmentedControlTitlesTabs
+            return .TabsTray.TabTraySegmentedControlTitlesTabs
         case .privateTabs:
-            return String.TabTraySegmentedControlTitlesPrivateTabs
+            return .TabsTray.TabTraySegmentedControlTitlesPrivateTabs
         case .syncedTabs:
             return String.Settings.Notifications.SyncNotificationsTitle
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
@@ -44,7 +44,7 @@ class EmptyPrivateTabsView: UIView, EmptyPrivateTabView {
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.textAlignment = .center
         label.numberOfLines = 0
-        label.text = .TabTrayPrivateBrowsingDescription
+        label.text = .TabsTray.TabTrayPrivateBrowsingDescription
     }
 
     private lazy var learnMoreButton: LinkButton = .build { button in

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
@@ -45,7 +45,7 @@ class ExperimentEmptyPrivateTabsView: UIView, EmptyPrivateTabView {
         label.font = FXFontStyles.Regular.footnote.scaledFont()
         label.textAlignment = .center
         label.numberOfLines = 0
-        label.text = .TabTrayPrivateBrowsingDescription
+        label.text = .TabsTray.TabTrayPrivateBrowsingDescription
     }
 
     private lazy var learnMoreButton: SecondaryRoundedButton = .build { button in

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -126,7 +126,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         backgroundHolder.addSubviews(screenshotView, smallFaviconView, closeButton, closeButtonOverlay)
 
         accessibilityCustomActions = [
-            UIAccessibilityCustomAction(name: .TabTrayCloseAccessibilityCustomAction,
+            UIAccessibilityCustomAction(name: .TabsTray.TabTrayCloseAccessibilityCustomAction,
                                         target: animator,
                                         selector: #selector(SwipeAnimator.closeWithoutGesture))
         ]
@@ -151,7 +151,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         titleText.text = tabModel.tabTitle
         accessibilityLabel = getA11yTitleLabel(tabModel: tabModel)
         isAccessibilityElement = true
-        accessibilityHint = .TabTraySwipeToCloseAccessibilityHint
+        accessibilityHint = .TabsTray.TabTraySwipeToCloseAccessibilityHint
         accessibilityIdentifier = a11yId
 
         let identifier = StandardImageIdentifiers.Large.globe
@@ -339,9 +339,9 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         let baseName = tabModel.tabTitle
 
         if isSelectedTab, !baseName.isEmpty {
-            return baseName + ". " + String.TabTrayCurrentlySelectedTabAccessibilityLabel
+            return baseName + ". " + String.TabsTray.TabTrayCurrentlySelectedTabAccessibilityLabel
         } else if isSelectedTab {
-            return String.TabTrayCurrentlySelectedTabAccessibilityLabel
+            return String.TabsTray.TabTrayCurrentlySelectedTabAccessibilityLabel
         } else {
             return baseName
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -92,7 +92,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         backgroundHolder.addSubviews(screenshotView, faviconBG, headerView)
 
         accessibilityCustomActions = [
-            UIAccessibilityCustomAction(name: .TabTrayCloseAccessibilityCustomAction,
+            UIAccessibilityCustomAction(name: .TabsTray.TabTrayCloseAccessibilityCustomAction,
                                         target: animator,
                                         selector: #selector(SwipeAnimator.closeWithoutGesture))
         ]
@@ -121,7 +121,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         titleText.text = tabModel.tabTitle
         accessibilityLabel = getA11yTitleLabel(tabModel: tabModel)
         isAccessibilityElement = true
-        accessibilityHint = .TabTraySwipeToCloseAccessibilityHint
+        accessibilityHint = .TabsTray.TabTraySwipeToCloseAccessibilityHint
         accessibilityIdentifier = a11yId
 
         let identifier = StandardImageIdentifiers.Large.globe
@@ -312,9 +312,9 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         let baseName = tabModel.tabTitle
 
         if isSelectedTab, !baseName.isEmpty {
-            return baseName + ". " + String.TabTrayCurrentlySelectedTabAccessibilityLabel
+            return baseName + ". " + String.TabsTray.TabTrayCurrentlySelectedTabAccessibilityLabel
         } else if isSelectedTab {
-            return String.TabTrayCurrentlySelectedTabAccessibilityLabel
+            return String.TabsTray.TabTrayCurrentlySelectedTabAccessibilityLabel
         } else {
             return baseName
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -92,7 +92,7 @@ class TabDisplayPanelViewController: UIViewController,
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.accessibilityLabel = .TabTrayViewAccessibilityLabel
+        view.accessibilityLabel = .TabsTray.TabTrayViewAccessibilityLabel
         setupView()
         listenForThemeChange(view)
         applyTheme()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -365,7 +365,7 @@ class TabDisplayView: UIView,
                                         actionType: TabPanelViewActionType.closeTab)
         store.dispatch(action)
         UIAccessibility.post(notification: UIAccessibility.Notification.announcement,
-                             argument: String.TabTrayClosingTabAccessibilityMessage)
+                             argument: String.TabsTray.TabTrayClosingTabAccessibilityMessage)
     }
 
     func swipeAnimatorIsAnimateAwayEnabled(_ animator: SwipeAnimator) -> Bool {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -112,7 +112,7 @@ class TabTrayViewController: UIViewController,
                                            theme: themeManager.getCurrentTheme(for: windowUUID))
         selector.delegate = self
         selector.items = [TabTrayPanelType.privateTabs.label,
-                          "0 \(TabTrayPanelType.tabs.label)",
+                          String(format: TabTrayPanelType.tabs.label, "0"),
                           TabTrayPanelType.syncedTabs.label]
 
         didSelectSection(panelType: tabTrayState.selectedPanel)
@@ -386,7 +386,7 @@ class TabTrayViewController: UIViewController,
         segmentedControl.setImage(TabTrayPanelType.tabs.image!.overlayWith(image: countLabel),
                                   forSegmentAt: 0)
         if isTabTrayUIExperimentsEnabled {
-            experimentSegmentControl.items[1] = "\(count) \(TabTrayPanelType.tabs.label)"
+            experimentSegmentControl.items[1] = String(format: TabTrayPanelType.tabs.label, count)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -163,7 +163,7 @@ class TabTrayViewController: UIViewController,
         return createButtonItem(imageName: StandardImageIdentifiers.Large.plus,
                                 action: #selector(newTabButtonTapped),
                                 a11yId: AccessibilityIdentifiers.TabTray.newTabButton,
-                                a11yLabel: .TabTrayAddTabAccessibilityLabel)
+                                a11yLabel: .TabsTray.TabTrayAddTabAccessibilityLabel)
     }()
 
     private lazy var flexibleSpace: UIBarButtonItem = {
@@ -672,7 +672,7 @@ class TabTrayViewController: UIViewController,
                                            style: .default,
                                            handler: { _ in self.confirmCloseAll() }),
                              accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
-        controller.addAction(UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel,
+        controller.addAction(UIAlertAction(title: .TabsTray.TabTrayCloseAllTabsPromptCancel,
                                            style: .cancel,
                                            handler: nil),
                              accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCancelButton)

--- a/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
@@ -204,9 +204,9 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFl
         let baseName = tab.getTabTrayTitle()
 
         if isSelectedTab, !tab.getTabTrayTitle().isEmpty {
-            return baseName + ". " + String.TabTrayCurrentlySelectedTabAccessibilityLabel
+            return baseName + ". " + String.TabsTray.TabTrayCurrentlySelectedTabAccessibilityLabel
         } else if isSelectedTab {
-            return String.TabTrayCurrentlySelectedTabAccessibilityLabel
+            return String.TabsTray.TabTrayCurrentlySelectedTabAccessibilityLabel
         } else {
             return baseName
         }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2687,16 +2687,6 @@ extension String {
             tableName: nil,
             value: "Open Tabs",
             comment: "The title for the tab tray")
-        public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString(
-            key: "TabTray.SegmentedControlTitles.Tabs",
-            tableName: nil,
-            value: "Tabs",
-            comment: "The title on the button to look at regular tabs.")
-        public static let TabTraySegmentedControlTitlesPrivateTabs = MZLocalizedString(
-            key: "TabTray.SegmentedControlTitles.PrivateTabs",
-            tableName: nil,
-            value: "Private",
-            comment: "The title on the button to look at private tabs.")
         public static let TabTrayToggleAccessibilityLabel = MZLocalizedString(
             key: "PrivateBrowsing.Toggle.A11y.Label.v132",
             tableName: "PrivateBrowsing",
@@ -2757,6 +2747,21 @@ extension String {
             tableName: nil,
             value: "Currently selected tab.",
             comment: "Accessibility label for the currently selected tab.")
+        public static let TabsSelectorNormalTabsTitle = MZLocalizedString(
+            key: "TabTray.TabsSelectorNormalTabsTitle",
+            tableName: "TabsTray",
+            value: "%@ Tabs",
+            comment: "The title on the button to look at regular tabs. %@ is the number of regular tabs.")
+        public static let TabsSelectorSyncedTabsTitle = MZLocalizedString(
+            key: "TabTray.TabsSelectorSyncedTabsTitle",
+            tableName: "TabsTray",
+            value: "Sync",
+            comment: "The title on the button to look at synced tabs.")
+        public static let TabsSelectorPrivateTabsTitle = MZLocalizedString(
+            key: "TabTray.SegmentedControlTitles.PrivateTabs",
+            tableName: nil,
+            value: "Private",
+            comment: "The title on the button to look at private tabs.")
 
         public struct InactiveTabs {
             public static let TabsTrayInactiveTabsSectionClosedAccessibilityTitle = MZLocalizedString(
@@ -7792,6 +7797,11 @@ extension String {
                 tableName: nil,
                 value: "Synced",
                 comment: "The title on the button to look at synced tabs.")
+            public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString(
+                key: "TabTray.SegmentedControlTitles.Tabs",
+                tableName: nil,
+                value: "Tabs",
+                comment: "The title on the button to look at regular tabs.")
         }
     }
 }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2748,12 +2748,12 @@ extension String {
             value: "Currently selected tab.",
             comment: "Accessibility label for the currently selected tab.")
         public static let TabsSelectorNormalTabsTitle = MZLocalizedString(
-            key: "TabTray.TabsSelectorNormalTabsTitle",
+            key: "TabTray.TabsSelectorNormalTabsTitle.v140",
             tableName: "TabsTray",
             value: "%@ Tabs",
             comment: "The title on the button to look at regular tabs. %@ is the number of regular tabs.")
         public static let TabsSelectorSyncedTabsTitle = MZLocalizedString(
-            key: "TabTray.TabsSelectorSyncedTabsTitle",
+            key: "TabTray.TabsSelectorSyncedTabsTitle.v140",
             tableName: "TabsTray",
             value: "Sync",
             comment: "The title on the button to look at synced tabs.")

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2682,6 +2682,82 @@ extension String {
 // MARK: - Tabs Tray
 extension String {
     public struct TabsTray {
+        public static let TabTrayV2Title = MZLocalizedString(
+            key: "TabTray.Title",
+            tableName: nil,
+            value: "Open Tabs",
+            comment: "The title for the tab tray")
+        public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString(
+            key: "TabTray.SegmentedControlTitles.Tabs",
+            tableName: nil,
+            value: "Tabs",
+            comment: "The title on the button to look at regular tabs.")
+        public static let TabTraySegmentedControlTitlesPrivateTabs = MZLocalizedString(
+            key: "TabTray.SegmentedControlTitles.PrivateTabs",
+            tableName: nil,
+            value: "Private",
+            comment: "The title on the button to look at private tabs.")
+        public static let TabTrayToggleAccessibilityLabel = MZLocalizedString(
+            key: "PrivateBrowsing.Toggle.A11y.Label.v132",
+            tableName: "PrivateBrowsing",
+            value: "Private browsing",
+            comment: "Accessibility label for toggling on/off private mode")
+        public static let TabTrayToggleAccessibilityValueOn = MZLocalizedString(
+            key: "On",
+            tableName: "PrivateBrowsing",
+            value: nil,
+            comment: "Toggled ON accessibility value")
+        public static let TabTrayToggleAccessibilityValueOff = MZLocalizedString(
+            key: "Off",
+            tableName: "PrivateBrowsing",
+            value: nil,
+            comment: "Toggled OFF accessibility value")
+        public static let TabTrayViewAccessibilityLabel = MZLocalizedString(
+            key: "Tabs Tray",
+            tableName: nil,
+            value: nil,
+            comment: "Accessibility label for the Tabs Tray view.")
+        public static let TabTrayClosingTabAccessibilityMessage =  MZLocalizedString(
+            key: "Closing tab",
+            tableName: nil,
+            value: nil,
+            comment: "Accessibility label (used by assistive technology) notifying the user that the tab is being closed.")
+        public static let TabTrayCloseAllTabsPromptCancel = MZLocalizedString(
+            key: "Cancel",
+            tableName: nil,
+            value: nil,
+            comment: "Label for Cancel button")
+        public static let TabTrayPrivateBrowsingTitle = MZLocalizedString(
+            key: "Private Browsing",
+            tableName: "PrivateBrowsing",
+            value: nil,
+            comment: "Title displayed for when there are no open tabs while in private mode")
+        public static let TabTrayPrivateBrowsingDescription =  MZLocalizedString(
+            key: "Firefox won’t remember any of your history or cookies, but new bookmarks will be saved.",
+            tableName: "PrivateBrowsing",
+            value: nil,
+            comment: "Description text displayed when there are no open tabs while in private mode")
+        public static let TabTrayAddTabAccessibilityLabel = MZLocalizedString(
+            key: "Add Tab",
+            tableName: nil,
+            value: nil,
+            comment: "Accessibility label for the Add Tab button in the Tab Tray.")
+        public static let TabTrayCloseAccessibilityCustomAction = MZLocalizedString(
+            key: "Close",
+            tableName: nil,
+            value: nil,
+            comment: "Accessibility label for action denoting closing a tab in tab list (tray)")
+        public static let TabTraySwipeToCloseAccessibilityHint = MZLocalizedString(
+            key: "Swipe right or left with three fingers to close the tab.",
+            tableName: nil,
+            value: nil,
+            comment: "Accessibility hint for tab tray's displayed tab.")
+        public static let TabTrayCurrentlySelectedTabAccessibilityLabel = MZLocalizedString(
+            key: "TabTray.CurrentSelectedTab.A11Y",
+            tableName: nil,
+            value: "Currently selected tab.",
+            comment: "Accessibility label for the currently selected tab.")
+
         public struct InactiveTabs {
             public static let TabsTrayInactiveTabsSectionClosedAccessibilityTitle = MZLocalizedString(
                 key: "TabsTray.InactiveTabs.SectionTitle.Closed.Accessibility.v103",
@@ -3561,32 +3637,6 @@ extension String {
         tableName: nil,
         value: "URL",
         comment: "The label for the URL field when editing a bookmark")
-}
-
-// MARK: - Tab tray (chronological tabs)
-extension String {
-    public static let TabTrayV2Title = MZLocalizedString(
-        key: "TabTray.Title",
-        tableName: nil,
-        value: "Open Tabs",
-        comment: "The title for the tab tray")
-
-    // Segmented Control tites for iPad
-    public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString(
-        key: "TabTray.SegmentedControlTitles.Tabs",
-        tableName: nil,
-        value: "Tabs",
-        comment: "The title on the button to look at regular tabs.")
-    public static let TabTraySegmentedControlTitlesPrivateTabs = MZLocalizedString(
-        key: "TabTray.SegmentedControlTitles.PrivateTabs",
-        tableName: nil,
-        value: "Private",
-        comment: "The title on the button to look at private tabs.")
-    public static let TabTraySegmentedControlTitlesSyncedTabs = MZLocalizedString(
-        key: "TabTray.SegmentedControlTitles.SyncedTabs",
-        tableName: nil,
-        value: "Synced",
-        comment: "The title on the button to look at synced tabs.")
 }
 
 // MARK: - Clipboard Toast
@@ -6219,70 +6269,6 @@ extension String {
         comment: "Accessibility label for the navigation toolbar displayed at the bottom of the screen.")
 }
 
-// MARK: - Tab Tray v1
-extension String {
-    public static let TabTrayToggleAccessibilityLabel = MZLocalizedString(
-        key: "PrivateBrowsing.Toggle.A11y.Label.v132",
-        tableName: "PrivateBrowsing",
-        value: "Private browsing",
-        comment: "Accessibility label for toggling on/off private mode")
-    public static let TabTrayToggleAccessibilityValueOn = MZLocalizedString(
-        key: "On",
-        tableName: "PrivateBrowsing",
-        value: nil,
-        comment: "Toggled ON accessibility value")
-    public static let TabTrayToggleAccessibilityValueOff = MZLocalizedString(
-        key: "Off",
-        tableName: "PrivateBrowsing",
-        value: nil,
-        comment: "Toggled OFF accessibility value")
-    public static let TabTrayViewAccessibilityLabel = MZLocalizedString(
-        key: "Tabs Tray",
-        tableName: nil,
-        value: nil,
-        comment: "Accessibility label for the Tabs Tray view.")
-    public static let TabTrayClosingTabAccessibilityMessage =  MZLocalizedString(
-        key: "Closing tab",
-        tableName: nil,
-        value: nil,
-        comment: "Accessibility label (used by assistive technology) notifying the user that the tab is being closed.")
-    public static let TabTrayCloseAllTabsPromptCancel = MZLocalizedString(
-        key: "Cancel",
-        tableName: nil,
-        value: nil,
-        comment: "Label for Cancel button")
-    public static let TabTrayPrivateBrowsingTitle = MZLocalizedString(
-        key: "Private Browsing",
-        tableName: "PrivateBrowsing",
-        value: nil,
-        comment: "Title displayed for when there are no open tabs while in private mode")
-    public static let TabTrayPrivateBrowsingDescription =  MZLocalizedString(
-        key: "Firefox won’t remember any of your history or cookies, but new bookmarks will be saved.",
-        tableName: "PrivateBrowsing",
-        value: nil,
-        comment: "Description text displayed when there are no open tabs while in private mode")
-    public static let TabTrayAddTabAccessibilityLabel = MZLocalizedString(
-        key: "Add Tab",
-        tableName: nil,
-        value: nil,
-        comment: "Accessibility label for the Add Tab button in the Tab Tray.")
-    public static let TabTrayCloseAccessibilityCustomAction = MZLocalizedString(
-        key: "Close",
-        tableName: nil,
-        value: nil,
-        comment: "Accessibility label for action denoting closing a tab in tab list (tray)")
-    public static let TabTraySwipeToCloseAccessibilityHint = MZLocalizedString(
-        key: "Swipe right or left with three fingers to close the tab.",
-        tableName: nil,
-        value: nil,
-        comment: "Accessibility hint for tab tray's displayed tab.")
-    public static let TabTrayCurrentlySelectedTabAccessibilityLabel = MZLocalizedString(
-        key: "TabTray.CurrentSelectedTab.A11Y",
-        tableName: nil,
-        value: "Currently selected tab.",
-        comment: "Accessibility label for the currently selected tab.")
-}
-
 // MARK: - URL Bar
 extension String {
     public static let URLBarLocationAccessibilityLabel = MZLocalizedString(
@@ -7801,6 +7787,11 @@ extension String {
                 tableName: "PasswordGenerator",
                 value: "Password Generator",
                 comment: "Accessibility label describing a feature that generates a password when the password field of a signup form is interacted with.")
+            public static let TabTraySegmentedControlTitlesSyncedTabs = MZLocalizedString(
+                key: "TabTray.SegmentedControlTitles.SyncedTabs",
+                tableName: nil,
+                value: "Synced",
+                comment: "The title on the button to look at synced tabs.")
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
@@ -38,7 +38,7 @@ class TabCellTests: XCTestCase {
         let state = createDefaultState()
         cell.configure(with: state, theme: nil, delegate: cellDelegate, a11yId: "")
         XCTAssertEqual(cell.accessibilityHint!,
-                       String.TabTraySwipeToCloseAccessibilityHint)
+                       .TabsTray.TabTraySwipeToCloseAccessibilityHint)
     }
 
     func testConfigureTabSelectedState() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12133)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26395)

## :bulb: Description
Took the opportunity to put some `TabsTray` strings in the right struct + added two new strings for the tab tray experiment.

### 🎥 Screenshot
<details>
<summary>Tab tray current state</summary>

![Simulator Screenshot - iPhone 16 - 2025-05-01 at 14 49 25](https://github.com/user-attachments/assets/75453311-0655-4917-83f8-49d17e23dd63)

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
