### PR TITLE
Fixes [MTE-4656]-for M4 flaky tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
@@ -18,8 +18,16 @@ class ClipBoardTests: BaseTestCase {
         navigator.goto(URLBarOpen)
         urlBarAddress.waitAndTap()
         if iPad() {
-            app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
+            urlBarAddress.waitAndTap()
             app.menuItems["Select All"].waitAndTap()
+        }
+        // Retry tapping urlBarAddress if "Copy" is not visible
+        var attempts = 2
+        if !iPad() {
+            while !app.menuItems["Copy"].exists && attempts > 0 {
+                urlBarAddress.waitAndTap()
+                attempts -= 1
+            }
         }
         app.menuItems["Copy"].waitAndTap()
         app.typeText("\r")
@@ -65,11 +73,10 @@ class ClipBoardTests: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         navigator.goto(URLBarOpen)
         if #available(iOS 17, *) {
-            urlBarAddress.press(forDuration: 3)
-            var attempts = 3
-            while !app.otherElements.buttons["Paste"].exists && attempts > 0 {
+            if iPad() {
+                urlBarAddress.waitAndTap()
+            } else {
                 urlBarAddress.press(forDuration: 3)
-                attempts -= 1
             }
             app.otherElements.buttons["Paste"].waitAndTap()
             mozWaitForValueContains(urlBarAddress, value: "http://www.example.com/")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -189,6 +189,10 @@ class CreditCardsTests: BaseTestCase {
             app.webViews["Web content"].textFields["Expiration month:"].waitAndTap()
             app.webViews["Web content"].textFields["Expiration year:"].waitAndTap()
         }
+        if #available(iOS 16, *), ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 16 {
+            app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].waitAndTap()
+            app.webViews["Web content"].staticTexts["Card Number:"].waitAndTap()
+        }
         mozWaitForElementToExist(app.buttons[useSavedCard])
     }
 
@@ -246,6 +250,7 @@ class CreditCardsTests: BaseTestCase {
         if #available(iOS 16, *) {
             reachAutofillWebsite()
             app.scrollViews.otherElements.tables.cells.firstMatch.tapOnApp()
+            app.buttons["Test2"].tapIfExists()
             // The credit card's number and name are imported correctly on the designated fields
             validateAutofillCardInfo(cardNr: "4111111111111111", expYear: "2040", expMonth: "05", name: updatedName)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -119,8 +119,14 @@ class NavigationTest: BaseTestCase {
             defaultMailPlaceholder = email.label
             XCTAssertEqual(mailPlaceholder, defaultMailPlaceholder, "The mail placeholder does not show the correct value")
         } else if #available(iOS 16, *), ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 16 {
-            defaultMailPlaceholder = email.placeholderValue!
-            XCTAssertEqual(mailPlaceholder, defaultMailPlaceholder, "The mail placeholder does not show the correct value")
+            if let value = app.staticTexts["Enter your email"].value as? String {
+                defaultMailPlaceholder = value
+                XCTAssertEqual(mailPlaceholder,
+                               defaultMailPlaceholder,
+                               "The mail placeholder does not show the correct value")
+            } else {
+                XCTFail("The mail placeholder value is not a String")
+            }
         } else {
             mozWaitForElementToExist(app.staticTexts[mailPlaceholder])
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
@@ -83,6 +83,7 @@ class PocketTests: BaseTestCase {
         scrollToElement(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.Pocket.footerLearnMoreLabel],
                         direction: SwipeDirection.up,
                         maxSwipes: MAX_SWIPE)
+        app.swipeUp()
         scrollToElement(app.cells.buttons["Discover more"], direction: .left, maxSwipes: MAX_SWIPE)
 
         app.cells.buttons["Discover more"].waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -279,7 +279,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         if #available(iOS 16, *) {
             navigator.performAction(Action.CloseURLBarOpen)
-            waitForTabsButton()
+            navigator.nowAt(NewTabScreen)
             navigator.goto(TabTray)
             let numTab = app.otherElements[tabsTray].cells.count
             XCTAssertEqual(2, numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
@@ -167,7 +167,9 @@ class ShareLongPressTests: BaseTestCase {
         app.buttons["Share Link"].waitAndTap()
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.collectionViews.cells[option])
-            app.collectionViews.cells[option].tapOnApp()
+            app.collectionViews.cells[option].waitAndTap()
+            // Workaround needed for iOS 17 to make sure the element is getting tapped and to avoid using sleeps
+            app.collectionViews.cells[option].tapIfExists()
         } else {
             app.buttons[option].waitAndTap()
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
@@ -172,7 +172,9 @@ class ShareMenuTests: BaseTestCase {
         navigator.performAction(Action.ShareBrowserTabMenuOption)
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.collectionViews.cells[option])
-            app.collectionViews.cells[option].tapOnApp()
+            app.collectionViews.cells[option].waitAndTap()
+            // Workaround needed for iOS 17 to make sure the element is getting tapped and to avoid using sleeps
+            app.collectionViews.cells[option].tapIfExists()
         } else {
             app.buttons[option].waitAndTap()
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SyncFAUITests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SyncFAUITests.swift
@@ -137,6 +137,7 @@ class SyncUITests: BaseTestCase {
         let passMessage = "Your password is currently hidden."
         mozWaitForElementToExist(app.webViews.switches[passMessage])
         // Remove the password typed, Show (password) option should not be shown
+        app.secureTextFields.element(boundBy: 1).waitAndTap()
         app.keyboards.keys["delete"].waitAndTap()
         mozWaitForElementToNotExist(app.webViews.staticTexts[passMessage])
     }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4656

## :bulb: Description
Multiple fixes made for iPad, iOS 16, 17, 18 on tests that are failing only on M4.
The investigation has been made on M4 and implemented accordingly. Most of the failures are caused by fast screen loadings, and in some cases workarounds have been added in order to make sure the element is properly tapped.