### PR TITLE
Add [MTE-4603]-identifier for tabs tray string

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -280,6 +280,7 @@ struct AccessibilityIdentifiers {
         static let collectionView = "TabDisplayView.collectionView"
         static let tabCell = "TabDisplayView.tabCell"
         static let closeButton = "tabCloseButton"
+        static let tabsTray = "Tabs Tray"
 
         struct InactiveTabs {
             static let headerLabel = "InactiveTabs.headerLabel"

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -13,6 +13,7 @@ let newTopSite = [
     "bookmarkLabel": "Mozilla - Internet for people, not profit (US)"
 ]
 let allDefaultTopSites = ["Facebook", "YouTube", "Amazon", "Wikipedia", "X"]
+let tabsTray = AccessibilityIdentifiers.TabTray.tabsTray
 
 class ActivityStreamTest: FeatureFlaggedTestBase {
     typealias TopSites = AccessibilityIdentifiers.FirefoxHomepage.TopSites
@@ -218,7 +219,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         navigator.goto(TabTray)
         waitForExistence(app.cells.staticTexts.element(boundBy: 0))
         navigator.nowAt(TabTray)
-        app.otherElements["Tabs Tray"].collectionViews.cells["Wikipedia"].waitAndTap()
+        app.otherElements[tabsTray].collectionViews.cells["Wikipedia"].waitAndTap()
         // The website is open
         mozWaitForElementToNotExist(TopSiteCellgroup)
         waitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField],
@@ -248,8 +249,8 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         if iPad() {
             navigator.goto(TabTray)
         }
-        waitForExistence(app.otherElements["Tabs Tray"].collectionViews.cells.firstMatch)
-        let numTabsOpen = app.otherElements["Tabs Tray"].collectionViews.cells.count
+        waitForExistence(app.otherElements[tabsTray].collectionViews.cells.firstMatch)
+        let numTabsOpen = app.otherElements[tabsTray].collectionViews.cells.count
         XCTAssertEqual(numTabsOpen, 1, "New tab not open")
     }
 
@@ -275,8 +276,8 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         var numTabsOpen = app.collectionViews.element(boundBy: 1).cells.count
         if iPad() {
             navigator.goto(TabTray)
-            numTabsOpen = app.otherElements["Tabs Tray"].collectionViews.cells.count
-            waitForExistence(app.otherElements["Tabs Tray"].collectionViews.cells.firstMatch)
+            numTabsOpen = app.otherElements[tabsTray].collectionViews.cells.count
+            waitForExistence(app.otherElements[tabsTray].collectionViews.cells.firstMatch)
         } else {
             waitForExistence(app.collectionViews.element(boundBy: 1).cells.firstMatch)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -123,7 +123,7 @@ class DragAndDropTests: FeatureFlaggedTestBase {
                     XCTFail("Failed to retrieve a valid URL string from the browser's URL bar")
                 }
             } else {
-                XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+                XCTAssertEqual(app.otherElements[tabsTray].cells.element(boundBy: 0).label, secondWebsite.tabName)
             }
         }
     }
@@ -146,7 +146,7 @@ class DragAndDropTests: FeatureFlaggedTestBase {
                 dropOnElement: app.collectionViews.cells[secondWebsite.tabName].firstMatch
             )
             checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
-            XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+            XCTAssertEqual(app.otherElements[tabsTray].cells.element(boundBy: 0).label, secondWebsite.tabName)
         }
     }
 
@@ -179,7 +179,7 @@ class DragAndDropTests: FeatureFlaggedTestBase {
                     XCTFail("Failed to retrieve a valid URL string from the browser's URL bar")
                 }
             } else {
-                XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+                XCTAssertEqual(app.otherElements[tabsTray].cells.element(boundBy: 0).label, secondWebsite.tabName)
             }
         }
     }
@@ -203,7 +203,7 @@ class DragAndDropTests: FeatureFlaggedTestBase {
             )
             checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: homeTabName)
             // Check that focus is kept on last website open
-            XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+            XCTAssertEqual(app.otherElements[tabsTray].cells.element(boundBy: 0).label, secondWebsite.tabName)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -912,10 +912,11 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         }
 
         screenState.onEnter { userState in
+            let tabsTray = AccessibilityIdentifiers.TabTray.tabsTray
             let exists = NSPredicate(format: "exists == true")
-            let expectation = XCTNSPredicateExpectation(predicate: exists, object: app.otherElements["Tabs Tray"])
+            let expectation = XCTNSPredicateExpectation(predicate: exists, object: app.otherElements[tabsTray])
             let _ = XCTWaiter().wait(for: [expectation], timeout: 5)
-            userState.numTabs = Int(app.otherElements["Tabs Tray"].cells.count)
+            userState.numTabs = Int(app.otherElements[tabsTray].cells.count)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
@@ -43,7 +43,7 @@ final class InactiveTabsTest: BaseTestCase {
         waitForElementsToExist(
             [
                 app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView],
-                app.otherElements["Tabs Tray"].staticTexts.firstMatch
+                app.otherElements[tabsTray].staticTexts.firstMatch
             ]
         )
 
@@ -52,10 +52,10 @@ final class InactiveTabsTest: BaseTestCase {
         waitForElementsToExist(
             [
                 app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerButton],
-                app.otherElements["Tabs Tray"].staticTexts["Homepage"],
-                app.otherElements["Tabs Tray"].staticTexts["Google"],
-                app.otherElements["Tabs Tray"].staticTexts["Facebook - log in or sign up"],
-                app.otherElements["Tabs Tray"].staticTexts["Amazon.com. Spend less. Smile more."]
+                app.otherElements[tabsTray].staticTexts["Homepage"],
+                app.otherElements[tabsTray].staticTexts["Google"],
+                app.otherElements[tabsTray].staticTexts["Facebook - log in or sign up"],
+                app.otherElements[tabsTray].staticTexts["Amazon.com. Spend less. Smile more."]
             ]
         )
         app.buttons[AccessibilityIdentifiers.TabTray.doneButton].waitAndTap()
@@ -74,15 +74,15 @@ final class InactiveTabsTest: BaseTestCase {
 
         // Return to tabs tray
         navigator.goto(TabTray)
-        app.otherElements["Tabs Tray"].swipeDown()
-        app.otherElements["Tabs Tray"].swipeDown()
-        app.otherElements["Tabs Tray"].swipeDown()
+        app.otherElements[tabsTray].swipeDown()
+        app.otherElements[tabsTray].swipeDown()
+        app.otherElements[tabsTray].swipeDown()
         waitForElementsToExist(
             [
-                app.otherElements["Tabs Tray"].staticTexts["Homepage"],
-                app.otherElements["Tabs Tray"].staticTexts["Google"],
-                app.otherElements["Tabs Tray"].staticTexts["Facebook - log in or sign up"],
-                app.otherElements["Tabs Tray"].staticTexts["Amazon.com. Spend less. Smile more."],
+                app.otherElements[tabsTray].staticTexts["Homepage"],
+                app.otherElements[tabsTray].staticTexts["Google"],
+                app.otherElements[tabsTray].staticTexts["Facebook - log in or sign up"],
+                app.otherElements[tabsTray].staticTexts["Amazon.com. Spend less. Smile more."],
             ]
         )
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerButton])
@@ -105,11 +105,11 @@ final class InactiveTabsTest: BaseTestCase {
         waitForElementsToExist(
             [
                 app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerButton],
-                app.otherElements["Tabs Tray"].staticTexts["Homepage"]
+                app.otherElements[tabsTray].staticTexts["Homepage"]
             ]
         )
-        app.otherElements["Tabs Tray"].staticTexts["Homepage"].waitAndTap()
-        mozWaitForElementToNotExist(app.otherElements["Tabs Tray"])
+        app.otherElements[tabsTray].staticTexts["Homepage"].waitAndTap()
+        mozWaitForElementToNotExist(app.otherElements[tabsTray])
 
         navigator.nowAt(NewTabScreen)
         navigator.goto(TabTray)
@@ -125,23 +125,23 @@ final class InactiveTabsTest: BaseTestCase {
         waitForElementsToExist(
             [
                 app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerButton],
-                app.otherElements["Tabs Tray"].staticTexts["Google"]
+                app.otherElements[tabsTray].staticTexts["Google"]
             ]
         )
         if !iPad() {
             // The active tabs on iPhone is so far down that "Homepage" is invisible.
             // iPad is large enough that "Homepage" is still visible"
-            mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Homepage"])
+            mozWaitForElementToNotExist(app.otherElements[tabsTray].staticTexts["Homepage"])
         }
 
         // Swipe on a tab from the list to delete
-        app.otherElements["Tabs Tray"].staticTexts["Google"].swipeLeft()
-        app.otherElements["Tabs Tray"].buttons["Close"].waitAndTap() // Note: No AccessibilityIdentifier
-        mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Google"])
+        app.otherElements[tabsTray].staticTexts["Google"].swipeLeft()
+        app.otherElements[tabsTray].buttons["Close"].waitAndTap() // Note: No AccessibilityIdentifier
+        mozWaitForElementToNotExist(app.otherElements[tabsTray].staticTexts["Google"])
         waitForElementsToExist(
             [
-                app.otherElements["Tabs Tray"].staticTexts["Facebook - log in or sign up"],
-                app.otherElements["Tabs Tray"].staticTexts["Amazon.com. Spend less. Smile more."]
+                app.otherElements[tabsTray].staticTexts["Facebook - log in or sign up"],
+                app.otherElements[tabsTray].staticTexts["Amazon.com. Spend less. Smile more."]
             ]
         )
 
@@ -153,11 +153,11 @@ final class InactiveTabsTest: BaseTestCase {
 
         // All inactive tabs are deleted
         navigator.nowAt(TabTray)
-        mozWaitForElementToExist(app.otherElements["Tabs Tray"].staticTexts["Homepage"])
-        XCTAssertEqual(app.otherElements["Tabs Tray"].collectionViews.cells.count, 2)
+        mozWaitForElementToExist(app.otherElements[tabsTray].staticTexts["Homepage"])
+        XCTAssertEqual(app.otherElements[tabsTray].collectionViews.cells.count, 2)
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView])
-        mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Google"])
-        mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Facebook - log in or sign up"])
-        mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Amazon.com. Spend less. Smile more."])
+        mozWaitForElementToNotExist(app.otherElements[tabsTray].staticTexts["Google"])
+        mozWaitForElementToNotExist(app.otherElements[tabsTray].staticTexts["Facebook - log in or sign up"])
+        mozWaitForElementToNotExist(app.otherElements[tabsTray].staticTexts["Amazon.com. Spend less. Smile more."])
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -566,9 +566,9 @@ class LoginTest: BaseTestCase {
     }
 
     func enterTextInField(typedText: String) {
+        mozWaitForElementToExist(app.keyboards.firstMatch)
         // iOS 15 does not expand the keyboard for entering the credentials sometimes.
         if #unavailable(iOS 16) {
-            mozWaitForElementToExist(app.keyboards.firstMatch)
             if app.keyboards.buttons["Continue"].exists {
                 app.keyboards.buttons["Continue"].waitAndTap()
                 mozWaitForElementToNotExist(app.keyboards.buttons["Continue"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -477,10 +477,10 @@ class NavigationTest: BaseTestCase {
         app.buttons["Open in New Tab"].waitAndTap()
         // A new tab loading the article page should open
         navigator.goto(TabTray)
-        mozWaitForElementToExist(app.otherElements["Tabs Tray"].cells.staticTexts["Example Domain"])
-        let numTabs = app.otherElements["Tabs Tray"].cells.count
+        mozWaitForElementToExist(app.otherElements[tabsTray].cells.staticTexts["Example Domain"])
+        let numTabs = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(numTabs, 2, "Total number of opened tabs should be 2")
-        mozWaitForElementToExist(app.otherElements["Tabs Tray"].cells.elementContainingText("Example Domain."))
+        mozWaitForElementToExist(app.otherElements[tabsTray].cells.elementContainingText("Example Domain."))
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441773
@@ -490,9 +490,9 @@ class NavigationTest: BaseTestCase {
         app.buttons["Open in New Private Tab"].waitAndTap()
         // The article is loaded in a new private tab
         navigator.goto(TabTray)
-        var numTabs = app.otherElements["Tabs Tray"].cells.count
+        var numTabs = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(numTabs, 1, "Total number of regulat opened tabs should be 1")
-        mozWaitForElementToExist(app.otherElements["Tabs Tray"].cells.elementContainingText("Example Domain."))
+        mozWaitForElementToExist(app.otherElements[tabsTray].cells.elementContainingText("Example Domain."))
         if iPad() {
             app.buttons["Private"].waitAndTap()
         } else {
@@ -502,9 +502,9 @@ class NavigationTest: BaseTestCase {
             // workaround end
             app.buttons[StandardImageIdentifiers.Large.privateMode].waitAndTap()
         }
-        numTabs = app.otherElements["Tabs Tray"].cells.count
+        numTabs = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(numTabs, 1, "Total number of private opened tabs should be 1")
-        mozWaitForElementToExist(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).staticTexts["Example Domains"])
+        mozWaitForElementToExist(app.otherElements[tabsTray].cells.element(boundBy: 0).staticTexts["Example Domains"])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441774

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -61,13 +61,13 @@ class PrivateBrowsingTest: BaseTestCase {
         waitUntilPageLoad()
         waitForTabsButton()
         navigator.goto(TabTray)
-        mozWaitForElementToExist(app.otherElements["Tabs Tray"])
+        mozWaitForElementToExist(app.otherElements[tabsTray])
         XCTAssertNotNil(
-            app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts
+            app.otherElements[tabsTray].collectionViews.cells.staticTexts
                 .element(boundBy: 1).label
                 .range(of: url2Label)
         )
-        let numTabs = app.otherElements["Tabs Tray"].cells.count
+        let numTabs = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(numTabs, 2, "The number of regular tabs is not correct")
 
         // Open one tab in private browsing and check the total number of tabs
@@ -81,20 +81,20 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         navigator.goto(TabTray)
-        mozWaitForElementToExist(app.otherElements["Tabs Tray"].cells.staticTexts[url1And3Label])
-        let numPrivTabs = app.otherElements["Tabs Tray"].cells.count
+        mozWaitForElementToExist(app.otherElements[tabsTray].cells.staticTexts[url1And3Label])
+        let numPrivTabs = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(numPrivTabs, 1, "The number of private tabs is not correct")
         // Go back to regular mode and check the total number of tabs
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
 
-        mozWaitForElementToExist(app.otherElements["Tabs Tray"])
+        mozWaitForElementToExist(app.otherElements[tabsTray])
         XCTAssertNotNil(
-            app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts
+            app.otherElements[tabsTray].collectionViews.cells.staticTexts
                 .element(boundBy: 1).label
                 .range(of: url2Label)
         )
-        mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts[url1And3Label])
-        let numRegularTabs = app.otherElements["Tabs Tray"].cells.count
+        mozWaitForElementToNotExist(app.otherElements[tabsTray].collectionViews.cells.staticTexts[url1And3Label])
+        let numRegularTabs = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(numRegularTabs, 2, "The number of regular tabs is not correct")
     }
 
@@ -122,7 +122,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         waitForElementsToExist(
             [
-                app.otherElements["Tabs Tray"],
+                app.otherElements[tabsTray],
                 app.staticTexts["Private Browsing"]
             ]
         )
@@ -169,7 +169,7 @@ class PrivateBrowsingTest: BaseTestCase {
         // If no private tabs are open, there should be a initial screen with label Private Browsing
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
-        let numPrivTabsFirstTime = app.otherElements["Tabs Tray"].cells.count
+        let numPrivTabsFirstTime = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(
             numPrivTabsFirstTime,
             0,
@@ -188,7 +188,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         navigator.nowAt(TabTray)
-        let numPrivTabsOpen = app.otherElements["Tabs Tray"].cells.count
+        let numPrivTabsOpen = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(numPrivTabsOpen, 1, "The number of private tabs is not correct")
     }
 
@@ -227,7 +227,7 @@ class PrivateBrowsingTest: BaseTestCase {
             }
         }
         navigator.goto(TabTray)
-        var numTab = app.otherElements["Tabs Tray"].cells.count
+        var numTab = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(4, numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
         app.buttons[AccessibilityIdentifiers.TabTray.closeAllTabsButton].waitAndTap()
 
@@ -248,10 +248,10 @@ class PrivateBrowsingTest: BaseTestCase {
         waitForElementsToExist(
             [
                 app.staticTexts["Private Browsing"],
-                app.otherElements["Tabs Tray"]
+                app.otherElements[tabsTray]
             ]
         )
-        numTab = app.otherElements["Tabs Tray"].cells.count
+        numTab = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(0, numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
         mozWaitForElementToExist(app.staticTexts["Private Browsing"])
 
@@ -259,7 +259,7 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // All the private tabs are restored
         navigator.goto(TabTray)
-        numTab = app.otherElements["Tabs Tray"].cells.count
+        numTab = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(4, numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
     }
 
@@ -281,7 +281,7 @@ class PrivateBrowsingTest: BaseTestCase {
             navigator.performAction(Action.CloseURLBarOpen)
             waitForTabsButton()
             navigator.goto(TabTray)
-            let numTab = app.otherElements["Tabs Tray"].cells.count
+            let numTab = app.otherElements[tabsTray].cells.count
             XCTAssertEqual(2, numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
         }
     }
@@ -289,7 +289,7 @@ class PrivateBrowsingTest: BaseTestCase {
 
 fileprivate extension BaseTestCase {
     func checkOpenTabsBeforeClosingPrivateMode() {
-        let numPrivTabs = app.otherElements["Tabs Tray"].cells.count
+        let numPrivTabs = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(
             numPrivTabs,
             0,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
@@ -57,7 +57,7 @@ class TabCounterTests: BaseTestCase {
         navigator.goto(TabTray)
 
         if isTablet {
-            app.otherElements["Tabs Tray"]
+            app.otherElements[tabsTray]
                 .collectionViews.cells.element(boundBy: 0)
                 .buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
         } else {
@@ -67,11 +67,11 @@ class TabCounterTests: BaseTestCase {
             let tabsOpenTabTray: String = navBarTabTrayButton.label
             XCTAssertTrue(tabsOpenTabTray.hasSuffix("2"))
 
-            app.otherElements["Tabs Tray"].cells
+            app.otherElements[tabsTray].cells
                 .element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
         }
 
-        app.otherElements["Tabs Tray"].cells.element(boundBy: 0).waitAndTap()
+        app.otherElements[tabsTray].cells.element(boundBy: 0).waitAndTap()
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -338,7 +338,7 @@ class TabsTests: BaseTestCase {
         mozWaitForElementToExist(navBarTabTrayButton)
         let tabsOpenTabTray: String = navBarTabTrayButton.label
         XCTAssertTrue(tabsOpenTabTray.hasSuffix(numTab!))
-        let tabsTrayCell = app.otherElements["Tabs Tray"].cells
+        let tabsTrayCell = app.otherElements[tabsTray].cells
         // Go to a tab that is below the fold of the scrollable “Open Tabs” view
         if !iPad() {
             tabsTrayCell.staticTexts.element(boundBy: 3).waitAndTap()
@@ -381,7 +381,7 @@ class TabsTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         waitForTabsButton()
         navigator.goto(TabTray)
-        let tabsTrayCell = app.otherElements["Tabs Tray"].cells
+        let tabsTrayCell = app.otherElements[tabsTray].cells
         if !iPad() {
             let button = AccessibilityIdentifiers.Toolbar.tabsButton
             let numTab = app.buttons[button].value as? String
@@ -398,7 +398,7 @@ class TabsTests: BaseTestCase {
         app.buttons["Undo"].waitAndTap()
         // Only the latest tab closed is restored
         if !iPad() {
-            let tabsTrayCell = app.otherElements["Tabs Tray"].cells
+            let tabsTrayCell = app.otherElements[tabsTray].cells
             XCTAssertEqual(1, tabsTrayCell.count)
         }
         mozWaitForElementToExist(app.otherElements.cells.staticTexts[urlLabelExample])
@@ -503,8 +503,8 @@ class TabsTests: BaseTestCase {
         XCTAssertEqual("4", numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
         navigator.goto(TabTray)
         // Long press on the tab tray to open the context menu
-        let tabsTrayCell = app.otherElements["Tabs Tray"].cells
-        app.otherElements["Tabs Tray"].cells.staticTexts.element(boundBy: 3).press(forDuration: 1.6)
+        let tabsTrayCell = app.otherElements[tabsTray].cells
+        app.otherElements[tabsTray].cells.staticTexts.element(boundBy: 3).press(forDuration: 1.6)
         // Context menu opens
         waitForElementsToExist(
             [


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4603

## :bulb: Description
The string “Tabs Tray” is currently hardcoded in multiple places across our tests.
To improve maintainability, reduce duplication we should centralize this string by adding it to the AccesibilityIdentifiers struct.
Also included a small attempt to fix the login tests that are failing on M4