### PR TITLE
Bugfix FXIOS-12349 [Reader Mode] Reading Mode bar is Misplaced when toolbar position is changed while it’s visible

### DIFF
--- a/firefox-ios/Client/Protocols/TopBottomInterchangeable.swift
+++ b/firefox-ios/Client/Protocols/TopBottomInterchangeable.swift
@@ -20,7 +20,7 @@ extension TopBottomInterchangeable {
     func addToParent(parent: UIStackView, addToTop: Bool = true) {
         self.parent = parent
         if addToTop {
-            parent.addArrangedSubview(self)
+            parent.addArrangedViewToTop(self)
         } else {
             parent.addArrangedViewToBottom(self)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12349)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26902)

## :bulb: Description
Add view in the correct place when `addToTop` is true.

## :movie_camera: Demos

<details>
<summary>Demo</summary>

**Before:**

https://github.com/user-attachments/assets/229f1130-951b-4983-b40e-c0b66516dfa8


**After:**

https://github.com/user-attachments/assets/e640ba85-77de-4f5d-b057-295317c6d94e

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
