### PR TITLE
Add FXIOS-12174 [Tab tray experiment] Add selected hint for voice over

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -47,6 +47,7 @@ class TabTraySelectorView: UIView,
     var items: [String] = ["", "", ""] {
         didSet {
             updateLabels()
+            adjustSelectedButtonFont(toIndex: selectedIndex)
             // We need the labels on the buttons to adjust proper frame size
             applyInitalSelectionBackgroundFrame()
         }
@@ -89,14 +90,7 @@ class TabTraySelectorView: UIView,
             button.tag = index
             button.addTarget(self, action: #selector(sectionSelected(_:)), for: .touchUpInside)
 
-            button.titleLabel?.font = index == selectedIndex ?
-                FXFontStyles.Bold.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize) :
-                FXFontStyles.Regular.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
-
             button.accessibilityIdentifier = "\(AccessibilityIdentifiers.TabTray.selectorCell)\(index)"
-            button.accessibilityHint = String(format: .TabsTray.TabTraySelectorAccessibilityHint,
-                                              NSNumber(value: index + 1),
-                                              NSNumber(value: items.count))
             button.translatesAutoresizingMaskIntoConstraints = false
             buttons.append(button)
             stackView.addArrangedSubview(button)
@@ -168,9 +162,15 @@ class TabTraySelectorView: UIView,
     private func adjustSelectedButtonFont(toIndex: Int) {
         for (index, button) in buttons.enumerated() {
             button.transform = .identity
-            button.titleLabel?.font = index == toIndex ?
-            FXFontStyles.Bold.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize) :
-            FXFontStyles.Regular.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
+            let isSelected = index == toIndex
+            button.titleLabel?.font = isSelected ?
+                FXFontStyles.Bold.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize) :
+                FXFontStyles.Regular.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
+            let selectedHint = isSelected ? .TabsTray.TabsPanelSelectorSelectedLabel : ""
+            let panelNumberHint = String(format: .TabsTray.TabTraySelectorAccessibilityHint,
+                                         NSNumber(value: index + 1),
+                                         NSNumber(value: items.count))
+            button.accessibilityHint = "\(panelNumberHint), \(selectedHint)"
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -89,8 +89,11 @@ class TabTraySelectorView: UIView,
             button.setTitle(title, for: .normal)
             button.tag = index
             button.addTarget(self, action: #selector(sectionSelected(_:)), for: .touchUpInside)
-
+            button.accessibilityHint = String(format: .TabsTray.TabTraySelectorAccessibilityHint,
+                                              NSNumber(value: index + 1),
+                                              NSNumber(value: items.count))
             button.accessibilityIdentifier = "\(AccessibilityIdentifiers.TabTray.selectorCell)\(index)"
+
             button.translatesAutoresizingMaskIntoConstraints = false
             buttons.append(button)
             stackView.addArrangedSubview(button)
@@ -166,11 +169,7 @@ class TabTraySelectorView: UIView,
             button.titleLabel?.font = isSelected ?
                 FXFontStyles.Bold.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize) :
                 FXFontStyles.Regular.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
-            let selectedHint = isSelected ? .TabsTray.TabsPanelSelectorSelectedLabel : ""
-            let panelNumberHint = String(format: .TabsTray.TabTraySelectorAccessibilityHint,
-                                         NSNumber(value: index + 1),
-                                         NSNumber(value: items.count))
-            button.accessibilityHint = "\(panelNumberHint), \(selectedHint)"
+            button.isSelected = isSelected
         }
     }
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2947,11 +2947,6 @@ extension String {
             tableName: nil,
             value: "Private",
             comment: "The title on the button to look at private tabs.")
-        public static let TabsPanelSelectorSelectedLabel = MZLocalizedString(
-            key: "Settings.TabsTray.Accessibility.TabsPanelSelectorSelectedLabel.v141",
-            tableName: "TabsTray",
-            value: "Currently selected",
-            comment: "This is the accessibility label describing the selected tabs panel on the tabs tray.")
 
         public struct InactiveTabs {
             public static let TabsTrayInactiveTabsSectionClosedAccessibilityTitle = MZLocalizedString(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2947,6 +2947,11 @@ extension String {
             tableName: nil,
             value: "Private",
             comment: "The title on the button to look at private tabs.")
+        public static let TabsPanelSelectorSelectedLabel = MZLocalizedString(
+            key: "Settings.TabsTray.Accessibility.TabsPanelSelectorSelectedLabel.v141",
+            tableName: "TabsTray",
+            value: "Currently selected",
+            comment: "This is the accessibility label describing the selected tabs panel on the tabs tray.")
 
         public struct InactiveTabs {
             public static let TabsTrayInactiveTabsSectionClosedAccessibilityTitle = MZLocalizedString(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12174)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26504)

## :bulb: Description
Use the native way to select a button using `isSelected` which adds the proper "Selected" information on the button accessibility label read on voice over. Thanks Winnie!

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [X] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
