### PR TITLE
Refactor FXIOS-12277 [Tab tray UI experiment] Make adjustment X button on tab with reduce transparency

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -198,6 +198,14 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         favicon.tintColor = theme.colors.textPrimary
         smallFaviconView.tintColor = theme.colors.textPrimary
         setupShadow(theme: theme)
+
+        if UIAccessibility.isReduceTransparencyEnabled {
+            closeButtonBlurView.backgroundColor = theme.colors.iconSecondary
+        } else {
+            closeButtonBlurView.backgroundColor = .clear
+            closeButtonBlurView.addBlurEffectWithClearBackgroundAndClipping(using: .systemUltraThinMaterialDark)
+        }
+
         guard let tabModel else { return }
         updateUIForSelectedState(tabModel.isSelected,
                                  isPrivate: tabModel.isPrivate,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12277)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26751)

## :bulb: Description
We are introducing blur on the X button in v139. Realized this would break experience for reduce transparency users, so fixing that now!

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<details>
<summary>Reduce transparency enabled</summary>

![Simulator Screenshot - iPhone 16 - 2025-05-16 at 16 01 10](https://github.com/user-attachments/assets/01c59bde-0d49-4df6-9c51-b8ef7cd0b05b)

</details>

<details>
<summary>Reduce transparency disabled</summary>

![Simulator Screenshot - iPhone 16 - 2025-05-16 at 16 01 21](https://github.com/user-attachments/assets/c202d3e7-0b51-4c98-bc25-38583aeef741)

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [X] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
