### PR TITLE
Add FXIOS-10711 [Tab Loss] Add a duplicate tab loss log that fires on preserve/restore

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -593,6 +593,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
             // Only attempt a tab data store fetch if we know we should have tabs on disk (ignore new windows)
             let windowData: WindowData? = windowIsNew ? nil : await tabDataStore.fetchWindowData(uuid: windowUUID)
             await buildTabRestore(window: windowData)
+            await TabErrorTelemetryHelper.shared.validateTabCountAfterRestoringTabs(windowUUID)
             await MainActor.run {
                 // Log on main thread, where computed `tab` properties can be accessed without risk of races
                 logger.log("Tabs restore ended after fetching window data", level: .debug, category: .tabs)
@@ -804,6 +805,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
             windowManager.performMultiWindowAction(.saveSimpleTabs)
 
             logger.log("Preserve tabs ended", level: .debug, category: .tabs)
+            await TabErrorTelemetryHelper.shared.recordTabCountAfterPreservingTabs(windowUUID)
         }
     }
 

--- a/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
@@ -14,6 +14,11 @@ final class TabErrorTelemetryHelper {
     private let windowManager: WindowManager
     private let logger: Logger
 
+    private enum EntryPoint: String {
+        case foreground = "on foreground"
+        case tabRestore = "on tab restore"
+    }
+
     private init(logger: Logger = DefaultLogger.shared,
                  telemetryWrapper: TelemetryWrapperProtocol = TelemetryWrapper.shared,
                  windowManager: WindowManager = AppContainer.shared.resolve(),
@@ -36,7 +41,17 @@ final class TabErrorTelemetryHelper {
     /// Validates the tab count when the app is foregrounded to ensure the
     /// count is consistent with the count upon backgrounding.
     func validateTabCountForForegroundedScene(_ window: WindowUUID) {
-        ensureMainThread { self.validateTabCount(window) }
+        ensureMainThread { self.validateTabCount(window, entryPoint: .foreground) }
+    }
+
+    @MainActor
+    func recordTabCountAfterPreservingTabs(_ window: WindowUUID) async {
+        self.recordTabCount(window)
+    }
+
+    @MainActor
+    func validateTabCountAfterRestoringTabs(_ window: WindowUUID) async {
+        self.validateTabCount(window, entryPoint: .tabRestore)
     }
 
     // MARK: - Internal Utility
@@ -49,19 +64,18 @@ final class TabErrorTelemetryHelper {
         defaults.set(tabCounts, forKey: defaultsKey)
     }
 
-    private func validateTabCount(_ window: WindowUUID) {
+    private func validateTabCount(_ window: WindowUUID, entryPoint: EntryPoint) {
         guard tabManagerAvailable(for: window) else { return }
         guard let tabCounts = defaults.object(forKey: defaultsKey) as? [String: Int],
               let expectedTabCount = tabCounts[window.uuidString] else { return }
         let currentTabCount = getTotalTabCount(window: window)
-        let currentActiveTabCount = getNormalActiveTabCount(window: window)
 
         if expectedTabCount > 1 && (expectedTabCount - currentTabCount) > 1 {
             // Potential tab loss bug detected. Log a MetricKit error.
             sendTelemetryTabLossDetectedEvent(
                 expected: expectedTabCount,
                 actual: currentTabCount,
-                actualNormalActive: currentActiveTabCount
+                entryPoint: entryPoint
             )
         }
 
@@ -90,25 +104,16 @@ final class TabErrorTelemetryHelper {
 
     private func getTotalTabCount(window: WindowUUID) -> Int {
         assert(tabManagerAvailable(for: window), "getTabCount() should not be called prior to TabManager config.")
-        return windowManager.tabManager(for: window).normalTabs.count
+        return windowManager.tabManager(for: window).tabs.count
     }
 
-    private func getNormalActiveTabCount(window: WindowUUID) -> Int {
-        assert(
-            tabManagerAvailable(for: window),
-            "getNormalActiveTabCount() should not be called prior to TabManager config."
-        )
-        return windowManager.tabManager(for: window).normalActiveTabs.count
-    }
-
-    private func sendTelemetryTabLossDetectedEvent(expected: Int, actual: Int, actualNormalActive: Int) {
-        logger.log("Tab loss detected",
+    private func sendTelemetryTabLossDetectedEvent(expected: Int, actual: Int, entryPoint: EntryPoint) {
+        logger.log("Tab loss detected \(entryPoint.rawValue).",
                    level: .fatal,
                    category: .tabs,
                    extra: [
                     "expected": String(expected),
                     "actual": String(actual),
-                    "actualNormalActive": String(actualNormalActive),
                     "windows": String(windowManager.windows.count)
                    ]
         )

--- a/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
@@ -8,15 +8,35 @@ import Common
 /// Helper utility that aims to detect potential bugs in production which could result in tab loss.
 final class TabErrorTelemetryHelper {
     static let shared = TabErrorTelemetryHelper()
-    private let defaultsKey = "TabErrorTelemetryHelper_Data"
     private let telemetryWrapper: TelemetryWrapperProtocol
     private let defaults: UserDefaultsInterface
     private let windowManager: WindowManager
     private let logger: Logger
 
-    private enum EntryPoint: String {
-        case foreground = "on foreground"
-        case tabRestore = "on tab restore"
+    private enum EntryPoint {
+        case backgroundForeground
+        case preserveRestore
+
+        var logInfo: String {
+            switch self {
+            case .backgroundForeground:
+                return "on foreground"
+            case .preserveRestore:
+                return "on tab restore"
+            }
+        }
+
+        var defaultsKey: String {
+            let foregroundDefaultsKey = "TabErrorTelemetryHelper_Data_BackgroundForegroundEvent"
+            let restoreDefaultsKey = "TabErrorTelemetryHelper_Data_PreserveRestoreEvent"
+
+            switch self {
+            case .backgroundForeground:
+                return foregroundDefaultsKey
+            case .preserveRestore:
+                return restoreDefaultsKey
+            }
+        }
     }
 
     private init(logger: Logger = DefaultLogger.shared,
@@ -35,38 +55,38 @@ final class TabErrorTelemetryHelper {
     /// This count is then checked again upon foregrounding in an attempt to
     /// identify potential tab-loss errors.
     func recordTabCountForBackgroundedScene(_ window: WindowUUID) {
-        ensureMainThread { self.recordTabCount(window) }
+        ensureMainThread { self.recordTabCount(window, entryPoint: .backgroundForeground) }
     }
 
     /// Validates the tab count when the app is foregrounded to ensure the
     /// count is consistent with the count upon backgrounding.
     func validateTabCountForForegroundedScene(_ window: WindowUUID) {
-        ensureMainThread { self.validateTabCount(window, entryPoint: .foreground) }
+        ensureMainThread { self.validateTabCount(window, entryPoint: .backgroundForeground) }
     }
 
     @MainActor
     func recordTabCountAfterPreservingTabs(_ window: WindowUUID) async {
-        self.recordTabCount(window)
+        self.recordTabCount(window, entryPoint: .preserveRestore)
     }
 
     @MainActor
     func validateTabCountAfterRestoringTabs(_ window: WindowUUID) async {
-        self.validateTabCount(window, entryPoint: .tabRestore)
+        self.validateTabCount(window, entryPoint: .preserveRestore)
     }
 
     // MARK: - Internal Utility
 
-    private func recordTabCount(_ window: WindowUUID) {
+    private func recordTabCount(_ window: WindowUUID, entryPoint: EntryPoint) {
         guard self.tabManagerAvailable(for: window) else { return }
-        var tabCounts = defaults.object(forKey: defaultsKey) as? [String: Int] ?? [String: Int]()
+        var tabCounts = defaults.object(forKey: entryPoint.defaultsKey) as? [String: Int] ?? [String: Int]()
         let tabCount = getTotalTabCount(window: window)
         tabCounts[window.uuidString] = tabCount
-        defaults.set(tabCounts, forKey: defaultsKey)
+        defaults.set(tabCounts, forKey: entryPoint.defaultsKey)
     }
 
     private func validateTabCount(_ window: WindowUUID, entryPoint: EntryPoint) {
         guard tabManagerAvailable(for: window) else { return }
-        guard let tabCounts = defaults.object(forKey: defaultsKey) as? [String: Int],
+        guard let tabCounts = defaults.object(forKey: entryPoint.defaultsKey) as? [String: Int],
               let expectedTabCount = tabCounts[window.uuidString] else { return }
         let currentTabCount = getTotalTabCount(window: window)
 
@@ -85,13 +105,13 @@ final class TabErrorTelemetryHelper {
         // is still in preferences and the app crashes. If the user removed
         // any tabs during this time, it means the next launch there will be
         // fewer tabs than recorded and we'll send the event erroneously.
-        invalidateTabCount(for: window)
+        invalidateTabCount(for: window, entryPoint: entryPoint)
     }
 
-    private func invalidateTabCount(for window: WindowUUID) {
-        guard var tabCounts = defaults.object(forKey: defaultsKey) as? [String: Int] else { return }
+    private func invalidateTabCount(for window: WindowUUID, entryPoint: EntryPoint) {
+        guard var tabCounts = defaults.object(forKey: entryPoint.defaultsKey) as? [String: Int] else { return }
         tabCounts.removeValue(forKey: window.uuidString)
-        defaults.set(tabCounts, forKey: defaultsKey)
+        defaults.set(tabCounts, forKey: entryPoint.defaultsKey)
     }
 
     /// It's possible for this telemetry helper to be called during onboarding flow before
@@ -108,7 +128,7 @@ final class TabErrorTelemetryHelper {
     }
 
     private func sendTelemetryTabLossDetectedEvent(expected: Int, actual: Int, entryPoint: EntryPoint) {
-        logger.log("Tab loss detected \(entryPoint.rawValue).",
+        logger.log("Tab loss detected \(entryPoint.logInfo).",
                    level: .fatal,
                    category: .tabs,
                    extra: [
@@ -120,7 +140,7 @@ final class TabErrorTelemetryHelper {
 
         // Only send the telemetry event for the foregrounding log so we don't mess with our existing metrics
         // around tab loss
-        if case .foreground = entryPoint {
+        if case .backgroundForeground = entryPoint {
             telemetryWrapper.recordEvent(
                 category: .information,
                 method: .error,

--- a/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
@@ -117,9 +117,16 @@ final class TabErrorTelemetryHelper {
                     "windows": String(windowManager.windows.count)
                    ]
         )
-        telemetryWrapper.recordEvent(category: .information,
-                                     method: .error,
-                                     object: .app,
-                                     value: .tabLossDetected)
+
+        // Only send the telemetry event for the foregrounding log so we don't mess with our existing metrics
+        // around tab loss
+        if case .foreground = entryPoint {
+            telemetryWrapper.recordEvent(
+                category: .information,
+                method: .error,
+                object: .app,
+                value: .tabLossDetected
+            )
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10711)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Adapt the current tab loss logging to allow for two separate tab loss metrics. This adds an additional tab loss metric for when preserve and restore happen so that any weird lifecycle things are decoupled from the tab loss logging. This also updates the count to be taken on the total number of tabs so that we are only dealing with the complete picture. The new log should not effect any of the looker metrics.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
