### PR TITLE
Bugfix FXIOS-12348 [Top Sites Visual Refresh] Increase favicon transparency threshold

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -22,7 +22,7 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
         static let textSafeSpace: CGFloat = 6
         static let faviconCornerRadius: CGFloat = 16
         static let faviconTransparentBackgroundInset: CGFloat = 8
-        static let transparencyThreshold: CGFloat = 10
+        static let transparencyThreshold: CGFloat = 15
     }
 
     private var rootContainer: UIView = .build { view in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12348)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26897)

## :bulb: Description
- Increase the transparency threshold for full-size favicons to consider assets with pre-rounded corners (often 10%-14% transparent)

## :movie_camera: Demos
*See the "yap" favicon
| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 16 - 2025-05-29 at 13 39 26](https://github.com/user-attachments/assets/e4e35e6c-3938-42df-93ba-2379510f42e2) | ![Simulator Screenshot - iPhone 16 - 2025-05-29 at 13 42 12](https://github.com/user-attachments/assets/5d6c2b66-9f7c-4766-a01c-40516e9d8275) | 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
