### PR TITLE
Add EXP-5499: Update Experiment Integration tests for new menubar promo.

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ExperimentIntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ExperimentIntegrationTests.swift
@@ -10,12 +10,19 @@ final class ExperimentIntegrationTests: BaseTestCase {
 
     override func setUpApp() {
         app.activate()
+
         let closeButton = app.buttons["CloseButton"]
+        let menuPromoBox = app.buttons["Close"]
+
         if closeButton.waitForExistence(timeout: TIMEOUT) {
             closeButton.waitAndTap()
         }
         super.setUpScreenGraph()
         UIView.setAnimationsEnabled(false) // IMPORTANT
+
+        if menuPromoBox.waitForExistence(timeout: TIMEOUT) {
+            menuPromoBox.waitAndTap()
+        }
     }
 
     func enableSecretMenu() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-5499)

## :bulb: Description
The new promo for the redesigned menubar was causing the experiment integration tests to fail. I have added some steps to close it.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
