### PR TITLE
Refactor FXIOS-12083 [Unit Tests] tests to be isolated from global middlewares

### DIFF
--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -87,7 +87,7 @@ let middlewares = [
 #if TESTING
 var store: any DefaultDispatchStore<AppState> = Store(state: AppState(),
                                                       reducer: AppState.reducer,
-                                                      middlewares: middlewares)
+                                                      middlewares: [])
 #else
 let store: any DefaultDispatchStore<AppState> = Store(state: AppState(),
                                                       reducer: AppState.reducer,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -158,10 +158,10 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         subject.tabManager(tabManager, didSelectedTabChange: testTab, previousTab: testTab, isRestoring: false)
         wait(for: [expectation])
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions[3] as? GeneralBrowserAction)
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions[2] as? GeneralBrowserAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? GeneralBrowserActionType)
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 6)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 5)
         XCTAssertEqual(actionType, GeneralBrowserActionType.didSelectedTabChangeToHomepage)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
@@ -21,9 +21,9 @@ class TopSitesHelperTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
         self.deleteDatabases()
         self.profile = nil
+        super.tearDown()
     }
 
     override func setUp() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
@@ -8,16 +8,21 @@ import XCTest
 
 @testable import Client
 
-class ThemeSettingsControllerTests: XCTestCase {
+class ThemeSettingsControllerTests: XCTestCase, StoreTestUtility {
     let windowUUID: WindowUUID = .XCTestDefaultUUID
+    var mockStore: MockStoreForMiddleware<AppState>!
+    var appState: AppState!
+
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
+        setupStore()
     }
 
     override func tearDown() {
-        super.tearDown()
         DependencyHelperMock().reset()
+        resetStore()
+        super.tearDown()
     }
 
     func testUseSystemAppearance_WithRedux() {
@@ -133,5 +138,33 @@ class ThemeSettingsControllerTests: XCTestCase {
         let themeSwitch = UISwitch(frame: .zero)
         themeSwitch.isOn = isOn
         return themeSwitch
+    }
+
+    // MARK: StoreTestUtility
+    func setupAppState() -> Client.AppState {
+        let appState = AppState(
+            activeScreens: ActiveScreensState(
+                screens: [
+                    .themeSettings(
+                        ThemeSettingsState(
+                            windowUUID: .XCTestDefaultUUID
+                        )
+                    )
+                ]
+            )
+        )
+        self.appState = appState
+        return appState
+    }
+
+    func setupStore() {
+        StoreTestUtilityHelper.setupStore(
+            with: setupAppState(),
+            middlewares: [ThemeManagerMiddleware().themeManagerProvider]
+        )
+    }
+
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
@@ -32,7 +32,7 @@ class StoreTestUtilityHelper {
         store = Store(
             state: AppState(),
             reducer: AppState.reducer,
-            middlewares: middlewares
+            middlewares: []
         )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12083)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26299)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12197)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26545)

## :bulb: Description
This address the issue that was discovered from this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/26298#discussion_r2060556382). The issue was that tests were now observing notifications from middlewares. This caused an unrelated test `BrowserViewControllerTests` to be modified (which we reverted back in this PR). The fix is to pass an empty array instead of the actual middleware. 

If a test, such as `ThemeSettingsControllerTests`, needs to know about a middleware, then we can use `StoreTestUtilityHelper.setupStore` and pass in the appropriate middlewares. In the case of the theme settings test, we pass in `[ThemeManagerMiddleware().themeManagerProvider]`.

The top sites tests started being flaky shortly after the PR mentioned above, so hoping this PR will tackle both issues in one.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
