### PR TITLE
Bugfix FXIOS-12187 [Tab tray UI experiment] Add a cap to scaled font

### DIFF
--- a/BrowserKit/Sources/Common/Utilities/TextStyling.swift
+++ b/BrowserKit/Sources/Common/Utilities/TextStyling.swift
@@ -17,8 +17,11 @@ public struct TextStyling {
         self.weight = weight
     }
 
-    public func scaledFont() -> UIFont {
-        return DefaultDynamicFontHelper.preferredFont(withTextStyle: textStyle, size: size, weight: weight)
+    public func scaledFont(sizeCap: CGFloat? = nil) -> UIFont {
+        return DefaultDynamicFontHelper.preferredFont(withTextStyle: textStyle,
+                                                      size: size,
+                                                      sizeCap: sizeCap,
+                                                      weight: weight)
     }
 
     public func systemFont() -> UIFont {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -16,6 +16,7 @@ struct TabTraySelectorUX {
     static let estimatedCellWidth: CGFloat = 100
     static let cornerRadius: CGFloat = 12
     static let verticalInsets: CGFloat = 4
+    static let maxFontSize: CGFloat = 30
 }
 
 class TabTraySelectorView: UIView,
@@ -75,8 +76,8 @@ class TabTraySelectorView: UIView,
             stackView.addArrangedSubview(button)
 
             button.titleLabel?.font = index == selectedIndex ?
-                FXFontStyles.Bold.body.scaledFont() :
-                FXFontStyles.Regular.body.scaledFont()
+                FXFontStyles.Bold.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize) :
+                FXFontStyles.Regular.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
 
             button.accessibilityIdentifier = "\(AccessibilityIdentifiers.TabTray.selectorCell)\(index)"
             button.accessibilityHint = String(format: .TabsTray.TabTraySelectorAccessibilityHint,
@@ -110,9 +111,9 @@ class TabTraySelectorView: UIView,
 
         for (index, button) in buttons.enumerated() {
             if index == selectedIndex {
-                button.titleLabel?.font = FXFontStyles.Bold.body.scaledFont()
+                button.titleLabel?.font = FXFontStyles.Bold.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
             } else {
-                button.titleLabel?.font = FXFontStyles.Regular.body.scaledFont()
+                button.titleLabel?.font = FXFontStyles.Regular.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
             }
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12187)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26522)

## :bulb: Description
Puts a cap on the scaled font method for cases where it is impossible to scale without harming readability.

![Screenshot 2025-05-08 at 4 02 01 PM](https://github.com/user-attachments/assets/906e8047-648b-4ccc-ba96-455ad1acf471)

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
