### PR TITLE
Bugfix FXIOS-0000 Fix theoretical tab loss false positive

### DIFF
--- a/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
@@ -59,7 +59,14 @@ final class TabErrorTelemetryHelper {
             // fewer tabs than recorded and we'll send the event erroneously.
             invalidateTabCount(for: window)
         }
-        guard tabManagerAvailable(for: window) else { return }
+        guard tabManagerAvailable(for: window) else {
+            logger.log("Can't validate tab count. Tab manager unavailable.",
+                       level: .info,
+                       category: .tabs,
+                       extra: ["uuid": window.uuidString]
+            )
+            return
+        }
         guard let tabCounts = defaults.object(forKey: defaultsKey) as? [String: Int],
               let expectedTabCount = tabCounts[window.uuidString] else { return }
         let currentTabCount = getTotalTabCount(window: window)


### PR DESCRIPTION
## :scroll: Tickets
n/a

## :bulb: Description

There's been speculation that we have race conditions when attempting to access the tab manager for the current window and that it can be nil in some scenarios; I don't believe that should be happening in `validateTabCount` due the timing of when it's called, and I think it's unlikely this is related to the 5/21 incident, but this change ensures that a missing tab manager reference won't lead to a false positive. 

Change is to ensure we always invalidate the stored tab count after hitting `validateTabCount`, even if we return early.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
