### PR TITLE
Fix [Release Automation] Add a 2mn wait before adding the nightly group to testflight

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1256,6 +1256,9 @@ workflows:
     - opts:
         is_expand: false
       BITRISE_SCHEME: Firefox
+    - opts:
+        is_expand: false
+      WAIT_TIME_BEFORE_NIGHTLY_GROUP: 120
     description: This step is to build, archive and upload Firefox Release and Beta
 
   SPM_Common_Steps:
@@ -2251,7 +2254,7 @@ workflows:
 
   _testflight_add_nightly_group:
     description: This step is used to add the Nightly group to the Beta build in TestFlight.
-    # Note: This step requires repository cloning
+    # Note: This step requires repository cloning and a `WAIT_TIME_BEFORE_NIGHTLY_GROUP` environment variable
     steps:
     - script@1.2.1:
         title: Add Nightly Group to Beta Build
@@ -2259,7 +2262,18 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             python3 -m pip install --upgrade pip pyjwt cryptography requests
+            echo "Waiting ${WAIT_TIME_BEFORE_NIGHTLY_GROUP}s to give apple time to process the build"
+            sleep ${WAIT_TIME_BEFORE_NIGHTLY_GROUP}
             python3 scripts/nightly_testflight_add_group.py
+
+  ForceTestFlightAddNightlyGroup:
+    before_run:
+    - SPM_Common_Steps
+    - _testflight_add_nightly_group
+    envs:
+      - opts:
+          is_expand: false
+        WAIT_TIME_BEFORE_NIGHTLY_GROUP: 0
 
   release_promotion_push:
     before_run:


### PR DESCRIPTION
## :bulb: Description
Apple is a small company that cannot afford to have their APIs return fresh data. Which leads to us adding the nightly group to the previous nigthly if they're not done "processing" the new build. We don't have a lot of options here so just wait 2 minutes after a nightly is built before adding the nightly group to the new build. This is very inefficient compute power wise but given those builds run once a day, I don't think we should worry about it too much.

I also added a manual workflow (`ForceTestFlightAddNightlyGroup`) in case 2 minutes isn't enough at some point which calls the same script without any delay and can be run from the bitrise UI manually.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
