### PR TITLE
Bugfix FXIOS-12311 - [Toolbar Swipe Animations] - RTL Implementation

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -91,8 +91,10 @@ final class AddressBarPanGestureHandler: NSObject {
         guard let selectedTab = tabManager.selectedTab else { return }
         let tabs = selectedTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         guard let index = tabs.firstIndex(where: { $0 === selectedTab }) else { return }
+
         let isSwipingLeft = translation.x < 0
-        let nextTab = tabs[safe: isSwipingLeft ? index + 1 : index - 1]
+        let nextTabIndex = nextTabIndex(from: index, isSwipingLeft: isSwipingLeft)
+        let nextTab = tabs[safe: nextTabIndex]
 
         switch gesture.state {
         case .began:
@@ -173,5 +175,19 @@ final class AddressBarPanGestureHandler: NSObject {
         let width = contentContainer.frame.width
         let xTranslation = isSwipingLeft ? width + translation.x + UX.offset : -width + translation.x - UX.offset
         webPagePreview.transform = CGAffineTransform(translationX: xTranslation, y: 0)
+    }
+
+    /// Calculates the index of the next tab to display based on the current index, swipe direction, and layout direction.
+    /// This function ensures that tab navigation behaves intuitively for both left-to-right (LTR) and right-to-left (RTL) user interfaces.
+    /// Swiping left advances to the next tab in LTR, but to the previous tab in RTL, and vice versa.
+    private func nextTabIndex(from index: Int, isSwipingLeft: Bool) -> Int {
+        let isRTL = UIView.userInterfaceLayoutDirection(
+            for: addressToolbarContainer.semanticContentAttribute
+        ) == .rightToLeft
+        if isSwipingLeft {
+            return isRTL ? index - 1 : index + 1
+        } else {
+            return isRTL ? index + 1 : index - 1
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -178,7 +178,8 @@ final class AddressBarPanGestureHandler: NSObject {
     }
 
     /// Calculates the index of the next tab to display based on the current index, swipe direction, and layout direction.
-    /// This function ensures that tab navigation behaves intuitively for both left-to-right (LTR) and right-to-left (RTL) user interfaces.
+    /// This function ensures that tab navigation behaves intuitively for
+    /// both left-to-right (LTR) and right-to-left (RTL) user interfaces.
     /// Swiping left advances to the next tab in LTR, but to the previous tab in RTL, and vice versa.
     private func nextTabIndex(from index: Int, isSwipingLeft: Bool) -> Int {
         let isRTL = UIView.userInterfaceLayoutDirection(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12311)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26809)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
 introduces a helper function to determine the next tab index, taking into account both the swipe direction and the current UI layout direction (RTL or LTR).
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

`LTR`

https://github.com/user-attachments/assets/40993a0d-28ae-4742-b79a-c18da13bdc38

`RTL`


https://github.com/user-attachments/assets/73bb8b63-4833-4c3a-a5ae-b1ccbff4d8dd


</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
