### PR TITLE
Refactor FXIOS-12124 #26382 ⁃ [Toast audit] Remove toast on Settings > Credit cards action in setting: add, update and remove cards

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -169,8 +169,6 @@ class CreditCardSettingsViewController: SensitiveViewController, UIAdaptivePrese
         creditCardEditView = CreditCardInputView(viewModel: viewModel.cardInputViewModel, windowUUID: windowUUID)
         viewModel.cardInputViewModel.dismiss = { [weak self] status, successVal in
             DispatchQueue.main.async {
-                self?.showToast(status: status)
-
                 if successVal {
                     self?.updateCreditCardList()
                     self?.sendTelemetry(forStatus: status)
@@ -188,13 +186,6 @@ class CreditCardSettingsViewController: SensitiveViewController, UIAdaptivePrese
         creditCardAddEditView.modalPresentationStyle = .formSheet
         creditCardAddEditView.presentationController?.delegate = self
         present(creditCardAddEditView, animated: true, completion: nil)
-    }
-
-    private func showToast(status: CreditCardModifiedStatus) {
-        guard status != .none else { return }
-        SimpleToast().showAlertWithText(status.message,
-                                        bottomContainer: view,
-                                        theme: self.themeManager.getCurrentTheme(for: self.windowUUID))
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
@@ -74,7 +74,8 @@ class CreditCardSettingsViewModel {
                 completionHandler(nil)
                 return
             }
-            self.updateCreditCardsList(creditCards: cards)
+            let sortedCards = cards.sorted { $0.timeCreated > $1.timeCreated }
+            self.updateCreditCardsList(creditCards: sortedCards)
             completionHandler(creditCards)
         })
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12124)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26382)

## :bulb: Description
- Remove Toast from Settings > Autofills & password > Payment methods (credit cards) 
- Sort credit cards to show last created first as suggested from UX for a clearer visual effect

## :movie_camera: Demos

https://github.com/user-attachments/assets/b00d1192-8008-4ae9-af25-2832c47291de


| Before | After |
| - | - |
| <![Simulator Screenshot - iPhone 16 - 2025-05-01 at 10 01 01](https://github.com/user-attachments/assets/4d77327e-80cb-419c-8cc7-a8f00ced557e)> | <![Simulator Screenshot - iPhone 16 - 2025-05-01 at 09 59 11](https://github.com/user-attachments/assets/eb13ede5-bd96-43c5-baba-56a1ae192487)> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
