### PR TITLE
Add FXIOS-12227 #26611 [Tab tray] trash can telemetry adjustment

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -788,6 +788,9 @@ class TabTrayViewController: UIViewController,
     }
 
     private func showTabsDeletionPicker() {
+        let telemetry = TabsPanelTelemetry()
+        telemetry.closeAllTabsSheetOptionSelected(option: .old, mode: .normal)
+
         let alert = AlertController(title: .TabsTray.TabTrayCloseTabsOlderThanTitle,
                                     message: nil,
                                     preferredStyle: .actionSheet)

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -3563,7 +3563,7 @@ tabs_panel.close_all_tabs_sheet:
         type: string
         description: |
           The option selected from the close all tabs sheet, either
-          all or cancel.
+          all, old or cancel.
       mode:
         type: string
         description: |

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -5668,7 +5668,7 @@ webview:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/25951
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/issues/26220
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-01-01"

--- a/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
@@ -25,6 +25,7 @@ struct TabsPanelTelemetry {
     enum CloseAllPanelOption: String {
         case all
         case cancel
+        case old
     }
 
     private enum TabType: String {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12227)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26611)

## :bulb: Description
Ideally telemetry events are fired from the middleware, but since we don't have any events fired when the "Close Old Tabs..." button is clicked, I am proposing to add them in the VC out of simplicity.

Also taking the opportunity to fix a TODO I had left by mistake in `process_did_terminate` telemetry event.

## :movie_camera: Screenshot

<details>
<summary>Trash can menu</summary>

![simulator_screenshot_A6770941-4500-4025-99A4-38D22CAC3CF8](https://github.com/user-attachments/assets/3017b839-50ec-467b-976d-8de0735d0c6e)

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
