### PR TITLE
Add FXIOS-12440 [SEC] Fallback search engine icon

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineIconDataFetcher.swift
@@ -100,7 +100,7 @@ final class ASSearchEngineIconDataFetcher: ASSearchEngineIconDataFetcherProtocol
     // MARK: - Private Utilities
 
     private func fetchIcon(for iconRecord: ASSearchEngineIconRecord) -> UIImage? {
-        guard let client else { return nil }
+        guard let client else { return fallbackEngineIcon }
         do {
             var fetchedIcon: UIImage?
             let data = try client.getAttachment(record: iconRecord.backingRecord)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12440)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27123)

## :bulb: Description

Per discussions around Consolidated Search, this adds a fallback search engine icon in the event that we can't successfully fetch one for a given engine.

**This a failsafe only**; this icon likely won't ever be visible for users (for now, we're simply using our `.search` image asset).

## :movie_camera: Demos

![Screenshot 2025-06-05 at 1 22 05 PM](https://github.com/user-attachments/assets/41e4164e-db5d-49a4-b1d6-7b407fb50013)

![Screenshot 2025-06-05 at 1 22 24 PM](https://github.com/user-attachments/assets/6d07a67c-f680-454d-8c34-5762a2581a01)


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
