### PR TITLE
Bugfix FXIOS-11376 [Web Engine] sample browser + evaluatejavascript

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -73,7 +73,7 @@ protocol WKEngineWebView: UIView {
         _ javaScript: String,
         in frame: WKFrameInfo?,
         in contentWorld: WKContentWorld,
-        completionHandler: ((Result<Any, Error>) -> Void)?
+        completionHandler: (@MainActor @Sendable (Result<Any, Error>) -> Void)?
     )
 
     func close()
@@ -84,7 +84,7 @@ extension WKEngineWebView {
         _ javaScript: String,
         in frame: WKFrameInfo? = nil,
         in contentWorld: WKContentWorld,
-        completionHandler: ((Result<Any, Error>) -> Void)? = nil
+        completionHandler: (@MainActor @Sendable (Result<Any, Error>) -> Void)? = nil
     ) {
         evaluateJavaScript(javaScript,
                            in: frame,

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -129,7 +129,7 @@ class MockWKEngineWebView: UIView, WKEngineWebView {
     func evaluateJavaScript(_ javaScript: String,
                             in frame: WKFrameInfo?,
                             in contentWorld: WKContentWorld,
-                            completionHandler: ((Result<Any, Error>) -> Void)?) {
+                            completionHandler: (@MainActor @Sendable (Result<Any, Error>) -> Void)?) {
         evaluateJavaScriptCalled += 1
         savedJavaScript = javaScript
 

--- a/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainerModel.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainerModel.swift
@@ -25,7 +25,7 @@ struct AddressToolbarContainerModel {
             trailingPageActions: trailingPageActions,
             browserActions: browserActions,
             borderPosition: borderPosition,
-            uxConfiguration: AddressToolbarUXConfiguration.default,
+            uxConfiguration: AddressToolbarUXConfiguration.default(),
             shouldAnimate: false)
     }
 

--- a/SampleBrowser/SampleBrowser/UI/Components/NavigationToolbarContainer.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/NavigationToolbarContainer.swift
@@ -61,7 +61,7 @@ class NavigationToolbarContainer: UIView,
     }
 
     func configure(_ model: NavigationToolbarContainerModel) {
-        toolbar.configure(config: model.state, isVersionLayout: true, toolbarDelegate: self)
+        toolbar.configure(config: model.state, toolbarDelegate: self)
     }
 
     private func setupLayout() {

--- a/SampleBrowser/SampleBrowser/UI/Components/NavigationToolbarContainerModel.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/NavigationToolbarContainerModel.swift
@@ -11,7 +11,11 @@ struct NavigationToolbarContainerModel {
     var manager: ToolbarManager = DefaultToolbarManager()
 
     var state: NavigationToolbarConfiguration {
-        return NavigationToolbarConfiguration(actions: actions, shouldDisplayBorder: shouldDisplayBorder)
+        return NavigationToolbarConfiguration(
+            actions: actions,
+            shouldDisplayBorder: shouldDisplayBorder,
+            isTranslucencyEnabled: true
+        )
     }
 
     private var shouldDisplayBorder: Bool {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11376)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24754)

## :bulb: Description
Was working on a separate Web Engine ticket and notice that I was unable to build the Sample Browser project. There were a couple of issues found:
- Compile errors related to toolbar
- Recursion issue of `evaluateJavascript`
- Library not loaded crash 

<img width="645" alt="image" src="https://github.com/user-attachments/assets/3d7b4d6e-4c8c-4f6b-98c9-8e69d926be51" />

It seems that the issue of recursion (see ticket for details) occurs for Xcode 16.3+. The fix was to update the method definition with `@MainActor` due to the change from:
```
@MainActor @preconcurrency public func evaluateJavaScript(_ javaScript: String, in frame: WKFrameInfo? = nil, in contentWorld: WKContentWorld, completionHandler: ((Result<Any, any Error>) -> Void)? = nil)
```  
to 
```
@MainActor @preconcurrency public func evaluateJavaScript(_ javaScript: String, in frame: WKFrameInfo? = nil, in contentWorld: WKContentWorld, completionHandler: (@MainActor @Sendable (Result<Any, any Error>) -> Void)? = nil)
```
However, this led to another issue in which a library could not be loaded. This seems to be a bug that others are facing [here](https://developer.apple.com/forums/thread/780073?answerId=841245022#841245022). The workaround for now is to run on iOS 18.2 when working with Sample Browser for now and can revisit later when needed. 

## :movie_camera: Demos
<details>
<summary>Demo</summary>
https://github.com/user-attachments/assets/65f49d7b-fdf9-48d9-a1cc-1f1cca26c940
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
