### PR TITLE
Bugfix FXIOS-12352 [Tab tray UI experiment] Tab tray selector title elided

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -37,6 +37,13 @@ class TabTraySelectorView: UIView,
     private lazy var selectionBackgroundView: UIView = .build { _ in }
     private var selectionBackgroundWidthConstraint: NSLayoutConstraint?
 
+    private lazy var stackView: UIStackView = .build { stackView in
+        stackView.axis = .horizontal
+        stackView.spacing = TabTraySelectorUX.horizontalPadding
+        stackView.distribution = .equalCentering
+        stackView.alignment = .center
+    }
+
     var items: [String] = ["", "", ""] {
         didSet {
             updateLabels()
@@ -74,14 +81,6 @@ class TabTraySelectorView: UIView,
         selectionBackgroundView.backgroundColor = theme.colors.actionSecondary
         selectionBackgroundView.layer.cornerRadius = TabTraySelectorUX.cornerRadius
         addSubview(selectionBackgroundView)
-
-        let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.spacing = TabTraySelectorUX.horizontalPadding
-        stackView.distribution = .equalCentering
-        stackView.alignment = .center
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-
         addSubview(stackView)
 
         for (index, title) in items.enumerated() {
@@ -139,11 +138,12 @@ class TabTraySelectorView: UIView,
     /// This prevents visual layout shifts during font weight transitions (e.g., from regular to bold),
     /// ensuring consistent spacing and avoiding jitter in horizontally stacked button layouts.
     private func applyButtonWidthAnchor(on button: UIButton, with title: NSString) {
-        let preferredFont = UIFont.preferredFont(forTextStyle: .body)
-        let baseFontSize = preferredFont.pointSize
+        if let existingConstraint = button.constraints.first(where: { $0.firstAttribute == .width }) {
+            existingConstraint.isActive = false
+        }
 
-        let boldFont = UIFont.systemFont(ofSize: baseFontSize, weight: .bold)
-        let boldWidth = title.size(withAttributes: [.font: boldFont]).width
+        let boldFont = FXFontStyles.Bold.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
+        let boldWidth = ceil(title.size(withAttributes: [.font: boldFont]).width)
         button.widthAnchor.constraint(equalToConstant: boldWidth).isActive = true
     }
 
@@ -282,16 +282,22 @@ class TabTraySelectorView: UIView,
         switch notification.name {
         case UIContentSizeCategory.didChangeNotification:
             dynamicTypeChanged()
-            break
         default:
             break
         }
     }
 
     private func dynamicTypeChanged() {
+        adjustSelectedButtonFont(toIndex: selectedIndex)
+
         for (index, title) in items.enumerated() {
             guard let button = buttons[safe: index] else { continue }
             applyButtonWidthAnchor(on: button, with: title as NSString)
         }
+
+        applyInitalSelectionBackgroundFrame()
+
+        setNeedsLayout()
+        layoutIfNeeded()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12352)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26909)

## :bulb: Description
Fixing some issues with dynamic type and the tab selector view. Its not entirely perfect yet, there are some layout issues if you have the tab tray opened when the dynamic type changes. But if you close and reopen the tab tray all should be layout fine, so I think we can live with this edge case for now.

## :movie_camera: Demos

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-05-28 at 13 14 37](https://github.com/user-attachments/assets/2cd465c7-9858-46e0-afa1-651182cc1a51) |  ![Simulator Screenshot - iPhone 16 Pro - 2025-05-28 at 13 13 57](https://github.com/user-attachments/assets/165796c6-a861-4ffc-acdf-996c0c6b6380) |

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
