### PR TITLE
Bugfix [Release Automation] Change the release tag name to contain the product name

### DIFF
--- a/taskcluster/ffios_taskgraph/release_promotion.py
+++ b/taskcluster/ffios_taskgraph/release_promotion.py
@@ -178,7 +178,7 @@ def release_promotion_action(parameters, graph_config, input, task_group_id, tas
         )
 
     parameters["version"] = version_string
-    parameters["head_tag"] = "v{}".format(version_string)
+    parameters["head_tag"] = "firefox-v{}".format(version_string)
     parameters["next_version"] = input["next_version"]
 
     release_type = "release"

--- a/taskcluster/test/params/release-promote-beta.yml
+++ b/taskcluster/test/params/release-promote-beta.yml
@@ -16,10 +16,10 @@ filters:
 head_ref: refs/heads/main
 head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
-head_tag: v137.0
+head_tag: firefox-v137.0b1
 level: '1'
 moz_build_date: '20250226191326'
-next_version: 137.0.1
+next_version: 137.0b2
 optimize_strategies: null
 optimize_target_tasks: true
 owner: nobody@mozilla.com
@@ -32,5 +32,5 @@ repository_type: git
 shipping_phase: promote
 target_tasks_method: promote
 tasks_for: action
-version: '137.0.0'
+version: '137.0b1'
 

--- a/taskcluster/test/params/release-promote.yml
+++ b/taskcluster/test/params/release-promote.yml
@@ -16,7 +16,7 @@ filters:
 head_ref: refs/heads/main
 head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
-head_tag: v137.0
+head_tag: firefox-v137.0
 level: '1'
 moz_build_date: '20250226191326'
 next_version: '137.1'

--- a/taskcluster/test/params/release-push-beta.yml
+++ b/taskcluster/test/params/release-push-beta.yml
@@ -16,10 +16,10 @@ filters:
 head_ref: refs/heads/main
 head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
-head_tag: v137.0.0
+head_tag: firefox-v137.0b1
 level: '1'
 moz_build_date: '20250226191326'
-next_version: 137.0.1
+next_version: 137.0b2
 optimize_strategies: null
 optimize_target_tasks: true
 owner: nobody@mozilla.com
@@ -32,4 +32,4 @@ repository_type: git
 shipping_phase: push
 target_tasks_method: push
 tasks_for: action
-version: '137.0.0'
+version: '137.0b1'

--- a/taskcluster/test/params/release-push.yml
+++ b/taskcluster/test/params/release-push.yml
@@ -16,7 +16,7 @@ filters:
 head_ref: refs/heads/main
 head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
-head_tag: v137.0
+head_tag: firefox-v137.0
 level: '1'
 moz_build_date: '20250226191326'
 next_version: '137.1'

--- a/taskcluster/test/params/release-ship-beta.yml
+++ b/taskcluster/test/params/release-ship-beta.yml
@@ -16,7 +16,7 @@ filters:
 head_ref: refs/heads/main
 head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
-head_tag: v137.0b1
+head_tag: firefox-v137b1
 level: '1'
 moz_build_date: '20250226191326'
 next_version: 137.0.1

--- a/taskcluster/test/params/release-ship.yml
+++ b/taskcluster/test/params/release-ship.yml
@@ -16,7 +16,7 @@ filters:
 head_ref: refs/heads/main
 head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
-head_tag: v137.0
+head_tag: firefox-v137.0
 level: '1'
 moz_build_date: '20250226191326'
 next_version: '137.1'


### PR DESCRIPTION
Because focus is a thing, we need a way to distinguish firefox tags from focus tags.


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
