### PR TITLE
Fix FXIOS-11506 [Release Automation] Actually override `BITRISE_SCHEME` in promotion tasks

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2167,6 +2167,16 @@ workflows:
         run_if: |-
           {{enveq "BITRISE_APP_TITLE" "staging-firefox-ios"}}
     - script@1.2.1:
+        title: Override default bitrise scheme
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            if [[ ! -z "${API_BITRISE_SCHEME}" ]]; then
+              envman add --key BITRISE_SCHEME --value "${API_BITRISE_SCHEME}"
+            fi
+    - script@1.2.1:
         inputs:
         - content: |-
             #!/usr/bin/env bash

--- a/taskcluster/kinds/promote/kind.yml
+++ b/taskcluster/kinds/promote/kind.yml
@@ -25,4 +25,4 @@ tasks:
         artifact_prefix: public
         workflows:
           - release_promotion_promote:
-              - BITRISE_SCHEME: "<release-type-scheme>"
+              - API_BITRISE_SCHEME: "<release-type-scheme>"


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11506)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25045)
## :bulb: Description

So it turns out that you cannot override default environment variables through the API to trigger builds, bitrise will just ignore any environment variable that has a default set. Because there's a global default for `BITRISE_SCHEME` set to `Fennec`, it means that we're always trying to build Fennec on promotion instead of Firefox or FirefoxBeta, which of course, fails.

This uses a trick from [here](https://discuss.bitrise.io/t/how-to-override-environment-variables-through-the-build-trigger-api/191) to override the default if there's a value to override it with by using a different key and then forcing the value through envman. Note that we were already forcing the value through envman for staging which is why we didn't catch this earlier.


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
