### PR TITLE
Add FXIOS-12149 [Tab tray UI experiment] new trash can options

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -264,6 +264,10 @@ struct AccessibilityIdentifiers {
     struct TabTray {
         static let deleteCloseAllButton = "TabTrayController.deleteButton.closeAll"
         static let deleteCancelButton = "TabTrayController.deleteButton.cancel"
+        static let deleteOlderTabsButton = "TabTrayController.deleteButton.closeOlderTabs"
+        static let deleteTabsOlderThan1DayButton = "TabTrayController.deleteButton.olderThan1Day"
+        static let deleteTabsOlderThan1WeekButton = "TabTrayController.deleteButton.olderThan1Week"
+        static let deleteTabsOlderThan1MonthButton = "TabTrayController.deleteButton.olderThan1Month"
         static let syncedTabs = "Synced Tabs"
         static let closeAllTabsButton = "closeAllTabsButtonTabTray"
         static let newTabButton = "newTabButtonTabTray"

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -20,6 +20,7 @@ class TabPanelViewAction: Action {
     let toastType: ToastType?
     let shareSheetURL: URL?
     let isInactiveTab: Bool?
+    let deleteTabPeriod: TabsDeletionPeriod?
 
     init(panelType: TabTrayPanelType?,
          isPrivateModeActive: Bool? = nil,
@@ -29,6 +30,7 @@ class TabPanelViewAction: Action {
          toastType: ToastType? = nil,
          shareSheetURL: URL? = nil,
          isInactiveTab: Bool? = nil,
+         deleteTabPeriod: TabsDeletionPeriod? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
         self.panelType = panelType
@@ -39,6 +41,7 @@ class TabPanelViewAction: Action {
         self.toastType = toastType
         self.shareSheetURL = shareSheetURL
         self.isInactiveTab = isInactiveTab
+        self.deleteTabPeriod = deleteTabPeriod
         super.init(windowUUID: windowUUID,
                    actionType: actionType)
     }
@@ -53,6 +56,7 @@ enum TabPanelViewActionType: ActionType {
     case undoClose
     case closeAllTabs
     case confirmCloseAllTabs
+    case deleteTabsOlderThan
     case undoCloseAllTabs
     case moveTab
     case toggleInactiveTabs
@@ -62,7 +66,6 @@ enum TabPanelViewActionType: ActionType {
     case undoCloseAllInactiveTabs
     case learnMorePrivateMode
     case selectTab
-    case hideUndoToast
 }
 
 class TabPanelMiddlewareAction: Action {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -183,6 +183,10 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
         case TabPanelViewActionType.confirmCloseAllTabs:
             closeAllTabs(state: state, uuid: action.windowUUID)
 
+        case TabPanelViewActionType.deleteTabsOlderThan:
+            guard let period = action.deleteTabPeriod else { return }
+            deleteTabsOlderThan(period: period, uuid: action.windowUUID)
+
         case TabPanelViewActionType.undoCloseAllTabs:
             undoCloseAllTabs(uuid: action.windowUUID)
 
@@ -543,6 +547,11 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
                                               actionType: TabTrayActionType.dismissTabTray)
             store.dispatch(dismissAction)
         }
+    }
+
+    private func deleteTabsOlderThan(period: TabsDeletionPeriod, uuid: WindowUUID) {
+        let tabManager = tabManager(for: uuid)
+        tabManager.removeNormalTabsOlderThan(period: period)
     }
 
     /// Add a new tab when privateMode is selected and all or last normal tabs/tab are/is going to be closed

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -549,7 +549,6 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
         }
     }
 
-    // TODO: Laurie - test
     private func deleteNormalTabsOlderThan(period: TabsDeletionPeriod, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         tabManager.removeNormalTabsOlderThan(period: period)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -549,9 +549,17 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
         }
     }
 
+    // TODO: Laurie - test
     private func deleteTabsOlderThan(period: TabsDeletionPeriod, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         tabManager.removeNormalTabsOlderThan(period: period)
+
+        // We are not closing the tab tray, so we need to refresh the tabs on screen
+        let model = getTabsDisplayModel(for: true, uuid: uuid)
+        let refreshAction = TabPanelMiddlewareAction(tabDisplayModel: model,
+                                                     windowUUID: uuid,
+                                                     actionType: TabPanelMiddlewareActionType.refreshTabs)
+        store.dispatch(refreshAction)
     }
 
     /// Add a new tab when privateMode is selected and all or last normal tabs/tab are/is going to be closed

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -185,7 +185,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
         case TabPanelViewActionType.deleteTabsOlderThan:
             guard let period = action.deleteTabPeriod else { return }
-            deleteTabsOlderThan(period: period, uuid: action.windowUUID)
+            deleteNormalTabsOlderThan(period: period, uuid: action.windowUUID)
 
         case TabPanelViewActionType.undoCloseAllTabs:
             undoCloseAllTabs(uuid: action.windowUUID)
@@ -550,12 +550,12 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     }
 
     // TODO: Laurie - test
-    private func deleteTabsOlderThan(period: TabsDeletionPeriod, uuid: WindowUUID) {
+    private func deleteNormalTabsOlderThan(period: TabsDeletionPeriod, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         tabManager.removeNormalTabsOlderThan(period: period)
 
         // We are not closing the tab tray, so we need to refresh the tabs on screen
-        let model = getTabsDisplayModel(for: true, uuid: uuid)
+        let model = getTabsDisplayModel(for: false, uuid: uuid)
         let refreshAction = TabPanelMiddlewareAction(tabDisplayModel: model,
                                                      windowUUID: uuid,
                                                      actionType: TabPanelMiddlewareActionType.refreshTabs)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -29,6 +29,10 @@ struct TabTrayState: ScreenState, Equatable {
         return selectedPanel == .syncedTabs
     }
 
+    var isNormalTabsPanel: Bool {
+        return selectedPanel == .tabs
+    }
+
     init(appState: AppState, uuid: WindowUUID) {
         guard let panelState = store.state.screenState(TabTrayState.self,
                                                        for: .tabsTray,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -688,7 +688,7 @@ class TabTrayViewController: UIViewController,
         }), accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton
         )
 
-        alert.addAction(UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel, style: .cancel, handler: nil),
+        alert.addAction(UIAlertAction(title: .TabsTray.TabTrayCloseAllTabsPromptCancel, style: .cancel, handler: nil),
                         accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCancelButton)
         alert.popoverPresentationController?.barButtonItem = deleteButton
         present(alert, animated: true, completion: nil)
@@ -724,7 +724,7 @@ class TabTrayViewController: UIViewController,
             alert.addAction(action, accessibilityIdentifier: option.accessibilityID)
         }
 
-        alert.addAction(UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel, style: .cancel, handler: nil),
+        alert.addAction(UIAlertAction(title: .TabsTray.TabTrayCloseAllTabsPromptCancel, style: .cancel, handler: nil),
                         accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCancelButton)
 
         alert.popoverPresentationController?.barButtonItem = deleteButton

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -666,18 +666,68 @@ class TabTrayViewController: UIViewController,
         store.dispatch(action)
     }
 
+//    private func showCloseAllConfirmation() {
+//        let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+//        controller.addAction(UIAlertAction(title: .LegacyAppMenu.AppMenuCloseAllTabsTitleString,
+//                                           style: .default,
+//                                           handler: { _ in self.confirmCloseAll() }),
+//                             accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
+//        controller.addAction(UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel,
+//                                           style: .cancel,
+//                                           handler: nil),
+//                             accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCancelButton)
+//        controller.popoverPresentationController?.barButtonItem = deleteButton
+//        present(controller, animated: true, completion: nil)
+//    }
+
+    // TODO: Laurie - Add new strings
+    // TODO: Laurie - Add actions
     private func showCloseAllConfirmation() {
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.addAction(UIAlertAction(title: .LegacyAppMenu.AppMenuCloseAllTabsTitleString,
+
+        controller.addAction(UIAlertAction(title: "Close Tabs Older Than...",
                                            style: .default,
-                                           handler: { _ in self.confirmCloseAll() }),
-                             accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
-        controller.addAction(UIAlertAction(title: .TabsTray.TabTrayCloseAllTabsPromptCancel,
-                                           style: .cancel,
-                                           handler: nil),
-                             accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCancelButton)
+                                           handler: { _ in
+            // Delay to allow current sheet to dismiss
+            DispatchQueue.main.async {
+                self.showTimeRangePicker()
+            }
+        }))
+
+        controller.addAction(UIAlertAction(title: "Close Duplicate Tabs",
+                                           style: .default,
+                                           handler: { _ in
+        }))
+
+        controller.addAction(UIAlertAction(title: "Close All Tabs",
+                                           style: .destructive,
+                                           handler: { _ in
+        }))
+
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         controller.popoverPresentationController?.barButtonItem = deleteButton
         present(controller, animated: true, completion: nil)
+    }
+
+    private func showTimeRangePicker() {
+        let alert = UIAlertController(title: "Delete tabs older than...",
+                                      message: "Tabs older than the selected time range will be closed.",
+                                      preferredStyle: .actionSheet)
+
+        ["24 hours ago", "7 days ago", "2 weeks ago", "4 weeks ago"].forEach { title in
+            alert.addAction(UIAlertAction(title: title, style: .default, handler: { _ in
+                print("Selected: \(String(describing: title))")
+            }))
+        }
+
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+
+        // On iPad: you need to set a sourceView or barButtonItem
+        if let popover = alert.popoverPresentationController {
+            popover.barButtonItem = deleteButton
+        }
+
+        present(alert, animated: true, completion: nil)
     }
 
     private func confirmCloseAll() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -669,6 +669,7 @@ class TabTrayViewController: UIViewController,
     private func showCloseAllConfirmation() {
         let alert = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
+        // We only show the potion to delete old tabs with normal tabs tray
         if tabTrayState.isNormalTabsPanel {
             alert.addAction(UIAlertAction(title: .TabsTray.TabTrayCloseOldTabsTitle,
                                           style: .default,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -685,18 +685,13 @@ class TabTrayViewController: UIViewController,
     private func showCloseAllConfirmation() {
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        controller.addAction(UIAlertAction(title: "Close Tabs Older Than...",
+        controller.addAction(UIAlertAction(title: "Close Old Tabs…",
                                            style: .default,
                                            handler: { _ in
             // Delay to allow current sheet to dismiss
             DispatchQueue.main.async {
                 self.showTimeRangePicker()
             }
-        }))
-
-        controller.addAction(UIAlertAction(title: "Close Duplicate Tabs",
-                                           style: .default,
-                                           handler: { _ in
         }))
 
         controller.addAction(UIAlertAction(title: "Close All Tabs",
@@ -710,11 +705,11 @@ class TabTrayViewController: UIViewController,
     }
 
     private func showTimeRangePicker() {
-        let alert = UIAlertController(title: "Delete tabs older than...",
-                                      message: "Tabs older than the selected time range will be closed.",
+        let alert = UIAlertController(title: "Close tabs older than…",
+                                      message: nil,
                                       preferredStyle: .actionSheet)
 
-        ["24 hours ago", "7 days ago", "2 weeks ago", "4 weeks ago"].forEach { title in
+        ["1 Day Ago", "1 Week Ago", "1 Month Ago"].forEach { title in
             alert.addAction(UIAlertAction(title: title, style: .default, handler: { _ in
                 print("Selected: \(String(describing: title))")
             }))

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -10,6 +10,10 @@ enum TabManagerConstants {
     static let tabScreenshotNamespace = "TabManagerScreenshots"
 }
 
+enum TabsDeletionPeriod {
+    case oneDay, oneWeek, oneMonth
+}
+
 // MARK: - TabManager protocol
 protocol TabManager: AnyObject {
     var windowUUID: WindowUUID { get }
@@ -65,6 +69,9 @@ protocol TabManager: AnyObject {
     /// Removes all tabs matching the urls, used when other clients request to close tabs on this device.
     func removeTabs(by urls: [URL]) async
     func removeTabs(_ tabs: [Tab])
+
+    /// Remove normal tabs older than a certain period of time
+    func removeNormalTabsOlderThan(period: TabsDeletionPeriod)
 
     // MARK: - Undo Close
     func undoCloseTab()

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -364,6 +364,29 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
     }
 
+    // TODO: Laurie - add tests for removeTabsOlderThan and removeTabs
+    func removeNormalTabsOlderThan(period: TabsDeletionPeriod) {
+        let calendar = Calendar.current
+        let now = Date()
+        let cutoffDate: Date
+
+        switch period {
+        case .oneDay:
+            cutoffDate = calendar.date(byAdding: .day, value: -1, to: now) ?? now
+        case .oneWeek:
+            cutoffDate = calendar.date(byAdding: .day, value: -7, to: now) ?? now
+        case .oneMonth:
+            cutoffDate = calendar.date(byAdding: .month, value: -1, to: now) ?? now
+        }
+
+        let tabsToRemove = normalTabs.filter { tab in
+            let lastUsed = Date.fromTimestamp(tab.lastExecutedTime)
+            return lastUsed < cutoffDate
+        }
+
+        removeTabs(tabsToRemove)
+    }
+
     // MARK: - Add Tab
     func addTab(_ request: URLRequest?, afterTab: Tab?, isPrivate: Bool) -> Tab {
         return addTab(request,

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -364,7 +364,6 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
     }
 
-    // TODO: Laurie - add tests for removeTabsOlderThan and removeTabs
     func removeNormalTabsOlderThan(period: TabsDeletionPeriod) {
         let calendar = Calendar.current
         let now = Date()
@@ -384,6 +383,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
             return lastUsed < cutoffDate
         }
 
+        guard !tabsToRemove.isEmpty else { return }
         removeTabs(tabsToRemove)
     }
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2840,6 +2840,31 @@ extension String {
             tableName: "TabsTray",
             value: "%1$@ of %2$@",
             comment: "Message spoken by VoiceOver saying the position of the currently selected page in the tab tray selector (%1$@), along with the total number of selector (%2$@). E.g. “1 of 3” says that page 1 is visible, out of 3 pages total.")
+        public static let TabTrayCloseOldTabsTitle = MZLocalizedString(
+            key: "TabTrayCloseOldTabsTitle.v140",
+            tableName: "TabsTray",
+            value: "Close Old Tabs…",
+            comment: "Text for a button in the tabs tray used to open another menu to close older tabs.")
+        public static let TabTrayCloseTabsOlderThanTitle = MZLocalizedString(
+            key: "TabTrayCloseTabsOlderThanTitle.v140",
+            tableName: "TabsTray",
+            value: "Close tabs older than…",
+            comment: "Text for the menu title under the tabs tray in which users can close tabs older than a certain period of time.")
+        public static let TabTrayOneDayAgoTitle = MZLocalizedString(
+            key: "TabTrayOneDayAgoTitle.v140",
+            tableName: "TabsTray",
+            value: "1 Day Ago",
+            comment: "The label for a button that closes tabs older than 1 day ago. Shown in a menu under the tabs tray.")
+        public static let TabTrayOneWeekAgoTitle = MZLocalizedString(
+            key: "TabTrayOneWeekAgoTitle.v140",
+            tableName: "TabsTray",
+            value: "1 Week Ago",
+            comment: "The label for a button that closes tabs older than 1 week ago. Shown in a menu under the tabs tray.")
+        public static let TabTrayOneMonthAgoTitle = MZLocalizedString(
+            key: "TabTrayOneMonthAgoTitle.v140",
+            tableName: "TabsTray",
+            value: "1 Month Ago",
+            comment: "The label for a button that closes tabs older than 1 month ago. Shown in a menu under the tabs tray.")
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -93,6 +93,8 @@ class MockTabManager: TabManager {
         removeTabsByURLCalled += 1
     }
 
+    func removeNormalTabsOlderThan(period: TabsDeletionPeriod) {}
+
     func undoCloseAllTabs() {}
 
     func undoCloseTab() {}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -1513,6 +1513,98 @@ class TabManagerTests: XCTestCase {
         XCTAssertEqual(tabManager.selectedIndex, 0, "Index of new normal active tab")
     }
 
+    // MARK: - Remove Tabs Older than
+
+    func testRemoveNormalTabsOlderThan_whenNotOldNormalTabs_thenNoTabsRemoved() {
+        let numberTabs = 3
+        let tabs = generateTabs(ofType: .normalActive, count: numberTabs)
+        let tabManager = createSubject(tabs: tabs)
+
+        tabManager.removeNormalTabsOlderThan(period: .oneDay)
+
+        XCTAssertEqual(tabManager.normalTabs.count, numberTabs)
+    }
+
+    func testRemoveNormalTabsOlderThan_whenInactiveNormalTabs_thenTabsRemoved() {
+        let numberTabs = 3
+        let tabs = generateTabs(ofType: .normalInactive, count: numberTabs)
+        let tabManager = createSubject(tabs: tabs)
+
+        tabManager.removeNormalTabsOlderThan(period: .oneWeek)
+
+        XCTAssertEqual(tabManager.normalTabs.count, 0)
+    }
+
+    func testRemoveNormalTabsOlderThan_whenPrivateTabs_thenNoTabsRemoved() {
+        let numberPrivateTabs = 3
+        let tabs = generateTabs(ofType: .privateAny, count: numberPrivateTabs)
+        let tabManager = createSubject(tabs: tabs)
+
+        tabManager.removeNormalTabsOlderThan(period: .oneDay)
+
+        XCTAssertEqual(tabManager.privateTabs.count, numberPrivateTabs)
+    }
+
+    func testRemoveNormalTabsOlderThan_whenYesterdayNormalTabs_thenTabsRemoved() {
+        let numberTabs = 3
+        let tabs = generateTabs(ofType: .normalInactiveYesterday, count: numberTabs)
+        let tabManager = createSubject(tabs: tabs)
+
+        tabManager.removeNormalTabsOlderThan(period: .oneDay)
+
+        XCTAssertEqual(tabManager.normalTabs.count, 0)
+    }
+
+    func testRemoveNormalTabsOlderThan_whenYesterdayNormalTabsOlderThanOneWeek_thenTabsNotRemoved() {
+        let numberTabs = 3
+        let tabs = generateTabs(ofType: .normalInactiveYesterday, count: numberTabs)
+        let tabManager = createSubject(tabs: tabs)
+
+        tabManager.removeNormalTabsOlderThan(period: .oneWeek)
+
+        XCTAssertEqual(tabManager.normalTabs.count, numberTabs)
+    }
+
+    func testRemoveNormalTabsOlderThan_whenYesterdayNormalTabsOlderThanOneMonth_thenTabsNotRemoved() {
+        let numberTabs = 3
+        let tabs = generateTabs(ofType: .normalInactiveYesterday, count: numberTabs)
+        let tabManager = createSubject(tabs: tabs)
+
+        tabManager.removeNormalTabsOlderThan(period: .oneMonth)
+
+        XCTAssertEqual(tabManager.normalTabs.count, numberTabs)
+    }
+
+    func testRemoveNormalTabsOlderThan_when2WeeksNormalTabs_thenTabsRemoved() {
+        let numberTabs = 3
+        let tabs = generateTabs(ofType: .normalInactive2Weeks, count: numberTabs)
+        let tabManager = createSubject(tabs: tabs)
+
+        tabManager.removeNormalTabsOlderThan(period: .oneDay)
+
+        XCTAssertEqual(tabManager.normalTabs.count, 0)
+    }
+
+    func testRemoveNormalTabsOlderThan_when2WeeksNormalTabsOlderThanOneWeek_thenTabsRemoved() {
+        let numberTabs = 3
+        let tabs = generateTabs(ofType: .normalInactive2Weeks, count: numberTabs)
+        let tabManager = createSubject(tabs: tabs)
+
+        tabManager.removeNormalTabsOlderThan(period: .oneWeek)
+
+        XCTAssertEqual(tabManager.normalTabs.count, 0)
+    }
+
+    func testRemoveNormalTabsOlderThan_when2WeeksNormalTabsOlderThanOneMonth_thenTabsNotRemoved() {
+        let numberTabs = 3
+        let tabs = generateTabs(ofType: .normalInactive2Weeks, count: numberTabs)
+        let tabManager = createSubject(tabs: tabs)
+
+        tabManager.removeNormalTabsOlderThan(period: .oneMonth)
+
+        XCTAssertEqual(tabManager.normalTabs.count, numberTabs)
+    }
+
     // MARK: - removeAllInactiveTabs (removing unselected tabs at array bounds)
 
     @MainActor
@@ -1658,6 +1750,8 @@ class TabManagerTests: XCTestCase {
     enum TabType {
         case normalActive
         case normalInactive
+        case normalInactive2Weeks
+        case normalInactiveYesterday
         case privateAny // `private` alone is a reserved compiler keyword
     }
 
@@ -1674,6 +1768,12 @@ class TabManagerTests: XCTestCase {
                 tab = Tab(profile: MockProfile(), windowUUID: tabWindowUUID, tabCreatedTime: lastMonthDate)
             case .privateAny:
                 tab = Tab(profile: mockProfile, isPrivate: true, windowUUID: tabWindowUUID)
+            case .normalInactive2Weeks:
+                let twoWeeksDate = Date().lastTwoWeek
+                tab = Tab(profile: MockProfile(), windowUUID: tabWindowUUID, tabCreatedTime: twoWeeksDate)
+            case .normalInactiveYesterday:
+                let yesterdayDate = Date.yesterday
+                tab = Tab(profile: MockProfile(), windowUUID: tabWindowUUID, tabCreatedTime: yesterdayDate)
             }
 
             tab.url = testURL(count: i)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
My next PR will contain the telemetry for this feature. This PR adds new trash can options in the tab tray. This is not protected behind a feature flag, we want this to be included as is in v139. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<details>
<summary>Trash can menu</summary>

![Simulator Screenshot - iPhone 15 Pro - 2025-05-01 at 11 45 40](https://github.com/user-attachments/assets/1baf3a25-0ad8-4494-b6f8-d1de33b5d2ce)

</details>

<details>
<summary>Delete old tabs sub-menu</summary>

![Simulator Screenshot - iPhone 15 Pro - 2025-05-01 at 11 45 43](https://github.com/user-attachments/assets/a45610b5-daf3-4877-bc9c-2d4f7c610c85)

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
