### PR TITLE
Bugfix FXIOS-12171 [Focus] Fix RTL settings alignment and direction

### DIFF
--- a/focus-ios/Blockzilla/Settings/Cells/SettingsTableViewAccessoryCell.swift
+++ b/focus-ios/Blockzilla/Settings/Cells/SettingsTableViewAccessoryCell.swift
@@ -7,26 +7,11 @@ import UIKit
 class SettingsTableViewAccessoryCell: SettingsTableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        accessoryView = UIImageView(image: UIImage(systemName: "chevron.right"))
+        accessoryView = UIImageView(image: UIImage(systemName: "chevron.right")?.imageFlippedForRightToLeftLayoutDirection())
         tintColor = .secondaryText.withAlphaComponent(0.3)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    func setConfiguration(text: String, secondaryText: String? = nil) {
-        var configuration = defaultContentConfiguration()
-        configuration.text = text
-        configuration.textProperties.color = .primaryText
-        
-        if let secondaryText {
-            configuration.secondaryText = secondaryText
-        }
-        
-        let margins = configuration.directionalLayoutMargins
-        configuration.directionalLayoutMargins = NSDirectionalEdgeInsets(top: margins.top, leading: UIConstants.layout.settingsCellLeftInset, bottom: margins.bottom, trailing: margins.trailing)
-        configuration.prefersSideBySideTextAndSecondaryText = true
-        contentConfiguration = configuration
     }
 }

--- a/focus-ios/Blockzilla/Settings/Cells/SettingsTableViewCell.swift
+++ b/focus-ios/Blockzilla/Settings/Cells/SettingsTableViewCell.swift
@@ -15,15 +15,18 @@ class SettingsTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    internal func setupDynamicFont(forLabels labels: [UILabel], addObserver: Bool = false) {
-        for label in labels {
-            label.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
-            label.adjustsFontForContentSizeCategory = true
+    func setConfiguration(text: String, secondaryText: String? = nil) {
+        var configuration = defaultContentConfiguration()
+        configuration.text = text
+        configuration.textProperties.color = .primaryText
+        
+        if let secondaryText {
+            configuration.secondaryText = secondaryText
         }
-
-        NotificationCenter.default.addObserver(forName: UIContentSizeCategory.didChangeNotification, object: nil, queue: nil) { [weak self] _ in
-            guard let self = self else { return }
-            self.setupDynamicFont(forLabels: labels)
-        }
+        
+        let margins = configuration.directionalLayoutMargins
+        configuration.directionalLayoutMargins = NSDirectionalEdgeInsets(top: margins.top, leading: UIConstants.layout.settingsCellLeftInset, bottom: margins.bottom, trailing: margins.trailing)
+        configuration.prefersSideBySideTextAndSecondaryText = true
+        contentConfiguration = configuration
     }
 }

--- a/focus-ios/Blockzilla/Settings/Cells/SettingsTableViewToggleCell.swift
+++ b/focus-ios/Blockzilla/Settings/Cells/SettingsTableViewToggleCell.swift
@@ -10,18 +10,7 @@ class SettingsTableViewToggleCell: SettingsTableViewCell {
 
     init(style: UITableViewCell.CellStyle, reuseIdentifier: String?, toggle: BlockerToggle) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupDynamicFont(forLabels: [newLabel], addObserver: true)
-
-        newLabel.numberOfLines = 0
-        newLabel.text = toggle.label
-
-        textLabel?.numberOfLines = 0
-        textLabel?.text = toggle.label
-
-        newLabel.textColor = .primaryText
-        textLabel?.textColor = .primaryText
-        layoutMargins = UIEdgeInsets.zero
-
+        setConfiguration(text: toggle.label)
         accessoryView = PaddedSwitch(switchView: toggle.toggle)
         selectionStyle = .none
     }

--- a/focus-ios/Blockzilla/Settings/Controller/AutocompleteSettingViewController.swift
+++ b/focus-ios/Blockzilla/Settings/Controller/AutocompleteSettingViewController.swift
@@ -74,10 +74,11 @@ class AutocompleteSettingViewController: UIViewController, UITableViewDelegate, 
                 toggle.onTintColor = .accent
                 cell.accessoryView = PaddedSwitch(switchView: toggle)
             } else {
-                cell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "newDomainCell")
-                cell.accessoryType = .disclosureIndicator
-                cell.accessibilityIdentifier = "customURLS"
-                cell.textLabel?.text = UIConstants.strings.autocompleteManageSitesLabel
+                let settingCell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "newDomainCell")
+                settingCell.accessoryType = .disclosureIndicator
+                settingCell.accessibilityIdentifier = "customURLS"
+                settingCell.setConfiguration(text: UIConstants.strings.autocompleteManageSitesLabel)
+                cell = settingCell
             }
         }
 

--- a/focus-ios/Blockzilla/Settings/Controller/AutocompleteSettingViewController.swift
+++ b/focus-ios/Blockzilla/Settings/Controller/AutocompleteSettingViewController.swift
@@ -53,26 +53,24 @@ class AutocompleteSettingViewController: UIViewController, UITableViewDelegate, 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         var cell: UITableViewCell
         if indexPath.section == 0 {
-            cell = UITableViewCell(style: .subtitle, reuseIdentifier: "enableCell")
-            cell.textLabel?.text = UIConstants.strings.autocompleteTopSites
-            cell.contentView.layoutMargins = UIEdgeInsets(top: 0, left: UIConstants.layout.settingsCellLeftInset, bottom: 0, right: 0)
-            let toggle = UISwitch()
-            toggle.addTarget(self, action: #selector(defaultToggleSwitched(_:)), for: .valueChanged)
-            toggle.accessibilityIdentifier = "toggleAutocompleteSwitch"
-            toggle.isOn = Settings.getToggle(.enableDomainAutocomplete)
-            toggle.onTintColor = .accent
-            cell.accessoryView = PaddedSwitch(switchView: toggle)
+            let blockerToggle = BlockerToggle(label: UIConstants.strings.settingsAutocompleteSection, setting: .enableCustomDomainAutocomplete)
+            blockerToggle.toggle.isOn = Settings.getToggle(.enableDomainAutocomplete)
+            blockerToggle.toggle.accessibilityIdentifier = "toggleAutocompleteSwitch"
+            blockerToggle.toggle.addTarget(self, action: #selector(defaultToggleSwitched(_:)), for: .valueChanged)
+            blockerToggle.toggle.onTintColor = .accent
+            let toggleCell = SettingsTableViewToggleCell(style: .subtitle, reuseIdentifier: "enableCell", toggle: blockerToggle)
+            toggleCell.setConfiguration(text: UIConstants.strings.autocompleteTopSites)
+            cell = toggleCell
         } else {
             if indexPath.row == 0 {
-                cell = UITableViewCell(style: .subtitle, reuseIdentifier: "enableCell")
-                cell.textLabel?.text = UIConstants.strings.autocompleteMySites
-                cell.contentView.layoutMargins = UIEdgeInsets(top: 0, left: UIConstants.layout.settingsCellLeftInset, bottom: 0, right: 0)
-                let toggle = UISwitch()
-                toggle.addTarget(self, action: #selector(customToggleSwitched(_:)), for: .valueChanged)
-                toggle.accessibilityIdentifier = "toggleCustomAutocompleteSwitch"
-                toggle.isOn = Settings.getToggle(.enableCustomDomainAutocomplete)
-                toggle.onTintColor = .accent
-                cell.accessoryView = PaddedSwitch(switchView: toggle)
+                let blockerToggle = BlockerToggle(label: UIConstants.strings.settingsAutocompleteSection, setting: .enableCustomDomainAutocomplete)
+                blockerToggle.toggle.isOn = Settings.getToggle(.enableCustomDomainAutocomplete)
+                blockerToggle.toggle.accessibilityIdentifier = "toggleCustomAutocompleteSwitch"
+                blockerToggle.toggle.addTarget(self, action: #selector(customToggleSwitched(_:)), for: .valueChanged)
+                blockerToggle.toggle.onTintColor = .accent
+                let toggleCell = SettingsTableViewToggleCell(style: .subtitle, reuseIdentifier: "enableCell", toggle: blockerToggle)
+                toggleCell.setConfiguration(text: UIConstants.strings.autocompleteMySites)
+                cell = toggleCell
             } else {
                 let settingCell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "newDomainCell")
                 settingCell.accessoryType = .disclosureIndicator

--- a/focus-ios/Blockzilla/Settings/Controller/SettingsViewController.swift
+++ b/focus-ios/Blockzilla/Settings/Controller/SettingsViewController.swift
@@ -318,7 +318,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         switch sections[indexPath.section] {
         case .defaultBrowser:
             let defaultBrowserCell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "defaultBrowserCell")
-            defaultBrowserCell.textLabel?.text = String(format: UIConstants.strings.setAsDefaultBrowserLabel)
+            defaultBrowserCell.setConfiguration(text: String(format: UIConstants.strings.setAsDefaultBrowserLabel))
             defaultBrowserCell.accessibilityIdentifier = "settingsViewController.defaultBrowserCell"
             cell = defaultBrowserCell
         case .general:
@@ -381,21 +381,25 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             cell = setupToggleCell(indexPath: indexPath, navigationController: navigationController)
         case .mozilla:
             if indexPath.row == 0 {
-                cell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "aboutCell")
-                cell.textLabel?.text = String(format: UIConstants.strings.aboutTitle, AppInfo.productName)
-                cell.accessibilityIdentifier = "settingsViewController.about"
+                let settingCell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "aboutCell")
+                settingCell.setConfiguration(text: String(format: UIConstants.strings.aboutTitle, AppInfo.productName))
+                settingCell.accessibilityIdentifier = "settingsViewController.about"
+                cell = settingCell
             } else if indexPath.row == 1 {
-                cell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "ratingCell")
-                cell.textLabel?.text = String(format: UIConstants.strings.ratingSetting, AppInfo.productName)
-                cell.accessibilityIdentifier = "settingsViewController.rateFocus"
+                let settingCell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "ratingCell")
+                settingCell.setConfiguration(text: String(format: UIConstants.strings.ratingSetting, AppInfo.productName))
+                settingCell.accessibilityIdentifier = "settingsViewController.rateFocus"
+                cell = settingCell
             } else {
-                cell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "licensesCell")
-                cell.textLabel?.text = UIConstants.strings.licenses
-                cell.accessibilityIdentifier = "settingsViewController.licenses"
+                let settingCell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "licensesCell")
+                settingCell.setConfiguration(text: UIConstants.strings.licenses)
+                settingCell.accessibilityIdentifier = "settingsViewController.licenses"
+                cell = settingCell
             }
         case .secret:
-            cell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "secretSettingsCell")
-            cell.textLabel?.text = "Internal Settings"
+            let settingCell = SettingsTableViewCell(style: .subtitle, reuseIdentifier: "secretSettingsCell")
+            settingCell.setConfiguration(text: "Internal Settings")
+            cell = settingCell
         case .crashReports:
             cell = setupToggleCell(indexPath: indexPath, navigationController: navigationController)
         case .dailyUsagePing:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12171)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26495)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Replace dynamic label for cell configuration and add imageFlippedForRightToLeftLayoutDirection() for image

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| <img src="https://github.com/user-attachments/assets/b9678977-ca27-4aa6-8d37-58b06334b8bd" width=20% height=20%> | <img src="https://github.com/user-attachments/assets/8f60e784-9ef3-40f2-804f-10eebea2c8a1" width=20% height=20%> |
| <img src="https://github.com/user-attachments/assets/ba50eaee-ab29-4263-a274-18adb9260aad" width=20% height=20%> | <img src="https://github.com/user-attachments/assets/b1f70e85-5dae-4d44-898b-c066bf5f1235" width=20% height=20%> |

| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
