### PR TITLE
Refactor FXIOS-6765 #15058 ⁃ [Default zoom] default page zoom setting

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		211046CD2A7D842A00A7309F /* TPAccessoryInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211046CC2A7D842A00A7309F /* TPAccessoryInfo.swift */; };
 		21112968289480630082C08B /* HomepageMessageCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21112967289480630082C08B /* HomepageMessageCardViewModel.swift */; };
 		211F00AC27F4D918001D9189 /* HistoryPanel+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211F00AB27F4D918001D9189 /* HistoryPanel+Search.swift */; };
+		2122EE552DDCFD8C00D42716 /* PageZoomSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2122EE542DDCFD8C00D42716 /* PageZoomSettingsViewModel.swift */; };
 		2128E27B292E624400FB91BE /* SendToDeviceActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2128E27A292E624400FB91BE /* SendToDeviceActivity.swift */; };
 		2128E27C2930216F00FB91BE /* SendToDeviceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AFBAF8292EA0330065E35E /* SendToDeviceHelper.swift */; };
 		2128E27E2934F78600FB91BE /* CustomAppActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2128E27D2934F78600FB91BE /* CustomAppActivity.swift */; };
@@ -2760,6 +2761,7 @@
 		211046CC2A7D842A00A7309F /* TPAccessoryInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPAccessoryInfo.swift; sourceTree = "<group>"; };
 		21112967289480630082C08B /* HomepageMessageCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageMessageCardViewModel.swift; sourceTree = "<group>"; };
 		211F00AB27F4D918001D9189 /* HistoryPanel+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HistoryPanel+Search.swift"; sourceTree = "<group>"; };
+		2122EE542DDCFD8C00D42716 /* PageZoomSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageZoomSettingsViewModel.swift; sourceTree = "<group>"; };
 		2128E27A292E624400FB91BE /* SendToDeviceActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendToDeviceActivity.swift; sourceTree = "<group>"; };
 		2128E27D2934F78600FB91BE /* CustomAppActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAppActivity.swift; sourceTree = "<group>"; };
 		212985E32A6F078800546684 /* ScreenState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenState.swift; sourceTree = "<group>"; };
@@ -10963,6 +10965,7 @@
 				214099642DD295F5004881E1 /* ZoomLevelPickerView.swift */,
 				214099662DD392D1004881E1 /* ZoomSiteListView.swift */,
 				2140995E2DCBEC2B004881E1 /* PageZoomSettingView.swift */,
+				2122EE542DDCFD8C00D42716 /* PageZoomSettingsViewModel.swift */,
 				214099682DD3B8AD004881E1 /* ZoomLevelCellView.swift */,
 			);
 			path = Zoom;
@@ -17784,6 +17787,7 @@
 				8A3233FC286270CF003E1C33 /* FxBookmarkNode.swift in Sources */,
 				E1CEC2022A28C3F100B177D5 /* LoginDetailCenteredTableViewCell.swift in Sources */,
 				C2D71B972A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift in Sources */,
+				2122EE552DDCFD8C00D42716 /* PageZoomSettingsViewModel.swift in Sources */,
 				8A83B7462A264FA0002FF9AC /* SettingsCoordinator.swift in Sources */,
 				619FE8932CE6595B004F83E2 /* WallpaperMiddleware.swift in Sources */,
 				8A5435562D53CB6800501214 /* JumpBackInAction.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		21112968289480630082C08B /* HomepageMessageCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21112967289480630082C08B /* HomepageMessageCardViewModel.swift */; };
 		211F00AC27F4D918001D9189 /* HistoryPanel+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211F00AB27F4D918001D9189 /* HistoryPanel+Search.swift */; };
 		2122EE552DDCFD8C00D42716 /* PageZoomSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2122EE542DDCFD8C00D42716 /* PageZoomSettingsViewModel.swift */; };
+		2122EE572DDD75D600D42716 /* GenericButtonCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2122EE562DDD75D600D42716 /* GenericButtonCellView.swift */; };
 		2128E27B292E624400FB91BE /* SendToDeviceActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2128E27A292E624400FB91BE /* SendToDeviceActivity.swift */; };
 		2128E27C2930216F00FB91BE /* SendToDeviceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AFBAF8292EA0330065E35E /* SendToDeviceHelper.swift */; };
 		2128E27E2934F78600FB91BE /* CustomAppActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2128E27D2934F78600FB91BE /* CustomAppActivity.swift */; };
@@ -2762,6 +2763,7 @@
 		21112967289480630082C08B /* HomepageMessageCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageMessageCardViewModel.swift; sourceTree = "<group>"; };
 		211F00AB27F4D918001D9189 /* HistoryPanel+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HistoryPanel+Search.swift"; sourceTree = "<group>"; };
 		2122EE542DDCFD8C00D42716 /* PageZoomSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageZoomSettingsViewModel.swift; sourceTree = "<group>"; };
+		2122EE562DDD75D600D42716 /* GenericButtonCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericButtonCellView.swift; sourceTree = "<group>"; };
 		2128E27A292E624400FB91BE /* SendToDeviceActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendToDeviceActivity.swift; sourceTree = "<group>"; };
 		2128E27D2934F78600FB91BE /* CustomAppActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAppActivity.swift; sourceTree = "<group>"; };
 		212985E32A6F078800546684 /* ScreenState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenState.swift; sourceTree = "<group>"; };
@@ -10974,6 +10976,7 @@
 		214099632DCE665F004881E1 /* Generic views */ = {
 			isa = PBXGroup;
 			children = (
+				2122EE562DDD75D600D42716 /* GenericButtonCellView.swift */,
 				2109726F2DCBA4CF001162A2 /* GenericItemCellView.swift */,
 				214099612DCE579D004881E1 /* GenericSectionHeaderView.swift */,
 				BA1237BB2DAE607B00BB6333 /* GenericSectionView.swift */,
@@ -18108,6 +18111,7 @@
 				E4C358551AF144BA00299F7E /* FSReadingList.m in Sources */,
 				E17798A22BD804D300F6F0EB /* AddressToolbarContainerModel.swift in Sources */,
 				8AE1E1CB27B18F560024C45E /* SearchBarSettingsViewController.swift in Sources */,
+				2122EE572DDD75D600D42716 /* GenericButtonCellView.swift in Sources */,
 				8A454D3F2CB9B8A0009436D9 /* TopSitesSectionState.swift in Sources */,
 				8AD40FC527BADC1F00672675 /* TabToolbarHelper.swift in Sources */,
 				9609F4CA26B57CE800F81493 /* Calendar+Extension.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -156,7 +156,6 @@ final class SettingsCoordinator: BaseCoordinator,
         case .theme:
             if themeManager.isNewAppearanceMenuOn {
                 let appearanceView = AppearanceSettingsView(windowUUID: windowUUID,
-                                                            shouldShowPageZoom: true,
                                                             delegate: self)
                 return UIHostingController(rootView: appearanceView)
             } else {
@@ -412,7 +411,6 @@ final class SettingsCoordinator: BaseCoordinator,
 
         if themeManager.isNewAppearanceMenuOn {
             let appearanceView = AppearanceSettingsView(windowUUID: windowUUID,
-                                                        shouldShowPageZoom: true,
                                                         delegate: self)
             let viewController = UIHostingController(rootView: appearanceView)
             viewController.title = .SettingsAppearanceTitle

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -16,6 +16,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case bookmarksRefactor
     case bottomSearchBar
     case deeplinkOptimizationRefactor
+    case defaultZoomFeature
     case downloadLiveActivities
     case feltPrivacyFeltDeletion
     case feltPrivacySimplifiedUI
@@ -123,6 +124,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .addressBarMenu,
                 .bookmarksRefactor,
                 .deeplinkOptimizationRefactor,
+                .defaultZoomFeature,
                 .downloadLiveActivities,
                 .feltPrivacyFeltDeletion,
                 .feltPrivacySimplifiedUI,

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomLevel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomLevel.swift
@@ -13,7 +13,9 @@ enum ZoomLevel: CGFloat, CaseIterable, Identifiable {
     case oneHundredTwentyFivePercent = 1.25
     case oneHundredFiftyPercent = 1.5
     case oneHundredSeventyFivePercent = 1.75
-    case twoHundred = 2.0
+    case twoHundredPercent = 2.0
+    case twoHundredFiftyPercent = 2.5
+    case threeHundredPercent = 3.0
 
     var displayName: String {
          let text = NumberFormatter.localizedString(
@@ -34,7 +36,9 @@ enum ZoomLevel: CGFloat, CaseIterable, Identifiable {
         case .oneHundredTwentyFivePercent: return 125
         case .oneHundredFiftyPercent: return 150
         case .oneHundredSeventyFivePercent: return 175
-        case .twoHundred: return 200
+        case .twoHundredPercent: return 200
+        case .twoHundredFiftyPercent: return 250
+        case .threeHundredPercent: return 300
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -7,8 +7,8 @@ import Storage
 
 struct ZoomConstants {
     static let defaultZoomLimit: CGFloat = 1.0
-    static let lowerZoomLimit: CGFloat = 0.5
-    static let upperZoomLimit: CGFloat = 2.0
+    static let lowerZoomLimit: CGFloat = ZoomLevel.fiftyPercent.rawValue
+    static let upperZoomLimit: CGFloat = ZoomLevel.threeHundredPercent.rawValue
 }
 
 class ZoomPageManager: TabEventHandler {

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -114,7 +114,7 @@ class ZoomPageManager: TabEventHandler {
     ///   - zoomLevel: The zoom level value to save
     private func saveZoomLevel(for host: String, zoomLevel: CGFloat) {
         let domainZoomLevel = DomainZoomLevel(host: host, zoomLevel: zoomLevel)
-        zoomStore.saveDomainZoom(domainZoomLevel)
+        zoomStore.saveDomainZoom(domainZoomLevel, completion: nil)
 
         // Notify other windows of zoom change (other pages with identical host should also update)
         let userInfo: [AnyHashable: Any] = [WindowUUID.userInfoKey: windowUUID, "zoom": domainZoomLevel]

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -92,7 +92,7 @@ class ZoomPageManager: TabEventHandler {
     ///   - zoomLevel: The zoom level value to save
     private func saveZoomLevel(for host: String, zoomLevel: CGFloat) {
         let domainZoomLevel = DomainZoomLevel(host: host, zoomLevel: zoomLevel)
-        zoomStore.save(domainZoomLevel, completion: nil)
+        zoomStore.saveDomainZoom(domainZoomLevel)
 
         // Notify other windows of zoom change (other pages with identical host should also update)
         let userInfo: [AnyHashable: Any] = [WindowUUID.userInfoKey: windowUUID, "zoom": domainZoomLevel]

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -20,7 +20,7 @@ class ZoomPageManager: TabEventHandler {
 
     // TODO: Implement feature flag properly
     var defaultZoomIsEnabled: Bool {
-        return false
+        return true
     }
 
     var defaultZoomLevel: CGFloat {
@@ -95,6 +95,8 @@ class ZoomPageManager: TabEventHandler {
         return host
     }
 
+    // MARK: - Store level
+
     func saveDefaultZoomLevel(defaultZoom: CGFloat) {
         zoomStore.saveDefaultZoomLevel(defaultZoom: defaultZoom)
     }
@@ -102,8 +104,6 @@ class ZoomPageManager: TabEventHandler {
     func getDomainLevel() -> [DomainZoomLevel] {
         return zoomStore.getDomainZoomLevel()
     }
-
-    // MARK: - Store level
 
     /// Saves the zoom level for a given host and notifies other windows of the change
     /// - Parameters:
@@ -128,6 +128,14 @@ class ZoomPageManager: TabEventHandler {
         }
 
         return domainZoomLevel.zoomLevel
+    }
+
+    func deleteZoomLevel(for host: String) {
+        zoomStore.deleteZoomLevel(for: host)
+    }
+
+    func resetDomainZoomLevel() {
+        zoomStore.resetDomainZoomLevel()
     }
 
     // MARK: - TabEventHandler

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -102,7 +102,10 @@ class ZoomPageManager: TabEventHandler {
     }
 
     func getDomainLevel() -> [DomainZoomLevel] {
-        return zoomStore.getDomainZoomLevel()
+        let domainZoomLevels = zoomStore.getDomainZoomLevel()
+
+        // Filter current default zoom level from the list
+        return domainZoomLevels.filter { $0.zoomLevel != defaultZoomLevel }
     }
 
     /// Saves the zoom level for a given host and notifies other windows of the change

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -18,6 +18,7 @@ class ZoomPageManager: TabEventHandler {
     let zoomStore: ZoomLevelStorage
     var tab: Tab?
 
+    // TODO: Implement feature flag properly
     var defaultZoomIsEnabled: Bool {
         return false
     }
@@ -92,6 +93,14 @@ class ZoomPageManager: TabEventHandler {
               tab.readerModeAvailableOrActive,
               let host = tab.url?.decodeReaderModeURL?.host else { return nil }
         return host
+    }
+
+    func saveDefaultZoomLevel(defaultZoom: CGFloat) {
+        zoomStore.saveDefaultZoomLevel(defaultZoom: defaultZoom)
+    }
+
+    func getDomainLevel() -> [DomainZoomLevel] {
+        return zoomStore.getDomainZoomLevel()
     }
 
     // MARK: - Store level

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -11,16 +11,15 @@ struct ZoomConstants {
     static let upperZoomLimit: CGFloat = ZoomLevel.threeHundredPercent.rawValue
 }
 
-class ZoomPageManager: TabEventHandler {
+class ZoomPageManager: TabEventHandler, FeatureFlaggable {
     var tabEventWindowResponseType: TabEventHandlerWindowResponseType { return .singleWindow(windowUUID) }
 
     let windowUUID: WindowUUID
     let zoomStore: ZoomLevelStorage
     var tab: Tab?
 
-    // TODO: Implement feature flag properly
     var defaultZoomIsEnabled: Bool {
-        return true
+        return featureFlags.isFeatureEnabled(.defaultZoomFeature, checking: .buildOnly)
     }
 
     var defaultZoomLevel: CGFloat {

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -18,6 +18,16 @@ class ZoomPageManager: TabEventHandler {
     let zoomStore: ZoomLevelStorage
     var tab: Tab?
 
+    var defaultZoomIsEnabled: Bool {
+        return false
+    }
+
+    var defaultZoomLevel: CGFloat {
+        guard defaultZoomIsEnabled else { return ZoomConstants.defaultZoomLimit }
+
+        return zoomStore.getDefaultZoom()
+    }
+
     init(windowUUID: WindowUUID,
          zoomStore: ZoomLevelStorage = ZoomLevelStore.shared) {
         self.windowUUID = windowUUID
@@ -26,14 +36,14 @@ class ZoomPageManager: TabEventHandler {
     }
 
     func getZoomLevel() -> CGFloat {
-        guard let tab else { return ZoomConstants.defaultZoomLimit}
+        guard let tab else { return defaultZoomLevel}
 
         return getZoomLevel(for: tab.url?.host)
     }
 
     func zoomIn() -> CGFloat {
         guard let tab = tab,
-              let host = tab.url?.host else { return ZoomConstants.defaultZoomLimit}
+              let host = tab.url?.host else { return defaultZoomLevel}
 
         let newZoom = ZoomLevel.getNewZoomInLevel(for: tab.pageZoom)
         tab.pageZoom = newZoom
@@ -43,7 +53,7 @@ class ZoomPageManager: TabEventHandler {
 
     func zoomOut() -> CGFloat {
         guard let tab = tab,
-              let host = tab.url?.host else { return ZoomConstants.defaultZoomLimit}
+              let host = tab.url?.host else { return defaultZoomLevel}
 
         let newZoom = ZoomLevel.getNewZoomOutLevel(for: tab.pageZoom)
         tab.pageZoom = newZoom
@@ -105,7 +115,7 @@ class ZoomPageManager: TabEventHandler {
     private func getZoomLevel(for host: String?) -> CGFloat {
         guard let host = host,
               let domainZoomLevel = zoomStore.findZoomLevel(forDomain: host) else {
-            return ZoomConstants.defaultZoomLimit
+            return defaultZoomLevel
         }
 
         return domainZoomLevel.zoomLevel

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -105,7 +105,8 @@ class ZoomPageManager: TabEventHandler {
         let domainZoomLevels = zoomStore.getDomainZoomLevel()
 
         // Filter current default zoom level from the list
-        return domainZoomLevels.filter { $0.zoomLevel != defaultZoomLevel }
+        let filterList = domainZoomLevels.filter { $0.zoomLevel != defaultZoomLevel }
+        return filterList
     }
 
     /// Saves the zoom level for a given host and notifies other windows of the change

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
@@ -13,7 +13,9 @@ protocol AppearanceSettingsDelegate: AnyObject {
 /// The main view displaying the settings for the appearance menu.
 struct AppearanceSettingsView: View {
     let windowUUID: WindowUUID
-    var shouldShowPageZoom: Bool
+    var shouldShowPageZoom: Bool {
+        return ZoomPageManager(windowUUID: windowUUID).defaultZoomIsEnabled
+    }
     let delegate: AppearanceSettingsDelegate?
 
     @Environment(\.themeManager)

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
@@ -44,32 +44,33 @@ struct AppearanceSettingsView: View, FeatureFlaggable {
     }
 
     var body: some View {
-        VStack {
-            // Section for selecting the browser theme.
-            GenericSectionView(theme: currentTheme, title: String.BrowserThemeSectionHeader) {
-                ThemeSelectionView(theme: currentTheme,
-                                   selectedThemeOption: themeOption,
-                                   onThemeSelected: updateBrowserTheme)
-            }
-            // Section for toggling website appearance (e.g., dark mode).
-            GenericSectionView(theme: currentTheme,
-                               title: String.WebsiteAppearanceSectionHeader,
-                               description: String.WebsiteDarkModeDescription) {
-                DarkModeToggleView(theme: currentTheme,
-                                   isEnabled: NightModeHelper.isActivated(),
-                                   onChange: setWebsiteDarkMode)
-            }
-            if shouldShowPageZoom {
-                GenericSectionView(theme: currentTheme, title: .Settings.Appearance.PageZoom.SectionHeader) {
-                    GenericItemCellView(title: .Settings.Appearance.PageZoom.PageZoomTitle,
-                                        image: .chevronRightLarge,
-                                        theme: currentTheme) {
-                        delegate?.pressedPageZoom()
+        ScrollView {
+            VStack {
+                // Section for selecting the browser theme.
+                GenericSectionView(theme: currentTheme, title: String.BrowserThemeSectionHeader) {
+                    ThemeSelectionView(theme: currentTheme,
+                                       selectedThemeOption: themeOption,
+                                       onThemeSelected: updateBrowserTheme)
+                }
+                // Section for toggling website appearance (e.g., dark mode).
+                GenericSectionView(theme: currentTheme,
+                                   title: String.WebsiteAppearanceSectionHeader,
+                                   description: String.WebsiteDarkModeDescription) {
+                    DarkModeToggleView(theme: currentTheme,
+                                       isEnabled: NightModeHelper.isActivated(),
+                                       onChange: setWebsiteDarkMode)
+                }
+                if shouldShowPageZoom {
+                    GenericSectionView(theme: currentTheme, title: .Settings.Appearance.PageZoom.SectionHeader) {
+                        GenericItemCellView(title: .Settings.Appearance.PageZoom.PageZoomTitle,
+                                            image: .chevronRightLarge,
+                                            theme: currentTheme) {
+                            delegate?.pressedPageZoom()
+                        }
                     }
                 }
+                Spacer()
             }
-
-            Spacer()
         }
         .padding(.top, UX.spacing)
         .frame(maxWidth: .infinity)

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
@@ -11,17 +11,18 @@ protocol AppearanceSettingsDelegate: AnyObject {
 }
 
 /// The main view displaying the settings for the appearance menu.
-struct AppearanceSettingsView: View {
+struct AppearanceSettingsView: View, FeatureFlaggable {
     let windowUUID: WindowUUID
-    var shouldShowPageZoom: Bool {
-        return ZoomPageManager(windowUUID: windowUUID).defaultZoomIsEnabled
-    }
     let delegate: AppearanceSettingsDelegate?
 
     @Environment(\.themeManager)
     var themeManager
 
     @State private var currentTheme: Theme?
+
+    var shouldShowPageZoom: Bool {
+        return featureFlags.isFeatureEnabled(.defaultZoomFeature, checking: .buildOnly)
+    }
 
     /// Compute the theme option to display in the ThemeSelectionView.
     /// - Returns: .automatic if system theme or automatic brightness is enabled;

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericButtonCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericButtonCellView.swift
@@ -31,6 +31,7 @@ struct GenericButtonCellView: View {
             }) {
                 Text(title)
                     .foregroundColor(theme.colors.textCritical.color)
+                    .font(.callout)
             }
             .background(theme.colors.layer5.color)
             .padding([.top, .bottom], UX.buttonPadding)

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericButtonCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericButtonCellView.swift
@@ -32,12 +32,12 @@ struct GenericButtonCellView: View {
                 Text(title)
                     .foregroundColor(theme.colors.textCritical.color)
             }
-            .background(theme.colors.layer1.color)
+            .background(theme.colors.layer5.color)
             .padding([.top, .bottom], UX.buttonPadding)
 
             Divider()
                 .frame(height: UX.dividerHeight)
         }
-        .background(theme.colors.layer1.color)
+        .background(theme.colors.layer5.color)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericButtonCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericButtonCellView.swift
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+import Common
+
+struct GenericButtonCellView: View {
+    private let theme: Theme
+    private let title: String
+    private let onTap: () -> Void
+
+    private struct UX {
+        static let dividerHeight: CGFloat = 0.7
+        static var buttonPadding: CGFloat { 4 }
+    }
+
+    init(theme: Theme, title: String, onTap: @escaping () -> Void) {
+        self.theme = theme
+        self.title = title
+        self.onTap = onTap
+    }
+
+    var body: some View {
+        VStack {
+            Divider()
+                .frame(height: UX.dividerHeight)
+
+            Button(action: {
+                onTap()
+            }) {
+                Text(title)
+                    .foregroundColor(theme.colors.textCritical.color)
+            }
+            .background(theme.colors.layer1.color)
+            .padding([.top, .bottom], UX.buttonPadding)
+
+            Divider()
+                .frame(height: UX.dividerHeight)
+        }
+        .background(theme.colors.layer1.color)
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericButtonCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericButtonCellView.swift
@@ -12,7 +12,7 @@ struct GenericButtonCellView: View {
 
     private struct UX {
         static let dividerHeight: CGFloat = 0.7
-        static var buttonPadding: CGFloat { 4 }
+        static var buttonPadding: CGFloat = 4
     }
 
     init(theme: Theme, title: String, onTap: @escaping () -> Void) {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericItemCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericItemCellView.swift
@@ -54,7 +54,6 @@ struct GenericItemCellView: View {
         .accessibilityLabel(title)
         .accessibilityAddTraits(.isButton)
         .onTapGesture {
-            print("YRD on gesture is working")
             onTap()
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
@@ -39,29 +39,35 @@ struct PageZoomSettingsView: View {
     }
 
     var body: some View {
-        VStack {
-            List {
-                // Default level picker
-                ZoomLevelPickerView(theme: theme, zoomManager: viewModel.zoomManager)
-                    .listRowInsets(EdgeInsets())
+        ScrollView {
+            VStack(spacing: 0) {
+                // Default zoom level section
+                VStack {
+                    // Header
+                    GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.DefaultSectionHeader.uppercased(),
+                                             sectionTitleColor: theme.colors.textSecondary.color)
+                        .padding([.leading, .trailing, .top], UX.sectionPadding)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(viewBackground)
+
+                    // Picker
+                    ZoomLevelPickerView(theme: theme, zoomManager: viewModel.zoomManager)
+                        .background(theme.colors.layer5.color)
+                }
 
                 if !viewModel.domainZoomLevels.isEmpty {
-                    // Specific site zoom levels
-                    ZoomSiteListView(theme: theme,
-                                     domainZoomLevels: $viewModel.domainZoomLevels,
-                                     onDelete: viewModel.deleteZoomLevel)
-                        .listRowInsets(EdgeInsets())
-
-                    // Reset Zoom
-                    GenericButtonCellView(theme: theme,
-                                          title: String.Settings.Appearance.PageZoom.ResetButtonTitle,
-                                          onTap: viewModel.resetDomainZoomLevel)
-                        .listRowInsets(EdgeInsets())
+                    // Specific site zoom level section
+                    VStack {
+                        ZoomSiteListView(theme: theme,
+                                         domainZoomLevels: $viewModel.domainZoomLevels,
+                                         onDelete: viewModel.deleteZoomLevel,
+                                         resetDomain: viewModel.resetDomainZoomLevel)
+                    }
                 }
             }
-            .background(viewBackground)
-            .listStyle(.inset)
+            .frame(maxWidth: .infinity)
         }
+        .background(viewBackground)
         .onAppear {
             themeColors = themeManager.getCurrentTheme(for: windowUUID).colors
         }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
@@ -4,35 +4,10 @@
 
 import Common
 import SwiftUI
-import Storage
-
-class PageZoomSettingsViewModel: ObservableObject {
-    private let zoomManager: ZoomPageManager
-    @Published var domainZoomLevels: [DomainZoomLevel]
-
-    init(zoomManager: ZoomPageManager) {
-        self.zoomManager = zoomManager
-        self.domainZoomLevels = zoomManager.getDomainLevel()
-    }
-
-    func resetDomainZoomLevel() {
-        domainZoomLevels.removeAll()
-        zoomManager.resetDomainZoomLevel()
-    }
-
-    func deleteZoomLevel(at indexSet: IndexSet) {
-        guard let index = indexSet.first else { return }
-
-        let deleteItem = domainZoomLevels[index]
-        zoomManager.deleteZoomLevel(for: deleteItem.host)
-        domainZoomLevels.remove(at: index)
-    }
-}
 
 struct PageZoomSettingsView: View {
     private let windowUUID: WindowUUID
     @ObservedObject var viewModel: PageZoomSettingsViewModel
-    private let zoomManager: ZoomPageManager
     @Environment(\.themeManager)
     var themeManager
     @State private var themeColors: ThemeColourPalette = LightTheme().colors
@@ -40,6 +15,7 @@ struct PageZoomSettingsView: View {
     private struct UX {
         static var dividerHeight: CGFloat { 0.7 }
         static var buttonPadding: CGFloat { 4 }
+        static var sectionPadding: CGFloat { 16 }
     }
 
     private var viewBackground: Color {
@@ -54,14 +30,9 @@ struct PageZoomSettingsView: View {
         return themeColors.textPrimary.color
     }
 
-    var descriptionTextColor: Color {
-        return themeColors.textSecondary.color
-    }
-
     init(windowUUID: WindowUUID) {
         self.windowUUID = windowUUID
-        self.zoomManager = ZoomPageManager(windowUUID: windowUUID)
-        self.viewModel = PageZoomSettingsViewModel(zoomManager: zoomManager)
+        self.viewModel = PageZoomSettingsViewModel(zoomManager: ZoomPageManager(windowUUID: windowUUID))
     }
 
     var theme: Theme {
@@ -72,50 +43,20 @@ struct PageZoomSettingsView: View {
         VStack {
             List {
                 // Default level picker
-                Section {
-                    ZoomLevelPickerView(theme: theme, zoomManager: zoomManager)
-                        .background(themeColors.layer1.color)
-                } header: {
-                    GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.DefaultSectionHeader.uppercased(),
-                                             sectionTitleColor: sectionTitleColor)
-                }
+                ZoomLevelPickerView(theme: theme, zoomManager: viewModel.zoomManager)
+                    .background(viewBackground)
 
                 // Specific site zoom levels
-                Section {
-                    ZoomSiteListView(theme: theme,
-                                     domainZoomLevels: $viewModel.domainZoomLevels,
-                                     onDelete: viewModel.deleteZoomLevel)
-                        .background(themeColors.layer1.color)
-                } header: {
-                    GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.SpecificSiteSectionHeader.uppercased(),
-                                             sectionTitleColor: sectionTitleColor)
-                } footer: {
-                    Text(String.Settings.Appearance.PageZoom.SpecificSiteFooterTitle)
-                        .background(themeColors.layer1.color)
-                        .font(.caption)
-                        .foregroundColor(descriptionTextColor)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+                ZoomSiteListView(theme: theme,
+                                 domainZoomLevels: $viewModel.domainZoomLevels,
+                                 onDelete: viewModel.deleteZoomLevel)
+
+                // Reset Zoom
+                resetButton(String.Settings.Appearance.PageZoom.ResetButtonTitle)
             }
+            .background(viewBackground)
             .listStyle(.plain)
-            .listRowBackground(theme.colors.layer2.color)
-
-            VStack {
-                Divider().frame(height: UX.dividerHeight)
-
-                Button(action: {
-                    viewModel.resetDomainZoomLevel()
-                }) {
-                    Text(String.Settings.Appearance.PageZoom.ResetButtonTitle)
-                        .foregroundColor(theme.colors.textCritical.color)
-                }
-                .padding([.top, .bottom], UX.buttonPadding)
-
-                Divider().frame(height: UX.dividerHeight)
-            }
         }
-        .background(themeColors.layer1.color)
-        .frame(maxWidth: .infinity)
         .onAppear {
             themeColors = themeManager.getCurrentTheme(for: windowUUID).colors
         }
@@ -123,5 +64,25 @@ struct PageZoomSettingsView: View {
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             themeColors = themeManager.getCurrentTheme(for: windowUUID).colors
         }
+    }
+
+    private func resetButton(_ title: String) -> some View {
+        VStack {
+            Divider()
+                .frame(height: UX.dividerHeight)
+
+            Button(action: {
+                viewModel.resetDomainZoomLevel()
+            }) {
+                Text(title)
+                    .foregroundColor(theme.colors.textCritical.color)
+            }
+            .background(themeColors.layer1.color)
+            .padding([.top, .bottom], UX.buttonPadding)
+
+            Divider()
+                .frame(height: UX.dividerHeight)
+        }
+        .background(viewBackground)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
@@ -14,7 +14,6 @@ struct PageZoomSettingsView: View {
 
     private struct UX {
         static var dividerHeight: CGFloat { 0.7 }
-        static var buttonPadding: CGFloat { 4 }
         static var sectionPadding: CGFloat { 16 }
     }
 
@@ -44,16 +43,19 @@ struct PageZoomSettingsView: View {
             List {
                 // Default level picker
                 ZoomLevelPickerView(theme: theme, zoomManager: viewModel.zoomManager)
-                    .background(viewBackground)
+                    .listRowInsets(EdgeInsets())
 
                 if !viewModel.domainZoomLevels.isEmpty {
                     // Specific site zoom levels
                     ZoomSiteListView(theme: theme,
                                      domainZoomLevels: $viewModel.domainZoomLevels,
                                      onDelete: viewModel.deleteZoomLevel)
+                        .listRowInsets(EdgeInsets())
 
                     // Reset Zoom
-                    resetButton(String.Settings.Appearance.PageZoom.ResetButtonTitle)
+                    GenericButtonCellView(theme: theme,
+                                          title: String.Settings.Appearance.PageZoom.ResetButtonTitle,
+                                          onTap: viewModel.resetDomainZoomLevel)
                 }
             }
             .background(viewBackground)
@@ -66,25 +68,5 @@ struct PageZoomSettingsView: View {
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             themeColors = themeManager.getCurrentTheme(for: windowUUID).colors
         }
-    }
-
-    private func resetButton(_ title: String) -> some View {
-        VStack {
-            Divider()
-                .frame(height: UX.dividerHeight)
-
-            Button(action: {
-                viewModel.resetDomainZoomLevel()
-            }) {
-                Text(title)
-                    .foregroundColor(theme.colors.textCritical.color)
-            }
-            .background(themeColors.layer1.color)
-            .padding([.top, .bottom], UX.buttonPadding)
-
-            Divider()
-                .frame(height: UX.dividerHeight)
-        }
-        .background(viewBackground)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
@@ -56,6 +56,7 @@ struct PageZoomSettingsView: View {
                     GenericButtonCellView(theme: theme,
                                           title: String.Settings.Appearance.PageZoom.ResetButtonTitle,
                                           onTap: viewModel.resetDomainZoomLevel)
+                        .listRowInsets(EdgeInsets())
                 }
             }
             .background(viewBackground)

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
@@ -40,29 +40,17 @@ struct PageZoomSettingsView: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 0) {
+            VStack {
                 // Default zoom level section
-                VStack {
-                    // Header
-                    GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.DefaultSectionHeader.uppercased(),
-                                             sectionTitleColor: theme.colors.textSecondary.color)
-                        .padding([.leading, .trailing, .top], UX.sectionPadding)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(viewBackground)
+                ZoomLevelPickerView(theme: theme, zoomManager: viewModel.zoomManager)
+                    .background(theme.colors.layer5.color)
 
-                    // Picker
-                    ZoomLevelPickerView(theme: theme, zoomManager: viewModel.zoomManager)
-                        .background(theme.colors.layer5.color)
-                }
-
+                // Specific site zoom level section
                 if !viewModel.domainZoomLevels.isEmpty {
-                    // Specific site zoom level section
-                    VStack {
-                        ZoomSiteListView(theme: theme,
-                                         domainZoomLevels: $viewModel.domainZoomLevels,
-                                         onDelete: viewModel.deleteZoomLevel,
-                                         resetDomain: viewModel.resetDomainZoomLevel)
-                    }
+                    ZoomSiteListView(theme: theme,
+                                     domainZoomLevels: $viewModel.domainZoomLevels,
+                                     onDelete: viewModel.deleteZoomLevel,
+                                     resetDomain: viewModel.resetDomainZoomLevel)
                 }
             }
             .frame(maxWidth: .infinity)

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
@@ -60,7 +60,7 @@ struct PageZoomSettingsView: View {
                 }
             }
             .background(viewBackground)
-            .listStyle(.plain)
+            .listStyle(.inset)
         }
         .onAppear {
             themeColors = themeManager.getCurrentTheme(for: windowUUID).colors

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
@@ -6,7 +6,12 @@ import SwiftUI
 import Common
 
 struct PageZoomSettingsView: View {
-    let windowUUID: WindowUUID
+    private let windowUUID: WindowUUID
+    private let zoomManager: ZoomPageManager
+    @Environment(\.themeManager)
+    var themeManager
+    @State private var themeColors: ThemeColourPalette = LightTheme().colors
+
     private struct UX {
         static var dividerHeight: CGFloat { 0.7 }
         static var buttonPadding: CGFloat { 4 }
@@ -28,9 +33,10 @@ struct PageZoomSettingsView: View {
         return themeColors.textSecondary.color
     }
 
-    @Environment(\.themeManager)
-    var themeManager
-    @State private var themeColors: ThemeColourPalette = LightTheme().colors
+    init(windowUUID: WindowUUID) {
+        self.windowUUID = windowUUID
+        self.zoomManager = ZoomPageManager(windowUUID: windowUUID)
+    }
 
     var theme: Theme {
         return themeManager.getCurrentTheme(for: windowUUID)
@@ -41,7 +47,7 @@ struct PageZoomSettingsView: View {
             List {
                 // Default level picker
                 Section {
-                    ZoomLevelPickerView(theme: theme)
+                    ZoomLevelPickerView(theme: theme, zoomManager: zoomManager)
                         .background(themeColors.layer1.color)
                 } header: {
                     GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.DefaultSectionHeader.uppercased(),
@@ -50,7 +56,7 @@ struct PageZoomSettingsView: View {
 
                 // Specific site zoom levels
                 Section {
-                    ZoomSiteListView(theme: theme)
+                    ZoomSiteListView(theme: theme, zoomManager: zoomManager)
                         .background(themeColors.layer1.color)
                 } header: {
                     GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.SpecificSiteSectionHeader.uppercased(),

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
@@ -21,11 +21,6 @@ class PageZoomSettingsViewModel: ObservableObject {
     }
 
     func deleteZoomLevel(at indexSet: IndexSet) {
-//        for index in offsets {
-//            let item = domainZoomLevels[index]
-//            zoomManager.deleteZoomLevel(for: item.domain) // Your DB/file logic
-//        }
-//        domainZoomLevels.remove(atOffsets: offsets)
         guard let index = indexSet.first else { return }
 
         let deleteItem = domainZoomLevels[index]

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
@@ -46,13 +46,15 @@ struct PageZoomSettingsView: View {
                 ZoomLevelPickerView(theme: theme, zoomManager: viewModel.zoomManager)
                     .background(viewBackground)
 
-                // Specific site zoom levels
-                ZoomSiteListView(theme: theme,
-                                 domainZoomLevels: $viewModel.domainZoomLevels,
-                                 onDelete: viewModel.deleteZoomLevel)
+                if !viewModel.domainZoomLevels.isEmpty {
+                    // Specific site zoom levels
+                    ZoomSiteListView(theme: theme,
+                                     domainZoomLevels: $viewModel.domainZoomLevels,
+                                     onDelete: viewModel.deleteZoomLevel)
 
-                // Reset Zoom
-                resetButton(String.Settings.Appearance.PageZoom.ResetButtonTitle)
+                    // Reset Zoom
+                    resetButton(String.Settings.Appearance.PageZoom.ResetButtonTitle)
+                }
             }
             .background(viewBackground)
             .listStyle(.plain)

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
@@ -13,8 +13,8 @@ struct PageZoomSettingsView: View {
     @State private var themeColors: ThemeColourPalette = LightTheme().colors
 
     private struct UX {
-        static var dividerHeight: CGFloat { 0.7 }
-        static var sectionPadding: CGFloat { 16 }
+        static var dividerHeight: CGFloat = 0.7
+        static var sectionPadding: CGFloat = 16
     }
 
     private var viewBackground: Color {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingsViewModel.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Storage
+
+class PageZoomSettingsViewModel: ObservableObject {
+    let zoomManager: ZoomPageManager
+    @Published var domainZoomLevels: [DomainZoomLevel]
+
+    init(zoomManager: ZoomPageManager) {
+        self.zoomManager = zoomManager
+        self.domainZoomLevels = zoomManager.getDomainLevel()
+    }
+
+    func resetDomainZoomLevel() {
+        domainZoomLevels.removeAll()
+        zoomManager.resetDomainZoomLevel()
+    }
+
+    func deleteZoomLevel(at indexSet: IndexSet) {
+        guard let index = indexSet.first else { return }
+
+        let deleteItem = domainZoomLevels[index]
+        zoomManager.deleteZoomLevel(for: deleteItem.host)
+        domainZoomLevels.remove(at: index)
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
@@ -7,22 +7,16 @@ import SwiftUI
 import Storage
 
 struct ZoomLevelCellView: View {
-    private let theme: Theme
     private let domainZoomLevel: DomainZoomLevel
+    private let textColor: Color
 
     private struct UX {
-        static var dividerHeight: CGFloat { 0.7 }
-        static var buttonPadding: CGFloat { 4 }
         static var textPadding: CGFloat { 10 }
     }
 
-    var textColor: Color {
-        return theme.colors.textPrimary.color
-    }
-
-    init(theme: Theme, domainZoomLevel: DomainZoomLevel) {
-        self.theme = theme
+    init(domainZoomLevel: DomainZoomLevel, textColor: Color) {
         self.domainZoomLevel = domainZoomLevel
+        self.textColor = textColor
     }
 
     var body: some View {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
@@ -32,5 +32,8 @@ struct ZoomLevelCellView: View {
                 .font(.body)
                 .foregroundColor(textColor)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(UX.textPadding)
+        .listRowBackground(Color.clear)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
@@ -11,7 +11,7 @@ struct ZoomLevelCellView: View {
     private let textColor: Color
 
     private struct UX {
-        static var textPadding: CGFloat { 10 }
+        static var textPadding: CGFloat = 10
     }
 
     init(domainZoomLevel: DomainZoomLevel, textColor: Color) {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
@@ -11,7 +11,7 @@ struct ZoomLevelCellView: View {
     private let textColor: Color
 
     private struct UX {
-        static var textPadding: CGFloat = 10
+        static var textPadding: CGFloat = 16
     }
 
     init(domainZoomLevel: DomainZoomLevel, textColor: Color) {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -54,7 +54,6 @@ struct ZoomLevelPickerView: View {
         header: {
             GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.DefaultSectionHeader.uppercased(),
                                      sectionTitleColor: theme.colors.textSecondary.color)
-            .background(theme.colors.layer1.color)
             .padding([.leading, .trailing], UX.sectionPadding)
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -12,6 +12,9 @@ struct ZoomLevelPickerView: View {
 
     private struct UX {
         static var sectionPadding: CGFloat = 16
+        static var verticalPadding: CGFloat = 12
+        static var dividerHeight: CGFloat = 0.7
+        static var pickerLabelSpacing: CGFloat = 4
     }
 
     private var sectionBackground: Color {
@@ -34,7 +37,7 @@ struct ZoomLevelPickerView: View {
     }
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.DefaultSectionHeader.uppercased(),
                                      sectionTitleColor: theme.colors.textSecondary.color)
                 .padding([.leading, .trailing, .top], UX.sectionPadding)
@@ -46,42 +49,55 @@ struct ZoomLevelPickerView: View {
     }
 
     var defaultZoomPicker: some View {
-        HStack {
-            Text(pickerText)
-                .font(.body)
-                .foregroundColor(theme.colors.textPrimary.color)
+        VStack(spacing: 0) {
+            // Top divider
+            Divider()
+                .frame(height: UX.dividerHeight)
+                .background(theme.colors.borderPrimary.color)
 
-            Spacer()
+            // Picker content
+            HStack {
+                Text(pickerText)
+                    .font(.body)
+                    .foregroundColor(theme.colors.textPrimary.color)
 
-            // Right side - picker with current value
-            Menu {
-                Picker(selection: $selectedZoomLevel, label: EmptyView()) {
-                    ForEach(ZoomLevel.allCases, id: \.self) { item in
-                        Text(item.displayName)
-                            .tag(item)
+                Spacer()
+
+                // Right side - picker with current value
+                Menu {
+                    Picker(selection: $selectedZoomLevel, label: EmptyView()) {
+                        ForEach(ZoomLevel.allCases, id: \.self) { item in
+                            Text(item.displayName)
+                                .tag(item)
+                        }
+                    }
+                    .onChange(of: selectedZoomLevel) { newValue in
+                        zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
+                    }
+                    .pickerStyle(.inline)
+                    .labelsHidden()
+                } label: {
+                    HStack(spacing: UX.pickerLabelSpacing) {
+                        Text(selectedZoomLevel.displayName)
+                            .font(.body)
+                            .foregroundColor(theme.colors.textPrimary.color)
+
+                        Image(StandardImageIdentifiers.Large.chevronDown)
+                            .renderingMode(.template)
+                            .font(.caption)
+                            .foregroundColor(theme.colors.textPrimary.color)
+                            .accessibilityHidden(true)
                     }
                 }
-                .onChange(of: selectedZoomLevel) { newValue in
-                    zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
-                }
-                .pickerStyle(.inline)
-                .labelsHidden()
-            } label: {
-                HStack(spacing: 4) {
-                    Text(selectedZoomLevel.displayName)
-                        .font(.body)
-                        .foregroundColor(theme.colors.textPrimary.color)
-
-                    Image(StandardImageIdentifiers.Large.chevronDown)
-                        .renderingMode(.template)
-                        .font(.caption)
-                        .foregroundColor(theme.colors.textPrimary.color)
-                        .accessibilityHidden(true)
-                }
             }
+            .padding(.horizontal, UX.sectionPadding)
+            .padding(.vertical, UX.verticalPadding)
+
+            // Bottom divider
+            Divider()
+                .frame(height: UX.dividerHeight)
+                .background(theme.colors.borderPrimary.color)
         }
-        .padding(.horizontal, UX.sectionPadding)
-        .padding(.vertical, 12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(backgroundColor)
     }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import SwiftUI
 import Common
+import SwiftUI
+import Storage
 
 struct ZoomLevelPickerView: View {
-    @State private var defaultZoom = "100%"
+    @State private var selectedZoomLevel: ZoomLevel
     private let theme: Theme
 
     var textColor: Color {
@@ -19,19 +20,26 @@ struct ZoomLevelPickerView: View {
 
     init(theme: Theme) {
         self.theme = theme
+        let currentZoom = ZoomLevel(from: ZoomLevelStore.shared.getDefaultZoom())
+        _selectedZoomLevel = State(initialValue: currentZoom)
     }
 
     var body: some View {
         List {
-            Picker(pickerText, selection: $defaultZoom) {
-                ForEach(ZoomLevel.allCases, id: \.displayName) { item in
+            Picker(pickerText, selection: $selectedZoomLevel) {
+                ForEach(ZoomLevel.allCases, id: \.self) { item in
                     Text(item.displayName)
                         .font(.body)
                         .foregroundColor(textColor)
+                        .tag(item)
                 }
             }
             .accentColor(textColor)
             .pickerStyle(.menu)
+            .onChange(of: selectedZoomLevel) { newValue in
+                print("YRD --- New selected zoom level: \(newValue)")
+                ZoomLevelStore.shared.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
+            }
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -10,16 +10,12 @@ struct ZoomLevelPickerView: View {
     private let theme: Theme
     private let zoomManager: ZoomPageManager
 
-    var textColor: Color {
-        return theme.colors.textPrimary.color
+    private struct UX {
+        static var sectionPadding: CGFloat { 16 }
     }
 
     var backgroundColor: Color {
-        return .white // theme.colors.layer1.color
-    }
-
-    var sectionTitleColor: Color {
-        return theme.colors.textSecondary.color
+        return theme.colors.layer5.color
     }
 
     var pickerText: String {
@@ -42,23 +38,24 @@ struct ZoomLevelPickerView: View {
                     ForEach(ZoomLevel.allCases, id: \.self) { item in
                         Text(item.displayName)
                             .font(.body)
-                            .foregroundColor(textColor)
+                            .foregroundColor(theme.colors.textSecondary.color)
                             .tag(item)
                     }
                 }
-                .frame(maxWidth: .infinity)
-                .accentColor(textColor)
+                .accentColor(theme.colors.textPrimary.color)
                 .pickerStyle(.menu)
                 .onChange(of: selectedZoomLevel) { newValue in
                     zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
                 }
+                .padding([.leading, .trailing], UX.sectionPadding)
                 .background(backgroundColor)
-                .listRowInsets(EdgeInsets())
             }
         }
         header: {
             GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.DefaultSectionHeader.uppercased(),
-                                     sectionTitleColor: sectionTitleColor)
+                                     sectionTitleColor: theme.colors.textSecondary.color)
+            .background(theme.colors.layer1.color)
+            .padding([.leading, .trailing], UX.sectionPadding)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -14,6 +14,14 @@ struct ZoomLevelPickerView: View {
         return theme.colors.textPrimary.color
     }
 
+    var backgroundColor: Color {
+        return theme.colors.layer1.color
+    }
+
+    var sectionTitleColor: Color {
+        return theme.colors.textSecondary.color
+    }
+
     var pickerText: String {
         return .Settings.Appearance.PageZoom.ZoomLevelSelectorTitle
     }
@@ -26,7 +34,7 @@ struct ZoomLevelPickerView: View {
     }
 
     var body: some View {
-        List {
+        Section {
             Picker(pickerText, selection: $selectedZoomLevel) {
                 ForEach(ZoomLevel.allCases, id: \.self) { item in
                     Text(item.displayName)
@@ -35,11 +43,17 @@ struct ZoomLevelPickerView: View {
                         .tag(item)
                 }
             }
+            .frame(maxWidth: .infinity)
+            .background(backgroundColor)
             .accentColor(textColor)
             .pickerStyle(.menu)
             .onChange(of: selectedZoomLevel) { newValue in
                 zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
             }
+        }
+        header: {
+            GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.DefaultSectionHeader.uppercased(),
+                                     sectionTitleColor: sectionTitleColor)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -30,31 +30,46 @@ struct ZoomLevelPickerView: View {
     }
 
     var body: some View {
-        Section {
-            ZStack {
-                backgroundColor
+        HStack {
+            // Left side - text label
+            Text(pickerText)
+                .font(.body)
+                .foregroundColor(theme.colors.textPrimary.color)
 
-                Picker(pickerText, selection: $selectedZoomLevel) {
+            Spacer()
+
+            // Right side - picker with current value
+            Menu {
+                Picker(selection: $selectedZoomLevel, label: EmptyView()) {
                     ForEach(ZoomLevel.allCases, id: \.self) { item in
                         Text(item.displayName)
-                            .font(.body)
-                            .foregroundColor(theme.colors.textSecondary.color)
                             .tag(item)
                     }
                 }
-                .accentColor(theme.colors.textPrimary.color)
-                .pickerStyle(.menu)
                 .onChange(of: selectedZoomLevel) { newValue in
                     zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
                 }
-                .padding([.leading, .trailing], UX.sectionPadding)
-                .background(backgroundColor)
+                .pickerStyle(.inline)
+                .labelsHidden()
+            } label: {
+                HStack(spacing: 4) {
+                    Text(selectedZoomLevel.displayName)
+                        .font(.body)
+                        .foregroundColor(theme.colors.textPrimary.color)
+
+                    Image(StandardImageIdentifiers.Large.chevronDown)
+                        .renderingMode(.template)
+                        .font(.caption)
+                        .foregroundColor(theme.colors.textPrimary.color)
+                        .accessibilityElement()
+                        // TODO: Add label
+                        .accessibilityLabel("Show options")
+                }
             }
         }
-        header: {
-            GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.DefaultSectionHeader.uppercased(),
-                                     sectionTitleColor: theme.colors.textSecondary.color)
-            .padding([.leading, .trailing], UX.sectionPadding)
-        }
+        .padding(.horizontal, UX.sectionPadding)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(backgroundColor)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -4,11 +4,11 @@
 
 import Common
 import SwiftUI
-import Storage
 
 struct ZoomLevelPickerView: View {
     @State private var selectedZoomLevel: ZoomLevel
     private let theme: Theme
+    private let zoomManager: ZoomPageManager
 
     var textColor: Color {
         return theme.colors.textPrimary.color
@@ -18,9 +18,10 @@ struct ZoomLevelPickerView: View {
         return .Settings.Appearance.PageZoom.ZoomLevelSelectorTitle
     }
 
-    init(theme: Theme) {
+    init(theme: Theme, zoomManager: ZoomPageManager) {
         self.theme = theme
-        let currentZoom = ZoomLevel(from: ZoomLevelStore.shared.getDefaultZoom())
+        self.zoomManager = zoomManager
+        let currentZoom = ZoomLevel(from: zoomManager.defaultZoomLevel)
         _selectedZoomLevel = State(initialValue: currentZoom)
     }
 
@@ -37,8 +38,7 @@ struct ZoomLevelPickerView: View {
             .accentColor(textColor)
             .pickerStyle(.menu)
             .onChange(of: selectedZoomLevel) { newValue in
-                print("YRD --- New selected zoom level: \(newValue)")
-                ZoomLevelStore.shared.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
+                zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -14,6 +14,10 @@ struct ZoomLevelPickerView: View {
         static var sectionPadding: CGFloat = 16
     }
 
+    private var sectionBackground: Color {
+        return theme.colors.layer1.color
+    }
+
     var backgroundColor: Color {
         return theme.colors.layer5.color
     }
@@ -30,8 +34,19 @@ struct ZoomLevelPickerView: View {
     }
 
     var body: some View {
+        VStack {
+            GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.DefaultSectionHeader.uppercased(),
+                                     sectionTitleColor: theme.colors.textSecondary.color)
+                .padding([.leading, .trailing, .top], UX.sectionPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(sectionBackground)
+
+            defaultZoomPicker
+        }
+    }
+
+    var defaultZoomPicker: some View {
         HStack {
-            // Left side - text label
             Text(pickerText)
                 .font(.body)
                 .foregroundColor(theme.colors.textPrimary.color)
@@ -61,9 +76,7 @@ struct ZoomLevelPickerView: View {
                         .renderingMode(.template)
                         .font(.caption)
                         .foregroundColor(theme.colors.textPrimary.color)
-                        .accessibilityElement()
-                        // TODO: Add label
-                        .accessibilityLabel("Show options")
+                        .accessibilityHidden(true)
                 }
             }
         }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -15,7 +15,7 @@ struct ZoomLevelPickerView: View {
     }
 
     var backgroundColor: Color {
-        return theme.colors.layer1.color
+        return .white // theme.colors.layer1.color
     }
 
     var sectionTitleColor: Color {
@@ -35,20 +35,25 @@ struct ZoomLevelPickerView: View {
 
     var body: some View {
         Section {
-            Picker(pickerText, selection: $selectedZoomLevel) {
-                ForEach(ZoomLevel.allCases, id: \.self) { item in
-                    Text(item.displayName)
-                        .font(.body)
-                        .foregroundColor(textColor)
-                        .tag(item)
+            ZStack {
+                backgroundColor
+
+                Picker(pickerText, selection: $selectedZoomLevel) {
+                    ForEach(ZoomLevel.allCases, id: \.self) { item in
+                        Text(item.displayName)
+                            .font(.body)
+                            .foregroundColor(textColor)
+                            .tag(item)
+                    }
                 }
-            }
-            .frame(maxWidth: .infinity)
-            .background(backgroundColor)
-            .accentColor(textColor)
-            .pickerStyle(.menu)
-            .onChange(of: selectedZoomLevel) { newValue in
-                zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
+                .frame(maxWidth: .infinity)
+                .accentColor(textColor)
+                .pickerStyle(.menu)
+                .onChange(of: selectedZoomLevel) { newValue in
+                    zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
+                }
+                .background(backgroundColor)
+                .listRowInsets(EdgeInsets())
             }
         }
         header: {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -11,7 +11,7 @@ struct ZoomLevelPickerView: View {
     private let zoomManager: ZoomPageManager
 
     private struct UX {
-        static var sectionPadding: CGFloat { 16 }
+        static var sectionPadding: CGFloat = 16
     }
 
     var backgroundColor: Color {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -45,12 +45,13 @@ struct ZoomSiteListView: View {
             }
             .onDelete(perform: onDelete)
             .background(cellBackground)
+
+            // Footer as a final row
+            footerView()
         } header: {
             GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.SpecificSiteSectionHeader.uppercased(),
                                      sectionTitleColor: theme.colors.textSecondary.color)
                 .padding([.leading, .trailing], UX.sectionPadding)
-        } footer: {
-            footerView()
         }
     }
 
@@ -61,8 +62,11 @@ struct ZoomSiteListView: View {
             Text(String.Settings.Appearance.PageZoom.SpecificSiteFooterTitle)
                 .font(.caption)
                 .foregroundColor(theme.colors.textSecondary.color)
-                .padding([.top], UX.footerTopPadding)
-                .padding([.bottom], UX.footerBottomPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(EdgeInsets(top: UX.footerTopPadding,
+                                    leading: UX.sectionPadding,
+                                    bottom: UX.footerBottomPadding,
+                                    trailing: UX.sectionPadding))
         }
         .background(sectionBackground)
     }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -12,9 +12,9 @@ struct ZoomSiteListView: View {
     let onDelete: (IndexSet) -> Void
 
     private struct UX {
-        static var sectionPadding: CGFloat { 16 }
-        static var footerBottomPadding: CGFloat { 40 }
-        static var footerTopPadding: CGFloat { 8 }
+        static var sectionPadding: CGFloat = 16
+        static var footerBottomPadding: CGFloat = 40
+        static var footerTopPadding: CGFloat = 8
     }
 
     var cellBackground: Color {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -11,8 +11,23 @@ struct ZoomSiteListView: View {
     @Binding var domainZoomLevels: [DomainZoomLevel]
     let onDelete: (IndexSet) -> Void
 
+    private struct UX {
+        static var sectionPadding: CGFloat { 16 }
+    }
+
     var textColor: Color {
         return theme.colors.textPrimary.color
+    }
+    var cellBackground: Color {
+        return theme.colors.layer2.color
+    }
+
+    var sectionTitleColor: Color {
+        return theme.colors.textSecondary.color
+    }
+
+    var footerTextColor: Color {
+        return theme.colors.textSecondary.color
     }
 
     init(theme: Theme,
@@ -24,9 +39,28 @@ struct ZoomSiteListView: View {
     }
 
     var body: some View {
-        ForEach(domainZoomLevels, id: \.host) { zoomItem in
-            ZoomLevelCellView(theme: theme, domainZoomLevel: zoomItem)
+        Section {
+            ForEach(domainZoomLevels, id: \.host) { zoomItem in
+                ZoomLevelCellView(domainZoomLevel: zoomItem, textColor: textColor)
+            }
+            .onDelete(perform: onDelete)
+            .background(cellBackground)
+        } header: {
+            GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.SpecificSiteSectionHeader.uppercased(),
+                                     sectionTitleColor: sectionTitleColor)
+        } footer: {
+            footerView()
         }
-        .onDelete(perform: onDelete)
+    }
+
+    private func footerView() -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String.Settings.Appearance.PageZoom.SpecificSiteFooterTitle)
+                .font(.caption)
+                .padding([.leading, .trailing], UX.sectionPadding)
+                .foregroundColor(footerTextColor)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .listRowInsets(EdgeInsets())
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -36,9 +36,12 @@ struct ZoomSiteListView: View {
     var body: some View {
         Section {
             ForEach(domainZoomLevels, id: \.host) { zoomItem in
-                ZoomLevelCellView(domainZoomLevel: zoomItem,
-                                  textColor: theme.colors.textPrimary.color)
-                .padding([.leading, .trailing], UX.sectionPadding)
+                ZStack {
+                    cellBackground
+                    ZoomLevelCellView(domainZoomLevel: zoomItem,
+                                      textColor: theme.colors.textPrimary.color)
+                    .padding([.leading, .trailing], UX.sectionPadding)
+                }
             }
             .onDelete(perform: onDelete)
             .background(cellBackground)

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -17,7 +17,7 @@ struct ZoomSiteListView: View {
     init(theme: Theme,
          zoomStore: ZoomLevelStorage = ZoomLevelStore.shared) {
         self.theme = theme
-        zoomLevels = zoomStore.loadAll()
+        zoomLevels = zoomStore.getDomainZoomLevel()
     }
 
     var body: some View {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -15,9 +15,9 @@ struct ZoomSiteListView: View {
     }
 
     init(theme: Theme,
-         zoomStore: ZoomLevelStorage = ZoomLevelStore.shared) {
+         zoomManager: ZoomPageManager) {
         self.theme = theme
-        zoomLevels = zoomStore.getDomainZoomLevel()
+        zoomLevels = zoomManager.getDomainLevel()
     }
 
     var body: some View {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -16,7 +16,8 @@ struct ZoomSiteListView: View {
         static var sectionPadding: CGFloat = 16
         static var footerBottomPadding: CGFloat = 40
         static var footerTopPadding: CGFloat = 8
-        static var cellHeight = 44
+        static var cellHeight: CGFloat = 50
+        static var listPadding: CGFloat = 5
     }
 
     var cellBackground: Color {
@@ -25,6 +26,15 @@ struct ZoomSiteListView: View {
 
     var sectionBackground: Color {
         return theme.colors.layer1.color
+    }
+
+    // Calculate list height to avoid scroll in inner list view
+    // Base height calculation with cell height and extra padding
+    var listViewHeight: CGFloat {
+        let baseHeight = CGFloat(domainZoomLevels.count) * UX.cellHeight
+        let extraPadding = CGFloat(domainZoomLevels.count) * UX.listPadding
+
+        return baseHeight + extraPadding
     }
 
     init(theme: Theme,
@@ -56,7 +66,7 @@ struct ZoomSiteListView: View {
                 }
                 .onDelete(perform: onDelete)
             }
-            .frame(height: CGFloat(domainZoomLevels.count * UX.cellHeight))
+            .frame(height: listViewHeight)
             .listStyle(.plain)
             .background(cellBackground)
 

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -8,26 +8,25 @@ import Storage
 
 struct ZoomSiteListView: View {
     let theme: Theme
-    let zoomLevels: [DomainZoomLevel]
+    @Binding var domainZoomLevels: [DomainZoomLevel]
+    let onDelete: (IndexSet) -> Void
 
     var textColor: Color {
         return theme.colors.textPrimary.color
     }
 
     init(theme: Theme,
-         zoomManager: ZoomPageManager) {
+         domainZoomLevels: Binding<[DomainZoomLevel]>,
+         onDelete: @escaping (IndexSet) -> Void) {
         self.theme = theme
-        zoomLevels = zoomManager.getDomainLevel()
+        self._domainZoomLevels = domainZoomLevels
+        self.onDelete = onDelete
     }
 
     var body: some View {
-        ForEach(zoomLevels, id: \.host) { zoomItem in
+        ForEach(domainZoomLevels, id: \.host) { zoomItem in
             ZoomLevelCellView(theme: theme, domainZoomLevel: zoomItem)
         }
-        .onDelete(perform: delete)
-    }
-
-    func delete(at index: IndexSet) {
-        // TODO: Integration task delete item from the list and save
+        .onDelete(perform: onDelete)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -13,21 +13,16 @@ struct ZoomSiteListView: View {
 
     private struct UX {
         static var sectionPadding: CGFloat { 16 }
+        static var footerBottomPadding: CGFloat { 40 }
+        static var footerTopPadding: CGFloat { 8 }
     }
 
-    var textColor: Color {
-        return theme.colors.textPrimary.color
-    }
     var cellBackground: Color {
-        return theme.colors.layer2.color
+        return theme.colors.layer5.color
     }
 
-    var sectionTitleColor: Color {
-        return theme.colors.textSecondary.color
-    }
-
-    var footerTextColor: Color {
-        return theme.colors.textSecondary.color
+    var sectionBackground: Color {
+        return theme.colors.layer1.color
     }
 
     init(theme: Theme,
@@ -40,27 +35,36 @@ struct ZoomSiteListView: View {
 
     var body: some View {
         Section {
-            ForEach(domainZoomLevels, id: \.host) { zoomItem in
-                ZoomLevelCellView(domainZoomLevel: zoomItem, textColor: textColor)
+            ZStack {
+                cellBackground
+                ForEach(domainZoomLevels, id: \.host) { zoomItem in
+                    ZoomLevelCellView(domainZoomLevel: zoomItem,
+                                      textColor: theme.colors.textPrimary.color)
+                }
+                .onDelete(perform: onDelete)
+                .background(cellBackground)
             }
-            .onDelete(perform: onDelete)
+            .padding([.leading, .trailing], UX.sectionPadding)
             .background(cellBackground)
         } header: {
             GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.SpecificSiteSectionHeader.uppercased(),
-                                     sectionTitleColor: sectionTitleColor)
+                                     sectionTitleColor: theme.colors.textSecondary.color)
+                .padding([.leading, .trailing], UX.sectionPadding)
         } footer: {
             footerView()
         }
     }
 
     private func footerView() -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+        ZStack {
+            sectionBackground
+
             Text(String.Settings.Appearance.PageZoom.SpecificSiteFooterTitle)
                 .font(.caption)
-                .padding([.leading, .trailing], UX.sectionPadding)
-                .foregroundColor(footerTextColor)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .foregroundColor(theme.colors.textSecondary.color)
+                .padding([.top], UX.footerTopPadding)
+                .padding([.bottom], UX.footerBottomPadding)
         }
-        .listRowInsets(EdgeInsets())
+        .background(sectionBackground)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -10,6 +10,7 @@ struct ZoomSiteListView: View {
     let theme: Theme
     @Binding var domainZoomLevels: [DomainZoomLevel]
     let onDelete: (IndexSet) -> Void
+    let resetDomain: () -> Void
 
     private struct UX {
         static var sectionPadding: CGFloat = 16
@@ -27,47 +28,43 @@ struct ZoomSiteListView: View {
 
     init(theme: Theme,
          domainZoomLevels: Binding<[DomainZoomLevel]>,
-         onDelete: @escaping (IndexSet) -> Void) {
+         onDelete: @escaping (IndexSet) -> Void,
+         resetDomain: @escaping () -> Void) {
         self.theme = theme
         self._domainZoomLevels = domainZoomLevels
         self.onDelete = onDelete
+        self.resetDomain = resetDomain
     }
 
     var body: some View {
-        Section {
-            ForEach(domainZoomLevels, id: \.host) { zoomItem in
-                ZStack {
-                    cellBackground
-                    ZoomLevelCellView(domainZoomLevel: zoomItem,
-                                      textColor: theme.colors.textPrimary.color)
-                    .padding([.leading, .trailing], UX.sectionPadding)
-                }
-            }
-            .onDelete(perform: onDelete)
-            .background(cellBackground)
-
-            // Footer as a final row
-            footerView()
-        } header: {
+        VStack {
+            // Header
             GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.SpecificSiteSectionHeader.uppercased(),
                                      sectionTitleColor: theme.colors.textSecondary.color)
-                .padding([.leading, .trailing], UX.sectionPadding)
-        }
-    }
+                .padding([.leading, .trailing, .top], UX.sectionPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(sectionBackground)
 
-    private func footerView() -> some View {
-        ZStack {
-            sectionBackground
+            // Domain cells
+            ForEach(domainZoomLevels, id: \.host) { zoomItem in
+                ZoomLevelCellView(domainZoomLevel: zoomItem,
+                                  textColor: theme.colors.textPrimary.color)
+                    .background(theme.colors.layer5.color)
+            }
+            .onDelete(perform: onDelete)
 
+            // Footer
             Text(String.Settings.Appearance.PageZoom.SpecificSiteFooterTitle)
                 .font(.caption)
                 .foregroundColor(theme.colors.textSecondary.color)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(EdgeInsets(top: UX.footerTopPadding,
-                                    leading: UX.sectionPadding,
-                                    bottom: UX.footerBottomPadding,
-                                    trailing: UX.sectionPadding))
+                .padding(EdgeInsets(top: 8, leading: UX.sectionPadding, bottom: 40, trailing: UX.sectionPadding))
+                .background(sectionBackground)
+            // Reset button
+            GenericButtonCellView(theme: theme,
+                                  title: String.Settings.Appearance.PageZoom.ResetButtonTitle,
+                                  onTap: resetDomain)
+                .background(theme.colors.layer5.color)
         }
-        .background(sectionBackground)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -35,16 +35,12 @@ struct ZoomSiteListView: View {
 
     var body: some View {
         Section {
-            ZStack {
-                cellBackground
-                ForEach(domainZoomLevels, id: \.host) { zoomItem in
-                    ZoomLevelCellView(domainZoomLevel: zoomItem,
-                                      textColor: theme.colors.textPrimary.color)
-                }
-                .onDelete(perform: onDelete)
-                .background(cellBackground)
+            ForEach(domainZoomLevels, id: \.host) { zoomItem in
+                ZoomLevelCellView(domainZoomLevel: zoomItem,
+                                  textColor: theme.colors.textPrimary.color)
+                .padding([.leading, .trailing], UX.sectionPadding)
             }
-            .padding([.leading, .trailing], UX.sectionPadding)
+            .onDelete(perform: onDelete)
             .background(cellBackground)
         } header: {
             GenericSectionHeaderView(title: .Settings.Appearance.PageZoom.SpecificSiteSectionHeader.uppercased(),

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -16,6 +16,7 @@ struct ZoomSiteListView: View {
         static var sectionPadding: CGFloat = 16
         static var footerBottomPadding: CGFloat = 40
         static var footerTopPadding: CGFloat = 8
+        static var cellHeight = 44
     }
 
     var cellBackground: Color {
@@ -45,21 +46,31 @@ struct ZoomSiteListView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(sectionBackground)
 
-            // Domain cells
-            ForEach(domainZoomLevels, id: \.host) { zoomItem in
-                ZoomLevelCellView(domainZoomLevel: zoomItem,
-                                  textColor: theme.colors.textPrimary.color)
-                    .background(theme.colors.layer5.color)
+            List {
+                ForEach(domainZoomLevels, id: \.host) { zoomItem in
+                    ZoomLevelCellView(domainZoomLevel: zoomItem,
+                                      textColor: theme.colors.textPrimary.color)
+                        .background(theme.colors.layer5.color)
+                        .listRowBackground(cellBackground)
+                        .listRowInsets(EdgeInsets())
+                }
+                .onDelete(perform: onDelete)
             }
-            .onDelete(perform: onDelete)
+            .frame(height: CGFloat(domainZoomLevels.count * UX.cellHeight))
+            .listStyle(.plain)
+            .background(cellBackground)
 
             // Footer
             Text(String.Settings.Appearance.PageZoom.SpecificSiteFooterTitle)
                 .font(.caption)
                 .foregroundColor(theme.colors.textSecondary.color)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(EdgeInsets(top: 8, leading: UX.sectionPadding, bottom: 40, trailing: UX.sectionPadding))
+                .padding(EdgeInsets(top: UX.footerTopPadding,
+                                    leading: UX.sectionPadding,
+                                    bottom: UX.footerBottomPadding,
+                                    trailing: UX.sectionPadding))
                 .background(sectionBackground)
+
             // Reset button
             GenericButtonCellView(theme: theme,
                                   title: String.Settings.Appearance.PageZoom.ResetButtonTitle,

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -29,6 +29,9 @@ final class NimbusFeatureFlagLayer {
         case .deeplinkOptimizationRefactor:
             return checkDeeplinkOptimizationRefactorFeature(from: nimbus)
 
+        case .defaultZoomFeature:
+            return checkDefaultZoomFeature(from: nimbus)
+
         case .downloadLiveActivities:
             return checkDownloadLiveActivitiesFeature(from: nimbus)
 
@@ -331,6 +334,10 @@ final class NimbusFeatureFlagLayer {
     private func checkDeeplinkOptimizationRefactorFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.deeplinkOptimizationRefactorFeature.value()
         return config.enabled
+    }
+
+    private func checkDefaultZoomFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.defaultZoomFeature.value().enabled
     }
 
     private func checkDownloadLiveActivitiesFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2149,7 +2149,7 @@ extension String {
                 public static let ResetButtonTitle = MZLocalizedString(
                     key: "Settings.Appearance.Zoom.Reset.Button.v140",
                     tableName: "Settings",
-                    value: "Reset site Settings",
+                    value: "Reset Site Settings",
                     comment: "Button to reset specific zoom site levels back to default")
             }
         }

--- a/firefox-ios/Storage/ZoomLevelStore.swift
+++ b/firefox-ios/Storage/ZoomLevelStore.swift
@@ -22,7 +22,7 @@ public struct DomainZoomLevel: Codable, Equatable {
 
 public protocol ZoomLevelStorage {
     func saveDefaultZoomLevel(defaultZoom: CGFloat)
-    func saveDomainZoom(_ domainZoomLevel: DomainZoomLevel)
+    func saveDomainZoom(_ domainZoomLevel: DomainZoomLevel, completion: (() -> Void)?)
     func findZoomLevel(forDomain host: String) -> DomainZoomLevel?
     func getDefaultZoom() -> CGFloat
     func getDomainZoomLevel() -> [DomainZoomLevel]
@@ -57,7 +57,7 @@ public class ZoomLevelStore: ZoomLevelStorage {
         save()
     }
 
-    public func saveDomainZoom(_ domainZoomLevel: DomainZoomLevel) {
+    public func saveDomainZoom(_ domainZoomLevel: DomainZoomLevel, completion: (() -> Void)? = nil) {
         if let index = zoomSetting.zoomLevels.firstIndex(where: {
             $0.host == domainZoomLevel.host
         }) {
@@ -66,10 +66,10 @@ public class ZoomLevelStore: ZoomLevelStorage {
         if domainZoomLevel.zoomLevel != ZoomLevelStore.defaultZoomLimit {
             zoomSetting.zoomLevels.append(domainZoomLevel)
         }
-        save()
+        save(completion)
     }
 
-    private func save(completion: (() -> Void)? = nil) {
+    private func save(_ completion: (() -> Void)? = nil) {
         concurrentQueue.async(flags: .barrier) { [unowned self] in
             let encoder = JSONEncoder()
             do {

--- a/firefox-ios/Storage/ZoomLevelStore.swift
+++ b/firefox-ios/Storage/ZoomLevelStore.swift
@@ -93,7 +93,7 @@ public class ZoomLevelStore: ZoomLevelStorage {
     }
 
     public func deleteZoomLevel(for host: String) {
-        guard let index = zoomSetting.zoomLevels.firstIndex(where: { return $0.host == host}) else { return }
+        guard let index = zoomSetting.zoomLevels.firstIndex(where: { return $0.host == host }) else { return }
 
         zoomSetting.zoomLevels.remove(at: index)
         save()

--- a/firefox-ios/Storage/ZoomLevelStore.swift
+++ b/firefox-ios/Storage/ZoomLevelStore.swift
@@ -56,20 +56,18 @@ public class ZoomLevelStore: ZoomLevelStorage {
     }
 
     public func saveDomainZoom(_ domainZoomLevel: DomainZoomLevel) {
-        var domainZoomLevels = zoomSetting.zoomLevels
-
-        if let index = domainZoomLevels.firstIndex(where: {
+        if let index = zoomSetting.zoomLevels.firstIndex(where: {
             $0.host == domainZoomLevel.host
         }) {
-            domainZoomLevels.remove(at: index)
+            zoomSetting.zoomLevels.remove(at: index)
         }
         if domainZoomLevel.zoomLevel != ZoomLevelStore.defaultZoomLimit {
-            domainZoomLevels.append(domainZoomLevel)
+            zoomSetting.zoomLevels.append(domainZoomLevel)
         }
         save()
     }
 
-    func save(completion: (() -> Void)? = nil) {
+    private func save(completion: (() -> Void)? = nil) {
         concurrentQueue.async(flags: .barrier) { [unowned self] in
             let encoder = JSONEncoder()
             do {

--- a/firefox-ios/Storage/ZoomLevelStore.swift
+++ b/firefox-ios/Storage/ZoomLevelStore.swift
@@ -5,6 +5,11 @@
 import Foundation
 import Common
 
+public struct ZoomSettings: Codable {
+    var defaultZoom: CGFloat
+    var zoomLevels: [DomainZoomLevel]
+}
+
 public struct DomainZoomLevel: Codable, Equatable {
     public let host: String
     public let zoomLevel: CGFloat
@@ -16,18 +21,21 @@ public struct DomainZoomLevel: Codable, Equatable {
 }
 
 public protocol ZoomLevelStorage {
-    func save(_ domainZoomLevel: DomainZoomLevel, completion: (() -> Void)?)
+    func saveDefaultZoomLevel(defaultZoom: CGFloat)
+    func saveDomainZoom(_ domainZoomLevel: DomainZoomLevel)
     func findZoomLevel(forDomain host: String) -> DomainZoomLevel?
-    func loadAll() -> [DomainZoomLevel]
+    func getDefaultZoom() -> CGFloat
+    func getDomainZoomLevel() -> [DomainZoomLevel]
 }
 
 public class ZoomLevelStore: ZoomLevelStorage {
     public static let shared = ZoomLevelStore()
 
-    private(set) var domainZoomLevels = [DomainZoomLevel]()
+    private(set) var zoomSetting = ZoomSettings(defaultZoom: ZoomLevelStore.defaultZoomLimit,
+                                                zoomLevels: [DomainZoomLevel]())
     private var logger: Logger
-
     private static let fileName = "domain-zoom-levels"
+    static let defaultZoomLimit: CGFloat = 1.0
 
     private let concurrentQueue = DispatchQueue(
         label: "org.mozilla.ios.Fennec.zoomLevelStoreQueue",
@@ -39,22 +47,33 @@ public class ZoomLevelStore: ZoomLevelStorage {
 
     private init(logger: Logger = DefaultLogger.shared) {
         self.logger = logger
-        domainZoomLevels = loadAll()
+        zoomSetting = self.loadZoomSettings()
     }
 
-    public func save(_ domainZoomLevel: DomainZoomLevel, completion: (() -> Void)? = nil) {
+    public func saveDefaultZoomLevel(defaultZoom: CGFloat) {
+        zoomSetting.defaultZoom = defaultZoom
+        save()
+    }
+
+    public func saveDomainZoom(_ domainZoomLevel: DomainZoomLevel) {
+        var domainZoomLevels = zoomSetting.zoomLevels
+
+        if let index = domainZoomLevels.firstIndex(where: {
+            $0.host == domainZoomLevel.host
+        }) {
+            domainZoomLevels.remove(at: index)
+        }
+        if domainZoomLevel.zoomLevel != ZoomLevelStore.defaultZoomLimit {
+            domainZoomLevels.append(domainZoomLevel)
+        }
+        save()
+    }
+
+    func save(completion: (() -> Void)? = nil) {
         concurrentQueue.async(flags: .barrier) { [unowned self] in
-            if let index = domainZoomLevels.firstIndex(where: {
-                $0.host == domainZoomLevel.host
-            }) {
-                domainZoomLevels.remove(at: index)
-            }
-            if domainZoomLevel.zoomLevel != 1.0 {
-                domainZoomLevels.append(domainZoomLevel)
-            }
             let encoder = JSONEncoder()
             do {
-                guard let data = try? encoder.encode(domainZoomLevels) else { return }
+                guard let data = try? encoder.encode(zoomSetting) else { return }
                 try data.write(to: url, options: .atomic)
             } catch {
                 logger.log("Unable to write data to disk: \(error)",
@@ -65,24 +84,42 @@ public class ZoomLevelStore: ZoomLevelStorage {
         }
     }
 
-    public func loadAll() -> [DomainZoomLevel] {
-        var domainZoomLevels = [DomainZoomLevel]()
+    public func getDomainZoomLevel() -> [DomainZoomLevel] {
+        return zoomSetting.zoomLevels
+    }
+
+    public func getDefaultZoom() -> CGFloat {
+        return zoomSetting.defaultZoom
+    }
+
+    private func loadZoomSettings() -> ZoomSettings {
         let decoder = JSONDecoder()
+
         do {
+            // Try to decode new Zoom format including default zoom (new) and existing `DomainZoomLevel` array
             let data = try Data(contentsOf: url)
-            domainZoomLevels = try decoder.decode([DomainZoomLevel].self, from: data)
+            let settings = try decoder.decode(ZoomSettings.self, from: data)
+            return settings
         } catch {
-            logger.log("Failed to decode data: \(error)",
-                       level: .debug,
-                       category: .storage)
+            // Fallback to legacy format (just an array of `DomainZoomLevel`)
+            do {
+                let data = try Data(contentsOf: url)
+                let legacyLevels = try decoder.decode([DomainZoomLevel].self, from: data)
+                return ZoomSettings(defaultZoom: ZoomLevelStore.defaultZoomLimit,
+                                    zoomLevels: legacyLevels)
+            } catch {
+                logger.log("Failed to decode data: \(error)",
+                           level: .debug,
+                           category: .storage)
+                return ZoomSettings(defaultZoom: ZoomLevelStore.defaultZoomLimit, zoomLevels: [])
+            }
         }
-        return domainZoomLevels
     }
 
     public func findZoomLevel(forDomain host: String) -> DomainZoomLevel? {
         var zoomLevel: DomainZoomLevel?
         concurrentQueue.sync {
-            zoomLevel = domainZoomLevels.first { $0.host == host }
+            zoomLevel = zoomSetting.zoomLevels.first { $0.host == host }
         }
         return zoomLevel
     }

--- a/firefox-ios/Storage/ZoomLevelStore.swift
+++ b/firefox-ios/Storage/ZoomLevelStore.swift
@@ -26,6 +26,8 @@ public protocol ZoomLevelStorage {
     func findZoomLevel(forDomain host: String) -> DomainZoomLevel?
     func getDefaultZoom() -> CGFloat
     func getDomainZoomLevel() -> [DomainZoomLevel]
+    func deleteZoomLevel(for host: String)
+    func resetDomainZoomLevel()
 }
 
 public class ZoomLevelStore: ZoomLevelStorage {
@@ -88,6 +90,18 @@ public class ZoomLevelStore: ZoomLevelStorage {
 
     public func getDefaultZoom() -> CGFloat {
         return zoomSetting.defaultZoom
+    }
+
+    public func deleteZoomLevel(for host: String) {
+        guard let index = zoomSetting.zoomLevels.firstIndex(where: { return $0.host == host}) else { return }
+
+        zoomSetting.zoomLevels.remove(at: index)
+        save()
+    }
+
+    public func resetDomainZoomLevel() {
+        zoomSetting.zoomLevels.removeAll()
+        save()
     }
 
     private func loadZoomSettings() -> ZoomSettings {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockZoomStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockZoomStore.swift
@@ -5,21 +5,42 @@
 import Storage
 
 final class MockZoomStore: ZoomLevelStorage {
+    var savedDefaultZoom: CGFloat = 1.0
     var store = [DomainZoomLevel]()
     var saveCalledCount = 0
     var findZoomLevelCalledCount = 0
-
-    func save(_ domainZoomLevel: DomainZoomLevel, completion: (() -> Void)?) {
-        saveCalledCount += 1
-        store.append(domainZoomLevel)
-    }
 
     func findZoomLevel(forDomain host: String) -> DomainZoomLevel? {
         findZoomLevelCalledCount += 1
         return store.first { $0.host == host }
     }
 
-    func loadAll() -> [DomainZoomLevel] {
+    func saveDefaultZoomLevel(defaultZoom: CGFloat) {
+        saveCalledCount += 1
+        savedDefaultZoom = defaultZoom
+    }
+
+    func saveDomainZoom(_ domainZoomLevel: Storage.DomainZoomLevel, completion: (() -> Void)?) {
+        saveCalledCount += 1
+        store.append(domainZoomLevel)
+    }
+
+    func getDefaultZoom() -> CGFloat {
+        return savedDefaultZoom
+    }
+
+    func getDomainZoomLevel() -> [Storage.DomainZoomLevel] {
         return [DomainZoomLevel]()
+    }
+
+    func deleteZoomLevel(for host: String) {
+        guard let index = store.firstIndex(where: { return $0.host == host }) else { return }
+
+        store.remove(at: index)
+        saveCalledCount += 1
+    }
+
+    func resetDomainZoomLevel() {
+        store.removeAll()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ZoomPageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ZoomPageManagerTests.swift
@@ -76,7 +76,7 @@ class ZoomPageManagerTests: XCTestCase {
         let subject = createSubject()
         let domainZoomLevel = DomainZoomLevel(host: "www.website.com",
                                               zoomLevel: ZoomConstants.upperZoomLimit)
-        zoomStore.save(domainZoomLevel, completion: nil)
+        zoomStore.saveDomainZoom(domainZoomLevel, completion: nil)
         let tab = createTab()
         subject.tabDidGainFocus(tab)
         let newZoom = subject.zoomIn()
@@ -90,7 +90,7 @@ class ZoomPageManagerTests: XCTestCase {
         let subject = createSubject()
         let domainZoomLevel = DomainZoomLevel(host: "www.website.com",
                                               zoomLevel: ZoomConstants.lowerZoomLimit)
-        zoomStore.save(domainZoomLevel, completion: nil)
+        zoomStore.saveDomainZoom(domainZoomLevel, completion: nil)
         let tab = createTab()
         subject.tabDidGainFocus(tab)
         let newZoom = subject.zoomOut()

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/ZoomLevelStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/ZoomLevelStoreTests.swift
@@ -39,7 +39,7 @@ final class ZoomLevelStoreTests: XCTestCase {
 
     func testSaveAndFindZoomLevel() {
         let domainZoomLevel = DomainZoomLevel(host: testHost1, zoomLevel: testZoomLevel)
-        zoomLevelStore.save(domainZoomLevel)
+        zoomLevelStore.saveDomainZoom(domainZoomLevel)
 
         let retrievedZoomLevel = zoomLevelStore.findZoomLevel(forDomain: testHost1)
         XCTAssertEqual(retrievedZoomLevel, domainZoomLevel)
@@ -48,8 +48,8 @@ final class ZoomLevelStoreTests: XCTestCase {
     func testSaveMultipleZoomLevels() {
         let domainZoomLevel1 = DomainZoomLevel(host: testHost1, zoomLevel: testZoomLevel)
         let domainZoomLevel2 = DomainZoomLevel(host: testHost2, zoomLevel: testZoomLevel)
-        zoomLevelStore.save(domainZoomLevel1)
-        zoomLevelStore.save(domainZoomLevel2)
+        zoomLevelStore.saveDomainZoom(domainZoomLevel1)
+        zoomLevelStore.saveDomainZoom(domainZoomLevel2)
 
         let retrievedZoomLevel1 = zoomLevelStore.findZoomLevel(forDomain: testHost1)
         XCTAssertEqual(retrievedZoomLevel1, domainZoomLevel1)
@@ -61,8 +61,8 @@ final class ZoomLevelStoreTests: XCTestCase {
     func testSaveAndUpdateZoomLevel() {
         let domainZoomLevel1 = DomainZoomLevel(host: testHost1, zoomLevel: testZoomLevel)
         let domainZoomLevel2 = DomainZoomLevel(host: testHost1, zoomLevel: testZoomLevel + 1)
-        zoomLevelStore.save(domainZoomLevel1)
-        zoomLevelStore.save(domainZoomLevel2)
+        zoomLevelStore.saveDomainZoom(domainZoomLevel1)
+        zoomLevelStore.saveDomainZoom(domainZoomLevel2)
 
         let retrievedZoomLevel = zoomLevelStore.findZoomLevel(forDomain: testHost1)
         XCTAssertEqual(retrievedZoomLevel, domainZoomLevel2)
@@ -70,9 +70,9 @@ final class ZoomLevelStoreTests: XCTestCase {
 
     func testSaveNoZoomLevel() {
         let domainZoomLevel = DomainZoomLevel(host: testHost1, zoomLevel: 1.0)
-        zoomLevelStore.save(domainZoomLevel)
+        zoomLevelStore.saveDomainZoom(domainZoomLevel)
 
-        XCTAssertFalse(zoomLevelStore.domainZoomLevels.contains(domainZoomLevel))
+        XCTAssertFalse(zoomLevelStore.getDomainZoomLevel().contains(domainZoomLevel))
     }
 
     func testFindZoomLevelNotFound() {
@@ -86,19 +86,19 @@ final class ZoomLevelStoreTests: XCTestCase {
 
         let domainZoomLevel = DomainZoomLevel(host: testHost3, zoomLevel: 1.5)
         dispatchGroup.enter()
-        zoomLevelStore.save(domainZoomLevel) {
+        zoomLevelStore.saveDomainZoom(domainZoomLevel) {
             dispatchGroup.leave()
         }
 
         let updatedDomainZoomLevel = DomainZoomLevel(host: testHost3, zoomLevel: 2.0)
         dispatchGroup.enter()
-        zoomLevelStore.save(updatedDomainZoomLevel) {
+        zoomLevelStore.saveDomainZoom(updatedDomainZoomLevel) {
             dispatchGroup.leave()
         }
         dispatchGroup.wait()
 
-        XCTAssertTrue(zoomLevelStore.domainZoomLevels.contains(updatedDomainZoomLevel))
-        XCTAssertFalse(zoomLevelStore.domainZoomLevels.contains(domainZoomLevel))
+        XCTAssertTrue(zoomLevelStore.getDomainZoomLevel().contains(updatedDomainZoomLevel))
+        XCTAssertFalse(zoomLevelStore.getDomainZoomLevel().contains(domainZoomLevel))
     }
 
     func testSingletonInstance() {

--- a/firefox-ios/nimbus-features/defaultZoomFeature.yaml
+++ b/firefox-ios/nimbus-features/defaultZoomFeature.yaml
@@ -1,0 +1,19 @@
+# The configuration for the defaultZoomFeature feature
+features:
+  default-zoom-feature:
+    description: >
+        The feature flag to manage the rollout of default zoom feature.
+    variables:
+      enabled:
+        description: >
+          If true, page zoom settings and default zoom feature is shown
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+            enabled: false
+      - channel: developer
+        value:
+            enabled: true
+

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -16,6 +16,7 @@ include:
   - nimbus-features/addressAutofillFeature.yaml
   - nimbus-features/bookmarkRefactorFeature.yaml
   - nimbus-features/deeplinkOptimizationRefactorFeature.yaml
+  - nimbus-features/defaultZoomFeature.yaml
   - nimbus-features/downloadLiveActivitiesFeature.yaml
   - nimbus-features/feltPrivacyFeature.yaml
   - nimbus-features/firefoxSuggestFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6765)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15058)

## :bulb: Description
**Manager and storage:**
    - Add functionality to list all domain zoom level
    - Delete a domain zoom level for a host 
    - Add default zoom to existing model and add migration for existing format

**UI integration:**
- Default zoom can be set in Settings and will be applied to websites that don't have a custom zoom level already
- List of websites with custom zoom level and can be individually deleted
- Reset custom zoom levels (delete all elements)

## :movie_camera: Demos

https://github.com/user-attachments/assets/843a808b-5e54-4548-890b-c0b2e1fb915c

https://github.com/user-attachments/assets/5ad6ced3-99b2-44ca-8286-fd8c9427a3b5


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
