### PR TITLE
Fix [MTE-4646] - testPrivateClosedSiteDoesNotAppearOnRecentlyClosed test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTabTrayUIExperimentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTabTrayUIExperimentTests.swift
@@ -384,7 +384,7 @@ class HistoryTabTrayUIExperimentTests: FeatureFlaggedTestSuite {
         // Close the private tab "Book of Mozilla" by tapping 'x' button
         waitForTabsButton()
         navigator.goto(TabTray)
-        mozWaitForElementToExist(app.cells.staticTexts[webpage["label"]!])
+        mozWaitForElementToExist(app.staticTexts.elementContainingText(webpage["label"]!))
         if iPad() {
             app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
         } else {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4646

## :bulb: Description
The tab might be or not "currently the selected tab'.
Either way i have added validation for elementContainingText to make sure the website name appears.
