### PR TITLE
Bugfix FXIOS-12162 [Localization] Fix script not importing new strings

### DIFF
--- a/firefox-ios/import-strings.sh
+++ b/firefox-ios/import-strings.sh
@@ -18,7 +18,7 @@ echo "\n\n[*] Building tools/Localizations"
 echo "\n\n[*] Importing Strings - takes a minute. (output in import-strings.log)"
 (cd LocalizationTools && swift run LocalizationTools \
   --import \
-  --project-path "$PWD/../firefox-ios/Client.xcodeproj" \
+  --project-path "$PWD/../Client.xcodeproj" \
   --l10n-project-path "$PWD/../firefoxios-l10n") > import-strings.log 2>&1
 
 echo "\n\n[!] Strings have been imported. You can now create a PR."


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12162)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26457)

## :bulb: Description
Strings were no longer being imported, I believe it's due to the filepath not being quite right for Client.xcodeproj, so I've updated it.
