### PR TITLE
Fix [MTE-4579] - drag and drop tests on iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -343,6 +343,10 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2861436
     func testShortcutsToggle() {
         app.launch()
+        XCTExpectFailure("The app was not launched", strict: false) {
+            mozWaitForElementToExist(TopSiteCellgroup, timeout: TIMEOUT_LONG)
+        }
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         //  Go to customize homepage
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -285,7 +285,16 @@ private extension BaseTestCase {
                 )
             ]
         )
-        let collectionView = app.collectionViews[AccessibilityIdentifiers.TabTray.collectionView]
+        // Determine which collection view to use based on the current screen
+        let collectionView: XCUIElement
+        if app.collectionViews[AccessibilityIdentifiers.Browser.TopTabs.collectionView].exists {
+            collectionView = app.collectionViews[AccessibilityIdentifiers.Browser.TopTabs.collectionView]
+        } else if app.collectionViews[AccessibilityIdentifiers.TabTray.collectionView].exists {
+            collectionView = app.collectionViews[AccessibilityIdentifiers.TabTray.collectionView]
+        } else {
+            XCTFail("Neither Top Tabs nor Tab Tray collection view is present", file: file, line: line)
+            return
+        }
         let firstTabCell = collectionView.cells.element(boundBy: 0).label
         let secondTabCell = collectionView.cells.element(boundBy: 1).label
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4579

## :bulb: Description
Fixes for drag and drop failures on iPad.
Also included an attempt to fix flaky test testShortcutsToggle