### PR TITLE
Bugfix FXIOS-12328 [Toolbar] Bottom bar is shown after scrolling

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1274,6 +1274,10 @@ class BrowserViewController: UIViewController,
         checkForJSAlerts()
         switchToolbarIfNeeded()
         adjustURLBarHeightBasedOnLocationViewHeight()
+
+        // when toolbars are hidden/shown the mask on the content view that is used for
+        // toolbar translucency needs to be updated
+        updateBlurViews()
     }
 
     func checkForJSAlerts() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12328)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26848)

## :bulb: Description
Updates blur view mask when layout gets updated.

## :movie_camera: Demos

<details>
<summary>Demo</summary>

Before:
https://github.com/user-attachments/assets/9810aae2-e70f-498b-b9da-cacde1891b69

After: 
https://github.com/user-attachments/assets/39fc9b83-3494-44f3-87d1-7a9c6a7b1235
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
