### PR TITLE
Add FXIOS-12154 #26444 [Tab tray] trash can telemetry

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -568,6 +568,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     }
 
     private func deleteNormalTabsOlderThan(period: TabsDeletionPeriod, uuid: WindowUUID) {
+        tabsPanelTelemetry.deleteNormalTabsSheetOptionSelected(period: period)
         let tabManager = tabManager(for: uuid)
         tabManager.removeNormalTabsOlderThan(period: period, currentDate: .now)
 

--- a/firefox-ios/Client/Glean/metrics.yaml
+++ b/firefox-ios/Client/Glean/metrics.yaml
@@ -3650,7 +3650,7 @@ tabs_panel:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/26444
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/26584
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-11-01"

--- a/firefox-ios/Client/Glean/metrics.yaml
+++ b/firefox-ios/Client/Glean/metrics.yaml
@@ -3593,7 +3593,7 @@ tabs_panel:
         - TabsPanel
   new_tab_button_tapped:
     type: event
-    description: | 
+    description: |
       Recorded when the user taps the button in the tabs panel to open a new
       tab.
     extra_keys:
@@ -3617,7 +3617,7 @@ tabs_panel:
         - TabsPanel
   tab_mode_selected:
     type: event
-    description: | 
+    description: |
       Recorded when the user changes the tabs panel mode with the segmented 
       control in the tabs panel.
     extra_keys:
@@ -3637,11 +3637,31 @@ tabs_panel:
     metadata:
       tags:
         - TabsPanel
+  delete_tabs_sheet_option_selected:
+    type: event
+    description: |
+      Recorded when the user taps an option in the close old tabs sheet.
+    extra_keys:
+      period:
+        type: string
+        description: |
+          The period of time chosen by the user to delete their older tabs.
+          Either `oneDay`, `oneWeek` or `oneMonth`.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/26444
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-11-01"
+    metadata:
+      tags:
+        - TabsPanel
 
 tabs_panel.close_all_tabs_sheet:
   option_selected:
     type: event
-    description: | 
+    description: |
       Recorded when the user taps an option in the close all tabs sheet.
     extra_keys:
       option:
@@ -3673,7 +3693,7 @@ tabs_panel.close_all_tabs_sheet:
 toasts.close_single_tab:
   undo_tapped:
     type: event
-    description: | 
+    description: |
       Records when the user selects undo after closing a tab.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-11714
@@ -3690,7 +3710,7 @@ toasts.close_single_tab:
 toasts.close_all_tabs:
   undo_tapped:
     type: event
-    description: | 
+    description: |
       Records when the user selects undo after closing all tabs.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-11714

--- a/firefox-ios/Client/Glean/metrics.yaml
+++ b/firefox-ios/Client/Glean/metrics.yaml
@@ -3637,7 +3637,9 @@ tabs_panel:
     metadata:
       tags:
         - TabsPanel
-  delete_tabs_sheet_option_selected:
+
+tabs_panel.close_old_tabs_sheet:
+  option_selected:
     type: event
     description: |
       Recorded when the user taps an option in the close old tabs sheet.

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -10,7 +10,7 @@ enum TabManagerConstants {
     static let tabScreenshotNamespace = "TabManagerScreenshots"
 }
 
-enum TabsDeletionPeriod {
+enum TabsDeletionPeriod: String {
     case oneDay, oneWeek, oneMonth
 }
 

--- a/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
@@ -84,10 +84,9 @@ struct TabsPanelTelemetry {
     }
 
     func deleteNormalTabsSheetOptionSelected(period: TabsDeletionPeriod) {
-        // Laurie
-//        let extras = GleanMetrics.DeleteNormalTabsSheetOptionSelected.OptionSelectedExtra(
-//            period: period.rawValue,
-//        )
-//        gleanWrapper.recordEvent(for: GleanMetrics.DeleteNormalTabsSheetOptionSelected.optionSelected, extras: extras)
+        let extras = GleanMetrics.TabsPanel.DeleteTabsSheetOptionSelectedExtra(
+            period: period.rawValue
+        )
+        gleanWrapper.recordEvent(for: GleanMetrics.TabsPanel.deleteTabsSheetOptionSelected, extras: extras)
     }
 }

--- a/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
@@ -84,9 +84,9 @@ struct TabsPanelTelemetry {
     }
 
     func deleteNormalTabsSheetOptionSelected(period: TabsDeletionPeriod) {
-        let extras = GleanMetrics.TabsPanel.DeleteTabsSheetOptionSelectedExtra(
+        let extras = GleanMetrics.TabsPanelCloseOldTabsSheet.OptionSelectedExtra(
             period: period.rawValue
         )
-        gleanWrapper.recordEvent(for: GleanMetrics.TabsPanel.deleteTabsSheetOptionSelected, extras: extras)
+        gleanWrapper.recordEvent(for: GleanMetrics.TabsPanelCloseOldTabsSheet.optionSelected, extras: extras)
     }
 }

--- a/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
@@ -82,4 +82,12 @@ struct TabsPanelTelemetry {
         let extras = GleanMetrics.TabsPanel.DoneButtonTappedExtra(mode: mode.rawValue)
         gleanWrapper.recordEvent(for: GleanMetrics.TabsPanel.doneButtonTapped, extras: extras)
     }
+
+    func deleteNormalTabsSheetOptionSelected(period: TabsDeletionPeriod) {
+        // Laurie
+//        let extras = GleanMetrics.DeleteNormalTabsSheetOptionSelected.OptionSelectedExtra(
+//            period: period.rawValue,
+//        )
+//        gleanWrapper.recordEvent(for: GleanMetrics.DeleteNormalTabsSheetOptionSelected.optionSelected, extras: extras)
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12154)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26444)

## :bulb: Description
This is aiming for v139 to add telemetry for the new trash can options under the tab tray

## :movie_camera: Screenshot
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<details>
<summary>New trash can options</summary>

![Simulator Screenshot - iPhone 16 - 2025-05-07 at 11 09 21](https://github.com/user-attachments/assets/1fe0a8fd-64dc-45d4-a2cc-add1e0e610a1)

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
