### PR TITLE
Bugfix FXIOS-12429 [Tab tray UI experiment] dynamic type live change

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -293,6 +293,10 @@ class TabTraySelectorView: UIView,
         self.theme = theme
         backgroundColor = theme.colors.layer1
         selectionBackgroundView.backgroundColor = theme.colors.actionSecondary
+
+        for button in buttons {
+            button.applyTheme(theme: theme)
+        }
     }
 
     // MARK: - Notifiable

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -138,6 +138,7 @@ class TabTraySelectorView: UIView,
         let selectedButton = buttons[selectedIndex]
         let width = selectedButton.frame.width
 
+        selectionBackgroundWidthConstraint?.isActive = false
         selectionBackgroundWidthConstraint = selectionBackgroundView.widthAnchor.constraint(equalToConstant: width)
         selectionBackgroundWidthConstraint?.isActive = true
     }
@@ -319,6 +320,10 @@ class TabTraySelectorView: UIView,
         }
 
         applyInitalSelectionBackgroundFrame()
+        updateSelectionBackground(from: selectedIndex,
+                                  to: selectedIndex,
+                                  progress: 1.0,
+                                  animated: false)
 
         setNeedsLayout()
         layoutIfNeeded()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12429)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27101)

## :bulb: Description
Fixing a theming issue + fixing live dynamic type change

### Video
Better, not perfect but better. We want to to investigate to use a native `UIControl` instead of a `UIStackView` to get us to a 100% for this component.

https://github.com/user-attachments/assets/1202c3e4-fb2d-45b9-9c01-ec46c70e1ba0

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [X] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
