### PR TITLE
Add FXIOS-12391 Add temporary events to test glean notifications email sendability

### DIFF
--- a/firefox-ios/Client/Glean/metrics.yaml
+++ b/firefox-ios/Client/Glean/metrics.yaml
@@ -6083,6 +6083,8 @@ testing:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-17"
+    no_lint: 
+      - COMMON_PREFIX
   test_event_2:
     type: event
     description: |
@@ -6095,3 +6097,5 @@ testing:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-18"
+    no_lint: 
+      - COMMON_PREFIX


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12391)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27021)

## :bulb: Description
Adding temporary events to test glean notifications email sendability to our data stewards email address.

No review needed as we are not actually adding any new probes in the code, and these test metrics will be expired shortly (and then deleted from the metrics.yaml).

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
