### PR TITLE
Refactor FXIOS-7301 - Remove 3 closure_body_length violations from RemoteTabsPanelState.swift, UserScriptManager.swift, and OpenTabsWidget.swift

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,8 +103,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 42
-  error: 42
+  warning: 41
+  error: 41
 
 file_header:
   required_string: |

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -113,13 +113,7 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
                                                  action: action)
         case RemoteTabsPanelActionType.remoteDevicesChanged:
             guard let devices = action.devices else { return defaultState(from: state) }
-            let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                                refreshState: .idle,
-                                                allowsRefresh: state.allowsRefresh,
-                                                clientAndTabs: state.clientAndTabs,
-                                                showingEmptyState: state.showingEmptyState,
-                                                devices: devices)
-            return newState
+            return handleRemoteDevicesChangedAction(devices: devices, state: state)
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -142,13 +142,12 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
     private static func handleRefreshDidSucceedAction(clientAndTabs: [ClientAndTabs],
                                                       state: RemoteTabsPanelState,
                                                       action: RemoteTabsPanelAction) -> RemoteTabsPanelState {
-        let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                            refreshState: .idle,
-                                            allowsRefresh: true,
-                                            clientAndTabs: clientAndTabs,
-                                            showingEmptyState: nil,
-                                            devices: action.devices ?? state.devices)
-        return newState
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .idle,
+                                    allowsRefresh: true,
+                                    clientAndTabs: clientAndTabs,
+                                    showingEmptyState: nil,
+                                    devices: action.devices ?? state.devices)
     }
 
     private static func handleRemoteDevicesChangedAction(devices: [Device],

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -151,6 +151,18 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
         return newState
     }
 
+    private static func handleRefreshDidSucceedAction(clientAndTabs: [ClientAndTabs],
+                                                      state: RemoteTabsPanelState,
+                                                      action: RemoteTabsPanelAction) -> RemoteTabsPanelState {
+        let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                            refreshState: .idle,
+                                            allowsRefresh: true,
+                                            clientAndTabs: clientAndTabs,
+                                            showingEmptyState: nil,
+                                            devices: action.devices ?? state.devices)
+        return newState
+    }
+
     static func defaultState(from state: RemoteTabsPanelState) -> RemoteTabsPanelState {
         return RemoteTabsPanelState(windowUUID: state.windowUUID,
                                     refreshState: state.refreshState,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -105,14 +105,7 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
         case RemoteTabsPanelActionType.refreshDidFail:
             guard let reason = action.reason else { return defaultState(from: state) }
             // Refresh failed. Show error empty state.
-            let allowsRefresh = reason.allowsRefresh
-            let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                                refreshState: .idle,
-                                                allowsRefresh: allowsRefresh,
-                                                clientAndTabs: state.clientAndTabs,
-                                                showingEmptyState: reason,
-                                                devices: state.devices)
-            return newState
+            return handleRefreshDidFailAction(reason: reason, state: state)
         case RemoteTabsPanelActionType.refreshDidSucceed:
             guard let clientAndTabs = action.clientAndTabs else { return defaultState(from: state) }
             let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -101,13 +101,7 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
 
         switch action.actionType {
         case RemoteTabsPanelActionType.refreshDidBegin:
-            let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                                refreshState: .refreshing,
-                                                allowsRefresh: state.allowsRefresh,
-                                                clientAndTabs: state.clientAndTabs,
-                                                showingEmptyState: state.showingEmptyState,
-                                                devices: state.devices)
-            return newState
+            return handleRefreshDidBeginAction(state: state)
         case RemoteTabsPanelActionType.refreshDidFail:
             guard let reason = action.reason else { return defaultState(from: state) }
             // Refresh failed. Show error empty state.

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -131,13 +131,12 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
     private static func handleRefreshDidFailAction(reason: RemoteTabsPanelEmptyStateReason,
                                                    state: RemoteTabsPanelState) -> RemoteTabsPanelState {
         let allowsRefresh = reason.allowsRefresh
-        let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                            refreshState: .idle,
-                                            allowsRefresh: allowsRefresh,
-                                            clientAndTabs: state.clientAndTabs,
-                                            showingEmptyState: reason,
-                                            devices: state.devices)
-        return newState
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .idle,
+                                    allowsRefresh: allowsRefresh,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: reason,
+                                    devices: state.devices)
     }
 
     private static func handleRefreshDidSucceedAction(clientAndTabs: [ClientAndTabs],

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -108,13 +108,9 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
             return handleRefreshDidFailAction(reason: reason, state: state)
         case RemoteTabsPanelActionType.refreshDidSucceed:
             guard let clientAndTabs = action.clientAndTabs else { return defaultState(from: state) }
-            let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                                refreshState: .idle,
-                                                allowsRefresh: true,
-                                                clientAndTabs: clientAndTabs,
-                                                showingEmptyState: nil,
-                                                devices: action.devices ?? state.devices)
-            return newState
+            return handleRefreshDidSucceedAction(clientAndTabs: clientAndTabs,
+                                                 state: state,
+                                                 action: action)
         case RemoteTabsPanelActionType.remoteDevicesChanged:
             guard let devices = action.devices else { return defaultState(from: state) }
             let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -159,6 +159,17 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
         return newState
     }
 
+    private static func handleRemoteDevicesChangedAction(devices: [Device],
+                                                         state: RemoteTabsPanelState) -> RemoteTabsPanelState {
+        let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                            refreshState: .idle,
+                                            allowsRefresh: state.allowsRefresh,
+                                            clientAndTabs: state.clientAndTabs,
+                                            showingEmptyState: state.showingEmptyState,
+                                            devices: devices)
+        return newState
+    }
+
     static func defaultState(from state: RemoteTabsPanelState) -> RemoteTabsPanelState {
         return RemoteTabsPanelState(windowUUID: state.windowUUID,
                                     refreshState: state.refreshState,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -146,6 +146,18 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
         return newState
     }
 
+    private static func handleRefreshDidFailAction(reason: RemoteTabsPanelEmptyStateReason,
+                                                   state: RemoteTabsPanelState) -> RemoteTabsPanelState {
+        let allowsRefresh = reason.allowsRefresh
+        let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                            refreshState: .idle,
+                                            allowsRefresh: allowsRefresh,
+                                            clientAndTabs: state.clientAndTabs,
+                                            showingEmptyState: reason,
+                                            devices: state.devices)
+        return newState
+    }
+
     static func defaultState(from state: RemoteTabsPanelState) -> RemoteTabsPanelState {
         return RemoteTabsPanelState(windowUUID: state.windowUUID,
                                     refreshState: state.refreshState,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -142,6 +142,16 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
         }
     }
 
+    private static func handleRefreshDidBeginAction(state: RemoteTabsPanelState) -> RemoteTabsPanelState {
+        let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                            refreshState: .refreshing,
+                                            allowsRefresh: state.allowsRefresh,
+                                            clientAndTabs: state.clientAndTabs,
+                                            showingEmptyState: state.showingEmptyState,
+                                            devices: state.devices)
+        return newState
+    }
+
     static func defaultState(from state: RemoteTabsPanelState) -> RemoteTabsPanelState {
         return RemoteTabsPanelState(windowUUID: state.windowUUID,
                                     refreshState: state.refreshState,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -120,13 +120,12 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
     }
 
     private static func handleRefreshDidBeginAction(state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                            refreshState: .refreshing,
-                                            allowsRefresh: state.allowsRefresh,
-                                            clientAndTabs: state.clientAndTabs,
-                                            showingEmptyState: state.showingEmptyState,
-                                            devices: state.devices)
-        return newState
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .refreshing,
+                                    allowsRefresh: state.allowsRefresh,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: state.showingEmptyState,
+                                    devices: state.devices)
     }
 
     private static func handleRefreshDidFailAction(reason: RemoteTabsPanelEmptyStateReason,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -152,13 +152,12 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
 
     private static func handleRemoteDevicesChangedAction(devices: [Device],
                                                          state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                            refreshState: .idle,
-                                            allowsRefresh: state.allowsRefresh,
-                                            clientAndTabs: state.clientAndTabs,
-                                            showingEmptyState: state.showingEmptyState,
-                                            devices: devices)
-        return newState
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .idle,
+                                    allowsRefresh: state.allowsRefresh,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: state.showingEmptyState,
+                                    devices: devices)
     }
 
     static func defaultState(from state: RemoteTabsPanelState) -> RemoteTabsPanelState {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/UserScriptManager.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/UserScriptManager.swift
@@ -37,52 +37,9 @@ class UserScriptManager: FeatureFlaggable {
          (WKUserScriptInjectionTime.atDocumentStart, mainFrameOnly: true),
          (WKUserScriptInjectionTime.atDocumentEnd, mainFrameOnly: true)].forEach { arg in
             let (injectionTime, mainFrameOnly) = arg
-            let mainframeString = mainFrameOnly ? "MainFrame" : "AllFrames"
-            let injectionString = injectionTime == .atDocumentStart ? "Start" : "End"
-            let name = mainframeString + "AtDocument" + injectionString
-            if let source = UserScriptManager.getScriptSource(name) {
-                let wrappedSource = "(function() { const APP_ID_TOKEN = '\(UserScriptManager.appIdToken)'; \(source) })()"
-                let userScript = WKUserScript.createInDefaultContentWorld(
-                    source: wrappedSource,
-                    injectionTime: injectionTime,
-                    forMainFrameOnly: mainFrameOnly
-                )
-                compiledUserScripts[name] = userScript
-            }
-
-            // NightMode scripts
-            let nightModeName = "NightMode\(name)"
-            if let source = UserScriptManager.getScriptSource(nightModeName) {
-                let wrappedSource = "(function() { const APP_ID_TOKEN = '\(UserScriptManager.appIdToken)'; \(source) })()"
-                let userScript = WKUserScript(
-                    source: wrappedSource,
-                    injectionTime: injectionTime,
-                    forMainFrameOnly: mainFrameOnly,
-                    in: .world(name: NightModeHelper.name()))
-                compiledUserScripts[nightModeName] = userScript
-            }
-
-            // Autofill scripts
-            let autofillName = "Autofill\(name)"
-            if let source = UserScriptManager.getScriptSource(autofillName) {
-                let wrappedSource = "(function() { const APP_ID_TOKEN = '\(UserScriptManager.appIdToken)'; \(source) })()"
-                let userScript = WKUserScript.createInDefaultContentWorld(
-                    source: wrappedSource,
-                    injectionTime: injectionTime,
-                    forMainFrameOnly: mainFrameOnly)
-                compiledUserScripts[autofillName] = userScript
-            }
-
-            let webcompatName = "Webcompat\(name)"
-            if let source = UserScriptManager.getScriptSource(webcompatName) {
-                let wrappedSource = "(function() { const APP_ID_TOKEN = '\(UserScriptManager.appIdToken)'; \(source) })()"
-                let userScript = WKUserScript.createInPageContentWorld(
-                    source: wrappedSource,
-                    injectionTime: injectionTime,
-                    forMainFrameOnly: mainFrameOnly
-                )
-                compiledUserScripts[webcompatName] = userScript
-            }
+            UserScriptManager.addScripts(mainFrameOnly: mainFrameOnly,
+                                         injectionTime: injectionTime,
+                                         scripts: &compiledUserScripts)
         }
 
         self.compiledUserScripts = compiledUserScripts

--- a/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -132,33 +132,7 @@ struct OpenTabsView: View {
             if entry.tabs.isEmpty {
                 emptyView
             } else {
-                VStack(spacing: 8) {
-                    ForEach(entry.tabs.suffix(numberOfTabsToDisplay), id: \.self) { tab in
-                        lineItemForTab(tab)
-                    }
-
-                    if entry.tabs.count > numberOfTabsToDisplay {
-                        HStack(alignment: .center, spacing: 15) {
-                            Image(decorative: StandardImageIdentifiers.Small.externalLink)
-                                .foregroundColor(Color("openTabsContentColor"))
-                                .frame(width: 16, height: 16)
-                            Text(
-                                String.localizedStringWithFormat(
-                                    String.MoreTabsLabel,
-                                    (entry.tabs.count - numberOfTabsToDisplay)
-                                )
-                            )
-                            .foregroundColor(Color("openTabsContentColor"))
-                            .lineLimit(1)
-                            .font(.system(size: 13, weight: .semibold, design: .default))
-                            Spacer()
-                        }.padding([.horizontal])
-                    } else {
-                        openFirefoxButton
-                    }
-
-                    Spacer()
-                }.padding(.top, 14)
+                tabsView
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -77,6 +77,36 @@ struct OpenTabsView: View {
         .foregroundColor(Color("backgroundColor"))
     }
 
+    var tabsView: some View {
+        VStack(spacing: 8) {
+            ForEach(entry.tabs.suffix(numberOfTabsToDisplay), id: \.self) { tab in
+                lineItemForTab(tab)
+            }
+
+            if entry.tabs.count > numberOfTabsToDisplay {
+                HStack(alignment: .center, spacing: 15) {
+                    Image(decorative: StandardImageIdentifiers.Small.externalLink)
+                        .foregroundColor(Color("openTabsContentColor"))
+                        .frame(width: 16, height: 16)
+                    Text(
+                        String.localizedStringWithFormat(
+                            String.MoreTabsLabel,
+                            (entry.tabs.count - numberOfTabsToDisplay)
+                        )
+                    )
+                    .foregroundColor(Color("openTabsContentColor"))
+                    .lineLimit(1)
+                    .font(.system(size: 13, weight: .semibold, design: .default))
+                    Spacer()
+                }.padding([.horizontal])
+            } else {
+                openFirefoxButton
+            }
+
+            Spacer()
+        }.padding(.top, 14)
+    }
+
     var openFirefoxButton: some View {
         HStack(alignment: .center, spacing: 15) {
             Image(decorative: StandardImageIdentifiers.Small.externalLink)

--- a/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -100,20 +100,7 @@ struct OpenTabsView: View {
     var body: some View {
         Group {
             if entry.tabs.isEmpty {
-                VStack {
-                    Text(String.NoOpenTabsLabel)
-                    HStack {
-                        Spacer()
-                        Image(decorative: StandardImageIdentifiers.Small.externalLink)
-                            .foregroundColor(Color("openTabsContentColor"))
-                        Text(String.OpenFirefoxLabel)
-                            .foregroundColor(Color("openTabsContentColor"))
-                            .lineLimit(1)
-                            .font(.system(size: 13, weight: .semibold, design: .default))
-                        Spacer()
-                    }.padding(10)
-                }
-                .foregroundColor(Color("backgroundColor"))
+                emptyView
             } else {
                 VStack(spacing: 8) {
                     ForEach(entry.tabs.suffix(numberOfTabsToDisplay), id: \.self) { tab in

--- a/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -60,6 +60,23 @@ struct OpenTabsView: View {
         }
     }
 
+    var emptyView: some View {
+        VStack {
+            Text(String.NoOpenTabsLabel)
+            HStack {
+                Spacer()
+                Image(decorative: StandardImageIdentifiers.Small.externalLink)
+                    .foregroundColor(Color("openTabsContentColor"))
+                Text(String.OpenFirefoxLabel)
+                    .foregroundColor(Color("openTabsContentColor"))
+                    .lineLimit(1)
+                    .font(.system(size: 13, weight: .semibold, design: .default))
+                Spacer()
+            }.padding(10)
+        }
+        .foregroundColor(Color("backgroundColor"))
+    }
+
     var openFirefoxButton: some View {
         HStack(alignment: .center, spacing: 15) {
             Image(decorative: StandardImageIdentifiers.Small.externalLink)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 3 `closure_body_length` violations and decreases the threshold to 41. In all these files, I've implemented some code block extractions.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
