### PR TITLE
Add FXIOS-12178 [Top Sites Visual Refresh] Create feature flag

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -20,6 +20,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case feltPrivacySimplifiedUI
     case feltPrivacyFeltDeletion
     case firefoxSuggestFeature
+    case hntTopSitesVisualRefresh
     case homepageRebuild
     case inactiveTabs
     case menuRefactor
@@ -58,6 +59,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .addressBarMenu,
                 .bookmarksRefactor,
                 .deeplinkOptimizationRefactor,
+                .hntTopSitesVisualRefresh,
                 .homepageRebuild,
                 .feltPrivacyFeltDeletion,
                 .feltPrivacySimplifiedUI,
@@ -117,6 +119,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .addressAutofillEdit,
                 .cleanupHistoryReenabled,
                 .deeplinkOptimizationRefactor,
+                .hntTopSitesVisualRefresh,
                 .homepageRebuild,
                 .microsurvey,
                 .menuRefactor,

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -11,46 +11,46 @@ import UIKit
 /// Please add new features alphabetically.
 enum NimbusFeatureFlagID: String, CaseIterable {
     case addressAutofillEdit
-    case appearanceMenu
     case addressBarMenu
+    case appearanceMenu
     case bookmarksRefactor
     case bottomSearchBar
     case cleanupHistoryReenabled
     case deeplinkOptimizationRefactor
-    case feltPrivacySimplifiedUI
+    case downloadLiveActivities
     case feltPrivacyFeltDeletion
+    case feltPrivacySimplifiedUI
     case firefoxSuggestFeature
     case hntTopSitesVisualRefresh
     case homepageRebuild
     case inactiveTabs
+    case loginsVerificationEnabled
     case menuRefactor
     case menuRefactorHint
     case microsurvey
-    case loginsVerificationEnabled
     case nativeErrorPage
     case noInternetConnectionErrorPage
     case pdfRefactor
-    case downloadLiveActivities
     case ratingPromptFeature
     case reportSiteIssue
+    case revertUnsafeContinuationsRefactor
     case searchEngineConsolidation
     case sentFromFirefox
     case sentFromFirefoxTreatmentA
     case splashScreen
     case startAtHome
-    case unifiedAds
-    case unifiedSearch
     case tabAnimation
     case tabTrayUIExperiments
-    case toolbarRefactor
-    case toolbarOneTapNewTab
-    case toolbarSwipingTabs
     case toolbarNavigationHint
+    case toolbarOneTapNewTab
+    case toolbarRefactor
+    case toolbarSwipingTabs
     case tosFeature
     case trackingProtectionRefactor
-    case revertUnsafeContinuationsRefactor
-    case useRustKeychain
+    case unifiedAds
+    case unifiedSearch
     case updatedPasswordManager
+    case useRustKeychain
 
     // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`. Add in alphabetical order.
     var debugKey: String? {
@@ -114,41 +114,41 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.StartAtHome
         // Cases where users do not have the option to manipulate a setting.
         case .appearanceMenu,
+                .addressAutofillEdit,
                 .addressBarMenu,
                 .bookmarksRefactor,
-                .addressAutofillEdit,
                 .cleanupHistoryReenabled,
                 .deeplinkOptimizationRefactor,
+                .downloadLiveActivities,
+                .feltPrivacyFeltDeletion,
+                .feltPrivacySimplifiedUI,
                 .hntTopSitesVisualRefresh,
                 .homepageRebuild,
-                .microsurvey,
+                .loginsVerificationEnabled,
                 .menuRefactor,
                 .menuRefactorHint,
-                .loginsVerificationEnabled,
+                .microsurvey,
                 .nativeErrorPage,
                 .noInternetConnectionErrorPage,
                 .pdfRefactor,
-                .downloadLiveActivities,
                 .ratingPromptFeature,
                 .reportSiteIssue,
-                .feltPrivacySimplifiedUI,
-                .feltPrivacyFeltDeletion,
+                .revertUnsafeContinuationsRefactor,
                 .searchEngineConsolidation,
                 .sentFromFirefoxTreatmentA,
                 .splashScreen,
-                .unifiedAds,
-                .unifiedSearch,
                 .tabAnimation,
                 .tabTrayUIExperiments,
-                .toolbarRefactor,
-                .toolbarOneTapNewTab,
-                .toolbarSwipingTabs,
                 .toolbarNavigationHint,
+                .toolbarOneTapNewTab,
+                .toolbarRefactor,
+                .toolbarSwipingTabs,
                 .tosFeature,
                 .trackingProtectionRefactor,
-                .revertUnsafeContinuationsRefactor,
-                .useRustKeychain,
-                .updatedPasswordManager:
+                .unifiedAds,
+                .unifiedSearch,
+                .updatedPasswordManager,
+                .useRustKeychain:
             return nil
         }
     }

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -112,7 +112,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.SentFromFirefox
         case .startAtHome:
             return FlagKeys.StartAtHome
-        // Cases where users do not have the option to manipulate a setting.
+        // Cases where users do not have the option to manipulate a setting. Please add in alphabetical order.
         case .appearanceMenu,
                 .addressAutofillEdit,
                 .addressBarMenu,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -28,36 +28,22 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
             children: [
                 FeatureFlagsBoolSetting(
                     with: .addressBarMenu,
-                    titleText: format(string: "Enable New AddressBar Menu"),
+                    titleText: format(string: "AddressBar Menu"),
                     statusText: format(string: "Toggle to show the new address bar menu")
                 ) { [weak self] _ in
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
                     with: .appearanceMenu,
-                    titleText: format(string: "Enable New Appearance Menu"),
+                    titleText: format(string: "Appearance Menu"),
                     statusText: format(string: "Toggle to show the new apperance menu")
                 ) { [weak self] _ in
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
-                    with: .tabTrayUIExperiments,
-                    titleText: format(string: "Enable Tab Tray UI Experiment"),
-                    statusText: format(string: "Toggle to use the new tab tray UI")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
-                    with: .tabAnimation,
-                    titleText: format(string: "Enable Tab Tray Animation"),
-                    statusText: format(string: "Toggle to use the new tab tray animation when new tab experiment is enabled")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
                     with: .bookmarksRefactor,
-                    titleText: format(string: "Enable Bookmarks Redesign"),
-                    statusText: format(string: "Toggle to use the new bookmarks design")
+                    titleText: format(string: "Bookmarks Redesign"),
+                    statusText: format(string: "Toggle to use the bookmarks redesign")
                 ) { [weak self] _ in
                     guard let self else { return }
                     self.reloadView()
@@ -66,66 +52,115 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self.profile?.prefs.setBool(isBookmarksRefactorEnabled, forKey: PrefsKeys.IsBookmarksRefactorEnabled)
                 },
                 FeatureFlagsBoolSetting(
+                    with: .deeplinkOptimizationRefactor,
+                    titleText: format(string: "Deeplink Optimization Refactor"),
+                    statusText: format(string: "Toggle to enable deeplink optimization refactor")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .downloadLiveActivities,
+                    titleText: format(string: "Download Live Activities"),
+                    statusText: format(string: "Toggle to enable download live activities")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .trackingProtectionRefactor,
+                    titleText: format(string: "Enhanced Tracking Protection"),
+                    statusText: format(string: "Toggle to use enhanced tracking protection")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .feltPrivacyFeltDeletion,
+                    titleText: format(string: "Felt Privacy Deletion"),
+                    statusText: format(string: "Toggle to enable felt privacy deletion")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .feltPrivacySimplifiedUI,
+                    titleText: format(string: "Felt Privacy UI"),
+                    statusText: format(string: "Toggle to enable felt privacy UI")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .homepageRebuild,
+                    titleText: format(string: "Homepage Rebuild"),
+                    statusText: format(string: "Toggle to use the homepage rebuild")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .loginsVerificationEnabled,
+                    titleText: format(string: "Logins Verification"),
+                    statusText: format(string: "Toggle to enable logins verification")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .menuRefactor,
+                    titleText: format(string: "Menu Redesign"),
+                    statusText: format(string: "Toggle to use the menu redesign")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .microsurvey,
-                    titleText: format(string: "Enable Microsurvey"),
+                    titleText: format(string: "Microsurvey"),
                     statusText: format(string: "Toggle to reset microsurvey expiration")
                 ) { [weak self] _ in
                     UserDefaults.standard.set(nil, forKey: "\(GleanPlumbMessageStore.rootKey)\("homepage-microsurvey-message")")
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
-                    with: .homepageRebuild,
-                    titleText: format(string: "Enable New Homepage"),
-                    statusText: format(string: "Toggle to use the new homepage")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
-                    with: .menuRefactor,
-                    titleText: format(string: "Enable New Menu"),
-                    statusText: format(string: "Toggle to use the new menu")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
-                    with: .loginsVerificationEnabled,
-                    titleText: format(string: "Enable Logins Verification"),
-                    statusText: format(string: "Toggle to enable logins verification")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
-                    with: .trackingProtectionRefactor,
-                    titleText: format(string: "Enable New Tracking Protection"),
-                    statusText: format(string: "Toggle to use the new tracking protection")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
                     with: .nativeErrorPage,
-                    titleText: format(string: "Enable Native Error Page"),
+                    titleText: format(string: "Native Error Page"),
                     statusText: format(string: "Toggle to display natively created error pages")
                 ) { [weak self] _ in
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
                     with: .noInternetConnectionErrorPage,
-                    titleText: format(string: "Enable NIC Native Error Page"),
+                    titleText: format(string: "NIC Native Error Page"),
                     statusText: format(string: "Toggle to display natively created no internet connection error page")
                 ) { [weak self] _ in
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
-                    with: .feltPrivacyFeltDeletion,
-                    titleText: format(string: "Enable Felt Privacy Deletion"),
-                    statusText: format(string: "Toggle to felt privacy deletion")
+                    with: .pdfRefactor,
+                    titleText: format(string: "PDF Refactor"),
+                    statusText: format(string: "Toggle to enable PDF Refactor feature")
                 ) { [weak self] _ in
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
-                    with: .feltPrivacySimplifiedUI,
-                    titleText: format(string: "Enable Felt Privacy UI"),
-                    statusText: format(string: "Toggle to felt privacy UI")
+                    with: .useRustKeychain,
+                    titleText: format(string: "Rust Keychain"),
+                    statusText: format(string: "Toggle to enable rust keychain")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .sentFromFirefox,
+                    titleText: format(string: "Sent from Firefox"),
+                    statusText: format(string: "Toggle to enable Sent from Firefox to append text to WhatsApp shares")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .tabTrayUIExperiments,
+                    titleText: format(string: "Tab Tray UI Experiment"),
+                    statusText: format(string: "Toggle to use the new tab tray UI")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .tabAnimation,
+                    titleText: format(string: "Tab Tray Animation"),
+                    statusText: format(string: "Toggle to use the new tab tray animation when new tab experiment is enabled")
                 ) { [weak self] _ in
                     self?.reloadView()
                 },
@@ -137,65 +172,30 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
+                    with: .hntTopSitesVisualRefresh,
+                    titleText: format(string: "Top Sites Visual Refresh"),
+                    statusText: format(string: "Toggle to enable the top sites visual refresh")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .unifiedAds,
-                    titleText: format(string: "Enable Unified Ads"),
+                    titleText: format(string: "Unified Ads"),
                     statusText: format(string: "Toggle to use unified ads API")
                 ) { [weak self] _ in
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
                     with: .unifiedSearch,
-                    titleText: format(string: "Enable Unified Search"),
+                    titleText: format(string: "Unified Search"),
                     statusText: format(string: "Toggle to use unified search within the new toolbar")
                 ) { [weak self] _ in
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
-                    with: .pdfRefactor,
-                    titleText: format(string: "Enable PDF Refactor"),
-                    statusText: format(string: "Toggle to enable PDF Refactor feature")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
-                    with: .downloadLiveActivities,
-                    titleText: format(string: "Enable Download Live Activities"),
-                    statusText: format(string: "Toggle to enable download live activities")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
-                    with: .useRustKeychain,
-                    titleText: format(string: "Enable Rust Keychain"),
-                    statusText: format(string: "Toggle to enable rust keychain")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
                     with: .updatedPasswordManager,
-                    titleText: format(string: "Enable Updated Password Manager"),
-                    statusText: format(string: "Toggle to enable updated password manager")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
-                    with: .sentFromFirefox,
-                    titleText: format(string: "Enable Sent from Firefox"),
-                    statusText: format(string: "Toggle to enable Sent from Firefox to append text to WhatsApp shares")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
-                    with: .deeplinkOptimizationRefactor,
-                    titleText: format(string: "Enable Deeplink Optimization Refactor"),
-                    statusText: format(string: "Toggle to enable deeplink optimization refactor")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
-                    with: .hntTopSitesVisualRefresh,
-                    titleText: format(string: "Enable Top Sites Visual Refresh"),
-                    statusText: format(string: "Toggle to enable top sites visual refresh")
+                    titleText: format(string: "Updated Password Manager"),
+                    statusText: format(string: "Toggle to enable the updated password manager")
                 ) { [weak self] _ in
                     self?.reloadView()
                 },

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -192,6 +192,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 ) { [weak self] _ in
                     self?.reloadView()
                 },
+                FeatureFlagsBoolSetting(
+                    with: .hntTopSitesVisualRefresh,
+                    titleText: format(string: "Enable Top Sites Visual Refresh"),
+                    statusText: format(string: "Toggle to enable top sites visual refresh")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
             ]
         )
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -23,6 +23,7 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
     }
 
     private func generateFeatureFlagToggleSettings() -> SettingSection {
+        // For better code readability and parsability in-app, please keep in alphabetical order by title
         return SettingSection(
             title: nil,
             children: [

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -9,6 +9,7 @@ final class NimbusFeatureFlagLayer {
     public func checkNimbusConfigFor(_ featureID: NimbusFeatureFlagID,
                                      from nimbus: FxNimbus = FxNimbus.shared
     ) -> Bool {
+        // For better code readability, please keep in alphabetical order by NimbusFeatureFlagID
         switch featureID {
         case .addressAutofillEdit:
             return checkAddressAutofillEditing(from: nimbus)

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -175,8 +175,7 @@ final class NimbusFeatureFlagLayer {
     }
 
     public func checkHntTopSitesVisualRefreshFeature(from nimbus: FxNimbus) -> Bool {
-        let config = nimbus.features.hntTopSitesVisualRefreshFeature.value()
-        return config.enabled
+        return nimbus.features.hntTopSitesVisualRefreshFeature.value().enabled
     }
 
     private func checkHomepageFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -40,6 +40,9 @@ final class NimbusFeatureFlagLayer {
         case .feltPrivacySimplifiedUI, .feltPrivacyFeltDeletion:
             return checkFeltPrivacyFeature(for: featureID, from: nimbus)
 
+        case .hntTopSitesVisualRefresh:
+            return checkHntTopSitesVisualRefreshFeature(from: nimbus)
+
         case .homepageRebuild:
             return checkHomepageFeature(from: nimbus)
 
@@ -169,6 +172,11 @@ final class NimbusFeatureFlagLayer {
         case .bottomSearchBar: return config.position.isPositionFeatureEnabled
         default: return false
         }
+    }
+
+    public func checkHntTopSitesVisualRefreshFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.hntTopSitesVisualRefreshFeature.value()
+        return config.enabled
     }
 
     private func checkHomepageFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/nimbus-features/hntTopSitesVisualRefresh.yaml
+++ b/firefox-ios/nimbus-features/hntTopSitesVisualRefresh.yaml
@@ -1,0 +1,16 @@
+# The configuration for the top sites visual refresh
+features:
+  hnt-top-sites-visual-refresh-feature:
+    description: This feature manages the top sites visual refresh.
+    variables:
+      enabled:
+        description: Determines whether the top sites visual refresh is shown.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: false

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -21,6 +21,7 @@ include:
   - nimbus-features/feltPrivacyFeature.yaml
   - nimbus-features/firefoxSuggestFeature.yaml
   - nimbus-features/generalFeatures.yaml
+  - nimbus-features/hntTopSitesVisualRefresh.yaml
   - nimbus-features/homepageRebuildFeature.yaml
   - nimbus-features/homescreenFeature.yaml
   - nimbus-features/menuRefactorFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12178)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26510)

## :bulb: Description
- Add nimbus feature flag for top sites visual refresh (`hnt-top-sites-visual-refresh-feature`)

### 📝 Notes:
- Updated the feature flag toggle list in the debug menu so that it is alphabetized and easier to parse

## :movie_camera: Demos

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 16 - 2025-05-05 at 12 40 47](https://github.com/user-attachments/assets/d4797d02-fe73-47e9-bf7b-4fed9a4280fe) | ![Simulator Screenshot - iPhone 16 - 2025-05-05 at 12 39 35](https://github.com/user-attachments/assets/c24960b3-e03f-4328-b63f-c94f0ccfc415) |


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
