### PR TITLE
Add FXIOS-12376 Highlight phone numbers in webpages

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
@@ -58,6 +58,7 @@ public struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvide
 
     private static let nonPersistentStore = WKWebsiteDataStore.nonPersistent()
     private static let defaultStore = WKWebsiteDataStore.default()
+    private static let defaultDataDetectorTypes: WKDataDetectorTypes = [.phoneNumber]
     private let configuration: WKWebViewConfiguration
 
     public init(configuration: WKWebViewConfiguration = WKWebViewConfiguration()) {
@@ -75,6 +76,7 @@ public struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvide
         configuration.mediaTypesRequiringUserActionForPlayback = parameters.autoPlay
         configuration.userContentController = WKUserContentController()
         configuration.allowsInlineMediaPlayback = true
+        configuration.dataDetectorTypes = DefaultWKEngineConfigurationProvider.defaultDataDetectorTypes
 
         // TODO: FXIOS-8086 - Evaluate if ignoresViewportScaleLimits is still needed
         // We do this to go against the configuration of the <meta name="viewport">

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -190,6 +190,8 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
 
     static func makeWebViewConfig(isPrivate: Bool, prefs: Prefs?) -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
+        // Highlight phone numbers as links in the webview
+        configuration.dataDetectorTypes = [.phoneNumber]
         configuration.processPool = WKProcessPool()
         let blockPopups = prefs?.boolForKey(PrefsKeys.KeyBlockPopups) ?? true
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = !blockPopups


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12376)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26977)

## :bulb: Description
This PR:
- Adds `phoneNumber` data detector type to webview config.
- Reflects the change in the WebEngine.



## :movie_camera: Demos

| Before | After |
| - | - |
| Phone number not highlighted | Phone number highlighted and clickable |
| <img src="https://github.com/user-attachments/assets/eec95a82-f80c-459b-bde2-4b40d08a9578"/> | <img src="https://github.com/user-attachments/assets/b8e0ca0d-060e-4c43-a588-f90caa312b1b"/> |



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
