### PR TITLE
Bugfix FXIOS-12320 Correctly return favicon URLs with relative paths from the metadata parser

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentEnd/MetadataHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentEnd/MetadataHelper.js
@@ -9,7 +9,7 @@ const metadataParser = require("page-metadata-parser/parser.js");
 
 function MetadataWrapper() {
   this.getMetadata = function() {
-    let metadata = metadataParser.getMetadata(document, location.origin);
+    let metadata = metadataParser.getMetadata(document, new URL('.', location.href).href);
 
     // Set metadata.url to document URL by default
     metadata.url = document.URL;


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12320)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26833)

## :bulb: Description

Fix for parsing favicon URLs at relative paths outside the root directory.

See the ticket for detailed testing instructions.

Visiting this URL will now correctly parse the website's favicon instead of generating a letter favicon:
```
https://client.game-studio.sensei.games/ten-times-treat/index.html?token=7fdb7775-76d9-4c4b-b51e-2ecf54412237&backUrl=https%3A%2F%2Fgoogle.com&lang=en&platform=desktop&sig=30B09ACFCFE20FA8CE63467C42A1CC70381BDC476F057A17C390A0636C8C89FF
```

Thanks @issammani for the quick suggested fix! 🥳 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
