### PR TITLE
Add FXIOS-12303 ⁃ [Menu Redesign] Implement the logic for displaying items in horizontal options section

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuCollectionView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuCollectionView.swift
@@ -78,13 +78,13 @@ final class MenuCollectionView: UIView,
         collectionView.accessibilityLabel = menuA11yLabel
     }
 
-    // TODO: FXIOS-12303 [Menu Redesign] Implement the logic for displaying items in horizontal options section
     // MARK: - UICollectionView Methods
     func collectionView(
         _ collectionView: UICollectionView,
         numberOfItemsInSection section: Int
     ) -> Int {
-        return 10
+        guard let section = menuData.first(where: { $0.isTopTabsSection }) else { return 0 }
+        return section.options.count
     }
 
     func collectionView(
@@ -98,19 +98,17 @@ final class MenuCollectionView: UIView,
             return UICollectionViewCell()
         }
 
-        cell.configureCellWith(model:
-                                MenuElement(
-                                    title: "Title Test",
-                                    iconName: StandardImageIdentifiers.Large.readingList,
-                                    isEnabled: true,
-                                    isActive: false,
-                                    a11yLabel: "A11yLabel",
-                                    a11yHint: "",
-                                    a11yId: "A11yId",
-                                    action: {}
-                                ))
+        guard let section = menuData.first(where: { $0.isTopTabsSection }) else { return UICollectionViewCell() }
+        cell.configureCellWith(model: section.options[indexPath.row])
         if let theme { cell.applyTheme(theme: theme) }
         return cell
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionView.deselectItem(at: indexPath, animated: false)
+        guard let section = menuData.first(where: { $0.isTopTabsSection }),
+              let action = section.options[indexPath.row].action else { return }
+        action()
     }
 
     func reloadCollectionView(with data: [MenuSection]) {

--- a/BrowserKit/Sources/MenuKit/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesignMainView.swift
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+import ComponentLibrary
+
+public final class MenuRedesignMainView: UIView,
+                                 ThemeApplicable {
+    private struct UX {
+        static let headerTopMargin: CGFloat = 15
+    }
+
+    // MARK: - UI Elements
+    private var collectionView: MenuCollectionView = .build()
+    private var tableView: MenuTableView = .build()
+    public var accountHeaderView: HeaderView = .build()
+
+    // MARK: - Initializers
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+        handleUpdateHeaderLineView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI Setup
+    private func setupView() {
+        accountHeaderView.updateHeaderLineView(isHidden: true)
+        self.addSubview(accountHeaderView)
+        self.addSubview(collectionView)
+        self.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            accountHeaderView.topAnchor.constraint(equalTo: self.topAnchor, constant: UX.headerTopMargin),
+            accountHeaderView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            accountHeaderView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+
+            collectionView.topAnchor.constraint(equalTo: accountHeaderView.bottomAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+
+            tableView.topAnchor.constraint(equalTo: collectionView.bottomAnchor),
+            tableView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+        ])
+    }
+
+    public func setupDetails(subtitle: String, title: String, icon: UIImage?) {
+        accountHeaderView.setupDetails(subtitle: subtitle,
+                                       title: title,
+                                       icon: icon)
+    }
+
+    public func setupAccessibilityIdentifiers(closeButtonA11yLabel: String,
+                                              closeButtonA11yId: String,
+                                              mainButtonA11yLabel: String,
+                                              mainButtonA11yId: String,
+                                              menuA11yId: String,
+                                              menuA11yLabel: String) {
+        accountHeaderView.setupAccessibility(closeButtonA11yLabel: closeButtonA11yLabel,
+                                             closeButtonA11yId: closeButtonA11yId,
+                                             mainButtonA11yLabel: mainButtonA11yLabel,
+                                             mainButtonA11yId: mainButtonA11yId)
+        collectionView.setupAccessibilityIdentifiers(menuA11yId: menuA11yId, menuA11yLabel: menuA11yLabel)
+        tableView.setupAccessibilityIdentifiers(menuA11yId: menuA11yId, menuA11yLabel: menuA11yLabel)
+    }
+
+    private func handleUpdateHeaderLineView() {
+        tableView.updateHeaderLineView = { [weak self] isHidden in
+            guard let self else { return }
+            self.accountHeaderView.updateHeaderLineView(isHidden: isHidden)
+        }
+    }
+
+    // MARK: - Interface
+    public func reloadDataView(with data: [MenuSection]) {
+        collectionView.reloadCollectionView(with: data)
+        tableView.reloadTableView(with: data)
+    }
+
+    // MARK: - ThemeApplicable
+    public func applyTheme(theme: Theme) {
+        backgroundColor = .clear
+        collectionView.applyTheme(theme: theme)
+        tableView.applyTheme(theme: theme)
+        accountHeaderView.applyTheme(theme: theme)
+        accountHeaderView.setIconTheme(with: theme)
+    }
+}

--- a/BrowserKit/Sources/MenuKit/MenuSection.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSection.swift
@@ -5,9 +5,11 @@
 import Foundation
 
 public struct MenuSection: Equatable {
+    public let isTopTabsSection: Bool
     public let options: [MenuElement]
 
-    public init(options: [MenuElement]) {
+    public init(isTopTabsSection: Bool = false, options: [MenuElement]) {
+        self.isTopTabsSection = isTopTabsSection
         self.options = options
     }
 }

--- a/BrowserKit/Sources/MenuKit/MenuTableView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuTableView.swift
@@ -19,6 +19,14 @@ final class MenuTableView: UIView,
     private var tableView: UITableView
     private var menuData: [MenuSection]
     private var theme: Theme?
+    private var isRedesignEnabled: Bool {
+        guard let firstSection = menuData.first else {
+            tableView.showsVerticalScrollIndicator = true
+            return false
+        }
+        tableView.showsVerticalScrollIndicator = !firstSection.isTopTabsSection
+        return firstSection.isTopTabsSection
+    }
 
     var updateHeaderLineView: ((_ isHidden: Bool) -> Void)?
 
@@ -75,6 +83,10 @@ final class MenuTableView: UIView,
         _ tableView: UITableView,
         heightForHeaderInSection section: Int
     ) -> CGFloat {
+        if isRedesignEnabled {
+            guard section != 0 else { return 0 }
+            return section == 1 ? UX.topPadding : UX.distanceBetweenSections
+        }
         return section == 0 ? UX.topPadding : UX.distanceBetweenSections
     }
 
@@ -82,6 +94,7 @@ final class MenuTableView: UIView,
         _ tableView: UITableView,
         numberOfRowsInSection section: Int
     ) -> Int {
+        if isRedesignEnabled, section == 0 { return 0 }
         return menuData[section].options.count
     }
 
@@ -96,6 +109,7 @@ final class MenuTableView: UIView,
             return UITableViewCell()
         }
 
+        if isRedesignEnabled, indexPath.section == 0 { return UITableViewCell() }
         cell.configureCellWith(model: menuData[indexPath.section].options[indexPath.row])
         if let theme { cell.applyTheme(theme: theme) }
         return cell
@@ -107,6 +121,7 @@ final class MenuTableView: UIView,
     ) {
         tableView.deselectRow(at: indexPath, animated: false)
 
+        if isRedesignEnabled, indexPath.section == 0 { return }
         if let action = menuData[indexPath.section].options[indexPath.row].action {
             action()
         }
@@ -116,10 +131,10 @@ final class MenuTableView: UIView,
         _ tableView: UITableView,
         viewForHeaderInSection section: Int
     ) -> UIView? {
-        if section == 0 {
-            let headerView = UIView()
-            headerView.backgroundColor = .clear
-            return headerView
+        if isRedesignEnabled, section == 1 {
+            return clearBackgroundHeaderView()
+        } else if !isRedesignEnabled, section == 0 {
+            return clearBackgroundHeaderView()
         }
         return nil
     }
@@ -135,6 +150,12 @@ final class MenuTableView: UIView,
         } else {
             updateHeaderLineView?(true)
         }
+    }
+
+    private func clearBackgroundHeaderView() -> UIView {
+        let headerView = UIView()
+        headerView.backgroundColor = .clear
+        return headerView
     }
 
     // MARK: - Theme Applicable

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -54,6 +54,10 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         featureFlags.isFeatureEnabled(.appearanceMenu, checking: .buildOnly)
     }
 
+    private var isMenuRedesignOn: Bool {
+        featureFlags.isFeatureEnabled(.menuRedesign, checking: .buildOnly)
+    }
+
     public func generateMenuElements(
         with tabInfo: MainMenuTabInfo,
         for viewType: MainMenuDetailsViewType?,
@@ -97,7 +101,98 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
             )
         }
 
+        if isMenuRedesignOn {
+            menuSections.insert(
+                getTopTabsSection(with: uuid, tabInfo: tabInfo),
+                at: 0)
+        }
+
         return menuSections
+    }
+
+    // TODO: FXIOS-12306 Update MainMenuConfigurationUtility based on the final design
+    // MARK: - Top Tabs Section
+    private func getTopTabsSection(with uuid: WindowUUID, tabInfo: MainMenuTabInfo) -> MenuSection {
+        return MenuSection(
+            isTopTabsSection: true,
+            options: [
+            MenuElement(
+                title: .MainMenu.PanelLinkSection.History,
+                iconName: Icons.history,
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: .MainMenu.PanelLinkSection.AccessibilityLabels.History,
+                a11yHint: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.history,
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.tapNavigateToDestination,
+                            navigationDestination: MenuNavigationDestination(.history),
+                            telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.PanelLinkSection.Bookmarks,
+                iconName: Icons.bookmarks,
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: .MainMenu.PanelLinkSection.AccessibilityLabels.Bookmarks,
+                a11yHint: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.bookmarks,
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.tapNavigateToDestination,
+                            navigationDestination: MenuNavigationDestination(.bookmarks),
+                            telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.PanelLinkSection.Downloads,
+                iconName: Icons.downloads,
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: .MainMenu.PanelLinkSection.AccessibilityLabels.Downloads,
+                a11yHint: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.downloads,
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.tapNavigateToDestination,
+                            navigationDestination: MenuNavigationDestination(.downloads),
+                            telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.PanelLinkSection.Passwords,
+                iconName: Icons.passwords,
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: .MainMenu.PanelLinkSection.AccessibilityLabels.Passwords,
+                a11yHint: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.passwords,
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.tapNavigateToDestination,
+                            navigationDestination: MenuNavigationDestination(.passwords),
+                            telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)
+                        )
+                    )
+                }
+            ),
+        ])
     }
 
     // MARK: - New Tabs Section

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -25,6 +25,7 @@ class MainMenuViewController: UIViewController,
     typealias SubscriberStateType = MainMenuState
 
     // MARK: - UI/UX elements
+    // Based on the isMenuRedesign flag, we have two versions of the menu
     private lazy var menuRedesignContent: MenuRedesignMainView = .build()
     private lazy var menuContent: MenuMainView = .build()
     private var hintView: ContextualHintView = .build { view in

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -99,7 +99,11 @@ class MainMenuViewController: UIViewController,
         presentationController?.delegate = self
         sheetPresentationController?.delegate = self
 
-        isMenuRedesign ? setupRedesignView() : setupView()
+        if isMenuRedesign {
+            setupRedesignView()
+        } else {
+            setupView()
+        }
         setupTableView()
         listenForThemeChange(view)
         store.dispatch(
@@ -424,7 +428,11 @@ class MainMenuViewController: UIViewController,
     }
 
     private func adjustLayout(isDeviceRotating: Bool = false) {
-        isMenuRedesign ? menuRedesignContent.accountHeaderView.adjustLayout() : menuContent.accountHeaderView.adjustLayout()
+        if isMenuRedesign {
+            menuRedesignContent.accountHeaderView.adjustLayout()
+        } else {
+            menuContent.accountHeaderView.adjustLayout()
+        }
         if isDeviceRotating {
             hintView.removeFromSuperview()
         } else {
@@ -484,6 +492,10 @@ class MainMenuViewController: UIViewController,
 
     // MARK: - MenuTableViewDelegate
     func reloadTableView(with data: [MenuSection]) {
-        isMenuRedesign ? menuRedesignContent.reloadDataView(with: data) : menuContent.reloadTableView(with: data)
+        if isMenuRedesign {
+            menuRedesignContent.reloadDataView(with: data)
+        } else {
+            menuContent.reloadTableView(with: data)
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -25,6 +25,7 @@ class MainMenuViewController: UIViewController,
     typealias SubscriberStateType = MainMenuState
 
     // MARK: - UI/UX elements
+    private lazy var menuRedesignContent: MenuRedesignMainView = .build()
     private lazy var menuContent: MenuMainView = .build()
     private var hintView: ContextualHintView = .build { view in
         view.isAccessibilityElement = true
@@ -49,6 +50,10 @@ class MainMenuViewController: UIViewController,
     private var isPad: Bool {
         traitCollection.verticalSizeClass == .regular &&
         !(UIDevice.current.userInterfaceIdiom == .phone)
+    }
+
+    private var isMenuRedesign: Bool {
+        return featureFlags.isFeatureEnabled(.menuRedesign, checking: .buildOnly)
     }
 
     // Used to save the last screen orientation
@@ -94,7 +99,7 @@ class MainMenuViewController: UIViewController,
         presentationController?.delegate = self
         sheetPresentationController?.delegate = self
 
-        setupView()
+        isMenuRedesign ? setupRedesignView() : setupView()
         setupTableView()
         listenForThemeChange(view)
         store.dispatch(
@@ -104,27 +109,26 @@ class MainMenuViewController: UIViewController,
             )
         )
 
-        menuContent.accountHeaderView.closeButtonCallback = { [weak self] in
-            guard let self else { return }
-            store.dispatch(
-                MainMenuAction(
-                    windowUUID: self.windowUUID,
-                    actionType: MainMenuActionType.tapCloseMenu,
-                    currentTabInfo: menuState.currentTabInfo
-                )
-            )
-        }
+        if isMenuRedesign {
+            menuRedesignContent.accountHeaderView.closeButtonCallback = { [weak self] in
+                guard let self else { return }
+                self.dispatchCloseMenuAction()
+            }
 
-        menuContent.accountHeaderView.mainButtonCallback = { [weak self] in
-            guard let self else { return }
-            store.dispatch(
-                MainMenuAction(
-                    windowUUID: self.windowUUID,
-                    actionType: MainMenuActionType.tapNavigateToDestination,
-                    navigationDestination: MenuNavigationDestination(.syncSignIn),
-                    currentTabInfo: menuState.currentTabInfo
-                )
-            )
+            menuRedesignContent.accountHeaderView.mainButtonCallback = { [weak self] in
+                guard let self else { return }
+                self.dispatchSyncSignInAction()
+            }
+        } else {
+            menuContent.accountHeaderView.closeButtonCallback = { [weak self] in
+                guard let self else { return }
+                self.dispatchCloseMenuAction()
+            }
+
+            menuContent.accountHeaderView.mainButtonCallback = { [weak self] in
+                guard let self else { return }
+                self.dispatchSyncSignInAction()
+            }
         }
 
         setupAccessibilityIdentifiers()
@@ -204,6 +208,23 @@ class MainMenuViewController: UIViewController,
                                  icon: icon)
     }
 
+    private func setupRedesignView() {
+        view.addSubview(menuRedesignContent)
+
+        NSLayoutConstraint.activate([
+            menuRedesignContent.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            menuRedesignContent.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            menuRedesignContent.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            menuRedesignContent.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+        ])
+
+        let icon = UIImage(named: StandardImageIdentifiers.Large.avatarCircle)?
+            .withRenderingMode(.alwaysTemplate)
+        menuRedesignContent.setupDetails(subtitle: .MainMenu.Account.SignedOutDescription,
+                                         title: .MainMenu.Account.SignedOutTitle,
+                                         icon: icon)
+    }
+
     private func setupHintView() {
         var viewModel = ContextualHintViewModel(
             actionButtonTitle: viewProvider.getCopyFor(.action),
@@ -225,17 +246,27 @@ class MainMenuViewController: UIViewController,
             if isPad {
                 NSLayoutConstraint.activate([
                     hintView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: UX.hintViewMargin * 4),
-                    hintView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -UX.hintViewMargin * 4),
-                    hintView.topAnchor.constraint(equalTo: menuContent.accountHeaderView.topAnchor,
-                                                  constant: UX.hintViewMargin)
+                    hintView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -UX.hintViewMargin * 4)
                 ])
+                if isMenuRedesign {
+                    hintView.topAnchor.constraint(equalTo: menuRedesignContent.accountHeaderView.topAnchor,
+                                                  constant: UX.hintViewMargin).isActive = true
+                } else {
+                    hintView.topAnchor.constraint(equalTo: menuContent.accountHeaderView.topAnchor,
+                                                  constant: UX.hintViewMargin).isActive = true
+                }
             } else {
                 NSLayoutConstraint.activate([
                     hintView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: UX.hintViewMargin),
-                    hintView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -UX.hintViewMargin),
-                    hintView.bottomAnchor.constraint(equalTo: menuContent.accountHeaderView.topAnchor,
-                                                     constant: -UX.hintViewMargin)
+                    hintView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -UX.hintViewMargin)
                 ])
+                if isMenuRedesign {
+                    hintView.bottomAnchor.constraint(equalTo: menuRedesignContent.accountHeaderView.topAnchor,
+                                                     constant: -UX.hintViewMargin).isActive = true
+                } else {
+                    hintView.bottomAnchor.constraint(equalTo: menuContent.accountHeaderView.topAnchor,
+                                                     constant: -UX.hintViewMargin).isActive = true
+                }
             }
             hintViewHeightConstraint = hintView.heightAnchor.constraint(equalToConstant: UX.hintViewHeight)
             hintViewHeightConstraint?.isActive = true
@@ -298,19 +329,49 @@ class MainMenuViewController: UIViewController,
         reloadTableView(with: menuState.menuElements)
     }
 
+    private func dispatchCloseMenuAction() {
+        store.dispatch(
+            MainMenuAction(
+                windowUUID: self.windowUUID,
+                actionType: MainMenuActionType.tapCloseMenu,
+                currentTabInfo: menuState.currentTabInfo
+            )
+        )
+    }
+
+    private func dispatchSyncSignInAction() {
+        store.dispatch(
+            MainMenuAction(
+                windowUUID: self.windowUUID,
+                actionType: MainMenuActionType.tapNavigateToDestination,
+                navigationDestination: MenuNavigationDestination(.syncSignIn),
+                currentTabInfo: menuState.currentTabInfo
+            )
+        )
+    }
+
     // MARK: - UX related
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer3
+        menuRedesignContent.applyTheme(theme: theme)
         menuContent.applyTheme(theme: theme)
     }
 
     private func updateHeaderWith(accountData: AccountData, icon: UIImage?) {
-        menuContent.accountHeaderView.setupDetails(subtitle: accountData.subtitle ?? "",
-                                                   title: accountData.title,
-                                                   icon: icon,
-                                                   warningIcon: accountData.warningIcon,
-                                                   theme: themeManager.getCurrentTheme(for: windowUUID))
+        if isMenuRedesign {
+            menuRedesignContent.accountHeaderView.setupDetails(subtitle: accountData.subtitle ?? "",
+                                                               title: accountData.title,
+                                                               icon: icon,
+                                                               warningIcon: accountData.warningIcon,
+                                                               theme: themeManager.getCurrentTheme(for: windowUUID))
+        } else {
+            menuContent.accountHeaderView.setupDetails(subtitle: accountData.subtitle ?? "",
+                                                       title: accountData.title,
+                                                       icon: icon,
+                                                       warningIcon: accountData.warningIcon,
+                                                       theme: themeManager.getCurrentTheme(for: windowUUID))
+        }
     }
 
     // MARK: - A11y
@@ -343,17 +404,27 @@ class MainMenuViewController: UIViewController,
 
     private func setupAccessibilityIdentifiers(
         mainButtonA11yLabel: String = .MainMenu.Account.AccessibilityLabels.MainButton) {
-        menuContent.setupAccessibilityIdentifiers(
-            closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButton,
-            closeButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.closeButton,
-            mainButtonA11yLabel: mainButtonA11yLabel,
-            mainButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.mainButton,
-            menuA11yId: AccessibilityIdentifiers.MainMenu.mainMenu,
-            menuA11yLabel: .MainMenu.TabsSection.AccessibilityLabels.MainMenu)
+            if isMenuRedesign {
+                menuRedesignContent.setupAccessibilityIdentifiers(
+                    closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButton,
+                    closeButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.closeButton,
+                    mainButtonA11yLabel: mainButtonA11yLabel,
+                    mainButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.mainButton,
+                    menuA11yId: AccessibilityIdentifiers.MainMenu.mainMenu,
+                    menuA11yLabel: .MainMenu.TabsSection.AccessibilityLabels.MainMenu)
+            } else {
+                menuContent.setupAccessibilityIdentifiers(
+                    closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButton,
+                    closeButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.closeButton,
+                    mainButtonA11yLabel: mainButtonA11yLabel,
+                    mainButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.mainButton,
+                    menuA11yId: AccessibilityIdentifiers.MainMenu.mainMenu,
+                    menuA11yLabel: .MainMenu.TabsSection.AccessibilityLabels.MainMenu)
+            }
     }
 
     private func adjustLayout(isDeviceRotating: Bool = false) {
-        menuContent.accountHeaderView.adjustLayout()
+        isMenuRedesign ? menuRedesignContent.accountHeaderView.adjustLayout() : menuContent.accountHeaderView.adjustLayout()
         if isDeviceRotating {
             hintView.removeFromSuperview()
         } else {
@@ -413,6 +484,6 @@ class MainMenuViewController: UIViewController,
 
     // MARK: - MenuTableViewDelegate
     func reloadTableView(with data: [MenuSection]) {
-        menuContent.reloadTableView(with: data)
+        isMenuRedesign ? menuRedesignContent.reloadDataView(with: data) : menuContent.reloadTableView(with: data)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12303)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26791)

## :bulb: Description
Added the logic to display or not, the horizontal options, based on the menu redesign subflag.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
