### PR TITLE
Fix [MTE-4602]-testOpenInNewPrivateTabRecentlyClosedItem test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -912,6 +912,9 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         }
 
         screenState.onEnter { userState in
+            let exists = NSPredicate(format: "exists == true")
+            let expectation = XCTNSPredicateExpectation(predicate: exists, object: app.otherElements["Tabs Tray"])
+            let _ = XCTWaiter().wait(for: [expectation], timeout: 5)
             userState.numTabs = Int(app.otherElements["Tabs Tray"].cells.count)
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4602

## :bulb: Description
testOpenInNewPrivateTabRecentlyClosedItem test with tab-tray-ui-experiments on started to be flaky.
The final count on private tab was equal to 2, even if there was only one tab opened and my guess was that the transition from regular to private was to fast and somehow userState.numTabs returned 2, maybe counting the tab from the regular side.
I have tried several solutions inside the test for waiting the tabs tray element to appear, but the only way to make this test pass was to add a wait inside the user state  where we wait for element before the number of cells are counted correctly.
