### PR TITLE
Refactor FXIOS-XXXX Renew all glean metrics until 2026-01-01

### DIFF
--- a/firefox-ios/Client/Glean/metrics.yaml
+++ b/firefox-ios/Client/Glean/metrics.yaml
@@ -25,7 +25,7 @@ app_cycle:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   background:
     type: event
     description: |
@@ -37,7 +37,7 @@ app_cycle:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 # App icon
 app_icon:
   new_private_tab_tapped:
@@ -50,7 +50,7 @@ app_icon:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 # Accessibility
 accessibility:
   voice_over:
@@ -69,7 +69,7 @@ accessibility:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   switch_control:
     type: event
     description: |
@@ -86,7 +86,7 @@ accessibility:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   reduce_transparency:
     type: event
     description: |
@@ -103,7 +103,7 @@ accessibility:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   reduce_motion:
     type: event
     description: |
@@ -120,7 +120,7 @@ accessibility:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   invert_colors:
     type: event
     description: |
@@ -137,7 +137,7 @@ accessibility:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   dynamic_text:
     type: event
     description: |
@@ -158,7 +158,7 @@ accessibility:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 # App menu
 app_menu:
   main_menu_option_selected:
@@ -180,7 +180,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22788
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   save_menu_option_selected:
     type: event
     description: |
@@ -200,7 +200,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/23046
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   tools_menu_option_selected:
     type: event
     description: |
@@ -220,7 +220,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/23046
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   close_button:
     type: event
     description: |
@@ -236,7 +236,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22788
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   menu_dismissed:
     type: event
     description: |
@@ -252,7 +252,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22788
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   homepage_menu:
     type: counter
     description: |
@@ -265,7 +265,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   site_menu:
     type: counter
     description: |
@@ -278,7 +278,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   home:
     type: counter
     description: |
@@ -292,7 +292,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   block_images_enabled:
     type: counter
     description: |
@@ -307,7 +307,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   block_images_disabled:
     type: counter
     description: |
@@ -322,7 +322,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   night_mode_enabled:
     type: counter
     description: |
@@ -337,7 +337,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   night_mode_disabled:
     type: counter
     description: |
@@ -352,7 +352,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   whats_new:
     type: counter
     description: |
@@ -366,7 +366,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   help:
     type: counter
     description: |
@@ -378,7 +378,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   customize_homepage:
     type: counter
     description: |
@@ -391,7 +391,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   settings:
     type: counter
     description: |
@@ -405,7 +405,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   logins:
     type: counter
     description: |
@@ -420,7 +420,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   sign_into_sync:
     type: counter
     description: |
@@ -436,7 +436,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15181
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   passwords:
     type: event
     description: |
@@ -447,7 +447,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16685
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Bookmark metrics
 bookmarks:
@@ -467,7 +467,7 @@ bookmarks:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   add:
     type: labeled_counter
     description: |
@@ -490,7 +490,7 @@ bookmarks:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   delete:
     type: labeled_counter
     description: |
@@ -512,7 +512,7 @@ bookmarks:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   edit:
     type: labeled_counter
     description: |
@@ -532,7 +532,7 @@ bookmarks:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   open:
     type: labeled_counter
     description: |
@@ -554,7 +554,7 @@ bookmarks:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15833
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   has_mobile_bookmarks:
     type: boolean
     description: |
@@ -566,7 +566,7 @@ bookmarks:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15833
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   mobile_bookmarks_count:
     type: quantity
     description: |
@@ -578,7 +578,7 @@ bookmarks:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15833
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     unit: quantity of mobile bookmarks
   folder_add:
     type: event
@@ -590,7 +590,7 @@ bookmarks:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15833
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Context menus
 context_menu:
@@ -615,7 +615,7 @@ context_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25805
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - ContextMenu
@@ -635,7 +635,7 @@ context_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25805
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - ContextMenu
@@ -655,7 +655,7 @@ context_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25805
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - ContextMenu
@@ -675,7 +675,7 @@ default_browser_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   go_to_settings_pressed:
     type: counter
     description: |
@@ -690,7 +690,7 @@ default_browser_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   evergreen_impression:
     type: event
     description: |
@@ -702,7 +702,7 @@ default_browser_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Default browser onboarding metrics
 default_browser_onboarding:
@@ -719,7 +719,7 @@ default_browser_onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   go_to_settings_pressed:
     type: counter
     description: |
@@ -734,7 +734,7 @@ default_browser_onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 app:
   default_browser:
@@ -798,7 +798,7 @@ app:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   last_opened_as_default_browser:
     type: datetime
     time_unit: day
@@ -819,7 +819,7 @@ app:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
       - glean-team@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Usage reporting
 usage:
@@ -1049,7 +1049,7 @@ downloads:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   downloads_panel_row_tapped:
     type: event
     description: |
@@ -1061,7 +1061,7 @@ downloads:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   view_download_complete_toast:
     type: event
     description: |
@@ -1073,7 +1073,7 @@ downloads:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Password Generator
 password_generator:
@@ -1087,7 +1087,7 @@ password_generator:
       - https://github.com/mozilla-mobile/firefox-ios/issues/21248
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   filled:
     type: counter
     description: |
@@ -1098,7 +1098,7 @@ password_generator:
       - https://github.com/mozilla-mobile/firefox-ios/issues/21248
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Microsurvey
 microsurvey:
@@ -1119,7 +1119,7 @@ microsurvey:
       - https://github.com/mozilla-mobile/firefox-ios/pull/20903
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
   privacy_notice_tapped:
     type: event
@@ -1140,7 +1140,7 @@ microsurvey:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
       - interaction
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
   dismiss_button_tapped:
     type: event
@@ -1161,7 +1161,7 @@ microsurvey:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
       - interaction
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
   submit_button_tapped:
     type: event
@@ -1186,7 +1186,7 @@ microsurvey:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
       - interaction
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
   confirmation_shown:
     type: event
@@ -1205,7 +1205,7 @@ microsurvey:
       - https://github.com/mozilla-mobile/firefox-ios/pull/20903
     notification_emails:
         - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Settings main menu
 settings.main_menu:
@@ -1224,7 +1224,7 @@ settings.main_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25029
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - Settings
@@ -1248,7 +1248,7 @@ key_commands:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Onboarding metrics
 onboarding:
@@ -1262,7 +1262,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24123
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   terms_of_service_accepted:
     type: event
     description: |
@@ -1273,7 +1273,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24123
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   terms_of_service_link_clicked:
     type: event
     description: |
@@ -1284,7 +1284,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24123
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   terms_of_service_manage_link_clicked:
     type: event
     description: |
@@ -1295,7 +1295,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24123
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   terms_of_service_privacy_notice_link_clicked:
     type: event
     description: |
@@ -1306,7 +1306,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24123
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   toggle_technical_interaction_data:
     type: event
     description: |
@@ -1322,7 +1322,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24123
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   toggle_automatic_crash_reports:
     type: event
     description: |
@@ -1338,7 +1338,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24123
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   card_view:
     type: event
     description: |
@@ -1367,7 +1367,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/10984
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   primary_button_tap:
     type: event
     description: |
@@ -1401,7 +1401,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   secondary_button_tap:
     type: event
     description: |
@@ -1435,7 +1435,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   multiple_choice_button_tap:
     type: event
     description: |
@@ -1467,7 +1467,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/19678
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   close_tap:
     type: event
     description: |
@@ -1497,7 +1497,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   wallpaper_selected:
     type: event
     description: |
@@ -1519,7 +1519,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   wallpaper_selector_view:
     type: event
     description: |
@@ -1532,7 +1532,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   wallpaper_selector_close:
     type: event
     description: |
@@ -1546,7 +1546,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   wallpaper_selector_selected:
     type: event
     description: |
@@ -1570,7 +1570,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   notification_permission_prompt:
     type: event
     description: |
@@ -1587,7 +1587,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   engagement_notification_tapped:
     type: event
     description: |
@@ -1599,7 +1599,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   engagement_notification_cancel:
     type: event
     description: |
@@ -1611,7 +1611,7 @@ onboarding:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Top Site
 top_sites:
@@ -1638,7 +1638,7 @@ top_sites:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   pressed_tile_origin:
     type: labeled_counter
     description: |
@@ -1656,7 +1656,7 @@ top_sites:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   contextual_menu:
     type: event
     description: |
@@ -1675,7 +1675,7 @@ top_sites:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   context_id:
     type: uuid
     description: |
@@ -1695,7 +1695,7 @@ top_sites:
       - highly_sensitive
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TopSites
@@ -1717,7 +1717,7 @@ top_sites:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     unit: integer
     metadata:
       tags:
@@ -1740,7 +1740,7 @@ top_sites:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TopSites
@@ -1763,7 +1763,7 @@ top_sites:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TopSites
@@ -1791,7 +1791,7 @@ top_sites:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TopSites
@@ -1819,7 +1819,7 @@ top_sites:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TopSites
@@ -1833,7 +1833,7 @@ top_sites:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   sponsored_shortcuts:
     type: boolean
     description: |
@@ -1844,7 +1844,7 @@ top_sites:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15768
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 # HomePage - Normal
 firefox_home_page:
   open_from_menu_home_button:
@@ -1862,7 +1862,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   open_from_awesomebar:
     type: counter
     description: |
@@ -1877,7 +1877,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   recently_saved_show_all:
     type: counter
     description: |
@@ -1892,7 +1892,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   recently_saved_show_all_origin:
     type: labeled_counter
     description: |
@@ -1911,7 +1911,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   recently_saved_bookmark_item:
     type: counter
     description: |
@@ -1926,7 +1926,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   recently_saved_bookmark_origin:
     type: labeled_counter
     description: |
@@ -1945,7 +1945,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   recently_saved_bookmark_view:
     type: event
     description: |
@@ -1966,7 +1966,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   reading_list_view:
     type: event
     description: |
@@ -1988,7 +1988,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   recently_saved_reading_item:
     type: counter
     description: |
@@ -2003,7 +2003,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   recently_saved_read_origin:
     type: labeled_counter
     description: |
@@ -2022,7 +2022,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   jump_back_in_show_all:
     type: counter
     description: |
@@ -2037,7 +2037,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   jump_back_in_show_all_origin:
     type: labeled_counter
     description: |
@@ -2056,7 +2056,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   jump_back_in_tile_view:
     type: counter
     description: |
@@ -2070,7 +2070,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   jump_back_in_tab_opened:
     type: counter
     description: |
@@ -2085,7 +2085,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   jump_back_in_tab_opened_origin:
     type: labeled_counter
     description: |
@@ -2104,7 +2104,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   jump_back_in_group_opened:
     type: counter
     description: |
@@ -2119,7 +2119,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   jump_back_in_group_open_origin:
     type: labeled_counter
     description: |
@@ -2138,7 +2138,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   synced_tab_tile_view:
     type: counter
     description: |
@@ -2152,7 +2152,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   synced_tab_show_all:
     type: counter
     description: |
@@ -2166,7 +2166,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   synced_tab_show_all_origin:
     type: labeled_counter
     description: |
@@ -2184,7 +2184,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   synced_tab_opened:
     type: counter
     description: |
@@ -2198,7 +2198,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   synced_tab_opened_origin:
     type: labeled_counter
     description: |
@@ -2216,7 +2216,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
   customize_homepage_button:
     type: counter
@@ -2232,7 +2232,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   firefox_homepage_view:
     type: counter
     description: |
@@ -2246,7 +2246,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   firefox_homepage_origin:
     type: labeled_counter
     description: |
@@ -2264,7 +2264,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   pocket_stories_visible:
     type: boolean
     description: |
@@ -2277,7 +2277,7 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # HomePage - General
 homepage:
@@ -2291,7 +2291,7 @@ homepage:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25923
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - Homepage
@@ -2315,7 +2315,7 @@ homepage:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25297
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - Homepage
@@ -2336,7 +2336,7 @@ homepage:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26234
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - Homepage
@@ -2365,7 +2365,7 @@ library:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Library
 library.history_panel:
@@ -2385,7 +2385,7 @@ library.history_panel:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25614
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - HistoryPanel
@@ -2403,7 +2403,7 @@ history:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15696
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   group_list:
     type: counter
     description: |
@@ -2419,7 +2419,7 @@ history:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   selected_item:
     type: labeled_counter
     description: |
@@ -2437,7 +2437,7 @@ history:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   opened_item:
     type: event
     description: |
@@ -2448,7 +2448,7 @@ history:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17462
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   search_tap:
     type: event
     description: |
@@ -2461,7 +2461,7 @@ history:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   delete_tap:
     type: event
     description: |
@@ -2474,7 +2474,7 @@ history:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   removed:
     type: event
     description: |
@@ -2485,7 +2485,7 @@ history:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15696
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Legacy IDs for continuity and for deletion-request
 legacy.ids:
@@ -2540,7 +2540,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   send_to_device:
     type: counter
     description: |
@@ -2555,7 +2555,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   copy_address:
     type: counter
     description: |
@@ -2570,7 +2570,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   report_site_issue:
     type: counter
     description: |
@@ -2585,7 +2585,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   find_in_page:
     type: counter
     description: |
@@ -2600,7 +2600,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   request_desktop_site:
     type: counter
     description: |
@@ -2615,7 +2615,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   request_mobile_site:
     type: counter
     description: |
@@ -2630,7 +2630,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   pin_to_top_sites:
     type: counter
     description: |
@@ -2645,7 +2645,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   remove_pinned_site:
     type: counter
     description: |
@@ -2660,7 +2660,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   view_downloads_panel:
     type: counter
     description: |
@@ -2674,7 +2674,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   view_history_panel:
     type: counter
     description: |
@@ -2688,7 +2688,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   create_new_tab:
     type: counter
     description: |
@@ -2702,7 +2702,7 @@ page_action_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Pocket
 pocket:
@@ -2721,7 +2721,7 @@ pocket:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   section_impressions:
     type: counter
     description: |
@@ -2736,7 +2736,7 @@ pocket:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   open_story_origin:
     type: labeled_counter
     description: |
@@ -2754,7 +2754,7 @@ pocket:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   open_in_private_tab:
     type: event
     description: |
@@ -2765,7 +2765,7 @@ pocket:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Private Browsing
 private_browsing:
@@ -2784,7 +2784,7 @@ private_browsing:
       - https://github.com/mozilla-mobile/firefox-ios/pull/18080
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Password Manager metrics
 logins:
@@ -2798,7 +2798,7 @@ logins:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16685
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_failed:
     type: event
     description: |
@@ -2809,7 +2809,7 @@ logins:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16685
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   management_add_tapped:
     type: event
     description: |
@@ -2820,7 +2820,7 @@ logins:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16685
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   management_logins_tapped:
     type: event
     description: |
@@ -2831,7 +2831,7 @@ logins:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16685
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   saved:
     type: counter
     description: |
@@ -2842,7 +2842,7 @@ logins:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16685
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   saved_all:
     type: quantity
     description: |
@@ -2853,7 +2853,7 @@ logins:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16685
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     unit: quantity of logins.saved_all
   deleted:
     type: counter
@@ -2865,7 +2865,7 @@ logins:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16685
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   modified:
     type: counter
     description: |
@@ -2876,7 +2876,7 @@ logins:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16685
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   sync_enabled:
     type: event
     description: |
@@ -2894,7 +2894,7 @@ logins:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16685
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_prompt_shown:
     type: event
     description: |
@@ -2907,7 +2907,7 @@ logins:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_prompt_expanded:
     type: event
     description: |
@@ -2918,7 +2918,7 @@ logins:
       - https://github.com/mozilla-mobile/firefox-ios/pull/19791
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_prompt_dismissed:
     type: event
     description: |
@@ -2931,7 +2931,7 @@ logins:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 # QR Code metrics
 qr_code:
   scanned:
@@ -2947,7 +2947,7 @@ qr_code:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Reading List metrics
 reading_list:
@@ -2972,7 +2972,7 @@ reading_list:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   open:
     type: counter
     description: |
@@ -2987,7 +2987,7 @@ reading_list:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   delete:
     type: labeled_counter
     description: |
@@ -3008,7 +3008,7 @@ reading_list:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Reader Mode metrics
 reader_mode:
@@ -3025,7 +3025,7 @@ reader_mode:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   close:
     type: counter
     description: |
@@ -3039,7 +3039,7 @@ reader_mode:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Default Browser Settings Menu Option
 settings_menu:
@@ -3073,7 +3073,7 @@ settings_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/13827
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   passwords:
     type: event
     description: |
@@ -3084,7 +3084,7 @@ settings_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16685
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 # Search and search related metrics
 search:
   counts:
@@ -3112,7 +3112,7 @@ search:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1923843
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     send_in_pings:
       - metrics
       - baseline
@@ -3136,7 +3136,7 @@ search:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1923843
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     send_in_pings:
       - metrics
       - baseline
@@ -3156,7 +3156,7 @@ search:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   in_content:
     type: labeled_counter
     description: |
@@ -3172,7 +3172,7 @@ search:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1923843
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     send_in_pings:
       - metrics
       - baseline
@@ -3192,7 +3192,7 @@ search:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Sync
 sync:
@@ -3210,7 +3210,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   sign_in_sync_pressed:
     type: counter
     description: |
@@ -3226,7 +3226,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   create_account_pressed:
     type: counter
     description: |
@@ -3241,7 +3241,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   registration_view:
     type: event
     description: |
@@ -3254,7 +3254,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   registration_completed_view:
     type: event
     description: |
@@ -3267,7 +3267,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   login_view:
     type: event
     description: |
@@ -3280,7 +3280,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   login_completed_view:
     type: event
     description: |
@@ -3293,7 +3293,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   login_token_view:
     type: event
     description: |
@@ -3306,7 +3306,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   registration_code_view:
     type: event
     description: |
@@ -3319,7 +3319,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   use_email:
     type: event
     description: |
@@ -3331,7 +3331,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15181
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   paired:
     type: event
     description: |
@@ -3342,7 +3342,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15181
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   disconnect:
     type: event
     description: |
@@ -3353,7 +3353,7 @@ sync:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15181
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 
 # Tab metrics
@@ -3372,7 +3372,7 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/23252
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   pull_to_refresh_easter_egg:
     type: event
     description: |
@@ -3383,7 +3383,7 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/23252
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   normal_and_private_uri_count:
     type: counter
     description: |
@@ -3414,7 +3414,7 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   navigate_tab_back_swipe:
     type: counter
     description: |
@@ -3428,7 +3428,7 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   navigate_tab_history_forward:
     type: counter
     description: |
@@ -3442,7 +3442,7 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   reload_from_url_bar:
     type: counter
     description: |
@@ -3456,7 +3456,7 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   press_tab_toolbar:
     type: event
     description: |
@@ -3468,7 +3468,7 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   press_top_tab:
     type: event
     description: |
@@ -3480,7 +3480,7 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   restore_tabs_alert:
     type: event
     description: |
@@ -3498,7 +3498,7 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/16515
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   tab_switch:
     type: timing_distribution
     time_unit: millisecond
@@ -3534,7 +3534,7 @@ tabs_panel:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26131
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-12-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TabsPanel
@@ -3559,7 +3559,7 @@ tabs_panel:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26131
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-12-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TabsPanel
@@ -3587,7 +3587,7 @@ tabs_panel:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26131
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-12-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TabsPanel
@@ -3611,7 +3611,7 @@ tabs_panel:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TabsPanel
@@ -3633,7 +3633,7 @@ tabs_panel:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TabsPanel
@@ -3655,7 +3655,7 @@ tabs_panel.close_old_tabs_sheet:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26584
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-11-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TabsPanel
@@ -3686,7 +3686,7 @@ tabs_panel.close_all_tabs_sheet:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26131
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-12-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - TabsPanel
@@ -3703,7 +3703,7 @@ toasts.close_single_tab:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25569
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - Toasts
@@ -3720,7 +3720,7 @@ toasts.close_all_tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25569
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - Toasts
@@ -3742,7 +3742,7 @@ tracking_protection:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   strength:
     type: string
     description: |
@@ -3759,7 +3759,7 @@ tracking_protection:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   etp_setting_changed:
     type: event
     description: |
@@ -3782,7 +3782,7 @@ tracking_protection:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   show_clear_cookies_alert:
     type: event
     description: |
@@ -3793,7 +3793,7 @@ tracking_protection:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24252
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   show_etp_details:
     type: event
     description: |
@@ -3804,7 +3804,7 @@ tracking_protection:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24252
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   show_etp_blocked_trackers_details:
     type: event
     description: |
@@ -3815,7 +3815,7 @@ tracking_protection:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24252
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   show_etp_settings:
     type: event
     description: |
@@ -3826,7 +3826,7 @@ tracking_protection:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24252
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   tapped_clear_cookies:
     type: event
     description: |
@@ -3837,7 +3837,7 @@ tracking_protection:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24252
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   dismiss_etp_panel:
     type: event
     description: |
@@ -3848,7 +3848,7 @@ tracking_protection:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24252
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   show_certificates:
     type: event
     description: |
@@ -3859,7 +3859,7 @@ tracking_protection:
       - https://github.com/mozilla-mobile/firefox-ios/pull/24252
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 # iOS 14 widget metrics
 # m: medium, s: small, l: large
 widget:
@@ -3876,7 +3876,7 @@ widget:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   l_tabs_open_url:
     type: counter
     description: |
@@ -3890,7 +3890,7 @@ widget:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   s_quick_action_search:
     type: counter
     description: |
@@ -3905,7 +3905,7 @@ widget:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   m_quick_action_search:
     type: counter
     description: |
@@ -3920,7 +3920,7 @@ widget:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   m_quick_action_private_search:
     type: counter
     description: |
@@ -3935,7 +3935,7 @@ widget:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   m_quick_action_copied_link:
     type: counter
     description: |
@@ -3950,7 +3950,7 @@ widget:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   m_quick_action_close_private:
     type: counter
     description: |
@@ -3965,7 +3965,7 @@ widget:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   m_top_sites_widget:
     type: counter
     description: |
@@ -3979,7 +3979,7 @@ widget:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Wallpaper metrics
 wallpaper_analytics:
@@ -4007,7 +4007,7 @@ wallpaper_analytics:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   themed_wallpaper:
     type: labeled_counter
     description: |
@@ -4021,7 +4021,7 @@ wallpaper_analytics:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # CFR Metrics
 cfr_analytics:
@@ -4045,7 +4045,7 @@ cfr_analytics:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   dismiss_cfr_from_outside_tap:
     type: event
     description: |
@@ -4065,7 +4065,7 @@ cfr_analytics:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   press_cfr_action_button:
     type: event
     description: |
@@ -4085,7 +4085,7 @@ cfr_analytics:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Tabs Tray metrics
 tabs_tray:
@@ -4105,7 +4105,7 @@ tabs_tray:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   new_private_tab_tapped:
     type: event
     description: |
@@ -4116,7 +4116,7 @@ tabs_tray:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     
 # Inactive Tabs metrics
 inactive_tabs_tray:
@@ -4140,7 +4140,7 @@ inactive_tabs_tray:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   open_inactive_tab:
     type: counter
     description: |
@@ -4153,7 +4153,7 @@ inactive_tabs_tray:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   inactive_tabs_close_all_btn:
     type: counter
     description: |
@@ -4166,7 +4166,7 @@ inactive_tabs_tray:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   inactive_tab_swipe_close:
     type: counter
     description: |
@@ -4179,7 +4179,7 @@ inactive_tabs_tray:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   inactive_tab_shown:
     type: counter
     description: |
@@ -4192,7 +4192,7 @@ inactive_tabs_tray:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 browser_search:
   with_ads:
@@ -4215,7 +4215,7 @@ browser_search:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1923843
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   ad_clicks:
     type: labeled_counter
     description: |
@@ -4237,7 +4237,7 @@ browser_search:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1923843
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 installed_mozilla_products:
   klar:
@@ -4256,7 +4256,7 @@ installed_mozilla_products:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   focus:
     type: boolean
     lifetime: application
@@ -4273,7 +4273,7 @@ installed_mozilla_products:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # URLbar related telemetry
 urlbar:
@@ -4335,7 +4335,7 @@ urlbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/18507
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
   engagement:
     type: event
@@ -4407,7 +4407,7 @@ urlbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/18654
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   abandonment:
     type: event
     description: |
@@ -4460,7 +4460,7 @@ urlbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/18507
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Awesomebar related telemetry
 
@@ -4483,7 +4483,7 @@ awesomebar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   drag_location_bar:
     type: event
     description: |
@@ -4495,7 +4495,7 @@ awesomebar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   search_result_impression:
     type: event
     description: |
@@ -4514,7 +4514,7 @@ awesomebar:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
       - interaction
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   search_result_tap:
     type: event
     description: |
@@ -4537,7 +4537,7 @@ awesomebar:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
       - interaction
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   query_time:
     type: timing_distribution
     time_unit: millisecond
@@ -4570,7 +4570,7 @@ awesomebar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Toolbar related metrics
 toolbar:
@@ -4589,7 +4589,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   clear_search_button_tapped:
     type: event
     description: |
@@ -4605,7 +4605,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   share_button_tapped:
     type: event
     description: |
@@ -4621,7 +4621,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   refresh_button_tapped:
     type: event
     description: |
@@ -4637,7 +4637,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   reader_mode_button_tapped:
     type: event
     description: |
@@ -4656,7 +4656,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   site_info_button_tapped:
     type: event
     description: |
@@ -4679,7 +4679,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26604
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   back_button_tapped:
     type: event
     description: |
@@ -4695,7 +4695,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   forward_button_tapped:
     type: event
     description: |
@@ -4711,7 +4711,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   back_long_press:
     type: event
     description: |
@@ -4727,7 +4727,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   forward_long_press:
     type: event
     description: |
@@ -4743,7 +4743,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   home_button_tapped:
     type: event
     description: |
@@ -4759,7 +4759,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   one_tap_new_tab_button_tapped:
     type: event
     description: |
@@ -4775,7 +4775,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   one_tap_new_tab_long_press:
     type: event
     description: |
@@ -4791,7 +4791,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   search_button_tapped:
     type: event
     description: |
@@ -4807,7 +4807,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   tab_tray_button_tapped:
     type: event
     description: |
@@ -4823,7 +4823,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   tab_tray_long_press:
     type: event
     description: |
@@ -4839,7 +4839,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   app_menu_button_tapped:
     type: event
     description: |
@@ -4855,7 +4855,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
   data_clearance_button_tapped:
     type: event
     description: |
@@ -4871,7 +4871,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
 
 # Share sheet specific metrics
 
@@ -4888,7 +4888,7 @@ share_sheet:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   pocket_action_tapped:
     type: event
     description: |
@@ -4901,7 +4901,7 @@ share_sheet:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   save_to_pocket_tapped:
     type: event
     description: |
@@ -4914,7 +4914,7 @@ share_sheet:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   shared_to:
     type: event
     description: |
@@ -4925,7 +4925,7 @@ share_sheet:
       - https://github.com/mozilla-mobile/firefox-ios/pull/23786
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     extra_keys:
       activity_identifier:
         type: string
@@ -4965,7 +4965,7 @@ share:
       - technical
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 # Device specific metrics
 
@@ -4986,7 +4986,7 @@ device:
       - technical
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 messaging:
   shown:
@@ -5009,7 +5009,7 @@ messaging:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
       - interaction
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   dismissed:
     type: event
     description: |
@@ -5030,7 +5030,7 @@ messaging:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
       - interaction
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   clicked:
     type: event
     description: |
@@ -5054,7 +5054,7 @@ messaging:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
       - interaction
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   expired:
     type: event
     description: |
@@ -5075,7 +5075,7 @@ messaging:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
       - interaction
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   malformed:
     type: event
     description: |
@@ -5096,7 +5096,7 @@ messaging:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
       - technical
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 adjust:
   deeplink_received:
     type: event
@@ -5120,7 +5120,7 @@ adjust:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
       - technical
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   campaign:
     type: string
     lifetime: ping
@@ -5140,7 +5140,7 @@ adjust:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   ad_group:
     type: string
     lifetime: ping
@@ -5160,7 +5160,7 @@ adjust:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   creative:
     type: string
     lifetime: ping
@@ -5180,7 +5180,7 @@ adjust:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   network:
     type: string
     lifetime: ping
@@ -5200,7 +5200,7 @@ adjust:
       - interaction
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 migration:
   image_sd_cache_cleanup:
     type: counter
@@ -5215,7 +5215,7 @@ migration:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 places_history_migration:
   duration:
@@ -5233,7 +5233,7 @@ places_history_migration:
     notification_emails:
       - mhammond@mozilla.com
       - sync-team@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   num_to_migrate:
     type: quantity
     unit: visits
@@ -5249,7 +5249,7 @@ places_history_migration:
     notification_emails:
       - mhammond@mozilla.com
       - sync-team@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   num_migrated:
     type: quantity
     unit: visits
@@ -5265,7 +5265,7 @@ places_history_migration:
     notification_emails:
       - mhammond@mozilla.com
       - sync-team@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   migration_ended_rate:
     type: rate
     description: |
@@ -5280,7 +5280,7 @@ places_history_migration:
     notification_emails:
       - mhammond@mozilla.com
       - sync-team@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   migration_error_rate:
     type: rate
     description: |
@@ -5295,7 +5295,7 @@ places_history_migration:
     notification_emails:
       - mhammond@mozilla.com
       - sync-team@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 # Address autofill
 addresses:
   form_detected:
@@ -5308,7 +5308,7 @@ addresses:
       - https://github.com/mozilla-mobile/firefox-ios/pull/19228
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_prompt_shown:
     type: event
     description: |
@@ -5319,7 +5319,7 @@ addresses:
       - https://github.com/mozilla-mobile/firefox-ios/pull/19228
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_prompt_expanded:
     type: event
     description: |
@@ -5330,7 +5330,7 @@ addresses:
       - https://github.com/mozilla-mobile/firefox-ios/pull/19228
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_prompt_dismissed:
     type: event
     description: |
@@ -5341,7 +5341,7 @@ addresses:
       - https://github.com/mozilla-mobile/firefox-ios/pull/19228
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofilled:
     type: event
     description: |
@@ -5352,7 +5352,7 @@ addresses:
       - https://github.com/mozilla-mobile/firefox-ios/pull/19228
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   modified:
     type: event
     description: |
@@ -5363,7 +5363,7 @@ addresses:
       - https://github.com/mozilla-mobile/firefox-ios/pull/19228
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   settings_autofill:
     type: event
     description: |
@@ -5374,7 +5374,7 @@ addresses:
       - https://github.com/mozilla-mobile/firefox-ios/pull/19228
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   saved_all:
     type: quantity
     description: |
@@ -5385,7 +5385,7 @@ addresses:
       - https://github.com/mozilla-mobile/firefox-ios/pull/19228
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     unit: quantity of addresses.saved_all
 # Credit card autofill
 credit_card:
@@ -5401,7 +5401,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   form_detected:
     type: event
     description: |
@@ -5413,7 +5413,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15251
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofilled:
     type: event
     description: |
@@ -5426,7 +5426,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15251
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_failed:
     type: event
     description: |
@@ -5439,7 +5439,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15251
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   save_prompt_create:
     type: event
     description: |
@@ -5451,7 +5451,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15251
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_toggle:
     type: event
     description: |
@@ -5470,7 +5470,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15251
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   sync_toggle:
     type: event
     description: |
@@ -5489,7 +5489,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15251
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_enabled:
     type: boolean
     description: |
@@ -5502,7 +5502,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15251
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   sync_enabled:
     type: boolean
     description: |
@@ -5515,7 +5515,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15251
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
   autofill_prompt_shown:
     type: event
@@ -5527,7 +5527,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17331
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_prompt_expanded:
     type: event
     description: |
@@ -5538,7 +5538,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17331
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autofill_prompt_dismissed:
     type: event
     description: |
@@ -5549,7 +5549,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17331
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   save_prompt_shown:
     type: event
     description: |
@@ -5560,7 +5560,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17331
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   save_prompt_update:
     type: event
     description: |
@@ -5571,7 +5571,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17331
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   management_add_tapped:
     type: event
     description: |
@@ -5582,7 +5582,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17331
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   management_card_tapped:
     type: event
     description: |
@@ -5593,7 +5593,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17331
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   saved:
     type: counter
     description: |
@@ -5604,7 +5604,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17331
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   saved_all:
     type: quantity
     description: |
@@ -5615,7 +5615,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17331
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     unit: quantity of credit_card.saved_all
   deleted:
     type: counter
@@ -5627,7 +5627,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17331
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   modified:
     type: counter
     description: |
@@ -5638,7 +5638,7 @@ credit_card:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17331
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 app_errors:
   large_file_write:
@@ -5778,7 +5778,7 @@ webview:
       - https://github.com/mozilla-mobile/firefox-ios/issues/TODO
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-10-01"
+    expires: "2026-01-01"
 
 fx_suggest:
   ping_type:
@@ -5951,7 +5951,7 @@ zoom_bar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26555
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - ZoomBar
@@ -5971,7 +5971,7 @@ zoom_bar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26555
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - ZoomBar
@@ -5987,7 +5987,7 @@ zoom_bar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26555
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - ZoomBar
@@ -6001,7 +6001,7 @@ zoom_bar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26555
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - ZoomBar
@@ -6018,7 +6018,7 @@ windows:
       - https://github.com/mozilla-mobile/firefox-ios/pull/20133
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
     unit: quantity of iPad windows
 
 nimbus_system:

--- a/firefox-ios/Client/Glean/settings.yaml
+++ b/firefox-ios/Client/Glean/settings.yaml
@@ -45,7 +45,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   new_tab_experience:
     type: string
     description: |
@@ -63,7 +63,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   home_page_setting:
     type: string
     description: |
@@ -78,7 +78,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   save_logins:
     type: boolean
     description: |
@@ -92,7 +92,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   show_clipboard_bar:
     type: boolean
     description: |
@@ -106,7 +106,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   tips_and_features_notifs:
     type: boolean
     description: |
@@ -117,7 +117,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15114
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   sync_notifs:
     type: boolean
     description: |
@@ -128,7 +128,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15114
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   fxa_logged_in:
     type: boolean
     description: |
@@ -139,7 +139,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15181
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   close_private_tabs:
     type: boolean
     description: |
@@ -153,7 +153,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   jump_back_in:
     type: boolean
     description: |
@@ -165,7 +165,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15583
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   recently_visited:
     type: boolean
     description: |
@@ -177,7 +177,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15583
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   recently_saved:
     type: boolean
     description: |
@@ -189,7 +189,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15583
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   pocket:
     type: boolean
     description: |
@@ -200,7 +200,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15583
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   opening_screen:
     type: string
     description: |
@@ -213,7 +213,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15583
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
   autoplay_setting_changed:
     type: event
     description: |
@@ -230,7 +230,7 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-07-01"
+    expires: "2026-01-01"
 
 ###############################################################################
 # New "settings" telemetry properly nested under "settings".
@@ -259,7 +259,7 @@ settings.app_icon:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25029
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2025-06-01"
+    expires: "2026-01-01"
     metadata:
       tags:
         - AppIconSelection


### PR DESCRIPTION
## :scroll: Tickets
N/A

## :bulb: Description
We have some expired metrics as of Jun 1. Renew all metrics until 2026-01-01. Fixes xcode warnings. Should be backported.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
