### PR TITLE
Bugfix FXIOS-12359 - [iPad] - FF crashes after putting the app in background and accessing the menu

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -318,7 +318,8 @@ class PhotonActionSheet: UIViewController, Themeable {
                                change: [NSKeyValueChangeKey: Any]?,
                                context: UnsafeMutableRawPointer?) {
         if viewModel.presentationStyle == .popover && !wasHeightOverridden {
-            DispatchQueue.main.async { [self] in
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
                 let size = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
                 preferredContentSize = CGSize(width: size.width, height: tableView.contentSize.height)
             }

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -318,8 +318,10 @@ class PhotonActionSheet: UIViewController, Themeable {
                                change: [NSKeyValueChangeKey: Any]?,
                                context: UnsafeMutableRawPointer?) {
         if viewModel.presentationStyle == .popover && !wasHeightOverridden {
-            let size = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-            preferredContentSize = CGSize(width: size.width, height: tableView.contentSize.height)
+            DispatchQueue.main.async { [self] in
+                let size = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+                preferredContentSize = CGSize(width: size.width, height: tableView.contentSize.height)
+            }
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12359)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26934)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
