### PR TITLE
Refactor FXIOS-12276 [Tab tray UI experiment] Adjust gradient layer look and a11y

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -65,6 +65,7 @@ class TabDisplayPanelViewController: UIViewController,
     }
 
     private lazy var gradientLayer = CAGradientLayer()
+    private lazy var statusBarView: UIView = .build { _ in }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
@@ -176,7 +177,6 @@ class TabDisplayPanelViewController: UIViewController,
 
     private func setupFadeView() {
         guard isTabTrayUIExperimentsEnabled, isCompactLayout else { return }
-        gradientLayer.locations = [0.0, 0.02, 0.08, 0.12]
         fadeView.layer.addSublayer(gradientLayer)
         view.addSubview(fadeView)
 
@@ -220,11 +220,23 @@ class TabDisplayPanelViewController: UIViewController,
         tabDisplayView.applyTheme(theme: theme)
         emptyPrivateTabsView.applyTheme(theme: theme)
 
-        if isTabTrayUIExperimentsEnabled {
+        guard isTabTrayUIExperimentsEnabled else { return }
+
+        if UIAccessibility.isReduceTransparencyEnabled {
+            statusBarView.backgroundColor = theme.colors.layer3
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let statusBarHeight = windowScene.statusBarManager?.statusBarFrame.height {
+                statusBarView.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: statusBarHeight)
+            }
+
+            view.addSubview(statusBarView)
+            gradientLayer.isHidden = true
+        } else {
+            gradientLayer.isHidden = false
+            statusBarView.removeFromSuperview()
+            gradientLayer.locations = [0.0, 0.12]
             gradientLayer.colors = [
                 theme.colors.layer3.cgColor,
-                theme.colors.layer3.cgColor,
-                theme.colors.layer3.withAlphaComponent(0.95).cgColor,
                 theme.colors.layer3.withAlphaComponent(0.0).cgColor
             ]
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12276)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26750)

## :bulb: Description
- Adjusted the gradient to the top of the screen
- Realized this is not great for users with `isReduceTransparencyEnabled`, so ensured we have a solid block of colors without transparency/gradient for those users.

## :movie_camera: Demos
<details>
<summary>With isReduceTransparencyEnabled</summary>

![Simulator Screenshot - iPhone 16 - 2025-05-16 at 15 46 54](https://github.com/user-attachments/assets/0615be54-fd5e-4682-82c7-68f5ef29d414)

</details>

<details>
<summary>Without isReduceTransparencyEnabled</summary>

![Simulator Screenshot - iPhone 16 - 2025-05-16 at 15 31 21](https://github.com/user-attachments/assets/77ad7a34-6695-44a9-838a-6bd9b04a633b)

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [X] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
