### PR TITLE
Refactor FXIOS-12292 [Swiping Tabs] AddressBarPanGestureHandler with transform

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
@@ -13,33 +13,37 @@ public struct AddressToolbarUXConfiguration {
     let shouldBlur: Bool
     let backgroundAlpha: CGFloat
 
-    public static func experiment(backgroundAlpha: CGFloat = 1.0) -> AddressToolbarUXConfiguration {
+    public static func experiment(backgroundAlpha: CGFloat = 1.0,
+                                  shouldBlur: Bool = false) -> AddressToolbarUXConfiguration {
         AddressToolbarUXConfiguration(
             toolbarCornerRadius: 12.0,
             browserActionsAddressBarDividerWidth: 0.0,
             isLocationTextCentered: true,
             locationTextFieldTrailingPadding: 0,
-            shouldBlur: true,
+            shouldBlur: shouldBlur,
             backgroundAlpha: backgroundAlpha
         )
     }
 
-    public static func `default`(backgroundAlpha: CGFloat = 1.0) -> AddressToolbarUXConfiguration {
+    public static func `default`(backgroundAlpha: CGFloat = 1.0,
+                                 shouldBlur: Bool = false) -> AddressToolbarUXConfiguration {
         AddressToolbarUXConfiguration(
             toolbarCornerRadius: 8.0,
             browserActionsAddressBarDividerWidth: 4.0,
             isLocationTextCentered: false,
             locationTextFieldTrailingPadding: 8.0,
-            shouldBlur: false,
+            shouldBlur: shouldBlur,
             backgroundAlpha: backgroundAlpha
         )
     }
 
     func addressToolbarBackgroundColor(theme: any Theme) -> UIColor {
-        let blurBackgroundColor = theme.colors.layer3.withAlphaComponent(backgroundAlpha)
-        let centerBackgroundColor = shouldBlur ? blurBackgroundColor : theme.colors.layer3
+        var backgroundColor = isLocationTextCentered ? theme.colors.layer3 : theme.colors.layer1
+        if shouldBlur {
+            backgroundColor = backgroundColor.withAlphaComponent(backgroundAlpha)
+        }
 
-        return isLocationTextCentered ? centerBackgroundColor : theme.colors.layer1
+        return backgroundColor
     }
 
     func locationContainerBackgroundColor(theme: any Theme) -> UIColor {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -895,7 +895,9 @@ class BrowserViewController: UIViewController,
         // Update theme of already existing views
         let theme = currentTheme()
         contentContainer.backgroundColor = theme.colors.layer1
-        if isSwipingTabsEnabled, isToolbarRefactorEnabled { webPagePreview.applyTheme(theme: theme) }
+        if isSwipingTabsEnabled, isToolbarRefactorEnabled {
+            webPagePreview.applyTheme(theme: theme)
+        }
         header.applyTheme(theme: theme)
         overKeyboardContainer.applyTheme(theme: theme)
         bottomContainer.applyTheme(theme: theme)
@@ -1153,7 +1155,9 @@ class BrowserViewController: UIViewController,
     }
 
     func addSubviews() {
-        if isSwipingTabsEnabled, isToolbarRefactorEnabled { view.addSubviews(addressBarBackgroundView, webPagePreview) }
+        if isSwipingTabsEnabled, isToolbarRefactorEnabled {
+            view.addSubviews(addressBarBackgroundView, webPagePreview)
+        }
         view.addSubviews(contentContainer)
 
         view.addSubview(topTouchArea)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -101,7 +101,6 @@ final class AddressBarPanGestureHandler: NSObject {
 
         switch gesture.state {
         case .began:
-            applyPreviewTransform(translation: translation)
             screenshotHelper?.takeScreenshot(selectedTab, windowUUID: windowUUID)
         case .changed:
             handleGestureChangedState(translation: translation, nextTab: nextTab)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -39,10 +39,11 @@ final class AddressToolbarContainerModel: Equatable {
         let term = searchTerm ?? searchTermFromURL(url)
         let isVersionLayout = toolbarLayoutStyle == .version1 || toolbarLayoutStyle == .version2
         let backgroundAlpha = toolbarHelper.backgroundAlpha()
+        let shouldBlur = toolbarHelper.shouldBlur()
         let uxConfiguration: AddressToolbarUXConfiguration = if isVersionLayout {
-            .experiment(backgroundAlpha: backgroundAlpha)
+            .experiment(backgroundAlpha: backgroundAlpha, shouldBlur: shouldBlur)
         } else {
-            .default(backgroundAlpha: backgroundAlpha)
+            .default(backgroundAlpha: backgroundAlpha, shouldBlur: shouldBlur)
         }
 
         var droppableUrl: URL?

--- a/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
@@ -97,7 +97,7 @@ final class TabWebViewPreview: UIView, Notifiable, ThemeApplicable {
         switch searchBarPosition {
         case .bottom:
             bottomStackView.addArrangedSubview(skeletonAddressBar)
-            webViewTopConstraint = webPageScreenshotImageView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor)
+            webViewTopConstraint = webPageScreenshotImageView.topAnchor.constraint(equalTo: topAnchor)
             addressBarBorderViewTopBottomConstraint = addressBarBorderView.bottomAnchor.constraint(
                 equalTo: skeletonAddressBar.topAnchor, constant: -UX.edgePadding
             )

--- a/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
@@ -97,7 +97,7 @@ final class TabWebViewPreview: UIView, Notifiable, ThemeApplicable {
         switch searchBarPosition {
         case .bottom:
             bottomStackView.addArrangedSubview(skeletonAddressBar)
-            webViewTopConstraint = webPageScreenshotImageView.topAnchor.constraint(equalTo: topAnchor)
+            webViewTopConstraint = webPageScreenshotImageView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor)
             addressBarBorderViewTopBottomConstraint = addressBarBorderView.bottomAnchor.constraint(
                 equalTo: skeletonAddressBar.topAnchor, constant: -UX.edgePadding
             )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12292)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26769)

## :bulb: Description
Refactor `AddressBarPanGestureHandler` with transform to make it easier to handle transition and restore to initial position.
Fixed background color for address bar baseline layout with translucency enabled.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
