### PR TITLE
Bugfix FXIOS-12244 tracking protection icon scaling with dynamic font size

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -401,8 +401,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     private func getTrackingProtectionAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .SettingsTrackingProtectionSectionName,
-                                     iconString: StandardImageIdentifiers.Large.shieldCheckmark,
-                                     allowIconScaling: true) { [weak self] _ in
+                                     iconString: StandardImageIdentifiers.Large.shieldCheckmark) { [weak self] _ in
             let isPrivate = self?.selectedTab?.isPrivate ?? false
             let extra = GleanMetrics.Toolbar.SiteInfoButtonTappedExtra(isPrivate: isPrivate,
                                                                        isToolbar: false)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12244)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26665)

## :bulb: Description
Bugfix shield icon scaling with dynamic font size,

## :movie_camera: Demos
![Simulator Screenshot - iPhone 16 - 2025-06-06 at 15 09 34](https://github.com/user-attachments/assets/65940a61-ca6a-4e77-a487-b756c18e73a6)


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
