### PR TITLE
Refactor FXIOS-12358 [Firefox suggest ping] Send ping over OHTTP and add client's country to data

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -955,6 +955,7 @@
 		8A720C5E2A4C85DA0003018A /* AccountSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */; };
 		8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */; };
 		8A720C622A4CBB370003018A /* SupportSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C612A4CBB370003018A /* SupportSettingsDelegate.swift */; };
+		8A732A822DE8AFD40099F575 /* FxSuggestTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A732A812DE8AFCA0099F575 /* FxSuggestTelemetry.swift */; };
 		8A7368AD27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7368AC27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift */; };
 		8A75F1B828B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A75F1B728B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift */; };
 		8A7653BD28A2C61D00924ABF /* PocketDataAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653BC28A2C61D00924ABF /* PocketDataAdaptor.swift */; };
@@ -8344,6 +8345,7 @@
 		8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A720C612A4CBB370003018A /* SupportSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportSettingsDelegate.swift; sourceTree = "<group>"; };
+		8A732A812DE8AFCA0099F575 /* FxSuggestTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxSuggestTelemetry.swift; sourceTree = "<group>"; };
 		8A7368AC27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanRemoveQuickActionBookmark.swift; sourceTree = "<group>"; };
 		8A75F1B728B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardDataAdaptorImplementationTests.swift; sourceTree = "<group>"; };
 		8A75F1D428B56A2C0054E34D /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
@@ -14901,6 +14903,7 @@
 		E69DB0B91E97E301008A67E6 /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				8A732A812DE8AFCA0099F575 /* FxSuggestTelemetry.swift */,
 				8A0DF2C12D6D1C670066EC00 /* AutoplaySettingTelemetry.swift */,
 				43175DB726B87D2C00C41C31 /* AdsTelemetryHelper.swift */,
 				AB3DB0C82B596739001D32CB /* AppStartupTelemetry.swift */,
@@ -18051,6 +18054,7 @@
 				21A7C44E283539170071D996 /* IntroViewModel.swift in Sources */,
 				E1FF93E228A2E55700E6360E /* WallpaperSelectorViewController.swift in Sources */,
 				D3A9949C1A3686BD008AD1AC /* BrowserViewController.swift in Sources */,
+				8A732A822DE8AFD40099F575 /* FxSuggestTelemetry.swift in Sources */,
 				8A9B87AD2C1B39100042B894 /* SearchViewModel.swift in Sources */,
 				8A5D1CBB2A30DC0B005AD35C /* ConnectSetting.swift in Sources */,
 				E6CF28E71CB43B7900151AB3 /* SensitiveViewController.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4149,14 +4149,16 @@ extension BrowserViewController: SearchViewControllerDelegate {
         switch searchSessionState {
         case .engaged:
             let visibleSuggestionsTelemetryInfo = searchViewController.visibleSuggestionsTelemetryInfo
-            visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0,
-                                                                             suggestTelemetry: suggestTelemetry) }
+            visibleSuggestionsTelemetryInfo.forEach {
+                trackVisibleSuggestion(telemetryInfo: $0, suggestTelemetry: suggestTelemetry)
+            }
             searchViewController.searchTelemetry?.recordURLBarSearchEngagementTelemetryEvent()
         case .abandoned:
             searchViewController.searchTelemetry?.engagementType = .dismiss
             let visibleSuggestionsTelemetryInfo = searchViewController.visibleSuggestionsTelemetryInfo
-            visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0,
-                                                                             suggestTelemetry: suggestTelemetry) }
+            visibleSuggestionsTelemetryInfo.forEach {
+                trackVisibleSuggestion(telemetryInfo: $0, suggestTelemetry: suggestTelemetry)
+            }
             searchViewController.searchTelemetry?.recordURLBarSearchAbandonmentTelemetryEvent()
         default:
             break

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4144,15 +4144,19 @@ extension BrowserViewController: SearchViewControllerDelegate {
     }
 
     func searchViewControllerWillHide(_ searchViewController: SearchViewController) {
+        let suggestTelemetry = FxSuggestTelemetry()
+
         switch searchSessionState {
         case .engaged:
             let visibleSuggestionsTelemetryInfo = searchViewController.visibleSuggestionsTelemetryInfo
-            visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0) }
+            visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0,
+                                                                             suggestTelemetry: suggestTelemetry) }
             searchViewController.searchTelemetry?.recordURLBarSearchEngagementTelemetryEvent()
         case .abandoned:
             searchViewController.searchTelemetry?.engagementType = .dismiss
             let visibleSuggestionsTelemetryInfo = searchViewController.visibleSuggestionsTelemetryInfo
-            visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0) }
+            visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0,
+                                                                             suggestTelemetry: suggestTelemetry) }
             searchViewController.searchTelemetry?.recordURLBarSearchAbandonmentTelemetryEvent()
         default:
             break
@@ -4163,32 +4167,20 @@ extension BrowserViewController: SearchViewControllerDelegate {
     /// abandoned search session. The user may have tapped on this suggestion
     /// or on a different suggestion, typed in a search term or a URL, or
     /// dismissed the URL bar without completing their search.
-    func trackVisibleSuggestion(telemetryInfo info: SearchViewVisibleSuggestionTelemetryInfo) {
+    func trackVisibleSuggestion(telemetryInfo info: SearchViewVisibleSuggestionTelemetryInfo,
+                                suggestTelemetry: FxSuggestTelemetry) {
         switch info {
         // A sponsored or non-sponsored suggestion from Firefox Suggest.
         case let .firefoxSuggestion(telemetryInfo, position, didTap):
             let didAbandonSearchSession = searchSessionState == .abandoned
-            TelemetryWrapper.gleanRecordEvent(
-                category: .action,
-                method: .view,
-                object: TelemetryWrapper.EventObject.fxSuggest,
-                extras: [
-                    TelemetryWrapper.EventValue.fxSuggestionTelemetryInfo.rawValue: telemetryInfo,
-                    TelemetryWrapper.EventValue.fxSuggestionPosition.rawValue: position,
-                    TelemetryWrapper.EventValue.fxSuggestionDidTap.rawValue: didTap,
-                    TelemetryWrapper.EventValue.fxSuggestionDidAbandonSearchSession.rawValue: didAbandonSearchSession,
-                ]
-            )
+            suggestTelemetry.impressionEvent(telemetryInfo: telemetryInfo,
+                                             position: position,
+                                             didTap: didTap,
+                                             didAbandonSearchSession: didAbandonSearchSession)
+
             if didTap {
-                TelemetryWrapper.gleanRecordEvent(
-                    category: .action,
-                    method: .tap,
-                    object: TelemetryWrapper.EventObject.fxSuggest,
-                    extras: [
-                        TelemetryWrapper.EventValue.fxSuggestionTelemetryInfo.rawValue: telemetryInfo,
-                        TelemetryWrapper.EventValue.fxSuggestionPosition.rawValue: position,
-                    ]
-                )
+                suggestTelemetry.clickEvent(telemetryInfo: telemetryInfo,
+                                            position: position)
             }
         }
     }

--- a/firefox-ios/Client/Glean/metrics.yaml
+++ b/firefox-ios/Client/Glean/metrics.yaml
@@ -5793,7 +5793,6 @@ fx_suggest:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-      - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
     expires: never
@@ -5813,7 +5812,6 @@ fx_suggest:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-      - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
     expires: never
@@ -5831,7 +5829,6 @@ fx_suggest:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-      - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
     expires: never
@@ -5850,7 +5847,6 @@ fx_suggest:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-      - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
     expires: never
@@ -5870,7 +5866,6 @@ fx_suggest:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-      - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
     expires: never
@@ -5889,7 +5884,6 @@ fx_suggest:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-      - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
     expires: never
@@ -5907,7 +5901,6 @@ fx_suggest:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-      - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
     expires: never
@@ -5926,7 +5919,24 @@ fx_suggest:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest
+  country:
+    type: string
+    description: >
+      Records the home region of the user, the same used for configuring
+      region specific search providers.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/26928
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/metrics.yaml
+++ b/firefox-ios/Client/Glean/metrics.yaml
@@ -5927,12 +5927,12 @@ fx_suggest:
   country:
     type: string
     description: >
-      Records the home region of the user, the same used for configuring
+      Records the system region of the user, the same used for configuring
       region specific search providers.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/26928
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/26949
     data_sensitivity:
       - interaction
     notification_emails:

--- a/firefox-ios/Client/Glean/pings.yaml
+++ b/firefox-ios/Client/Glean/pings.yaml
@@ -35,13 +35,15 @@ fx-suggest:
     Distinguishable by its `ping_type`.
     Does not contain a `client_id`, preferring a `context_id` instead.
   include_client_id: false
+  uploader_capabilities:
+    - ohttp
   bugs:
     - https://github.com/mozilla-mobile/firefox-ios/issues/16589
+    - https://github.com/mozilla-mobile/firefox-ios/issues/26928
   data_reviews:
     - https://github.com/mozilla-mobile/firefox-ios/pull/17556
   notification_emails:
     - fx-ios-data-stewards@mozilla.com
-    - lina@mozilla.com
     - ttran@mozilla.com
     - najiang@mozilla.com
 

--- a/firefox-ios/Client/Telemetry/FxSuggestTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/FxSuggestTelemetry.swift
@@ -17,8 +17,7 @@ class FxSuggestTelemetry {
 
     private let systemRegion: String
 
-    init() {
-        let locale = Locale(identifier: Locale.preferredLanguages.first ?? Locale.current.identifier)
+    init(locale: Locale = Locale(identifier: Locale.preferredLanguages.first ?? Locale.current.identifier)) {
         systemRegion = Self.regionCode(from: locale)
     }
 

--- a/firefox-ios/Client/Telemetry/FxSuggestTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/FxSuggestTelemetry.swift
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Glean
+import Storage
+
+class FxSuggestTelemetry {
+    private enum EventInfo: String {
+        case ampSuggestion = "amp-suggestion"
+        case wikipediaSuggestion = "wikipedia-suggestion"
+        case pingTypeClick = "fxsuggest-click"
+        case pingTypeImpression = "fxsuggest-impression"
+        case wikipediaAdvertiser = "wikipedia"
+    }
+
+    func clickEvent(telemetryInfo: RustFirefoxSuggestionTelemetryInfo, position: Int) {
+        // MARK: - FX Suggest
+        guard let contextIdString = TelemetryContextualIdentifier.contextId,
+              let contextId = UUID(uuidString: contextIdString) else {
+            return
+        }
+
+        // Record an event for this tap in the `events` ping.
+        // These events include the `client_id`.
+        let searchResultTapExtra = switch telemetryInfo {
+        case .amp: GleanMetrics.Awesomebar.SearchResultTapExtra(type: EventInfo.ampSuggestion.rawValue)
+        case .wikipedia: GleanMetrics.Awesomebar.SearchResultTapExtra(type: EventInfo.wikipediaSuggestion.rawValue)
+        }
+        GleanMetrics.Awesomebar.searchResultTap.record(searchResultTapExtra)
+
+        // Submit a separate `fx-suggest` ping for this tap.
+        // These pings do not include the `client_id`.
+        GleanMetrics.FxSuggest.contextId.set(contextId)
+        GleanMetrics.FxSuggest.pingType.set(EventInfo.pingTypeClick.rawValue)
+        GleanMetrics.FxSuggest.isClicked.set(true)
+        GleanMetrics.FxSuggest.position.set(Int64(position))
+        switch telemetryInfo {
+        case let .amp(blockId, advertiser, iabCategory, _, clickReportingURL):
+            GleanMetrics.FxSuggest.blockId.set(blockId)
+            GleanMetrics.FxSuggest.advertiser.set(advertiser)
+            GleanMetrics.FxSuggest.iabCategory.set(iabCategory)
+            if let clickReportingURL {
+                GleanMetrics.FxSuggest.reportingUrl.set(url: clickReportingURL)
+            }
+        case .wikipedia:
+            GleanMetrics.FxSuggest.advertiser.set(EventInfo.wikipediaAdvertiser.rawValue)
+        }
+        GleanMetrics.Pings.shared.fxSuggest.submit()
+    }
+
+    func impressionEvent(telemetryInfo: RustFirefoxSuggestionTelemetryInfo,
+                         position: Int,
+                         didTap: Bool,
+                         didAbandonSearchSession: Bool) {
+        guard let contextIdString = TelemetryContextualIdentifier.contextId,
+              let contextId = UUID(uuidString: contextIdString) else {
+            return
+        }
+
+        // Record an event for this impression in the `events` ping.
+        // These events include the `client_id`, and we record them for
+        // engaged and abandoned search sessions.
+        let searchResultImpressionExtra = switch telemetryInfo {
+        case .amp: GleanMetrics.Awesomebar.SearchResultImpressionExtra(type: EventInfo.ampSuggestion.rawValue)
+        case .wikipedia: GleanMetrics.Awesomebar.SearchResultImpressionExtra(type: EventInfo.wikipediaSuggestion.rawValue)
+        }
+        GleanMetrics.Awesomebar.searchResultImpression.record(searchResultImpressionExtra)
+
+        // Submit a separate `fx-suggest` ping for this impression.
+        // These pings do not include the `client_id`, and we only submit
+        // them for engaged search sessions.
+        if didAbandonSearchSession { return }
+        GleanMetrics.FxSuggest.contextId.set(contextId)
+        GleanMetrics.FxSuggest.pingType.set(EventInfo.pingTypeImpression.rawValue)
+        GleanMetrics.FxSuggest.isClicked.set(didTap)
+        GleanMetrics.FxSuggest.position.set(Int64(position))
+        switch telemetryInfo {
+        case let .amp(blockId, advertiser, iabCategory, impressionReportingURL, _):
+            GleanMetrics.FxSuggest.blockId.set(blockId)
+            GleanMetrics.FxSuggest.advertiser.set(advertiser)
+            GleanMetrics.FxSuggest.iabCategory.set(iabCategory)
+            if let impressionReportingURL {
+                GleanMetrics.FxSuggest.reportingUrl.set(url: impressionReportingURL)
+            }
+        case .wikipedia:
+            GleanMetrics.FxSuggest.advertiser.set(EventInfo.wikipediaAdvertiser.rawValue)
+        }
+        GleanMetrics.Pings.shared.fxSuggest.submit()
+    }
+}

--- a/firefox-ios/Client/Telemetry/FxSuggestTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/FxSuggestTelemetry.swift
@@ -17,7 +17,7 @@ class FxSuggestTelemetry {
 
     private let systemRegion: String
 
-    init(locale: Locale = Locale(identifier: Locale.preferredLanguages.first ?? Locale.current.identifier)) {
+    init(locale: Locale = Locale.current) {
         systemRegion = Self.regionCode(from: locale)
     }
 

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -329,7 +329,6 @@ extension TelemetryWrapper {
         case enrollment = "enrollment"
         case firefoxAccount = "firefox_account"
         case information = "information"
-        case firefoxSuggest = "fx-suggest"
     }
 
     public enum EventMethod: String {
@@ -562,7 +561,6 @@ extension TelemetryWrapper {
         case viewHistoryPanel = "view-history-panel"
         case createNewTab = "create-new-tab"
         case sponsoredShortcuts = "sponsored-shortcuts"
-        case fxSuggest = "fx-suggest"
         case webview = "webview"
         case urlbarImpression = "urlbar-impression"
         case urlbarEngagement = "urlbar-engagement"
@@ -649,10 +647,6 @@ extension TelemetryWrapper {
         case cpuException = "cpu_exception"
         case hangException = "hang-exception"
         case tabLossDetected = "tab_loss_detected"
-        case fxSuggestionTelemetryInfo = "fx-suggestion-telemetry-info"
-        case fxSuggestionPosition = "fx-suggestion-position"
-        case fxSuggestionDidTap = "fx-suggestion-did-tap"
-        case fxSuggestionDidAbandonSearchSession = "fx-suggestion-did-abandon-search-session"
         case webviewFail = "webview-fail"
         case webviewFailProvisional = "webview-fail-provisional"
         case webviewShowErrorPage = "webview-show-error-page"
@@ -1791,82 +1785,6 @@ extension TelemetryWrapper {
             } else {
                 recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
             }
-
-        // MARK: - FX Suggest
-        case(.action, .tap, .fxSuggest, _, let extras):
-            guard let contextIdString = TelemetryContextualIdentifier.contextId,
-                  let contextId = UUID(uuidString: contextIdString),
-                  let telemetryInfo = extras?[EventValue.fxSuggestionTelemetryInfo.rawValue] as? RustFirefoxSuggestionTelemetryInfo,
-                  let position = extras?[EventValue.fxSuggestionPosition.rawValue] as? Int else {
-                return recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
-            }
-
-            // Record an event for this tap in the `events` ping.
-            // These events include the `client_id`.
-            let searchResultTapExtra = switch telemetryInfo {
-            case .amp: GleanMetrics.Awesomebar.SearchResultTapExtra(type: "amp-suggestion")
-            case .wikipedia: GleanMetrics.Awesomebar.SearchResultTapExtra(type: "wikipedia-suggestion")
-            }
-            GleanMetrics.Awesomebar.searchResultTap.record(searchResultTapExtra)
-
-            // Submit a separate `fx-suggest` ping for this tap.
-            // These pings do not include the `client_id`.
-            GleanMetrics.FxSuggest.contextId.set(contextId)
-            GleanMetrics.FxSuggest.pingType.set("fxsuggest-click")
-            GleanMetrics.FxSuggest.isClicked.set(true)
-            GleanMetrics.FxSuggest.position.set(Int64(position))
-            switch telemetryInfo {
-            case let .amp(blockId, advertiser, iabCategory, _, clickReportingURL):
-                GleanMetrics.FxSuggest.blockId.set(blockId)
-                GleanMetrics.FxSuggest.advertiser.set(advertiser)
-                GleanMetrics.FxSuggest.iabCategory.set(iabCategory)
-                if let clickReportingURL {
-                    GleanMetrics.FxSuggest.reportingUrl.set(url: clickReportingURL)
-                }
-            case .wikipedia:
-                GleanMetrics.FxSuggest.advertiser.set("wikipedia")
-            }
-            GleanMetrics.Pings.shared.fxSuggest.submit()
-
-        case(.action, .view, .fxSuggest, _, let extras):
-            guard let contextIdString = TelemetryContextualIdentifier.contextId,
-                  let contextId = UUID(uuidString: contextIdString),
-                  let telemetryInfo = extras?[EventValue.fxSuggestionTelemetryInfo.rawValue] as? RustFirefoxSuggestionTelemetryInfo,
-                  let position = extras?[EventValue.fxSuggestionPosition.rawValue] as? Int,
-                  let didTap = extras?[EventValue.fxSuggestionDidTap.rawValue] as? Bool,
-                  let didAbandonSearchSession = extras?[EventValue.fxSuggestionDidAbandonSearchSession.rawValue] as? Bool else {
-                return recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
-            }
-
-            // Record an event for this impression in the `events` ping.
-            // These events include the `client_id`, and we record them for
-            // engaged and abandoned search sessions.
-            let searchResultImpressionExtra = switch telemetryInfo {
-            case .amp: GleanMetrics.Awesomebar.SearchResultImpressionExtra(type: "amp-suggestion")
-            case .wikipedia: GleanMetrics.Awesomebar.SearchResultImpressionExtra(type: "wikipedia-suggestion")
-            }
-            GleanMetrics.Awesomebar.searchResultImpression.record(searchResultImpressionExtra)
-
-            // Submit a separate `fx-suggest` ping for this impression.
-            // These pings do not include the `client_id`, and we only submit
-            // them for engaged search sessions.
-            if didAbandonSearchSession { break }
-            GleanMetrics.FxSuggest.contextId.set(contextId)
-            GleanMetrics.FxSuggest.pingType.set("fxsuggest-impression")
-            GleanMetrics.FxSuggest.isClicked.set(didTap)
-            GleanMetrics.FxSuggest.position.set(Int64(position))
-            switch telemetryInfo {
-            case let .amp(blockId, advertiser, iabCategory, impressionReportingURL, _):
-                GleanMetrics.FxSuggest.blockId.set(blockId)
-                GleanMetrics.FxSuggest.advertiser.set(advertiser)
-                GleanMetrics.FxSuggest.iabCategory.set(iabCategory)
-                if let impressionReportingURL {
-                    GleanMetrics.FxSuggest.reportingUrl.set(url: impressionReportingURL)
-                }
-            case .wikipedia:
-                GleanMetrics.FxSuggest.advertiser.set("wikipedia")
-            }
-            GleanMetrics.Pings.shared.fxSuggest.submit()
 
         // MARK: - Uninstrumented
         default:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -62,9 +62,12 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
             XCTAssertEqual(GleanMetrics.FxSuggest.advertiser.testGetValue(), "test advertiser")
             XCTAssertEqual(GleanMetrics.FxSuggest.iabCategory.testGetValue(), "999 - Test Category")
             XCTAssertEqual(GleanMetrics.FxSuggest.reportingUrl.testGetValue(), "https://example.com/ios_test_impression_reporting_url")
+            XCTAssertEqual(GleanMetrics.FxSuggest.country.testGetValue(), "US")
             expectation.fulfill()
         }
 
+        let locale = Locale(identifier: "en-US")
+        let telemetry = FxSuggestTelemetry(locale: locale)
         subject.trackVisibleSuggestion(telemetryInfo: .firefoxSuggestion(
             RustFirefoxSuggestionTelemetryInfo.amp(
                 blockId: 1,
@@ -75,7 +78,7 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
             ),
             position: 3,
             didTap: false
-        ))
+        ), suggestTelemetry: telemetry)
 
         wait(for: [expectation], timeout: 5.0)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12358)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26928)

## :bulb: Description
- We got a request to migrate the `fx-suggest` to OHTTP through `Glean`. This can be done in the `yaml` file definition directly. 
- We also need to add the `country` code. I am using the same `Locale` code as used in the new search engine provider code @mattreaganmozilla, hence why I am asking your feedback in case you see something amiss! 
- I took the opportunity to remove this telemetry from the big `TelemetryWrapper` and move it to it's own `FxSuggestTelemetry` class.
 
## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
