### PR TITLE
Fix-[MTE-4648]-tracking protection tests

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -110,6 +110,7 @@ struct AccessibilityIdentifiers {
         static let nightMode = "MainMenu.NightModeOn"
         static let zoom = "MainMenu.Zoom"
         static let moreLess = "MainMenu.MoreLess"
+        static let trackigProtection = "shieldCheckmarkLarge"
     }
 
     struct UnifiedSearch {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -980,7 +980,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         )
 
         screenState.tap(
-            app.buttons[AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon],
+            app.buttons[AccessibilityIdentifiers.MainMenu.trackigProtection],
             to: TrackingProtectionContextMenuDetails
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarMenuTests.swift
@@ -39,8 +39,8 @@ class ToolbarMenuTests: BaseTestCase {
         } else {
             mozWaitForElementToExist(tabsButton)
             XCTAssertTrue(
-                hamburgerMenu.isRightOf(rightElement: tabsButton),
-                "Menu button is not on the right side of tabs button"
+                hamburgerMenu.isLeftOf(rightElement: tabsButton),
+                "Menu button is not on the left side of tabs button"
             )
             XCTAssertTrue(
                 hamburgerMenu.isBelow(element: firstPocketCell),
@@ -63,8 +63,8 @@ class ToolbarMenuTests: BaseTestCase {
             ]
         )
         XCTAssertTrue(
-            hamburgerMenu.isRightOf(rightElement: tabsButton),
-            "Menu button is not on the right side of tabs button"
+            hamburgerMenu.isLeftOf(rightElement: tabsButton),
+            "Menu button is not on the left side of tabs button"
         )
         XCTAssertTrue(
             hamburgerMenu.isAbove(element: firstPocketCell),

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -17,7 +17,7 @@ let reloadWithWithoutProtectionButton = "shieldSlashLarge"
 let secureTrackingProtectionOnLabel = "Privacy & Security Settings"
 let secureTrackingProtectionOffLabel = "Secure connection. Enhanced Tracking Protection is off."
 
-class TrackingProtectionTests: BaseTestCase {
+class TrackingProtectionTests: FeatureFlaggedTestBase {
     private func disableEnableTrackingProtectionForSite() {
         navigator.performAction(Action.TrackingProtectionperSiteToggle)
     }
@@ -80,6 +80,7 @@ class TrackingProtectionTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2307059
     // Smoketest
     func testStandardProtectionLevel() {
+        app.launch()
         navigator.goto(URLBarOpen)
         let cancelButton = app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton]
         mozWaitForElementToExist(cancelButton, timeout: TIMEOUT_LONG)
@@ -127,7 +128,9 @@ class TrackingProtectionTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2319381
-    func testLockIconMenu() {
+    func testLockIconMenu_menuRefactorFeatureOff() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "menu-refactor-feature")
+        app.launch()
         navigator.openURL(differentWebsite)
         waitUntilPageLoad()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon])
@@ -136,6 +139,7 @@ class TrackingProtectionTests: BaseTestCase {
             sleep(2)
         }
         navigator.nowAt(BrowserTab)
+        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].waitAndTap()
         navigator.goto(TrackingProtectionContextMenuDetails)
         mozWaitForElementToExist(app.staticTexts["Connection not secure"], timeout: 5)
         var switchValue = app.switches.firstMatch.value!
@@ -161,6 +165,7 @@ class TrackingProtectionTests: BaseTestCase {
         app.buttons["Settings"].waitAndTap()
         app.buttons["Done"].waitAndTap()
         navigator.nowAt(BrowserTab)
+        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].waitAndTap()
         navigator.goto(TrackingProtectionContextMenuDetails)
         mozWaitForElementToExist(app.staticTexts["Connection not secure"], timeout: 5)
         XCTAssertFalse(app.switches.element.exists)
@@ -168,6 +173,7 @@ class TrackingProtectionTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2318742
     func testProtectionLevelMoreInfoMenu() {
+        app.launch()
         navigator.nowAt(NewTabScreen)
         navigator.goto(TrackingProtectionSettings)
         // See Basic mode info
@@ -195,7 +201,9 @@ class TrackingProtectionTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307061
-    func testLockIconSecureConnection() {
+    func testLockIconSecureConnection_menuRefactorFeatureOff() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "menu-refactor-feature")
+        app.launch()
         navigator.openURL("https://www.mozilla.org")
         waitUntilPageLoad()
         // iOS 15 displays a toast for the paste. The toast may cover areas to be
@@ -205,6 +213,7 @@ class TrackingProtectionTests: BaseTestCase {
         }
         // Tap "Secure connection"
         navigator.nowAt(BrowserTab)
+        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].waitAndTap()
         navigator.goto(TrackingProtectionContextMenuDetails)
         // A page displaying the connection is secure
         waitForElementsToExist(
@@ -238,7 +247,9 @@ class TrackingProtectionTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2693741
-    func testLockIconCloseMenu() {
+    func testLockIconCloseMenu_menuRefactorFeatureOff() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "menu-refactor-feature")
+        app.launch()
         navigator.openURL("https://www.mozilla.org")
         waitUntilPageLoad()
         // iOS 15 displays a toast for the paste. The toast may cover areas to be
@@ -248,6 +259,7 @@ class TrackingProtectionTests: BaseTestCase {
         }
         // Tap "Secure connection"
         navigator.nowAt(BrowserTab)
+        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].waitAndTap()
         navigator.goto(TrackingProtectionContextMenuDetails)
         mozWaitForElementToExist(
             app.buttons[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusButton])
@@ -258,6 +270,7 @@ class TrackingProtectionTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307063
     func testStrictTrackingProtection() {
+        app.launch()
         navigator.goto(TrackingProtectionSettings)
         // Enable Strict Protection Level
         enableStrictMode()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4648

## :bulb: Description
Menu refactor redesign experiment has been enabled on developer, causing some tracking protection tests to fail.
Because the navigation to tracking protection hasn't been implemented yet on this  variant of the experiment, i have disabled the experiment for these tests to run with the old menu.
Also added a small fix for testToolbarMenu test. The menu button is now on the left side of the tab tray button.