### PR TITLE
Bugfix FXIOS-12395 [Tab tray UI Experiment] Only show "Tabs" label without the count

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -131,7 +131,7 @@ class TabTrayViewController: UIViewController,
         let selector = TabTraySelectorView(selectedIndex: selectedIndex, theme: retrieveTheme())
         selector.delegate = self
         selector.items = [TabTrayPanelType.privateTabs.label,
-                          "0 \(TabTrayPanelType.tabs.label)",
+                          TabTrayPanelType.tabs.label,
                           TabTrayPanelType.syncedTabs.label]
 
         didSelectSection(panelType: tabTrayState.selectedPanel)
@@ -394,9 +394,6 @@ class TabTrayViewController: UIViewController,
         countLabel.text = count
         segmentedControl.setImage(TabTrayPanelType.tabs.image!.overlayWith(image: countLabel),
                                   forSegmentAt: 0)
-        if isTabTrayUIExperimentsEnabled {
-            experimentSegmentControl.items[1] = "\(count) \(TabTrayPanelType.tabs.label)"
-        }
     }
 
     // MARK: Themeable


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12395)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27037)

## :bulb: Description
Aiming for 139.2 for this change. Not doing a backport since this is a fix only on the weekly release. The main branch and v140 are already using the right string.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
