### PR TITLE
Refactor FXIOS-12305 #26797 ⁃ [Unit test] Danger add names to PR warning to get notified for failure to create unit test

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -77,7 +77,8 @@ func failOnNewFilesWithoutCoverage() {
 
         if let (_, coveragePercent) = matching {
             if coveragePercent == 0 {
-                warn("New file `\(file)` has 0% test coverage. Please add unit tests.")
+                let contact = "(cc: @cyndichin @yoanarios )."
+                warn("New file `\(file)` has 0% test coverage. Please add unit tests. \(contact)")
             }
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12305)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26797)

## :bulb: Description
We added a danger warning if a new file is created and it code coverage is 0 to encourage team members to write unit test for every new file. ATM we have to check each PR if fails this condition manually. Here we are adding our handles to get notified.


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
