### PR TITLE
Bugfix FXIOS TabManager Date related tests

### DIFF
--- a/BrowserKit/Sources/Shared/TimeConstants.swift
+++ b/BrowserKit/Sources/Shared/TimeConstants.swift
@@ -124,6 +124,7 @@ extension Date {
     }
 }
 
+// TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-12175
 extension Date {
     public static var yesterday: Date { return Date().dayBefore }
     public static var tomorrow: Date { return Date().dayAfter }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -551,7 +551,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
     private func deleteNormalTabsOlderThan(period: TabsDeletionPeriod, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
-        tabManager.removeNormalTabsOlderThan(period: period)
+        tabManager.removeNormalTabsOlderThan(period: period, currentDate: .now)
 
         // We are not closing the tab tray, so we need to refresh the tabs on screen
         let model = getTabsDisplayModel(for: false, uuid: uuid)

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -71,7 +71,7 @@ protocol TabManager: AnyObject {
     func removeTabs(_ tabs: [Tab])
 
     /// Remove normal tabs older than a certain period of time
-    func removeNormalTabsOlderThan(period: TabsDeletionPeriod)
+    func removeNormalTabsOlderThan(period: TabsDeletionPeriod, currentDate: Date)
 
     // MARK: - Undo Close
     func undoCloseTab()
@@ -133,5 +133,9 @@ extension TabManager {
 
     func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool = true, isPrivate: Bool = false) {
         addTabsForURLs(urls, zombie: zombie, shouldSelectTab: shouldSelectTab, isPrivate: isPrivate)
+    }
+
+    func removeNormalTabsOlderThan(period: TabsDeletionPeriod, currentDate: Date = Date()) {
+        removeNormalTabsOlderThan(period: period, currentDate: currentDate)
     }
 }

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -134,8 +134,4 @@ extension TabManager {
     func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool = true, isPrivate: Bool = false) {
         addTabsForURLs(urls, zombie: zombie, shouldSelectTab: shouldSelectTab, isPrivate: isPrivate)
     }
-
-    func removeNormalTabsOlderThan(period: TabsDeletionPeriod, currentDate: Date = Date()) {
-        removeNormalTabsOlderThan(period: period, currentDate: currentDate)
-    }
 }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -378,7 +378,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
 
         let tabsToRemove = normalTabs.filter { tab in
             let lastUsed = Date.fromTimestamp(tab.lastExecutedTime)
-            return lastUsed < cutoffDate
+            return lastUsed <= cutoffDate
         }
 
         guard !tabsToRemove.isEmpty else { return }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -364,8 +364,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
     }
 
-    func removeNormalTabsOlderThan(period: TabsDeletionPeriod,
-                                   currentDate: Date = Date()) {
+    func removeNormalTabsOlderThan(period: TabsDeletionPeriod, currentDate: Date) {
         let calendar = Calendar.current
         let cutoffDate: Date
         switch period {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -364,18 +364,17 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
     }
 
-    func removeNormalTabsOlderThan(period: TabsDeletionPeriod) {
+    func removeNormalTabsOlderThan(period: TabsDeletionPeriod,
+                                   currentDate: Date = Date()) {
         let calendar = Calendar.current
-        let now = Date()
         let cutoffDate: Date
-
         switch period {
         case .oneDay:
-            cutoffDate = calendar.date(byAdding: .day, value: -1, to: now) ?? now
+            cutoffDate = calendar.date(byAdding: .day, value: -1, to: currentDate) ?? currentDate
         case .oneWeek:
-            cutoffDate = calendar.date(byAdding: .day, value: -7, to: now) ?? now
+            cutoffDate = calendar.date(byAdding: .day, value: -7, to: currentDate) ?? currentDate
         case .oneMonth:
-            cutoffDate = calendar.date(byAdding: .month, value: -1, to: now) ?? now
+            cutoffDate = calendar.date(byAdding: .month, value: -1, to: currentDate) ?? currentDate
         }
 
         let tabsToRemove = normalTabs.filter { tab in

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -93,7 +93,7 @@ class MockTabManager: TabManager {
         removeTabsByURLCalled += 1
     }
 
-    func removeNormalTabsOlderThan(period: TabsDeletionPeriod) {}
+    func removeNormalTabsOlderThan(period: TabsDeletionPeriod, currentDate: Date) {}
 
     func undoCloseAllTabs() {}
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -22,6 +22,7 @@ class TabManagerTests: XCTestCase {
     var mockDiskImageStore: MockDiskImageStore!
     let sleepTime: UInt64 = 1 * NSEC_PER_SEC
     let windowUUID: WindowUUID = .XCTestDefaultUUID
+    let testDate = Date(timeIntervalSince1970: 1_000_000_000)
 
     override func setUp() {
         super.setUp()
@@ -1520,7 +1521,7 @@ class TabManagerTests: XCTestCase {
         let tabs = generateTabs(ofType: .normalActive, count: numberTabs)
         let tabManager = createSubject(tabs: tabs)
 
-        tabManager.removeNormalTabsOlderThan(period: .oneDay)
+        tabManager.removeNormalTabsOlderThan(period: .oneDay, currentDate: testDate)
 
         XCTAssertEqual(tabManager.normalTabs.count, numberTabs)
     }
@@ -1530,7 +1531,7 @@ class TabManagerTests: XCTestCase {
         let tabs = generateTabs(ofType: .normalInactive, count: numberTabs)
         let tabManager = createSubject(tabs: tabs)
 
-        tabManager.removeNormalTabsOlderThan(period: .oneWeek)
+        tabManager.removeNormalTabsOlderThan(period: .oneWeek, currentDate: testDate)
 
         XCTAssertEqual(tabManager.normalTabs.count, 0)
     }
@@ -1540,7 +1541,7 @@ class TabManagerTests: XCTestCase {
         let tabs = generateTabs(ofType: .privateAny, count: numberPrivateTabs)
         let tabManager = createSubject(tabs: tabs)
 
-        tabManager.removeNormalTabsOlderThan(period: .oneDay)
+        tabManager.removeNormalTabsOlderThan(period: .oneDay, currentDate: testDate)
 
         XCTAssertEqual(tabManager.privateTabs.count, numberPrivateTabs)
     }
@@ -1550,7 +1551,7 @@ class TabManagerTests: XCTestCase {
         let tabs = generateTabs(ofType: .normalInactiveYesterday, count: numberTabs)
         let tabManager = createSubject(tabs: tabs)
 
-        tabManager.removeNormalTabsOlderThan(period: .oneDay)
+        tabManager.removeNormalTabsOlderThan(period: .oneDay, currentDate: testDate)
 
         XCTAssertEqual(tabManager.normalTabs.count, 0)
     }
@@ -1560,7 +1561,7 @@ class TabManagerTests: XCTestCase {
         let tabs = generateTabs(ofType: .normalInactiveYesterday, count: numberTabs)
         let tabManager = createSubject(tabs: tabs)
 
-        tabManager.removeNormalTabsOlderThan(period: .oneWeek)
+        tabManager.removeNormalTabsOlderThan(period: .oneWeek, currentDate: testDate)
 
         XCTAssertEqual(tabManager.normalTabs.count, numberTabs)
     }
@@ -1570,7 +1571,7 @@ class TabManagerTests: XCTestCase {
         let tabs = generateTabs(ofType: .normalInactiveYesterday, count: numberTabs)
         let tabManager = createSubject(tabs: tabs)
 
-        tabManager.removeNormalTabsOlderThan(period: .oneMonth)
+        tabManager.removeNormalTabsOlderThan(period: .oneMonth, currentDate: testDate)
 
         XCTAssertEqual(tabManager.normalTabs.count, numberTabs)
     }
@@ -1580,7 +1581,7 @@ class TabManagerTests: XCTestCase {
         let tabs = generateTabs(ofType: .normalInactive2Weeks, count: numberTabs)
         let tabManager = createSubject(tabs: tabs)
 
-        tabManager.removeNormalTabsOlderThan(period: .oneDay)
+        tabManager.removeNormalTabsOlderThan(period: .oneDay, currentDate: testDate)
 
         XCTAssertEqual(tabManager.normalTabs.count, 0)
     }
@@ -1590,7 +1591,7 @@ class TabManagerTests: XCTestCase {
         let tabs = generateTabs(ofType: .normalInactive2Weeks, count: numberTabs)
         let tabManager = createSubject(tabs: tabs)
 
-        tabManager.removeNormalTabsOlderThan(period: .oneWeek)
+        tabManager.removeNormalTabsOlderThan(period: .oneWeek, currentDate: testDate)
 
         XCTAssertEqual(tabManager.normalTabs.count, 0)
     }
@@ -1600,7 +1601,7 @@ class TabManagerTests: XCTestCase {
         let tabs = generateTabs(ofType: .normalInactive2Weeks, count: numberTabs)
         let tabManager = createSubject(tabs: tabs)
 
-        tabManager.removeNormalTabsOlderThan(period: .oneMonth)
+        tabManager.removeNormalTabsOlderThan(period: .oneMonth, currentDate: testDate)
 
         XCTAssertEqual(tabManager.normalTabs.count, numberTabs)
     }
@@ -1764,15 +1765,15 @@ class TabManagerTests: XCTestCase {
             case .normalActive:
                 tab = Tab(profile: mockProfile, windowUUID: tabWindowUUID)
             case .normalInactive:
-                let lastMonthDate = Date().lastMonth
+                let lastMonthDate = testDate.lastMonth
                 tab = Tab(profile: MockProfile(), windowUUID: tabWindowUUID, tabCreatedTime: lastMonthDate)
             case .privateAny:
                 tab = Tab(profile: mockProfile, isPrivate: true, windowUUID: tabWindowUUID)
             case .normalInactive2Weeks:
-                let twoWeeksDate = Date().lastTwoWeek
+                let twoWeeksDate = testDate.lastTwoWeek
                 tab = Tab(profile: MockProfile(), windowUUID: tabWindowUUID, tabCreatedTime: twoWeeksDate)
             case .normalInactiveYesterday:
-                let yesterdayDate = Date.yesterday
+                let yesterdayDate = yesterdayDate()
                 tab = Tab(profile: MockProfile(), windowUUID: tabWindowUUID, tabCreatedTime: yesterdayDate)
             }
 
@@ -1781,6 +1782,14 @@ class TabManagerTests: XCTestCase {
         }
 
         return tabs
+    }
+
+    /// Returns yesterday test date minus one hour
+    private func yesterdayDate() -> Date {
+        var components = DateComponents()
+        components.day = -1
+        components.hour = -1
+        return Calendar.current.date(byAdding: components, to: testDate)!
     }
 
     private func getMockTabData(count: Int) -> [TabData] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -1785,14 +1785,6 @@ class TabManagerTests: XCTestCase {
         return tabs
     }
 
-    /// Returns yesterday test date minus one hour
-    private func yesterdayDate() -> Date {
-        var components = DateComponents()
-        components.day = -1
-        components.hour = -1
-        return Calendar.current.date(byAdding: components, to: testDate)!
-    }
-
     private func getMockTabData(count: Int) -> [TabData] {
         var tabData = [TabData]()
         for i in 0..<count {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -22,7 +22,8 @@ class TabManagerTests: XCTestCase {
     var mockDiskImageStore: MockDiskImageStore!
     let sleepTime: UInt64 = 1 * NSEC_PER_SEC
     let windowUUID: WindowUUID = .XCTestDefaultUUID
-    let testDate = Date(timeIntervalSince1970: 1_000_000_000)
+    /// 9 Sep 2001 8:00 pm GMT + 0
+    let testDate = Date(timeIntervalSince1970: 1_000_065_600)
 
     override func setUp() {
         super.setUp()
@@ -1773,7 +1774,7 @@ class TabManagerTests: XCTestCase {
                 let twoWeeksDate = testDate.lastTwoWeek
                 tab = Tab(profile: MockProfile(), windowUUID: tabWindowUUID, tabCreatedTime: twoWeeksDate)
             case .normalInactiveYesterday:
-                let yesterdayDate = yesterdayDate()
+                let yesterdayDate = testDate.dayBefore
                 tab = Tab(profile: MockProfile(), windowUUID: tabWindowUUID, tabCreatedTime: yesterdayDate)
             }
 


### PR DESCRIPTION
## :scroll: Tickets
~~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~~
~~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~~

## :bulb: Description
Bugfix `TabManager` date related tests by injecting custom test date.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
