### PR TITLE
 Refactor FXIOS-12086 [Dark Reader] Enable Appearance Screen by default

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -404,6 +404,15 @@ struct AccessibilityIdentifiers {
         static let tableViewController = "AppSettingsTableViewController.tableView"
         static let navigationBarItem = "AppSettingsTableViewController.navigationItem.rightBarButtonItem"
 
+        struct Appearance {
+            static let browserThemeSectionTitle = "BrowserThemeSectionTitle"
+            static let websiteAppearanceSectionTitle = "WebsiteAppearanceSectionTitle"
+            static let automaticThemeView = "AutomaticThemeView"
+            static let lightThemeView = "LightThemeView"
+            static let darkThemeView = "DarkThemeView"
+            static let darkModeToggle = "DarkModeToggle"
+        }
+
         struct AppIconSelection {
             static let settingsRowTitle = "AppIconSelectionTitle"
         }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
@@ -33,12 +33,22 @@ struct AddressBarSelectionView: View {
                         onSelected?(selectedAddressBarPosition)
                     },
                     label: addressBarPosition.label,
-                    imageName: addressBarPosition.imageName
+                    imageName: addressBarPosition.imageName,
+                    a11yIdentifier: identifierName(for: addressBarPosition)
                 )
             }
         }
         .padding(.vertical, UX.sectionPadding)
         .frame(maxWidth: .infinity)
         .background(backgroundColor)
+    }
+
+    func identifierName(for addressBarPosition: SearchBarPosition) -> String {
+        switch addressBarPosition {
+        case .top:
+            return AccessibilityIdentifiers.Settings.SearchBar.topSetting
+        case .bottom:
+            return AccessibilityIdentifiers.Settings.SearchBar.bottomSetting
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSettingsView.swift
@@ -32,7 +32,9 @@ struct AddressBarSettingsView: View {
 
     var body: some View {
         VStack {
-            GenericSectionView(theme: currentTheme, title: .Settings.AddressBar.AddressBarSectionTitle) {
+            GenericSectionView(theme: currentTheme,
+                               title: .Settings.AddressBar.AddressBarSectionTitle,
+                               identifier: AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting) {
                 AddressBarSelectionView(
                     theme: currentTheme,
                     selectedAddressBarPosition: addressBarPosition,

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
@@ -13,7 +13,7 @@ protocol AppearanceSettingsDelegate: AnyObject {
 /// The main view displaying the settings for the appearance menu.
 struct AppearanceSettingsView: View, FeatureFlaggable {
     let windowUUID: WindowUUID
-    let delegate: AppearanceSettingsDelegate?
+    weak var delegate: AppearanceSettingsDelegate?
 
     @Environment(\.themeManager)
     var themeManager
@@ -47,7 +47,9 @@ struct AppearanceSettingsView: View, FeatureFlaggable {
         ScrollView {
             VStack {
                 // Section for selecting the browser theme.
-                GenericSectionView(theme: currentTheme, title: String.BrowserThemeSectionHeader) {
+                GenericSectionView(theme: currentTheme,
+                                   title: String.BrowserThemeSectionHeader,
+                                   identifier: AccessibilityIdentifiers.Settings.Appearance.browserThemeSectionTitle) {
                     ThemeSelectionView(theme: currentTheme,
                                        selectedThemeOption: themeOption,
                                        onThemeSelected: updateBrowserTheme)
@@ -55,13 +57,16 @@ struct AppearanceSettingsView: View, FeatureFlaggable {
                 // Section for toggling website appearance (e.g., dark mode).
                 GenericSectionView(theme: currentTheme,
                                    title: String.WebsiteAppearanceSectionHeader,
-                                   description: String.WebsiteDarkModeDescription) {
+                                   description: String.WebsiteDarkModeDescription,
+                                   identifier: AccessibilityIdentifiers.Settings.Appearance.websiteAppearanceSectionTitle) {
                     DarkModeToggleView(theme: currentTheme,
                                        isEnabled: NightModeHelper.isActivated(),
                                        onChange: setWebsiteDarkMode)
                 }
                 if shouldShowPageZoom {
-                    GenericSectionView(theme: currentTheme, title: .Settings.Appearance.PageZoom.SectionHeader) {
+                    GenericSectionView(theme: currentTheme,
+                                       title: .Settings.Appearance.PageZoom.SectionHeader,
+                                       identifier: .Settings.Appearance.PageZoom.SectionHeader) {
                         GenericItemCellView(title: .Settings.Appearance.PageZoom.PageZoomTitle,
                                             image: .chevronRightLarge,
                                             theme: currentTheme) {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/DarkModeToggleView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/DarkModeToggleView.swift
@@ -56,6 +56,7 @@ struct DarkModeToggleView: View {
         .padding(.vertical, UX.verticalSpacing)
         .background(backgroundColor)
         .accessibilityElement()
+        .accessibilityIdentifier(AccessibilityIdentifiers.Settings.Appearance.darkModeToggle)
         .accessibilityLabel("\(String.WebsiteDarkModeToggleTitle)")
         .accessibilityValue("\(isEnabled ? 1 : 0)")
         .accessibilityAddTraits(traits)

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionView.swift
@@ -15,6 +15,7 @@ struct GenericSectionView<Content: View>: View {
     let title: String
     let description: String?
     let content: () -> Content
+    let identifier: String
 
     let theme: Theme?
 
@@ -33,11 +34,16 @@ struct GenericSectionView<Content: View>: View {
         static var contentPadding: CGFloat { 4 }
     }
 
-    init(theme: Theme?, title: String, description: String? = nil, @ViewBuilder content: @escaping () -> Content) {
+    init(theme: Theme?,
+         title: String, 
+         description: String? = nil,
+         identifier: String,
+         @ViewBuilder content: @escaping () -> Content) {
         self.title = title
         self.description = description
         self.content = content
         self.theme = theme
+        self.identifier = identifier
     }
 
     var body: some View {
@@ -61,6 +67,7 @@ struct GenericSectionView<Content: View>: View {
             }
         }
         .padding(.bottom, UX.sectionPadding)
+        .accessibilityIdentifier(identifier)
     }
 
     /// Creates the footer view with the provided text.

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionView.swift
@@ -35,7 +35,7 @@ struct GenericSectionView<Content: View>: View {
     }
 
     init(theme: Theme?,
-         title: String, 
+         title: String,
          description: String? = nil,
          identifier: String,
          @ViewBuilder content: @escaping () -> Content) {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionView.swift
@@ -67,6 +67,7 @@ struct GenericSectionView<Content: View>: View {
             }
         }
         .padding(.bottom, UX.sectionPadding)
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier(identifier)
     }
 

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/GenericImageOption.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/GenericImageOption.swift
@@ -28,6 +28,7 @@ struct GenericImageOption: View {
     let onSelected: (() -> Void)?
     let label: String
     let imageName: String
+    let a11yIdentifier: String
 
     var body: some View {
         VStack(spacing: UX.spacing) {
@@ -39,6 +40,7 @@ struct GenericImageOption: View {
             onSelected?()
         }
         .accessibilityElement()
+        .accessibilityIdentifier(a11yIdentifier)
         .accessibilityLabel("\(label)")
         .accessibilityValue("\(isSelected ? 1 : 0)")
         .accessibilityAddTraits([.isButton])

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/ThemeOptionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/ThemeOptionView.swift
@@ -18,7 +18,8 @@ struct ThemeOptionView: View {
             isSelected: isSelected,
             onSelected: onSelected,
             label: theme.rawValue,
-            imageName: imageName(for: theme)
+            imageName: imageName(for: theme),
+            a11yIdentifier: identifierName(for: theme)
         )
     }
 
@@ -30,6 +31,17 @@ struct ThemeOptionView: View {
             return ImageIdentifiers.Appearance.lightBrowserThemeGradient
         case .dark:
             return ImageIdentifiers.Appearance.darkBrowserThemeGradient
+        }
+    }
+
+    func identifierName(for themeOption: ThemeSelectionView.ThemeOption) -> String {
+        switch themeOption {
+        case .automatic:
+            return AccessibilityIdentifiers.Settings.Appearance.automaticThemeView
+        case .light:
+            return AccessibilityIdentifiers.Settings.Appearance.lightThemeView
+        case .dark:
+            return AccessibilityIdentifiers.Settings.Appearance.darkThemeView
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -109,7 +109,7 @@ final class SettingsCoordinatorTests: XCTestCase {
         subject.start(with: .theme)
 
         XCTAssertEqual(mockRouter.pushCalled, 1)
-        XCTAssertTrue(mockRouter.pushedViewController is ThemeSettingsController)
+        XCTAssertTrue(mockRouter.pushedViewController is UIHostingController<AppearanceSettingsView>)
     }
 
     func testWallpaperSettingsRoute_cannotBeShown_showsWallpaperSettingsPage() throws {
@@ -156,7 +156,7 @@ final class SettingsCoordinatorTests: XCTestCase {
         subject.start(with: .toolbar)
 
         XCTAssertEqual(mockRouter.pushCalled, 1)
-        XCTAssertTrue(mockRouter.pushedViewController is SearchBarSettingsViewController)
+        XCTAssertTrue(mockRouter.pushedViewController is UIHostingController<AddressBarSettingsView>)
     }
 
     func testTopSitesSettingsRoute_showsTopSitesSettingsPage() throws {
@@ -370,7 +370,7 @@ final class SettingsCoordinatorTests: XCTestCase {
         subject.pressedToolbar()
 
         XCTAssertEqual(mockRouter.pushCalled, 1)
-        XCTAssertTrue(mockRouter.pushedViewController is SearchBarSettingsViewController)
+        XCTAssertTrue(mockRouter.pushedViewController is UIHostingController<AddressBarSettingsView>)
     }
 
     func testGeneralSettingsDelegate_pushedTheme() {
@@ -379,7 +379,7 @@ final class SettingsCoordinatorTests: XCTestCase {
         subject.pressedTheme()
 
         XCTAssertEqual(mockRouter.pushCalled, 1)
-        XCTAssertTrue(mockRouter.pushedViewController is ThemeSettingsController)
+        XCTAssertTrue(mockRouter.pushedViewController is UIHostingController<AppearanceSettingsView>)
     }
 
     // MARK: - BrowsingSettingsDelegate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Theme/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Theme/MockThemeManager.swift
@@ -7,7 +7,7 @@ import UIKit
 import Foundation
 
 class MockThemeManager: ThemeManager {
-    var isNewAppearanceMenuOn: Bool = true
+    var isNewAppearanceMenuOn = true
 
     var getCurrentThemeCallCount = 0
     private var currentThemeStorage: Theme = LightTheme()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Theme/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Theme/MockThemeManager.swift
@@ -7,7 +7,7 @@ import UIKit
 import Foundation
 
 class MockThemeManager: ThemeManager {
-    var isNewAppearanceMenuOn = false
+    var isNewAppearanceMenuOn: Bool = true
 
     var getCurrentThemeCallCount = 0
     private var currentThemeStorage: Theme = LightTheme()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
@@ -7,7 +7,7 @@ import UIKit
 import Foundation
 
 class MockThemeManager: ThemeManager {
-    var isNewAppearanceMenuOn = false
+    var isNewAppearanceMenuOn = true
 
     var getCurrentThemeCallCount = 0
     private var currentThemeStorage: Theme = LightTheme()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -413,6 +413,7 @@ class BaseTestCase: XCTestCase {
         XCTAssertEqual(result, .completed, "Element did not become hittable in time.")
     }
 
+    // Theme settings has been replaced with Appearance screen
     func switchThemeToDarkOrLight(theme: String) {
         if !app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].isHittable {
             app.buttons["Done"].waitAndTap()
@@ -423,17 +424,14 @@ class BaseTestCase: XCTestCase {
         navigator.goto(SettingsScreen)
         navigator.goto(DisplaySettings)
         sleep(3)
-        if !app.switches["SystemThemeSwitchValue"].exists {
+        if !app.navigationBars["Appearance"].exists {
             navigator.goto(DisplaySettings)
         }
-        mozWaitForElementToExist(app.switches["SystemThemeSwitchValue"])
-        if (app.switches["SystemThemeSwitchValue"].value as? String) == "1" {
-            navigator.performAction(Action.SystemThemeSwitch)
-        }
+        mozWaitForElementToExist(app.navigationBars["Appearance"])
         if theme == "Dark" {
-            app.cells.staticTexts["Dark"].waitAndTap()
+            navigator.performAction(Action.SelectDarkTheme)
         } else {
-            app.cells.staticTexts["Light"].waitAndTap()
+            navigator.performAction(Action.SelectLightTheme)
         }
         app.buttons["Settings"].waitAndTap()
         navigator.nowAt(SettingsScreen)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DisplaySettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DisplaySettingsTests.swift
@@ -11,61 +11,40 @@ class DisplaySettingTests: BaseTestCase {
         navigator.goto(DisplaySettings)
         waitForElementsToExist(
             [
-                app.navigationBars["Theme"],
-                app.tables["DisplayTheme.Setting.Options"]
+                app.navigationBars["Appearance"],
+                app.buttons[AccessibilityIdentifiers.Settings.Appearance.automaticThemeView],
+                app.switches[AccessibilityIdentifiers.Settings.Appearance.darkModeToggle]
             ]
         )
-        let switchValue = app.switches["SystemThemeSwitchValue"].value!
-        XCTAssertEqual(switchValue as? String, "1")
+
+        let automaticIsSelected = app.buttons[AccessibilityIdentifiers.Settings.Appearance.automaticThemeView].value
+        XCTAssertEqual(automaticIsSelected as? String, "1")
+
+        let lightThemeValue = app.buttons[AccessibilityIdentifiers.Settings.Appearance.lightThemeView].value
+        XCTAssertEqual(lightThemeValue as? String, "0")
+
+        let darkThemeValue = app.buttons[AccessibilityIdentifiers.Settings.Appearance.darkThemeView].value
+        XCTAssertEqual(darkThemeValue as? String, "0")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2337487
     func testCheckSystemThemeChanges() {
         navigator.nowAt(NewTabScreen)
         navigator.goto(DisplaySettings)
-        mozWaitForElementToExist(app.switches["SystemThemeSwitchValue"])
-        navigator.performAction(Action.SystemThemeSwitch)
-        waitForElementsToExist(
-            [
-                app.tables["DisplayTheme.Setting.Options"].otherElements.staticTexts["SWITCH MODE"],
-                app.tables["DisplayTheme.Setting.Options"].otherElements.staticTexts["THEME PICKER"]
-            ]
-        )
 
-        // Going back to Settings and Display settings keeps the value
-        navigator.goto(SettingsScreen)
-        navigator.goto(DisplaySettings)
-        mozWaitForElementToExist(app.switches["SystemThemeSwitchValue"])
-        let switchValue = app.switches["SystemThemeSwitchValue"].value!
-        XCTAssertEqual(switchValue as? String, "0")
-        waitForElementsToExist(
-            [
-                app.cells.staticTexts["Light"],
-                app.cells.staticTexts["Dark"]
-            ]
-        )
+        // Select Light mode
+        navigator.performAction(Action.SelectLightTheme)
+        let lightIsSelected = app.buttons[AccessibilityIdentifiers.Settings.Appearance.lightThemeView].value
+        XCTAssertEqual(lightIsSelected as? String, "1")
 
-        // Select the Automatic mode
-        navigator.performAction(Action.SelectAutomatically)
-        mozWaitForElementToExist(app.tables.otherElements["THRESHOLD"])
-        mozWaitForElementToNotExist(app.cells.staticTexts["Light"])
-        mozWaitForElementToNotExist(app.cells.staticTexts["Dark"])
+        // Select Dark mode
+        navigator.performAction(Action.SelectDarkTheme)
+        let darkIsSelected = app.buttons[AccessibilityIdentifiers.Settings.Appearance.darkThemeView].value
+        XCTAssertEqual(darkIsSelected as? String, "1")
 
-        // Now select the Manual mode
-        navigator.performAction(Action.SelectManually)
-        mozWaitForElementToNotExist(app.tables.otherElements["THRESHOLD"])
-        waitForElementsToExist(
-            [
-                app.cells.staticTexts["Light"],
-                app.cells.staticTexts["Dark"]
-            ]
-        )
-
-        // Enable back system theme
-        navigator.performAction(Action.SystemThemeSwitch)
-        let switchValueAfter = app.switches["SystemThemeSwitchValue"].value!
-        XCTAssertEqual(switchValueAfter as? String, "1")
-        mozWaitForElementToNotExist(app.tables["DisplayTheme.Setting.Options"].otherElements.staticTexts["SWITCH MODE"])
-        mozWaitForElementToNotExist(app.tables["DisplayTheme.Setting.Options"].otherElements.staticTexts["THEME PICKER"])
+        // Select Automatic mode
+        navigator.performAction(Action.SelectAutomaticTheme)
+        let automaticIsSelected = app.buttons[AccessibilityIdentifiers.Settings.Appearance.automaticThemeView].value
+        XCTAssertEqual(automaticIsSelected as? String, "1")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -205,9 +205,10 @@ class Action {
     static let SentToDevice = "SentToDevice"
     static let AddToReadingListBrowserTabMenu = "AddToReadingListBrowserTabMenu"
 
-    static let SelectAutomatically = "SelectAutomatically"
-    static let SelectManually = "SelectManually"
-    static let SystemThemeSwitch = "SystemThemeSwitch"
+    static let SelectAutomaticTheme = "SelectAutomaticTheme"
+    static let SelectLightTheme = "SelectLightTheme"
+    static let SelectDarkTheme = "SelectDarkTheme"
+    static let SelectBrowserDarkTheme = "SelectBrowserDarkTheme"
 
     static let AddCustomSearchEngine = "AddCustomSearchEngine"
     static let RemoveCustomSearchEngine = "RemoveCustomSearchEngine"
@@ -620,14 +621,17 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(DisplaySettings) { screenState in
-        screenState.gesture(forAction: Action.SelectAutomatically) { userState in
-            app.cells.staticTexts["Automatically"].waitAndTap()
+        screenState.gesture(forAction: Action.SelectAutomaticTheme) { userState in
+            app.buttons[AccessibilityIdentifiers.Settings.Appearance.automaticThemeView].waitAndTap()
         }
-        screenState.gesture(forAction: Action.SelectManually) { userState in
-            app.cells.staticTexts["Manually"].waitAndTap()
+        screenState.gesture(forAction: Action.SelectLightTheme) { userState in
+            app.buttons[AccessibilityIdentifiers.Settings.Appearance.lightThemeView].waitAndTap()
         }
-        screenState.gesture(forAction: Action.SystemThemeSwitch) { userState in
-            app.switches["SystemThemeSwitchValue"].waitAndTap()
+        screenState.gesture(forAction: Action.SelectDarkTheme) { userState in
+            app.buttons[AccessibilityIdentifiers.Settings.Appearance.darkThemeView].waitAndTap()
+        }
+        screenState.gesture(forAction: Action.SelectBrowserDarkTheme) { userState in
+            app.switches[AccessibilityIdentifiers.Settings.Appearance.darkModeToggle].waitAndTap()
         }
         screenState.backAction = navigationControllerBackAction
     }
@@ -776,11 +780,11 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(ToolbarSettings) { screenState in
         screenState.gesture(forAction: Action.SelectToolbarBottom) { UserState in
-            app.cells[AccessibilityIdentifiers.Settings.SearchBar.bottomSetting].waitAndTap()
+            app.buttons[AccessibilityIdentifiers.Settings.SearchBar.bottomSetting].waitAndTap()
         }
 
         screenState.gesture(forAction: Action.SelectToolbarTop) { UserState in
-            app.cells[AccessibilityIdentifiers.Settings.SearchBar.topSetting].waitAndTap()
+            app.buttons[AccessibilityIdentifiers.Settings.SearchBar.topSetting].waitAndTap()
         }
 
         screenState.backAction = navigationControllerBackAction

--- a/firefox-ios/nimbus-features/newAddressBarMenu.yaml
+++ b/firefox-ios/nimbus-features/newAddressBarMenu.yaml
@@ -7,11 +7,11 @@ features:
       status:
         description: If true, we will show the new address bar menu entry
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:
-          status: false
+          status: true
       - channel: developer
         value:
-          status: false
+          status: true

--- a/firefox-ios/nimbus-features/newAppearanceMenu.yaml
+++ b/firefox-ios/nimbus-features/newAppearanceMenu.yaml
@@ -7,11 +7,11 @@ features:
       status:
         description: If true, we will show the new appearance menu entry
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:
-          status: false
+          status: true
       - channel: developer
         value:
-          status: false
+          status: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12086)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26305)

## :bulb: Description
This PR:
- Enables appearance menu by default
- Adds a11y ids for fixing tests


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
