### PR TITLE
Refactor FXIOS-12189 [Tab tray UI experiment] Make hit box bigger for close button

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -18,11 +18,8 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         static let faviconSize = CGSize(width: 16, height: 16)
         static let fallbackFaviconSize = CGSize(width: 24, height: 24)
         static let closeButtonSize: CGFloat = 24
+        static let closeButtonHitTarget: CGFloat = 44
         static let textBoxHeight: CGFloat = 32
-        static let closeButtonEdgeInset = NSDirectionalEdgeInsets(top: 12,
-                                                                  leading: 12,
-                                                                  bottom: 12,
-                                                                  trailing: 12)
         static let closeButtonTop: CGFloat = 6
         static let closeButtonTrailing: CGFloat = 8
         static let closeButtonOverlaySpacing: CGFloat = 6
@@ -82,13 +79,18 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         label.setContentHuggingPriority(.defaultHigh, for: .vertical)
     }
 
+    /// Invisible button without corner radius to ensure the button has the required hitbox size
     private lazy var closeButton: UIButton = .build { button in
-        var configuration = UIButton.Configuration.plain()
-        configuration.contentInsets = UX.closeButtonEdgeInset
-        button.configuration = configuration
         button.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.closeButton
     }
 
+    /// Contains the blur background for the X icon
+    private lazy var closeButtonBlur: UIView = .build { view in
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = .clear
+    }
+
+    /// Contains the cross image for the close button
     private lazy var closeButtonOverlay: UIImageView = .build { imageView in
         imageView.image = UIImage(named: StandardImageIdentifiers.Medium.cross)?.withRenderingMode(.alwaysTemplate)
     }
@@ -104,8 +106,8 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             cornerRadius: self.backgroundHolder.layer.cornerRadius
         ).cgPath
 
-        closeButton.addBlurEffectWithClearBackgroundAndClipping(using: .systemUltraThinMaterialDark)
-        closeButton.layer.cornerRadius = closeButton.frame.height / 2
+        closeButtonBlur.addBlurEffectWithClearBackgroundAndClipping(using: .systemUltraThinMaterialDark)
+        closeButtonBlur.layer.cornerRadius = closeButtonBlur.frame.height / 2
     }
 
     // MARK: - Initializer
@@ -123,7 +125,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         footerView.addArrangedSubview(titleText)
         faviconContainer.addSubview(favicon)
 
-        backgroundHolder.addSubviews(screenshotView, smallFaviconView, closeButton, closeButtonOverlay)
+        backgroundHolder.addSubviews(screenshotView, smallFaviconView, closeButton, closeButtonBlur, closeButtonOverlay)
 
         accessibilityCustomActions = [
             UIAccessibilityCustomAction(name: .TabsTray.TabTrayCloseAccessibilityCustomAction,
@@ -296,12 +298,17 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             favicon.widthAnchor.constraint(equalToConstant: UX.faviconSize.width),
             favicon.centerYAnchor.constraint(equalTo: titleText.centerYAnchor),
 
-            closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
-            closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
-            closeButton.topAnchor.constraint(equalTo: backgroundHolder.topAnchor,
-                                             constant: UX.closeButtonTop),
-            closeButton.trailingAnchor.constraint(equalTo: backgroundHolder.trailingAnchor,
-                                                  constant: -UX.closeButtonTrailing),
+            closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonHitTarget),
+            closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonHitTarget),
+            closeButton.centerXAnchor.constraint(equalTo: closeButtonBlur.centerXAnchor),
+            closeButton.centerYAnchor.constraint(equalTo: closeButtonBlur.centerYAnchor),
+
+            closeButtonBlur.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
+            closeButtonBlur.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
+            closeButtonBlur.topAnchor.constraint(equalTo: backgroundHolder.topAnchor,
+                                                 constant: UX.closeButtonTop),
+            closeButtonBlur.trailingAnchor.constraint(equalTo: backgroundHolder.trailingAnchor,
+                                                      constant: -UX.closeButtonTrailing),
 
             // Screenshot either shown or favicon takes its place as fallback
             screenshotView.topAnchor.constraint(equalTo: backgroundHolder.topAnchor),
@@ -314,11 +321,11 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             smallFaviconView.centerYAnchor.constraint(equalTo: backgroundHolder.centerYAnchor),
             smallFaviconView.centerXAnchor.constraint(equalTo: backgroundHolder.centerXAnchor),
 
-            closeButtonOverlay.centerXAnchor.constraint(equalTo: closeButton.centerXAnchor),
-            closeButtonOverlay.centerYAnchor.constraint(equalTo: closeButton.centerYAnchor),
-            closeButtonOverlay.widthAnchor.constraint(equalTo: closeButton.widthAnchor,
+            closeButtonOverlay.centerXAnchor.constraint(equalTo: closeButtonBlur.centerXAnchor),
+            closeButtonOverlay.centerYAnchor.constraint(equalTo: closeButtonBlur.centerYAnchor),
+            closeButtonOverlay.widthAnchor.constraint(equalTo: closeButtonBlur.widthAnchor,
                                                       constant: -UX.closeButtonOverlaySpacing),
-            closeButtonOverlay.heightAnchor.constraint(equalTo: closeButton.heightAnchor,
+            closeButtonOverlay.heightAnchor.constraint(equalTo: closeButtonBlur.heightAnchor,
                                                        constant: -UX.closeButtonOverlaySpacing)
         ])
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -85,13 +85,13 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     }
 
     /// Contains the blur background for the X icon
-    private lazy var closeButtonBlur: UIView = .build { view in
+    private lazy var closeButtonBlurView: UIView = .build { view in
         view.isUserInteractionEnabled = false
         view.backgroundColor = .clear
     }
 
     /// Contains the cross image for the close button
-    private lazy var closeButtonOverlay: UIImageView = .build { imageView in
+    private lazy var closeButtonImageOverlay: UIImageView = .build { imageView in
         imageView.image = UIImage(named: StandardImageIdentifiers.Medium.cross)?.withRenderingMode(.alwaysTemplate)
     }
 
@@ -106,8 +106,8 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             cornerRadius: self.backgroundHolder.layer.cornerRadius
         ).cgPath
 
-        closeButtonBlur.addBlurEffectWithClearBackgroundAndClipping(using: .systemUltraThinMaterialDark)
-        closeButtonBlur.layer.cornerRadius = closeButtonBlur.frame.height / 2
+        closeButtonBlurView.addBlurEffectWithClearBackgroundAndClipping(using: .systemUltraThinMaterialDark)
+        closeButtonBlurView.layer.cornerRadius = closeButtonBlurView.frame.height / 2
     }
 
     // MARK: - Initializer
@@ -125,7 +125,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         footerView.addArrangedSubview(titleText)
         faviconContainer.addSubview(favicon)
 
-        backgroundHolder.addSubviews(screenshotView, smallFaviconView, closeButton, closeButtonBlur, closeButtonOverlay)
+        backgroundHolder.addSubviews(screenshotView, smallFaviconView, closeButton, closeButtonBlurView, closeButtonImageOverlay)
 
         accessibilityCustomActions = [
             UIAccessibilityCustomAction(name: .TabsTray.TabTrayCloseAccessibilityCustomAction,
@@ -188,7 +188,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
 
     func applyTheme(theme: Theme) {
         backgroundHolder.backgroundColor = theme.colors.layer1
-        closeButtonOverlay.tintColor = theme.colors.textOnDark
+        closeButtonImageOverlay.tintColor = theme.colors.textOnDark
         titleText.textColor = theme.colors.textPrimary
         screenshotView.backgroundColor = theme.colors.layer1
         favicon.tintColor = theme.colors.textPrimary
@@ -300,14 +300,14 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
 
             closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonHitTarget),
             closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonHitTarget),
-            closeButton.centerXAnchor.constraint(equalTo: closeButtonBlur.centerXAnchor),
-            closeButton.centerYAnchor.constraint(equalTo: closeButtonBlur.centerYAnchor),
+            closeButton.centerXAnchor.constraint(equalTo: closeButtonBlurView.centerXAnchor),
+            closeButton.centerYAnchor.constraint(equalTo: closeButtonBlurView.centerYAnchor),
 
-            closeButtonBlur.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
-            closeButtonBlur.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
-            closeButtonBlur.topAnchor.constraint(equalTo: backgroundHolder.topAnchor,
+            closeButtonBlurView.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
+            closeButtonBlurView.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
+            closeButtonBlurView.topAnchor.constraint(equalTo: backgroundHolder.topAnchor,
                                                  constant: UX.closeButtonTop),
-            closeButtonBlur.trailingAnchor.constraint(equalTo: backgroundHolder.trailingAnchor,
+            closeButtonBlurView.trailingAnchor.constraint(equalTo: backgroundHolder.trailingAnchor,
                                                       constant: -UX.closeButtonTrailing),
 
             // Screenshot either shown or favicon takes its place as fallback
@@ -321,11 +321,11 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             smallFaviconView.centerYAnchor.constraint(equalTo: backgroundHolder.centerYAnchor),
             smallFaviconView.centerXAnchor.constraint(equalTo: backgroundHolder.centerXAnchor),
 
-            closeButtonOverlay.centerXAnchor.constraint(equalTo: closeButtonBlur.centerXAnchor),
-            closeButtonOverlay.centerYAnchor.constraint(equalTo: closeButtonBlur.centerYAnchor),
-            closeButtonOverlay.widthAnchor.constraint(equalTo: closeButtonBlur.widthAnchor,
+            closeButtonImageOverlay.centerXAnchor.constraint(equalTo: closeButtonBlurView.centerXAnchor),
+            closeButtonImageOverlay.centerYAnchor.constraint(equalTo: closeButtonBlurView.centerYAnchor),
+            closeButtonImageOverlay.widthAnchor.constraint(equalTo: closeButtonBlurView.widthAnchor,
                                                       constant: -UX.closeButtonOverlaySpacing),
-            closeButtonOverlay.heightAnchor.constraint(equalTo: closeButtonBlur.heightAnchor,
+            closeButtonImageOverlay.heightAnchor.constraint(equalTo: closeButtonBlurView.heightAnchor,
                                                        constant: -UX.closeButtonOverlaySpacing)
         ])
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -125,7 +125,11 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         footerView.addArrangedSubview(titleText)
         faviconContainer.addSubview(favicon)
 
-        backgroundHolder.addSubviews(screenshotView, smallFaviconView, closeButton, closeButtonBlurView, closeButtonImageOverlay)
+        backgroundHolder.addSubviews(screenshotView,
+                                     smallFaviconView,
+                                     closeButton,
+                                     closeButtonBlurView,
+                                     closeButtonImageOverlay)
 
         accessibilityCustomActions = [
             UIAccessibilityCustomAction(name: .TabsTray.TabTrayCloseAccessibilityCustomAction,
@@ -306,9 +310,9 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             closeButtonBlurView.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
             closeButtonBlurView.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
             closeButtonBlurView.topAnchor.constraint(equalTo: backgroundHolder.topAnchor,
-                                                 constant: UX.closeButtonTop),
+                                                     constant: UX.closeButtonTop),
             closeButtonBlurView.trailingAnchor.constraint(equalTo: backgroundHolder.trailingAnchor,
-                                                      constant: -UX.closeButtonTrailing),
+                                                          constant: -UX.closeButtonTrailing),
 
             // Screenshot either shown or favicon takes its place as fallback
             screenshotView.topAnchor.constraint(equalTo: backgroundHolder.topAnchor),
@@ -324,9 +328,9 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             closeButtonImageOverlay.centerXAnchor.constraint(equalTo: closeButtonBlurView.centerXAnchor),
             closeButtonImageOverlay.centerYAnchor.constraint(equalTo: closeButtonBlurView.centerYAnchor),
             closeButtonImageOverlay.widthAnchor.constraint(equalTo: closeButtonBlurView.widthAnchor,
-                                                      constant: -UX.closeButtonOverlaySpacing),
+                                                           constant: -UX.closeButtonOverlaySpacing),
             closeButtonImageOverlay.heightAnchor.constraint(equalTo: closeButtonBlurView.heightAnchor,
-                                                       constant: -UX.closeButtonOverlaySpacing)
+                                                            constant: -UX.closeButtonOverlaySpacing)
         ])
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12189)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26525)

## :bulb: Description
I had put a `layer.cornerRadius` on the `closeButton` (which has a blur and needed to be round for UX purpose). But it turns out this corner radius was reducing the size of the hit box to a 24x24 circle. It made the button very hard to press with our fat fingers. With this PR I am moving the blur to it's own `UIView`, and the `UIButton` is now in fact invisible to the user. This allows us to have the recommended 44x44 hit box. I double-checked and the navigation still works as it should with Voice Over on.

## :movie_camera: Demos
<details>
<summary>The new hit box (in red for demo)</summary>

![Simulator Screenshot - iPhone 16 - 2025-05-08 at 14 12 14](https://github.com/user-attachments/assets/97f70575-6c39-41c1-9ec7-ec6a1d1c3673)

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [X] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
