### PR TITLE
Refactor [Toolbar] Turn off swiping tabs in beta

### DIFF
--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -47,7 +47,7 @@ features:
           unified_search: false
           one_tap_new_tab: false
           navigation_hint: true
-          swiping_tabs: true
+          swiping_tabs: false
           translucency: false
           layout: version1
       - channel: developer


### PR DESCRIPTION
## :scroll: Tickets
~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~
~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~

## :bulb: Description
Turns off swiping tabs in beta as it is complicating QA testing. Swiping will enabled using an experiment instead. This is a request that came from Slack.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
