### PR TITLE
Add FXIOS-12235 #26637 Refactor Onboarding card models for generic package usage

### DIFF
--- a/BrowserKit/Sources/OnboardingKit/Models/Buttons/OnboardingButtonInfoModel.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/Buttons/OnboardingButtonInfoModel.swift
@@ -7,7 +7,7 @@ import Foundation
 public struct OnboardingButtonInfoModel<OnboardingActionType> {
     let title: String
     let action: OnboardingActionType
-    
+
     public init(title: String, action: OnboardingActionType) {
         self.title = title
         self.action = action

--- a/BrowserKit/Sources/OnboardingKit/Models/Buttons/OnboardingButtonInfoModel.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/Buttons/OnboardingButtonInfoModel.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public struct OnboardingButtonInfoModel<OnboardingActionType> {
+    let title: String
+    let action: OnboardingActionType
+    
+    public init(title: String, action: OnboardingActionType) {
+        self.title = title
+        self.action = action
+    }
+}

--- a/BrowserKit/Sources/OnboardingKit/Models/Buttons/OnboardingButtons.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/Buttons/OnboardingButtons.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public struct OnboardingButtons<OnboardingActionType> {
+    let primary: OnboardingButtonInfoModel<OnboardingActionType>
+    let secondary: OnboardingButtonInfoModel<OnboardingActionType>?
+    
+    init(
+        primary: OnboardingButtonInfoModel<OnboardingActionType>,
+        secondary: OnboardingButtonInfoModel<OnboardingActionType>? = nil
+    ) {
+        self.primary = primary
+        self.secondary = secondary
+    }
+}

--- a/BrowserKit/Sources/OnboardingKit/Models/Buttons/OnboardingButtons.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/Buttons/OnboardingButtons.swift
@@ -7,7 +7,7 @@ import Foundation
 public struct OnboardingButtons<OnboardingActionType> {
     let primary: OnboardingButtonInfoModel<OnboardingActionType>
     let secondary: OnboardingButtonInfoModel<OnboardingActionType>?
-    
+
     init(
         primary: OnboardingButtonInfoModel<OnboardingActionType>,
         secondary: OnboardingButtonInfoModel<OnboardingActionType>? = nil

--- a/BrowserKit/Sources/OnboardingKit/Models/Buttons/OnboardingMultipleChoiceButtonModel.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/Buttons/OnboardingMultipleChoiceButtonModel.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public struct OnboardingMultipleChoiceButtonModel<OnboardingMultipleChoiceActionType> {
+    let title: String
+    let action: OnboardingMultipleChoiceActionType
+    var imageID: String
+}

--- a/BrowserKit/Sources/OnboardingKit/Models/OnboardingCardInfoModelProtocol.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/OnboardingCardInfoModelProtocol.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+public protocol OnboardingCardInfoModelProtocol {
+    associatedtype OnboardingType
+    associatedtype OnboardingPopupActionType
+    associatedtype OnboardingMultipleChoiceActionType: Hashable
+    associatedtype OnboardingActionType
+    var cardType: OnboardingCardType { get set }
+    var name: String { get set }
+    var order: Int { get set }
+    var title: String { get set }
+    var body: String { get set }
+    var instructionsPopup: OnboardingInstructionsPopupInfoModel<OnboardingPopupActionType>? { get set }
+    var link: OnboardingLinkInfoModel? { get set }
+    var buttons: OnboardingButtons<OnboardingActionType> { get set }
+    var multipleChoiceButtons: [OnboardingMultipleChoiceButtonModel<OnboardingMultipleChoiceActionType>] { get set }
+    var onboardingType: OnboardingType { get set }
+    var a11yIdRoot: String { get set }
+    var imageID: String { get set }
+    
+    var image: UIImage? { get }
+    
+    init(
+        cardType: OnboardingCardType,
+        name: String,
+        order: Int,
+        title: String,
+        body: String,
+        link: OnboardingLinkInfoModel?,
+        buttons: OnboardingButtons<OnboardingActionType>,
+        multipleChoiceButtons: [OnboardingMultipleChoiceButtonModel<OnboardingMultipleChoiceActionType>],
+        onboardingType: OnboardingType,
+        a11yIdRoot: String,
+        imageID: String,
+        instructionsPopup: OnboardingInstructionsPopupInfoModel<OnboardingPopupActionType>?
+    )
+}

--- a/BrowserKit/Sources/OnboardingKit/Models/OnboardingCardInfoModelProtocol.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/OnboardingCardInfoModelProtocol.swift
@@ -21,9 +21,9 @@ public protocol OnboardingCardInfoModelProtocol {
     var onboardingType: OnboardingType { get set }
     var a11yIdRoot: String { get set }
     var imageID: String { get set }
-    
+
     var image: UIImage? { get }
-    
+
     init(
         cardType: OnboardingCardType,
         name: String,

--- a/BrowserKit/Sources/OnboardingKit/Models/OnboardingCardType.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/OnboardingCardType.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public enum OnboardingCardType: String, Codable {
+    case basic
+    case multipleChoice = "multiple-choice"
+}

--- a/BrowserKit/Sources/OnboardingKit/Models/OnboardingInstructionsPopupInfoModel.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/OnboardingInstructionsPopupInfoModel.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+protocol OnboardingDefaultBrowserModelProtocol {
+    associatedtype OnboardingPopupActionType
+    var title: String { get set }
+    var instructionSteps: [String] { get set }
+    var buttonTitle: String { get set }
+    var buttonAction: OnboardingPopupActionType { get set }
+    var a11yIdRoot: String { get set }
+}
+
+public struct OnboardingInstructionsPopupInfoModel<OnboardingPopupActionType>: OnboardingDefaultBrowserModelProtocol {
+    var title: String
+    var instructionSteps: [String]
+    var buttonTitle: String
+    var buttonAction: OnboardingPopupActionType
+    var a11yIdRoot: String
+}

--- a/BrowserKit/Sources/OnboardingKit/Models/OnboardingLinkInfoModel.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/OnboardingLinkInfoModel.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public struct OnboardingLinkInfoModel {
+    let title: String
+    let url: URL
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Make our onboarding-card data models reusable in the new package by converting them to generic types over action handlers and Nimbus-generated model structs. UI will be added in a later PR.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
