### PR TITLE
Remove FXIOS-12315 [Feature flag cleanup] Remove cleanupHistoryReenabled flag

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -204,9 +204,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
 
         // Cleanup can be a heavy operation, take it out of the startup path. Instead check after a few seconds.
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
-            if self?.featureFlags.isFeatureEnabled(.cleanupHistoryReenabled, checking: .buildOnly) ?? false {
-                self?.profile.cleanupHistoryIfNeeded()
-            }
+            self?.profile.cleanupHistoryIfNeeded()
         }
 
         DispatchQueue.global().async { [weak self] in

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -15,7 +15,6 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case appearanceMenu
     case bookmarksRefactor
     case bottomSearchBar
-    case cleanupHistoryReenabled
     case deeplinkOptimizationRefactor
     case downloadLiveActivities
     case feltPrivacyFeltDeletion
@@ -123,7 +122,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .addressAutofillEdit,
                 .addressBarMenu,
                 .bookmarksRefactor,
-                .cleanupHistoryReenabled,
                 .deeplinkOptimizationRefactor,
                 .downloadLiveActivities,
                 .feltPrivacyFeltDeletion,

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -26,9 +26,6 @@ final class NimbusFeatureFlagLayer {
         case .bottomSearchBar:
             return checkAwesomeBarFeature(for: featureID, from: nimbus)
 
-        case .cleanupHistoryReenabled:
-            return checkCleanupHistoryReenabled(from: nimbus)
-
         case .deeplinkOptimizationRefactor:
             return checkDeeplinkOptimizationRefactorFeature(from: nimbus)
 
@@ -148,11 +145,6 @@ final class NimbusFeatureFlagLayer {
     // MARK: - Private methods
     private func checkBookmarksRefactor(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.bookmarkRefactorFeature.value().enabled
-    }
-
-    private func checkCleanupHistoryReenabled(from nimbus: FxNimbus) -> Bool {
-        let config = nimbus.features.cleanupHistoryReenabled.value()
-        return config.enabled
     }
 
     private func checkGeneralFeature(for featureID: NimbusFeatureFlagID,

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -15,7 +15,6 @@ channels:
 include:
   - nimbus-features/addressAutofillFeature.yaml
   - nimbus-features/bookmarkRefactorFeature.yaml
-  - nimbus-features/cleanupHistoryReenabled.yaml
   - nimbus-features/deeplinkOptimizationRefactorFeature.yaml
   - nimbus-features/downloadLiveActivitiesFeature.yaml
   - nimbus-features/feltPrivacyFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12315)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26817)

## :bulb: Description
Remove `cleanupHistoryReenabled` flag since the feature is now rolled out.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
