### PR TITLE
Refactor FXIOS-12286 [Toolbar] Enable translucency by default on dev and beta in 140

### DIFF
--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -54,7 +54,7 @@ features:
           navigation_hint: true
           toolbar_update_hint: true
           swiping_tabs: false
-          translucency: false
+          translucency: true
           layout: version1
       - channel: developer
         value:
@@ -64,7 +64,7 @@ features:
           navigation_hint: true
           toolbar_update_hint: true
           swiping_tabs: true
-          translucency: false
+          translucency: true
           layout: baseline
 
 enums:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12286)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26762)

## :bulb: Description
Enables translucency for dev and beta.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
