### PR TITLE
Add FXIOS-12371 #26968 ⁃ [Default Zoom] telemetry for Page Zoom Settings

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -6,7 +6,7 @@ import Common
 import Storage
 
 struct ZoomConstants {
-    static let defaultZoomLimit: CGFloat = 1.0
+    static let defaultZoomLimit: CGFloat = ZoomLevel.oneHundredPercent.rawValue
     static let lowerZoomLimit: CGFloat = ZoomLevel.fiftyPercent.rawValue
     static let upperZoomLimit: CGFloat = ZoomLevel.threeHundredPercent.rawValue
 }

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
@@ -43,8 +43,8 @@ struct ZoomTelemetry {
     }
 
     func deleteZoomDomainLevel(value: Int32) {
-        let extra = GleanMetrics.SettingsZoomBar.DomainListItemSwipedExtra(index: value)
-        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoomBar.domainListItemSwiped, extras: extra)
+        let extra = GleanMetrics.SettingsZoomBar.DomainListItemSwipedToDeleteExtra(index: value)
+        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoomBar.domainListItemSwipedToDelete, extras: extra)
     }
 
     func resetDomainZoomLevel() {

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
@@ -32,9 +32,9 @@ struct ZoomTelemetry {
     }
 
     // Page Zoom Settings actions
-    func updateDefaultZoomLevel(value: Int32) {
-        let extra = GleanMetrics.SettingsZoom.UpdateDefaultLevelExtra(level: value)
-        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoom.updateDefaultLevel, extras: extra)
+    func updateDefaultZoomLevel(zoomLevel: ZoomLevel) {
+        let extras = GleanMetrics.Preferences.DefaultZoomChangedExtra(level: zoomLevel.displayName)
+        gleanWrapper.recordEvent(for: GleanMetrics.Preferences.defaultZoomChanged, extras: extras)
     }
 
     func deleteZoomDomainLevel(value: Int32) {

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
@@ -43,11 +43,11 @@ struct ZoomTelemetry {
     }
 
     func deleteZoomDomainLevel(value: Int32) {
-        let extra = GleanMetrics.SettingsZoomBar.DomainDeletedExtra(index: value)
-        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoomBar.domainDeleted, extras: extra)
+        let extra = GleanMetrics.SettingsZoomBar.DomainListItemSwipedExtra(index: value)
+        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoomBar.domainListItemSwiped, extras: extra)
     }
 
     func resetDomainZoomLevel() {
-        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoomBar.resetButtonTapped)
+        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoomBar.domainListResetButtonTapped)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
@@ -7,6 +7,7 @@ import Glean
 
 struct ZoomTelemetry {
     private let gleanWrapper: GleanWrapper
+    static let defaultZoomExtraKey = "settings.zoom_bar.default_zoom"
 
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.gleanWrapper = gleanWrapper
@@ -33,8 +34,12 @@ struct ZoomTelemetry {
 
     // Page Zoom Settings actions
     func updateDefaultZoomLevel(zoomLevel: ZoomLevel) {
-        let extras = GleanMetrics.Preferences.DefaultZoomChangedExtra(level: zoomLevel.displayName)
-        gleanWrapper.recordEvent(for: GleanMetrics.Preferences.defaultZoomChanged, extras: extras)
+        let changedTo = zoomLevel.displayName
+        let preference = ZoomTelemetry.defaultZoomExtraKey
+
+        let extra = GleanMetrics.Preferences.ChangedExtra(changedTo: changedTo,
+                                                          preference: preference)
+        gleanWrapper.recordEvent(for: GleanMetrics.Preferences.changed, extras: extra)
     }
 
     func deleteZoomDomainLevel(value: Int32) {

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
@@ -43,11 +43,11 @@ struct ZoomTelemetry {
     }
 
     func deleteZoomDomainLevel(value: Int32) {
-        let extra = GleanMetrics.SettingsZoom.DeleteDomainLevelExtra(domainIndex: value)
-        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoom.deleteDomainLevel, extras: extra)
+        let extra = GleanMetrics.SettingsZoomBar.DomainDeletedExtra(index: value)
+        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoomBar.domainDeleted, extras: extra)
     }
 
     func resetDomainZoomLevel() {
-        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoom.resetDomainList)
+        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoomBar.resetButtonTapped)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
@@ -12,6 +12,7 @@ struct ZoomTelemetry {
         self.gleanWrapper = gleanWrapper
     }
 
+    // Zoom bar actions
     func zoomIn(zoomLevel: ZoomLevel) {
         let extra = GleanMetrics.ZoomBar.ZoomInButtonTappedExtra(level: zoomLevel.telemetryQuantity)
         gleanWrapper.recordEvent(for: GleanMetrics.ZoomBar.zoomInButtonTapped, extras: extra)
@@ -28,5 +29,20 @@ struct ZoomTelemetry {
 
     func closeZoomBar() {
         gleanWrapper.recordEvent(for: GleanMetrics.ZoomBar.closeButtonTapped)
+    }
+
+    // Page Zoom Settings actions
+    func changeDefaultZoomLevel(value: Int32) {
+        let extra = GleanMetrics.SettingsZoom.UpdateDefaultLevelExtra(level: value)
+        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoom.updateDefaultLevel, extras: extra)
+    }
+
+    func deleteZoomDomainLevel(value: Int32) {
+        let extra = GleanMetrics.SettingsZoom.DeleteDomainLevelExtra(domainIndex: value)
+        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoom.deleteDomainLevel)
+    }
+
+    func resetDomainZoomLevel() {
+        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoom.resetDomainList)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomTelemetry.swift
@@ -32,14 +32,14 @@ struct ZoomTelemetry {
     }
 
     // Page Zoom Settings actions
-    func changeDefaultZoomLevel(value: Int32) {
+    func updateDefaultZoomLevel(value: Int32) {
         let extra = GleanMetrics.SettingsZoom.UpdateDefaultLevelExtra(level: value)
         gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoom.updateDefaultLevel, extras: extra)
     }
 
     func deleteZoomDomainLevel(value: Int32) {
         let extra = GleanMetrics.SettingsZoom.DeleteDomainLevelExtra(domainIndex: value)
-        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoom.deleteDomainLevel)
+        gleanWrapper.recordEvent(for: GleanMetrics.SettingsZoom.deleteDomainLevel, extras: extra)
     }
 
     func resetDomainZoomLevel() {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingView.swift
@@ -42,7 +42,9 @@ struct PageZoomSettingsView: View {
         ScrollView {
             VStack {
                 // Default zoom level section
-                ZoomLevelPickerView(theme: theme, zoomManager: viewModel.zoomManager)
+                ZoomLevelPickerView(theme: theme,
+                                    zoomManager: viewModel.zoomManager,
+                                    onZoomLevelChanged: viewModel.updateDefaultZoomLevel)
                     .background(theme.colors.layer5.color)
 
                 // Specific site zoom level section

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingsViewModel.swift
@@ -20,6 +20,7 @@ class PageZoomSettingsViewModel: ObservableObject {
 
     func updateDefaultZoomLevel(newValue: ZoomLevel) {
         zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
+        notificationCenter.post(name: .PageZoomSettingsChanged)
         zoomTelemetry.updateDefaultZoomLevel(zoomLevel: newValue)
     }
 

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingsViewModel.swift
@@ -7,6 +7,7 @@ import Storage
 
 class PageZoomSettingsViewModel: ObservableObject {
     let zoomManager: ZoomPageManager
+    private let zoomTelemetry = ZoomTelemetry()
     @Published var domainZoomLevels: [DomainZoomLevel]
     public var notificationCenter: NotificationProtocol
 
@@ -17,10 +18,16 @@ class PageZoomSettingsViewModel: ObservableObject {
         self.notificationCenter = notificationCenter
     }
 
+    func updateDefaultZoomLevel(newValue: ZoomLevel) {
+        zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
+        zoomTelemetry.changeDefaultZoomLevel(value: newValue.telemetryQuantity)
+    }
+
     func resetDomainZoomLevel() {
         domainZoomLevels.removeAll()
         zoomManager.resetDomainZoomLevel()
         notificationCenter.post(name: .PageZoomSettingsChanged)
+        zoomTelemetry.resetDomainZoomLevel()
     }
 
     func deleteZoomLevel(at indexSet: IndexSet) {
@@ -30,5 +37,6 @@ class PageZoomSettingsViewModel: ObservableObject {
         zoomManager.deleteZoomLevel(for: deleteItem.host)
         domainZoomLevels.remove(at: index)
         notificationCenter.post(name: .PageZoomSettingsChanged)
+        zoomTelemetry.deleteZoomDomainLevel(value: Int32(index))
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingsViewModel.swift
@@ -20,7 +20,7 @@ class PageZoomSettingsViewModel: ObservableObject {
 
     func updateDefaultZoomLevel(newValue: ZoomLevel) {
         zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
-        zoomTelemetry.updateDefaultZoomLevel(value: newValue.telemetryQuantity)
+        zoomTelemetry.updateDefaultZoomLevel(zoomLevel: newValue)
     }
 
     func resetDomainZoomLevel() {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/PageZoomSettingsViewModel.swift
@@ -20,7 +20,7 @@ class PageZoomSettingsViewModel: ObservableObject {
 
     func updateDefaultZoomLevel(newValue: ZoomLevel) {
         zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
-        zoomTelemetry.changeDefaultZoomLevel(value: newValue.telemetryQuantity)
+        zoomTelemetry.updateDefaultZoomLevel(value: newValue.telemetryQuantity)
     }
 
     func resetDomainZoomLevel() {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -9,6 +9,7 @@ struct ZoomLevelPickerView: View {
     @State private var selectedZoomLevel: ZoomLevel
     private let theme: Theme
     private let zoomManager: ZoomPageManager
+    private let onZoomLevelChanged: (ZoomLevel) -> Void
 
     private struct UX {
         static let chevronImageIdentifier = "chevron.down"
@@ -30,9 +31,10 @@ struct ZoomLevelPickerView: View {
         return .Settings.Appearance.PageZoom.ZoomLevelSelectorTitle
     }
 
-    init(theme: Theme, zoomManager: ZoomPageManager) {
+    init(theme: Theme, zoomManager: ZoomPageManager, onZoomLevelChanged: @escaping(ZoomLevel) -> Void) {
         self.theme = theme
         self.zoomManager = zoomManager
+        self.onZoomLevelChanged = onZoomLevelChanged
         let currentZoom = ZoomLevel(from: zoomManager.defaultZoomLevel)
         _selectedZoomLevel = State(initialValue: currentZoom)
     }
@@ -72,10 +74,7 @@ struct ZoomLevelPickerView: View {
                                 .tag(item)
                         }
                     }
-                    .onChange(of: selectedZoomLevel) { newValue in
-                        zoomManager.saveDefaultZoomLevel(defaultZoom: newValue.rawValue)
-                        NotificationCenter.default.post(name: .PageZoomSettingsChanged, object: nil)
-                    }
+                    .onChange(of: selectedZoomLevel, perform: onZoomLevelChanged)
                     .pickerStyle(.inline)
                     .labelsHidden()
                 } label: {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -9,8 +9,8 @@ import Storage
 struct ZoomSiteListView: View {
     let theme: Theme
     @Binding var domainZoomLevels: [DomainZoomLevel]
-    let onDelete: (IndexSet) -> Void
-    let resetDomain: () -> Void
+    private let onDelete: (IndexSet) -> Void
+    private let resetDomain: () -> Void
 
     private struct UX {
         static var sectionPadding: CGFloat = 16

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -266,7 +266,7 @@ settings.app_icon:
         
 # Default Zoom Settings
 settings.zoom_bar:
-  domain_list_item_swiped:
+  domain_list_item_swiped_to_delete:
     type: event
     description: |
       Recorded when the user swipes to delete a specific zoom domain level in the app settings.

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -263,3 +263,58 @@ settings.app_icon:
     metadata:
       tags:
         - AppIconSelection
+        
+# Default Zoom Settings
+settings.zoom:
+  update_default_level:
+    type: event
+    description: |
+      Records when the user changes their app icon in the app settings.
+    extra_keys:
+      level:
+        type: quantity
+        description: |
+          The new default zoom level for domain that don't have a custom zoom level.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-12371
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25029
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-08-01"
+    metadata:
+      tags:
+        - ZoomBar
+  delete_domain_level:
+    type: event
+    description: |
+      Records when the user deletes a specific zoom domain level in the app settings.
+    extra_keys:
+      domain_index:
+        type: quantity
+        description: |
+          The new default zoom level for domain that don't have a custom zoom level.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-12371
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25029
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-08-01"
+    metadata:
+      tags:
+        - ZoomBar
+  reset_domain_list:
+    type: event
+    description: |
+      Records when the user resets the list of zoom domain level in the app settings.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-12371
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25029
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-08-01"
+    metadata:
+      tags:
+        - ZoomBar

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -243,7 +243,7 @@ preferences:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-12371
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/27006
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-07-01"
@@ -294,7 +294,7 @@ settings.zoom:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-12371
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/25029
+      - https://github.com/mozilla-mobile/firefox-ios/pull/27006
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-08-01"
@@ -308,7 +308,7 @@ settings.zoom:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-12371
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/25029
+      - https://github.com/mozilla-mobile/firefox-ios/pull/27006
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-08-01"

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -304,7 +304,7 @@ settings.zoom_bar:
   reset_domain_list:
     type: event
     description: |
-      Records when the user resets the list of zoom domain level in the app settings.
+      Recorded when the user resets the list of zoom domain levels in the app settings.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-12371
     data_reviews:

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -301,7 +301,7 @@ settings.zoom_bar:
     metadata:
       tags:
         - ZoomBar
-  reset_domain_list:
+  domain_list_reset_button_tapped:
     type: event
     description: |
       Recorded when the user resets the list of zoom domain levels in the app settings.

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -287,7 +287,7 @@ settings.zoom_bar:
     description: |
       Recorded when the user deletes a specific zoom domain level in the app settings.
     extra_keys:
-      domain_index:
+      index:
         type: quantity
         description: |
           The new default zoom level for domain that don't have a custom zoom level.

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -282,7 +282,7 @@ settings.app_icon:
         
 # Default Zoom Settings
 settings.zoom_bar:
-  delete_domain_level:
+  domain_deleted:
     type: event
     description: |
       Records when the user deletes a specific zoom domain level in the app settings.

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -290,7 +290,7 @@ settings.zoom_bar:
       index:
         type: quantity
         description: |
-          The new default zoom level for domain that don't have a custom zoom level.
+          The index of the site in the list of domains that have a user-configured page zoom level. Index 0 is the top of the list.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-12371
     data_reviews:

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -246,7 +246,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/27006
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 ###############################################################################
 # New "settings" telemetry properly nested under "settings".
@@ -297,7 +297,7 @@ settings.zoom:
       - https://github.com/mozilla-mobile/firefox-ios/pull/27006
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-08-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - ZoomBar
@@ -311,7 +311,7 @@ settings.zoom:
       - https://github.com/mozilla-mobile/firefox-ios/pull/27006
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-08-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - ZoomBar

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -231,6 +231,22 @@ preferences:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-01-01"
+  default_zoom_changed:
+    type: event
+    description: |
+      Records when the user changes their default zoom level in the app settings.
+    extra_keys:
+      level:
+        type: string
+        description: |
+          The default zoom value that will be used. The values range between 50% and 300%.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-12371
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-07-01"
 
 ###############################################################################
 # New "settings" telemetry properly nested under "settings".
@@ -266,25 +282,6 @@ settings.app_icon:
         
 # Default Zoom Settings
 settings.zoom:
-  update_default_level:
-    type: event
-    description: |
-      Records when the user changes their app icon in the app settings.
-    extra_keys:
-      level:
-        type: quantity
-        description: |
-          The new default zoom level for domain that don't have a custom zoom level.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-12371
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/25029
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2025-08-01"
-    metadata:
-      tags:
-        - ZoomBar
   delete_domain_level:
     type: event
     description: |

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -269,7 +269,7 @@ settings.zoom_bar:
   domain_deleted:
     type: event
     description: |
-      Recorded when the user deletes a specific zoom domain level in the app settings.
+      Recorded when the user swipes to delete a specific zoom domain level in the app settings.
     extra_keys:
       index:
         type: quantity
@@ -285,7 +285,7 @@ settings.zoom_bar:
     metadata:
       tags:
         - ZoomBar
-  domain_list_reset_button_tapped:
+  reset_button_tapped:
     type: event
     description: |
       Recorded when the user resets the list of zoom domain levels in the app settings.

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -266,7 +266,7 @@ settings.app_icon:
         
 # Default Zoom Settings
 settings.zoom_bar:
-  domain_deleted:
+  domain_list_item_swiped:
     type: event
     description: |
       Recorded when the user swipes to delete a specific zoom domain level in the app settings.
@@ -285,7 +285,7 @@ settings.zoom_bar:
     metadata:
       tags:
         - ZoomBar
-  reset_button_tapped:
+  domain_list_reset_button_tapped:
     type: event
     description: |
       Recorded when the user resets the list of zoom domain levels in the app settings.
@@ -299,3 +299,5 @@ settings.zoom_bar:
     metadata:
       tags:
         - ZoomBar
+    no_lint:
+      - COMMON_PREFIX

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -281,7 +281,7 @@ settings.app_icon:
         - AppIconSelection
         
 # Default Zoom Settings
-settings.zoom:
+settings.zoom_bar:
   delete_domain_level:
     type: event
     description: |

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -231,22 +231,6 @@ preferences:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-01-01"
-  default_zoom_changed:
-    type: event
-    description: |
-      Records when the user changes their default zoom level in the app settings.
-    extra_keys:
-      level:
-        type: string
-        description: |
-          The default zoom value that will be used. The values range between 50% and 300%.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-12371
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/27006
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
 
 ###############################################################################
 # New "settings" telemetry properly nested under "settings".

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -285,7 +285,7 @@ settings.zoom_bar:
   domain_deleted:
     type: event
     description: |
-      Records when the user deletes a specific zoom domain level in the app settings.
+      Recorded when the user deletes a specific zoom domain level in the app settings.
     extra_keys:
       domain_index:
         type: quantity

--- a/firefox-ios/Storage/ZoomLevelStore.swift
+++ b/firefox-ios/Storage/ZoomLevelStore.swift
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Foundation
 import Common
+import Foundation
 
 public struct ZoomSettings: Codable {
     var defaultZoom: CGFloat

--- a/firefox-ios/Storage/ZoomLevelStore.swift
+++ b/firefox-ios/Storage/ZoomLevelStore.swift
@@ -63,9 +63,7 @@ public class ZoomLevelStore: ZoomLevelStorage {
         }) {
             zoomSetting.zoomLevels.remove(at: index)
         }
-        if domainZoomLevel.zoomLevel != ZoomLevelStore.defaultZoomLimit {
-            zoomSetting.zoomLevels.append(domainZoomLevel)
-        }
+        zoomSetting.zoomLevels.append(domainZoomLevel)
         save(completion)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
@@ -88,12 +88,12 @@ final class ZoomTelemetryTests: XCTestCase {
     }
 
     func testRecordEvent_WhenDefaultZoomChanges_ThenGleanIsCalled() throws {
-        let event = GleanMetrics.SettingsZoom.updateDefaultLevel
-        typealias EventExtrasType = GleanMetrics.SettingsZoom.UpdateDefaultLevelExtra
+        let event = GleanMetrics.Preferences.defaultZoomChanged
+        typealias EventExtrasType = GleanMetrics.Preferences.DefaultZoomChangedExtra
         let expectedZoomLevel = ZoomLevel(from: 110)
         let expectedMetricType = type(of: event)
 
-        subject?.updateDefaultZoomLevel(value: expectedZoomLevel.telemetryQuantity)
+        subject?.updateDefaultZoomLevel(zoomLevel: expectedZoomLevel)
 
         let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
         let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
@@ -101,7 +101,7 @@ final class ZoomTelemetryTests: XCTestCase {
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
         XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.level, expectedZoomLevel.telemetryQuantity)
+        XCTAssertEqual(savedExtras.level, expectedZoomLevel.displayName)
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 
@@ -109,8 +109,9 @@ final class ZoomTelemetryTests: XCTestCase {
         let event = GleanMetrics.SettingsZoom.deleteDomainLevel
         typealias EventExtrasType = GleanMetrics.SettingsZoom.DeleteDomainLevelExtra
         let expectedMetricType = type(of: event)
+        let expectedIndex: Int32 = 1
 
-        subject?.deleteZoomDomainLevel(value: Int32(1))
+        subject?.deleteZoomDomainLevel(value: expectedIndex)
 
         let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
         let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
@@ -118,7 +119,7 @@ final class ZoomTelemetryTests: XCTestCase {
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
         XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.level, expectedZoomLevel.telemetryQuantity)
+        XCTAssertEqual(savedExtras.domainIndex, expectedIndex)
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
@@ -106,8 +106,8 @@ final class ZoomTelemetryTests: XCTestCase {
     }
 
     func testRecordEvent_WhenSpecificZoomIsDeleted_ThenGleanIsCalled() throws {
-        let event = GleanMetrics.SettingsZoom.deleteDomainLevel
-        typealias EventExtrasType = GleanMetrics.SettingsZoom.DeleteDomainLevelExtra
+        let event = GleanMetrics.SettingsZoomBar.domainDeleted
+        typealias EventExtrasType = GleanMetrics.SettingsZoomBar.DomainDeletedExtra
         let expectedMetricType = type(of: event)
         let expectedIndex: Int32 = 1
 
@@ -119,12 +119,12 @@ final class ZoomTelemetryTests: XCTestCase {
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
         XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.domainIndex, expectedIndex)
+        XCTAssertEqual(savedExtras.index, expectedIndex)
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 
     func testRecordEvent_WhenSpecificZoomResets_ThenGleanIsCalled() throws {
-        let event = GleanMetrics.SettingsZoom.resetDomainList
+        let event = GleanMetrics.SettingsZoomBar.resetButtonTapped
         let expectedMetricType = type(of: event)
 
         subject?.resetDomainZoomLevel()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
@@ -86,4 +86,53 @@ final class ZoomTelemetryTests: XCTestCase {
         XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
+
+    func testRecordEvent_WhenDefaultZoomChanges_ThenGleanIsCalled() throws {
+        let event = GleanMetrics.SettingsZoom.updateDefaultLevel
+        typealias EventExtrasType = GleanMetrics.SettingsZoom.UpdateDefaultLevelExtra
+        let expectedZoomLevel = ZoomLevel(from: 110)
+        let expectedMetricType = type(of: event)
+
+        subject?.updateDefaultZoomLevel(value: expectedZoomLevel.telemetryQuantity)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.level, expectedZoomLevel.telemetryQuantity)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func testRecordEvent_WhenSpecificZoomIsDeleted_ThenGleanIsCalled() throws {
+        let event = GleanMetrics.SettingsZoom.deleteDomainLevel
+        typealias EventExtrasType = GleanMetrics.SettingsZoom.DeleteDomainLevelExtra
+        let expectedMetricType = type(of: event)
+
+        subject?.deleteZoomDomainLevel(value: Int32(1))
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.level, expectedZoomLevel.telemetryQuantity)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func testRecordEvent_WhenSpecificZoomResets_ThenGleanIsCalled() throws {
+        let event = GleanMetrics.SettingsZoom.resetDomainList
+        let expectedMetricType = type(of: event)
+
+        subject?.resetDomainZoomLevel()
+
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<NoExtras>)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
@@ -88,8 +88,8 @@ final class ZoomTelemetryTests: XCTestCase {
     }
 
     func testRecordEvent_WhenDefaultZoomChanges_ThenGleanIsCalled() throws {
-        let event = GleanMetrics.Preferences.defaultZoomChanged
-        typealias EventExtrasType = GleanMetrics.Preferences.DefaultZoomChangedExtra
+        let event = GleanMetrics.Preferences.changed
+        typealias EventExtrasType = GleanMetrics.Preferences.ChangedExtra
         let expectedZoomLevel = ZoomLevel(from: 110)
         let expectedMetricType = type(of: event)
 
@@ -101,7 +101,7 @@ final class ZoomTelemetryTests: XCTestCase {
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
         XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.level, expectedZoomLevel.displayName)
+        XCTAssertEqual(savedExtras.changedTo, expectedZoomLevel.displayName)
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
@@ -106,8 +106,8 @@ final class ZoomTelemetryTests: XCTestCase {
     }
 
     func testRecordEvent_WhenSpecificZoomIsDeleted_ThenGleanIsCalled() throws {
-        let event = GleanMetrics.SettingsZoomBar.domainDeleted
-        typealias EventExtrasType = GleanMetrics.SettingsZoomBar.DomainDeletedExtra
+        let event = GleanMetrics.SettingsZoomBar.domainListItemSwipedToDelete
+        typealias EventExtrasType = GleanMetrics.SettingsZoomBar.DomainListItemSwipedToDeleteExtra
         let expectedMetricType = type(of: event)
         let expectedIndex: Int32 = 1
 
@@ -124,7 +124,7 @@ final class ZoomTelemetryTests: XCTestCase {
     }
 
     func testRecordEvent_WhenSpecificZoomResets_ThenGleanIsCalled() throws {
-        let event = GleanMetrics.SettingsZoomBar.resetButtonTapped
+        let event = GleanMetrics.SettingsZoomBar.domainListResetButtonTapped
         let expectedMetricType = type(of: event)
 
         subject?.resetDomainZoomLevel()

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/ZoomLevelStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/ZoomLevelStoreTests.swift
@@ -68,11 +68,11 @@ final class ZoomLevelStoreTests: XCTestCase {
         XCTAssertEqual(retrievedZoomLevel, domainZoomLevel2)
     }
 
-    func testSaveNoZoomLevel() {
+    func testSaveDefaultZoomLevel() {
         let domainZoomLevel = DomainZoomLevel(host: testHost1, zoomLevel: 1.0)
         zoomLevelStore.saveDomainZoom(domainZoomLevel)
 
-        XCTAssertFalse(zoomLevelStore.getDomainZoomLevel().contains(domainZoomLevel))
+        XCTAssertTrue(zoomLevelStore.getDomainZoomLevel().contains(domainZoomLevel))
     }
 
     func testFindZoomLevelNotFound() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12371)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26968)

## :bulb: Description
- Add telemetry events for Page zoom settings when the user:
  - Updates default zoom level
  - Deletes a specific domain zoom level
  - Reset zoom level list
- Add unit test 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
