### PR TITLE
Bugfix FXIOS-12124 Fix UITest failing fue to changes to remove toast from Settings> Credit card

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -51,10 +51,6 @@ class CreditCardsTests: BaseTestCase {
         addCreditCard(name: "Test", cardNumber: cards[0], expirationDate: "0540")
         waitForElementsToExist(
             [
-                app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.savedCards],
-                app.staticTexts.containingText(
-                    "New"
-                ).element,
                 app.tables.cells.element(
                     boundBy: 1
                 ).buttons.elementContainingText(
@@ -275,7 +271,7 @@ class CreditCardsTests: BaseTestCase {
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
         app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].waitAndTap()
         addCreditCard(name: "Test2", cardNumber: cards[1], expirationDate: "0640")
-        mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
+        mozWaitForElementToExist(app.staticTexts [creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
         app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].waitAndTap()
         addCreditCard(name: "Test3", cardNumber: cards[2], expirationDate: "0740")
         // The cards are saved and displayed in Saved cards
@@ -283,15 +279,16 @@ class CreditCardsTests: BaseTestCase {
         let cardsInfo = [["1252", "Test", "5/40"],
                          ["1111", "Test2", "6/40"],
                          ["9631", "Test3", "7/40"]]
-        for index in 1...3 {
-            mozWaitForElementToExist(app.tables.cells.element(boundBy: index).buttons.firstMatch)
-            XCTAssertTrue(app.tables.cells.element(boundBy: index).buttons
-                .elementContainingText(cardsInfo[index-1][0]).exists,
-                          "\(cardsInfo[index-1][0]) info is not displayed")
-            XCTAssertTrue(app.tables.cells.element(boundBy: index).buttons[cardsInfo[index-1][1]].exists,
-                          "\(cardsInfo[index-1][1]) info is not displayed")
-            XCTAssertTrue(app.tables.cells.element(boundBy: index).buttons[cardsInfo[index-1][2]].exists,
-                          "\(cardsInfo[index-1][2]) info is not displayed")
+
+        // Reverse the expected order to match new UI logic (newest at top)
+        let expectedOrder = cardsInfo.reversed()
+        for (index, card) in expectedOrder.enumerated() {
+            mozWaitForElementToExist(app.tables.cells.element(boundBy: index+1).buttons.firstMatch)
+
+            let cellElement = app.tables.cells.element(boundBy: index+1).buttons
+            XCTAssertTrue(cellElement.elementContainingText(card[0]).exists, "\(card[0]) info is not displayed")
+            XCTAssertTrue(cellElement[card[1]].exists, "\(card[1]) info is not displayed")
+            XCTAssertTrue(cellElement[card[2]].exists, "\(card[2]) info is not displayed")
         }
         // reachAutofillWebsite() not working on iOS 15
         if #available(iOS 16, *) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -271,7 +271,7 @@ class CreditCardsTests: BaseTestCase {
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
         app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].waitAndTap()
         addCreditCard(name: "Test2", cardNumber: cards[1], expirationDate: "0640")
-        mozWaitForElementToExist(app.staticTexts [creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
+        mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
         app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].waitAndTap()
         addCreditCard(name: "Test3", cardNumber: cards[2], expirationDate: "0740")
         // The cards are saved and displayed in Saved cards


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12124)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26382)

## :bulb: Description
The 
Fix UI test after removing toasts, reverse order and remove toast check

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
