### PR TITLE
Bugfix FXIOS-12329 [Tab tray UI experiment] Fix logic with swipeFromIndex

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -390,7 +390,7 @@ class TabTrayViewController: UIViewController,
         }
 
         // Only apply normal theme when there's no on going animations
-        if !themeAnimator.isAnimating {
+        if !themeAnimator.isAnimating && swipeFromIndex == nil {
             applyTheme()
         }
     }
@@ -933,15 +933,11 @@ class TabTrayViewController: UIViewController,
                             didFinishAnimating finished: Bool,
                             previousViewControllers: [UIViewController],
                             transitionCompleted completed: Bool) {
-        guard completed else {
-            swipeFromIndex = nil
-            return
-        }
+        guard completed,
+              let currentVC = pageViewController.viewControllers?.first as? UINavigationController,
+              let currentIndex = childPanelControllers.firstIndex(of: currentVC) else { return }
 
-        guard let currentVC = pageViewController.viewControllers?.first as? UINavigationController,
-              let index = childPanelControllers.firstIndex(of: currentVC) else { return }
-
-        let newPanelType = TabTrayPanelType.getExperimentConvert(index: index)
+        let newPanelType = TabTrayPanelType.getExperimentConvert(index: currentIndex)
         if tabTrayState.selectedPanel != newPanelType {
             tabTrayState.selectedPanel = newPanelType
             let action = TabTrayAction(panelType: newPanelType,
@@ -952,9 +948,8 @@ class TabTrayViewController: UIViewController,
             experimentSegmentControl.didFinishSelection(to: experimentConvertSelectedIndex())
 
             navigationHandler?.start(panelType: newPanelType, navigationController: currentVC)
+            swipeFromIndex = nil
         }
-
-        swipeFromIndex = nil
     }
 
     func pageViewController(_ pageViewController: UIPageViewController,
@@ -990,5 +985,9 @@ class TabTrayViewController: UIViewController,
             progress: progress
         )
         applyTheme(fromIndex: fromIndex, toIndex: toIndex, progress: abs(progress))
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        swipeFromIndex = nil
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12329)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26859)

## :bulb: Description
The swipe logic was not good enough when the transition was not entirely completed. This fixes that!

## :movie_camera: Demos

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/edf7c7d2-a3d7-46b5-ab2e-b4393c1974a2

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/8f371b0f-4e96-45e5-9c75-209a3b8fb867

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
