### PR TITLE
Add FXIOS-12198 Feature flag toggle for Consolidated Search

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -68,6 +68,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .loginsVerificationEnabled,
                 .nativeErrorPage,
                 .noInternetConnectionErrorPage,
+                .searchEngineConsolidation,
                 .sentFromFirefox,
                 .tabAnimation,
                 .tabTrayUIExperiments,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -53,6 +53,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self.profile?.prefs.setBool(isBookmarksRefactorEnabled, forKey: PrefsKeys.IsBookmarksRefactorEnabled)
                 },
                 FeatureFlagsBoolSetting(
+                    with: .searchEngineConsolidation,
+                    titleText: format(string: "Consolidated Search"),
+                    statusText: format(string: "Toggle to use Consolidated Search")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .deeplinkOptimizationRefactor,
                     titleText: format(string: "Deeplink Optimization Refactor"),
                     statusText: format(string: "Toggle to enable deeplink optimization refactor")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12198)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26547)

## :bulb: Description

Feature flag toggle for SEC.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
