### PR TITLE
Fix [Release Automation] Don't try to add the Nightly group to Betas after a nightly is built

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1250,15 +1250,10 @@ workflows:
             set -x
             firefox-ios/ThirdParty/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN_FIREFOX" upload-dif \
               --org mozilla --project firefox-ios "$BITRISE_DSYM_DIR_PATH"
-    after_run:
-    - _testflight_add_nightly_group
     envs:
     - opts:
         is_expand: false
       BITRISE_SCHEME: Firefox
-    - opts:
-        is_expand: false
-      WAIT_TIME_BEFORE_NIGHTLY_GROUP: 120
     description: This step is to build, archive and upload Firefox Release and Beta
 
   SPM_Common_Steps:
@@ -2252,9 +2247,10 @@ workflows:
       EXPORT_METHOD: app-store
     description: This step is used during release promotion to build a firefox release
 
-  _testflight_add_nightly_group:
+  AddNightlyGroupToTestFlightBeta:
     description: This step is used to add the Nightly group to the Beta build in TestFlight.
-    # Note: This step requires repository cloning and a `WAIT_TIME_BEFORE_NIGHTLY_GROUP` environment variable
+    before_run:
+    - SPM_Common_Steps
     steps:
     - script@1.2.1:
         title: Add Nightly Group to Beta Build
@@ -2262,18 +2258,7 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             python3 -m pip install --upgrade pip pyjwt cryptography requests
-            echo "Waiting ${WAIT_TIME_BEFORE_NIGHTLY_GROUP}s to give apple time to process the build"
-            sleep ${WAIT_TIME_BEFORE_NIGHTLY_GROUP}
             python3 scripts/nightly_testflight_add_group.py
-
-  ForceTestFlightAddNightlyGroup:
-    before_run:
-    - SPM_Common_Steps
-    - _testflight_add_nightly_group
-    envs:
-      - opts:
-          is_expand: false
-        WAIT_TIME_BEFORE_NIGHTLY_GROUP: 0
 
   release_promotion_push:
     before_run:


### PR DESCRIPTION
## :bulb: Description
In e528a9a4da9e7fe2f7ab203050cd84f0d263934f we tried adding a 2 minutes wait between pushing the build to TestFlight and the addition of the nightly group to said build. That is apparently not enough time for apple to start returning that new build as the latest.

This partially reverts e528a9a4da9e7fe2f7ab203050cd84f0d263934f and instead makes a `AddNightlyGroupToTestFlightBeta` workflow that we can call called on a bitrise schedule long after the nightly finishes building.


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
