### PR TITLE
Remove FXIOS-12141 ⁃ [Toast audit] - Remove tab tray undo close tab for regular, private and synced tabs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -322,11 +322,6 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
                 self.tabsPanelTelemetry.tabClosed(mode: tab.isPrivate ? .private : .normal)
                 self.tabManager.removeTabWithCompletion(tab.tabUUID) {
                     self.updateTabCountUsingTabManager(self.tabManager)
-
-                    if !self.featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
-                        || UIDevice.current.userInterfaceIdiom == .pad {
-                        self.showToast(message: .TabsTray.CloseTabsToast.SingleTabTitle, toastAction: .closeTab)
-                    }
                 }
             }
         }.items

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4611,10 +4611,6 @@ extension BrowserViewController: TopTabsDelegate {
     func topTabsDidPressPrivateMode() {
         updateZoomPageBarVisibility(visible: false)
     }
-
-    func topTabsShowCloseTabsToast() {
-        showToast(message: .TabsTray.CloseTabsToast.SingleTabTitle, toastAction: .closeTab)
-    }
 }
 
 extension BrowserViewController: DevicePickerViewControllerDelegate, InstructionsViewDelegate {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -56,7 +56,6 @@ enum TabPanelViewActionType: ActionType {
     case tabPanelDidAppear
     case addNewTab
     case closeTab
-    case undoClose
     case closeAllTabs
     case cancelCloseAllTabs
     case confirmCloseAllTabs
@@ -65,7 +64,6 @@ enum TabPanelViewActionType: ActionType {
     case moveTab
     case toggleInactiveTabs
     case closeInactiveTab
-    case undoCloseInactiveTab
     case closeAllInactiveTabs
     case undoCloseAllInactiveTabs
     case learnMorePrivateMode

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -367,19 +367,6 @@ class RemoteTabsTableViewController: UITableViewController,
             self.closeTabRemoteDeviceId = fxaDeviceId
             self.closeTab = tab
 
-            // Creating a modal with an undo button that will allow the user to undo closing the last remote tab
-            // they attempted to close
-            let viewModel = ButtonToastViewModel(labelText: .TabsTray.CloseTabsToast.SingleTabTitle,
-                                                 buttonText: .UndoString)
-            let toast = ButtonToast(viewModel: viewModel,
-                                    theme: retrieveTheme(),
-                                    completion: { didTapUndoButton in
-                                        if didTapUndoButton {
-                                            self.undo()
-                                        }
-                                    })
-            show(toast: toast)
-
             self.remoteTabsPanel?.remoteTabsClientAndTabsDataSourceDidCloseURL(deviceId: fxaDeviceId, url: tab.URL)
 
             // Initiating the process of sending (i.e. executing) any unsent commands
@@ -446,18 +433,6 @@ class RemoteTabsTableViewController: UITableViewController,
         * This will be the real time that the other client uploaded tabs.
         */
         return headerView
-    }
-
-    private func undo() {
-        guard let tabUrl = self.closeTab?.URL, let deviceId = self.closeTabRemoteDeviceId else {
-            return
-        }
-
-        // Removing the close tab command from the command queue
-        remoteTabsPanel?.remoteTabsClientAndTabsDataSourceDidUndo(deviceId: deviceId, url: tabUrl)
-
-        // Initiating the process of sending any unsent commands
-        self.flushTabCommands(deviceId: deviceId)
     }
 
     private func flushTabCommands(deviceId: String) {

--- a/firefox-ios/Client/Frontend/Browser/ToastType.swift
+++ b/firefox-ios/Client/Frontend/Browser/ToastType.swift
@@ -9,8 +9,6 @@ enum ToastType: Equatable {
     case addBookmark(urlString: String)
     case addToReadingList
     case clearCookies
-    case closedSingleTab
-    case closedSingleInactiveTab
     case closedAllTabs(count: Int)
     case closedAllInactiveTabs(count: Int)
     case removeFromReadingList
@@ -24,8 +22,6 @@ enum ToastType: Equatable {
             return .LegacyAppMenu.AddToReadingListConfirmMessage
         case .clearCookies:
             return .Menu.EnhancedTrackingProtection.clearDataToastMessage
-        case .closedSingleTab, .closedSingleInactiveTab:
-            return .TabsTray.CloseTabsToast.SingleTabTitle
         case let .closedAllInactiveTabs(tabsCount),
             let .closedAllTabs(count: tabsCount):
             return String.localizedStringWithFormat(
@@ -45,8 +41,6 @@ enum ToastType: Equatable {
     func reduxAction(for uuid: WindowUUID) -> TabPanelViewAction? {
         var actionType: TabPanelViewActionType
         switch self {
-        case .closedSingleTab: actionType = TabPanelViewActionType.undoClose
-        case .closedSingleInactiveTab: actionType = TabPanelViewActionType.undoCloseInactiveTab
         case .closedAllTabs: actionType = TabPanelViewActionType.undoCloseAllTabs
         case .closedAllInactiveTabs: actionType = TabPanelViewActionType.undoCloseAllInactiveTabs
         case .clearCookies,

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -13,7 +13,6 @@ protocol TopTabsDelegate: AnyObject {
     func topTabsDidLongPressNewTab(button: UIButton)
     func topTabsDidChangeTab()
     func topTabsDidPressPrivateMode()
-    func topTabsShowCloseTabsToast()
 }
 
 class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFlaggable {
@@ -380,7 +379,6 @@ extension TopTabsViewController: TabDisplayerDelegate {
 extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(_ cell: UICollectionViewCell) {
         topTabDisplayManager.closeActionPerformed(forCell: cell)
-        delegate?.topTabsShowCloseTabsToast()
         NotificationCenter.default.post(name: .TopTabsTabClosed, object: nil, userInfo: windowUUID.userInfo)
         store.dispatch(TopTabsAction(windowUUID: windowUUID, actionType: TopTabsActionType.didTapCloseTab))
     }

--- a/firefox-ios/Client/Telemetry/ToastTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/ToastTelemetry.swift
@@ -12,10 +12,6 @@ struct ToastTelemetry {
         self.gleanWrapper = gleanWrapper
     }
 
-    func undoClosedSingleTab() {
-        gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseSingleTab.undoTapped)
-    }
-
     func undoClosedAllTabs() {
         gleanWrapper.recordEvent(for: GleanMetrics.ToastsCloseAllTabs.undoTapped)
     }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2780,11 +2780,6 @@ extension String {
                 tableName: "TabsTray",
                 value: "Tabs Closed: %d",
                 comment: "When the user closes tabs in the tab tray, a popup will appear informing them how many tabs were closed. This is the text for the popup. %d is the number of tabs. ")
-            public static let SingleTabTitle = MZLocalizedString(
-                key: "CloseTabsToast.SingleTabTitle.v113",
-                tableName: "TabsTray",
-                value: "Tab Closed",
-                comment: "When the user closes an individual tab in the tab tray, a popup will appear informing them the tab was closed. This is the text for the popup.")
             public static let Action = MZLocalizedString(
                 key: "CloseTabsToast.Button.v113",
                 tableName: "TabsTray",
@@ -7834,6 +7829,11 @@ extension String {
                 value: "Address Saved",
                 comment: "Toast message confirming that an address has been successfully saved."
             )
+            public static let SingleTabTitle = MZLocalizedString(
+                key: "CloseTabsToast.SingleTabTitle.v113",
+                tableName: "TabsTray",
+                value: "Tab Closed",
+                comment: "When the user closes an individual tab in the tab tray, a popup will appear informing them the tab was closed. This is the text for the popup.")
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ToastTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ToastTelemetryTests.swift
@@ -16,23 +16,6 @@ final class ToastTelemetryTests: XCTestCase {
         mockGleanWrapper = MockGleanWrapper()
     }
 
-    func testClosedSingleTabToastUndoSelected_callsGlean() throws {
-        let event = GleanMetrics.ToastsCloseSingleTab.undoTapped
-        let expectedMetricType = type(of: event)
-        let subject = createSubject()
-
-        subject.undoClosedSingleTab()
-
-        let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?.first as? EventMetricType<NoExtras>
-        )
-        let resultMetricType = type(of: savedMetric)
-        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
-
-        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
-        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
-    }
-
     func testClosedAllTabsToastUndoSelected_callsGlean() throws {
         let event = GleanMetrics.ToastsCloseAllTabs.undoTapped
         let expectedMetricType = type(of: event)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -404,59 +404,6 @@ class TabsTests: BaseTestCase {
         mozWaitForElementToExist(app.otherElements.cells.staticTexts[urlLabelExample])
     }
 
-    // https://mozilla.testrail.io/index.php?/cases/view/2306867
-    func testCloseOneTabUndo() {
-        // Open a few tabs
-        waitForTabsButton()
-        navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
-        waitUntilPageLoad()
-        navigator.createNewTab()
-        navigator.openURL("http://localhost:\(serverPort)/test-fixture/test-example.html")
-        waitUntilPageLoad()
-        navigator.createNewTab()
-        navigator.openURL("localhost:\(serverPort)/test-fixture/test-mozilla-org.html")
-        waitUntilPageLoad()
-        navigator.goto(TabTray)
-
-        // Experiment from #25337: "Undo" button no longer available on iPhone.
-        if iPad() {
-            // Tap "x"
-            app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"].buttons[StandardImageIdentifiers.Large.cross].tap()
-            mozWaitForElementToNotExist(app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"])
-            app.buttons["Undo"].waitAndTap()
-            mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"])
-
-            // Long press tab. Tap "Close Tab" from the context menu
-            app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"].press(forDuration: 2)
-            mozWaitForElementToExist(app.collectionViews.buttons["Close Tab"])
-            app.collectionViews.buttons["Close Tab"].waitAndTap()
-            mozWaitForElementToNotExist(app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"])
-            app.buttons["Undo"].waitAndTap()
-            mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"])
-
-            // Swipe tab
-            app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"].swipeLeft()
-            mozWaitForElementToNotExist(app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"])
-            app.buttons["Undo"].waitAndTap()
-            mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"])
-        } else {
-            // Tap "x"
-            app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"]
-                .buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
-            mozWaitForElementToNotExist(app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"])
-
-            // Long press tab. Tap "Close Tab" from the context menu
-            app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_1"].press(forDuration: 2)
-            mozWaitForElementToExist(app.collectionViews.buttons["Close Tab"])
-            app.collectionViews.buttons["Close Tab"].waitAndTap()
-            mozWaitForElementToNotExist(app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_2"])
-
-            // Swipe tab
-            app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_0"].swipeLeft()
-            mozWaitForElementToNotExist(app.cells[AccessibilityIdentifiers.TabTray.tabCell+"_1_0"])
-        }
-    }
-
     private func validateToastWhenClosingMultipleTabs() {
         // Have multiple tabs opened in the tab tray
         navigator.openURL(urlExample)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12141)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26412)

## :bulb: Description
Removed undo toast when close a tab

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
