### PR TITLE
update animation speed and curve

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -22,7 +22,7 @@ extension TabTrayViewController: UIViewControllerTransitioningDelegate {
 
         static let dimmedWhiteValue = 0.0
 
-        static let presentDuration: TimeInterval = 0.4
+        static let presentDuration: TimeInterval = 0.3
         static let dismissDuration: TimeInterval = 0.3
 
         static let cvScalingFactor = 1.2
@@ -255,7 +255,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
 
         CATransaction.begin()
         CATransaction.setAnimationDuration(UX.presentDuration)
-        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeInEaseOut))
+        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
         CATransaction.setCompletionBlock { [weak self] in
             snapshotContainer.removeFromSuperview()
             self?.unhideCellBorder(tabCell: tabCell, isPrivate: selectedTab.isPrivate, theme: theme)
@@ -273,10 +273,10 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         fadeAnimation.fromValue = UX.initialOpacity
         fadeAnimation.toValue = UX.finalOpacity
         fadeAnimation.duration = UX.presentDuration
-        fadeAnimation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        fadeAnimation.timingFunction = CAMediaTimingFunction(name: .easeOut)
         borderLayer.add(fadeAnimation, forKey: UX.opacityKeyPath)
 
-        let animator = UIViewPropertyAnimator(duration: UX.presentDuration, curve: .easeInOut) {
+        let animator = UIViewPropertyAnimator(duration: UX.presentDuration, curve: .easeOut) {
             if let frame = cellFrame {
                 tabSnapshot.frame = frame
                 snapshotContainer.frame = frame


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12409)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27056)

## :bulb: Description
Adjusted the tab tray presentation animation duration and animation curve based on feedback from Rick in the tab tray weekly meeting.

Changed the presentation of the tab tray from 0.4s duration to 0.3s and from .easeInOut to .easeOut

## :movie_camera: Demos
### After
https://github.com/user-attachments/assets/700d9dec-7cda-482b-b56d-7670dc823165

### Before
https://github.com/user-attachments/assets/b2505628-b7d2-46b7-aa6e-b593256bd436

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
