### PR TITLE
Add FXIOS-12181 [Top Sites Visual Refresh] Update "Pin' icon

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -13,6 +13,7 @@ final class HomepageViewController: UIViewController,
                                     UIAdaptivePresentationControllerDelegate,
                                     FeatureFlaggable,
                                     ContentContainable,
+                                    Notifiable,
                                     Themeable,
                                     StoreSubscriber {
     // MARK: - Typealiases
@@ -144,6 +145,7 @@ final class HomepageViewController: UIViewController,
             )
         )
 
+        setupNotifications(forObserver: self, observing: [UIContentSizeCategory.didChangeNotification])
         listenForThemeChange(view)
         applyTheme()
         addTapGestureRecognizerToDismissKeyboard()
@@ -304,6 +306,19 @@ final class HomepageViewController: UIViewController,
             screen: .homepage
         )
         store.dispatch(action)
+    }
+
+    // MARK: - Notifiable
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case UIContentSizeCategory.didChangeNotification:
+            if let newContentSizeCategory = notification.userInfo?[UIContentSizeCategory.newValueUserInfoKey]
+                as? UIContentSizeCategory {
+                dynamicTypeChanged(contentSizeCategory: newContentSizeCategory)
+            }
+        default:
+            break
+        }
     }
 
     // MARK: - Theming
@@ -628,6 +643,14 @@ final class HomepageViewController: UIViewController,
             return sectionLabelCell
         default:
             return nil
+        }
+    }
+
+    private func dynamicTypeChanged(contentSizeCategory: UIContentSizeCategory) {
+        collectionView?.visibleCells.forEach { cell in
+            if let customCell = cell as? TopSiteCell {
+                customCell.updateDynamicConstraints(contentSizeCategory: contentSizeCategory)
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -312,10 +312,7 @@ final class HomepageViewController: UIViewController,
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
         case UIContentSizeCategory.didChangeNotification:
-            if let newContentSizeCategory = notification.userInfo?[UIContentSizeCategory.newValueUserInfoKey]
-                as? UIContentSizeCategory {
-                dynamicTypeChanged(contentSizeCategory: newContentSizeCategory)
-            }
+            dynamicTypeChanged()
         default:
             break
         }
@@ -646,11 +643,10 @@ final class HomepageViewController: UIViewController,
         }
     }
 
-    private func dynamicTypeChanged(contentSizeCategory: UIContentSizeCategory) {
+    private func dynamicTypeChanged() {
         collectionView?.visibleCells.forEach { cell in
-            if let customCell = cell as? TopSiteCell {
-                customCell.updateDynamicConstraints(contentSizeCategory: contentSizeCategory)
-            }
+            guard let customCell = cell as? TopSiteCell else { return }
+            customCell.updateDynamicConstraints()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -16,11 +16,10 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
     private var homeTopSite: TopSiteConfiguration?
 
     struct UX {
-        static let titleOffset: CGFloat = 4
         static let iconSize = CGSize(width: 36, height: 36)
         static let imageBackgroundSize = CGSize(width: 60, height: 60)
         static let pinAlignmentSpacing: CGFloat = 2
-        static let pinIconSize = CGSize(width: 12, height: 12)
+        static let pinIconSize = CGSize(width: 16, height: 16)
         static let textSafeSpace: CGFloat = 6
         static let bottomSpace: CGFloat = 8
         static let imageTopSpace: CGFloat = 12
@@ -35,15 +34,7 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
 
     lazy var imageView: FaviconImageView = .build { _ in }
 
-    // Holds the title and the pin image of the top site
-    private lazy var titlePinWrapper: UIStackView = .build { stackView in
-        stackView.backgroundColor = .clear
-        stackView.axis = .horizontal
-        stackView.alignment = .top
-        stackView.distribution = .fillProportionally
-    }
-
-    // Holds the titlePinWrapper and the Sponsored text for a sponsored tile
+    // Holds the title text and optional sponsored text (for a sponsored tile)
     private lazy var descriptionWrapper: UIStackView = .build { stackView in
         stackView.backgroundColor = .clear
         stackView.axis = .vertical
@@ -51,12 +42,8 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
         stackView.distribution = .fillProportionally
     }
 
-    private lazy var pinViewHolder: UIView = .build { view in
-        view.isHidden = true
-    }
-
     private lazy var pinImageView: UIImageView = .build { imageView in
-        imageView.image = UIImage.templateImageNamed(StandardImageIdentifiers.Small.pinBadgeFill)
+        imageView.image = UIImage.init(named: StandardImageIdentifiers.Small.pinBadgeFill)
         imageView.isHidden = true
     }
 
@@ -114,7 +101,6 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
 
         titleLabel.text = nil
         sponsoredLabel.text = nil
-        pinViewHolder.isHidden = true
         pinImageView.isHidden = true
     }
 
@@ -182,17 +168,14 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
     // MARK: - Setup Helper methods
 
     private func setupLayout() {
-        titlePinWrapper.addArrangedSubview(pinViewHolder)
-        titlePinWrapper.addArrangedSubview(titleLabel)
-        pinViewHolder.addSubview(pinImageView)
-
-        descriptionWrapper.addArrangedSubview(titlePinWrapper)
+        descriptionWrapper.addArrangedSubview(titleLabel)
         descriptionWrapper.addArrangedSubview(sponsoredLabel)
 
         rootContainer.addSubview(imageView)
         rootContainer.addSubview(selectedOverlay)
         contentView.addSubview(rootContainer)
         contentView.addSubview(descriptionWrapper)
+        contentView.addSubview(pinImageView)
 
         NSLayoutConstraint.activate([
             rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor),
@@ -222,12 +205,8 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
             selectedOverlay.trailingAnchor.constraint(equalTo: rootContainer.trailingAnchor),
             selectedOverlay.bottomAnchor.constraint(equalTo: rootContainer.bottomAnchor),
 
-            pinViewHolder.bottomAnchor.constraint(equalTo: titleLabel.firstBaselineAnchor,
-                                                  constant: UX.pinAlignmentSpacing),
-            pinViewHolder.leadingAnchor.constraint(equalTo: pinImageView.leadingAnchor),
-            pinViewHolder.trailingAnchor.constraint(equalTo: pinImageView.trailingAnchor,
-                                                    constant: UX.titleOffset),
-            pinViewHolder.topAnchor.constraint(equalTo: pinImageView.topAnchor),
+            pinImageView.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+            pinImageView.trailingAnchor.constraint(equalTo: titleLabel.leadingAnchor, constant: -UX.pinAlignmentSpacing),
 
             pinImageView.widthAnchor.constraint(equalToConstant: UX.pinIconSize.width),
             pinImageView.heightAnchor.constraint(equalToConstant: UX.pinIconSize.height),
@@ -237,7 +216,6 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
     private func configurePinnedSite(_ topSite: TopSiteConfiguration) {
         guard topSite.isPinned else { return }
 
-        pinViewHolder.isHidden = false
         pinImageView.isHidden = false
     }
 
@@ -261,7 +239,6 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
 // MARK: ThemeApplicable
 extension TopSiteCell: ThemeApplicable {
     func applyTheme(theme: Theme) {
-        pinImageView.tintColor = textColor ?? theme.colors.iconPrimary
         titleLabel.textColor = textColor ?? theme.colors.textPrimary
         sponsoredLabel.textColor = textColor ?? theme.colors.textPrimary
         selectedOverlay.backgroundColor = theme.colors.layer5Hover.withAlphaComponent(0.25)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -241,7 +241,7 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
         largeContentConstraints = [
             pinImageView.centerXAnchor.constraint(equalTo: titleLabel.centerXAnchor),
             pinImageView.topAnchor.constraint(equalTo: rootContainer.bottomAnchor, constant: UX.textSafeSpace),
-            descriptionWrapper.topAnchor.constraint(equalTo: pinImageView.bottomAnchor, constant: 2)
+            descriptionWrapper.topAnchor.constraint(equalTo: pinImageView.bottomAnchor)
         ]
 
         pinHeightConstraint = pinImageView.heightAnchor.constraint(equalToConstant: UX.pinIconSize.height)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -229,8 +229,8 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
         // When preferredContentSizeCategory is > extraLarge, place the pin icon above the title (largeContentConstraints)
         // When preferredContentSizeCategory is <= extraLarge, place the pin icon in front of (smallContentConstraints)
         smallContentConstraints = [
-            pinImageView.topAnchor.constraint(equalTo: titleLabel.topAnchor),
-            pinImageView.bottomAnchor.constraint(equalTo: titleLabel.bottomAnchor),
+            pinImageView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor),
+            pinImageView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor),
             pinImageView.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
             pinImageView.trailingAnchor.constraint(equalTo: titleLabel.leadingAnchor, constant: -UX.pinAlignmentSpacing),
             descriptionWrapper.topAnchor.constraint(equalTo: rootContainer.bottomAnchor,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -83,8 +83,8 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
     private var textColor: UIColor?
     private var pinHeightConstraint: NSLayoutConstraint?
     private var pinWidthConstraint: NSLayoutConstraint?
-    var smallContentConstraints: [NSLayoutConstraint] = []
-    var largeContentConstraints: [NSLayoutConstraint] = []
+    private var smallContentConstraints: [NSLayoutConstraint] = []
+    private var largeContentConstraints: [NSLayoutConstraint] = []
 
     // MARK: - Inits
 
@@ -204,8 +204,8 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
         NSLayoutConstraint.activate([
             rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor),
             rootContainer.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-            rootContainer.widthAnchor.constraint(greaterThanOrEqualToConstant: UX.imageBackgroundSize.width),
-            rootContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.imageBackgroundSize.height),
+            rootContainer.widthAnchor.constraint(equalToConstant: UX.imageBackgroundSize.width),
+            rootContainer.heightAnchor.constraint(equalToConstant: UX.imageBackgroundSize.height),
 
             imageView.topAnchor.constraint(equalTo: rootContainer.topAnchor,
                                            constant: UX.imageTopSpace),
@@ -215,12 +215,9 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
                                                 constant: -UX.imageLeadingTrailingSpace),
             imageView.bottomAnchor.constraint(equalTo: rootContainer.bottomAnchor,
                                               constant: -UX.imageBottomSpace),
-            imageView.widthAnchor.constraint(equalToConstant: UX.iconSize.width),
-            imageView.heightAnchor.constraint(equalToConstant: UX.iconSize.height),
 
             descriptionWrapper.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             descriptionWrapper.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            descriptionWrapper.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
 
             selectedOverlay.topAnchor.constraint(equalTo: rootContainer.topAnchor),
             selectedOverlay.leadingAnchor.constraint(equalTo: rootContainer.leadingAnchor),
@@ -244,6 +241,9 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
             descriptionWrapper.topAnchor.constraint(equalTo: pinImageView.bottomAnchor)
         ]
 
+        let bottomConstraint = descriptionWrapper.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        bottomConstraint.priority = .defaultHigh
+        bottomConstraint.isActive = true
         pinHeightConstraint = pinImageView.heightAnchor.constraint(equalToConstant: UX.pinIconSize.height)
         pinHeightConstraint?.isActive = true
         pinWidthConstraint = pinImageView.widthAnchor.constraint(equalToConstant: UX.pinIconSize.width)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -229,6 +229,8 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
         // When preferredContentSizeCategory is > extraLarge, place the pin icon above the title (largeContentConstraints)
         // When preferredContentSizeCategory is <= extraLarge, place the pin icon in front of (smallContentConstraints)
         smallContentConstraints = [
+            pinImageView.topAnchor.constraint(equalTo: titleLabel.topAnchor),
+            pinImageView.bottomAnchor.constraint(equalTo: titleLabel.bottomAnchor),
             pinImageView.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
             pinImageView.trailingAnchor.constraint(equalTo: titleLabel.leadingAnchor, constant: -UX.pinAlignmentSpacing),
             descriptionWrapper.topAnchor.constraint(equalTo: rootContainer.bottomAnchor,
@@ -236,6 +238,8 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
         ]
 
         largeContentConstraints = [
+            pinImageView.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor),
+            pinImageView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor),
             pinImageView.centerXAnchor.constraint(equalTo: titleLabel.centerXAnchor),
             pinImageView.topAnchor.constraint(equalTo: rootContainer.bottomAnchor, constant: UX.textSafeSpace),
             descriptionWrapper.topAnchor.constraint(equalTo: pinImageView.bottomAnchor)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -118,7 +118,7 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
 
         rootContainer.setNeedsLayout()
         rootContainer.layoutIfNeeded()
-        updateDynamicConstraints(contentSizeCategory: traitCollection.preferredContentSizeCategory)
+        updateDynamicConstraints()
 
         rootContainer.layer.shadowPath = UIBezierPath(roundedRect: rootContainer.bounds,
                                                       cornerRadius: HomepageViewModel.UX.generalCornerRadius).cgPath
@@ -170,11 +170,11 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
         applyTheme(theme: theme)
     }
 
-    func updateDynamicConstraints(contentSizeCategory: UIContentSizeCategory) {
+    func updateDynamicConstraints() {
         NSLayoutConstraint.deactivate(smallContentConstraints)
         NSLayoutConstraint.deactivate(largeContentConstraints)
 
-        if contentSizeCategory <= .extraLarge || pinImageView.isHidden {
+        if UIApplication.shared.preferredContentSizeCategory <= .extraLarge || pinImageView.isHidden {
             NSLayoutConstraint.activate(smallContentConstraints)
         } else {
             NSLayoutConstraint.activate(largeContentConstraints)
@@ -249,7 +249,7 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
         pinWidthConstraint = pinImageView.widthAnchor.constraint(equalToConstant: UX.pinIconSize.width)
         pinWidthConstraint?.isActive = true
 
-        updateDynamicConstraints(contentSizeCategory: traitCollection.preferredContentSizeCategory)
+        updateDynamicConstraints()
     }
 
     private func configurePinnedSite(_ topSite: TopSiteConfiguration) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -52,8 +52,8 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         sut.loadViewIfNeeded()
 
         XCTAssertEqual(mockThemeManager?.getCurrentThemeCallCount, 1)
-        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 1)
-        XCTAssertEqual(mockNotificationCenter?.observers, [.ThemeDidChange])
+        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 2)
+        XCTAssertEqual(mockNotificationCenter?.observers, [UIContentSizeCategory.didChangeNotification, .ThemeDidChange])
     }
 
     // MARK: - Deinit State


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12181)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26513)

## :bulb: Description
- Remove templating from the "Pin" icon so that it renders as default and no longer change it's tint based on theme
- Add support for dynamic type to the "Pin" icon so that it scaled with text
  - The layout of the top sites cell now updates dynamically to support a larger "Pin" icon (breakpoint at `UIContentSizeCategory.extraLarge`)

## :movie_camera: Demos

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 16 - 2025-05-12 at 14 59 49](https://github.com/user-attachments/assets/e755c3ba-7a0e-4a9f-82bd-b2725d455402) | ![Simulator Screenshot - iPhone 16 - 2025-05-12 at 14 54 06](https://github.com/user-attachments/assets/b00e0f40-0355-4c8e-9d6f-ec0d81e7fa69) |
| ![Simulator Screenshot - iPhone 16 - 2025-05-12 at 14 59 53](https://github.com/user-attachments/assets/9cccd138-8a00-4dee-9062-65aee4600ef1) | ![Simulator Screenshot - iPhone 16 - 2025-05-12 at 14 54 10](https://github.com/user-attachments/assets/47c8dbbf-f3eb-4650-91bb-ff823e51ffba) | 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
