### PR TITLE
Fix FXIOS-11506 [Release Automation] Clone the repo in the push step of promotion

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2248,6 +2248,8 @@ workflows:
     description: This step is used during release promotion to build a firefox release
 
   release_promotion_push:
+    before_run:
+    - SPM_Common_Steps
     envs:
     - IPA_PATH: /tmp/Client.ipa
     - DSYM_PATH: /tmp/symbols.zip


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11506)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25045)

## :bulb: Description
The step needs the sentry cli which is included in the repo (in third-party) so we need to clone it.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
