### PR TITLE
Fixed MTE-4563 - onboarding tests of ipad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
@@ -79,14 +79,16 @@ class OnboardingTests: BaseTestCase {
         XCTAssertFalse(app.buttons["\(rootA11yId)SecondaryButton"].exists)
 
         // Swipe to the fifth screen
-        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
-        currentScreen += 1
-        mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
-        XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
-        XCTAssertTrue(app.staticTexts["\(rootA11yId)TitleLabel"].exists)
-        XCTAssertTrue(app.staticTexts["\(rootA11yId)DescriptionLabel"].exists)
-        XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
-        XCTAssertFalse(app.buttons["\(rootA11yId)SecondaryButton"].exists)
+        if !iPad() {
+            app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
+            currentScreen += 1
+            mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
+            XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
+            XCTAssertTrue(app.staticTexts["\(rootA11yId)TitleLabel"].exists)
+            XCTAssertTrue(app.staticTexts["\(rootA11yId)DescriptionLabel"].exists)
+            XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
+            XCTAssertFalse(app.buttons["\(rootA11yId)SecondaryButton"].exists)
+        }
 
         // Finish onboarding
         app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
@@ -147,14 +149,16 @@ class OnboardingTests: BaseTestCase {
         XCTAssertFalse(app.buttons["\(rootA11yId)SecondaryButton"].exists)
 
         // Swipe to the fifth screen
-        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
-        currentScreen += 1
-        mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
-        XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
-        XCTAssertTrue(app.staticTexts["\(rootA11yId)TitleLabel"].exists)
-        XCTAssertTrue(app.staticTexts["\(rootA11yId)DescriptionLabel"].exists)
-        XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
-        XCTAssertFalse(app.buttons["\(rootA11yId)SecondaryButton"].exists)
+        if !iPad() {
+            app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
+            currentScreen += 1
+            mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
+            XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
+            XCTAssertTrue(app.staticTexts["\(rootA11yId)TitleLabel"].exists)
+            XCTAssertTrue(app.staticTexts["\(rootA11yId)DescriptionLabel"].exists)
+            XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
+            XCTAssertFalse(app.buttons["\(rootA11yId)SecondaryButton"].exists)
+        }
 
         // Finish onboarding
         let topSites = app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
@@ -244,8 +248,10 @@ class OnboardingTests: BaseTestCase {
         app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
-        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
-        currentScreen += 1
+        if !iPad() {
+            app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
+            currentScreen += 1
+        }
 
         let buttons = app.buttons.matching(identifier: "\(rootA11yId)MultipleChoiceButton")
         for i in 0..<buttons.count {
@@ -255,8 +261,11 @@ class OnboardingTests: BaseTestCase {
                 break
             }
         }
-
-        app.buttons["Save and Start Browsing"].waitAndTap()
+        if !iPad() {
+            app.buttons["Save and Start Browsing"].waitAndTap()
+        } else {
+            app.buttons["Save and Continue"].waitAndTap()
+        }
         let topSites = app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         mozWaitForElementToExist(topSites)
 
@@ -327,7 +336,9 @@ class OnboardingTests: BaseTestCase {
         app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
-        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
+        if !iPad() {
+            app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
+        }
         app.buttons["CloseButton"].waitAndTap()
         let topSites = app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         mozWaitForElementToExist(topSites)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -508,8 +508,7 @@ class TabsTests: BaseTestCase {
         // Context menu opens
         waitForElementsToExist(
             [
-                app.buttons["Close Tab"],
-                app.buttons["Copy URL"]
+                app.buttons["Close Tab"]
             ]
         )
         // Choose to close the tab


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4563

## :bulb: Description
Updated the onboarding tests on iPad since the toolbar card has been removed on this device
Also update testTabTrayContextMenuCloseTab test by removing the "Copy URL" validation since this should not be available on the context menu for homepage tabs.