### PR TITLE
 Fix FXIOS-11506 [Release Automation] Promote and push beta/release builds for prod releases 

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2151,6 +2151,16 @@ workflows:
     - SPM_Common_Steps
     steps:
     - script@1.2.1:
+        title: Override default bitrise scheme
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            if [[ ! -z "${API_BITRISE_SCHEME}" ]]; then
+              envman add --key BITRISE_SCHEME --value "${API_BITRISE_SCHEME}"
+            fi
+    - script@1.2.1:
         # If the current bitrise application is `staging-firefox-ios`, then
         # this is a test release made from the staging repository.
         # Ignore the value passed by release promotion for `BITRISE_SCHEME` and
@@ -2166,16 +2176,6 @@ workflows:
             envman add --key EXPORT_METHOD --value development
         run_if: |-
           {{enveq "BITRISE_APP_TITLE" "staging-firefox-ios"}}
-    - script@1.2.1:
-        title: Override default bitrise scheme
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -ex
-
-            if [[ ! -z "${API_BITRISE_SCHEME}" ]]; then
-              envman add --key BITRISE_SCHEME --value "${API_BITRISE_SCHEME}"
-            fi
     - script@1.2.1:
         inputs:
         - content: |-

--- a/taskcluster/ffios_taskgraph/build_types.py
+++ b/taskcluster/ffios_taskgraph/build_types.py
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskgraph.util.dependencies import group_by
+
+BUILD_TYPE_FOR_RELEASE_TYPE = {
+    "release": ["beta", "release"],
+    "beta": ["beta"],
+}
+
+def should_build_type_get_targetted_for_release_type(task, release_type):
+    task_build_type = task.attributes.get("build-type")
+    target_build_types = BUILD_TYPE_FOR_RELEASE_TYPE[release_type]
+
+    return task_build_type in target_build_types
+
+
+@group_by("filtered-build-type")
+def group_by_filter(config, tasks):
+    single_group = []
+    release_type = config.params.get("release_type")
+
+    for task in tasks:
+        if not should_build_type_get_targetted_for_release_type(task, release_type):
+            continue
+        single_group.append(task)
+
+    if not single_group:
+        return []
+
+    return [single_group]

--- a/taskcluster/ffios_taskgraph/target_tasks.py
+++ b/taskcluster/ffios_taskgraph/target_tasks.py
@@ -4,6 +4,7 @@
 
 
 from taskgraph.target_tasks import register_target_task
+from .build_types import should_build_type_get_targetted_for_release_type
 
 
 @register_target_task('l10n_screenshots')
@@ -68,12 +69,15 @@ def does_task_match_release_type(task, release_type):
     return task.attributes.get("release-type") == release_type
 
 def _filter_release_promotion(
-    full_task_graph, parameters, filtered_for_candidates, shipping_phase
+    full_task_graph, parameters, filtered_for_candidates, shipping_phase,
 ):
     def filter(task, parameters):
         # Include promotion tasks; these will be optimized out
         if task.label in filtered_for_candidates:
             return True
+
+        if not should_build_type_get_targetted_for_release_type(task, parameters["release_type"]):
+            return False
 
         return task.attributes.get(
             "shipping_phase"

--- a/taskcluster/ffios_taskgraph/transforms/relpro_promote.py
+++ b/taskcluster/ffios_taskgraph/transforms/relpro_promote.py
@@ -8,29 +8,9 @@ from taskgraph.util.schema import resolve_keyed_by
 transforms = TransformSequence()
 
 @transforms.add
-def replace_bitrise_scheme_for_release_task(config, tasks):
-    """
-    This replaces `<release-type-scheme>` in all bitrise inputs to:
-
-    - "FirefoxBeta" if the current release-type is beta
-    - "Firefox" otherwise
-    """
-
-    # TODO: Replace this with `resolve_keyed_by` when https://github.com/taskcluster/taskgraph/pull/608 is merged
-
-    scheme = "Firefox"
-    if config.params.get("release_type") == "beta":
-        scheme = "FirefoxBeta"
-
+def add_release_type_attribute(config, tasks):
     for task in tasks:
         task.setdefault("attributes", {})["release-type"] = config.params.get("release_type")
-        for workflow in task.get('bitrise', {}).get('workflows', {}):
-            if isinstance(workflow, str):
-                continue
-            for name, params in workflow.items():
-                for param in params:
-                    for param_name, param_value in param.items():
-                        param_value = param_value.replace("<release-type-scheme>", scheme)
-                        param[param_name] = param_value
+        resolve_keyed_by(task, 'treeherder.symbol', task["name"], **{'build-type': task['attributes']['build-type']})
 
         yield task

--- a/taskcluster/ffios_taskgraph/transforms/relpro_push.py
+++ b/taskcluster/ffios_taskgraph/transforms/relpro_push.py
@@ -1,0 +1,17 @@
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+
+transforms = TransformSequence()
+
+@transforms.add
+def resolve_keyed_by_build_type(config, tasks):
+    for task in tasks:
+        resolve_keyed_by(task, 'treeherder.symbol', task["name"], **{'build-type': task['attributes']['build-type']})
+        build_type = task["attributes"]["build-type"]
+
+        for workflow in task["worker"]["bitrise"]["workflows"]:
+            for params in workflow.values():
+                params.append({"BUILD_TASK_ID": {"task-reference": f"<promote-{build_type}>"}})
+
+        yield task

--- a/taskcluster/kinds/github-release/kind.yml
+++ b/taskcluster/kinds/github-release/kind.yml
@@ -16,14 +16,9 @@ tasks:
     publish:
       description: Create a Github release
       from-deps:
-        group-by:
-          attribute: release-type
+        group-by: filtered-build-type
         unique-kinds: false
         copy-attributes: true
-        with-attributes:
-          release-type:
-            - beta
-            - release
       run-on-tasks-for: []
       treeherder:
         symbol: gh-r

--- a/taskcluster/kinds/promote/kind.yml
+++ b/taskcluster/kinds/promote/kind.yml
@@ -10,19 +10,36 @@ transforms:
     - taskgraph.transforms.task
 
 
+task-defaults:
+  run-on-tasks-for: []
+  treeherder:
+    symbol:
+      by-build-type:
+        release: B
+        beta: Bb
+    kind: build
+    tier: 1
+    platform: ios/opt
+  worker-type: bitrise
+  shipping-phase: promote
+  bitrise:
+    artifact_prefix: public
+
+
 tasks:
-    build:
+    release:
       description: Start a release build
-      run-on-tasks-for: []
-      treeherder:
-        symbol: B
-        kind: build
-        tier: 1
-        platform: ios/opt
-      worker-type: bitrise
-      shipping-phase: promote
       bitrise:
-        artifact_prefix: public
         workflows:
           - release_promotion_promote:
-              - API_BITRISE_SCHEME: "<release-type-scheme>"
+              - API_BITRISE_SCHEME: Firefox
+      attributes:
+        build-type: release
+    beta:
+      description: Start a beta build
+      bitrise:
+        workflows:
+          - release_promotion_promote:
+              - API_BITRISE_SCHEME: FirefoxBeta
+      attributes:
+        build-type: beta

--- a/taskcluster/kinds/push/kind.yml
+++ b/taskcluster/kinds/push/kind.yml
@@ -7,6 +7,7 @@ loader: taskgraph.loader.transform:loader
 transforms:
     - taskgraph.transforms.from_deps
     - ffios_taskgraph.transforms.bitrise
+    - ffios_taskgraph.transforms.relpro_push
     - taskgraph.transforms.task
 
 kind-dependencies:
@@ -17,7 +18,7 @@ tasks:
       description: Start push workflow
       from-deps:
         group-by:
-          attribute: release-type
+          attribute: build-type
         unique-kinds: false
         copy-attributes: true
         with-attributes:
@@ -26,7 +27,10 @@ tasks:
             - release
       run-on-tasks-for: []
       treeherder:
-        symbol: P
+        symbol:
+          by-build-type:
+            release: P
+            beta: Pb
         tier: 1
         platform: ios/opt
       worker-type: bitrise
@@ -34,5 +38,4 @@ tasks:
       bitrise:
         artifact_prefix: public
         workflows:
-          - release_promotion_push:
-              - BUILD_TASK_ID: {task-reference: <promote-build>}
+          - release_promotion_push: []


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11506)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25045)

## :bulb: Description
Everyone completely missed that during the original work. Prod releases also push a beta build.

This changes the task graph to schedule both beta and release promote/push tasks on prod builds.

It was a bit of a pain because we have to join the graph back at the github-release point to avoid pushing a beta tag on prod release graphs.
This also includes a commit to fix staging releases by not overriding the schema late.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
