### PR TITLE
Add FXIOS-12437, FXIOS-12468 [TA 2025] Add settings.changed event and migrate preferences.changed out of TelemetryWrapper

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -132,7 +132,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
     }
 
     private func recordEventOnChecked(option: BlockingStrength, fromOption: BlockingStrength) {
-        SettingsTelemetry().changedSetting(.etpStrength, to: option.rawValue, from: fromOption.rawValue)
+        SettingsTelemetry().changedSetting("ETP-strength", to: option.rawValue, from: fromOption.rawValue)
 
         if option == .strict {
             TelemetryWrapper.recordEvent(

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -65,13 +65,15 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
                     return option == self.currentBlockingStrength
                 },
                 onChecked: {
+                    let previousOption = self.currentBlockingStrength
+
                     self.currentBlockingStrength = option
                     self.prefs.setString(self.currentBlockingStrength.rawValue,
                                          forKey: ContentBlockingConfig.Prefs.StrengthKey)
                     TabContentBlocker.prefsChanged()
                     self.tableView.reloadData()
 
-                    self.recordEventOnChecked(option: option)
+                    self.recordEventOnChecked(option: option, fromOption: previousOption)
                 })
 
             let uuid = windowUUID
@@ -129,17 +131,8 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
         return sections
     }
 
-    private func recordEventOnChecked(option: BlockingStrength) {
-        let extras = [
-            TelemetryWrapper.EventExtraKey.preference.rawValue: "ETP-strength",
-            TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: option.rawValue
-        ]
-        TelemetryWrapper.recordEvent(
-            category: .action,
-            method: .change,
-            object: .setting,
-            extras: extras
-        )
+    private func recordEventOnChecked(option: BlockingStrength, fromOption: BlockingStrength) {
+        SettingsTelemetry().changedSetting(.etpStrength, to: option.rawValue, from: fromOption.rawValue)
 
         if option == .strict {
             TelemetryWrapper.recordEvent(

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -217,7 +217,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             self?.tableView.reloadData()
 
             SettingsTelemetry().changedSetting(
-                .startAtHome,
+                PrefsKeys.FeatureFlags.StartAtHome,
                 to: newOption.rawValue,
                 from: previousOption?.rawValue ?? SettingsTelemetry.Placeholders.missingValue
             )

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -208,15 +208,19 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
 
         typealias a11y = AccessibilityIdentifiers.Settings.Homepage.StartAtHome
 
-        let onOptionSelected: (Bool, StartAtHomeSetting) -> Void = { [weak self] state, option in
-            self?.prefs.setString(option.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
+        let onOptionSelected: (
+            Bool,
+            StartAtHomeSetting,
+            StartAtHomeSetting?
+        ) -> Void = { [weak self] state, newOption, previousOption in
+            self?.prefs.setString(newOption.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
             self?.tableView.reloadData()
 
-            let extras = [
-                TelemetryWrapper.EventExtraKey.preference.rawValue: PrefsKeys.FeatureFlags.StartAtHome,
-                TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: option.rawValue
-            ]
-            TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: extras)
+            SettingsTelemetry().changedSetting(
+                .startAtHome,
+                to: newOption.rawValue,
+                from: previousOption?.rawValue ?? SettingsTelemetry.Placeholders.missingValue
+            )
         }
 
         let afterFourHoursOption = CheckmarkSetting(
@@ -225,8 +229,9 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             accessibilityIdentifier: a11y.afterFourHours,
             isChecked: { return self.currentStartAtHomeSetting == .afterFourHours },
             onChecked: {
+                let previousOption = self.currentStartAtHomeSetting
                 self.currentStartAtHomeSetting = .afterFourHours
-                onOptionSelected(true, .afterFourHours)
+                onOptionSelected(true, .afterFourHours, previousOption)
             })
 
         let alwaysOption = CheckmarkSetting(
@@ -235,8 +240,9 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             accessibilityIdentifier: a11y.always,
             isChecked: { return self.currentStartAtHomeSetting == .always },
             onChecked: {
+                let previousOption = self.currentStartAtHomeSetting
                 self.currentStartAtHomeSetting = .always
-                onOptionSelected(true, .always)
+                onOptionSelected(true, .always, previousOption)
             })
 
         let neverOption = CheckmarkSetting(
@@ -245,8 +251,9 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             accessibilityIdentifier: a11y.disabled,
             isChecked: { return self.currentStartAtHomeSetting == .disabled },
             onChecked: {
+                let previousOption = self.currentStartAtHomeSetting
                 self.currentStartAtHomeSetting = .disabled
-                onOptionSelected(false, .disabled)
+                onOptionSelected(false, .disabled, previousOption)
             })
 
         let section = SettingSection(

--- a/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -128,21 +128,22 @@ final class SearchBarSettingsViewModel: FeatureFlaggable {
 // MARK: Private
 extension SearchBarSettingsViewModel {
     func saveSearchBarPosition(_ searchBarPosition: SearchBarPosition) {
+        let previousPosition: SearchBarPosition? = featureFlags.getCustomState(for: .searchBarPosition)
+
         featureFlags.set(feature: .searchBarPosition, to: searchBarPosition)
         delegate?.didUpdateSearchBarPositionPreference()
-        recordPreferenceChange(searchBarPosition)
+        recordPreferenceChange(searchBarPosition, previousPosition: previousPosition)
 
         let notificationObject = [PrefsKeys.FeatureFlags.SearchBarPosition: searchBarPosition]
         notificationCenter.post(name: .SearchBarPositionDidChange, withObject: notificationObject)
     }
 
-    private func recordPreferenceChange(_ searchBarPosition: SearchBarPosition) {
-        let extras = [TelemetryWrapper.EventExtraKey.preference.rawValue: PrefsKeys.FeatureFlags.SearchBarPosition,
-                      TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: searchBarPosition.rawValue]
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .change,
-                                     object: .setting,
-                                     extras: extras)
+    private func recordPreferenceChange(_ searchBarPosition: SearchBarPosition, previousPosition: SearchBarPosition?) {
+        SettingsTelemetry().changedSetting(
+            PrefsKeys.FeatureFlags.SearchBarPosition,
+            to: searchBarPosition.rawValue,
+            from: previousPosition?.rawValue ?? SettingsTelemetry.Placeholders.missingValue
+        )
     }
 }
 

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -711,7 +711,7 @@ extension SearchSettingsTableViewController: SearchEnginePickerDelegate {
             self.tableView.reloadData()
 
             SettingsTelemetry().changedSetting(
-                .defaultSearchEngine,
+                "defaultSearchEngine",
                 to: engine.telemetryID,
                 from: previousEngine?.telemetryID ?? SettingsTelemetry.Placeholders.missingValue
             )

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -705,14 +705,16 @@ extension SearchSettingsTableViewController: SearchEnginePickerDelegate {
         didSelectSearchEngine searchEngine: OpenSearchEngine?
     ) {
         if let engine = searchEngine {
+            let previousEngine = model.defaultEngine
             model.defaultEngine = engine
             NotificationCenter.default.post(name: .SearchSettingsDidUpdateDefaultSearchEngine)
             self.tableView.reloadData()
 
-            let engineID: String = engine.telemetryID
-            let extras = [TelemetryWrapper.EventExtraKey.preference.rawValue: "defaultSearchEngine",
-                          TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: engineID]
-            TelemetryWrapper.recordEvent(category: .action, method: .change, object: .setting, extras: extras)
+            SettingsTelemetry().changedSetting(
+                .defaultSearchEngine,
+                to: engine.telemetryID,
+                from: previousEngine?.telemetryID ?? SettingsTelemetry.Placeholders.missingValue
+            )
         }
         _ = navigationController?.popViewController(animated: true)
     }

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -340,17 +340,15 @@ class BoolSetting: Setting, FeatureFlaggable {
     func switchValueChanged(_ control: UISwitch) {
         writeBool(control)
         settingDidChange?(control.isOn)
-        if let featureFlagName = featureFlagName {
-            TelemetryWrapper.recordEvent(category: .action,
-                                         method: .change,
-                                         object: .setting,
-                                         extras: ["pref": featureFlagName.rawValue as Any,
-                                                  "to": control.isOn])
+
+        if let settingChanged = featureFlagName?.rawValue ?? prefKey {
+            SettingsTelemetry().changedSetting(
+                settingChanged,
+                to: "\(control.isOn)",
+                from: "\(!control.isOn)"
+            )
         } else {
-            TelemetryWrapper.recordEvent(category: .action,
-                                         method: .change,
-                                         object: .setting,
-                                         extras: ["pref": prefKey as Any, "to": control.isOn])
+            assertionFailure("We should be able to get a unique key to describe the changed setting")
         }
     }
 

--- a/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
@@ -31,19 +31,19 @@ struct SettingsTelemetry {
         case AppIcon = "app_icon"
     }
 
-    /// Uniquely identifies a setting in the Settings screen hierarchy irrespective of its placement.
-    enum SettingKey: String {
-        // TODO
-        case defaultSearchEngine
-        case etpStrength = "ETP-strength"
-        case startAtHome = "StartAtHomeUserPrefsKey" // Formerly `PrefsKeys.FeatureFlags.StartAtHome`
-    }
-
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.gleanWrapper = gleanWrapper
     }
-
-    func changedSetting(_ setting: SettingKey, to changedTo: String, from changedFrom: String) {
+    
+    /// Records the event of a user changing a setting in one of the Settings screens.
+    /// - Parameters:
+    ///   - setting: A key uniquely identifying a setting in the Settings screen hierarchy irrespective of its placement.
+    ///              This key should not change even if the setting is moved to another screen later.
+    ///              Most often these are `PrefKeys`, `AppConstants`, or feature flag names, but any unique identifier may be
+    ///              used.
+    ///   - changedTo: The new value of the setting, recorded as a string.
+    ///   - changedFrom: The previous value of the setting, recorded as a string.
+    func changedSetting(_ setting: String, to changedTo: String, from changedFrom: String) {
         if changedTo.isEmpty || changedFrom.isEmpty {
             assertionFailure("changedTo and changedFrom should be valid string extras")
         }
@@ -51,7 +51,7 @@ struct SettingsTelemetry {
         let extras = GleanMetrics.Settings.ChangedExtra(
             changedFrom: changedFrom.isEmpty ? "unavailable" : changedFrom,
             changedTo: changedTo.isEmpty ? "unavailable" : changedTo,
-            setting: setting.rawValue
+            setting: setting
         )
         gleanWrapper.recordEvent(for: GleanMetrics.Settings.changed, extras: extras)
     }

--- a/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
@@ -20,11 +20,22 @@ struct SettingsTelemetry {
     enum OptionIdentifiers: String {
         case AppIconSelection = "app_icon_selection" // Tapping "App Icon >" to show the App Icon Selection screen
     }
+    
+    /// Standard fallback values to use in telemetry when needed (e.g. missing data).
+    struct Placeholders {
+        /// Used when a value is not available to send (e.g. settings.changed changedFrom value missing)
+        static let missingValue = "unavailable"
+    }
+
+    enum MainMenuOption: String {
+        case AppIcon = "app_icon"
+    }
 
     /// Uniquely identifies a setting in the Settings screen hierarchy irrespective of its placement.
     enum SettingKey: String {
         // TODO
         case etpStrength = "ETP-strength"
+        case startAtHome = "StartAtHomeUserPrefsKey" // Formerly `PrefsKeys.FeatureFlags.StartAtHome`
     }
 
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
@@ -50,7 +61,7 @@ struct SettingsTelemetry {
         let extra = GleanMetrics.Settings.OptionSelectedExtra(option: option.rawValue)
         gleanWrapper.recordEvent(for: GleanMetrics.Settings.optionSelected, extras: extra)
     }
-    
+
     func tappedAppIconSetting() {
         let extra = GleanMetrics.SettingsMainMenu.OptionSelectedExtra(option: MainMenuOption.AppIcon.rawValue)
         gleanWrapper.recordEvent(for: GleanMetrics.SettingsMainMenu.optionSelected, extras: extra)

--- a/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
@@ -5,30 +5,21 @@
 import Foundation
 import Glean
 
-/// Note: We will be slowly migrating our existing settings (i.e. "preferences") telemetry probes over to a "settings"
-/// namespace.
 struct SettingsTelemetry {
     private let gleanWrapper: GleanWrapper
 
-    /// Uniquely identifies a row on the settings screen (or one of its subscreens), which the user can tap to drill down
-    /// deeper into settings.
-    ///
-    /// If the row moves somewhere else due to a refactor or an experiment, the key should stay the same. The most important
-    /// feature of the key is that it identifies the tapped row irrespective of its location in the settings hierarchy.
-    ///
-    /// Note that the `option` identifies the __row tapped__, not necessarily the screen shown.
-    enum OptionIdentifiers: String {
-        case AppIconSelection = "app_icon_selection" // Tapping "App Icon >" to show the App Icon Selection screen
-    }
-    
     /// Standard fallback values to use in telemetry when needed (e.g. missing data).
     struct Placeholders {
         /// Used when a value is not available to send (e.g. settings.changed changedFrom value missing)
         static let missingValue = "unavailable"
     }
 
-    enum MainMenuOption: String {
-        case AppIcon = "app_icon"
+    /// Uniquely identifies a row on the settings screen (or one of its subscreens), which the user can tap to drill down
+    /// deeper into settings. The identifier is irrespective of the row's location in the settings hierarchy.
+    ///
+    /// Note that the `option` identifies the __row tapped__, not necessarily the screen shown.
+    enum OptionIdentifiers: String {
+        case AppIconSelection = "app_icon_selection" // Tapping "App Icon >" to show the App Icon Selection screen
     }
 
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
@@ -68,10 +59,5 @@ struct SettingsTelemetry {
     func optionSelected(option: OptionIdentifiers) {
         let extra = GleanMetrics.Settings.OptionSelectedExtra(option: option.rawValue)
         gleanWrapper.recordEvent(for: GleanMetrics.Settings.optionSelected, extras: extra)
-    }
-
-    func tappedAppIconSetting() {
-        let extra = GleanMetrics.SettingsMainMenu.OptionSelectedExtra(option: MainMenuOption.AppIcon.rawValue)
-        gleanWrapper.recordEvent(for: GleanMetrics.SettingsMainMenu.optionSelected, extras: extra)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
@@ -21,8 +21,27 @@ struct SettingsTelemetry {
         case AppIconSelection = "app_icon_selection" // Tapping "App Icon >" to show the App Icon Selection screen
     }
 
+    /// Uniquely identifies a setting in the Settings screen hierarchy irrespective of its placement.
+    enum SettingKey: String {
+        // TODO
+        case etpStrength = "ETP-strength"
+    }
+
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.gleanWrapper = gleanWrapper
+    }
+
+    func changedSetting(_ setting: SettingKey, to changedTo: String, from changedFrom: String) {
+        if changedTo.isEmpty || changedFrom.isEmpty {
+            assertionFailure("changedTo and changedFrom should be valid string extras")
+        }
+
+        let extras = GleanMetrics.Settings.ChangedExtra(
+            changedFrom: changedFrom.isEmpty ? "unavailable" : changedFrom,
+            changedTo: changedTo.isEmpty ? "unavailable" : changedTo,
+            setting: setting.rawValue
+        )
+        gleanWrapper.recordEvent(for: GleanMetrics.Settings.changed, extras: extras)
     }
 
     /// Recorded when a user taps a row on the settings screen (or one of its subscreens) to drill deeper into the settings.
@@ -30,5 +49,10 @@ struct SettingsTelemetry {
     func optionSelected(option: OptionIdentifiers) {
         let extra = GleanMetrics.Settings.OptionSelectedExtra(option: option.rawValue)
         gleanWrapper.recordEvent(for: GleanMetrics.Settings.optionSelected, extras: extra)
+    }
+    
+    func tappedAppIconSetting() {
+        let extra = GleanMetrics.SettingsMainMenu.OptionSelectedExtra(option: MainMenuOption.AppIcon.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.SettingsMainMenu.optionSelected, extras: extra)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
@@ -25,7 +25,7 @@ struct SettingsTelemetry {
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.gleanWrapper = gleanWrapper
     }
-    
+
     /// Records the event of a user changing a setting in one of the Settings screens.
     /// - Parameters:
     ///   - setting: A key uniquely identifying a setting in the Settings screen hierarchy irrespective of its placement.

--- a/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
@@ -34,6 +34,7 @@ struct SettingsTelemetry {
     /// Uniquely identifies a setting in the Settings screen hierarchy irrespective of its placement.
     enum SettingKey: String {
         // TODO
+        case defaultSearchEngine
         case etpStrength = "ETP-strength"
         case startAtHome = "StartAtHomeUserPrefsKey" // Formerly `PrefsKeys.FeatureFlags.StartAtHome`
     }

--- a/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTelemetry.swift
@@ -54,6 +54,13 @@ struct SettingsTelemetry {
             setting: setting
         )
         gleanWrapper.recordEvent(for: GleanMetrics.Settings.changed, extras: extras)
+
+        // Continue to record the `preferences.changed` until it's expired and we deprecate it in favor of `settings.changed`
+        let deprecatedExtras = GleanMetrics.Preferences.ChangedExtra(
+            changedTo: changedTo,
+            preference: setting
+        )
+        gleanWrapper.recordEvent(for: GleanMetrics.Preferences.changed, extras: deprecatedExtras)
     }
 
     /// Recorded when a user taps a row on the settings screen (or one of its subscreens) to drill deeper into the settings.

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -266,13 +266,14 @@ settings:
         description: |
           The previous value of the setting.
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-12437
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-12437
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
       - https://github.com/mozilla-mobile/firefox-ios/pull/9673
       - https://github.com/mozilla-mobile/firefox-ios/pull/12334
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+      - https://github.com/mozilla-mobile/firefox-ios/pull/27180
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-01-01"

--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -24,9 +24,15 @@ preferences:
   changed:
     type: event
     description: |
-      Recorded when a preference is changed and includes the
-      preference that changed as well as the value changed to
-      recorded in the extra keys.
+      Recorded when a preference is changed and includes the preference that
+      changed as well as the value changed to recorded in the extra keys.
+
+      Note: This setting will soon be deprecated in favor of
+      `settings.changed`, which also includes a new `changed_from` extra.
+
+      **Expiration:** This setting can be safely expired once the
+      `settings.changed` implementation completely shadows the old 
+      `preferences.changed` implementation.
     extra_keys:
       preference:
         type: string
@@ -236,8 +242,40 @@ preferences:
 # New "settings" telemetry properly nested under "settings".
 ###############################################################################
 
-# General settings events
+# General Settings Events
 settings:
+  changed:
+    type: event
+    description: |
+      Recorded when the user changes a setting on a Settings screen. Records
+      the new value, the previous value, and a key that uniquely identifies the
+      setting irrespective of its placement in the Settings screens hierarchy.
+
+      This setting will eventually replace `preferences.changed`.
+    extra_keys:
+      setting:
+        type: string
+        description: |
+          A unique key describing the setting that was changed.
+      changed_to:
+        type: string
+        description: |
+          The new value of the setting.
+      changed_from:
+        type: string
+        description: |
+          The previous value of the setting.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-12437
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9673
+      - https://github.com/mozilla-mobile/firefox-ios/pull/12334
+      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-01-01"
   option_selected:
     type: event
     description: |

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -835,7 +835,7 @@ extension TelemetryWrapper {
         case (.action, .tap, .newPrivateTab, .topSite, _):
             GleanMetrics.TopSites.openInPrivateTab.record()
         // MARK: Preferences
-        case (.action, .change, .setting, _, let extras):
+        case (.action, .change, .setting, _, _):
             assertionFailure("Please record telemetry for settings using the SettingsTelemetry().changedSetting() method")
 
         // MARK: - QR Codes

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -836,17 +836,7 @@ extension TelemetryWrapper {
             GleanMetrics.TopSites.openInPrivateTab.record()
         // MARK: Preferences
         case (.action, .change, .setting, _, let extras):
-            if let preference = extras?[EventExtraKey.preference.rawValue] as? String,
-                let to = ((extras?[EventExtraKey.preferenceChanged.rawValue]) ?? "undefined") as? String {
-                GleanMetrics.Preferences.changed.record(GleanMetrics.Preferences.ChangedExtra(changedTo: to,
-                                                                                              preference: preference))
-            } else if let preference = extras?[EventExtraKey.preference.rawValue] as? String,
-                        let to = ((extras?[EventExtraKey.preferenceChanged.rawValue]) ?? "undefined") as? Bool {
-                GleanMetrics.Preferences.changed.record(GleanMetrics.Preferences.ChangedExtra(changedTo: to.description,
-                                                                                              preference: preference))
-            } else {
-                recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
-            }
+            assertionFailure("Please record telemetry for settings using the SettingsTelemetry().changedSetting() method")
 
         // MARK: - QR Codes
         case (.action, .scan, .qrCodeText, _, _),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -141,33 +141,6 @@ class TelemetryWrapperTests: XCTestCase {
                               failureMessage: "Sponsored shortcut value not tracked")
     }
 
-    // MARK: - Preferences
-
-    func test_preferencesWithExtras_GleanIsCalled() {
-        let extras: [String: Any] = [
-            ExtraKey.preference.rawValue: "ETP-strength",
-            ExtraKey.preferenceChanged.rawValue: BlockingStrength.strict.rawValue
-        ]
-
-        TelemetryWrapper.recordEvent(
-            category: .action,
-            method: .change,
-            object: .setting,
-            extras: extras
-        )
-
-        testEventMetricRecordingSuccess(metric: GleanMetrics.Preferences.changed)
-    }
-
-    func test_preferencesWithoutExtras_GleanIsNotCalled() {
-        TelemetryWrapper.recordEvent(
-            category: .action,
-            method: .change,
-            object: .setting
-        )
-        XCTAssertNil(GleanMetrics.Preferences.changed.testGetValue())
-    }
-
     // MARK: - Firefox Home Page
 
     func test_recentlySavedBookmarkViewWithExtras_GleanIsCalled() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket FXIOS-12437](https://mozilla-hub.atlassian.net/browse/FXIOS-12437)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27120)

[Jira ticket FXIOS-12468](https://mozilla-hub.atlassian.net/browse/FXIOS-12468)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27178)

## :bulb: Description
This PR prepares to deprecate the `preferences.changed` event by adding a new `settings.changed` event, which will eventually replace it.

For now, `preferences.changed` will shadow `settings.changed` so we collect overlapping data for a while. It will then be expired and removed from the code.

This telemetry used to go through `TelemetryWrapper`. All call sites now instead use `SettingsTelemetry`. An `assertionFailure` was added to where the `TelemetryWrapper` triggered the old `preferences.changed` event to help catch any misuse until the `TelemetryWrapper` can be entirely deleted in the future. This TelemetryWrapper deprecation work is tracked in the FXIOS-12457 epic.

### Recording
The actual data being recorded (and where it is recorded) should not change. But we are now also additionally collecting the _previous_ value when the user changes a setting.

### Testing Note

Unit tests will be added for this event in FXIOS-12467.

We can't add them yet because there is a larger MockGleanWrapper change I would like to implement first in FXIOS-12469 which will touch on many files and I didn't want to pollute the changes in this PR.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
