### PR TITLE
Add FXIOS-12234 Support Metal shaders in separate Swift package

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -41,6 +41,9 @@ let package = Package(
         .library(
             name: "ContentBlockingGenerator",
             targets: ["ContentBlockingGenerator"]),
+        .library(
+            name: "OnboardingKit",
+            targets: ["OnboardingKit"]),
         .executable(
             name: "ExecutableContentBlockingGenerator",
             targets: ["ExecutableContentBlockingGenerator"]),
@@ -150,6 +153,17 @@ let package = Package(
         .testTarget(
             name: "ContentBlockingGeneratorTests",
             dependencies: ["ContentBlockingGenerator"]),
+        .target(
+            name: "OnboardingKit",
+            dependencies: ["Common", "ComponentLibrary"],
+            resources: [
+                .process("Shaders")
+            ],
+            swiftSettings: [.unsafeFlags(["-enable-testing"])],
+            linkerSettings: [
+                .linkedFramework("Metal"),
+                .linkedFramework("MetalKit")
+            ]),
         .executableTarget(
             name: "ExecutableContentBlockingGenerator",
             dependencies: ["ContentBlockingGenerator"]),

--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -44,6 +44,9 @@ public enum LoggerCategory: String {
 
     /// Related to the main menu.
     case mainMenu
+    
+    /// Related to onboarding
+    case onboarding
 
     /// Related to redux library or integration
     case redux

--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -44,7 +44,7 @@ public enum LoggerCategory: String {
 
     /// Related to the main menu.
     case mainMenu
-    
+
     /// Related to onboarding
     case onboarding
 

--- a/BrowserKit/Sources/OnboardingKit/MilkyWayRenderer.swift
+++ b/BrowserKit/Sources/OnboardingKit/MilkyWayRenderer.swift
@@ -42,9 +42,11 @@ class MilkyWayRenderer: NSObject, MTKViewDelegate {
 
         // Shader functions
         let library = try device.makeDefaultLibrary(bundle: .module)
-        guard
-            let vfn = library.makeFunction(name: "milky_way_vertex"),
-            let ffn = library.makeFunction(name: "milky_way_fragment")
+        guard let vfn = library.makeFunction(
+            name: "milky_way_vertex"
+        ), let ffn = library.makeFunction(
+            name: "milky_way_fragment"
+        )
         else {
             let msg = "Missing shader functions milky_way_vertex / milky_way_fragment"
             logger.log(msg, level: .fatal, category: .onboarding)

--- a/BrowserKit/Sources/OnboardingKit/MilkyWayRenderer.swift
+++ b/BrowserKit/Sources/OnboardingKit/MilkyWayRenderer.swift
@@ -1,113 +1,196 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-
 import SwiftUI
 import MetalKit
+import Common
+
+enum MilkyWayRendererError: Error {
+    case failedToCreateCommandQueue
+    case missingShaderFunction(name: String)
+}
 
 class MilkyWayRenderer: NSObject, MTKViewDelegate {
-    var device: MTLDevice!
-    var commandQueue: MTLCommandQueue!
-    var pipelineState: MTLRenderPipelineState!
-    var time: Float = 0.0
+    // MARK: – Logger
+    private var logger: Logger = DefaultLogger.shared
 
-    var previousFrameTexture: MTLTexture?
+    // MARK: – Properties
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private let pipelineState: MTLRenderPipelineState
 
-    init(device: MTLDevice = MTLCreateSystemDefaultDevice()!) {
+    private var time: Float = 0.0
+    private let timeIncrement: Float = 0.0045
+
+    private var previousFrameTexture: MTLTexture?
+
+    // MARK: – Init
+    init(device: MTLDevice = MTLCreateSystemDefaultDevice()!) throws {
         self.device = device
-        self.commandQueue = device.makeCommandQueue()
-        do {
-            let library = try device.makeDefaultLibrary(bundle: .module)
 
-            let vertexFunction = library.makeFunction(name: "milky_way_vertex")
-            let fragmentFunction = library.makeFunction(name: "milky_way_fragment")
-
-            let pipelineDescriptor = MTLRenderPipelineDescriptor()
-            pipelineDescriptor.vertexFunction = vertexFunction
-            pipelineDescriptor.fragmentFunction = fragmentFunction
-            pipelineDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
-
-            pipelineState = try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
-        } catch {
-            fatalError("Failed to create pipeline state: \(error)")
+        // Command queue
+        guard let queue = device.makeCommandQueue() else {
+            logger.log(
+                "Failed to create Metal command queue",
+                level: .fatal,
+                category: .onboarding
+            )
+            throw MilkyWayRendererError.failedToCreateCommandQueue
         }
-    }
+        self.commandQueue = queue
 
-    func draw(in view: MTKView) {
-        guard let drawable = view.currentDrawable,
-              let commandBuffer = commandQueue.makeCommandBuffer(),
-              let renderPassDescriptor = view.currentRenderPassDescriptor else { return }
-
-        if previousFrameTexture == nil ||
-           previousFrameTexture?.width != Int(view.drawableSize.width) ||
-           previousFrameTexture?.height != Int(view.drawableSize.height) {
-            createPreviousFrameTexture(size: view.drawableSize)
+        // Shader functions
+        let library = try device.makeDefaultLibrary(bundle: .module)
+        guard
+            let vfn = library.makeFunction(name: "milky_way_vertex"),
+            let ffn = library.makeFunction(name: "milky_way_fragment")
+        else {
+            let msg = "Missing shader functions milky_way_vertex / milky_way_fragment"
+            logger.log(msg, level: .fatal, category: .onboarding)
+            throw MilkyWayRendererError.missingShaderFunction(name: msg)
         }
 
-        let commandEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor)!
-        commandEncoder.setRenderPipelineState(pipelineState)
-        commandEncoder.setFragmentBytes(&time, length: MemoryLayout<Float>.size, index: 0)
-        commandEncoder.setFragmentTexture(previousFrameTexture, index: 0)
-        commandEncoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
-        commandEncoder.endEncoding()
+        // Pipeline
+        let pd = MTLRenderPipelineDescriptor()
+        pd.vertexFunction   = vfn
+        pd.fragmentFunction = ffn
+        pd.colorAttachments[0].pixelFormat = .bgra8Unorm
+        self.pipelineState = try device.makeRenderPipelineState(descriptor: pd)
 
-        copyCurrentFrameToPrevious(drawable: drawable, commandBuffer: commandBuffer)
+        super.init()
 
-        commandBuffer.present(drawable)
-        commandBuffer.commit()
-
-        time += 0.0045
+        logger.log(
+            "MilkyWayRenderer initialized successfully",
+            level: .info,
+            category: .onboarding
+        )
     }
 
+    // MARK: – MTKViewDelegate
     func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
         createPreviousFrameTexture(size: size)
     }
 
+    func draw(in view: MTKView) {
+        // Acquire drawable
+        guard let drawable = view.currentDrawable else {
+            logger.log(
+                "No currentDrawable available",
+                level: .warning,
+                category: .onboarding
+            )
+            return
+        }
+
+        // Acquire render pass descriptor
+        guard let rpd = view.currentRenderPassDescriptor else {
+            logger.log(
+                "No currentRenderPassDescriptor",
+                level: .warning,
+                category: .onboarding
+            )
+            return
+        }
+
+        // Make command buffer
+        guard let cmdBuf = commandQueue.makeCommandBuffer() else {
+            logger.log(
+                "Failed to create commandBuffer",
+                level: .warning,
+                category: .onboarding
+            )
+            return
+        }
+
+        // Resize history texture if needed
+        if previousFrameTexture?.width  != Int(view.drawableSize.width) ||
+           previousFrameTexture?.height != Int(view.drawableSize.height) {
+            createPreviousFrameTexture(size: view.drawableSize)
+        }
+
+        // Encode draw commands
+        guard let encoder = cmdBuf.makeRenderCommandEncoder(descriptor: rpd) else {
+            logger.log(
+                "Failed to create renderCommandEncoder",
+                level: .warning,
+                category: .onboarding
+            )
+            return
+        }
+        encoder.setRenderPipelineState(pipelineState)
+        encoder.setFragmentBytes(&time,
+                                 length: MemoryLayout<Float>.size,
+                                 index: 0)
+        encoder.setFragmentTexture(previousFrameTexture,
+                                   index: 0)
+        encoder.drawPrimitives(type: .triangleStrip,
+                               vertexStart: 0,
+                               vertexCount: 4)
+        encoder.endEncoding()
+
+        // Blit into history
+        copyCurrentFrameToPrevious(drawable: drawable,
+                                   commandBuffer: cmdBuf)
+
+        // Present & commit
+        cmdBuf.present(drawable)
+        cmdBuf.commit()
+
+        // Advance time
+        time += timeIncrement
+    }
+
+    // MARK: – Helpers
     private func createPreviousFrameTexture(size: CGSize) {
-        let textureDescriptor = MTLTextureDescriptor.texture2DDescriptor(
+        let desc = MTLTextureDescriptor.texture2DDescriptor(
             pixelFormat: .bgra8Unorm,
             width: Int(size.width),
             height: Int(size.height),
             mipmapped: false
         )
-        textureDescriptor.usage = [.shaderRead, .renderTarget]
-        previousFrameTexture = device.makeTexture(descriptor: textureDescriptor)
+        desc.usage = [.shaderRead, .renderTarget]
+        previousFrameTexture = device.makeTexture(descriptor: desc)
     }
 
-    private func copyCurrentFrameToPrevious(drawable: CAMetalDrawable, commandBuffer: MTLCommandBuffer) {
-        guard let previousFrameTexture = previousFrameTexture else { return }
-
-        let blitEncoder = commandBuffer.makeBlitCommandEncoder()
-        blitEncoder?.copy(from: drawable.texture,
-                          sourceSlice: 0,
-                          sourceLevel: 0,
-                          sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
-                          sourceSize: MTLSize(width: previousFrameTexture.width,
-                                              height: previousFrameTexture.height,
-                                              depth: 1),
-                          to: previousFrameTexture,
-                          destinationSlice: 0,
-                          destinationLevel: 0,
-                          destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0))
-        blitEncoder?.endEncoding()
+    private func copyCurrentFrameToPrevious(drawable: CAMetalDrawable,
+                                            commandBuffer: MTLCommandBuffer) {
+        guard let history = previousFrameTexture else { return }
+        let blit = commandBuffer.makeBlitCommandEncoder()
+        blit?.copy(from: drawable.texture,
+                   sourceSlice: 0, sourceLevel: 0,
+                   sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
+                   sourceSize: MTLSize(width: history.width,
+                                       height: history.height,
+                                       depth: 1),
+                   to: history,
+                   destinationSlice: 0, destinationLevel: 0,
+                   destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0))
+        blit?.endEncoding()
     }
 }
 
-// MARK: - Metal View
+// MARK: – SwiftUI Bridge
 struct MilkyWayMetalView: UIViewRepresentable {
     func makeUIView(context: Context) -> MTKView {
-        let metalView = MTKView()
-        metalView.device = MTLCreateSystemDefaultDevice()
-        metalView.framebufferOnly = false
-        metalView.colorPixelFormat = .bgra8Unorm
-        metalView.delegate = context.coordinator
-        return metalView
+        let view = MTKView()
+        view.device = MTLCreateSystemDefaultDevice()
+        view.framebufferOnly = false
+        view.colorPixelFormat = .bgra8Unorm
+        view.delegate = context.coordinator
+        return view
     }
 
-    func updateUIView(_ uiView: MTKView, context: Context) {}
+    func updateUIView(_ uiView: MTKView, context: Context) { }
 
     func makeCoordinator() -> MilkyWayRenderer {
-        return MilkyWayRenderer()
+        do {
+            return try MilkyWayRenderer()
+        } catch {
+            // If init fails here, it’s truly unrecoverable
+            DefaultLogger.shared.log(
+                "Fatal: could not instantiate MilkyWayRenderer – \(error)",
+                level: .fatal,
+                category: .onboarding
+            )
+            fatalError("MilkyWayRenderer init failed: \(error)")
+        }
     }
 }
 

--- a/BrowserKit/Sources/OnboardingKit/MilkyWayRenderer.swift
+++ b/BrowserKit/Sources/OnboardingKit/MilkyWayRenderer.swift
@@ -1,0 +1,119 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+import MetalKit
+
+class MilkyWayRenderer: NSObject, MTKViewDelegate {
+    var device: MTLDevice!
+    var commandQueue: MTLCommandQueue!
+    var pipelineState: MTLRenderPipelineState!
+    var time: Float = 0.0
+
+    var previousFrameTexture: MTLTexture?
+
+    init(device: MTLDevice = MTLCreateSystemDefaultDevice()!) {
+        self.device = device
+        self.commandQueue = device.makeCommandQueue()
+        do {
+            let library = try device.makeDefaultLibrary(bundle: .module)
+
+            let vertexFunction = library.makeFunction(name: "milky_way_vertex")
+            let fragmentFunction = library.makeFunction(name: "milky_way_fragment")
+
+            let pipelineDescriptor = MTLRenderPipelineDescriptor()
+            pipelineDescriptor.vertexFunction = vertexFunction
+            pipelineDescriptor.fragmentFunction = fragmentFunction
+            pipelineDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+
+            pipelineState = try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
+        } catch {
+            fatalError("Failed to create pipeline state: \(error)")
+        }
+    }
+
+    func draw(in view: MTKView) {
+        guard let drawable = view.currentDrawable,
+              let commandBuffer = commandQueue.makeCommandBuffer(),
+              let renderPassDescriptor = view.currentRenderPassDescriptor else { return }
+
+        if previousFrameTexture == nil ||
+           previousFrameTexture?.width != Int(view.drawableSize.width) ||
+           previousFrameTexture?.height != Int(view.drawableSize.height) {
+            createPreviousFrameTexture(size: view.drawableSize)
+        }
+
+        let commandEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor)!
+        commandEncoder.setRenderPipelineState(pipelineState)
+        commandEncoder.setFragmentBytes(&time, length: MemoryLayout<Float>.size, index: 0)
+        commandEncoder.setFragmentTexture(previousFrameTexture, index: 0)
+        commandEncoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        commandEncoder.endEncoding()
+
+        copyCurrentFrameToPrevious(drawable: drawable, commandBuffer: commandBuffer)
+
+        commandBuffer.present(drawable)
+        commandBuffer.commit()
+
+        time += 0.0045
+    }
+
+    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
+        createPreviousFrameTexture(size: size)
+    }
+
+    private func createPreviousFrameTexture(size: CGSize) {
+        let textureDescriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm,
+            width: Int(size.width),
+            height: Int(size.height),
+            mipmapped: false
+        )
+        textureDescriptor.usage = [.shaderRead, .renderTarget]
+        previousFrameTexture = device.makeTexture(descriptor: textureDescriptor)
+    }
+
+    private func copyCurrentFrameToPrevious(drawable: CAMetalDrawable, commandBuffer: MTLCommandBuffer) {
+        guard let previousFrameTexture = previousFrameTexture else { return }
+
+        let blitEncoder = commandBuffer.makeBlitCommandEncoder()
+        blitEncoder?.copy(from: drawable.texture,
+                          sourceSlice: 0,
+                          sourceLevel: 0,
+                          sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
+                          sourceSize: MTLSize(width: previousFrameTexture.width,
+                                              height: previousFrameTexture.height,
+                                              depth: 1),
+                          to: previousFrameTexture,
+                          destinationSlice: 0,
+                          destinationLevel: 0,
+                          destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0))
+        blitEncoder?.endEncoding()
+    }
+}
+
+// MARK: - Metal View
+struct MilkyWayMetalView: UIViewRepresentable {
+    func makeUIView(context: Context) -> MTKView {
+        let metalView = MTKView()
+        metalView.device = MTLCreateSystemDefaultDevice()
+        metalView.framebufferOnly = false
+        metalView.colorPixelFormat = .bgra8Unorm
+        metalView.delegate = context.coordinator
+        return metalView
+    }
+
+    func updateUIView(_ uiView: MTKView, context: Context) {}
+
+    func makeCoordinator() -> MilkyWayRenderer {
+        return MilkyWayRenderer()
+    }
+}
+
+struct MetalView_Previews: PreviewProvider {
+    static var previews: some View {
+        MilkyWayMetalView()
+            .edgesIgnoringSafeArea(.all)
+    }
+}

--- a/BrowserKit/Sources/OnboardingKit/MilkyWayRenderer.swift
+++ b/BrowserKit/Sources/OnboardingKit/MilkyWayRenderer.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import SwiftUI
 import MetalKit
 import Common
@@ -153,15 +157,21 @@ class MilkyWayRenderer: NSObject, MTKViewDelegate {
                                             commandBuffer: MTLCommandBuffer) {
         guard let history = previousFrameTexture else { return }
         let blit = commandBuffer.makeBlitCommandEncoder()
-        blit?.copy(from: drawable.texture,
-                   sourceSlice: 0, sourceLevel: 0,
-                   sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
-                   sourceSize: MTLSize(width: history.width,
-                                       height: history.height,
-                                       depth: 1),
-                   to: history,
-                   destinationSlice: 0, destinationLevel: 0,
-                   destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0))
+        blit?.copy(
+            from: drawable.texture,
+            sourceSlice: 0,
+            sourceLevel: 0,
+            sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
+            sourceSize: MTLSize(
+                width: history.width,
+                height: history.height,
+                depth: 1
+            ),
+            to: history,
+            destinationSlice: 0,
+            destinationLevel: 0,
+            destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0)
+        )
         blit?.endEncoding()
     }
 }

--- a/BrowserKit/Sources/OnboardingKit/MilkyWayRenderer.swift
+++ b/BrowserKit/Sources/OnboardingKit/MilkyWayRenderer.swift
@@ -42,11 +42,9 @@ class MilkyWayRenderer: NSObject, MTKViewDelegate {
 
         // Shader functions
         let library = try device.makeDefaultLibrary(bundle: .module)
-        guard let vfn = library.makeFunction(
-            name: "milky_way_vertex"
-        ), let ffn = library.makeFunction(
-            name: "milky_way_fragment"
-        )
+        guard
+            let vfn = library.makeFunction(name: "milky_way_vertex"),
+            let ffn = library.makeFunction(name: "milky_way_fragment")
         else {
             let msg = "Missing shader functions milky_way_vertex / milky_way_fragment"
             logger.log(msg, level: .fatal, category: .onboarding)

--- a/BrowserKit/Sources/OnboardingKit/Shaders/blurredPoints.metal
+++ b/BrowserKit/Sources/OnboardingKit/Shaders/blurredPoints.metal
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+
+//
+//  blurredPoints.metal
+//  OHarkonnen
+//
+//  Created by Nishant Bhasin on 2025-03-11.
+//
+#include <metal_stdlib>
+using namespace metal;
+
+struct VertexOut {
+    float4 position [[position]];
+    float2 texCoord;
+};
+
+vertex VertexOut milky_way_vertex(uint vertexID [[vertex_id]]) {
+    float2 positions[4] = {
+        {-1, -1},  // Bottom-left
+        { 1, -1},  // Bottom-right
+        {-1,  1},  // Top-left
+        { 1,  1}   // Top-right
+    };
+    
+    float2 texCoords[4] = {
+        {0, 0},  // Bottom-left
+        {1, 0},  // Bottom-right
+        {0, 1},  // Top-left
+        {1, 1}   // Top-right
+    };
+    
+    VertexOut out;
+    out.position = float4(positions[vertexID], 0, 1);
+    out.texCoord = texCoords[vertexID];
+    return out;
+}
+
+// ✅ Made static to avoid linker conflicts
+static float random(float2 p) {
+    return fract(sin(dot(p, float2(127.1, 311.7))) * 43758.5453);
+}
+
+static float noise(float2 p) {
+    float2 i = floor(p);
+    float2 f = fract(p);
+    
+    float a = random(i);
+    float b = random(i + float2(1.0, 0.0));
+    float c = random(i + float2(0.0, 1.0));
+    
+    float2 u = f * f * (3.0 - 2.0 * f);
+    return mix(a, b, u.x) + (c - a) * u.y * (b - a) * u.x;
+}
+
+fragment half4 milky_way_fragment(VertexOut in [[stage_in]],
+                                  constant float &time [[buffer(0)]],
+                                  texture2d<half> previousFrame [[texture(0)]]) {
+    // Five animated control points
+    float2 p1 = float2(0.2 + 0.2 * sin(time * 0.8), 0.3 + 0.2 * cos(time * 0.8));
+    float2 p2 = float2(0.8 + 0.2 * cos(time * 0.6), 0.7 + 0.2 * sin(time * 0.6));
+    float2 p3 = float2(0.6 + 0.2 * sin(time * 1.5), 0.3 + 0.2 * cos(time * 1.5));
+    float2 p4 = float2(0.4 + 0.2 * cos(time * 1.1), 0.6 + 0.2 * sin(time * 1.1));
+    float2 p5 = float2(0.7 + 0.2 * sin(time * 0.9), 0.5 + 0.2 * cos(time * 0.9));
+    
+    // Colors for each control point
+    half3 color1 = half3(1.0, 0.47, 0.2);
+    half3 color2 = half3(0.2, 0.55, 1.0);
+    half3 color3 = half3(1.0, 0.31, 0.12);
+    half3 color4 = half3(0.5, 1.0, 0.4);
+    half3 color5 = half3(0.8, 0.2, 0.6);
+    
+    // Pulsating effect
+    float sizeMod = 0.1 + 0.05 * sin(time * 1.2);
+    float maxDistance = 0.725 + sizeMod;
+    
+    // Influence calculation
+    float d1 = pow(max(1.0 - distance(in.texCoord, p1) / maxDistance, 0.0), 2.0);
+    float d2 = pow(max(1.0 - distance(in.texCoord, p2) / maxDistance, 0.0), 2.0);
+    float d3 = pow(max(1.0 - distance(in.texCoord, p3) / maxDistance, 0.0), 2.0);
+    float d4 = pow(max(1.0 - distance(in.texCoord, p4) / maxDistance, 0.0), 2.0);
+    float d5 = pow(max(1.0 - distance(in.texCoord, p5) / maxDistance, 0.0), 2.0);
+    
+    // Add Perlin noise to influence size
+    float noiseMod = noise(in.texCoord * 10.0 + time) * 0.1;
+    maxDistance += noiseMod;
+    
+    // Normalize weights
+    float totalWeight = d1 + d2 + d3 + d4 + d5;
+    if (totalWeight > 0.001) {
+        d1 /= totalWeight;
+        d2 /= totalWeight;
+        d3 /= totalWeight;
+        d4 /= totalWeight;
+        d5 /= totalWeight;
+    }
+    
+    // Blend colors based on influence
+    half3 blendedColor = d1 * color1 + d2 * color2 + d3 * color3 + d4 * color4 + d5 * color5;
+    
+    // Sample the previous frame for motion blur
+    half4 lastFrameColor = previousFrame.sample(sampler(coord::normalized), in.texCoord);
+    
+    // Apply motion blur by mixing with the last frame
+    half4 finalColor = half4(mix(lastFrameColor.rgb, blendedColor, 0.85), 1.0); // 85% current frame
+    
+    return finalColor;
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12234)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26636)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Creating new OnboardingKit package.
Added metal shaders.
Added metal renderer.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
