### PR TITLE
Bugfix FXIOS-11476 ⁃ Tab Toast Shows in the Middle of the Screen When Long Pressing

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -607,8 +607,7 @@ class TabTrayViewController: UIViewController,
             let toast = SimpleToast()
             toast.showAlertWithText(toastType.title,
                                     bottomContainer: view,
-                                    theme: retrieveTheme(),
-                                    bottomConstraintPadding: -toolbarHeight)
+                                    theme: retrieveTheme())
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11476)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26386)

## :bulb: Description
Removed bottom padding for toast

## :movie_camera: Demos
![image00003](https://github.com/user-attachments/assets/9142bc45-be02-44af-85ce-86b7ac418d7f)
![image00001](https://github.com/user-attachments/assets/af23b519-6144-4c1e-886b-a9cc29625249)
![image00004](https://github.com/user-attachments/assets/44cb906a-fcb6-4a45-baf9-d3b93f8e050d)
![Simulator Screenshot - iPhone 7 - 2025-05-06 at 12 33 00](https://github.com/user-attachments/assets/c74561b0-bae6-45c3-a8f9-3bf8d86d0726)
![image00002](https://github.com/user-attachments/assets/f4f68a0c-9291-4697-99c2-4d8a6d957c32)


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
