### PR TITLE
Bugfix FXIOS-12274 [Experiment] Advanced targeting for bottom toolbar and tips notification

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -987,6 +987,8 @@
 		8A83B7482A264FB7002FF9AC /* LibraryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A83B7472A264FB7002FF9AC /* LibraryCoordinator.swift */; };
 		8A83B74A2A265044002FF9AC /* SettingsCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A83B7492A265044002FF9AC /* SettingsCoordinatorTests.swift */; };
 		8A83B74C2A265061002FF9AC /* LibraryCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A83B74B2A265061002FF9AC /* LibraryCoordinatorTests.swift */; };
+		8A83C58C2DDF87E400FF60EF /* ProfilePrefsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A83C58B2DDF87E400FF60EF /* ProfilePrefsReader.swift */; };
+		8A83C58E2DDF887300FF60EF /* ProfilePrefsReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A83C58D2DDF887200FF60EF /* ProfilePrefsReaderTests.swift */; };
 		8A8482F02BE1602500F9007B /* MicrosurveyPromptStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8482EE2BE15FFE00F9007B /* MicrosurveyPromptStateTests.swift */; };
 		8A855C032D1EE9EF00C1A2F3 /* ContextMenuCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A855C022D1EE9EF00C1A2F3 /* ContextMenuCoordinator.swift */; };
 		8A8629E2288096C40096DDB1 /* BookmarksFolderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */; };
@@ -8380,6 +8382,8 @@
 		8A83B7472A264FB7002FF9AC /* LibraryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCoordinator.swift; sourceTree = "<group>"; };
 		8A83B7492A265044002FF9AC /* SettingsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A83B74B2A265061002FF9AC /* LibraryCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCoordinatorTests.swift; sourceTree = "<group>"; };
+		8A83C58B2DDF87E400FF60EF /* ProfilePrefsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePrefsReader.swift; sourceTree = "<group>"; };
+		8A83C58D2DDF887200FF60EF /* ProfilePrefsReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePrefsReaderTests.swift; sourceTree = "<group>"; };
 		8A8482EE2BE15FFE00F9007B /* MicrosurveyPromptStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyPromptStateTests.swift; sourceTree = "<group>"; };
 		8A855C022D1EE9EF00C1A2F3 /* ContextMenuCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuCoordinator.swift; sourceTree = "<group>"; };
 		8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksFolderCell.swift; sourceTree = "<group>"; };
@@ -11498,6 +11502,7 @@
 		39A359BD1BFCCE7B006B9E87 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				8A83C58B2DDF87E400FF60EF /* ProfilePrefsReader.swift */,
 				8AC8841C2D525EFF0033ABF5 /* CrashTracker.swift */,
 				966E4B2529F2D4AC00299B8D /* AccessoryViewProvider.swift */,
 				9614BF4328AD1C6700D3F7EA /* AccountSyncHandler.swift */,
@@ -12935,6 +12940,7 @@
 		8ACA8F722919870B00D3075D /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				8A83C58D2DDF887200FF60EF /* ProfilePrefsReaderTests.swift */,
 				8AC884202D5261FC0033ABF5 /* CrashTrackerTests.swift */,
 				8A967E412D30418A00B1017D /* TelemetryDebugMessage.swift */,
 				8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */,
@@ -18140,6 +18146,7 @@
 				21420EF72ABA338D00B28550 /* TabTrayCoordinator.swift in Sources */,
 				5A70EF1F295E3DFC00790249 /* UnitTestAppDelegate.swift in Sources */,
 				2128E27E2934F78600FB91BE /* CustomAppActivity.swift in Sources */,
+				8A83C58C2DDF87E400FF60EF /* ProfilePrefsReader.swift in Sources */,
 				81A3F6F22C2DB00900BDD86B /* MainMenuViewController.swift in Sources */,
 				E16E1C9828C25F1D00EE2EF5 /* SiteTableViewHeader.swift in Sources */,
 				BD2577992C9D85B5007B344C /* AnyHashable.swift in Sources */,
@@ -18567,6 +18574,7 @@
 				3B6F40181DC7849C00656CC6 /* TopSitesViewModelTests.swift in Sources */,
 				8A00BD882CAB401700680AF9 /* HomepageViewControllerTests.swift in Sources */,
 				C869915528917803007ACC5C /* WallpaperMetadataTestProvider.swift in Sources */,
+				8A83C58E2DDF887300FF60EF /* ProfilePrefsReaderTests.swift in Sources */,
 				BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -171,10 +171,7 @@ enum Experiments {
         let customTargetingAttributes: [String: Any] = [
             "isFirstRun": "\(isFirstRun)",
             "is_first_run": isFirstRun,
-            "is_phone": isPhone,
-            "is_default_browser": isDefaultBrowser(),
-            "is_bottom_toolbar_user": isBottomToolbarUser(),
-            "has_enabled_tips_notifications": hasEnabledTipsNotifications(),
+            "is_phone": isPhone
         ]
 
         // App settings, to allow experiments to target the app name and the

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -192,13 +192,13 @@ enum Experiments {
     }
 
     private static func isBottomToolbarUser() -> Bool {
-        return UserDefaults.standard
-            .bool(forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        let prefsReader = ProfilePrefsReader()
+        return prefsReader.isBottomToolbarUser()
     }
 
     private static func hasEnabledTipsNotifications() -> Bool {
-        return UserDefaults.standard
-            .bool(forKey: PrefsKeys.Notifications.TipsAndFeaturesNotifications)
+        let prefsReader = ProfilePrefsReader()
+        return prefsReader.hasEnabledTipsNotifications()
     }
 
     private static func buildNimbus(dbPath: String,

--- a/firefox-ios/Client/ProfilePrefsReader.swift
+++ b/firefox-ios/Client/ProfilePrefsReader.swift
@@ -9,7 +9,7 @@ import Shared
 /// without requiring access to the `Profile` object.
 ///
 /// This is useful in contexts where only the app group suite is available (e.g., startup code,
-/// onboarding, remote config logic), and certain known preference keys need to be queried.
+/// experiments), and certain known preference keys need to be queried.
 struct ProfilePrefsReader {
     /// Prefix used to simulate the `NSUserDefaultsPrefs` profile key namespace.
     static let prefix = "profile."

--- a/firefox-ios/Client/ProfilePrefsReader.swift
+++ b/firefox-ios/Client/ProfilePrefsReader.swift
@@ -25,7 +25,7 @@ struct ProfilePrefsReader {
     /// Returns `true` if the saved search bar position for the user is `.bottom`.
     ///
     /// This checks the `SearchBarPositionUsersPrefsKey` and deserializes it into
-    /// a `SearchBarPosition` enum. If the key is missing or not `"bottom"`, it returns `false`.
+    /// a `SearchBarPosition` enum. If the key is missing or not `SearchBarPosition.bottom`, it returns `false`.
     func isBottomToolbarUser() -> Bool {
         let key = ProfilePrefsReader.prefix + PrefsKeys.FeatureFlags.SearchBarPosition
         if let rawValue = userDefaults.string(forKey: key),

--- a/firefox-ios/Client/ProfilePrefsReader.swift
+++ b/firefox-ios/Client/ProfilePrefsReader.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Shared
+
+/// A helper for reading user preference values from a profile-based `UserDefaults` store
+/// without requiring access to the `Profile` object.
+///
+/// This is useful in contexts where only the app group suite is available (e.g., startup code,
+/// onboarding, remote config logic), and certain known preference keys need to be queried.
+struct ProfilePrefsReader {
+    /// Prefix used to simulate the `NSUserDefaultsPrefs` profile key namespace.
+    static let prefix = "profile."
+    private let userDefaults: UserDefaultsInterface
+
+    init(userDefaults: UserDefaultsInterface? = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)) {
+        guard let userDefaults = userDefaults else {
+            fatalError("Failed to create UserDefaults with suite: \(AppInfo.sharedContainerIdentifier)")
+        }
+        self.userDefaults = userDefaults
+    }
+
+    /// Returns `true` if the saved search bar position for the user is `.bottom`.
+    ///
+    /// This checks the `SearchBarPositionUsersPrefsKey` and deserializes it into
+    /// a `SearchBarPosition` enum. If the key is missing or not `"bottom"`, it returns `false`.
+    func isBottomToolbarUser() -> Bool {
+        let key = ProfilePrefsReader.prefix + PrefsKeys.FeatureFlags.SearchBarPosition
+        if let rawValue = userDefaults.string(forKey: key),
+           let position = SearchBarPosition(rawValue: rawValue) {
+            return position == .bottom
+        }
+
+        return false
+    }
+
+    /// Returns `true` if the user has enabled tips and feature notifications.
+    ///
+    /// This checks a boolean flag stored under `TipsAndFeaturesNotifications`.
+    /// If the key is missing, the result is `false`.
+    func hasEnabledTipsNotifications() -> Bool {
+        let key = ProfilePrefsReader.prefix + PrefsKeys.Notifications.TipsAndFeaturesNotifications
+        return userDefaults.bool(forKey: key)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/ProfilePrefsReaderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/ProfilePrefsReaderTests.swift
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import XCTest
+
+@testable import Client
+
+class ProfilePrefsReaderTests: XCTestCase {
+    private var mockUserDefaults: MockUserDefaults!
+    private var prefsReader: ProfilePrefsReader!
+
+    override func setUp() {
+        super.setUp()
+        mockUserDefaults = MockUserDefaults()
+        prefsReader = ProfilePrefsReader(userDefaults: mockUserDefaults)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        mockUserDefaults = nil
+        prefsReader = nil
+    }
+
+    func testIsBottomToolbarUser_returnsTrue_whenPositionIsBottom() {
+        let key = ProfilePrefsReader.prefix + PrefsKeys.FeatureFlags.SearchBarPosition
+        mockUserDefaults.set("bottom", forKey: key)
+
+        XCTAssertTrue(prefsReader.isBottomToolbarUser())
+    }
+
+    func testIsBottomToolbarUser_returnsFalse_whenPositionIsTop() {
+        let key = ProfilePrefsReader.prefix + PrefsKeys.FeatureFlags.SearchBarPosition
+        mockUserDefaults.set("top", forKey: key)
+
+        XCTAssertFalse(prefsReader.isBottomToolbarUser())
+    }
+
+    func testIsBottomToolbarUser_returnsFalse_whenNoValueIsSet() {
+        XCTAssertFalse(prefsReader.isBottomToolbarUser())
+    }
+
+    func testHasEnabledTipsNotifications_returnsTrue_whenFlagIsTrue() {
+        let key = ProfilePrefsReader.prefix + PrefsKeys.Notifications.TipsAndFeaturesNotifications
+        mockUserDefaults.set(true, forKey: key)
+
+        XCTAssertTrue(prefsReader.hasEnabledTipsNotifications())
+    }
+
+    func testHasEnabledTipsNotifications_returnsFalse_whenFlagIsFalse() {
+        let key = ProfilePrefsReader.prefix + PrefsKeys.Notifications.TipsAndFeaturesNotifications
+        mockUserDefaults.set(false, forKey: key)
+
+        XCTAssertFalse(prefsReader.hasEnabledTipsNotifications())
+    }
+
+    func testHasEnabledTipsNotifications_returnsFalse_whenNoFlagIsSet() {
+        XCTAssertFalse(prefsReader.hasEnabledTipsNotifications())
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/ProfilePrefsReaderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/ProfilePrefsReaderTests.swift
@@ -41,6 +41,14 @@ class ProfilePrefsReaderTests: XCTestCase {
         XCTAssertFalse(prefsReader.isBottomToolbarUser())
     }
 
+    func testIsBottomToolbarUser_savesIntoProfile_thenRetrievesThePrefs() {
+        let profile = BrowserProfile(localName: "profile").makePrefs()
+        profile.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        let prefs = ProfilePrefsReader()
+        XCTAssertTrue(prefs.isBottomToolbarUser())
+    }
+
     func testHasEnabledTipsNotifications_returnsTrue_whenFlagIsTrue() {
         let key = ProfilePrefsReader.prefix + PrefsKeys.Notifications.TipsAndFeaturesNotifications
         mockUserDefaults.set(true, forKey: key)
@@ -57,5 +65,13 @@ class ProfilePrefsReaderTests: XCTestCase {
 
     func testHasEnabledTipsNotifications_returnsFalse_whenNoFlagIsSet() {
         XCTAssertFalse(prefsReader.hasEnabledTipsNotifications())
+    }
+
+    func testHasEnabledTipsNotifications_savesIntoProfile_thenRetrievesThePrefs() {
+        let profile = BrowserProfile(localName: "profile").makePrefs()
+        profile.setBool(true, forKey: PrefsKeys.Notifications.TipsAndFeaturesNotifications)
+
+        let prefs = ProfilePrefsReader()
+        XCTAssertTrue(prefs.hasEnabledTipsNotifications())
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12274)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26745)

## :bulb: Description
A simple fix without changing the whole `Experiments` enum is to add an helper class `ProfilePrefsReader` so we can conveniently access prefs saved into our wonderful `NSUserDefaultsPrefs` without having access to the `Profile` object.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
