### PR TITLE
Bugfix FXIOS-12158 #26451 ⁃ User complaints about video player glitch when entering/exiting fullscreen mode

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -70,7 +70,8 @@ class BrowserViewController: UIViewController,
         .URL,
         .title,
         .hasOnlySecureContent,
-        .fullscreenState
+        // TODO: FXIOS-12158 Add back after investigating why video player is broken
+//        .fullscreenState
     ]
 
     weak var browserDelegate: BrowserDelegate?
@@ -2129,16 +2130,17 @@ class BrowserViewController: UIViewController,
                 legacyUrlBar?.locationView.hasSecureContent = webView.hasOnlySecureContent
                 legacyUrlBar?.locationView.showTrackingProtectionButton(for: webView.url)
             }
-        case .fullscreenState:
-            if #available(iOS 16.0, *) {
-                guard webView.fullscreenState == .enteringFullscreen ||
-                        webView.fullscreenState == .exitingFullscreen else { return }
-                if webView.fullscreenState == .enteringFullscreen {
-                    fullscreenDelegate?.enteringFullscreen()
-                } else {
-                    fullscreenDelegate?.exitingFullscreen()
-                }
-            }
+            // TODO: FXIOS-12158 Add back after investigating why video player is broken
+//        case .fullscreenState:
+//            if #available(iOS 16.0, *) {
+//                guard webView.fullscreenState == .enteringFullscreen ||
+//                        webView.fullscreenState == .exitingFullscreen else { return }
+//                if webView.fullscreenState == .enteringFullscreen {
+//                    fullscreenDelegate?.enteringFullscreen()
+//                } else {
+//                    fullscreenDelegate?.exitingFullscreen()
+//                }
+//            }
         default:
             assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
         }

--- a/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -14,7 +14,8 @@ class WebviewViewController: UIViewController,
                              FullscreenDelegate {
     private var webView: WKWebView
     var contentType: ContentType = .webview
-    var isFullScreen = false
+    // TODO: FXIOS-12158 Add back after investigating why video player is broken
+//    var isFullScreen = false
 
     init(webView: WKWebView) {
         self.webView = webView
@@ -39,7 +40,8 @@ class WebviewViewController: UIViewController,
         self.webView = webView
 
         // Avoid updating constraints while on fullscreen mode
-        guard !isFullScreen else { return }
+        // TODO: FXIOS-12158 Add back after investigating why video player is broken
+//        guard !isFullScreen else { return }
         setupWebView()
     }
 
@@ -69,13 +71,15 @@ class WebviewViewController: UIViewController,
     // MARK: - FullscreenDelegate
 
     func enteringFullscreen() {
-        isFullScreen = true
-        webView.translatesAutoresizingMaskIntoConstraints = true
-        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        // TODO: FXIOS-12158 Add back after investigating why video player is broken
+//        isFullScreen = true
+//        webView.translatesAutoresizingMaskIntoConstraints = true
+//        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     }
 
     func exitingFullscreen() {
-        setupWebView()
-        isFullScreen = false
+        // TODO: FXIOS-12158 Add back after investigating why video player is broken
+//        setupWebView()
+//        isFullScreen = false
     }
 }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -200,9 +200,10 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         // We do this to go against the configuration of the <meta name="viewport">
         // tag to behave the same way as Safari :-(
         configuration.ignoresViewportScaleLimits = true
-        if #available(iOS 15.4, *) {
-            configuration.preferences.isElementFullscreenEnabled = true
-        }
+        // TODO: FXIOS-12158 Add back after investigating why video player is broken
+//        if #available(iOS 15.4, *) {
+//            configuration.preferences.isElementFullscreenEnabled = true
+//        }
         if isPrivate {
             configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
         } else {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewViewControllerTests.swift
@@ -8,40 +8,40 @@ import XCTest
 import Glean
 
 @testable import Client
-
-class WebviewViewControllerTests: XCTestCase {
-    var webview: WKWebViewMock!
-
-    override func setUp() {
-        super.setUp()
-
-        webview = WKWebViewMock( URL(string: "https://foo.com")!)
-    }
-
-    override func tearDown() {
-        webview = nil
-        super.tearDown()
-    }
-
-    func testEnteringFullScreenCall_FullScreenStateTrue() {
-        let subject = createSubject()
-        subject.enteringFullscreen()
-        XCTAssertTrue(subject.isFullScreen)
-        XCTAssertTrue(webview.translatesAutoresizingMaskIntoConstraints)
-    }
-
-    func testExitingFullScreenCall_FullScreenStateFalse() {
-        let subject = createSubject()
-        subject.exitingFullscreen()
-        XCTAssertFalse(subject.isFullScreen)
-        XCTAssertFalse(webview.translatesAutoresizingMaskIntoConstraints)
-    }
-
-    // MARK: Helper
-    private func createSubject() -> WebviewViewController {
-        let subject = WebviewViewController(webView: webview)
-        trackForMemoryLeaks(subject)
-
-        return subject
-    }
-}
+// TODO: FXIOS-12158 Add back after investigating why video player is broken
+// class WebviewViewControllerTests: XCTestCase {
+//    var webview: WKWebViewMock!
+//
+//    override func setUp() {
+//        super.setUp()
+//
+//        webview = WKWebViewMock( URL(string: "https://foo.com")!)
+//    }
+//
+//    override func tearDown() {
+//        webview = nil
+//        super.tearDown()
+//    }
+//
+//    func testEnteringFullScreenCall_FullScreenStateTrue() {
+//        let subject = createSubject()
+//        subject.enteringFullscreen()
+//        XCTAssertTrue(subject.isFullScreen)
+//        XCTAssertTrue(webview.translatesAutoresizingMaskIntoConstraints)
+//    }
+//
+//    func testExitingFullScreenCall_FullScreenStateFalse() {
+//        let subject = createSubject()
+//        subject.exitingFullscreen()
+//        XCTAssertFalse(subject.isFullScreen)
+//        XCTAssertFalse(webview.translatesAutoresizingMaskIntoConstraints)
+//    }
+//
+//    // MARK: Helper
+//    private func createSubject() -> WebviewViewController {
+//        let subject = WebviewViewController(webView: webview)
+//        trackForMemoryLeaks(subject)
+//
+//        return subject
+//    }
+// }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12158)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26451)

## :bulb: Description
- Remove (commenting) fullscreen support on WKWebview because users complain that it breaks the video player experience. We want to add it back after investigating the video player behaviour, and release it behind a feature flag 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
