### PR TITLE
Refactor FXIOS-9909 block external links behavior

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -581,6 +581,8 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
+        let shouldBlockExternalApps = profile.prefs.boolForKey(PrefsKeys.BlockOpeningExternalApps) ?? false
+
         // This is the normal case, opening a http or https url, which we handle by loading them in this WKWebView.
         // We always allow this. Additionally, data URIs are also handled just like normal web pages.
         if let scheme = url.scheme, ["http", "https", "blob", "file"].contains(scheme) {
@@ -608,24 +610,19 @@ extension BrowserViewController: WKNavigationDelegate {
                 return
             }
 
-            let shouldBlockExternalApps = profile.prefs.boolForKey(PrefsKeys.BlockOpeningExternalApps) ?? false
             let isGoogleDomain = url.host?.contains("google") ?? false
             let isPrivate = tab.isPrivate
 
-            if navigationAction.navigationType == .linkActivated,
-               !shouldBlockExternalApps,
-               url != webView.url,
-               !isPrivate,
-               !isGoogleDomain {
-                decisionHandler(.allow)
+            if isPrivate || isGoogleDomain || shouldBlockExternalApps {
+                decisionHandler(allowPolicy)
                 return
             }
 
-            decisionHandler(allowPolicy)
+            decisionHandler(.allow)
             return
         }
 
-        if !(url.scheme?.contains("firefox") ?? true) {
+        if let scheme = url.scheme, !scheme.contains("firefox"), !shouldBlockExternalApps, !tab.isPrivate {
             // Try to open the custom scheme URL, if it doesn't work we show an error alert
             UIApplication.shared.open(url, options: [:]) { openedURL in
                 // Do not show error message for JS navigated links or

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -109,19 +109,6 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
-    func testWebViewDecidePolicyForNavigationAction_allowsGoogle_andBlockUniversalLink() {
-        let subject = createSubject()
-        let google = URL(string: "https://www.google.com")
-        let tab = createTab()
-        tabManager.tabs = [tab]
-
-        subject.webView(tab.webView!,
-                        decidePolicyFor: MockNavigationAction(url: google!,
-                                                              type: .linkActivated)) { policy in
-            XCTAssertEqual(policy, self.allowBlockingUniversalLinksPolicy)
-        }
-    }
-
     func testWebViewDecidePolicyForNavigationAction_allowsAnyWebsite_withNormalTabs() {
         let subject = createSubject()
         let tab = createTab()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -162,7 +162,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
-    func testWebViewDecidePolicyForNavigationAction_cancelLoading_whenBlobURLs() {
+    func testWebViewDecidePolicyForNavigationAction_allowsLoading_whenBlobURLsWithNavigationTypeOther() {
         let subject = createSubject()
         let tab = createTab()
         let blob = URL(string: "blob://blobfile")!
@@ -171,7 +171,20 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         subject.webView(tab.webView!,
                         decidePolicyFor: MockNavigationAction(url: blob,
                                                               type: .other)) { policy in
-            XCTAssertEqual(policy, self.allowBlockingUniversalLinksPolicy)
+            XCTAssertEqual(policy, .allow)
+        }
+    }
+
+    func testWebViewDecidePolicyForNavigationAction_cancelLoading() {
+        let subject = createSubject()
+        let tab = createTab()
+        let blob = URL(string: "blob://blobfile")!
+        tabManager.tabs = [tab]
+
+        subject.webView(tab.webView!,
+                        decidePolicyFor: MockNavigationAction(url: blob,
+                                                              type: .backForward)) { policy in
+            XCTAssertEqual(policy, .cancel)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9909)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21727)

## :bulb: Description
Refactor external link behavior by disabling to open not handled schemes when tab is private or user disabled the settings to open external links.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
