### PR TITLE
Bugfix FXIOS-12162 [Localization] Fix script not importing new strings

### DIFF
--- a/.github/workflows/firefox-ios-import-strings.yml
+++ b/.github/workflows/firefox-ios-import-strings.yml
@@ -15,7 +15,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.11]
-        xcode: ["16.3"]
+        xcode: ["16.2"]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/firefox-ios-import-strings.yml
+++ b/.github/workflows/firefox-ios-import-strings.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
-        xcode: ["16.2"]
+        python-version: [3.11]
+        xcode: ["16.3"]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/firefox-ios-l10n-linter.yml
+++ b/.github/workflows/firefox-ios-l10n-linter.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         xcode:
-          - "16.3"
+          - "16.2"
     steps:
       - name: Clone code repository
         uses: actions/checkout@v4

--- a/.github/workflows/firefox-ios-l10n-linter.yml
+++ b/.github/workflows/firefox-ios-l10n-linter.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         xcode:
-          - "16.2"
+          - "16.3"
     steps:
       - name: Clone code repository
         uses: actions/checkout@v4

--- a/.github/workflows/focus-ios-import-strings.yml
+++ b/.github/workflows/focus-ios-import-strings.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
-        xcode: ["16.2"]
+        python-version: [3.11]
+        xcode: ["16.3"]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/focus-ios-l10n-linter.yml
+++ b/.github/workflows/focus-ios-l10n-linter.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 4
       matrix:
         xcode:
-          - "16.2"
+          - "16.3"
     steps:
       - name: Clone code repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12162)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26457)

## :bulb: Description

I think the problem started with #25209, which introduced a new package that requires Python 3.11

In the import log ([example](https://github.com/mozilla-mobile/firefox-ios/actions/runs/14782082747/job/41502990521)), I see:

```
 Collecting lxml~=5.3.1 (from -r firefoxios-l10n/.github/scripts/requirements.txt (line 1))
  Downloading lxml-5.3.2-cp39-cp39-macosx_10_9_universal2.whl.metadata (3.6 kB)
ERROR: Ignored the following versions that require a different python version: 0.1.0 Requires-Python >=3.11; 0.1.1 Requires-Python >=3.11
ERROR: Could not find a version that satisfies the requirement moz-xliff-linter~=0.1.1 (from versions: none)
ERROR: No matching distribution found for moz-xliff-linter~=0.1.1
Traceback (most recent call last):
  File "/Users/runner/work/firefox-ios/firefox-ios/firefoxios-l10n/.github/scripts/rewrite_original_attribute.py", line 16, in <module>


    from lxml import etree
[*] Building tools/Localizations
ModuleNotFoundError: No module named 'lxml'
```

Looks like other workflows are using Xcode 16.3, so switching to that.

