### PR TITLE
Remove FXIOS-12125 ⁃ [Toast audit] Remove toast on Settings > Address for actions address saved and removed

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -222,8 +222,6 @@ final class AddressListViewModel: ObservableObject, FeatureFlaggable {
         self.addressProvider.addAddress(address: address) { [weak self] result in
             DispatchQueue.main.async {
                 switch result {
-                case .success:
-                    self?.presentToast?(.saved)
                 case .failure:
                     self?.presentToast?(
                         .error(
@@ -250,6 +248,7 @@ final class AddressListViewModel: ObservableObject, FeatureFlaggable {
                             })
                         )
                     )
+                default: break
                 }
                 self?.destination = nil
                 self?.fetchAddresses()
@@ -288,8 +287,6 @@ final class AddressListViewModel: ObservableObject, FeatureFlaggable {
             guard let self else { return }
             DispatchQueue.main.async {
                 switch result {
-                case .success:
-                    self.presentToast?(.removed)
                 case .failure:
                     self.presentToast?(
                         .error(
@@ -298,6 +295,7 @@ final class AddressListViewModel: ObservableObject, FeatureFlaggable {
                             })
                         )
                     )
+                default: break
                 }
                 self.toggleEditMode()
                 self.destination = nil

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
@@ -29,16 +29,12 @@ enum AddressModifiedStatus {
         }
     }
 
-    case saved
     case updated
-    case removed
     case error(ErrorType)
 
     var message: String {
         switch self {
-        case .saved: return .Addresses.Settings.Edit.AddressSavedConfirmation
         case .updated: return .Addresses.Settings.Edit.AddressUpdatedConfirmationV2
-        case .removed: return .Addresses.Settings.Edit.AddressRemovedConfirmation
         case .error(let type): return type.message
         }
     }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -381,18 +381,6 @@ extension String {
                 value: "Address for %@",
                 comment: "Accessibility label for an address list item in autofill settings screen. The %@ parameter is the address of the user that will read the name, street, city, state, postal code if available.")
             public struct Edit {
-                public static let AddressRemovedConfirmation = MZLocalizedString(
-                    key: "Addresses.Toast.AddressRemovedConfirmation.v129",
-                    tableName: "EditAddress",
-                    value: "Address Removed",
-                    comment: "Toast message confirming that an address has been successfully removed."
-                )
-                public static let AddressSavedConfirmation = MZLocalizedString(
-                    key: "Addresses.Toast.AddressSavedConfirmation.v129",
-                    tableName: "EditAddress",
-                    value: "Address Saved",
-                    comment: "Toast message confirming that an address has been successfully saved."
-                )
                 public static let AddressRemoveError = MZLocalizedString(
                     key: "Addresses.Toast.AddressSaveError.v130",
                     tableName: "EditAddress",
@@ -7834,6 +7822,18 @@ extension String {
                 tableName: nil,
                 value: "URL Copied To Clipboard",
                 comment: "Toast displayed to user after copy url pressed.")
+            public static let AddressRemovedConfirmation = MZLocalizedString(
+                key: "Addresses.Toast.AddressRemovedConfirmation.v129",
+                tableName: "EditAddress",
+                value: "Address Removed",
+                comment: "Toast message confirming that an address has been successfully removed."
+            )
+            public static let AddressSavedConfirmation = MZLocalizedString(
+                key: "Addresses.Toast.AddressSavedConfirmation.v129",
+                tableName: "EditAddress",
+                value: "Address Saved",
+                comment: "Toast message confirming that an address has been successfully saved."
+            )
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
@@ -5,9 +5,7 @@
 import Foundation
 
 class O_AddressesTests: BaseTestCase {
-    let addressSavedTxt = "Address Saved"
     let savedAddressesTxt = "SAVED ADDRESSES"
-    let removedAddressTxt = "Address Removed"
 
     override func setUp() {
         super.setUp()
@@ -44,8 +42,6 @@ class O_AddressesTests: BaseTestCase {
         // Enter valid date for all fields
         addNewAddress()
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         let addressInfo = ["Test", "test address", "city test, AL, 123456"]
@@ -63,8 +59,6 @@ class O_AddressesTests: BaseTestCase {
         // Enter a valid date for Full Name and press save
         typeName(name: "Test")
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         mozWaitForElementToExist(app.staticTexts["Test"])
@@ -79,8 +73,6 @@ class O_AddressesTests: BaseTestCase {
         // Enter a valid date for Full Name and press save
         typeOrganization(organization: "organization test")
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
     }
@@ -94,8 +86,6 @@ class O_AddressesTests: BaseTestCase {
         // Enter a valid date for Full Name and press save
         typeStreetAddress(street: "test address")
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         mozWaitForElementToExist(app.staticTexts["test address"])
@@ -110,8 +100,6 @@ class O_AddressesTests: BaseTestCase {
         // Enter a valid date for Full Name and press save
         typeCity(city: "city test")
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         mozWaitForElementToExist(app.staticTexts["city test, AL"])
@@ -126,8 +114,6 @@ class O_AddressesTests: BaseTestCase {
         // Enter a valid date for Full Name and press save
         typeZIP(zip: "123456")
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         mozWaitForElementToExist(app.staticTexts["AL, 123456"])
@@ -142,8 +128,6 @@ class O_AddressesTests: BaseTestCase {
         // Enter a valid date for Full Name and press save
         typePhone(phone: "01234567")
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         mozWaitForElementToExist(app.staticTexts["AL"])
@@ -158,8 +142,6 @@ class O_AddressesTests: BaseTestCase {
         // Enter a valid date for Full Name and press save
         typeEmail(email: "test@mozilla.com")
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         mozWaitForElementToExist(app.staticTexts["AL"])
@@ -174,8 +156,6 @@ class O_AddressesTests: BaseTestCase {
         // Enter a valid date for Country and press save
         selectCountry(country: "United Kingdom")
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
     }
@@ -263,8 +243,6 @@ class O_AddressesTests: BaseTestCase {
         // Enter a valid date for Country and press save
         selectCountry(country: "United Kingdom")
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
     }
@@ -575,8 +553,6 @@ class O_AddressesTests: BaseTestCase {
         tapEdit()
         // Remove address
         removeAddress()
-        // The "Address Removed" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[removedAddressTxt])
     }
 
     private func updateFieldsWithWithoutState(updateCountry: Bool, isPostalCode: Bool) {
@@ -586,8 +562,6 @@ class O_AddressesTests: BaseTestCase {
         tapEdit()
         updateAddress(updateCountry: updateCountry, isPostalCode: isPostalCode)
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         if updateCountry {
@@ -664,8 +638,6 @@ class O_AddressesTests: BaseTestCase {
         }
         app.typeText(newValue)
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         if isInfoDisplayed {
@@ -681,8 +653,6 @@ class O_AddressesTests: BaseTestCase {
             clearText()
         }
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         XCTAssertFalse(app.staticTexts.elementContainingText(newValue).exists, "\(newValue) is displayed")
@@ -691,8 +661,6 @@ class O_AddressesTests: BaseTestCase {
         app.staticTexts[field].waitAndTap()
         app.typeText(newValue)
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
         // The address is saved
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         if isInfoDisplayed {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12125)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26383)

## :bulb: Description
Removed toasts for Saving and Removing an address

## :movie_camera: Demos

https://github.com/user-attachments/assets/c14bec05-1622-4726-bedb-84b0d0ea1d25



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
