### PR TITLE
Bugfix FXIOS-12232 [Firefox Suggest] Make sure `ingest` runs at least once when the app starts

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -213,7 +213,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         /// On first run (when suggest‑data.db is empty) this populates the db; later calls are no‑ops due to `emptyOnly`.
         /// For details, see:
         ///     https://github.com/mozilla/application-services/blob/5aade8c09653ad2a2ec02746dc6bcf80dc8434c2/components/suggest/src/store.rs#L597-L599
-        /// Actual periodic refreshing happens in `BackgroundFirefoxSuggestIngestUtility.swift`.
+        /// Actual periodic refreshing happens in the background in `BackgroundFirefoxSuggestIngestUtility.swift`.
         /// `.utility` priority is used here because this blocks on network calls and would otherwise trigger a
         /// priority‑inversion warning if run at user‑initiated QoS.
         Task.detached(priority: .utility) {

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -216,7 +216,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         /// Actual periodic refreshing happens in the background in `BackgroundFirefoxSuggestIngestUtility.swift`.
         /// `.utility` priority is used here because this blocks on network calls and would otherwise trigger a
         /// priority‑inversion warning if run at user‑initiated QoS.
-        Task.detached(priority: .utility) {
+        Task(priority: .utility) {
             try await self.profile.firefoxSuggest?.ingest(emptyOnly: true)
         }
         logger.log("applicationDidBecomeActive end",

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -210,7 +210,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
 
         updateWallpaperMetadata()
         loadBackgroundTabs()
-
+        /// On first run (when suggest‑data.db is empty) this populates the db; later calls are no‑ops due to `emptyOnly`.
+        /// For details, see:
+        ///     https://github.com/mozilla/application-services/blob/5aade8c09653ad2a2ec02746dc6bcf80dc8434c2/components/suggest/src/store.rs#L597-L599
+        /// Actual periodic refreshing happens in `BackgroundFirefoxSuggestIngestUtility.swift`.
+        /// `.utility` priority is used here because this blocks on network calls and would otherwise trigger a
+        /// priority‑inversion warning if run at user‑initiated QoS.
+        Task.detached(priority: .utility) {
+            try await self.profile.firefoxSuggest?.ingest(emptyOnly: true)
+        }
         logger.log("applicationDidBecomeActive end",
                    level: .info,
                    category: .lifecycle)

--- a/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
@@ -54,7 +54,7 @@ class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol, FeatureF
                    level: .debug,
                    category: .storage)
         do {
-            try await firefoxSuggest.ingest()
+            try await firefoxSuggest.ingest(emptyOnly: false)
             logger.log("Successfully ingested new suggestions",
                        level: .debug,
                        category: .storage)

--- a/firefox-ios/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
@@ -69,7 +69,7 @@ class ForceFirefoxSuggestIngestSetting: Setting {
                        level: .info,
                        category: .storage)
             do {
-                try await self.profile?.firefoxSuggest?.ingest()
+                try await self.profile?.firefoxSuggest?.ingest(emptyOnly: false)
                 logger.log("Successfully ingested new suggestions",
                            level: .info,
                            category: .storage)

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -55,7 +55,7 @@ public class RustFirefoxSuggest: RustFirefoxSuggestProtocol {
         store = try builder.build()
     }
 
-    public func ingest(emptyOnly: Bool = false) async throws {
+    public func ingest(emptyOnly: Bool) async throws {
         // Ensure that the Rust networking stack has been initialized before
         // downloading new suggestions. This is safe to call multiple times.
         Viaduct.shared.useReqwestBackend()

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -15,7 +15,7 @@ import struct MozillaAppServices.SuggestionQuery
 @preconcurrency
 public protocol RustFirefoxSuggestProtocol {
     /// Downloads and stores new Firefox Suggest suggestions.
-    func ingest() async throws
+    func ingest(emptyOnly: Bool) async throws
 
     /// Searches the store for matching suggestions.
     func query(
@@ -55,7 +55,7 @@ public class RustFirefoxSuggest: RustFirefoxSuggestProtocol {
         store = try builder.build()
     }
 
-    public func ingest() async throws {
+    public func ingest(emptyOnly: Bool = false) async throws {
         // Ensure that the Rust networking stack has been initialized before
         // downloading new suggestions. This is safe to call multiple times.
         Viaduct.shared.useReqwestBackend()
@@ -63,7 +63,7 @@ public class RustFirefoxSuggest: RustFirefoxSuggestProtocol {
         try await withCheckedThrowingContinuation { continuation in
             writerQueue.async(qos: .utility) {
                 do {
-                    _ = try self.store.ingest(constraints: SuggestIngestionConstraints())
+                    _ = try self.store.ingest(constraints: SuggestIngestionConstraints(emptyOnly: emptyOnly))
                     continuation.resume()
                 } catch {
                     continuation.resume(throwing: error)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/MockRustFirefoxSuggest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/MockRustFirefoxSuggest.swift
@@ -7,7 +7,7 @@ import Storage
 import MozillaAppServices
 
 class MockRustFirefoxSuggest: RustFirefoxSuggestProtocol {
-    func ingest(emptyOnly: Bool = false) async throws {
+    func ingest(emptyOnly: Bool) async throws {
     }
     func query(
         _ keyword: String,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/MockRustFirefoxSuggest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/MockRustFirefoxSuggest.swift
@@ -7,7 +7,7 @@ import Storage
 import MozillaAppServices
 
 class MockRustFirefoxSuggest: RustFirefoxSuggestProtocol {
-    func ingest() async throws {
+    func ingest(emptyOnly: Bool = false) async throws {
     }
     func query(
         _ keyword: String,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12232)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26626)

## :bulb: Description
This PR:
- Adds a call to `ingest` on `applicationDidBecomeActive`. This makes sure that we ingest suggestions at least once and not have to background the app for suggestions. `ingest` is called with `emptyOnly` set to true so that we only update the db if it's empty. If the databse is not empty (i.e we have suggestions already even if outdated ) `ingest` will return early. Refetching/Refreshing suggestions happens in the background in `BackgroundFirefoxSuggestIngestUtility`.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
