### PR TITLE
Add FXIOS-12404 [SEC] Staging debug: allow engine prefs reset

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -293,6 +293,16 @@ class SearchEnginesManager: SearchEnginesManagerProvider {
         return nil
     }
 
+    func resetPrefs() {
+        let keys = [
+            orderedEngineIDsPrefsKey,
+            legacy_orderedEngineNamesPrefsKey,
+            disabledEngineIDsPrefsKey,
+            legacy_disabledEngineNamesPrefsKey
+        ];
+        keys.forEach { prefs.removeObjectForKey($0) }
+    }
+
     // MARK: - Private
 
     private func getDisabledEngines() -> [String] {

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -294,12 +294,10 @@ class SearchEnginesManager: SearchEnginesManagerProvider {
     }
 
     func resetPrefs() {
-        let keys = [
-            orderedEngineIDsPrefsKey,
-            legacy_orderedEngineNamesPrefsKey,
-            disabledEngineIDsPrefsKey,
-            legacy_disabledEngineNamesPrefsKey
-        ];
+        let keys = [orderedEngineIDsPrefsKey,
+                    legacy_orderedEngineNamesPrefsKey,
+                    disabledEngineIDsPrefsKey,
+                    legacy_disabledEngineNamesPrefsKey]
         keys.forEach { prefs.removeObjectForKey($0) }
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeRSServerSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeRSServerSetting.swift
@@ -19,7 +19,9 @@ class ChangeRSServerSetting: HiddenSetting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         let useStaging = (prefs.boolForKey(prefsKey) == true)
-        let message = "Current: \(useStaging ? "Staging" : "Production")\n\nChanges take effect on the next app launch."
+        // swiftlint:disable line_length
+        let message = "Current: \(useStaging ? "Staging" : "Production")\n\nChanges take effect on the next app launch.\n\nTo switch to Staging and reset ordering prefs for Consolidated Search, choose the SEC Reset option."
+        // swiftlint:enable line_length
         let alert = UIAlertController(title: "Remote Settings Server",
                                       message: message,
                                       preferredStyle: .alert)
@@ -31,6 +33,12 @@ class ChangeRSServerSetting: HiddenSetting {
         alert.addAction(UIAlertAction(title: "Staging", style: .default, handler: { [weak self] _ in
             guard let self else { return }
             self.prefs.setBool(true, forKey: self.prefsKey)
+        }))
+        alert.addAction(UIAlertAction(title: "Staging + SEC Reset", style: .default, handler: { [weak self] _ in
+            guard let self else { return }
+            self.prefs.setBool(true, forKey: self.prefsKey)
+            let searchManager: SearchEnginesManager = AppContainer.shared.resolve()
+            searchManager.resetPrefs()
         }))
         settings.present(alert, animated: true)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12404)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27050)

## :bulb: Description

Adds an additional debug option to the Remote Settings menu which will reset search preferences when switching to Staging.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
