### PR TITLE
Bugfix FXIOS-12200 Initialize feature flags before bootstrap

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -94,6 +94,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
             .browserIsReady
         ])
 
+        // Initialize the feature flag subsystem.
+        // Among other things, it toggles on and off Nimbus, Contile, Adjust.
+        // i.e. this must be run before initializing those systems.
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
+
         // Then setup dependency container as it's needed for everything else
         DependencyHelper().bootstrapDependencies()
 

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -37,11 +37,6 @@ final class AppLaunchUtil {
 
         DefaultBrowserUtil().processUserDefaultState(isFirstRun: introScreenManager.shouldShowIntroScreen)
 
-        // Initialize the feature flag subsystem.
-        // Among other things, it toggles on and off Nimbus, Contile, Adjust.
-        // i.e. this must be run before initializing those systems.
-        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
-
         // Need to get "settings.sendCrashReports" this way so that Sentry can be initialized before getting the Profile.
         let sendCrashReports = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.prefSendCrashReports) ?? true
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12200)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26553)

## :bulb: Description

Initialize feature flag manager early so that code run during bootstrap has access to flag state.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
