### PR TITLE
Add FXIOS-26243 [Blueprint Download Manager] Downloads should continue when the app is backgrounded

### DIFF
--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -110,7 +110,7 @@ class SceneDelegate: UIResponder,
         let logUUID = sceneCoordinator?.windowUUID.uuidString ?? "<nil>"
         logger.log("SceneDelegate: scene did enter background. UUID: \(logUUID)", level: .info, category: .lifecycle)
         if let uuid = sceneCoordinator?.windowUUID {
-            downloadQueue.pauseAll(for: uuid)
+//            downloadQueue.pauseAll(for: uuid)
             tabErrorTelemetryHelper.recordTabCountForBackgroundedScene(uuid)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -810,7 +810,8 @@ extension BrowserViewController: WKNavigationDelegate {
 
         // Open our helper and cancel this response from the webview.
         if let downloadViewModel = downloadHelper.downloadViewModel(windowUUID: windowUUID,
-                                                                    okAction: downloadAction) {
+                                                                    okAction: downloadAction,
+                                                                    isPrivate: tabManager.selectedTab?.isPrivate) {
             presentSheetWith(viewModel: downloadViewModel, on: self, from: urlBarView)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
@@ -84,7 +84,7 @@ class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate
     var state: URLSessionTask.State {
         return task?.state ?? .suspended
     }
-    fileprivate(set) var session: URLSession!
+    fileprivate(set) var session: URLSession?
     fileprivate(set) var task: URLSessionDownloadTask?
     fileprivate(set) var cookieStore: WKHTTPCookieStore
 
@@ -154,8 +154,9 @@ class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate
         } else {
             self.hasContentEncoding = false
         }
-
-        self.task = session.downloadTask(with: self.request)
+        guard case self.task = session!.downloadTask(with: self.request) else {
+            return
+        }
     }
 
     override func cancel() {
@@ -171,7 +172,7 @@ class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate
     override func resume() {
         cookieStore.getAllCookies { [self] cookies in
             cookies.forEach { cookie in
-                session.configuration.httpCookieStorage?.setCookie(cookie)
+                session!.configuration.httpCookieStorage?.setCookie(cookie)
             }
 
             guard let resumeData = self.resumeData else {
@@ -179,7 +180,7 @@ class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate
                 return
             }
 
-            self.task = session.downloadTask(withResumeData: resumeData)
+            self.task = session!.downloadTask(withResumeData: resumeData)
             self.task?.resume()
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadHelper.swift
@@ -62,7 +62,8 @@ class DownloadHelper: NSObject {
     }
 
     func downloadViewModel(windowUUID: WindowUUID,
-                           okAction: @escaping (HTTPDownload) -> Void) -> PhotonActionSheetViewModel? {
+                           okAction: @escaping (HTTPDownload) -> Void,
+                           isPrivate: Bool?) -> PhotonActionSheetViewModel? {
         var requestUrl = request.url
         if let url = requestUrl, url.scheme == "blob" {
             requestUrl = url.removeBlobFromUrl()
@@ -73,7 +74,8 @@ class DownloadHelper: NSObject {
         guard let download = HTTPDownload(originWindow: windowUUID,
                                           cookieStore: cookieStore,
                                           preflightResponse: preflightResponse,
-                                          request: request)
+                                          request: request,
+                                          isPrivate: isPrivate)
         else { return nil }
 
         let expectedSize = download.totalBytesExpected != nil ? ByteCountFormatter.string(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I noticed that the dynamic island progress was stuck when the app was backgrounded and I investigated and saw that background downloads are paused. 

My changes below:

- Worked on the allowing background downloads to continue when the app is backgrounded and the download that the user initiated from is a Normal Tab. 
- Continue having downloads paused when the app is in the background and the download the user initiated from is a Private Tab.

Note, for the download to pause for Private Tab, it takes around 5-10 seconds. So downloads will continue for some time after the app has been backgrounded.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
