### PR TITLE
Refactor FXIOS-12155 [TA 2025] Replace settings.main_menu.option_selected with a more generic settings.option_selected

### DIFF
--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -349,7 +349,7 @@ final class SettingsCoordinator: BaseCoordinator,
     // MARK: GeneralSettingsDelegate
 
     func pressedCustomizeAppIcon() {
-        settingsTelemetry.tappedAppIconSetting()
+        settingsTelemetry.optionSelected(option: .AppIconSelection)
 
         let viewController = UIHostingController(
             rootView: AppIconSelectionView(

--- a/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
@@ -10,16 +10,25 @@ import Glean
 struct SettingsTelemetry {
     private let gleanWrapper: GleanWrapper
 
-    enum MainMenuOption: String {
-        case AppIcon = "app_icon"
+    /// Uniquely identifies a row on the settings screen (or one of its subscreens), which the user can tap to drill down
+    /// deeper into settings.
+    ///
+    /// If the row moves somewhere else due to a refactor or an experiment, the key should stay the same. The most important
+    /// feature of the key is that it identifies the tapped row irrespective of its location in the settings hierarchy.
+    ///
+    /// Note that the `option` identifies the __row tapped__, not necessarily the screen shown.
+    enum OptionIdentifiers: String {
+        case AppIconSelection = "app_icon_selection" // Tapping "App Icon >" to show the App Icon Selection screen
     }
 
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.gleanWrapper = gleanWrapper
     }
 
-    func tappedAppIconSetting() {
-        let extra = GleanMetrics.SettingsMainMenu.OptionSelectedExtra(option: MainMenuOption.AppIcon.rawValue)
-        gleanWrapper.recordEvent(for: GleanMetrics.SettingsMainMenu.optionSelected, extras: extra)
+    /// Recorded when a user taps a row on the settings screen (or one of its subscreens) to drill deeper into the settings.
+    /// - Parameter option: A unique identifier for the selected row. Identifies the row tapped, not the screen shown.
+    func optionSelected(option: OptionIdentifiers) {
+        let extra = GleanMetrics.Settings.OptionSelectedExtra(option: option.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.Settings.optionSelected, extras: extra)
     }
 }

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -1100,28 +1100,6 @@ password_generator:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-01-01"
 
-# Settings main menu
-settings.main_menu:
-  option_selected:
-    type: event
-    description: |
-      Records when the user taps an option in the app settings main menu.
-    extra_keys:
-      option:
-        type: string
-        description: |
-          The option type selected from the settings main menu.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-11473
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/25029
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-    metadata:
-      tags:
-        - Settings
-
 # Key Commands
 key_commands:
   press_key_command_action:

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -236,6 +236,37 @@ preferences:
 # New "settings" telemetry properly nested under "settings".
 ###############################################################################
 
+# General settings events
+settings:
+  option_selected:
+    type: event
+    description: |
+      Recorded when the user taps an option to drill deeper into the
+      settings menu screens.
+      
+      For example, tapping the "App Icon >" option to show the app icon
+      selection screen, or tapping "Browsing >" to view the browsing settings.
+    extra_keys:
+      option:
+        type: string
+        description: |
+          A unique key describing the item selected from the settings menu and
+          its submenus. This unique key should describe the screen being shown
+          next to the user. 
+          
+          Keep in mind that experiments and redesigns sometimes move options to
+          different depths of the settings screens. However, this unique key
+          should always remain the same. As a result, it is useful to devise a
+          unique key irrespective of the option's current placement in the
+          settings hierarchy.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-12155
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-01-01"
+
 # App Icon Settings
 settings.app_icon:
   selected:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SettingsTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SettingsTelemetryTests.swift
@@ -19,16 +19,16 @@ final class SettingsTelemetryTests: XCTestCase {
         mockGleanWrapper = MockGleanWrapper()
     }
 
-    func testTappedAppIconSetting_firesOptionSelected() throws {
+    func testOptionSelected_recordsData() throws {
         // The event and event extras type under test
-        let event = GleanMetrics.SettingsMainMenu.optionSelected
-        typealias EventExtrasType = GleanMetrics.SettingsMainMenu.OptionSelectedExtra
+        let event = GleanMetrics.Settings.optionSelected
+        typealias EventExtrasType = GleanMetrics.Settings.OptionSelectedExtra
 
-        let subject = createSubject()
-        let expectedOption = SettingsTelemetry.MainMenuOption.AppIcon
+        let expectedOption = SettingsTelemetry.OptionIdentifiers.AppIconSelection
         let expectedMetricType = type(of: event)
 
-        subject.tappedAppIconSetting()
+        let subject = createSubject()
+        subject.optionSelected(option: .AppIconSelection)
 
         let savedExtras = try XCTUnwrap(
             mockGleanWrapper.savedExtras as? EventExtrasType


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12155)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26446)

## :bulb: Description
This PR replaces the `settings.main_menu.option_selected` event with a more generic `settings.option_selected` event.

Eventually this event will be able to record any Setting screen selections, but for now, it just records the user navigating to the new App Icon Selection screen from Settings.

A preexisting unit test was updated to be more generic as well.

### Testing Details

When the user taps “App Icon >” in on the main Settings screen, we should see an event for settings.option_selected with an extra option value of app_icon_selection.

e.g. `settings.option_selected`: `{"glean_timestamp": "1749162257516", "option": "app_icon_selection"}`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
