### PR TITLE
Refactor FXIOS-12393 Update the ShareTelemetryTests to use the MockGleanWrapper

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
@@ -9,6 +9,7 @@ import XCTest
 
 final class ShareTelemetryTests: XCTestCase {
     private let testWebURL = URL(string: "https://mozilla.org")!
+    var mockGleanWrapper: MockGleanWrapper!
 
     // For telemetry extras
     let activityIdentifierKey = "activity_identifier"
@@ -19,11 +20,7 @@ final class ShareTelemetryTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        // Due to changes allow certain custom pings to implement their own opt-out
-        // independent of Glean, custom pings may need to be registered manually in
-        // tests in order to put them in a state in which they can collect data.
-        Glean.shared.registerPings(GleanMetrics.Pings.shared)
-        Glean.shared.resetGlean(clearStores: true)
+        mockGleanWrapper = MockGleanWrapper()
     }
 
     func testSharedTo_withNoActivityType() throws {
@@ -132,6 +129,6 @@ final class ShareTelemetryTests: XCTestCase {
     }
 
     func createSubject() -> ShareTelemetry {
-        return ShareTelemetry()
+        return ShareTelemetry(gleanWrapper: mockGleanWrapper)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12393)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27025)

## :bulb: Description
Update the ShareTelemetryTests to use the MockGleanWrapper.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
