### PR TITLE
Bugfix FXIOS-12394 [Toolbar] Statur bar overlay is transparent when editing url

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -540,8 +540,9 @@ class BrowserViewController: UIViewController,
             // we disable the translucency when the keyboard is getting displayed
             overKeyboardContainer.isClearBackground = enableBlur && !isKeyboardShowing
 
+            let isFxHomeTab = tabManager.selectedTab?.isFxHomeTab ?? false
             let offset = scrollOffset ?? statusBarOverlay.scrollOffset
-            topBlurView.alpha = contentContainer.hasHomepage ? offset : 1
+            topBlurView.alpha = isFxHomeTab ? offset : 1
         } else {
             header.isClearBackground = enableBlur
             overKeyboardContainer.isClearBackground = false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12394)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27029)

## :bulb: Description
Uses selected tab to determine if we are on a homepage so that we update the status bar overlay correctly.

## :movie_camera: Demos

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-03 at 09 46 05](https://github.com/user-attachments/assets/6e3f71a0-6fd3-489b-89c9-5317f8c621a5) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-03 at 11 21 31](https://github.com/user-attachments/assets/eab6924a-48f1-49ed-bf30-61e6aeb51c32) |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
