### PR TITLE
Remove FXIOS-12339 [Unit tests] Skipping test testRandomThreading

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TestHistory.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TestHistory.swift
@@ -238,30 +238,31 @@ class TestHistory: XCTestCase {
 
     // Fuzzing tests. These fire random insert/query/clear commands into the history database from threads.
     // The don't check the results. Just look for crashes.
-    func testRandomThreading() {
-        let queue = DispatchQueue(
-            label: "My Queue",
-            qos: DispatchQoS.default,
-            attributes: DispatchQueue.Attributes.concurrent,
-            autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency.inherit,
-            target: nil
-        )
-        var counter = 0
-
-        let expectation = self.expectation(description: "Wait for history")
-        for _ in 0..<self.numThreads {
-            var places = profile.places
-            self.runRandom(&places, queue: queue, completion: { () in
-                counter += 1
-                if counter == self.numThreads {
-                    self.profile.places.deleteEverythingHistory().uponQueue(.global()) { result in
-                        XCTAssertTrue(result.isSuccess, "History cleared.")
-                        expectation .fulfill()
-                    }
-                }
-            })
-        }
-        self.waitForExpectations(timeout: 10, handler: nil)
+    func testRandomThreading() throws {
+        throw XCTSkip("Skipping this test since https://mozilla-hub.atlassian.net/browse/FXIOS-12339")
+//        let queue = DispatchQueue(
+//            label: "My Queue",
+//            qos: DispatchQoS.default,
+//            attributes: DispatchQueue.Attributes.concurrent,
+//            autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency.inherit,
+//            target: nil
+//        )
+//        var counter = 0
+//
+//        let expectation = self.expectation(description: "Wait for history")
+//        for _ in 0..<self.numThreads {
+//            var places = profile.places
+//            self.runRandom(&places, queue: queue, completion: { () in
+//                counter += 1
+//                if counter == self.numThreads {
+//                    self.profile.places.deleteEverythingHistory().uponQueue(.global()) { result in
+//                        XCTAssertTrue(result.isSuccess, "History cleared.")
+//                        expectation .fulfill()
+//                    }
+//                }
+//            })
+//        }
+//        self.waitForExpectations(timeout: 10, handler: nil)
     }
 
     // Same as testRandomThreading, but uses one history connection for all threads


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12339)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26879)

## :bulb: Description
I am proposing to entirely disable this test since:
- It's random. Unit tests are supposed to be reliable. When a test fails we should be able to reproduce the exact conditions, which is not the case here. I don't think this test helps us debug problems in the `Profile` layer very well.
- It's failing very often and made me restart way too many Bitrise builds.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
