### PR TITLE
Refactor FXIOS-12346 [Unit Tests] browser view web delegate tests

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -340,6 +340,8 @@ class BrowserViewController: UIViewController,
     weak var pendingDownloadWebView: WKWebView?
 
     let downloadQueue: DownloadQueue
+    let mainQueue: DispatchQueueInterface
+    let userInitiatedQueue: DispatchQueueInterface
 
     private let bookmarksSaver: BookmarksSaver
     let bookmarksHandler: BookmarksHandler
@@ -373,7 +375,9 @@ class BrowserViewController: UIViewController,
         logger: Logger = DefaultLogger.shared,
         documentLogger: DocumentLogger = AppContainer.shared.resolve(),
         appAuthenticator: AppAuthenticationProtocol = AppAuthenticator(),
-        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve()
+        searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
+        mainQueue: DispatchQueueInterface = DispatchQueue.main,
+        userInitiatedQueue: DispatchQueueInterface = DispatchQueue.global(qos: .userInitiated)
     ) {
         self.profile = profile
         self.tabManager = tabManager
@@ -390,6 +394,8 @@ class BrowserViewController: UIViewController,
         self.bookmarksHandler = profile.places
         self.zoomManager = ZoomPageManager(windowUUID: tabManager.windowUUID)
         self.tabsPanelTelemetry = TabsPanelTelemetry(gleanWrapper: gleanWrapper, logger: logger)
+        self.mainQueue = mainQueue
+        self.userInitiatedQueue = userInitiatedQueue
 
         super.init(nibName: nil, bundle: nil)
         didInit()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -314,7 +314,12 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
     }
 
     private func createSubject() -> BrowserViewController {
-        let subject = BrowserViewController(profile: profile, tabManager: tabManager)
+        let subject = BrowserViewController(
+            profile: profile,
+            tabManager: tabManager,
+            mainQueue: MockDispatchQueue(),
+            userInitiatedQueue: MockDispatchQueue()
+        )
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12346)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26895)

## :bulb: Description
Mock out the dispatch queues for `testWebViewDidReceiveChallenge_MethodServerTrust` . One for main and one for the user initiated queue.

- Unit tests seem to be flaky after `May 12`

Reference: https://app.bitrise.io/insights/095364a9afb324b2/explore/tests?interval=daily&duration=P30D&tab=failure_rate&app_slug=6c06d3a40422d10f&pipeline=pipeline_build_and_test&workflow=firefox_configure_build&branch=main&secondary_tab=related_test_case_runs&test_case_name=testWebViewDidReceiveChallenge_MethodServerTrust()&test_suite_name=ClientTests&module=BrowserViewControllerWebViewDelegateTests

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
