### PR TITLE
Bugfix FXIOS-12307 [SEC] Fix API errors when testing against staging

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
@@ -45,6 +45,14 @@ final class ASSearchEngineSelector: ASSearchEngineSelectorProtocol {
                                             version: AppInfo.appVersion,
                                             deviceType: deviceType)
 
+            // FXIOS-12307 For now we force a sync() when hitting stage server, otherwise we get API errors
+            // This should only impact QA and internal testing, not production.
+            let profile: Profile = AppContainer.shared.resolve()
+            let isStaging = profile.prefs.boolForKey(PrefsKeys.RemoteSettings.useQAStagingServerForRemoteSettings) == true
+            if isStaging {
+                _ = try? profile.remoteSettingsService?.sync()
+            }
+
             var searchResultsConfig = try engineSelector.filterEngineConfiguration(userEnvironment: env)
 
             // We want to be sure that our default engines list is always sorted with the default in position 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12307)
[Github Issue](https://github.com/mozilla-mobile/firefox-ios/issues/26805)

## :bulb: Description

Force a sync() when hitting stage server. This is necessary for QA testing, should have no impact for production/release.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
