### PR TITLE
Bugfix FXIOS-12327 [Tab tray UI experiment] Fix font jitter when swiping

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -138,11 +138,8 @@ class TabTraySelectorView: UIView,
         let baseFontSize = preferredFont.pointSize
 
         let boldFont = UIFont.systemFont(ofSize: baseFontSize, weight: .bold)
-        let regularFont = UIFont.systemFont(ofSize: baseFontSize, weight: .regular)
         let boldWidth = title.size(withAttributes: [.font: boldFont]).width
-        let regularWidth = title.size(withAttributes: [.font: regularFont]).width
-        let maxWidth = max(boldWidth, regularWidth)
-        button.widthAnchor.constraint(equalToConstant: maxWidth).isActive = true
+        button.widthAnchor.constraint(equalToConstant: boldWidth).isActive = true
     }
 
     @objc


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12327)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26847)

## :bulb: Description
The transition from regular to bold font cannot be animated, but this PR introduces a way of mimicking this. We are now scaling the font when we are swiping on the `UIPageViewController`. We also have a `widthAnchor` on the button to ensure there's enough space for the bold title. Those two changes combined makes the swipe transition much more smoother I think! Let me know what you think.

## :movie_camera: Demos

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/d840614d-ce73-4c84-bba1-a5fbb567a544

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/eca9590d-4b4d-4c04-90cd-c8d3019a4db5

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
