### PR TITLE
Remove FXIOS-12123 #26381 ⁃ [Toast audit]  toast related to adding/removing shortcuts

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -802,8 +802,7 @@ class BrowserViewController: UIViewController,
             )
         }
         switch toast {
-        case .addShortcut,
-                .clearCookies,
+        case .clearCookies,
                 .addToReadingList,
                 .removeShortcut,
                 .removeFromReadingList:

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -812,11 +812,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
             let site = Site.createBasicSite(url: url.absoluteString, title: title)
 
-            self.profile.pinnedSites.addPinnedTopSite(site).uponQueue(.main) { result in
-                guard result.isSuccess else { return }
-                self.delegate?.showToast(message: .LegacyAppMenu.AddPinToShortcutsConfirmMessage, toastAction: .pinPage)
-            }
-
+            _ = self.profile.pinnedSites.addPinnedTopSite(site)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .pinToTopSites)
         }
     }
@@ -829,14 +825,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
             let site = Site.createBasicSite(url: url.absoluteString, title: title)
 
-            self.profile.pinnedSites.removeFromPinnedTopSites(site).uponQueue(.main) { result in
-                if result.isSuccess {
-                    self.delegate?.showToast(
-                        message: .LegacyAppMenu.RemovePinFromShortcutsConfirmMessage,
-                        toastAction: .removePinPage
-                    )
-                }
-            }
+            _ = self.profile.pinnedSites.removeFromPinnedTopSites(site)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .removePinnedSite)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -812,7 +812,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
             let site = Site.createBasicSite(url: url.absoluteString, title: title)
 
-            _ = self.profile.pinnedSites.addPinnedTopSite(site)
+            self.profile.pinnedSites.addPinnedTopSite(site)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .pinToTopSites)
         }
     }
@@ -825,7 +825,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
             let site = Site.createBasicSite(url: url.absoluteString, title: title)
 
-            _ = self.profile.pinnedSites.removeFromPinnedTopSites(site)
+            self.profile.pinnedSites.removeFromPinnedTopSites(site)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .removePinnedSite)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -1054,7 +1054,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
         let site = Site.createBasicSite(url: url, title: tab.displayTitle)
 
-        _ = profile.pinnedSites.addPinnedTopSite(site)
+        profile.pinnedSites.addPinnedTopSite(site)
     }
 
     private func removeFromShortcuts(with tabID: TabUUID?, uuid: WindowUUID) {
@@ -1066,7 +1066,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
         let site = Site.createBasicSite(url: url, title: tab.displayTitle)
 
-        _ = profile.pinnedSites.removeFromPinnedTopSites(site)
+        profile.pinnedSites.removeFromPinnedTopSites(site)
     }
 
     private func preserveTabs(uuid: WindowUUID) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -1054,17 +1054,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
         let site = Site.createBasicSite(url: url, title: tab.displayTitle)
 
-        profile.pinnedSites.addPinnedTopSite(site).uponQueue(.main) { result in
-            guard result.isSuccess else { return }
-
-            store.dispatch(
-                GeneralBrowserAction(
-                    toastType: .addShortcut,
-                    windowUUID: uuid,
-                    actionType: GeneralBrowserActionType.showToast
-                )
-            )
-        }
+        _ = profile.pinnedSites.addPinnedTopSite(site)
     }
 
     private func removeFromShortcuts(with tabID: TabUUID?, uuid: WindowUUID) {
@@ -1076,16 +1066,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
         let site = Site.createBasicSite(url: url, title: tab.displayTitle)
 
-        profile.pinnedSites.removeFromPinnedTopSites(site).uponQueue(.main) { result in
-            guard result.isSuccess else { return }
-            store.dispatch(
-                GeneralBrowserAction(
-                    toastType: .removeShortcut,
-                    windowUUID: uuid,
-                    actionType: GeneralBrowserActionType.showToast
-                )
-            )
-        }
+        _ = profile.pinnedSites.removeFromPinnedTopSites(site)
     }
 
     private func preserveTabs(uuid: WindowUUID) {

--- a/firefox-ios/Client/Frontend/Browser/ToastType.swift
+++ b/firefox-ios/Client/Frontend/Browser/ToastType.swift
@@ -8,7 +8,6 @@ import Common
 enum ToastType: Equatable {
     case addBookmark(urlString: String)
     case addToReadingList
-    case addShortcut
     case clearCookies
     case closedSingleTab
     case closedSingleInactiveTab
@@ -24,8 +23,6 @@ enum ToastType: Equatable {
             return .LegacyAppMenu.AddBookmarkConfirmMessage
         case .addToReadingList:
             return .LegacyAppMenu.AddToReadingListConfirmMessage
-        case .addShortcut:
-            return .LegacyAppMenu.AddPinToShortcutsConfirmMessage
         case .clearCookies:
             return .Menu.EnhancedTrackingProtection.clearDataToastMessage
         case .closedSingleTab, .closedSingleInactiveTab:
@@ -58,7 +55,6 @@ enum ToastType: Equatable {
         case .clearCookies,
                 .copyURL,
                 .addBookmark,
-                .addShortcut,
                 .addToReadingList,
                 .removeFromReadingList,
                 .removeShortcut:

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
@@ -237,7 +237,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
     }
 
     func pinTopSite(_ site: Site) {
-        _ = profile.pinnedSites.addPinnedTopSite(site)
+        profile.pinnedSites.addPinnedTopSite(site)
     }
 
     func unpinTopSite(_ site: Site) {

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
@@ -38,7 +38,7 @@ class TopSiteHistoryManager: DataObserver, TopSiteHistoryManagerProvider {
     }
 
     func removeTopSite(site: Site) {
-        _ = profile.pinnedSites.removeFromPinnedTopSites(site)
+        profile.pinnedSites.removeFromPinnedTopSites(site)
     }
 
     /// If the default top sites contains the siteurl. also wipe it from default suggested sites.

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -131,7 +131,7 @@ class TopSitesViewModel {
     }
 
     func pinTopSite(_ site: Site) {
-        _ = profile.pinnedSites.addPinnedTopSite(site)
+        profile.pinnedSites.addPinnedTopSite(site)
     }
 
     func removePinTopSite(_ site: Site) {

--- a/firefox-ios/Storage/PinnedSites.swift
+++ b/firefox-ios/Storage/PinnedSites.swift
@@ -7,7 +7,9 @@ import Shared
 /// A protocol to manage pinned sites in BrowserDB
 public protocol PinnedSites {
     // Pinning top sites
+    @discardableResult
     func removeFromPinnedTopSites(_ site: Site) -> Success
+    @discardableResult
     func addPinnedTopSite(_ site: Site) -> Success
     func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>>
     func isPinnedTopSite(_ url: String) -> Deferred<Maybe<Bool>>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12123)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26381)

## :bulb: Description
Remove toast after adding or removing shortcuts from old and new menu

## :movie_camera: Demos

https://github.com/user-attachments/assets/c05746b1-594b-44d5-9333-a1175b84aa2a


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
