### PR TITLE
Fix FXIOS-11966 [Tab Tray UI] Fix blank screenshot when app goes in to the background

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -136,16 +136,15 @@ class BrowserViewController: UIViewController,
     // popover rotation handling
     var displayedPopoverController: UIViewController?
     var updateDisplayedPopoverProperties: (() -> Void)?
+    lazy var screenshotHelper = ScreenshotHelper(controller: self)
 
     // MARK: Lazy loading UI elements
-
     private var documentLoadingView: TemporaryDocumentLoadingView?
     private(set) lazy var mailtoLinkHandler = MailtoLinkHandler()
     private lazy var statusBarOverlay: StatusBarOverlay = .build { _ in }
     private var statusBarOverlayConstraints = [NSLayoutConstraint]()
     private(set) lazy var addressToolbarContainer: AddressToolbarContainer = .build()
     private(set) lazy var readerModeCache: ReaderModeCache = DiskReaderModeCache.shared
-    private lazy var screenshotHelper = ScreenshotHelper(controller: self)
     private(set) lazy var overlayManager: OverlayModeManager = DefaultOverlayModeManager()
 
     // Header stack view can contain the top url bar, top reader mode, top ZoomPageBar

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -145,7 +145,7 @@ class BrowserViewController: UIViewController,
     private var statusBarOverlayConstraints = [NSLayoutConstraint]()
     private(set) lazy var addressToolbarContainer: AddressToolbarContainer = .build()
     private(set) lazy var readerModeCache: ReaderModeCache = DiskReaderModeCache.shared
-    private lazy var screenshotHelper: ScreenshotHelper? = ScreenshotHelper(controller: self)
+    private lazy var screenshotHelper = ScreenshotHelper(controller: self)
     private(set) lazy var overlayManager: OverlayModeManager = DefaultOverlayModeManager()
 
     // Header stack view can contain the top url bar, top reader mode, top ZoomPageBar
@@ -701,7 +701,9 @@ class BrowserViewController: UIViewController,
             self.displayedPopoverController = nil
         }
 
-        if let tab = tabManager.selectedTab, let screenshotHelper {
+        // No need to take a screenshot if a view is presented over the current tab
+        // because a screenshot will already have been taken when we navigate away
+        if let tab = tabManager.selectedTab, presentedViewController == nil {
             screenshotHelper.takeScreenshot(tab, windowUUID: windowUUID)
         }
 
@@ -1222,7 +1224,7 @@ class BrowserViewController: UIViewController,
 
     func willNavigateAway(from tab: Tab?) {
         if let tab {
-            screenshotHelper?.takeScreenshot(tab, windowUUID: windowUUID)
+            screenshotHelper.takeScreenshot(tab, windowUUID: windowUUID)
         }
     }
 
@@ -3163,7 +3165,7 @@ class BrowserViewController: UIViewController,
                 // Issue created: https://github.com/mozilla-mobile/firefox-ios/issues/7003
                 let delayedTimeInterval = DispatchTimeInterval.milliseconds(500)
                 DispatchQueue.main.asyncAfter(deadline: .now() + delayedTimeInterval) {
-                    self.screenshotHelper?.takeScreenshot(tab, windowUUID: self.windowUUID)
+                    self.screenshotHelper.takeScreenshot(tab, windowUUID: self.windowUUID)
                     if webView.superview == self.view {
                         webView.removeFromSuperview()
                     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -14,6 +14,7 @@ import Shared
 class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
     var profile: MockProfile!
     var tabManager: MockTabManager!
+    var screenshotHelper: MockScreenshotHelper!
     var browserCoordinator: MockBrowserCoordinator!
     var mockStore: MockStoreForMiddleware<AppState>!
     var appState: AppState!
@@ -77,6 +78,25 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         ))
 
         wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testAppWillResignActiveNotification_takesScreenshot_ifNoViewIsPresented() {
+        let subject = createSubject()
+        tabManager.selectedTab = MockTab(profile: profile, windowUUID: .XCTestDefaultUUID)
+        subject.appWillResignActiveNotification()
+        XCTAssertTrue(screenshotHelper.takeScreenshotCalled)
+    }
+
+    func testAppWillResignActiveNotification_doesNotTakeScreenshot_ifAViewIsPresented() {
+        // Using the mock BVC here so we can "present" a view controller without loading it
+        // into the window. The function under test `appWillResignActiveNotification` is not stubbed out
+        let mockBVC = MockBrowserViewController(profile: profile, tabManager: tabManager)
+        screenshotHelper = MockScreenshotHelper(controller: mockBVC)
+        mockBVC.screenshotHelper = screenshotHelper
+        mockBVC.viewControllerToPresent = UIViewController()
+        tabManager.selectedTab = MockTab(profile: profile, windowUUID: .XCTestDefaultUUID)
+        mockBVC.appWillResignActiveNotification()
+        XCTAssertFalse(screenshotHelper.takeScreenshotCalled)
     }
 
     func testOpenURLInNewTab_withPrivateModeEnabled() {
@@ -184,6 +204,8 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
 
     private func createSubject() -> BrowserViewController {
         let subject = BrowserViewController(profile: profile, tabManager: tabManager)
+        screenshotHelper = MockScreenshotHelper(controller: subject)
+        subject.screenshotHelper = screenshotHelper
         subject.navigationHandler = browserCoordinator
         trackForMemoryLeaks(subject)
         return subject
@@ -225,5 +247,13 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
 
     func resetStore() {
         StoreTestUtilityHelper.resetStore()
+    }
+}
+
+class MockScreenshotHelper: ScreenshotHelper {
+    var takeScreenshotCalled = false
+
+    override func takeScreenshot(_ tab: Tab, windowUUID: WindowUUID) {
+        takeScreenshotCalled = true
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -56,6 +56,12 @@ class MockBrowserViewController: BrowserViewController {
 
     var mockContentContainer = MockContentContainer()
 
+    var viewControllerToPresent: UIViewController?
+
+    override var presentedViewController: UIViewController? {
+        return viewControllerToPresent
+    }
+
     override var contentContainer: ContentContainer {
         return mockContentContainer
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11966)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Bandaid fix for making sure that the app does not take a screenshot for a tab if the tab is presenting something. We got away with this when the tab tray was modally presented but it no longer works with the tab tray fullscreen.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
