### PR TITLE
Bugfix FXIOS-12337 - Respond to unknown webchannel message types

### DIFF
--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -22,7 +22,7 @@ enum FxAPageType: Equatable {
 // See https://mozilla.github.io/ecosystem-platform/docs/fxa-engineering/fxa-webchannel-protocol
 // For details on message types.
 private enum RemoteCommand: String {
-     case canLinkAccount = "fxaccounts:can_link_account"
+    case canLinkAccount = "fxaccounts:can_link_account"
     // case loaded = "fxaccounts:loaded"
     case status = "fxaccounts:fxa_status"
     case oauthLogin = "fxaccounts:oauth_login"
@@ -31,6 +31,7 @@ private enum RemoteCommand: String {
     case signOut = "fxaccounts:logout"
     case deleteAccount = "fxaccounts:delete"
     case profileChanged = "profile:change"
+    case unknown
 }
 
 class FxAWebViewModel: FeatureFlaggable {
@@ -243,50 +244,56 @@ extension FxAWebViewModel {
 
     // Handle a message coming from the content server.
     private func handleRemote(command rawValue: String, id: Int?, data: Any?, webView: WKWebView) {
-        if let command = RemoteCommand(rawValue: rawValue) {
-            switch command {
-            case .oauthLogin:
-                if let data = data {
-                    onLoginComplete(data: data, webView: webView)
-                } else {
-                    onDismissController?()
-                }
-            case .changePassword:
-                if let data = data {
-                    onPasswordChange(data: data, webView: webView)
-                }
-            case .status:
-                if let id = id {
-                    onSessionStatus(id: id, webView: webView)
-                }
-            case .deleteAccount, .signOut:
-                profile.removeAccount()
+        logger.log("webchannel message: \(rawValue)", level: .info, category: .sync)
+        let command = RemoteCommand(rawValue: rawValue) ?? .unknown
+        switch command {
+        case .oauthLogin:
+            if let data = data {
+                onLoginComplete(data: data, webView: webView)
+            } else {
                 onDismissController?()
-            case .profileChanged:
-                profile.rustFxA.accountManager?.refreshProfile(ignoreCache: true)
-                // dismiss keyboard after changing profile in order to see notification view
-                UIApplication.shared.sendAction(
-                    #selector(UIResponder.resignFirstResponder),
-                    to: nil,
-                    from: nil,
-                    for: nil
-                )
-            case .login:
-                guard let data = data as? [String: Any],
-                      let sessionToken = data["sessionToken"] as? String,
-                      let email = data["email"] as? String,
-                      let uid = data["uid"] as? String,
-                      let verified = data["verified"] as? Bool
-                else { return }
-                let userData = UserData(sessionToken: sessionToken,
-                                        uid: uid,
-                                        email: email,
-                                        verified: verified)
-                profile.rustFxA.accountManager?.setUserData(userData: userData) { }
-            case .canLinkAccount:
-                if let id = id {
-                    onCanLinkAccount(msgId: id, webView: webView)
-                }
+            }
+        case .changePassword:
+            if let data = data {
+                onPasswordChange(data: data, webView: webView)
+            }
+        case .status:
+            if let id = id {
+                onSessionStatus(id: id, webView: webView)
+            }
+        case .deleteAccount, .signOut:
+            profile.removeAccount()
+            onDismissController?()
+        case .profileChanged:
+            profile.rustFxA.accountManager?.refreshProfile(ignoreCache: true)
+            // dismiss keyboard after changing profile in order to see notification view
+            UIApplication.shared.sendAction(
+                #selector(UIResponder.resignFirstResponder),
+                to: nil,
+                from: nil,
+                for: nil
+            )
+        case .login:
+            guard let data = data as? [String: Any],
+                let sessionToken = data["sessionToken"] as? String,
+                let email = data["email"] as? String,
+                let uid = data["uid"] as? String,
+                let verified = data["verified"] as? Bool
+            else { return }
+            let userData = UserData(
+                sessionToken: sessionToken,
+                uid: uid,
+                email: email,
+                verified: verified
+            )
+            profile.rustFxA.accountManager?.setUserData(userData: userData) {}
+        case .canLinkAccount:
+            if let id = id {
+                onCanLinkAccount(msgId: id, webView: webView)
+            }
+        case .unknown:
+            if let id = id {
+                onUnknownMessage(msgId: id, webView: webView, rawValue: rawValue)
             }
         }
     }
@@ -408,6 +415,15 @@ extension FxAWebViewModel {
         """
 
         runJS(webView: webView, typeId: typeId, messageId: msgId, command: cmd, data: data)
+    }
+
+    private func onUnknownMessage(msgId: Int, webView: WKWebView, rawValue: String) {
+        let typeId = "account_updates"
+        let data = """
+            { "error": "Unrecognized FxAccountsWebChannel command: \(rawValue)" }
+        """
+
+        runJS(webView: webView, typeId: typeId, messageId: msgId, command: rawValue, data: data)
     }
 
     func shouldAllowRedirectAfterLogIn(basedOn navigationURL: URL?) -> WKNavigationActionPolicy {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12337)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26873)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Responds to the server with an error message that is identical in shape to Desktop and Android.

- Desktop reference: [searchfox.org](https://searchfox.org/mozilla-central/rev/932e5cded30452c4f009b4f9254021f8b9895217/services/fxaccounts/FxAccountsWebChannel.sys.mjs#425-434)
- Android reference: [phabricator.services.mozilla.com](https://phabricator.services.mozilla.com/D251604)

<details>
<summary>Tested this against a local FxA server with this sample patch.</summary>

```diff
diff --git a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.tsx b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.tsx
index befa20b45c..2ef901c9f4 100644
--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.tsx
@@ -10,7 +10,7 @@ import { useEscKeydownEffect } from '../../../lib/hooks';
 import { ReactComponent as SignOut } from './sign-out.svg';
 import { logViewEvent, settingsViewName } from '../../../lib/metrics';
 import { Localized, useLocalization } from '@fluent/react';
-import firefox from '../../../lib/channels/firefox';
+import firefox, { FirefoxCommand } from '../../../lib/channels/firefox';
 import { FtlMsg } from 'fxa-react/lib/utils';
 
 export const DropDownAvatarMenu = () => {
@@ -31,17 +31,18 @@ export const DropDownAvatarMenu = () => {
   );
 
   const signOut = async () => {
-    if (session.destroy) {
+    // if (session.destroy) {
       try {
-        await session.destroy();
+        // await session.destroy();
 
         // Send a logout event to Firefox even if the user is in a non-Sync flow.
         // If the user is signed into the browser, they need to drop the now
         // destroyed session token.
-        firefox.fxaLogout({ uid });
+        // firefox.fxaLogout({ uid });
+        firefox.send(FirefoxCommand.Blargh, {ok: true});
 
-        logViewEvent(settingsViewName, 'signout.success');
-        window.location.assign(window.location.origin);
+        // logViewEvent(settingsViewName, 'signout.success');
+        // window.location.assign(window.location.origin);
       } catch (e) {
         alertBar.error(
           l10n.getString(
@@ -51,7 +52,7 @@ export const DropDownAvatarMenu = () => {
           )
         );
       }
-    }
+    // }
   };
 
   return (
diff --git a/packages/fxa-settings/src/lib/channels/firefox.ts b/packages/fxa-settings/src/lib/channels/firefox.ts
index ee2bcc4a2c..78816b09b0 100644
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -11,6 +11,7 @@ export enum FirefoxCommand {
   Logout = 'fxaccounts:logout',
   Loaded = 'fxaccounts:loaded',
   Error = 'fxError',
+  Blargh = 'fxaccounts:blargh',
   OAuthLogin = 'fxaccounts:oauth_login',
   CanLinkAccount = 'fxaccounts:can_link_account',
 }
```

</details>


<details>
<summary>Also this patch in iOS to make the WKWebView inspectable from Safari Desktop: https://developer.apple.com/documentation/safari-developer-tools/inspecting-ios</summary>

```diff
diff --git a/firefox-ios/RustFxA/FxAWebViewController.swift b/firefox-ios/RustFxA/FxAWebViewController.swift
index 08697e292..b2513dbe0 100755
--- a/firefox-ios/RustFxA/FxAWebViewController.swift
+++ b/firefox-ios/RustFxA/FxAWebViewController.swift
@@ -59,6 +59,9 @@ class FxAWebViewController: UIViewController {
         webView.accessibilityLabel = .FxAWebContentAccessibilityLabel
         webView.scrollView.bounces = false  // Don't allow overscrolling.
         webView.customUserAgent = FxAWebViewModel.mobileUserAgent
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
 
         self.logger = logger
 
```

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
