### PR TITLE
Fix MTE-4573 - HistoryTabTrayUIExperiment smoke tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTabTrayUIExperimentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTabTrayUIExperimentTests.swift
@@ -452,9 +452,6 @@ class HistoryTabTrayUIExperimentTests: FeatureFlaggedTestSuite {
         waitUntilPageLoad()
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        let cancelButton = app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton]
-        mozWaitForElementToExist(cancelButton, timeout: TIMEOUT_LONG)
-        navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_History)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4573

## :bulb: Description
With this PR https://github.com/mozilla-mobile/firefox-ios/pull/26390 keyboard animation has been disabled with tab tray experiment enabled. Updated the smoke tests affected.
