### PR TITLE
First version of FxScreenGraph refactor

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -664,40 +664,22 @@
 		5F2B55FF2D4CD7FE00A4E2CF /* A11yUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */; };
 		5F7C8A042D09A62A00C9F89D /* A11yOnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */; };
 		5F8779132DE5E40D002DF55C /* FxUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779122DE5E40D002DF55C /* FxUserState.swift */; };
-		5F8779142DE5E40D002DF55C /* FxUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779122DE5E40D002DF55C /* FxUserState.swift */; };
 		5F8779162DE6F60D002DF55C /* NavigationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779152DE6F60D002DF55C /* NavigationRegistry.swift */; };
-		5F8779172DE6F60D002DF55C /* NavigationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779152DE6F60D002DF55C /* NavigationRegistry.swift */; };
 		5F8779192DE6FBD3002DF55C /* registerZoomNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779182DE6FBD3002DF55C /* registerZoomNavigation.swift */; };
-		5F87791A2DE6FBD3002DF55C /* registerZoomNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779182DE6FBD3002DF55C /* registerZoomNavigation.swift */; };
 		5F87791C2DE6FE51002DF55C /* registerToolbarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87791B2DE6FE51002DF55C /* registerToolbarNavigation.swift */; };
-		5F87791D2DE6FE51002DF55C /* registerToolbarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87791B2DE6FE51002DF55C /* registerToolbarNavigation.swift */; };
 		5F87791F2DE70643002DF55C /* registerSettingsNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87791E2DE70643002DF55C /* registerSettingsNavigation.swift */; };
-		5F8779202DE70643002DF55C /* registerSettingsNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87791E2DE70643002DF55C /* registerSettingsNavigation.swift */; };
 		5F8779222DE984BA002DF55C /* registerUrlBarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779212DE984BA002DF55C /* registerUrlBarNavigation.swift */; };
-		5F8779232DE984BA002DF55C /* registerUrlBarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779212DE984BA002DF55C /* registerUrlBarNavigation.swift */; };
 		5F8779252DE98B33002DF55C /* registerLibraryPanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779242DE98B33002DF55C /* registerLibraryPanelNavigation.swift */; };
-		5F8779262DE98B33002DF55C /* registerLibraryPanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779242DE98B33002DF55C /* registerLibraryPanelNavigation.swift */; };
 		5F8779282DE98C84002DF55C /* registerHomePanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779272DE98C84002DF55C /* registerHomePanelNavigation.swift */; };
-		5F8779292DE98C84002DF55C /* registerHomePanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779272DE98C84002DF55C /* registerHomePanelNavigation.swift */; };
 		5F87792B2DE9ABB9002DF55C /* registerTabMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87792A2DE9ABB9002DF55C /* registerTabMenuNavigation.swift */; };
-		5F87792C2DE9ABB9002DF55C /* registerTabMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87792A2DE9ABB9002DF55C /* registerTabMenuNavigation.swift */; };
 		5F87792E2DE9ACDE002DF55C /* registerTabTrayNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87792D2DE9ACDE002DF55C /* registerTabTrayNavigation.swift */; };
-		5F87792F2DE9ACDE002DF55C /* registerTabTrayNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87792D2DE9ACDE002DF55C /* registerTabTrayNavigation.swift */; };
 		5F8779312DE9AE7B002DF55C /* registerCommonNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779302DE9AE7B002DF55C /* registerCommonNavigation.swift */; };
-		5F8779322DE9AE7B002DF55C /* registerCommonNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779302DE9AE7B002DF55C /* registerCommonNavigation.swift */; };
 		5F8779342DE9B0B8002DF55C /* registerOnboardingNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779332DE9B0B8002DF55C /* registerOnboardingNavigation.swift */; };
-		5F8779352DE9B0B8002DF55C /* registerOnboardingNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779332DE9B0B8002DF55C /* registerOnboardingNavigation.swift */; };
 		5F8779372DE9FCE7002DF55C /* registerMobileNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779362DE9FCE7002DF55C /* registerMobileNavigation.swift */; };
-		5F8779382DE9FCE7002DF55C /* registerMobileNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779362DE9FCE7002DF55C /* registerMobileNavigation.swift */; };
 		5F87793A2DE9FF69002DF55C /* registerTrackingProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779392DE9FF69002DF55C /* registerTrackingProtection.swift */; };
-		5F87793B2DE9FF69002DF55C /* registerTrackingProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779392DE9FF69002DF55C /* registerTrackingProtection.swift */; };
 		5F87793D2DEDC251002DF55C /* registerContextMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87793C2DEDC251002DF55C /* registerContextMenuNavigation.swift */; };
-		5F87793E2DEDC251002DF55C /* registerContextMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87793C2DEDC251002DF55C /* registerContextMenuNavigation.swift */; };
 		5F8779402DEDC3F8002DF55C /* registerFxAccountNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87793F2DEDC3F8002DF55C /* registerFxAccountNavigation.swift */; };
-		5F8779412DEDC3F8002DF55C /* registerFxAccountNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87793F2DEDC3F8002DF55C /* registerFxAccountNavigation.swift */; };
 		5F8779432DEDC568002DF55C /* registerMiscellanousNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779422DEDC568002DF55C /* registerMiscellanousNavigation.swift */; };
-		5F8779442DEDC568002DF55C /* registerMiscellanousNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779422DEDC568002DF55C /* registerMiscellanousNavigation.swift */; };
-		5F87794A2DF1CCF3002DF55C /* registerMiscellanousActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779492DF1CCF3002DF55C /* registerMiscellanousActions.swift */; };
 		5F87794B2DF1CCF3002DF55C /* registerMiscellanousActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779492DF1CCF3002DF55C /* registerMiscellanousActions.swift */; };
 		5FA2233C27F74071005B3D87 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = 5FA2233B27F74071005B3D87 /* Glean */; };
 		5FACA10C2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 5FACA10B2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan */; };
@@ -7811,24 +7793,6 @@
 		5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A11yUtils.swift; sourceTree = "<group>"; };
 		5F684EB59A149BD03A1E5247 /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A11yOnboardingTests.swift; sourceTree = "<group>"; };
-		5F8779122DE5E40D002DF55C /* FxUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxUserState.swift; sourceTree = "<group>"; };
-		5F8779152DE6F60D002DF55C /* NavigationRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRegistry.swift; sourceTree = "<group>"; };
-		5F8779182DE6FBD3002DF55C /* registerZoomNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerZoomNavigation.swift; sourceTree = "<group>"; };
-		5F87791B2DE6FE51002DF55C /* registerToolbarNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerToolbarNavigation.swift; sourceTree = "<group>"; };
-		5F87791E2DE70643002DF55C /* registerSettingsNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerSettingsNavigation.swift; sourceTree = "<group>"; };
-		5F8779212DE984BA002DF55C /* registerUrlBarNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerUrlBarNavigation.swift; sourceTree = "<group>"; };
-		5F8779242DE98B33002DF55C /* registerLibraryPanelNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerLibraryPanelNavigation.swift; sourceTree = "<group>"; };
-		5F8779272DE98C84002DF55C /* registerHomePanelNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerHomePanelNavigation.swift; sourceTree = "<group>"; };
-		5F87792A2DE9ABB9002DF55C /* registerTabMenuNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerTabMenuNavigation.swift; sourceTree = "<group>"; };
-		5F87792D2DE9ACDE002DF55C /* registerTabTrayNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerTabTrayNavigation.swift; sourceTree = "<group>"; };
-		5F8779302DE9AE7B002DF55C /* registerCommonNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerCommonNavigation.swift; sourceTree = "<group>"; };
-		5F8779332DE9B0B8002DF55C /* registerOnboardingNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerOnboardingNavigation.swift; sourceTree = "<group>"; };
-		5F8779362DE9FCE7002DF55C /* registerMobileNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerMobileNavigation.swift; sourceTree = "<group>"; };
-		5F8779392DE9FF69002DF55C /* registerTrackingProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerTrackingProtection.swift; sourceTree = "<group>"; };
-		5F87793C2DEDC251002DF55C /* registerContextMenuNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerContextMenuNavigation.swift; sourceTree = "<group>"; };
-		5F87793F2DEDC3F8002DF55C /* registerFxAccountNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerFxAccountNavigation.swift; sourceTree = "<group>"; };
-		5F8779422DEDC568002DF55C /* registerMiscellanousNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerMiscellanousNavigation.swift; sourceTree = "<group>"; };
-		5F8779492DF1CCF3002DF55C /* registerMiscellanousActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerMiscellanousActions.swift; sourceTree = "<group>"; };
 		5FACA10B2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = AccessibilityTestPlan.xctestplan; sourceTree = "<group>"; };
 		5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A11ySearchTest.swift; sourceTree = "<group>"; };
 		5FAD4F1A8770848F48AF6023 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Today.strings; sourceTree = "<group>"; };
@@ -11650,24 +11614,6 @@
 				5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */,
 				3BF4B8E81D38497A00493393 /* BaseTestCase.swift */,
 				39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */,
-				5F8779122DE5E40D002DF55C /* FxUserState.swift */,
-				5F8779152DE6F60D002DF55C /* NavigationRegistry.swift */,
-				5F8779182DE6FBD3002DF55C /* registerZoomNavigation.swift */,
-				5F87791B2DE6FE51002DF55C /* registerToolbarNavigation.swift */,
-				5F87791E2DE70643002DF55C /* registerSettingsNavigation.swift */,
-				5F8779212DE984BA002DF55C /* registerUrlBarNavigation.swift */,
-				5F8779242DE98B33002DF55C /* registerLibraryPanelNavigation.swift */,
-				5F8779272DE98C84002DF55C /* registerHomePanelNavigation.swift */,
-				5F87792A2DE9ABB9002DF55C /* registerTabMenuNavigation.swift */,
-				5F87792D2DE9ACDE002DF55C /* registerTabTrayNavigation.swift */,
-				5F8779302DE9AE7B002DF55C /* registerCommonNavigation.swift */,
-				5F8779332DE9B0B8002DF55C /* registerOnboardingNavigation.swift */,
-				5F8779362DE9FCE7002DF55C /* registerMobileNavigation.swift */,
-				5F8779392DE9FF69002DF55C /* registerTrackingProtection.swift */,
-				5F87793C2DEDC251002DF55C /* registerContextMenuNavigation.swift */,
-				5F87793F2DEDC3F8002DF55C /* registerFxAccountNavigation.swift */,
-				5F8779422DEDC568002DF55C /* registerMiscellanousNavigation.swift */,
-				5F8779492DF1CCF3002DF55C /* registerMiscellanousActions.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -17103,48 +17049,31 @@
 				2CCB296720A99C9500121DD8 /* LoginsTests.swift in Sources */,
 				3D9CA9841EF456A8002434DD /* NightModeTests.swift in Sources */,
 				5F2B55FF2D4CD7FE00A4E2CF /* A11yUtils.swift in Sources */,
-				5F8779202DE70643002DF55C /* registerSettingsNavigation.swift in Sources */,
-				5F87794B2DF1CCF3002DF55C /* registerMiscellanousActions.swift in Sources */,
 				39012F281F8ED262002E3D31 /* ScreenGraphTest.swift in Sources */,
 				0B305E1B1E3A98A900BE0767 /* BookmarksTests.swift in Sources */,
 				5FF4AF5C2CC69CC900BABC62 /* TodayWidgetTests.swift in Sources */,
 				B126B8AA2D2FFD93002F4EFC /* ShareMenuTests.swift in Sources */,
-				5F87792C2DE9ABB9002DF55C /* registerTabMenuNavigation.swift in Sources */,
 				D81127D81F84023B0050841D /* PhotonActionSheetTests.swift in Sources */,
 				3BFE4B501D34673D00DDF53F /* ThirdPartySearchTest.swift in Sources */,
-<<<<<<< Updated upstream
-=======
-				8A5BD6032DC27B5000113E94 /* HistoryTabTrayUIExperimentTests.swift in Sources */,
-				5F87791A2DE6FBD3002DF55C /* registerZoomNavigation.swift in Sources */,
->>>>>>> Stashed changes
 				5F7C8A042D09A62A00C9F89D /* A11yOnboardingTests.swift in Sources */,
 				EB3A38A02032673E004C6E67 /* DatabaseFixtureTest.swift in Sources */,
 				EB63CA51228F0539005FD0EF /* DesktopModeTests.swift in Sources */,
 				2CF9D9AA20067FA10083DF2A /* BrowsingPDFTests.swift in Sources */,
 				B1158F2A2B5029F200AC9D70 /* URLValidationTests.swift in Sources */,
 				4FB4AF7526E7E789005FDF91 /* HomeButtonTests.swift in Sources */,
-				5F8779342DE9B0B8002DF55C /* registerOnboardingNavigation.swift in Sources */,
 				B1E156A62CD5080E009DF9E5 /* C_AddressesTests.swift in Sources */,
-				5F87793B2DE9FF69002DF55C /* registerTrackingProtection.swift in Sources */,
 				0BC9C9C41F26F54D000E8AB5 /* SiteLoadTest.swift in Sources */,
 				B12DDFED2A8DE825008CE9CF /* ToolbarMenuTests.swift in Sources */,
 				2C4B6BF320349EB800A009C2 /* OnboardingTests.swift in Sources */,
-				5F8779412DEDC3F8002DF55C /* registerFxAccountNavigation.swift in Sources */,
 				2C4A07DC20246EAD0083E320 /* DragAndDropTests.swift in Sources */,
 				2C2A5EF41E68469500F02659 /* PrivateBrowsingTest.swift in Sources */,
 				D4C35391283500A600F7DC7D /* PerformanceTests.swift in Sources */,
 				B10D0B692D38F00E00925997 /* ShareLongPressTests.swift in Sources */,
-				5F87792E2DE9ACDE002DF55C /* registerTabTrayNavigation.swift in Sources */,
 				2CF449A51E7BFE2C00FD7595 /* NavigationTest.swift in Sources */,
 				2C2A91291FA2410D002E36BD /* HistoryTests.swift in Sources */,
-				5F87793E2DEDC251002DF55C /* registerContextMenuNavigation.swift in Sources */,
 				580B0C4221748CFE00448DF8 /* DataManagementTests.swift in Sources */,
 				5FACA1102D099DCD00B289BC /* A11ySearchTest.swift in Sources */,
 				3BF4B8E91D38497A00493393 /* BaseTestCase.swift in Sources */,
-				5F87791C2DE6FE51002DF55C /* registerToolbarNavigation.swift in Sources */,
-				5F8779222DE984BA002DF55C /* registerUrlBarNavigation.swift in Sources */,
-				5F8779282DE98C84002DF55C /* registerHomePanelNavigation.swift in Sources */,
-				5F8779442DEDC568002DF55C /* registerMiscellanousNavigation.swift in Sources */,
 				3D9CAA1C1EFCD655002434DD /* ClipBoardTests.swift in Sources */,
 				2CB1A65A1FDEA8B60084E96D /* NewTabSettings.swift in Sources */,
 				0B3D670E1E09B90B00C1EFC7 /* AuthenticationTest.swift in Sources */,
@@ -17159,7 +17088,6 @@
 				4F2A06BE26F8E46E0017DA05 /* TabCounterTests.swift in Sources */,
 				E1AF27362A13BDFE00CE5991 /* EngagementNotificationTests.swift in Sources */,
 				78F28FC02CB81FDF00DA862E /* InactiveTabsTest.swift in Sources */,
-				5F8779312DE9AE7B002DF55C /* registerCommonNavigation.swift in Sources */,
 				2C473BD0209778900008C853 /* DownloadsTests.swift in Sources */,
 				8AC976C22DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift in Sources */,
 				39C261CC2018DE21009D97BD /* FxScreenGraphTests.swift in Sources */,
@@ -17169,16 +17097,12 @@
 				5FDE66032D94528A003961DC /* A11ySettingsTests.swift in Sources */,
 				B1F90EC12BB3F6B600A4D431 /* ZoomingTests.swift in Sources */,
 				8AEAD9F92C3DB0CD001A2C5A /* MicrosurveyTests.swift in Sources */,
-				5F8779172DE6F60D002DF55C /* NavigationRegistry.swift in Sources */,
 				E143BF652CE36FFD00A1D2D9 /* A11yTabTrayTests.swift in Sources */,
 				D4AFA84E2AFA5482000BFEAA /* ExperimentIntegrationTests.swift in Sources */,
 				3DEFED081F55EBE300F8620C /* TrackingProtectionTests.swift in Sources */,
-				5F8779132DE5E40D002DF55C /* FxUserState.swift in Sources */,
 				2CEDADA220207EC400223A89 /* SyncFAUITests.swift in Sources */,
-				5F8779372DE9FCE7002DF55C /* registerMobileNavigation.swift in Sources */,
 				C84266772728462900382274 /* AccessibilityIdentifiers.swift in Sources */,
 				0430A545203B372D00FDF76D /* IntegrationTests.swift in Sources */,
-				5F8779262DE98B33002DF55C /* registerLibraryPanelNavigation.swift in Sources */,
 				2C31A8471E8D447F00DAC646 /* HomePageSettingsUITest.swift in Sources */,
 				B1664E9E2B163B7A005D4C71 /* CreditCardsTests.swift in Sources */,
 				2CEA6F791E93E3A600D4100E /* SearchSettingsUITest.swift in Sources */,
@@ -17205,34 +17129,16 @@
 			files = (
 				D4859A7727328569009A2390 /* AccessibilityIdentifiers.swift in Sources */,
 				7BEB64441C7345600092C02E /* L10nSuite2SnapshotTests.swift in Sources */,
-				5F8779252DE98B33002DF55C /* registerLibraryPanelNavigation.swift in Sources */,
-				5F87791D2DE6FE51002DF55C /* registerToolbarNavigation.swift in Sources */,
-				5F87791F2DE70643002DF55C /* registerSettingsNavigation.swift in Sources */,
-				5F8779382DE9FCE7002DF55C /* registerMobileNavigation.swift in Sources */,
-				5F8779142DE5E40D002DF55C /* FxUserState.swift in Sources */,
 				7BEB64451C7345600092C02E /* SnapshotHelper.swift in Sources */,
 				5F2B55FE2D4CD7FE00A4E2CF /* A11yUtils.swift in Sources */,
-				5F87794A2DF1CCF3002DF55C /* registerMiscellanousActions.swift in Sources */,
 				D88C01B722B29EC200936951 /* ScreenGraphTest.swift in Sources */,
-				5F87793D2DEDC251002DF55C /* registerContextMenuNavigation.swift in Sources */,
-				5F8779192DE6FBD3002DF55C /* registerZoomNavigation.swift in Sources */,
-				5F8779402DEDC3F8002DF55C /* registerFxAccountNavigation.swift in Sources */,
 				E40AFC541DD0E93300DA5651 /* L10nPermissionStringsSnapshotTests.swift in Sources */,
 				E40AFC6C1DD128DA00DA5651 /* L10nSuite1SnapshotTests.swift in Sources */,
 				D437C4FD25FF5A3E00316F2C /* L10nMktSuiteSnapshotTests.swift in Sources */,
 				8AC976C32DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift in Sources */,
-				5F8779432DEDC568002DF55C /* registerMiscellanousNavigation.swift in Sources */,
-				5F87792F2DE9ACDE002DF55C /* registerTabTrayNavigation.swift in Sources */,
 				E40AFC651DD0F25500DA5651 /* L10nBaseSnapshotTests.swift in Sources */,
-				5F8779232DE984BA002DF55C /* registerUrlBarNavigation.swift in Sources */,
-				5F8779352DE9B0B8002DF55C /* registerOnboardingNavigation.swift in Sources */,
 				391B4FFF1F9767F50094F841 /* FxScreenGraph.swift in Sources */,
-				5F8779322DE9AE7B002DF55C /* registerCommonNavigation.swift in Sources */,
-				5F8779162DE6F60D002DF55C /* NavigationRegistry.swift in Sources */,
-				5F87793A2DE9FF69002DF55C /* registerTrackingProtection.swift in Sources */,
-				5F8779292DE98C84002DF55C /* registerHomePanelNavigation.swift in Sources */,
 				8A9F0B5727C59E1700FE09AE /* ImageIdentifiers.swift in Sources */,
-				5F87792B2DE9ABB9002DF55C /* registerTabMenuNavigation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -663,6 +663,42 @@
 		5F2B55FE2D4CD7FE00A4E2CF /* A11yUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */; };
 		5F2B55FF2D4CD7FE00A4E2CF /* A11yUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */; };
 		5F7C8A042D09A62A00C9F89D /* A11yOnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */; };
+		5F8779132DE5E40D002DF55C /* FxUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779122DE5E40D002DF55C /* FxUserState.swift */; };
+		5F8779142DE5E40D002DF55C /* FxUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779122DE5E40D002DF55C /* FxUserState.swift */; };
+		5F8779162DE6F60D002DF55C /* NavigationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779152DE6F60D002DF55C /* NavigationRegistry.swift */; };
+		5F8779172DE6F60D002DF55C /* NavigationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779152DE6F60D002DF55C /* NavigationRegistry.swift */; };
+		5F8779192DE6FBD3002DF55C /* registerZoomNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779182DE6FBD3002DF55C /* registerZoomNavigation.swift */; };
+		5F87791A2DE6FBD3002DF55C /* registerZoomNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779182DE6FBD3002DF55C /* registerZoomNavigation.swift */; };
+		5F87791C2DE6FE51002DF55C /* registerToolbarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87791B2DE6FE51002DF55C /* registerToolbarNavigation.swift */; };
+		5F87791D2DE6FE51002DF55C /* registerToolbarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87791B2DE6FE51002DF55C /* registerToolbarNavigation.swift */; };
+		5F87791F2DE70643002DF55C /* registerSettingsNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87791E2DE70643002DF55C /* registerSettingsNavigation.swift */; };
+		5F8779202DE70643002DF55C /* registerSettingsNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87791E2DE70643002DF55C /* registerSettingsNavigation.swift */; };
+		5F8779222DE984BA002DF55C /* registerUrlBarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779212DE984BA002DF55C /* registerUrlBarNavigation.swift */; };
+		5F8779232DE984BA002DF55C /* registerUrlBarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779212DE984BA002DF55C /* registerUrlBarNavigation.swift */; };
+		5F8779252DE98B33002DF55C /* registerLibraryPanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779242DE98B33002DF55C /* registerLibraryPanelNavigation.swift */; };
+		5F8779262DE98B33002DF55C /* registerLibraryPanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779242DE98B33002DF55C /* registerLibraryPanelNavigation.swift */; };
+		5F8779282DE98C84002DF55C /* registerHomePanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779272DE98C84002DF55C /* registerHomePanelNavigation.swift */; };
+		5F8779292DE98C84002DF55C /* registerHomePanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779272DE98C84002DF55C /* registerHomePanelNavigation.swift */; };
+		5F87792B2DE9ABB9002DF55C /* registerTabMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87792A2DE9ABB9002DF55C /* registerTabMenuNavigation.swift */; };
+		5F87792C2DE9ABB9002DF55C /* registerTabMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87792A2DE9ABB9002DF55C /* registerTabMenuNavigation.swift */; };
+		5F87792E2DE9ACDE002DF55C /* registerTabTrayNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87792D2DE9ACDE002DF55C /* registerTabTrayNavigation.swift */; };
+		5F87792F2DE9ACDE002DF55C /* registerTabTrayNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87792D2DE9ACDE002DF55C /* registerTabTrayNavigation.swift */; };
+		5F8779312DE9AE7B002DF55C /* registerCommonNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779302DE9AE7B002DF55C /* registerCommonNavigation.swift */; };
+		5F8779322DE9AE7B002DF55C /* registerCommonNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779302DE9AE7B002DF55C /* registerCommonNavigation.swift */; };
+		5F8779342DE9B0B8002DF55C /* registerOnboardingNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779332DE9B0B8002DF55C /* registerOnboardingNavigation.swift */; };
+		5F8779352DE9B0B8002DF55C /* registerOnboardingNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779332DE9B0B8002DF55C /* registerOnboardingNavigation.swift */; };
+		5F8779372DE9FCE7002DF55C /* registerMobileNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779362DE9FCE7002DF55C /* registerMobileNavigation.swift */; };
+		5F8779382DE9FCE7002DF55C /* registerMobileNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779362DE9FCE7002DF55C /* registerMobileNavigation.swift */; };
+		5F87793A2DE9FF69002DF55C /* registerTrackingProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779392DE9FF69002DF55C /* registerTrackingProtection.swift */; };
+		5F87793B2DE9FF69002DF55C /* registerTrackingProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779392DE9FF69002DF55C /* registerTrackingProtection.swift */; };
+		5F87793D2DEDC251002DF55C /* registerContextMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87793C2DEDC251002DF55C /* registerContextMenuNavigation.swift */; };
+		5F87793E2DEDC251002DF55C /* registerContextMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87793C2DEDC251002DF55C /* registerContextMenuNavigation.swift */; };
+		5F8779402DEDC3F8002DF55C /* registerFxAccountNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87793F2DEDC3F8002DF55C /* registerFxAccountNavigation.swift */; };
+		5F8779412DEDC3F8002DF55C /* registerFxAccountNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87793F2DEDC3F8002DF55C /* registerFxAccountNavigation.swift */; };
+		5F8779432DEDC568002DF55C /* registerMiscellanousNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779422DEDC568002DF55C /* registerMiscellanousNavigation.swift */; };
+		5F8779442DEDC568002DF55C /* registerMiscellanousNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779422DEDC568002DF55C /* registerMiscellanousNavigation.swift */; };
+		5F87794A2DF1CCF3002DF55C /* registerMiscellanousActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779492DF1CCF3002DF55C /* registerMiscellanousActions.swift */; };
+		5F87794B2DF1CCF3002DF55C /* registerMiscellanousActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779492DF1CCF3002DF55C /* registerMiscellanousActions.swift */; };
 		5FA2233C27F74071005B3D87 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = 5FA2233B27F74071005B3D87 /* Glean */; };
 		5FACA10C2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 5FACA10B2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan */; };
 		5FACA1102D099DCD00B289BC /* A11ySearchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */; };
@@ -7775,6 +7811,24 @@
 		5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A11yUtils.swift; sourceTree = "<group>"; };
 		5F684EB59A149BD03A1E5247 /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A11yOnboardingTests.swift; sourceTree = "<group>"; };
+		5F8779122DE5E40D002DF55C /* FxUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxUserState.swift; sourceTree = "<group>"; };
+		5F8779152DE6F60D002DF55C /* NavigationRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRegistry.swift; sourceTree = "<group>"; };
+		5F8779182DE6FBD3002DF55C /* registerZoomNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerZoomNavigation.swift; sourceTree = "<group>"; };
+		5F87791B2DE6FE51002DF55C /* registerToolbarNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerToolbarNavigation.swift; sourceTree = "<group>"; };
+		5F87791E2DE70643002DF55C /* registerSettingsNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerSettingsNavigation.swift; sourceTree = "<group>"; };
+		5F8779212DE984BA002DF55C /* registerUrlBarNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerUrlBarNavigation.swift; sourceTree = "<group>"; };
+		5F8779242DE98B33002DF55C /* registerLibraryPanelNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerLibraryPanelNavigation.swift; sourceTree = "<group>"; };
+		5F8779272DE98C84002DF55C /* registerHomePanelNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerHomePanelNavigation.swift; sourceTree = "<group>"; };
+		5F87792A2DE9ABB9002DF55C /* registerTabMenuNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerTabMenuNavigation.swift; sourceTree = "<group>"; };
+		5F87792D2DE9ACDE002DF55C /* registerTabTrayNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerTabTrayNavigation.swift; sourceTree = "<group>"; };
+		5F8779302DE9AE7B002DF55C /* registerCommonNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerCommonNavigation.swift; sourceTree = "<group>"; };
+		5F8779332DE9B0B8002DF55C /* registerOnboardingNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerOnboardingNavigation.swift; sourceTree = "<group>"; };
+		5F8779362DE9FCE7002DF55C /* registerMobileNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerMobileNavigation.swift; sourceTree = "<group>"; };
+		5F8779392DE9FF69002DF55C /* registerTrackingProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerTrackingProtection.swift; sourceTree = "<group>"; };
+		5F87793C2DEDC251002DF55C /* registerContextMenuNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerContextMenuNavigation.swift; sourceTree = "<group>"; };
+		5F87793F2DEDC3F8002DF55C /* registerFxAccountNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerFxAccountNavigation.swift; sourceTree = "<group>"; };
+		5F8779422DEDC568002DF55C /* registerMiscellanousNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerMiscellanousNavigation.swift; sourceTree = "<group>"; };
+		5F8779492DF1CCF3002DF55C /* registerMiscellanousActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerMiscellanousActions.swift; sourceTree = "<group>"; };
 		5FACA10B2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = AccessibilityTestPlan.xctestplan; sourceTree = "<group>"; };
 		5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A11ySearchTest.swift; sourceTree = "<group>"; };
 		5FAD4F1A8770848F48AF6023 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Today.strings; sourceTree = "<group>"; };
@@ -11596,6 +11650,24 @@
 				5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */,
 				3BF4B8E81D38497A00493393 /* BaseTestCase.swift */,
 				39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */,
+				5F8779122DE5E40D002DF55C /* FxUserState.swift */,
+				5F8779152DE6F60D002DF55C /* NavigationRegistry.swift */,
+				5F8779182DE6FBD3002DF55C /* registerZoomNavigation.swift */,
+				5F87791B2DE6FE51002DF55C /* registerToolbarNavigation.swift */,
+				5F87791E2DE70643002DF55C /* registerSettingsNavigation.swift */,
+				5F8779212DE984BA002DF55C /* registerUrlBarNavigation.swift */,
+				5F8779242DE98B33002DF55C /* registerLibraryPanelNavigation.swift */,
+				5F8779272DE98C84002DF55C /* registerHomePanelNavigation.swift */,
+				5F87792A2DE9ABB9002DF55C /* registerTabMenuNavigation.swift */,
+				5F87792D2DE9ACDE002DF55C /* registerTabTrayNavigation.swift */,
+				5F8779302DE9AE7B002DF55C /* registerCommonNavigation.swift */,
+				5F8779332DE9B0B8002DF55C /* registerOnboardingNavigation.swift */,
+				5F8779362DE9FCE7002DF55C /* registerMobileNavigation.swift */,
+				5F8779392DE9FF69002DF55C /* registerTrackingProtection.swift */,
+				5F87793C2DEDC251002DF55C /* registerContextMenuNavigation.swift */,
+				5F87793F2DEDC3F8002DF55C /* registerFxAccountNavigation.swift */,
+				5F8779422DEDC568002DF55C /* registerMiscellanousNavigation.swift */,
+				5F8779492DF1CCF3002DF55C /* registerMiscellanousActions.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -17031,31 +17103,48 @@
 				2CCB296720A99C9500121DD8 /* LoginsTests.swift in Sources */,
 				3D9CA9841EF456A8002434DD /* NightModeTests.swift in Sources */,
 				5F2B55FF2D4CD7FE00A4E2CF /* A11yUtils.swift in Sources */,
+				5F8779202DE70643002DF55C /* registerSettingsNavigation.swift in Sources */,
+				5F87794B2DF1CCF3002DF55C /* registerMiscellanousActions.swift in Sources */,
 				39012F281F8ED262002E3D31 /* ScreenGraphTest.swift in Sources */,
 				0B305E1B1E3A98A900BE0767 /* BookmarksTests.swift in Sources */,
 				5FF4AF5C2CC69CC900BABC62 /* TodayWidgetTests.swift in Sources */,
 				B126B8AA2D2FFD93002F4EFC /* ShareMenuTests.swift in Sources */,
+				5F87792C2DE9ABB9002DF55C /* registerTabMenuNavigation.swift in Sources */,
 				D81127D81F84023B0050841D /* PhotonActionSheetTests.swift in Sources */,
 				3BFE4B501D34673D00DDF53F /* ThirdPartySearchTest.swift in Sources */,
+<<<<<<< Updated upstream
+=======
+				8A5BD6032DC27B5000113E94 /* HistoryTabTrayUIExperimentTests.swift in Sources */,
+				5F87791A2DE6FBD3002DF55C /* registerZoomNavigation.swift in Sources */,
+>>>>>>> Stashed changes
 				5F7C8A042D09A62A00C9F89D /* A11yOnboardingTests.swift in Sources */,
 				EB3A38A02032673E004C6E67 /* DatabaseFixtureTest.swift in Sources */,
 				EB63CA51228F0539005FD0EF /* DesktopModeTests.swift in Sources */,
 				2CF9D9AA20067FA10083DF2A /* BrowsingPDFTests.swift in Sources */,
 				B1158F2A2B5029F200AC9D70 /* URLValidationTests.swift in Sources */,
 				4FB4AF7526E7E789005FDF91 /* HomeButtonTests.swift in Sources */,
+				5F8779342DE9B0B8002DF55C /* registerOnboardingNavigation.swift in Sources */,
 				B1E156A62CD5080E009DF9E5 /* C_AddressesTests.swift in Sources */,
+				5F87793B2DE9FF69002DF55C /* registerTrackingProtection.swift in Sources */,
 				0BC9C9C41F26F54D000E8AB5 /* SiteLoadTest.swift in Sources */,
 				B12DDFED2A8DE825008CE9CF /* ToolbarMenuTests.swift in Sources */,
 				2C4B6BF320349EB800A009C2 /* OnboardingTests.swift in Sources */,
+				5F8779412DEDC3F8002DF55C /* registerFxAccountNavigation.swift in Sources */,
 				2C4A07DC20246EAD0083E320 /* DragAndDropTests.swift in Sources */,
 				2C2A5EF41E68469500F02659 /* PrivateBrowsingTest.swift in Sources */,
 				D4C35391283500A600F7DC7D /* PerformanceTests.swift in Sources */,
 				B10D0B692D38F00E00925997 /* ShareLongPressTests.swift in Sources */,
+				5F87792E2DE9ACDE002DF55C /* registerTabTrayNavigation.swift in Sources */,
 				2CF449A51E7BFE2C00FD7595 /* NavigationTest.swift in Sources */,
 				2C2A91291FA2410D002E36BD /* HistoryTests.swift in Sources */,
+				5F87793E2DEDC251002DF55C /* registerContextMenuNavigation.swift in Sources */,
 				580B0C4221748CFE00448DF8 /* DataManagementTests.swift in Sources */,
 				5FACA1102D099DCD00B289BC /* A11ySearchTest.swift in Sources */,
 				3BF4B8E91D38497A00493393 /* BaseTestCase.swift in Sources */,
+				5F87791C2DE6FE51002DF55C /* registerToolbarNavigation.swift in Sources */,
+				5F8779222DE984BA002DF55C /* registerUrlBarNavigation.swift in Sources */,
+				5F8779282DE98C84002DF55C /* registerHomePanelNavigation.swift in Sources */,
+				5F8779442DEDC568002DF55C /* registerMiscellanousNavigation.swift in Sources */,
 				3D9CAA1C1EFCD655002434DD /* ClipBoardTests.swift in Sources */,
 				2CB1A65A1FDEA8B60084E96D /* NewTabSettings.swift in Sources */,
 				0B3D670E1E09B90B00C1EFC7 /* AuthenticationTest.swift in Sources */,
@@ -17070,6 +17159,7 @@
 				4F2A06BE26F8E46E0017DA05 /* TabCounterTests.swift in Sources */,
 				E1AF27362A13BDFE00CE5991 /* EngagementNotificationTests.swift in Sources */,
 				78F28FC02CB81FDF00DA862E /* InactiveTabsTest.swift in Sources */,
+				5F8779312DE9AE7B002DF55C /* registerCommonNavigation.swift in Sources */,
 				2C473BD0209778900008C853 /* DownloadsTests.swift in Sources */,
 				8AC976C22DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift in Sources */,
 				39C261CC2018DE21009D97BD /* FxScreenGraphTests.swift in Sources */,
@@ -17079,12 +17169,16 @@
 				5FDE66032D94528A003961DC /* A11ySettingsTests.swift in Sources */,
 				B1F90EC12BB3F6B600A4D431 /* ZoomingTests.swift in Sources */,
 				8AEAD9F92C3DB0CD001A2C5A /* MicrosurveyTests.swift in Sources */,
+				5F8779172DE6F60D002DF55C /* NavigationRegistry.swift in Sources */,
 				E143BF652CE36FFD00A1D2D9 /* A11yTabTrayTests.swift in Sources */,
 				D4AFA84E2AFA5482000BFEAA /* ExperimentIntegrationTests.swift in Sources */,
 				3DEFED081F55EBE300F8620C /* TrackingProtectionTests.swift in Sources */,
+				5F8779132DE5E40D002DF55C /* FxUserState.swift in Sources */,
 				2CEDADA220207EC400223A89 /* SyncFAUITests.swift in Sources */,
+				5F8779372DE9FCE7002DF55C /* registerMobileNavigation.swift in Sources */,
 				C84266772728462900382274 /* AccessibilityIdentifiers.swift in Sources */,
 				0430A545203B372D00FDF76D /* IntegrationTests.swift in Sources */,
+				5F8779262DE98B33002DF55C /* registerLibraryPanelNavigation.swift in Sources */,
 				2C31A8471E8D447F00DAC646 /* HomePageSettingsUITest.swift in Sources */,
 				B1664E9E2B163B7A005D4C71 /* CreditCardsTests.swift in Sources */,
 				2CEA6F791E93E3A600D4100E /* SearchSettingsUITest.swift in Sources */,
@@ -17111,16 +17205,34 @@
 			files = (
 				D4859A7727328569009A2390 /* AccessibilityIdentifiers.swift in Sources */,
 				7BEB64441C7345600092C02E /* L10nSuite2SnapshotTests.swift in Sources */,
+				5F8779252DE98B33002DF55C /* registerLibraryPanelNavigation.swift in Sources */,
+				5F87791D2DE6FE51002DF55C /* registerToolbarNavigation.swift in Sources */,
+				5F87791F2DE70643002DF55C /* registerSettingsNavigation.swift in Sources */,
+				5F8779382DE9FCE7002DF55C /* registerMobileNavigation.swift in Sources */,
+				5F8779142DE5E40D002DF55C /* FxUserState.swift in Sources */,
 				7BEB64451C7345600092C02E /* SnapshotHelper.swift in Sources */,
 				5F2B55FE2D4CD7FE00A4E2CF /* A11yUtils.swift in Sources */,
+				5F87794A2DF1CCF3002DF55C /* registerMiscellanousActions.swift in Sources */,
 				D88C01B722B29EC200936951 /* ScreenGraphTest.swift in Sources */,
+				5F87793D2DEDC251002DF55C /* registerContextMenuNavigation.swift in Sources */,
+				5F8779192DE6FBD3002DF55C /* registerZoomNavigation.swift in Sources */,
+				5F8779402DEDC3F8002DF55C /* registerFxAccountNavigation.swift in Sources */,
 				E40AFC541DD0E93300DA5651 /* L10nPermissionStringsSnapshotTests.swift in Sources */,
 				E40AFC6C1DD128DA00DA5651 /* L10nSuite1SnapshotTests.swift in Sources */,
 				D437C4FD25FF5A3E00316F2C /* L10nMktSuiteSnapshotTests.swift in Sources */,
 				8AC976C32DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift in Sources */,
+				5F8779432DEDC568002DF55C /* registerMiscellanousNavigation.swift in Sources */,
+				5F87792F2DE9ACDE002DF55C /* registerTabTrayNavigation.swift in Sources */,
 				E40AFC651DD0F25500DA5651 /* L10nBaseSnapshotTests.swift in Sources */,
+				5F8779232DE984BA002DF55C /* registerUrlBarNavigation.swift in Sources */,
+				5F8779352DE9B0B8002DF55C /* registerOnboardingNavigation.swift in Sources */,
 				391B4FFF1F9767F50094F841 /* FxScreenGraph.swift in Sources */,
+				5F8779322DE9AE7B002DF55C /* registerCommonNavigation.swift in Sources */,
+				5F8779162DE6F60D002DF55C /* NavigationRegistry.swift in Sources */,
+				5F87793A2DE9FF69002DF55C /* registerTrackingProtection.swift in Sources */,
+				5F8779292DE98C84002DF55C /* registerHomePanelNavigation.swift in Sources */,
 				8A9F0B5727C59E1700FE09AE /* ImageIdentifiers.swift in Sources */,
+				5F87792B2DE9ABB9002DF55C /* registerTabMenuNavigation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -662,25 +662,25 @@
 		5F130D2E2483508E00B0F7D0 /* FxAWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F130D2D2483508E00B0F7D0 /* FxAWebViewModel.swift */; };
 		5F2B55FE2D4CD7FE00A4E2CF /* A11yUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */; };
 		5F2B55FF2D4CD7FE00A4E2CF /* A11yUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */; };
+		5F5423DC2DF6E8FA000AA578 /* registerTrackingProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423D92DF6E8FA000AA578 /* registerTrackingProtection.swift */; };
+		5F5423DD2DF6E8FA000AA578 /* registerSettingsNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423D52DF6E8FA000AA578 /* registerSettingsNavigation.swift */; };
+		5F5423DE2DF6E8FA000AA578 /* registerLibraryPanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423D02DF6E8FA000AA578 /* registerLibraryPanelNavigation.swift */; };
+		5F5423DF2DF6E8FA000AA578 /* registerMiscellanousNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423D22DF6E8FA000AA578 /* registerMiscellanousNavigation.swift */; };
+		5F5423E02DF6E8FA000AA578 /* registerCommonNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423CC2DF6E8FA000AA578 /* registerCommonNavigation.swift */; };
+		5F5423E12DF6E8FA000AA578 /* NavigationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423CB2DF6E8FA000AA578 /* NavigationRegistry.swift */; };
+		5F5423E22DF6E8FA000AA578 /* registerOnboardingNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423D42DF6E8FA000AA578 /* registerOnboardingNavigation.swift */; };
+		5F5423E32DF6E8FA000AA578 /* registerTabTrayNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423D72DF6E8FA000AA578 /* registerTabTrayNavigation.swift */; };
+		5F5423E42DF6E8FA000AA578 /* registerToolbarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423D82DF6E8FA000AA578 /* registerToolbarNavigation.swift */; };
+		5F5423E52DF6E8FA000AA578 /* registerContextMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423CD2DF6E8FA000AA578 /* registerContextMenuNavigation.swift */; };
+		5F5423E62DF6E8FA000AA578 /* registerHomePanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423CF2DF6E8FA000AA578 /* registerHomePanelNavigation.swift */; };
+		5F5423E72DF6E8FA000AA578 /* registerMobileNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423D32DF6E8FA000AA578 /* registerMobileNavigation.swift */; };
+		5F5423E82DF6E8FA000AA578 /* registerFxAccountNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423CE2DF6E8FA000AA578 /* registerFxAccountNavigation.swift */; };
+		5F5423E92DF6E8FA000AA578 /* registerUrlBarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423DA2DF6E8FA000AA578 /* registerUrlBarNavigation.swift */; };
+		5F5423EA2DF6E8FA000AA578 /* registerZoomNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423DB2DF6E8FA000AA578 /* registerZoomNavigation.swift */; };
+		5F5423EB2DF6E8FA000AA578 /* registerMiscellanousActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423D12DF6E8FA000AA578 /* registerMiscellanousActions.swift */; };
+		5F5423EC2DF6E8FA000AA578 /* FxUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423CA2DF6E8FA000AA578 /* FxUserState.swift */; };
+		5F5423ED2DF6E8FA000AA578 /* registerTabMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5423D62DF6E8FA000AA578 /* registerTabMenuNavigation.swift */; };
 		5F7C8A042D09A62A00C9F89D /* A11yOnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */; };
-		5F8779132DE5E40D002DF55C /* FxUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779122DE5E40D002DF55C /* FxUserState.swift */; };
-		5F8779162DE6F60D002DF55C /* NavigationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779152DE6F60D002DF55C /* NavigationRegistry.swift */; };
-		5F8779192DE6FBD3002DF55C /* registerZoomNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779182DE6FBD3002DF55C /* registerZoomNavigation.swift */; };
-		5F87791C2DE6FE51002DF55C /* registerToolbarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87791B2DE6FE51002DF55C /* registerToolbarNavigation.swift */; };
-		5F87791F2DE70643002DF55C /* registerSettingsNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87791E2DE70643002DF55C /* registerSettingsNavigation.swift */; };
-		5F8779222DE984BA002DF55C /* registerUrlBarNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779212DE984BA002DF55C /* registerUrlBarNavigation.swift */; };
-		5F8779252DE98B33002DF55C /* registerLibraryPanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779242DE98B33002DF55C /* registerLibraryPanelNavigation.swift */; };
-		5F8779282DE98C84002DF55C /* registerHomePanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779272DE98C84002DF55C /* registerHomePanelNavigation.swift */; };
-		5F87792B2DE9ABB9002DF55C /* registerTabMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87792A2DE9ABB9002DF55C /* registerTabMenuNavigation.swift */; };
-		5F87792E2DE9ACDE002DF55C /* registerTabTrayNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87792D2DE9ACDE002DF55C /* registerTabTrayNavigation.swift */; };
-		5F8779312DE9AE7B002DF55C /* registerCommonNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779302DE9AE7B002DF55C /* registerCommonNavigation.swift */; };
-		5F8779342DE9B0B8002DF55C /* registerOnboardingNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779332DE9B0B8002DF55C /* registerOnboardingNavigation.swift */; };
-		5F8779372DE9FCE7002DF55C /* registerMobileNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779362DE9FCE7002DF55C /* registerMobileNavigation.swift */; };
-		5F87793A2DE9FF69002DF55C /* registerTrackingProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779392DE9FF69002DF55C /* registerTrackingProtection.swift */; };
-		5F87793D2DEDC251002DF55C /* registerContextMenuNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87793C2DEDC251002DF55C /* registerContextMenuNavigation.swift */; };
-		5F8779402DEDC3F8002DF55C /* registerFxAccountNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F87793F2DEDC3F8002DF55C /* registerFxAccountNavigation.swift */; };
-		5F8779432DEDC568002DF55C /* registerMiscellanousNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779422DEDC568002DF55C /* registerMiscellanousNavigation.swift */; };
-		5F87794B2DF1CCF3002DF55C /* registerMiscellanousActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8779492DF1CCF3002DF55C /* registerMiscellanousActions.swift */; };
 		5FA2233C27F74071005B3D87 /* Glean in Frameworks */ = {isa = PBXBuildFile; productRef = 5FA2233B27F74071005B3D87 /* Glean */; };
 		5FACA10C2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 5FACA10B2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan */; };
 		5FACA1102D099DCD00B289BC /* A11ySearchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */; };
@@ -7791,6 +7791,24 @@
 		5F130D2D2483508E00B0F7D0 /* FxAWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAWebViewModel.swift; sourceTree = "<group>"; };
 		5F194C3596E08BAB72BC6879 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A11yUtils.swift; sourceTree = "<group>"; };
+		5F5423CA2DF6E8FA000AA578 /* FxUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxUserState.swift; sourceTree = "<group>"; };
+		5F5423CB2DF6E8FA000AA578 /* NavigationRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRegistry.swift; sourceTree = "<group>"; };
+		5F5423CC2DF6E8FA000AA578 /* registerCommonNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerCommonNavigation.swift; sourceTree = "<group>"; };
+		5F5423CD2DF6E8FA000AA578 /* registerContextMenuNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerContextMenuNavigation.swift; sourceTree = "<group>"; };
+		5F5423CE2DF6E8FA000AA578 /* registerFxAccountNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerFxAccountNavigation.swift; sourceTree = "<group>"; };
+		5F5423CF2DF6E8FA000AA578 /* registerHomePanelNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerHomePanelNavigation.swift; sourceTree = "<group>"; };
+		5F5423D02DF6E8FA000AA578 /* registerLibraryPanelNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerLibraryPanelNavigation.swift; sourceTree = "<group>"; };
+		5F5423D12DF6E8FA000AA578 /* registerMiscellanousActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerMiscellanousActions.swift; sourceTree = "<group>"; };
+		5F5423D22DF6E8FA000AA578 /* registerMiscellanousNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerMiscellanousNavigation.swift; sourceTree = "<group>"; };
+		5F5423D32DF6E8FA000AA578 /* registerMobileNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerMobileNavigation.swift; sourceTree = "<group>"; };
+		5F5423D42DF6E8FA000AA578 /* registerOnboardingNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerOnboardingNavigation.swift; sourceTree = "<group>"; };
+		5F5423D52DF6E8FA000AA578 /* registerSettingsNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerSettingsNavigation.swift; sourceTree = "<group>"; };
+		5F5423D62DF6E8FA000AA578 /* registerTabMenuNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerTabMenuNavigation.swift; sourceTree = "<group>"; };
+		5F5423D72DF6E8FA000AA578 /* registerTabTrayNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerTabTrayNavigation.swift; sourceTree = "<group>"; };
+		5F5423D82DF6E8FA000AA578 /* registerToolbarNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerToolbarNavigation.swift; sourceTree = "<group>"; };
+		5F5423D92DF6E8FA000AA578 /* registerTrackingProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerTrackingProtection.swift; sourceTree = "<group>"; };
+		5F5423DA2DF6E8FA000AA578 /* registerUrlBarNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerUrlBarNavigation.swift; sourceTree = "<group>"; };
+		5F5423DB2DF6E8FA000AA578 /* registerZoomNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerZoomNavigation.swift; sourceTree = "<group>"; };
 		5F684EB59A149BD03A1E5247 /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A11yOnboardingTests.swift; sourceTree = "<group>"; };
 		5FACA10B2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = AccessibilityTestPlan.xctestplan; sourceTree = "<group>"; };
@@ -11610,6 +11628,24 @@
 		3BF4B8DA1D38493300493393 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				5F5423CA2DF6E8FA000AA578 /* FxUserState.swift */,
+				5F5423CB2DF6E8FA000AA578 /* NavigationRegistry.swift */,
+				5F5423CC2DF6E8FA000AA578 /* registerCommonNavigation.swift */,
+				5F5423CD2DF6E8FA000AA578 /* registerContextMenuNavigation.swift */,
+				5F5423CE2DF6E8FA000AA578 /* registerFxAccountNavigation.swift */,
+				5F5423CF2DF6E8FA000AA578 /* registerHomePanelNavigation.swift */,
+				5F5423D02DF6E8FA000AA578 /* registerLibraryPanelNavigation.swift */,
+				5F5423D12DF6E8FA000AA578 /* registerMiscellanousActions.swift */,
+				5F5423D22DF6E8FA000AA578 /* registerMiscellanousNavigation.swift */,
+				5F5423D32DF6E8FA000AA578 /* registerMobileNavigation.swift */,
+				5F5423D42DF6E8FA000AA578 /* registerOnboardingNavigation.swift */,
+				5F5423D52DF6E8FA000AA578 /* registerSettingsNavigation.swift */,
+				5F5423D62DF6E8FA000AA578 /* registerTabMenuNavigation.swift */,
+				5F5423D72DF6E8FA000AA578 /* registerTabTrayNavigation.swift */,
+				5F5423D82DF6E8FA000AA578 /* registerToolbarNavigation.swift */,
+				5F5423D92DF6E8FA000AA578 /* registerTrackingProtection.swift */,
+				5F5423DA2DF6E8FA000AA578 /* registerUrlBarNavigation.swift */,
+				5F5423DB2DF6E8FA000AA578 /* registerZoomNavigation.swift */,
 				8AC976C12DBFED8C00C4E298 /* FeatureFlaggedTestBase.swift */,
 				5F2B55FD2D4CD7F000A4E2CF /* A11yUtils.swift */,
 				3BF4B8E81D38497A00493393 /* BaseTestCase.swift */,
@@ -17098,6 +17134,24 @@
 				B1F90EC12BB3F6B600A4D431 /* ZoomingTests.swift in Sources */,
 				8AEAD9F92C3DB0CD001A2C5A /* MicrosurveyTests.swift in Sources */,
 				E143BF652CE36FFD00A1D2D9 /* A11yTabTrayTests.swift in Sources */,
+				5F5423DC2DF6E8FA000AA578 /* registerTrackingProtection.swift in Sources */,
+				5F5423DD2DF6E8FA000AA578 /* registerSettingsNavigation.swift in Sources */,
+				5F5423DE2DF6E8FA000AA578 /* registerLibraryPanelNavigation.swift in Sources */,
+				5F5423DF2DF6E8FA000AA578 /* registerMiscellanousNavigation.swift in Sources */,
+				5F5423E02DF6E8FA000AA578 /* registerCommonNavigation.swift in Sources */,
+				5F5423E12DF6E8FA000AA578 /* NavigationRegistry.swift in Sources */,
+				5F5423E22DF6E8FA000AA578 /* registerOnboardingNavigation.swift in Sources */,
+				5F5423E32DF6E8FA000AA578 /* registerTabTrayNavigation.swift in Sources */,
+				5F5423E42DF6E8FA000AA578 /* registerToolbarNavigation.swift in Sources */,
+				5F5423E52DF6E8FA000AA578 /* registerContextMenuNavigation.swift in Sources */,
+				5F5423E62DF6E8FA000AA578 /* registerHomePanelNavigation.swift in Sources */,
+				5F5423E72DF6E8FA000AA578 /* registerMobileNavigation.swift in Sources */,
+				5F5423E82DF6E8FA000AA578 /* registerFxAccountNavigation.swift in Sources */,
+				5F5423E92DF6E8FA000AA578 /* registerUrlBarNavigation.swift in Sources */,
+				5F5423EA2DF6E8FA000AA578 /* registerZoomNavigation.swift in Sources */,
+				5F5423EB2DF6E8FA000AA578 /* registerMiscellanousActions.swift in Sources */,
+				5F5423EC2DF6E8FA000AA578 /* FxUserState.swift in Sources */,
+				5F5423ED2DF6E8FA000AA578 /* registerTabMenuNavigation.swift in Sources */,
 				D4AFA84E2AFA5482000BFEAA /* ExperimentIntegrationTests.swift in Sources */,
 				3DEFED081F55EBE300F8620C /* TrackingProtectionTests.swift in Sources */,
 				2CEDADA220207EC400223A89 /* SyncFAUITests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
@@ -14,6 +14,12 @@ let testBLOBFileSize = "35 bytes"
 
 class DownloadsTests: BaseTestCase {
     override func tearDown() {
+        defer { super.tearDown() }
+
+            guard let navigator = navigator else {
+                print("⚠️ Navigator is nil in tearDown — skipping cleanup.")
+                return
+            }
         // The downloaded file has to be removed between tests
         app.terminate()
         app.launch()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -9,6 +9,28 @@ import Foundation
 import MappaMundi
 import XCTest
 
+
+func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScreenGraph<FxUserState> {
+    let map = MMScreenGraph(for: test, with: FxUserState.self)
+
+    NavigationRegistry.registerAll(in: map, app: app)
+
+    [WebImageContextMenu, WebLinkContextMenu].forEach { item in
+        map.addScreenState(item) { screenState in
+            screenState.dismissOnUse = true
+            screenState.backAction = {
+                let window = XCUIApplication().windows.element(boundBy: 0)
+                window.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
+            }
+        }
+    }
+    
+    return map
+}
+
+
+// MARK: - State Constants
+
 let FirstRun = "OptionalFirstRun"
 let TabTray = "TabTray"
 let PrivateTabTray = "PrivateTabTray"
@@ -64,14 +86,29 @@ let AddressesSettings = "AutofillAddress"
 let ToolsBrowserTabMenu = "ToolsBrowserTabMenu"
 let SaveBrowserTabMenu = "SaveBrowserTabMenu"
 let BrowsingSettings = "BrowsingSettings"
-let AutofillPasswordSettings = "AutofillsPasswordsSettings"
+let AutofillPasswordSettings = "AutofillPasswordSettings"
 let Shortcuts = "Shortcuts"
 let AutoplaySettings = "AutoplaySettings"
 
-// These are in the exact order they appear in the settings
-// screen. XCUIApplication loses them on small screens.
-// This list should only be for settings screens that can be navigated to
-// without changing userState. i.e. don't need conditional edges to be available
+let HistoryPanelContextMenu = "HistoryPanelContextMenu"
+let TopSitesPanelContextMenu = "TopSitesPanelContextMenu"
+
+let BasicAuthDialog = "BasicAuthDialog"
+let BookmarksPanelContextMenu = "BookmarksPanelContextMenu"
+
+let Intro_Welcome = "Intro.Welcome"
+let Intro_Sync = "Intro.Sync"
+
+let allIntroPages = [Intro_Welcome, Intro_Sync]
+
+let HomePanelsScreen = "HomePanels"
+let PrivateHomePanelsScreen = "PrivateHomePanels"
+let HomePanel_TopSites = "HomePanel.TopSites.0"
+let LibraryPanel_Bookmarks = "LibraryPanel.Bookmarks.1"
+let LibraryPanel_History = "LibraryPanel.History.2"
+let LibraryPanel_ReadingList = "LibraryPanel.ReadingList.3"
+let LibraryPanel_Downloads = "LibraryPanel.Downloads.4"
+
 let allSettingsScreens = [
     SearchSettings,
     AddCustomSearchSettings,
@@ -83,28 +120,6 @@ let allSettingsScreens = [
     NotificationsSettings
 ]
 
-let HistoryPanelContextMenu = "HistoryPanelContextMenu"
-let TopSitesPanelContextMenu = "TopSitesPanelContextMenu"
-
-let BasicAuthDialog = "BasicAuthDialog"
-let BookmarksPanelContextMenu = "BookmarksPanelContextMenu"
-
-let Intro_Welcome = "Intro.Welcome"
-let Intro_Sync = "Intro.Sync"
-
-let allIntroPages = [
-    Intro_Welcome,
-    Intro_Sync
-]
-
-let HomePanelsScreen = "HomePanels"
-let PrivateHomePanelsScreen = "PrivateHomePanels"
-let HomePanel_TopSites = "HomePanel.TopSites.0"
-let LibraryPanel_Bookmarks = "LibraryPanel.Bookmarks.1"
-let LibraryPanel_History = "LibraryPanel.History.2"
-let LibraryPanel_ReadingList = "LibraryPanel.ReadingList.3"
-let LibraryPanel_Downloads = "LibraryPanel.Downloads.4"
-
 let allHomePanels = [
     LibraryPanel_Bookmarks,
     LibraryPanel_History,
@@ -114,6 +129,28 @@ let allHomePanels = [
 
 let iOS_Settings = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
 let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+
+func navigationControllerBackAction(for app: XCUIApplication) ->  () -> Void {
+    return {
+        app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).waitAndTap()
+    }
+}
+
+func cancelBackAction(for app: XCUIApplication) ->  () -> Void {
+    return {
+        app.otherElements["PopoverDismissRegion"].waitAndTap()
+    }
+}
+
+func dismissContextMenuAction(app: XCUIApplication) ->  () -> Void {
+    return {
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.25)).tap()
+    }
+}
+
+func select(rows: Int, in app: XCUIApplication) {
+    app.staticTexts[String(rows)].firstMatch.waitAndTap()
+}
 
 class Action {
     static let LoadURL = "LoadURL"
@@ -236,46 +273,10 @@ class Action {
     static let SelectShortcuts = "TopSitesSettings"
 }
 
-@objcMembers
-class FxUserState: MMUserState {
-    required init() {
-        super.init()
-        initialScreenState = FirstRun
-    }
-
-    var isPrivate = false
-    var showIntro = false
-    var showWhatsNew = false
-    var waitForLoading = true
-    var url: String?
-    var requestDesktopSite = false
-
-    var noImageMode = false
-    var nightMode = false
-
-    var pocketInNewTab = false
-    var bookmarksInNewTab = true
-    var historyInNewTab = true
-
-    var fxaUsername: String?
-    var fxaPassword: String?
-
-    var numTabs: Int = 0
-
-    var numTopSitesRows: Int = 2
-
-    var trackingProtectionPerTabEnabled = true // TP can be shut off on a per-tab basis
-    var trackingProtectionSettingOnNormalMode = true
-    var trackingProtectionSettingOnPrivateMode = true
-
-    var localeIsExpectedDifferent = false
-}
-
 private let defaultURL = "https://www.mozilla.org/en-US/book/"
 
-func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScreenGraph<FxUserState> {
-    let map = MMScreenGraph(for: test, with: FxUserState.self)
 
+<<<<<<< Updated upstream
     let navigationControllerBackAction = {
         app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).waitAndTap()
     }
@@ -1257,6 +1258,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     return map
 }
+=======
+>>>>>>> Stashed changes
 
 extension MMNavigator where T == FxUserState {
     func openURL(_ urlString: String, waitForLoading: Bool = true) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxUserState.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxUserState.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import MappaMundi
+
+@objcMembers
+class FxUserState: MMUserState {
+    required init() {
+        super.init()
+        initialScreenState = FirstRun
+    }
+    var currentScreen: String = FirstRun
+
+    var isPrivate = false
+    var showIntro = false
+    var showWhatsNew = false
+    var waitForLoading = true
+    var url: String?
+    var requestDesktopSite = false
+
+    var noImageMode = false
+    var nightMode = false
+
+    var pocketInNewTab = false
+    var bookmarksInNewTab = true
+    var historyInNewTab = true
+
+    var fxaUsername: String?
+    var fxaPassword: String?
+
+    var numTabs = 0
+    var numTopSitesRows = 2
+
+    var trackingProtectionPerTabEnabled = true
+    var trackingProtectionSettingOnNormalMode = true
+    var trackingProtectionSettingOnPrivateMode = true
+
+    var localeIsExpectedDifferent = false
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationRegistry.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationRegistry.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+enum NavigationRegistry {
+    static func registerAll(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+        registerZoomNavigation(in: map, app: app)
+        registerToolBarNavigation(in: map, app: app)
+        registerSettingsNavigation(in: map, app: app)
+        registerUrlBarNavigation(in: map, app: app)
+        registerLibraryPanelNavigation(in: map, app: app)
+        registerHomePanelNavigation(in: map, app: app)
+        registerTabMenuNavigation(in: map, app: app)
+        registerTabTrayNavigation(in: map, app: app)
+        registerCommonNavigation(in: map, app: app)
+        registerOnboardingNavigation(in: map, app: app)
+        registerMobileNavigation(in: map, app: app)
+        registerTrackingProtection(in: map, app: app)
+        registerContextMenuNavigation(in: map, app: app)
+        registerFxAccountNavigation(in: map, app: app)
+        registerMiscellanousNavigation(in: map, app: app)
+        registerMiscellanousActions(in: map)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerCommonNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerCommonNavigation.swift
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+func registerCommonNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(WebPageLoading) { screenState in
+        screenState.dismissOnUse = true
+
+        // Would like to use app.otherElements.deviceStatusBars.networkLoadingIndicators.element
+        // but this means exposing some of SnapshotHelper to another target.
+        /*if !(app.progressIndicators.element(boundBy: 0).exists) {
+            screenState.onEnterWaitFor(
+                "exists != true",
+                element: app.progressIndicators.element(boundBy: 0),
+                if: "waitForLoading == true"
+            )
+        } else {
+            screenState.onEnterWaitFor(
+                element: app.progressIndicators.element(boundBy: 0),
+                if: "waitForLoading == false"
+            )
+        }*/
+
+        screenState.noop(to: BrowserTab, if: "waitForLoading == true")
+        screenState.noop(to: BasicAuthDialog, if: "waitForLoading == false")
+    }
+
+    map.addScreenState(BasicAuthDialog) { screenState in
+        screenState.onEnterWaitFor(element: app.alerts.element(boundBy: 0))
+        screenState.backAction = {
+            app.alerts.element(boundBy: 0).buttons.element(boundBy: 0).waitAndTap()
+        }
+        screenState.dismissOnUse = true
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerContextMenuNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerContextMenuNavigation.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+func registerContextMenuNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(HistoryPanelContextMenu) { screenState in
+        screenState.dismissOnUse = true
+    }
+
+    map.addScreenState(BookmarksPanelContextMenu) { screenState in
+        screenState.dismissOnUse = true
+    }
+    map.addScreenState(TopSitesPanelContextMenu) { screenState in
+        screenState.dismissOnUse = true
+        screenState.backAction = dismissContextMenuAction(app: app)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerFxAccountNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerFxAccountNavigation.swift
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+func registerFxAccountNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(Intro_FxASignin) { screenState in
+        screenState.tap(
+            app.buttons["EmailSignIn.button"],
+            forAction: Action.OpenEmailToSignIn,
+            transitionTo: FxASigninScreen
+        )
+        screenState.tap(
+            app.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.qrButton],
+            forAction: Action.OpenEmailToQR,
+            transitionTo: Intro_FxASignin
+        )
+
+        screenState.tap(app.navigationBars.buttons.element(boundBy: 0), to: SettingsScreen)
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(FxAccountManagementPage) { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(FxCreateAccount) { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(FxASigninScreen) { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+
+        screenState.gesture(forAction: Action.FxATypeEmail) { userState in
+            if #available(iOS 17, *) {
+                app.webViews.textFields.firstMatch.tapAndTypeText(userState.fxaUsername!)
+            } else {
+                app.staticTexts[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField]
+                    .waitAndTap()
+                app.typeText(userState.fxaUsername!)
+            }
+        }
+        screenState.gesture(forAction: Action.FxATypePasswordNewAccount) { userState in
+            app.secureTextFields.element(boundBy: 1).tapAndTypeText(userState.fxaPassword!)
+        }
+        screenState.gesture(forAction: Action.FxATypePasswordExistingAccount) { userState in
+            app.secureTextFields.element(boundBy: 0).tapAndTypeText(userState.fxaPassword!)
+        }
+        screenState.gesture(forAction: Action.FxATapOnContinueButton) { userState in
+            app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton].waitAndTap()
+        }
+        screenState.gesture(forAction: Action.FxATapOnSignInButton) { userState in
+            app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.signInButton].waitAndTap()
+        }
+        screenState.tap(app.webViews.links["Create an account"].firstMatch, to: FxCreateAccount)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerHomePanelNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerHomePanelNavigation.swift
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+func registerHomePanelNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(HomePanel_TopSites) { screenState in
+        let topSites = app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
+        screenState.press(
+            topSites.cells.matching(
+                identifier: AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell
+            ).element(boundBy: 0),
+            to: TopSitesPanelContextMenu
+        )
+    }
+
+    map.addScreenState(HomePanelsScreen) { screenState in
+        if isTablet {
+            screenState.tap(
+                app.buttons[AccessibilityIdentifiers.Browser.TopTabs.privateModeButton],
+                forAction: Action.TogglePrivateModeFromTabBarHomePanel
+            ) { userState in
+                userState.isPrivate = !userState.isPrivate
+            }
+        }
+
+        // Workaround to bug Bug 1417522
+        if isTablet {
+            screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], to: TabTray)
+        } else {
+            screenState.gesture(to: TabTray) {
+                app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].waitAndTap()
+            }
+        }
+
+        screenState.gesture(forAction: Action.CloseURLBarOpen, transitionTo: HomePanelsScreen) {_ in
+            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
+        }
+    }
+
+    map.addScreenState(HomeSettings) { screenState in
+        screenState.gesture(forAction: Action.SelectHomeAsFirefoxHomePage) { UserState in
+            app.cells["HomeAsFirefoxHome"].waitAndTap()
+        }
+
+        screenState.gesture(forAction: Action.SelectHomeAsCustomURL) { UserState in
+            app.cells["HomeAsCustomURL"].waitAndTap()
+        }
+
+        screenState.gesture(forAction: Action.TogglePocketInNewTab) { userState in
+            userState.pocketInNewTab = !userState.pocketInNewTab
+            app.tables.cells.switches["Thought-Provoking Stories, Articles powered by Pocket"].waitAndTap()
+        }
+
+        screenState.gesture(forAction: Action.SelectTopSitesRows) { userState in
+            app.tables.cells["TopSitesRows"].waitAndTap()
+            select(rows: userState.numTopSitesRows, in: app)
+            app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).waitAndTap()
+        }
+
+        screenState.gesture(forAction: Action.ToggleRecentlySaved) { userState in
+            app.tables.cells.switches["Bookmarks"].waitAndTap()
+        }
+
+        screenState.gesture(forAction: Action.SelectShortcuts) { userState in
+            let topSitesSetting = AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.settingsPage
+            app.tables.cells[topSitesSetting].waitAndTap()
+        }
+
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(HomePanel_Library) { screenState in
+        let librarySegmentControl = app.segmentedControls["librarySegmentControl"]
+        screenState.dismissOnUse = true
+        screenState.backAction = navigationControllerBackAction(for: app)
+
+        screenState.tap(
+            librarySegmentControl.buttons.element(boundBy: 0),
+            to: LibraryPanel_Bookmarks
+        )
+        screenState.tap(
+            librarySegmentControl.buttons.element(boundBy: 1),
+            to: LibraryPanel_History
+        )
+        screenState.tap(
+            librarySegmentControl.buttons.element(boundBy: 2),
+            to: LibraryPanel_Downloads
+        )
+        screenState.tap(
+            librarySegmentControl.buttons.element(boundBy: 3),
+            to: LibraryPanel_ReadingList
+        )
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerLibraryPanelNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerLibraryPanelNavigation.swift
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+func registerLibraryPanelNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    let doneButton = app.buttons["Done"]
+
+    map.addScreenState(LibraryPanel_ReadingList) { screenState in
+        screenState.dismissOnUse = true
+        screenState.gesture(forAction: Action.CloseReadingListPanel, transitionTo: HomePanelsScreen) { userState in
+            doneButton.waitAndTap()
+        }
+    }
+
+    map.addScreenState(LibraryPanel_Downloads) { screenState in
+        let readingListButton = app.buttons["readingListLarge"]
+
+        screenState.dismissOnUse = true
+        screenState.gesture(forAction: Action.CloseDownloadsPanel, transitionTo: HomePanelsScreen) { userState in
+            doneButton.waitAndTap()
+        }
+        screenState.tap(readingListButton, to: LibraryPanel_ReadingList)
+    }
+
+    map.addScreenState(LibraryPanel_History) { screenState in
+        screenState.press(
+            app.tables[AccessibilityIdentifiers.LibraryPanels.HistoryPanel.tableView].cells.element(boundBy: 2),
+            to: HistoryPanelContextMenu
+        )
+        screenState.tap(
+            app.cells[AccessibilityIdentifiers.LibraryPanels.HistoryPanel.recentlyClosedCell],
+            to: HistoryRecentlyClosed
+        )
+        screenState.gesture(forAction: Action.ClearRecentHistory) { userState in
+            app.toolbars.matching(identifier: "Toolbar").buttons["historyBottomDeleteButton"].waitAndTap()
+        }
+        screenState.gesture(forAction: Action.CloseHistoryListPanel, transitionTo: HomePanelsScreen) { userState in
+            doneButton.waitAndTap()
+        }
+    }
+
+    map.addScreenState(LibraryPanel_Bookmarks) { screenState in
+        let mobileBookmarksCell = app.cells.staticTexts["Mobile Bookmarks"]
+        let bookmarksTable = app.tables["Bookmarks List"]
+
+        screenState.tap(mobileBookmarksCell, to: MobileBookmarks)
+        screenState.gesture(forAction: Action.CloseBookmarkPanel, transitionTo: HomePanelsScreen) { userState in
+            doneButton.waitAndTap()
+        }
+
+        screenState.press(bookmarksTable.cells.element(boundBy: 4), to: BookmarksPanelContextMenu)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerMiscellanousActions.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerMiscellanousActions.swift
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+func registerMiscellanousActions(in map: MMScreenGraph<FxUserState>) {
+    // URLBarOpen is dismissOnUse, which ScreenGraph interprets as "now we've done this action,
+    // then go back to the one before it" but SetURL is an action than keeps us in URLBarOpen.
+    // So let's put it here.
+    map.addScreenAction(Action.SetURL, transitionTo: URLBarOpen)
+
+    // LoadURL points to WebPageLoading, which allows us to add additional
+    // onEntryWaitFor requirements, which we don't need when we're returning to BrowserTab without
+    // loading a webpage.
+    // We do end up at WebPageLoading however, so should lead quickly back to BrowserTab.
+    map.addScreenAction(Action.LoadURL, transitionTo: WebPageLoading)
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerMiscellanousNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerMiscellanousNavigation.swift
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+func registerMiscellanousNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(Shortcuts) { screenState in
+        let homePage = AccessibilityIdentifiers.Settings.Homepage.homePageNavigationBar
+        screenState.tap(app.navigationBars.buttons[homePage], to: HomeSettings)
+    }
+
+    map.addScreenState(FindInPage) { screenState in
+        screenState.tap(app.buttons[AccessibilityIdentifiers.FindInPage.findInPageCloseButton], to: BrowserTab)
+    }
+
+    map.addScreenState(PageZoom) { screenState in
+        screenState.tap(app.buttons[AccessibilityIdentifiers.ZoomPageBar.doneButton], to: BrowserTab)
+    }
+
+    map.addScreenState(ReloadLongPressMenu) { screenState in
+        screenState.backAction = cancelBackAction(for: app)
+        screenState.dismissOnUse = true
+
+        let rdsButton = app.tables["Context Menu"].cells.element(boundBy: 0)
+        screenState.tap(rdsButton, forAction: Action.ToggleRequestDesktopSite) { userState in
+            userState.requestDesktopSite = !userState.requestDesktopSite
+        }
+
+        let trackingProtectionButton = app.tables["Context Menu"].cells.element(boundBy: 1)
+
+        screenState.tap(
+            trackingProtectionButton,
+            forAction: Action.ToggleTrackingProtectionPerTabEnabled
+        ) { userState in
+            userState.trackingProtectionPerTabEnabled = !userState.trackingProtectionPerTabEnabled
+        }
+    }
+
+    map.addScreenState(EnterNewBookmarkTitleAndUrl) { screenState in
+        screenState.gesture(forAction: Action.SaveCreatedBookmark) { userState in
+            app.buttons["Save"].waitAndTap()
+        }
+    }
+
+    map.addScreenState(HistoryRecentlyClosed) { screenState in
+        screenState.dismissOnUse = true
+        screenState.tap(app.buttons["libraryPanelTopLeftButton"].firstMatch, to: LibraryPanel_History)
+    }
+
+    /*map.addScreenState("AutofillAddress") { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }*/
+
+    map.addScreenState(AddressesSettings ) { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(RequestDesktopSite) { _ in }
+
+    map.addScreenState(RequestMobileSite) { _ in }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerMobileNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerMobileNavigation.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+func registerMobileNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(MobileBookmarks) { screenState in
+        let bookmarksMenuNavigationBar = app.navigationBars["Mobile Bookmarks"]
+        let bookmarksButton = bookmarksMenuNavigationBar.buttons["Bookmarks"]
+        screenState.gesture(
+            forAction: Action.ExitMobileBookmarksFolder,
+            transitionTo: LibraryPanel_Bookmarks
+        ) { userState in
+                bookmarksButton.waitAndTap()
+        }
+        screenState.tap(app.buttons["Edit"], to: MobileBookmarksEdit)
+    }
+
+    map.addScreenState(MobileBookmarksEdit) { screenState in
+        screenState.tap(app.buttons["libraryPanelBottomLeftButton"], to: MobileBookmarksAdd)
+        screenState.gesture(forAction: Action.RemoveItemMobileBookmarks) { userState in
+            app.tables["Bookmarks List"].buttons.element(boundBy: 0).waitAndTap()
+        }
+        screenState.gesture(forAction: Action.ConfirmRemoveItemMobileBookmarks) { userState in
+            app.buttons["Delete"].waitAndTap()
+        }
+    }
+
+    map.addScreenState(MobileBookmarksAdd) { screenState in
+        screenState.gesture(forAction: Action.AddNewBookmark, transitionTo: EnterNewBookmarkTitleAndUrl) { userState in
+            app.otherElements["New Bookmark"].waitAndTap()
+        }
+        screenState.gesture(forAction: Action.AddNewFolder) { userState in
+            app.otherElements["New Folder"].waitAndTap()
+        }
+        screenState.gesture(forAction: Action.AddNewSeparator) { userState in
+            app.otherElements["New Separator"].waitAndTap()
+        }
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerOnboardingNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerOnboardingNavigation.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MappaMundi
+import XCTest
+
+func registerOnboardingNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(FirstRun) { screenState in
+        screenState.noop(to: BrowserTab, if: "showIntro == false && showWhatsNew == true")
+        screenState.noop(to: NewTabScreen, if: "showIntro == false && showWhatsNew == false")
+        screenState.noop(to: allIntroPages[0], if: "showIntro == true")
+    }
+
+    // Add the intro screens.
+    var i = 0
+    let introLast = allIntroPages.count - 1
+    for intro in allIntroPages {
+        _ = i == 0 ? nil : allIntroPages[i - 1]
+        let next = i == introLast ? nil : allIntroPages[i + 1]
+
+        map.addScreenState(intro) { screenState in
+            if let next = next {
+                screenState.tap(app.buttons["nextOnboardingButton"], to: next)
+            } else {
+                let startBrowsingButton = app.buttons["startBrowsingOnboardingButton"]
+                screenState.tap(startBrowsingButton, to: BrowserTab)
+            }
+        }
+
+        i += 1
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerSettingsNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerSettingsNavigation.swift
@@ -1,0 +1,224 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+// swiftlint:disable all
+import XCTest
+import MappaMundi
+
+func registerSettingsNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+
+    let table = app.tables.element(boundBy: 0)
+
+    map.addScreenState(SettingsScreen) { screenState in
+        screenState.tap(table.cells["Sync"], to: SyncSettings, if: "fxaUsername != nil")
+        screenState.tap(table.cells["SignInToSync"], to: Intro_FxASignin, if: "fxaUsername == nil")
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Search.searchNavigationBar], to: SearchSettings)
+        screenState.tap(table.cells["NewTab"], to: NewTabSettings)
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Homepage.homeSettings], to: HomeSettings)
+        screenState.tap(table.cells["Tabs"], to: TabsSettings)
+        screenState.tap(table.cells["DisplayThemeOption"], to: DisplaySettings)
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting], to: ToolbarSettings)
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Browsing.title], to: BrowsingSettings)
+        screenState.tap(table.cells["SiriSettings"], to: SiriSettings)
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.AutofillsPasswords.title], to: AutofillPasswordSettings)
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.ClearData.title], to: ClearPrivateDataSettings)
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.ContentBlocker.title],
+            to: TrackingProtectionSettings
+        )
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.ShowIntroduction.title],
+                        to: ShowTourInSettings)
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Notifications.title],
+                        to: NotificationsSettings)
+        screenState.gesture(forAction: Action.ToggleNoImageMode) { userState in
+            app.otherElements.tables.cells.switches[
+                AccessibilityIdentifiers.Settings.BlockImages.title].waitAndTap()
+        }
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(AutofillPasswordSettings) { screenState in
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Logins.title], to: LoginsSettings)
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.CreditCards.title], to: CreditCardsSettings)
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Address.title], to: AddressesSettings)
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(SearchSettings) { screenState in
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.Search.customEngineViewButton],
+            to: AddCustomSearchSettings
+        )
+        screenState.backAction = navigationControllerBackAction(for: app)
+        screenState.gesture(forAction: Action.RemoveCustomSearchEngine) {userSTate in
+            // Screengraph will go back to main Settings screen. Manually tap on settings
+            app.navigationBars[AccessibilityIdentifiers.Settings.Search.searchNavigationBar].buttons["Edit"].waitAndTap()
+            if #unavailable(iOS 17) {
+                app.tables.buttons["Delete Mozilla Engine"].waitAndTap()
+            } else {
+                app.tables.buttons[AccessibilityIdentifiers.Settings.Search.deleteMozillaEngine].waitAndTap()
+            }
+            app.tables.buttons[AccessibilityIdentifiers.Settings.Search.deleteButton].waitAndTap()
+        }
+    }
+
+    map.addScreenState(BrowsingSettings) { screenState in
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Browsing.autoPlay], to: AutoplaySettings)
+        screenState.tap(table.cells["OpenWith.Setting"], to: MailAppSettings)
+
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(LoginsSettings) {
+        screenState in screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(CreditCardsSettings) { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(AddressesSettings) { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(AutoplaySettings) { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(NotificationsSettings) { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(SiriSettings) { screenState in
+        screenState.gesture(forAction: Action.OpenSiriFromSettings) { userState in
+            // Tap on Open New Tab to open Siri
+            app.cells["SiriSettings"].staticTexts.element(boundBy: 0).waitAndTap()
+        }
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(SyncSettings) { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(DisplaySettings) { screenState in
+        screenState.gesture(forAction: Action.SelectAutomatically) { userState in
+            app.cells.staticTexts["Automatically"].waitAndTap()
+        }
+        screenState.gesture(forAction: Action.SelectManually) { userState in
+            app.cells.staticTexts["Manually"].waitAndTap()
+        }
+        screenState.gesture(forAction: Action.SystemThemeSwitch) { userState in
+            app.switches["SystemThemeSwitchValue"].waitAndTap()
+        }
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(ClearPrivateDataSettings) { screenState in
+        screenState.tap(
+            app.cells[AccessibilityIdentifiers.Settings.ClearData.websiteDataSection],
+            to: WebsiteDataSettings
+        )
+        screenState.gesture(forAction: Action.AcceptClearPrivateData) { userState in
+            app.tables.cells["ClearPrivateData"].waitAndTap()
+            app.alerts.buttons["OK"].waitAndTap()
+        }
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(MailAppSettings) { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(ShowTourInSettings) { screenState in
+        screenState.gesture(to: Intro_FxASignin) {
+            let turnOnSyncButton = app.buttons["signInOnboardingButton"]
+            turnOnSyncButton.waitAndTap()
+        }
+    }
+
+    map.addScreenState(TrackingProtectionSettings) { screenState in
+        screenState.backAction = navigationControllerBackAction(for: app)
+
+        screenState.tap(
+            app.switches["prefkey.trackingprotection.normalbrowsing"],
+            forAction: Action.SwitchETP
+        ) { userState in
+            userState.trackingProtectionSettingOnNormalMode = !userState.trackingProtectionSettingOnNormalMode
+        }
+
+        screenState.tap(
+            app.cells["Settings.TrackingProtectionOption.BlockListStrict"],
+            forAction: Action.EnableStrictMode
+        ) { userState in
+                userState.trackingProtectionPerTabEnabled = !userState.trackingProtectionPerTabEnabled
+        }
+    }
+
+    map.addScreenState(AddCustomSearchSettings) { screenState in
+        screenState.gesture(forAction: Action.AddCustomSearchEngine) { userState in
+            app.tables.textViews["customEngineTitle"].staticTexts["Search Engine"].waitAndTap()
+            app.typeText("Mozilla Engine")
+            app.tables.textViews["customEngineUrl"].waitAndTap()
+
+            let searchEngineUrl = "https://developer.mozilla.org/search?q=%s"
+            let tablesQuery = app.tables
+            let customengineurlTextView = tablesQuery.textViews["customEngineUrl"]
+            sleep(1)
+            UIPasteboard.general.string = searchEngineUrl
+            customengineurlTextView.press(forDuration: 1.0)
+            app.staticTexts["Paste"].waitAndTap()
+        }
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(TabsSettings) { screenState in
+        screenState.tap(app.switches.element(boundBy: 0), forAction: Action.ToggleInactiveTabs)
+        screenState.tap(app.switches.element(boundBy: 1), forAction: Action.ToggleTabGroups)
+        screenState.tap(app.navigationBars.buttons["Settings"], to: SettingsScreen)
+    }
+
+    map.addScreenState(NewTabSettings) { screenState in
+        screenState.gesture(forAction: Action.SelectNewTabAsBlankPage) { UserState in
+            table.cells["NewTabAsBlankPage"].waitAndTap()
+        }
+        screenState.gesture(forAction: Action.SelectNewTabAsFirefoxHomePage) { UserState in
+            table.cells["NewTabAsFirefoxHome"].waitAndTap()
+        }
+        screenState.gesture(forAction: Action.SelectNewTabAsCustomURL) { UserState in
+            table.cells["NewTabAsCustomURL"].waitAndTap()
+        }
+
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(WebsiteDataSettings) { screenState in
+        screenState.gesture(forAction: Action.AcceptClearAllWebsiteData) { userState in
+            app.tables.cells["ClearAllWebsiteData"].staticTexts["Clear All Website Data"].waitAndTap()
+            app.alerts.buttons["OK"].waitAndTap()
+        }
+        // The swipeDown() is a workaround for an intermittent issue that the search filed is not always in view.
+        screenState.gesture(forAction: Action.TapOnFilterWebsites) { userState in
+            app.searchFields["Filter Sites"].waitAndTap()
+        }
+        screenState.gesture(forAction: Action.ShowMoreWebsiteDataEntries) { userState in
+            app.tables.cells["ShowMoreWebsiteData"].waitAndTap()
+        }
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(ToolbarSettings) { screenState in
+        screenState.gesture(forAction: Action.SelectToolbarBottom) { UserState in
+            app.cells[AccessibilityIdentifiers.Settings.SearchBar.bottomSetting].waitAndTap()
+        }
+
+        screenState.gesture(forAction: Action.SelectToolbarTop) { UserState in
+            app.cells[AccessibilityIdentifiers.Settings.SearchBar.topSetting].waitAndTap()
+        }
+
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+}
+
+// swiftlint:enable all

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabMenuNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabMenuNavigation.swift
@@ -1,0 +1,119 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+func registerTabMenuNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(ToolsBrowserTabMenu) { screenState in
+        // Zoom
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.zoom],
+            to: PageZoom)
+        // Turn on night mode
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.nightMode],
+            forAction: Action.ToggleNightMode,
+            transitionTo: BrowserTab
+        ) { userState in
+            userState.nightMode = !userState.nightMode
+        }
+        // Report broken site (TODO)
+        // Share
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.share],
+            forAction: Action.ShareBrowserTabMenuOption
+        ) { userState in
+        }
+
+        screenState.dismissOnUse = true
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(SaveBrowserTabMenu) { screenState in
+        // Bookmark this page
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.bookmarkThisPage],
+            forAction: Action.BookmarkThreeDots
+        )
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.bookmarkThisPage],
+            forAction: Action.Bookmark
+        )
+        // Add to shortcuts
+        // No Copy link available (Action.CopyAddressPAM)
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.addToShortcuts],
+            forAction: Action.PinToTopSitesPAM
+        )
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.saveToReadingList],
+            forAction: Action.AddToReadingListBrowserTabMenu
+        )
+
+        screenState.dismissOnUse = true
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
+
+    map.addScreenState(BrowserTabMenu) { screenState in
+        sleep(1)
+
+        // Sign In (if unauthenticated)
+        screenState.tap(
+            app.buttons[AccessibilityIdentifiers.MainMenu.HeaderView.mainButton],
+            to: Intro_FxASignin,
+            if: "fxaUsername == nil")
+        // Signed in (TODO)
+        // New tab
+        screenState.tap(app.tables.cells[AccessibilityIdentifiers.MainMenu.newTab], to: NewTabScreen)
+        // New private tab (TODO: Action.OpenPrivateTabLongPressTabsButton
+        // Switch to Desktop/Mobile Site
+        // The cell's identifier is the same for desktop and mobile, so I use static
+        // texts for the RequestMobileSite case
+        screenState.tap(app.tables.cells[AccessibilityIdentifiers.MainMenu.switchToDesktopSite], to: RequestDesktopSite)
+        screenState.tap(app.tables.cells.staticTexts["Switch to Mobile Site"], to: RequestMobileSite)
+        // Find in Page...
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.findInPage],
+            to: FindInPage)
+        // Tools (Zoom, NightMode, Report, Share)
+        screenState.tap(app.tables.cells[AccessibilityIdentifiers.MainMenu.tools], to: ToolsBrowserTabMenu)
+        // Save (Add Bookmark, Shortcut)
+        screenState.tap(app.tables.cells[AccessibilityIdentifiers.MainMenu.save], to: SaveBrowserTabMenu)
+        // Bookmarks
+        screenState.tap(app.tables.cells[AccessibilityIdentifiers.MainMenu.bookmarks], to: LibraryPanel_Bookmarks)
+        // History
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.history],
+            to: LibraryPanel_History)
+        // Downloads
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.downloads],
+            to: LibraryPanel_Downloads
+        )
+        // Passwords (TODO)
+        // Customize Homepage (TODO)
+        // New in Firefox
+        screenState.tap(
+            app.otherElements.cells["MainMenu.WhatsNew"],
+            forAction: Action.OpenWhatsNewPage
+        )
+        // Get Help (TODO: Actions to open support.mozilla.org)
+        // SettingsScreen
+        screenState.tap(app.tables.cells[AccessibilityIdentifiers.MainMenu.settings], to: SettingsScreen)
+
+        // "x" for close the menu and go back
+        screenState.dismissOnUse = true
+        screenState.backAction = cancelBackAction(for: app)
+    }
+
+    map.addScreenState(CloseTabMenu) { screenState in
+        screenState.tap(
+            app.scrollViews.buttons[AccessibilityIdentifiers.TabTray.deleteCloseAllButton],
+            forAction: Action.AcceptRemovingAllTabs,
+            transitionTo: HomePanelsScreen
+        )
+        screenState.backAction = cancelBackAction(for: app)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabTrayNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabTrayNavigation.swift
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+import Common
+
+func registerTabTrayNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    // This menu is only available for iPhone, NOT for iPad, no menu when long tapping on tabs button
+    if !isTablet {
+        map.addScreenState(TabTrayLongPressMenu) { screenState in
+            screenState.dismissOnUse = true
+
+            let plusButton = app.buttons[StandardImageIdentifiers.Large.plus]
+            let closeButton = app.buttons[StandardImageIdentifiers.Large.cross]
+            let privateTabButton = app.tables.cells.buttons[StandardImageIdentifiers.Large.tab]
+
+            screenState.tap(
+                plusButton,
+                forAction: Action.OpenNewTabLongPressTabsButton,
+                transitionTo: NewTabScreen
+            )
+            screenState.tap(
+                closeButton,
+                forAction: Action.CloseTabFromTabTrayLongPressMenu,
+                Action.CloseTab,
+                transitionTo: HomePanelsScreen
+            )
+            screenState.tap(
+                privateTabButton,
+                forAction: Action.OpenPrivateTabLongPressTabsButton,
+                transitionTo: NewTabScreen
+            ) { userState in
+                userState.isPrivate = !userState.isPrivate
+            }
+        }
+    }
+
+    // swiftlint:disable closure_body_length
+    map.addScreenState(TabTray) { screenState in
+        let newTabButton = app.buttons[AccessibilityIdentifiers.TabTray.newTabButton]
+        let closeAllTabsButton = app.navigationBars.buttons["closeAllTabsButtonTabTray"]
+
+        // Both iPad and iPhone use the same accessibility identifiers for buttons,
+        // even thought they may be in separate locations design wise.
+        screenState.tap(newTabButton,
+                        forAction: Action.OpenNewTabFromTabTray,
+                        transitionTo: NewTabScreen)
+        if isTablet {
+            screenState.tap(closeAllTabsButton, to: CloseTabMenu)
+        } else {
+            screenState.tap(closeAllTabsButton, to: CloseTabMenu)
+        }
+
+        var regularModeSelector: XCUIElement
+        var privateModeSelector: XCUIElement
+        var syncModeSelector: XCUIElement
+
+        var regularModeExperimentSelector: XCUIElement
+        var privateModeExperimentSelector: XCUIElement
+        var syncModeExperimentSelector: XCUIElement
+
+        if isTablet {
+            regularModeSelector = app.navigationBars.segmentedControls.buttons.element(boundBy: 0)
+            privateModeSelector = app.navigationBars.segmentedControls.buttons.element(boundBy: 1)
+            syncModeSelector = app.navigationBars.segmentedControls.buttons.element(boundBy: 2)
+            regularModeExperimentSelector = regularModeSelector
+            privateModeExperimentSelector = privateModeSelector
+            syncModeExperimentSelector = syncModeSelector
+        } else {
+            regularModeSelector = app.toolbars["Toolbar"]
+                .segmentedControls[AccessibilityIdentifiers.TabTray.navBarSegmentedControl].buttons.element(boundBy: 0)
+            privateModeSelector = app.toolbars["Toolbar"]
+                .segmentedControls[AccessibilityIdentifiers.TabTray.navBarSegmentedControl].buttons.element(boundBy: 1)
+            syncModeSelector = app.toolbars["Toolbar"]
+                .segmentedControls[AccessibilityIdentifiers.TabTray.navBarSegmentedControl].buttons.element(boundBy: 2)
+
+            regularModeExperimentSelector = app.buttons["\(AccessibilityIdentifiers.TabTray.selectorCell)\(1)"]
+            privateModeExperimentSelector = app.buttons["\(AccessibilityIdentifiers.TabTray.selectorCell)\(0)"]
+            syncModeExperimentSelector = app.buttons["\(AccessibilityIdentifiers.TabTray.selectorCell)\(2)"]
+        }
+        screenState.tap(regularModeSelector, forAction: Action.ToggleRegularMode) { userState in
+            userState.isPrivate = !userState.isPrivate
+        }
+        screenState.tap(privateModeSelector, forAction: Action.TogglePrivateMode) { userState in
+            userState.isPrivate = !userState.isPrivate
+        }
+        screenState.tap(syncModeSelector, forAction: Action.ToggleSyncMode) { userState in
+        }
+
+        // Tab tray selector for the tab tray UI experiment
+        screenState.tap(regularModeExperimentSelector, forAction: Action.ToggleExperimentRegularMode) { userState in
+            userState.isPrivate = !userState.isPrivate
+        }
+        screenState.tap(privateModeExperimentSelector, forAction: Action.ToggleExperimentPrivateMode) { userState in
+            userState.isPrivate = !userState.isPrivate
+        }
+        screenState.tap(syncModeExperimentSelector, forAction: Action.ToggleExperimentSyncMode) { userState in
+        }
+
+        screenState.onEnter { userState in
+            let exists = NSPredicate(format: "exists == true")
+            let expectation = XCTNSPredicateExpectation(predicate: exists, object: app.otherElements["Tabs Tray"])
+            let _ = XCTWaiter().wait(for: [expectation], timeout: 5) // swiftlint:disable:this redundant_discardable_let
+            userState.numTabs = Int(app.otherElements["Tabs Tray"].cells.count)
+        }
+    }
+    // swiftlint:enable closure_body_length
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerToolbarNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerToolbarNavigation.swift
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+private func configureURLBarAvailable(_ screenState: MMScreenStateNode<FxUserState>, app: XCUIApplication) {
+    let textField = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
+    screenState.tap(textField, to: URLBarOpen)
+    screenState.gesture(to: URLBarLongPressMenu) {
+        textField.press(forDuration: 1.0)
+    }
+}
+
+private func configureToolBarAvailable(_ screenState: MMScreenStateNode<FxUserState>, app: XCUIApplication) {
+    let settingButton = app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton]
+    let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
+
+    screenState.tap(settingButton, to: BrowserTabMenu)
+
+    if isTablet {
+        screenState.tap(tabsButton, to: TabTray)
+    } else {
+        screenState.gesture(to: TabTray) {
+            tabsButton.waitAndTap()
+        }
+    }
+}
+
+// swiftlint:disable all
+func registerToolBarNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(NewTabScreen) { screenState in
+        screenState.noop(to: HomePanelsScreen)
+        let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
+
+        if isTablet {
+            screenState.tap(tabsButton, to: TabTray)
+        } else {
+            screenState.gesture(to: TabTray) {
+                tabsButton.waitAndTap()
+            }
+        }
+        configureURLBarAvailable(screenState, app: app)
+        screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], to: BrowserTabMenu)
+
+        if isTablet {
+            screenState.tap(
+                app.buttons[AccessibilityIdentifiers.Browser.TopTabs.privateModeButton],
+                forAction: Action.TogglePrivateModeFromTabBarNewTab
+            ) { userState in
+                userState.isPrivate = !userState.isPrivate
+            }
+        }
+    }
+
+    map.addScreenState(BrowserTab) { screenState in
+        configureURLBarAvailable(screenState, app: app)
+
+        screenState.tap(
+            app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton],
+            to: BrowserTabMenu
+        )
+
+        screenState.tap(
+            app.buttons[AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon],
+            to: TrackingProtectionContextMenuDetails
+        )
+
+        if isTablet {
+        screenState.tap(
+            app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton],
+            forAction: Action.GoToHomePage)
+            } else {
+                screenState.tap(
+                    app.buttons[AccessibilityIdentifiers.Toolbar.homeButton],
+                forAction: Action.GoToHomePage)
+            }
+
+        screenState.tap(
+            app.buttons[AccessibilityIdentifiers.Toolbar.searchButton],
+            forAction: Action.ClickSearchButton
+        ) { userState in
+        }
+
+        configureToolBarAvailable(screenState, app: app)
+        // swiftlint:disable unused_closure_parameter
+        let link = app.webViews.element(boundBy: 0).links.element(boundBy: 0)
+        let image = app.webViews.element(boundBy: 0).images.element(boundBy: 0)
+        // swiftlint:enable unused_closure_parameter
+
+        screenState.press(link, to: WebLinkContextMenu)
+        screenState.press(image, to: WebImageContextMenu)
+
+        let reloadButton = app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton]
+        // swiftlint:disable unused_closure_parameter
+        screenState.press(reloadButton, to: ReloadLongPressMenu)
+        screenState.tap(reloadButton, forAction: Action.ReloadURL, transitionTo: WebPageLoading) { _ in }
+        // swiftlint:enable unused_closure_parameter
+
+        let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
+        // For iPad there is no long press on tabs button
+        if !isTablet {
+            screenState.press(tabsButton, to: TabTrayLongPressMenu)
+        }
+
+        if isTablet {
+            screenState.tap(tabsButton, to: TabTray)
+        } else {
+            screenState.gesture(to: TabTray) {
+                tabsButton.waitAndTap()
+            }
+        }
+
+        screenState.tap(
+            app.buttons["TopTabsViewController.privateModeButton"],
+            forAction: Action.TogglePrivateModeFromTabBarBrowserTab
+        ) { userState in
+            userState.isPrivate = !userState.isPrivate
+        }
+    }
+}
+// swiftlint:enable all

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTrackingProtection.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTrackingProtection.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+func registerTrackingProtection(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(TrackingProtectionContextMenuDetails) { screenState in
+        screenState.gesture(forAction: Action.TrackingProtectionperSiteToggle) { userState in
+            app.tables.cells["tp.add-to-safelist"].waitAndTap()
+            userState.trackingProtectionPerTabEnabled = !userState.trackingProtectionPerTabEnabled
+        }
+
+        screenState.gesture(
+            forAction: Action.OpenSettingsFromTPMenu,
+            transitionTo: TrackingProtectionSettings
+        ) { userState in
+            app.cells["settings"].waitAndTap()
+        }
+
+        screenState.gesture(forAction: Action.CloseTPContextMenu) { userState in
+            if isTablet {
+                // There is no Cancel option in iPad.
+                app.otherElements["PopoverDismissRegion"].waitAndTap()
+            } else {
+                app.buttons[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.closeButton].waitAndTap()
+            }
+        }
+
+        screenState.tap(app.buttons["Close privacy and security menu"], to: BrowserTab)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerUrlBarNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerUrlBarNavigation.swift
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MappaMundi
+
+private let defaultURL = "https://www.mozilla.org/en-US/book/"
+
+func registerUrlBarNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(URLBarLongPressMenu) { screenState in
+        let menu = app.tables["Context Menu"].firstMatch
+
+        if #unavailable(iOS 16) {
+            screenState.gesture(forAction: Action.LoadURLByPasting, Action.LoadURL) { userState in
+                UIPasteboard.general.string = userState.url ?? defaultURL
+                menu.otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction].firstMatch.waitAndTap()
+            }
+        }
+
+        screenState.gesture(forAction: Action.SetURLByPasting) { userState in
+            UIPasteboard.general.string = userState.url ?? defaultURL
+            menu.cells[AccessibilityIdentifiers.Photon.pasteAction].firstMatch.waitAndTap()
+        }
+
+        screenState.backAction = {
+            if isTablet {
+                // There is no Cancel option in iPad.
+                app.otherElements["PopoverDismissRegion"].waitAndTap()
+            } else {
+                app.buttons["PhotonMenu.close"].waitAndTap()
+            }
+        }
+        screenState.dismissOnUse = true
+    }
+
+    map.addScreenState(URLBarOpen) { screenState in
+        let urlField = app.textFields.firstMatch
+        // This is used for opening BrowserTab with default mozilla URL
+        // For custom URL, should use Navigator.openNewURL or Navigator.openURL.
+        screenState.gesture(forAction: Action.LoadURLByTyping) { userState in
+            let url = userState.url ?? defaultURL
+            // Workaround BB iOS13 be sure tap happens on url bar
+            urlField.waitAndTap()
+            urlField.waitAndTap()
+            urlField.typeText(url)
+            urlField.typeText("\r")
+        }
+
+        screenState.gesture(forAction: Action.SetURLByTyping, Action.SetURL) { userState in
+            let url = userState.url ?? defaultURL
+            // Workaround BB iOS13 be sure tap happens on url bar
+            sleep(1)
+            urlField.waitAndTap()
+            urlField.waitAndTap()
+            urlField.typeText("\(url)")
+        }
+
+        screenState.noop(to: HomePanelsScreen)
+        screenState.noop(to: HomePanel_TopSites)
+
+        screenState.backAction = {
+            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
+        }
+        screenState.dismissOnUse = true
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerZoomNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerZoomNavigation.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import XCTest
+import MappaMundi
+
+func registerZoomNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
+    map.addScreenState(PageZoom) { screenState in
+        screenState.tap(app.buttons[AccessibilityIdentifiers.ZoomPageBar.doneButton], to: BrowserTab)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4536)

## :bulb: Description
This PR implements the refactor of the FxScreenGraph, splitting the monolithic into several specific navigation files.

## :movie_camera: Demos

![Screenshot 2025-06-09 at 12 04 33](https://github.com/user-attachments/assets/8b7aaa60-d49f-4b0b-96ed-d8324207b007)


## :pencil: Checklist
- [X ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
