### PR TITLE
Bugfix FXIOS-12299 First Run disabling send technical and interactiondata in the app setup, the Install and Run Studies option remains toggled on and greyed out in settings until the user re-toggles Send Technical and Interaction data (#26965)

### DIFF
--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -58,7 +58,8 @@ final class LaunchCoordinator: BaseCoordinator,
             TermsOfServiceTelemetry().termsOfServiceAcceptButtonTapped()
 
             let sendTechnicalData = profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
-            manager.shouldSendTechnicalData(value: sendTechnicalData)
+            let sendStudies = profile.prefs.boolForKey(AppConstants.prefStudiesToggle) ?? true
+            manager.shouldSendTechnicalData(telemetryValue: sendTechnicalData, studiesValue: sendStudies)
             self.profile.prefs.setBool(sendTechnicalData, forKey: AppConstants.prefSendUsageData)
 
             let sendCrashReports = profile.prefs.boolForKey(AppConstants.prefSendCrashReports) ?? true

--- a/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPreferencesViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPreferencesViewController.swift
@@ -173,6 +173,7 @@ final class PrivacyPreferencesViewController: UIViewController,
 
         technicalDataSwitch.switchCallback = { [weak self] value in
             self?.profile.prefs.setBool(value, forKey: AppConstants.prefSendUsageData)
+            self?.profile.prefs.setBool(value, forKey: AppConstants.prefStudiesToggle)
             if !value {
                 GleanMetrics.Pings.shared.onboardingOptOut.submit()
             }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -224,10 +224,11 @@ class AppSettingsTableViewController: SettingsTableViewController,
         )
 
         sendTechnicalDataSettings.settingDidChange = { [weak self] value in
-            guard let self, let profile = self.profile else { return }
-            TermsOfServiceManager(prefs: profile.prefs).shouldSendTechnicalData(value: value)
+            guard let self else { return }
+            DefaultGleanWrapper().setUpload(isEnabled: value)
+            Experiments.setTelemetrySetting(value)
             studiesSetting.updateSetting(for: value)
-            tableView.reloadData()
+            self.tableView.reloadData()
         }
         sendTechnicalDataSetting = sendTechnicalDataSettings
 

--- a/firefox-ios/Client/TermsOfServiceManager.swift
+++ b/firefox-ios/Client/TermsOfServiceManager.swift
@@ -40,10 +40,11 @@ struct TermsOfServiceManager: FeatureFlaggable {
         prefs.setInt(1, forKey: PrefsKeys.TermsOfServiceAccepted)
     }
 
-    func shouldSendTechnicalData(value: Bool) {
+    func shouldSendTechnicalData(telemetryValue: Bool, studiesValue: Bool) {
         // AdjustHelper.setEnabled($0)
-        DefaultGleanWrapper().setUpload(isEnabled: value)
-        Experiments.setTelemetrySetting(value)
+        DefaultGleanWrapper().setUpload(isEnabled: telemetryValue)
+        Experiments.setStudiesSetting(studiesValue)
+        Experiments.setTelemetrySetting(telemetryValue)
     }
 
     // MARK: – Constants


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
