### PR TITLE
Add FXIOS-12294 ⁃ [Menu Redesign] Add a subflag under the Menu Refactor Feature flag to enable/disable all new changes for menu

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -28,6 +28,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case loginsVerificationEnabled
     case menuRefactor
     case menuRefactorHint
+    case menuRedesign
     case microsurvey
     case nativeErrorPage
     case noInternetConnectionErrorPage
@@ -133,6 +134,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .loginsVerificationEnabled,
                 .menuRefactor,
                 .menuRefactorHint,
+                .menuRedesign,
                 .microsurvey,
                 .nativeErrorPage,
                 .noInternetConnectionErrorPage,

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -59,6 +59,9 @@ final class NimbusFeatureFlagLayer {
         case .menuRefactorHint:
             return checkMenuRefactorHint(from: nimbus)
 
+        case .menuRedesign:
+            return checkMenuRedesign(from: nimbus)
+
         case .microsurvey:
             return checkMicrosurveyFeature(from: nimbus)
 
@@ -355,6 +358,11 @@ final class NimbusFeatureFlagLayer {
     private func checkMenuRefactorHint(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.menuRefactorFeature.value()
         return config.menuHint
+    }
+
+    private func checkMenuRedesign(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.menuRefactorFeature.value()
+        return config.menuRedesign
     }
 
     private func checkMicrosurveyFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/nimbus-features/menuRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/menuRefactorFeature.yaml
@@ -14,12 +14,19 @@ features:
           If true, enables the menu contextual hint.
         type: Boolean
         default: false
+      menu-redesign:
+        description: >
+          If true, enables the menu redesign.
+        type: Boolean
+        default: false
     defaults:
       - channel: beta
         value:
           enabled: false
           menu-hint: false
+          menu-redesign: false
       - channel: developer
         value:
           enabled: true
           menu-hint: true
+          menu-redesign: false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12294)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26774)

## :bulb: Description
Added a subflag for menu redesign changes

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
