### PR TITLE
Bugfix FXIOS-12192 ⁃ "Copy URL" option available for homepage tab in Tab Tray context menu

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -714,6 +714,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
             let browserProfile = self.profile as? BrowserProfile
             browserProfile?.tabs.getClientGUIDs { (result, error) in
                 let model = TabPeekModel(canTabBeSaved: canBeSaved,
+                                         canCopyURL: !(tab?.isFxHomeTab ?? false),
                                          isSyncEnabled: !(result?.isEmpty ?? true),
                                          screenshot: tab?.screenshot ?? UIImage(),
                                          accessiblityLabel: tab?.webView?.accessibilityLabel ?? "")

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabPeekModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabPeekModel.swift
@@ -6,6 +6,7 @@ import Foundation
 
 struct TabPeekModel {
     let canTabBeSaved: Bool
+    let canCopyURL: Bool
     let isSyncEnabled: Bool
     let screenshot: UIImage
     let accessiblityLabel: String

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -59,6 +59,7 @@ struct TabPeekState: ScreenState, Equatable {
             return TabPeekState(windowUUID: state.windowUUID,
                                 showAddToBookmarks: tabPeekModel.canTabBeSaved,
                                 showSendToDevice: tabPeekModel.isSyncEnabled && tabPeekModel.canTabBeSaved,
+                                showCopyURL: tabPeekModel.canCopyURL,
                                 previewAccessibilityLabel: tabPeekModel.accessiblityLabel,
                                 screenshot: tabPeekModel.screenshot)
         default:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Redux/TabPeekStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Redux/TabPeekStateTests.swift
@@ -41,6 +41,7 @@ final class TabPeekStateTests: XCTestCase {
 
         let model = TabPeekModel(
             canTabBeSaved: false,
+            canCopyURL: true,
             isSyncEnabled: true,
             screenshot: UIImage(),
             accessiblityLabel: ""
@@ -61,6 +62,7 @@ final class TabPeekStateTests: XCTestCase {
 
         let model = TabPeekModel(
             canTabBeSaved: true,
+            canCopyURL: true,
             isSyncEnabled: false,
             screenshot: UIImage(),
             accessiblityLabel: ""
@@ -85,6 +87,7 @@ final class TabPeekStateTests: XCTestCase {
         for actionType: TabPeekActionType,
         with model: TabPeekModel = TabPeekModel(
             canTabBeSaved: true,
+            canCopyURL: true,
             isSyncEnabled: true,
             screenshot: UIImage(),
             accessiblityLabel: "tabpeek-a11y-label"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12192)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26531)

## :bulb: Description
Don't show copyURL option for homepages

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
