### PR TITLE
Bugfix FXIOS-12221 Activate telemetry for users who installed 138.0 and enrolled in the ToS experiment's control branch

### DIFF
--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -40,6 +40,12 @@ final class AppLaunchUtil {
         // Need to get "settings.sendCrashReports" this way so that Sentry can be initialized before getting the Profile.
         let sendCrashReports = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.prefSendCrashReports) ?? true
 
+        if termsOfServiceManager.isAffectedUser {
+            logger.setup(sendCrashReports: sendCrashReports)
+            TelemetryWrapper.shared.setup(profile: profile)
+            TelemetryWrapper.shared.recordStartUpTelemetry()
+        }
+
         if termsOfServiceManager.isFeatureEnabled {
             // Two cases:
             // 1. when ToS screen has been presented and user accepted it

--- a/firefox-ios/Client/TermsOfServiceManager.swift
+++ b/firefox-ios/Client/TermsOfServiceManager.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Shared
 import Glean
+import MozillaAppServices
 
 struct TermsOfServiceManager: FeatureFlaggable {
     var prefs: Prefs
@@ -31,5 +32,78 @@ struct TermsOfServiceManager: FeatureFlaggable {
         // AdjustHelper.setEnabled($0)
         DefaultGleanWrapper().setUpload(isEnabled: value)
         Experiments.setTelemetrySetting(value)
+    }
+
+    // MARK: – Constants
+
+    private enum VersionRange {
+        static let minimum = "138.0"
+        static let maximum = "138.1"
+    }
+
+    private enum Experiment {
+        static let onboardingPhase4ID = "new-onboarding-experience-experiment-phase-4-ios"
+        static let controlBranch = "control"
+    }
+
+    // MARK: – Public API
+
+    /// Returns `true` if all of the following are satisfied:
+    /// 1. App version is in [138.0, 138.1)
+    /// 2. The TOS feature flag is enabled
+    /// 3. User is in the "control" branch of the onboarding experiment
+    /// 4. User did not see the TOC screen
+    var isAffectedUser: Bool {
+        // 1) Version check
+        guard isAppVersion(in: VersionRange.minimum..<VersionRange.maximum) else {
+            // Outside of the target version window
+            return false
+        }
+
+        // 2) Feature-flag check
+        guard isFeatureEnabled else {
+            // TOS feature is disabled
+            return false
+        }
+
+        // 3) Experiment branch check
+        guard isInControlBranch(experimentId: Experiment.onboardingPhase4ID) else {
+            // Not in the control group
+            return false
+        }
+
+        // 4) TOS screen was not shown
+        guard shouldShowScreen else {
+            return false
+        }
+
+        return true
+    }
+
+    // MARK: – Helpers
+
+    /// Checks whether the app’s CFBundleShortVersionString lies within the half-open range [min, max).
+    private func isAppVersion(in range: Range<String>) -> Bool {
+        guard
+            let versionString = Bundle.main
+                .object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        else {
+            return false
+        }
+
+        let v = versionString as NSString
+        let meetsMinimum = v.compare(range.lowerBound, options: .numeric) != .orderedAscending
+        let belowMaximum = v.compare(range.upperBound, options: .numeric) == .orderedAscending
+        return meetsMinimum && belowMaximum
+    }
+
+    /// Returns `true` if the given experiment’s branch slug exists and equals “control”.
+    private func isInControlBranch(experimentId: String) -> Bool {
+        guard
+            let branch = Experiments.shared.getExperimentBranch(experimentId: experimentId)
+        else {
+            return false
+        }
+        return branch == Experiment.controlBranch
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12221)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26596)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
