### PR TITLE
Remove FXIOS-12126 ⁃ [Toast audit] Remove toast after URL is copied

### DIFF
--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -104,8 +104,6 @@ class ShareSheetCoordinator: BaseCoordinator,
         case .copyToPasteboard:
             if case .file = shareType {
                 showToast(text: .ShareFileCopiedToClipboard)
-            } else {
-                showToast(text: .LegacyAppMenu.AppMenuCopyURLConfirmMessage)
             }
             dequeueNotShownJSAlert()
         default:

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -417,7 +417,6 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .copyAddress)
             if let url = self.selectedTab?.canonicalURL?.displayURL {
                 UIPasteboard.general.url = url
-                self.delegate?.showToast(message: .LegacyAppMenu.AppMenuCopyURLConfirmMessage, toastAction: .copyUrl)
             }
         }.items
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -756,13 +756,6 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
     private func copyURL(tabID: TabUUID, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         UIPasteboard.general.url = tabManager.getTabForUUID(uuid: tabID)?.canonicalURL
-
-        if !isTabTrayUIExperimentsEnabled {
-            let toastAction = TabPanelMiddlewareAction(toastType: .copyURL,
-                                                       windowUUID: uuid,
-                                                       actionType: TabPanelMiddlewareActionType.showToast)
-            store.dispatch(toastAction)
-        }
     }
 
     private func tabPeekCloseTab(with tabID: TabUUID, uuid: WindowUUID, isPrivate: Bool) {

--- a/firefox-ios/Client/Frontend/Browser/ToastType.swift
+++ b/firefox-ios/Client/Frontend/Browser/ToastType.swift
@@ -14,7 +14,6 @@ enum ToastType: Equatable {
     case closedSingleInactiveTab
     case closedAllTabs(count: Int)
     case closedAllInactiveTabs(count: Int)
-    case copyURL
     case removeFromReadingList
     case removeShortcut
 
@@ -35,8 +34,6 @@ enum ToastType: Equatable {
             return String.localizedStringWithFormat(
                 .TabsTray.CloseTabsToast.Title,
                 tabsCount)
-        case .copyURL:
-            return .LegacyAppMenu.AppMenuCopyURLConfirmMessage
         case .removeFromReadingList:
             return .LegacyAppMenu.RemoveFromReadingListConfirmMessage
         case .removeShortcut:
@@ -56,7 +53,6 @@ enum ToastType: Equatable {
         case .closedAllTabs: actionType = TabPanelViewActionType.undoCloseAllTabs
         case .closedAllInactiveTabs: actionType = TabPanelViewActionType.undoCloseAllInactiveTabs
         case .clearCookies,
-                .copyURL,
                 .addBookmark,
                 .addShortcut,
                 .addToReadingList,

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -75,9 +75,6 @@ extension PhotonActionSheetProtocol {
             let currentURL = tabManager.selectedTab?.currentURL()
             if let url = tabManager.selectedTab?.canonicalURL?.displayURL ?? currentURL {
                 UIPasteboard.general.url = url
-                SimpleToast().showAlertWithText(.LegacyAppMenu.AppMenuCopyURLConfirmMessage,
-                                                bottomContainer: alertContainer,
-                                                theme: themeManager.getCurrentTheme(for: tabManager.windowUUID))
             }
         }
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4797,11 +4797,6 @@ extension String {
             tableName: nil,
             value: "Passwords",
             comment: "Label for the button, displayed in the menu, takes you to passwords screen when pressed.")
-        public static let AppMenuCopyURLConfirmMessage = MZLocalizedString(
-            key: "Menu.CopyURL.Confirm",
-            tableName: nil,
-            value: "URL Copied To Clipboard",
-            comment: "Toast displayed to user after copy url pressed.")
         public static let AppMenuTabSentConfirmMessage = MZLocalizedString(
             key: "Menu.TabSent.Confirm",
             tableName: nil,
@@ -7832,6 +7827,13 @@ extension String {
                 tableName: nil,
                 value: "Tabs",
                 comment: "The title on the button to look at regular tabs.")
+        }
+        struct v140 {
+            public static let AppMenuCopyURLConfirmMessage = MZLocalizedString(
+                key: "Menu.CopyURL.Confirm",
+                tableName: nil,
+                value: "URL Copied To Clipboard",
+                comment: "Toast displayed to user after copy url pressed.")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12126)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26384)

## :bulb: Description
Removed unnecessary toasts

## :movie_camera: Demos

https://github.com/user-attachments/assets/7192d09c-7467-41ff-91c0-078cf5dff185



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
