### PR TITLE
Bugfix FXIOS-12446 - [Toolbar Redesign] - Center URL Text in Address Bar with respect to its Superview and Prevent Overlap with Reader Mode Icon

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -54,17 +54,6 @@ final class LocationView: UIView,
         return urlTextFieldWidth >= locationViewVisibleWidth
     }
 
-    private var isPartOfBrowserAddressToolbar: Bool {
-        var ancestor = superview
-        while let current = ancestor {
-            if current is BrowserAddressToolbar {
-                return true
-            }
-            ancestor = current.superview
-        }
-        return false
-    }
-
     private var dotWidth: CGFloat {
         guard let font = urlTextField.font else { return 0 }
         let fontAttributes = [NSAttributedString.Key.font: font]
@@ -196,9 +185,7 @@ final class LocationView: UIView,
                 containerView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
                 containerView.centerXAnchor.constraint(equalTo: centerXAnchor)
             ]
-        } else if let superview,
-                  isPartOfBrowserAddressToolbar,
-                  !isURLTextFieldWiderThanVisibleArea(safeOffset: UX.safeOffset) {
+        } else if let superview, !isURLTextFieldWiderThanVisibleArea(safeOffset: UX.safeOffset) {
             newConstraints = [
                 containerView.leadingAnchor.constraint(greaterThanOrEqualTo: superview.leadingAnchor),
                 containerView.trailingAnchor.constraint(lessThanOrEqualTo: superview.trailingAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12446)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27137)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Constrains the URL text field to its superview to prevent it from being pushed when the reader mode icon appears later, using a safe offset to avoid overlapping the icon. In case the offset is violated, the previous constraints are set.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

![1](https://github.com/user-attachments/assets/6eb3c96f-353e-43f8-9228-de771b7491b4)
![2](https://github.com/user-attachments/assets/35e42b01-9190-49cc-90ae-52a14777ab57)
![3](https://github.com/user-attachments/assets/94f0ff7f-235c-47dd-8ac4-0bff31c6e91f)
![4](https://github.com/user-attachments/assets/59195a6c-cfe2-45e9-b068-ef6cc15e34ae)
![5](https://github.com/user-attachments/assets/a79359db-9d5c-4ae1-bd41-1e014b40bbb3)

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
