### PR TITLE
Refactor FXIOS-12395 [Tab tray UI experiment] Ensure we keep the Tabs string a bit longer

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -8032,11 +8032,6 @@ extension String {
                 tableName: nil,
                 value: "Synced",
                 comment: "The title on the button to look at synced tabs.")
-            public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString(
-                key: "TabTray.SegmentedControlTitles.Tabs",
-                tableName: nil,
-                value: "Tabs",
-                comment: "The title on the button to look at regular tabs.")
         }
         struct v140 {
             public static let AppMenuCopyURLConfirmMessage = MZLocalizedString(
@@ -8066,6 +8061,11 @@ extension String {
                 value: "Address Saved",
                 comment: "Toast message confirming that an address has been successfully saved."
             )
+            public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString(
+                key: "TabTray.SegmentedControlTitles.Tabs",
+                tableName: nil,
+                value: "Tabs",
+                comment: "The title on the button to look at regular tabs.")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12395)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27037)

## :bulb: Description
Move this string in the old string struct from v139 to v140 since it's still used in v139, this was a prior mistake so just fixing this to ensure we keep the string until the right moment it can be deleted.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
