### PR TITLE
Bugfix FXIOS-12336 [Toolbar Translucency] Zoom bar is not translucent

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -42,6 +42,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     private var stepperDefaultConstraints = [NSLayoutConstraint]()
     private let zoomManager: ZoomPageManager
     private let zoomTelemetry: ZoomTelemetry
+    private let toolbarHelper: ToolbarHelperInterface
 
     // MARK: - UI Elements
 
@@ -95,9 +96,11 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     // MARK: - Initializers
 
     init(zoomManager: ZoomPageManager,
-         gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+         gleanWrapper: GleanWrapper = DefaultGleanWrapper(),
+         toolbarHelper: ToolbarHelperInterface = ToolbarHelper()) {
         self.zoomManager = zoomManager
         self.zoomTelemetry = ZoomTelemetry(gleanWrapper: gleanWrapper)
+        self.toolbarHelper = toolbarHelper
         super.init(frame: .zero)
 
         setupViews()
@@ -290,7 +293,9 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
 
     func applyTheme(theme: Theme) {
         let colors = theme.colors
-        backgroundColor = colors.layer2
+        let backgroundAlpha = toolbarHelper.backgroundAlpha()
+        backgroundColor = colors.layer2.withAlphaComponent(backgroundAlpha)
+
         stepperContainer.backgroundColor = colors.layer5
         stepperContainer.layer.shadowColor = colors.shadowDefault.cgColor
         leftSeparator.backgroundColor = colors.borderPrimary


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12336)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26874)

## :bulb: Description
Applies alpha to zoom bar.

## :movie_camera: Demos

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-03 at 14 10 36](https://github.com/user-attachments/assets/cb8c5272-532f-4a5b-a3fb-587e2a51b225) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-03 at 13 59 11](https://github.com/user-attachments/assets/69d7b748-1bf5-4c2f-b01e-68ff99fa84bb) |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
