### PR TITLE
Refactor NO_TICKET [Dead code] Remove unused `FirefoxNightly` scheme from push code

### DIFF
--- a/firefox-ios/Push/PushConfiguration.swift
+++ b/firefox-ios/Push/PushConfiguration.swift
@@ -21,7 +21,6 @@ public enum PushConfigurationLabel: String {
     case fennec = "fennec"
     case fennecEnterprise = "fennecenterprise"
     case firefoxBeta = "firefoxbeta"
-    case firefoxNightlyEnterprise = "firefoxnightlyenterprise"
     case firefox = "firefox"
 
     static func fromScheme(scheme: String) throws -> PushConfigurationLabel {
@@ -29,7 +28,6 @@ public enum PushConfigurationLabel: String {
         case "Fennec": return .fennec
         case "FennecEnterprise": return .fennecEnterprise
         case "FirefoxBeta": return .firefoxBeta
-        case "FirefoxNightly": return .firefoxNightlyEnterprise
         case "Firefox": return .firefox
         default: throw InvalidSchemeError.InvalidScheme(scheme)
         }


### PR DESCRIPTION
## :scroll: Tickets
~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~
~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~

## :bulb: Description
This PR:
- Removes `FirefoxNightly` scheme from push code as this was removed [here](https://github.com/mozilla-mobile/firefox-ios/pull/2679/files#diff-bcbe2743c7e5ca02f44467ca5133ecb7efda957faca9b5d27f00942655b248ef)  


## :pencil: Checklist
- [] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
