### PR TITLE
Refactor [Tab Optimization] Clean up tab preservation logic 

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1060,7 +1060,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 tabManager.notifyCurrentTabDidFinishLoading()
             }
 
-            tabManager.commitChanges()
+            tabManager.saveAllTabData()
         }
 
         if isPDFRefactorEnabled {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -667,7 +667,6 @@ class BrowserViewController: UIViewController,
 
         // Formerly these calls were run during AppDelegate.didEnterBackground(), but we have
         // individual TabManager instances for each BVC, so we perform these here instead.
-        tabManager.preserveTabs()
         logTelemetryForAppDidEnterBackground()
     }
 
@@ -682,9 +681,11 @@ class BrowserViewController: UIViewController,
         guard let currentWindowScene = view.window?.windowScene,
               let notificationWindowScene = notification.object as? UIWindowScene,
               currentWindowScene === notificationWindowScene else { return }
-        guard canShowPrivacyWindow else { return }
 
-        privacyWindowHelper.showWindow(windowScene: currentWindowScene, withThemedColor: currentTheme().colors.layer3)
+        tabManager.saveAllTabData()
+        if canShowPrivacyWindow {
+            privacyWindowHelper.showWindow(windowScene: currentWindowScene, withThemedColor: currentTheme().colors.layer3)
+        }
     }
 
     @objc

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -103,7 +103,7 @@ protocol TabManager: AnyObject {
     func preserveTabs()
 
     /// Commits the pending changes to the persistent store.
-    func commitChanges()
+    func saveAllTabData()
 
     func notifyCurrentTabDidFinishLoading()
     func restoreTabs(_ forced: Bool)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -38,7 +38,7 @@ class MockTabManager: TabManager {
 
     var addTabWasCalled = false
     var notifyCurrentTabDidFinishLoadingCalled = 0
-    var commitChangesCalled = 0
+    var saveAllTabDataCalled = 0
 
     init(
         windowUUID: WindowUUID = WindowUUID.XCTestDefaultUUID,
@@ -106,8 +106,8 @@ class MockTabManager: TabManager {
 
     func clearAllTabsHistory() {}
 
-    func commitChanges() {
-        commitChangesCalled += 1
+    func saveAllTabData() {
+        saveAllTabDataCalled += 1
     }
 
     func willSwitchTabMode(leavingPBM: Bool) {}


### PR DESCRIPTION
## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Replace `commitChanges` with `saveAllTabData` since they are basically the same function. 

Also remove double call to preserve tabs on app background. Instead call `saveAllTabData` on `sceneDidEnterBackgroundNotification`

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
