### PR TITLE
Bugfix FXIOS-12137 [ShareTo] Make sure rust components is always initialized

### DIFF
--- a/firefox-ios/Extensions/ShareTo/InitialViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/InitialViewController.swift
@@ -6,6 +6,7 @@ import Common
 import UIKit
 import Shared
 import Storage
+import MozillaAppServices
 
 // Small iPhone screens in landscape require that the popup have a shorter height.
 func isLandscapeSmallScreen(_ traitCollection: UITraitCollection) -> Bool {
@@ -32,6 +33,9 @@ class InitialViewController: UIViewController {
     var shareViewController: ShareViewController?
 
     override func viewDidLoad() {
+        // Initialize app services ( including NSS ). Must be called before any other calls to rust components.
+        MozillaAppServices.initialize()
+
         UIDevice.current.beginGeneratingDeviceOrientationNotifications()
         super.viewDidLoad()
 


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12137)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26403)

## :bulb: Description
This PR:
- Adds call to initialize rust components when share is not called from main context (i.e another app like safari... )

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| nothing happens when sharing link from another app | <video src="https://github.com/user-attachments/assets/af521d4e-ce45-4366-91ff-db99b5597dab" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
