### PR TITLE
Refactor FXIOS-11272 [Tab Optimization] Remove instances where we are using removeTabWithCompletion

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -314,13 +314,14 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     private func getCloseTabAction() -> PhotonRowActions {
         let isRefactorEnabled = isToolbarRefactorEnabled && isOneTapNewTabEnabled
         let title = isRefactorEnabled ? String.Toolbars.TabToolbarLongPressActionsMenu.CloseThisTabButton :
-                                        String.KeyboardShortcuts.CloseCurrentTab
+        String.KeyboardShortcuts.CloseCurrentTab
         return SingleActionViewModel(title: title,
                                      iconString: StandardImageIdentifiers.Large.cross,
                                      iconType: .Image) { _ in
-            if let tab = self.tabManager.selectedTab {
-                self.tabsPanelTelemetry.tabClosed(mode: tab.isPrivate ? .private : .normal)
-                self.tabManager.removeTabWithCompletion(tab.tabUUID) {
+            Task { @MainActor in
+                if let tab = self.tabManager.selectedTab {
+                    self.tabsPanelTelemetry.tabClosed(mode: tab.isPrivate ? .private : .normal)
+                    await self.tabManager.removeTab(tab.tabUUID)
                     self.updateTabCountUsingTabManager(self.tabManager)
 
                     if !self.featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -365,10 +365,12 @@ extension TopTabsViewController: TabDisplayerDelegate {
 
 extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(_ cell: UICollectionViewCell) {
-        topTabDisplayManager.closeActionPerformed(forCell: cell)
-        delegate?.topTabsShowCloseTabsToast()
-        NotificationCenter.default.post(name: .TopTabsTabClosed, object: nil, userInfo: windowUUID.userInfo)
-        store.dispatch(TopTabsAction(windowUUID: windowUUID, actionType: TopTabsActionType.didTapCloseTab))
+        Task { @MainActor in
+            await topTabDisplayManager.closeActionPerformed(forCell: cell)
+            delegate?.topTabsShowCloseTabsToast()
+            NotificationCenter.default.post(name: .TopTabsTabClosed, object: nil, userInfo: windowUUID.userInfo)
+            store.dispatch(TopTabsAction(windowUUID: windowUUID, actionType: TopTabsActionType.didTapCloseTab))
+        }
     }
 }
 

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -50,14 +50,6 @@ protocol TabManager: AnyObject {
                 zombie: Bool,
                 isPrivate: Bool) -> Tab
 
-    // MARK: - Remove Tab
-    // TODO: FXIOS-11272 Remove this function in favor of the async remove tab.
-    /// GCD remove tab option using tabUUID with completion
-    /// - Parameters:
-    ///   - tabUUID: UUID from the tab
-    ///   - completion: closure called after remove tab completes on main thread
-    func removeTabWithCompletion(_ tabUUID: TabUUID, completion: (() -> Void)?)
-
     /// Async Remove tab option using tabUUID.
     /// - Parameter tabUUID: UUID from the tab
     func removeTab(_ tabUUID: TabUUID) async

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -251,17 +251,6 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         self.updateSelectedTabAfterRemovalOf(tab, deletedIndex: index)
     }
 
-    func removeTabWithCompletion(_ tabUUID: TabUUID, completion: (() -> Void)?) {
-        guard let index = tabs.firstIndex(where: { $0.tabUUID == tabUUID }) else { return }
-        let tab = tabs[index]
-
-        DispatchQueue.main.async { [weak self] in
-            self?.removeTab(tab, flushToDisk: true)
-            self?.updateSelectedTabAfterRemovalOf(tab, deletedIndex: index)
-            completion?()
-        }
-    }
-
     func removeTabs(_ tabs: [Tab]) {
         for tab in tabs {
             self.removeTab(tab, flushToDisk: false)
@@ -1083,8 +1072,8 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
             tabToSelect = addTab(request, afterTab: selectedTab, isPrivate: selectedTab.isPrivate)
         }
         selectTab(tabToSelect)
-        removeTabWithCompletion(selectedTab.tabUUID, completion: nil)
         Task {
+            await removeTab(selectedTab.tabUUID)
             await tabSessionStore.deleteUnusedTabSessionData(keeping: [])
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -86,8 +86,6 @@ class MockTabManager: TabManager {
 
     func reAddTabs(tabsToAdd: [Tab], previousTabUUID: String) {}
 
-    func removeTabWithCompletion(_ tabUUID: TabUUID, completion: (() -> Void)?) {}
-
     func removeTabs(_ tabs: [Tab]) {}
 
     func removeTab(_ tabUUID: TabUUID) async {}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11272)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24519)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
In `TabManagerImplementation` we currently support two interface methods for removing a tab. This is to allow for Swift Concurrency use cases and GCD implementations. This PR cleans up the remaining GCD implementations and moves them to Swift Concurrency in a _hopefully_ careful way. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
