### PR TITLE
Add [Tab Loss] Log all failure paths for tab loss

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -141,7 +141,7 @@ public actor DefaultTabDataStore: TabDataStore {
     public func saveWindowData(window: WindowData, forced: Bool) async {
         guard let windowSavingPath = windowURLPath(for: window.id, isBackup: false) else {
             logger.log("Not saving window data. Could not build window saving path.",
-                       level: .debug,
+                       level: .warning,
                        category: .tabs)
             return
         }
@@ -180,6 +180,9 @@ public actor DefaultTabDataStore: TabDataStore {
         }
 
         guard let backupDirectoryPath = fileManager.windowDataDirectory(isBackup: true) else {
+            logger.log("Failed to create window data backup. No backup directory path.",
+                       level: .warning,
+                       category: .tabs)
             return
         }
 

--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -139,7 +139,12 @@ public actor DefaultTabDataStore: TabDataStore {
     // MARK: - Saving Data
 
     public func saveWindowData(window: WindowData, forced: Bool) async {
-        guard let windowSavingPath = windowURLPath(for: window.id, isBackup: false) else { return }
+        guard let windowSavingPath = windowURLPath(for: window.id, isBackup: false) else {
+            logger.log("Not saving window data. Could not build window saving path.",
+                       level: .debug,
+                       category: .tabs)
+            return
+        }
 
         // Hold onto a copy of the latest window data so whenever the save happens it is using the latest
         windowDataToSave = window
@@ -160,10 +165,23 @@ public actor DefaultTabDataStore: TabDataStore {
     }
 
     private func createWindowDataBackup(windowPath: URL) {
-        guard let windowID = windowDataToSave?.id,
-              let backupWindowSavingPath = windowURLPath(for: windowID, isBackup: true),
-              let backupDirectoryPath = fileManager.windowDataDirectory(isBackup: true)
-        else { return }
+        guard let windowID = windowDataToSave?.id else {
+            logger.log("Failed to create window data backup. Window to save is nil",
+                       level: .warning,
+                       category: .tabs)
+            return
+        }
+
+        guard let backupWindowSavingPath = windowURLPath(for: windowID, isBackup: true) else {
+            logger.log("Failed to create window data backup. Could not create windowURLPath.",
+                       level: .warning,
+                       category: .tabs)
+            return
+        }
+
+        guard let backupDirectoryPath = fileManager.windowDataDirectory(isBackup: true) else {
+            return
+        }
 
         if !fileManager.fileExists(atPath: backupDirectoryPath) {
             fileManager.createDirectoryAtPath(path: backupDirectoryPath)

--- a/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
@@ -34,7 +34,12 @@ public class DefaultTabSessionStore: TabSessionStore {
     }
 
     public func saveTabSession(tabID: UUID, sessionData: Data) {
-        guard let directory = fileManager.tabSessionDataDirectory() else { return }
+        guard let directory = fileManager.tabSessionDataDirectory() else {
+            logger.log("Failed to save session data. No tab session data directory path.",
+                       level: .warning,
+                       category: .tabs)
+            return
+        }
 
         if !fileManager.fileExists(atPath: directory) {
             fileManager.createDirectoryAtPath(path: directory)
@@ -54,7 +59,12 @@ public class DefaultTabSessionStore: TabSessionStore {
 
     public func fetchTabSession(tabID: UUID) -> Data? {
         guard let path = fileManager.tabSessionDataDirectory()?.appendingPathComponent(filePrefix + tabID.uuidString)
-        else { return nil }
+        else {
+            logger.log("Failed to decode session data. No tab session data directory path.",
+                       level: .warning,
+                       category: .tabs)
+            return nil
+        }
 
         do {
             lock.lock()

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -632,15 +632,32 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
 
         let nonPrivateTabs = window?.tabData.filter { !$0.isPrivate }
 
-        guard let windowData = window,
-              let nonPrivateTabs,
-              !nonPrivateTabs.isEmpty,
-              tabs.isEmpty
-        else {
+        guard let windowData = window else {
             // Always make sure there is a single normal tab
             // Note: this is where the first tab in a newly-created browser window will be added
             await generateEmptyTab()
-            logger.log("There was no tabs restored, creating a normal tab",
+            logger.log("Not restoring tabs because there is no window data.",
+                       level: .debug,
+                       category: .tabs)
+            return
+        }
+
+        guard let nonPrivateTabs,
+              !nonPrivateTabs.isEmpty else {
+            // Always make sure there is a single normal tab
+            // Note: this is where the first tab in a newly-created browser window will be added
+            await generateEmptyTab()
+            logger.log("Not restoring tabs because there is no tab data on the window data.",
+                       level: .debug,
+                       category: .tabs)
+            return
+        }
+
+        guard tabs.isEmpty else {
+            // Always make sure there is a single normal tab
+            // Note: this is where the first tab in a newly-created browser window will be added
+            await generateEmptyTab()
+            logger.log("Not restoring tabs because there are in memory tabs already.",
                        level: .debug,
                        category: .tabs)
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -681,7 +681,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
 
     /// Creates the webview so needs to live on the main thread
     @MainActor
-    private func generateTabs(from windowData: WindowData) {
+    private func generateTabs(from windowData: WindowData) async {
         let filteredTabs = filterPrivateTabs(from: windowData,
                                              clearPrivateTabs: shouldClearPrivateTabs())
         var tabToSelect: Tab?

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -637,7 +637,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
             // Note: this is where the first tab in a newly-created browser window will be added
             await generateEmptyTab()
             logger.log("Not restoring tabs because there is no window data.",
-                       level: .debug,
+                       level: .warning,
                        category: .tabs)
             return
         }
@@ -648,7 +648,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
             // Note: this is where the first tab in a newly-created browser window will be added
             await generateEmptyTab()
             logger.log("Not restoring tabs because there is no tab data on the window data.",
-                       level: .debug,
+                       level: .warning,
                        category: .tabs)
             return
         }
@@ -658,7 +658,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
             // Note: this is where the first tab in a newly-created browser window will be added
             await generateEmptyTab()
             logger.log("Not restoring tabs because there are in memory tabs already.",
-                       level: .debug,
+                       level: .warning,
                        category: .tabs)
 
             return
@@ -681,7 +681,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
 
     /// Creates the webview so needs to live on the main thread
     @MainActor
-    private func generateTabs(from windowData: WindowData) async {
+    private func generateTabs(from windowData: WindowData) {
         let filteredTabs = filterPrivateTabs(from: windowData,
                                              clearPrivateTabs: shouldClearPrivateTabs())
         var tabToSelect: Tab?


### PR DESCRIPTION
## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Log ANY place where we could be returning early and not preserving or restoring tabs.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
