### PR TITLE
Add FXIOS-11506 [Release Automation] notify release-signoff after shipping releases

### DIFF
--- a/taskcluster/ffios_taskgraph/transforms/release_notifications.py
+++ b/taskcluster/ffios_taskgraph/transforms/release_notifications.py
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+transforms = TransformSequence()
+
+@transforms.add
+def build_notifications(config, tasks):
+    for task in tasks:
+        resolve_keyed_by(task, "notifications.emails", item_name=task["name"], level=config.params["level"])
+
+        notifications = task.pop("notifications", None)
+        if not notifications:
+            continue
+
+        emails = notifications["emails"]
+        if not emails:
+            continue
+
+        subject = notifications["subject"].format(**config.params)
+        message = notifications["message"].format(**config.params)
+
+        task.setdefault("routes", []).extend((f"notify.email.{email}.on-completed" for email in emails))
+        task.setdefault("extra", {}).update({
+            "notify": {
+                "email": {
+                    "subject": subject,
+                    "content": message,
+                }
+            }
+        })
+
+        yield task

--- a/taskcluster/kinds/release-notify-ship/kind.yml
+++ b/taskcluster/kinds/release-notify-ship/kind.yml
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - taskgraph.transforms.from_deps
+    - ffios_taskgraph.transforms.release_notifications:transforms
+    - taskgraph.transforms.task
+
+kind-dependencies:
+    - mark-as-shipped
+
+tasks:
+  firefox-ios:
+    name: notify-release-signoff-ship
+    description: Sends email to release-signoff telling a release was shipped.
+    run-on-projects: []
+    shipping-phase: ship
+    worker-type: succeed
+    notifications:
+      emails:
+        by-level:
+          '3': ["release-signoff@mozilla.org"]
+          default: []
+      subject: "firefox-ios {release_type} {version} build{build_number} is shipped!"
+      message: "firefox-ios {release_type} {version} build{build_number} is shipped!"
+    from-deps:
+      group-by:
+        attribute: release-type
+      unique-kinds: false
+      copy-attributes: true
+      with-attributes:
+        release-type:
+          - beta
+          - release

--- a/taskcluster/test/params/release-ship-beta.yml
+++ b/taskcluster/test/params/release-ship-beta.yml
@@ -16,7 +16,7 @@ filters:
 head_ref: refs/heads/main
 head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
-head_tag: v137.0.0
+head_tag: v137.0b1
 level: '1'
 moz_build_date: '20250226191326'
 next_version: 137.0.1
@@ -32,4 +32,4 @@ repository_type: git
 shipping_phase: ship
 target_tasks_method: ship
 tasks_for: action
-version: '137.0.0'
+version: '137.0b1'


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11506)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25045)

## :bulb: Description

This adds a task that notifies release-signoff after a build gets shipped.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
