### PR TITLE
Bugfix FXIOS-12362 [SEC] Updates to locale and region codes for RS search engines

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
@@ -53,7 +53,7 @@ final class ASSearchEngineProvider: SearchEngineProvider {
                                                        engineOrderingPrefs: SearchEnginePrefs,
                                                        prefsMigrator: SearchEnginePreferencesMigrator,
                                                        completion: @escaping SearchEngineCompletion) {
-        let locale = Locale(identifier: Locale.preferredLanguages.first ?? Locale.current.identifier)
+        let locale = Locale.current
         let prefsVersion = preferencesVersion
 
         // First load the unordered engines, based on the current locale and language
@@ -143,16 +143,23 @@ final class ASSearchEngineProvider: SearchEngineProvider {
     }
 
     private func localeCode(from locale: Locale) -> String {
-        // Per feedback from AS team, we want to pass in the 2-component BCP 47 code. In some
-        // rare cases this may include a script with the region, if so we remove that.
-        // See also: Locale+possibilitiesForLanguageIdentifier.swift
+        // Per updated discussions with AS team, for now we are using the `preferredLanguages`
+        // codes for the locale parameter as long as it's available
 
-        let identifier = locale.identifier
-        let components = identifier.components(separatedBy: "-")
-        if components.count == 3, let first = components.first, let last = components.last {
-            return "\(first)-\(last)"
+        let languages = Locale.preferredLanguages
+        if let langCode = languages.first {
+            return langCode
+        } else {
+            // Per feedback from AS team, we want to pass in the 2-component BCP 47 code. In some
+            // rare cases this may include a script with the region, if so we remove that.
+            // See also: Locale+possibilitiesForLanguageIdentifier.swift
+            let identifier = locale.identifier
+            let components = identifier.components(separatedBy: "-")
+            if components.count == 3, let first = components.first, let last = components.last {
+                return "\(first)-\(last)"
+            }
+            return identifier
         }
-        return identifier
     }
 
     private func regionCode(from locale: Locale) -> String {

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
@@ -58,7 +58,10 @@ final class ASSearchEngineSelector: ASSearchEngineSelectorProtocol {
             var searchResultsConfig = try engineSelector.filterEngineConfiguration(userEnvironment: env)
 
             let serverName = isStaging ? "STAGE" : "PROD"
-            let engineLogList = searchResultsConfig.engines.map { $0.name }
+            let engineLogList = searchResultsConfig.engines.map {
+                let isOptional = $0.optional ? " (OPTIONAL)" : ""
+                return $0.name + isOptional
+            }
             logger.log("Got search engines from \(serverName) for '\(locale)' and '\(region)': \(engineLogList)",
                        level: .info,
                        category: .remoteSettings)

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
@@ -22,9 +22,11 @@ protocol ASSearchEngineSelectorProtocol {
 final class ASSearchEngineSelector: ASSearchEngineSelectorProtocol {
     private let engineSelector = SearchEngineSelector()
     private let service: RemoteSettingsService
+    private let logger: Logger
 
-    init(service: RemoteSettingsService) {
+    init(service: RemoteSettingsService, logger: Logger = DefaultLogger.shared) {
         self.service = service
+        self.logger = logger
     }
 
     // MARK: - ASSearchEngineSelectorProtocol
@@ -54,6 +56,12 @@ final class ASSearchEngineSelector: ASSearchEngineSelectorProtocol {
             }
 
             var searchResultsConfig = try engineSelector.filterEngineConfiguration(userEnvironment: env)
+
+            let serverName = isStaging ? "STAGE" : "PROD"
+            let engineLogList = searchResultsConfig.engines.map { $0.name }
+            logger.log("Got search engines from \(serverName) for '\(locale)' and '\(region)': \(engineLogList)",
+                       level: .info,
+                       category: .remoteSettings)
 
             // We want to be sure that our default engines list is always sorted with the default in position 0
             // This is important in the case of new installs, for example, where the user does not have any


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12362)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26942)

## :bulb: Description

Per most recent discussions with AS team, this changes our locale/region code handling for RS based search engines to use the current locale and preferredLanguages codes.

**Note**: this has no impact on our existing search engine handling, it only impacts the Consolidated Search feature (which is still disabled by default).

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
