### PR TITLE
Add FXIOS-12179 [Top Sites Visual Refresh] Increase favicon size

### DIFF
--- a/BrowserKit/Sources/Shared/Extensions/UIImageExtensions.swift
+++ b/BrowserKit/Sources/Shared/Extensions/UIImageExtensions.swift
@@ -82,15 +82,15 @@ extension UIImage {
         var transparentPixelCount = 0
 
         // Step by 4 since each pixel is 4 bytes
-         for i in stride(from: 0, to: pixelData.count, by: bytesPerPixel) {
-             let alpha = pixelData[i + 3] // Alpha channel is the last byte since we are using CGContext
-             if alpha == 0 { // 0 = transparent, 255 = opaque
-                 transparentPixelCount += 1
-             }
-         }
+        for i in stride(from: 0, to: pixelData.count, by: bytesPerPixel) {
+            let alpha = pixelData[i + 3] // Alpha channel is the last byte since we are using CGContext
+            if alpha == 0 { // 0 = transparent, 255 = opaque
+                transparentPixelCount += 1
+            }
+        }
 
-         let percentageTransparent = CGFloat(transparentPixelCount) / CGFloat(pixelCount)
+        let percentageTransparent = CGFloat(transparentPixelCount) / CGFloat(pixelCount)
 
-         return percentageTransparent * 100
+        return percentageTransparent * 100
     }
 }

--- a/BrowserKit/Sources/Shared/Extensions/UIImageExtensions.swift
+++ b/BrowserKit/Sources/Shared/Extensions/UIImageExtensions.swift
@@ -21,6 +21,13 @@ extension Data {
 }
 
 extension UIImage {
+    public var hasAlpha: Bool {
+        guard let alphaInfo = self.cgImage?.alphaInfo else {return false}
+        return alphaInfo != CGImageAlphaInfo.none &&
+            alphaInfo != CGImageAlphaInfo.noneSkipFirst &&
+            alphaInfo != CGImageAlphaInfo.noneSkipLast
+    }
+
     public static func createWithColor(_ size: CGSize, color: UIColor) -> UIImage {
         UIGraphicsImageRenderer(size: size).image { (ctx) in
             color.setFill()

--- a/BrowserKit/Sources/Shared/Extensions/UIImageExtensions.swift
+++ b/BrowserKit/Sources/Shared/Extensions/UIImageExtensions.swift
@@ -62,7 +62,8 @@ extension UIImage {
         let bitsPerChannel = 8 // 8 bits (1 byte) for each channel in RGBA which represents the 0-255 (2^8) value
         let bytesPerRow = imageWidth * bytesPerPixel
 
-        var pixelData = [UInt8](repeating: 0, count: imageWidth * imageHeight * bytesPerPixel)
+        let pixelCount = imageWidth * imageHeight
+        var pixelData = [UInt8](repeating: 0, count: pixelCount * bytesPerPixel)
 
         guard let context = CGContext(
             data: &pixelData,
@@ -88,7 +89,6 @@ extension UIImage {
              }
          }
 
-         let pixelCount = imageWidth * imageHeight
          let percentageTransparent = CGFloat(transparentPixelCount) / CGFloat(pixelCount)
 
          return percentageTransparent * 100

--- a/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
@@ -25,6 +25,10 @@ public class FaviconImageView: UIImageView, SiteImageView {
         setupUI()
     }
 
+    public convenience init(completionHandler: @escaping () -> Void) {
+        self.init(frame: .zero, imageFetcher: DefaultSiteImageHandler(), completionHandler: completionHandler)
+    }
+
     // Internal init used in unit tests only
     init(frame: CGRect,
          imageFetcher: SiteImageHandler,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -278,7 +278,10 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
 
     // Add insets to favicons with transparent backgrounds
     private func configureFaviconWithTransparency() {
-        guard let image = imageView.image, image.hasAlpha else { return }
+        let transparencyThreshold: CGFloat = 10
+        guard let image = imageView.image,
+              let percentTransparent = image.percentTransparent,
+              percentTransparent > transparencyThreshold else { return }
 
         self.imageViewConstraints.forEach { constraint in
             if constraint.firstAttribute == .trailing || constraint.firstAttribute == .bottom {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -22,6 +22,7 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
         static let textSafeSpace: CGFloat = 6
         static let faviconCornerRadius: CGFloat = 16
         static let faviconTransparentBackgroundInset: CGFloat = 8
+        static let transparencyThreshold: CGFloat = 10
     }
 
     private var rootContainer: UIView = .build { view in
@@ -297,10 +298,9 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
 
     // Add insets to favicons with transparent backgrounds
     private func configureFaviconWithTransparency() {
-        let transparencyThreshold: CGFloat = 10
         guard let image = imageView.image,
               let percentTransparent = image.percentTransparent,
-              percentTransparent > transparencyThreshold else { return }
+              percentTransparent > UX.transparencyThreshold else { return }
 
         self.imageViewConstraints.forEach { constraint in
             if constraint.firstAttribute == .trailing || constraint.firstAttribute == .bottom {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12179)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26511)

## :bulb: Description
- Increase the size of favicons in top site cells
  - Shrunk insets for favicons containing > 10% transparent pixels (typically denoting a transparent background)

### 📝 Dev Notes:
- Add UIImage extension to check for the percentage of fully transparent pixe l
  - This is an improvement over checking for the existence of an alpha channel or images containing any translucency since it accounts for false positives where some favicons have a small amount of minimally translucent pixels. Having > 10% completely transparent pixels is a good indicator that the favicon does not have a background.

## :movie_camera: Demos
| Before | Detecting Alpha Channel | Detecting Transparency ✅ |
| - | - | - |
| <img src="https://github.com/user-attachments/assets/18c1511b-8ba1-440e-b0f9-09aed3cc7aed" width="400" /> | <img src="https://github.com/user-attachments/assets/c3a0bc67-b0f3-4e86-8ae3-d578e842576d" width="400" /> | <img src="https://github.com/user-attachments/assets/de628711-8ede-4392-b4bb-234e78890142" width="400" /> | 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
