### PR TITLE
Bugfix FXIOS-12190 [Homepage] fix crash due to missing windowUUID in notifications

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
@@ -88,6 +88,7 @@ final class HomepageMiddleware {
         // Time complexity: O(n), where n is the number of windows in windowManager.windows
         // In the case of the phone layout, there should only be one window so n = 1
 
+        // TODO: FXIOS-12199 Update to improve how we handle notifications for multi-window
         windowManager.windows.forEach { windowUUID, _ in
             switch notification.name {
             case UIApplication.willEnterForegroundNotification:

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
@@ -10,11 +10,14 @@ import Common
 final class HomepageMiddleware {
     private let homepageTelemetry: HomepageTelemetry
     private let notificationCenter: NotificationProtocol
+    private let windowManager: WindowManager
 
     init(homepageTelemetry: HomepageTelemetry = HomepageTelemetry(),
-         notificationCenter: NotificationProtocol) {
+         notificationCenter: NotificationProtocol,
+         windowManager: WindowManager = AppContainer.shared.resolve()) {
         self.homepageTelemetry = homepageTelemetry
         self.notificationCenter = notificationCenter
+        self.windowManager = windowManager
         observeNotifications()
     }
 
@@ -80,56 +83,60 @@ final class HomepageMiddleware {
 
     @objc
     private func handleNotifications(_ notification: Notification) {
-        // This update occurs independently of any specific window, so for now we send `.unavailable`
-        // as the window UUID. Reducers responding to these types of messages need to use care not to
-        // propagate that UUID in any subsequent actions or state changes.
-        switch notification.name {
-        case UIApplication.willEnterForegroundNotification:
-            let storiesAction = HomepageAction(
-                windowUUID: .unavailable,
-                actionType: HomepageMiddlewareActionType.enteredForeground
-            )
-            store.dispatch(storiesAction)
+        // This update occurs for all windows and we need to pass along
+        // the windowUUID to any subsequent actions or state changes.
+        // Time complexity: O(n), where n is the number of windows in windowManager.windows
+        // In the case of the phone layout, there should only be one window so n = 1
 
-        case .PrivateDataClearedHistory,
-                .TopSitesUpdated,
-                .DefaultSearchEngineUpdated:
-            dispatchActionToFetchTopSites()
+        windowManager.windows.forEach { windowUUID, _ in
+            switch notification.name {
+            case UIApplication.willEnterForegroundNotification:
+                let storiesAction = HomepageAction(
+                    windowUUID: windowUUID,
+                    actionType: HomepageMiddlewareActionType.enteredForeground
+                )
+                store.dispatch(storiesAction)
 
-        case .BookmarksUpdated, .RustPlacesOpened:
-            let bookmarksAction = HomepageAction(
-                windowUUID: .unavailable,
-                actionType: HomepageMiddlewareActionType.bookmarksUpdated
-            )
-            store.dispatch(bookmarksAction)
+            case .PrivateDataClearedHistory,
+                    .TopSitesUpdated,
+                    .DefaultSearchEngineUpdated:
+                dispatchActionToFetchTopSites(windowUUID: windowUUID)
 
-        case .ProfileDidFinishSyncing, .FirefoxAccountChanged:
-            dispatchActionToFetchTopSites()
-            dispatchActionToFetchTabs()
+            case .BookmarksUpdated, .RustPlacesOpened:
+                let bookmarksAction = HomepageAction(
+                    windowUUID: windowUUID,
+                    actionType: HomepageMiddlewareActionType.bookmarksUpdated
+                )
+                store.dispatch(bookmarksAction)
 
-        default: break
+            case .ProfileDidFinishSyncing, .FirefoxAccountChanged:
+                dispatchActionToFetchTopSites(windowUUID: windowUUID)
+                dispatchActionToFetchTabs(windowUUID: windowUUID)
+
+            default: break
+            }
         }
     }
 
-    private func dispatchActionToFetchTopSites() {
+    private func dispatchActionToFetchTopSites(windowUUID: WindowUUID) {
         store.dispatch(
             HomepageAction(
-                windowUUID: .unavailable,
+                windowUUID: windowUUID,
                 actionType: HomepageMiddlewareActionType.topSitesUpdated
             )
         )
     }
 
-    private func dispatchActionToFetchTabs() {
+    private func dispatchActionToFetchTabs(windowUUID: WindowUUID) {
         store.dispatch(
             HomepageAction(
-                windowUUID: .unavailable,
+                windowUUID: windowUUID,
                 actionType: HomepageMiddlewareActionType.jumpBackInLocalTabsUpdated
             )
         )
         store.dispatch(
             HomepageAction(
-                windowUUID: .unavailable,
+                windowUUID: windowUUID,
                 actionType: HomepageMiddlewareActionType.jumpBackInRemoteTabsUpdated
             )
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12190)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26528)

## :bulb: Description
Fix crash that was occurring when user was logging into sync and then hitting the crash mentioned in the ticket. The issue is due to passing in an unavailable windowUUID for an action that requires it. This is because when we send notifications, we want all windows to respond to the update and not a specific window. Therefore, updated the `HomepageMiddleware` to handle notifications for all windows.  

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
