### PR TITLE
Bugfix FXIOS-12402 [Homepage Rebuild] investigate top sites crashes

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteConfiguration.swift
@@ -7,7 +7,7 @@ import Storage
 
 /// Top site UI class, used in the homepage top site section
 struct TopSiteConfiguration: Hashable, Equatable, CustomStringConvertible, CustomDebugStringConvertible {
-    var site: Site
+    let site: Site
     var title: String
 
     var sponsoredText: String {
@@ -43,6 +43,10 @@ struct TopSiteConfiguration: Hashable, Equatable, CustomStringConvertible, Custo
 
     var type: SiteType {
         return site.type
+    }
+
+    var shortDomain: String? {
+        return site.url.asURL?.shortDomain
     }
 
     var isGooglePinnedTile: Bool {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
@@ -167,7 +167,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
     private func shouldShowSponsoredSite(with sponsoredSite: Site, and otherSites: [TopSiteConfiguration]) -> Bool {
         let siteDomain = sponsoredSite.url.asURL?.shortDomain
         let sponsoredSiteIsAlreadyPresent = otherSites.contains { (topSite: TopSiteConfiguration) in
-            (topSite.site.url.asURL?.shortDomain == siteDomain) && (topSite.isPinned)
+            (topSite.shortDomain == siteDomain) && (topSite.isPinned)
         }
 
         let shouldAddDefaultEngine = SponsoredTileDataUtility().shouldAdd(
@@ -217,8 +217,8 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
                 return state
             }
 
-            let siteDomain = state.site.url.asURL?.shortDomain
-            let shouldAddSite = !previousStates.contains(where: { $0.site.url.asURL?.shortDomain == siteDomain })
+            let siteDomain = state.shortDomain
+            let shouldAddSite = !previousStates.contains(where: { $0.shortDomain == siteDomain })
 
             // If shouldAddSite or site domain was not found, then insert the site
             guard shouldAddSite || siteDomain == nil else { return nil }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -17,11 +17,6 @@ final class TopSitesMiddleware: FeatureFlaggable {
     private let logger: Logger
     private let profile: Profile
 
-    // Raw data to build top sites with, we may want to revisit and fetch only the number of top sites we want
-    // but keeping logic consistent for now
-    private var otherSites: [TopSiteConfiguration] = []
-    private var sponsoredSites: [Site] = []
-
     init(
         profile: Profile = AppContainer.shared.resolve(),
         topSitesManager: TopSitesManagerInterface? = nil,
@@ -53,8 +48,9 @@ final class TopSitesMiddleware: FeatureFlaggable {
         case HomepageActionType.initialize,
             HomepageMiddlewareActionType.topSitesUpdated,
             TopSitesActionType.toggleShowSponsoredSettings:
-            self.getTopSitesDataAndUpdateState(for: action)
-
+            Task { @MainActor in
+                await self.getTopSitesDataAndUpdateState(for: action)
+            }
         case TopSitesActionType.topSitesSeen:
             self.handleSponsoredImpressionTracking(for: action)
 
@@ -101,45 +97,15 @@ final class TopSitesMiddleware: FeatureFlaggable {
         return site
     }
 
-    private func getTopSitesDataAndUpdateState(for action: Action) {
-        Task {
-            await withTaskGroup(of: Void.self) { group in
-                group.addTask {
-                    self.otherSites = await self.topSitesManager.getOtherSites()
-                    self.updateTopSites(
-                        for: action.windowUUID,
-                        otherSites: self.otherSites,
-                        sponsoredTiles: self.sponsoredSites
-                    )
-                }
-                group.addTask {
-                    self.sponsoredSites = await self.topSitesManager.fetchSponsoredSites()
-                    self.updateTopSites(
-                        for: action.windowUUID,
-                        otherSites: self.otherSites,
-                        sponsoredTiles: self.sponsoredSites
-                    )
-                }
-
-                await group.waitForAll()
-                updateTopSites(
-                    for: action.windowUUID,
-                    otherSites: self.otherSites,
-                    sponsoredTiles: self.sponsoredSites
-                )
-            }
-        }
+    @MainActor
+    private func getTopSitesDataAndUpdateState(for action: Action) async {
+        async let sponsoredSites = await self.topSitesManager.fetchSponsoredSites()
+        async let otherSites = await self.topSitesManager.getOtherSites()
+        let topSites = await self.topSitesManager.recalculateTopSites(otherSites: otherSites, sponsoredSites: sponsoredSites)
+        dispatchTopSitesRetrievedAction(for: action.windowUUID, topSites: topSites)
     }
 
-    private func updateTopSites(
-        for windowUUID: WindowUUID,
-        otherSites: [TopSiteConfiguration],
-        sponsoredTiles: [Site]
-    ) {
-        let topSites = self.topSitesManager.recalculateTopSites(
-            otherSites: otherSites,
-            sponsoredSites: sponsoredSites
-        )
+    private func dispatchTopSitesRetrievedAction(for windowUUID: WindowUUID, topSites: [TopSiteConfiguration]) {
         store.dispatch(
             TopSitesAction(
                 topSites: topSites,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
@@ -4,13 +4,12 @@
 
 import Foundation
 import Storage
+import XCTest
 
 @testable import Client
 
 final class MockTopSitesManager: TopSitesManagerInterface {
-    var getOtherSitesCalledCount = 0
-    var fetchSponsoredSitesCalledCount = 0
-    var recalculateTopSitesCalled: () -> Void = {}
+    var recalculateTopSitesCalledCount = 0
 
     var removeTopSiteCalledCount = 0
     var pinTopSiteCalledCount = 0
@@ -19,20 +18,18 @@ final class MockTopSitesManager: TopSitesManagerInterface {
     private let lock = NSLock()
 
     func getOtherSites() async -> [TopSiteConfiguration] {
-        getOtherSitesCalledCount += 1
         return createSites(count: 15, subtitle: ": otherSites")
     }
 
     func fetchSponsoredSites() async -> [Site] {
-        fetchSponsoredSitesCalledCount += 1
-
         let contiles = MockSponsoredProvider.defaultSuccessData
         return contiles.compactMap { Site.createSponsoredSite(fromContile: $0) }
     }
 
     func recalculateTopSites(otherSites: [TopSiteConfiguration], sponsoredSites: [Site]) -> [TopSiteConfiguration] {
         // We add this completion since this method is called in an asynchronous
-        recalculateTopSitesCalled()
+        recalculateTopSitesCalledCount += 1
+        XCTAssertTrue(Thread.isMainThread)
         return createSites(subtitle: ": total top sites")
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
@@ -39,32 +39,22 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         )
 
         let dispatchExpectation = XCTestExpectation(description: "All relevant top sites middleware actions are dispatched")
-        let recalculateExpectation = XCTestExpectation(
-            description: "Recalculate top sites method is called from top site manager"
-        )
-        dispatchExpectation.expectedFulfillmentCount = 3
-        recalculateExpectation.expectedFulfillmentCount = 3
 
         mockStore.dispatchCalled = {
             dispatchExpectation.fulfill()
         }
 
-        mockTopSitesManager.recalculateTopSitesCalled = {
-            recalculateExpectation.fulfill()
-        }
-
         subject.topSitesProvider(appState, action)
 
-        wait(for: [dispatchExpectation, recalculateExpectation])
+        wait(for: [dispatchExpectation], timeout: 1)
 
-        XCTAssertEqual(mockTopSitesManager.getOtherSitesCalledCount, 1)
-        XCTAssertEqual(mockTopSitesManager.fetchSponsoredSitesCalledCount, 1)
+        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 1)
 
         let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
         let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 3)
-        XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites, .retrievedUpdatedSites])
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionsType, [.retrievedUpdatedSites])
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 
@@ -130,26 +120,47 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         )
 
         let dispatchExpectation = XCTestExpectation(description: "All relevant top sites middleware actions are dispatched")
-        let recalculateExpectation = XCTestExpectation(
-            description: "Recalculate top sites method is called from top site manager"
-        )
-        dispatchExpectation.expectedFulfillmentCount = 3
-        recalculateExpectation.expectedFulfillmentCount = 3
 
         mockStore.dispatchCalled = {
             dispatchExpectation.fulfill()
         }
 
-        mockTopSitesManager.recalculateTopSitesCalled = {
-            recalculateExpectation.fulfill()
+        subject.topSitesProvider(appState, action)
+
+        wait(for: [dispatchExpectation], timeout: 1)
+
+        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 1)
+
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
+        let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionsType, [.retrievedUpdatedSites])
+        XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
+    }
+
+    func test_fetchTopSitesAction_withMultipleCalles_returnsTopSitesSection() throws {
+        let subject = createSubject(topSitesManager: mockTopSitesManager)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageMiddlewareActionType.topSitesUpdated
+        )
+
+        let dispatchExpectation = XCTestExpectation(description: "All relevant top sites middleware actions are dispatched")
+
+        dispatchExpectation.expectedFulfillmentCount = 3
+
+        mockStore.dispatchCalled = {
+            dispatchExpectation.fulfill()
         }
 
         subject.topSitesProvider(appState, action)
+        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider(appState, action)
 
-        wait(for: [dispatchExpectation, recalculateExpectation])
+        wait(for: [dispatchExpectation], timeout: 1)
 
-        XCTAssertEqual(mockTopSitesManager.getOtherSitesCalledCount, 1)
-        XCTAssertEqual(mockTopSitesManager.fetchSponsoredSitesCalledCount, 1)
+        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 3)
 
         let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
         let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12402)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27045)

## :bulb: Description
This new implementation should be more straightforward than the previous in that we fetch other sites and sponsored sites in parallel. Then, we await both results before recalculating the top sites to show. We ensure that when recalculate, we are on main thread.

Therefore, with this change we calculate top sites only once per task run instead of multiple times. We can avoid any possible race conditions that we may have faced before by running multiple tasks which may operate on the same references.

Using our benchmark tools, it seems that there is a delay, but hopefully its negligible enough. Confirm with product on merging this change.

**Current implementation:**
- On fresh install: 193 ms
- Already installed: ~8ms - 1ms

**New implementation:**
- On fresh install: 276 ms
- Already installed: ~13 - 3 ms

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
