### PR TITLE
Remove FXIOS-12127 - [Toast audit] Update bookmark action toast

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1979,7 +1979,6 @@ class BrowserViewController: UIViewController,
     func removeBookmark(urlString: String, title: String?, site: Site? = nil) {
         profile.places.deleteBookmarksWithURL(url: urlString).uponQueue(.main) { result in
             guard result.isSuccess else { return }
-            self.showBookmarkToast(urlString: urlString, title: title, action: .remove)
             self.removeBookmarkShortcut()
         }
     }
@@ -2009,18 +2008,7 @@ class BrowserViewController: UIViewController,
                     toastAction: .bookmarkPage
                 )
             }
-        case .remove:
-            let messageTitle: String = if let title {
-                String(format: .Bookmarks.Menu.DeletedBookmark, title)
-            } else {
-                .LegacyAppMenu.RemoveBookmarkConfirmMessage
-            }
-            showToast(
-                urlString,
-                title,
-                message: messageTitle,
-                toastAction: .removeBookmark
-            )
+        default: break
         }
     }
 
@@ -2044,13 +2032,8 @@ class BrowserViewController: UIViewController,
                                                                      windowUUID: self.windowUUID,
                                                                      bookmarkNode: bookmarkItem,
                                                                      parentBookmarkFolder: parentFolder,
-                                                                     presentedFromToast: true) { [weak self] in
-                        self?.showBookmarkToast(
-                            urlString: bookmarkItem.url,
-                            title: bookmarkItem.title,
-                            action: .remove
-                        )
-                    }
+                                                                     presentedFromToast: true,
+                                                                     deleteBookmark: {})
                     let controller: DismissableNavigationViewController
                     controller = DismissableNavigationViewController(rootViewController: detailController)
                     self.present(controller, animated: true, completion: nil)

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -779,10 +779,6 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
             self.profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
                 guard result.isSuccess else { return }
-                self.delegate?.showToast(
-                    message: .LegacyAppMenu.RemoveBookmarkConfirmMessage,
-                    toastAction: .removeBookmark
-                )
                 self.removeBookmarkShortcut()
             }
             let bookmarksTelemetry = BookmarksTelemetry()

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -177,11 +177,6 @@ extension String {
                 tableName: "Bookmarks",
                 value: "DESKTOP BOOKMARKS",
                 comment: "Header denoting that the proceeding folders in the parent folder selector table of the Edit Bookmarks Screen are folders shared with desktop.")
-            public static let DeletedBookmark = MZLocalizedString(
-                key: "Bookmarks.Menu.DeletedBookmark.v131",
-                tableName: "Bookmarks",
-                value: "Deleted “%@”",
-                comment: "Label of toast displayed after a bookmark is deleted in the Bookmarks menu. %@ is the name of the bookmark.")
             public static let DeleteBookmark = MZLocalizedString(
                 key: "Bookmarks.Menu.DeleteBookmark.v132",
                 tableName: "Bookmarks",
@@ -4881,11 +4876,6 @@ extension String {
             tableName: nil,
             value: "Remove",
             comment: "Label for the remove bookmark button in the menu. Pressing this button remove the current page from the bookmarks. Please keep the text as short as possible for this label.")
-        public static let RemoveBookmarkConfirmMessage = MZLocalizedString(
-            key: "Menu.RemoveBookmark.Confirm",
-            tableName: nil,
-            value: "Bookmark Removed",
-            comment: "Toast displayed to the user after a bookmark has been removed.")
         public static let EditBookmarkLabel = MZLocalizedString(
             key: "Menu.EditBookmark.Label.v135",
             tableName: "Menu",
@@ -7834,6 +7824,16 @@ extension String {
                 tableName: nil,
                 value: "URL Copied To Clipboard",
                 comment: "Toast displayed to user after copy url pressed.")
+            public static let RemoveBookmarkConfirmMessage = MZLocalizedString(
+                key: "Menu.RemoveBookmark.Confirm",
+                tableName: nil,
+                value: "Bookmark Removed",
+                comment: "Toast displayed to the user after a bookmark has been removed.")
+            public static let DeletedBookmark = MZLocalizedString(
+                key: "Bookmarks.Menu.DeletedBookmark.v131",
+                tableName: "Bookmarks",
+                value: "Deleted “%@”",
+                comment: "Label of toast displayed after a bookmark is deleted in the Bookmarks menu. %@ is the name of the bookmark.")
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -22,14 +22,6 @@ class BookmarksTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
     }
 
-    private func undoBookmarkRemoval() {
-        navigator.goto(LibraryPanel_Bookmarks)
-        app.buttons["More options"].waitAndTap()
-        app.tables["Context Menu"].otherElements["bookmarkSlashLarge"].waitAndTap()
-        app.buttons["Undo"].waitAndTap()
-        navigator.nowAt(BrowserTab)
-    }
-
     private func checkUnbookmarked() {
         navigator.goto(LibraryPanel_Bookmarks)
         app.buttons["Done"].waitAndTap()
@@ -258,17 +250,6 @@ class BookmarksTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306908
     // Smoketest
-    func testUndoDeleteBookmark() {
-        navigator.openURL(path(forTestPage: url_1))
-        navigator.nowAt(BrowserTab)
-        waitForTabsButton()
-        bookmark()
-        checkBookmarked()
-        undoBookmarkRemoval()
-        app.buttons["Done"].waitAndTap()
-        navigator.nowAt(BrowserTab)
-    }
-
     private func addNewBookmark() {
         navigator.goto(LibraryPanel_Bookmarks)
         navigator.nowAt(MobileBookmarks)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12127)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26285)

## :bulb: Description
Removed unnecessary toasts when deleting a bookmark

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
