### PR TITLE
Bugfix FXIOS-12275 [Tab tray UI experiment] Tab tray selector spacing fixes and color

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorButtonModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorButtonModel.swift
@@ -34,6 +34,7 @@ final class TabTraySelectorButton: UIButton, ThemeApplicable {
         }
         var updatedConfiguration = config
 
+        updatedConfiguration.titleLineBreakMode = .byTruncatingTail
         updatedConfiguration.title = viewModel.title
         updatedConfiguration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorButtonModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorButtonModel.swift
@@ -88,7 +88,7 @@ final class TabTraySelectorButton: UIButton, ThemeApplicable {
 
     func applyTheme(theme: Theme) {
         foregroundColorNormal = theme.colors.textPrimary
-        foregroundColorHighlighted = theme.colors.actionPrimaryHover
+        foregroundColorHighlighted = theme.colors.actionSecondaryHover
         backgroundColorNormal = .clear
         setNeedsUpdateConfiguration()
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorButtonModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorButtonModel.swift
@@ -23,7 +23,9 @@ final class TabTraySelectorButton: UIButton, ThemeApplicable {
         super.init(frame: frame)
 
         configuration = UIButton.Configuration.plain()
-        titleLabel?.adjustsFontForContentSizeCategory = true
+        titleLabel?.adjustsFontForContentSizeCategory = false
+        showsLargeContentViewer = true
+        addInteraction(UILargeContentViewerInteraction())
     }
 
     func configure(viewModel: TabTraySelectorButtonModel) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -293,7 +293,7 @@ class TabTraySelectorView: UIView,
     func applyTheme(theme: Theme) {
         self.theme = theme
         backgroundColor = theme.colors.layer1
-        selectionBackgroundView.backgroundColor = theme.colors.actionSecondary
+        selectionBackgroundView.backgroundColor = theme.colors.layer3
 
         for button in buttons {
             button.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -107,8 +107,8 @@ class TabTraySelectorView: UIView,
                           NSNumber(value: index + 1),
                           NSNumber(value: items.count))
         let font = index == selectedIndex
-            ? FXFontStyles.Bold.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
-            : FXFontStyles.Regular.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
+            ? FXFontStyles.Bold.body.systemFont()
+            : FXFontStyles.Regular.body.systemFont()
         let contentInsets = NSDirectionalEdgeInsets(
             top: TabTraySelectorUX.verticalInsets,
             leading: TabTraySelectorUX.horizontalInsets,
@@ -161,7 +161,7 @@ class TabTraySelectorView: UIView,
             existingConstraint.isActive = false
         }
 
-        let boldFont = FXFontStyles.Bold.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
+        let boldFont = FXFontStyles.Bold.body.systemFont()
         let boldWidth = ceil(title.size(withAttributes: [.font: boldFont]).width)
         let horizontalInsets = TabTraySelectorUX.horizontalInsets * 2
         button.widthAnchor.constraint(equalToConstant: boldWidth + horizontalInsets).isActive = true
@@ -192,8 +192,8 @@ class TabTraySelectorView: UIView,
             button.isSelected = isSelected
 
             let font = isSelected
-                ? FXFontStyles.Bold.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
-                : FXFontStyles.Regular.body.scaledFont(sizeCap: TabTraySelectorUX.maxFontSize)
+                ? FXFontStyles.Bold.body.systemFont()
+                : FXFontStyles.Regular.body.systemFont()
             button.applySelectedFontChange(font: font)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -11,10 +11,9 @@ protocol TabTraySelectorDelegate: AnyObject {
 
 // MARK: - UX Constants
 struct TabTraySelectorUX {
-    static let horizontalPadding: CGFloat = 20
+    static let horizontalPadding: CGFloat = 16
     static let cornerRadius: CGFloat = 12
     static let verticalInsets: CGFloat = 8
-    static let maxFontSize: CGFloat = 30
     static let horizontalInsets: CGFloat = 10
     static let fontScaleDelta: CGFloat = 0.055
 }
@@ -40,7 +39,7 @@ class TabTraySelectorView: UIView,
     private lazy var stackView: UIStackView = .build { stackView in
         stackView.axis = .horizontal
         stackView.spacing = TabTraySelectorUX.horizontalPadding
-        stackView.distribution = .equalCentering
+        stackView.distribution = .fillProportionally
         stackView.alignment = .center
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -11,12 +11,12 @@ protocol TabTraySelectorDelegate: AnyObject {
 
 // MARK: - UX Constants
 struct TabTraySelectorUX {
-    static let horizontalSpacing: CGFloat = 16
+    static let horizontalSpacing: CGFloat = 12
     static let cornerRadius: CGFloat = 12
     static let verticalInsets: CGFloat = 8
     static let horizontalInsets: CGFloat = 10
     static let fontScaleDelta: CGFloat = 0.055
-    static let stackViewLeadingTrailingPadding: CGFloat = 12
+    static let stackViewLeadingTrailingPadding: CGFloat = 8
 }
 
 /// Represents the visual state of the selection indicator during a transition.

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -11,11 +11,12 @@ protocol TabTraySelectorDelegate: AnyObject {
 
 // MARK: - UX Constants
 struct TabTraySelectorUX {
-    static let horizontalPadding: CGFloat = 16
+    static let horizontalSpacing: CGFloat = 16
     static let cornerRadius: CGFloat = 12
     static let verticalInsets: CGFloat = 8
     static let horizontalInsets: CGFloat = 10
     static let fontScaleDelta: CGFloat = 0.055
+    static let stackViewLeadingTrailingPadding: CGFloat = 12
 }
 
 /// Represents the visual state of the selection indicator during a transition.
@@ -38,7 +39,7 @@ class TabTraySelectorView: UIView,
 
     private lazy var stackView: UIStackView = .build { stackView in
         stackView.axis = .horizontal
-        stackView.spacing = TabTraySelectorUX.horizontalPadding
+        stackView.spacing = TabTraySelectorUX.horizontalSpacing
         stackView.distribution = .fillProportionally
         stackView.alignment = .center
     }
@@ -90,6 +91,10 @@ class TabTraySelectorView: UIView,
         }
 
         NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor,
+                                               constant: TabTraySelectorUX.stackViewLeadingTrailingPadding),
+            stackView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor,
+                                                constant: -TabTraySelectorUX.stackViewLeadingTrailingPadding),
             stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
             stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             selectionBackgroundView.heightAnchor.constraint(equalTo: stackView.heightAnchor),

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -124,11 +124,13 @@ class TabTrayViewController: UIViewController,
 
     private lazy var experimentSegmentControl: TabTraySelectorView = {
         let selectedIndex = experimentConvertSelectedIndex()
-        let selector = TabTraySelectorView(selectedIndex: selectedIndex, theme: retrieveTheme())
+        let titles = [TabTrayPanelType.privateTabs.label,
+                     TabTrayPanelType.tabs.label,
+                     TabTrayPanelType.syncedTabs.label]
+        let selector = TabTraySelectorView(selectedIndex: selectedIndex,
+                                           theme: retrieveTheme(),
+                                           buttonTitles: titles)
         selector.delegate = self
-        selector.items = [TabTrayPanelType.privateTabs.label,
-                          TabTrayPanelType.tabs.label,
-                          TabTrayPanelType.syncedTabs.label]
         selector.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.navBarSegmentedControl
 
         didSelectSection(panelType: tabTrayState.selectedPanel)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12275)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26746)

## :bulb: Description
Many little things:
- Fixing the `selectionBackgroundView` color
- Fixing the `tabTraySelectorButton` highlight color
- Disabling dynamic type and using a large content viewer instead
- Changing the stack view distribution to `.fillProportionally`

## :movie_camera: Demos

<details>
<summary>Demo</summary>

https://github.com/user-attachments/assets/7c8eeef8-f1bf-4f6c-8009-8999d7a6566c

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [X] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
