### PR TITLE
Refactor FXIOS-12472 [Support utils] Clean up URLs to use SupportUtils

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -460,7 +460,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getHelpAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .LegacyAppMenu.Help,
                                      iconString: StandardImageIdentifiers.Large.helpCircle) { _ in
-            if let url = URL(string: "https://support.mozilla.org/products/ios") {
+            if let url = SupportUtils.URLForGetHelp {
                 self.delegate?.openURLInNewTab(url, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false)
             }
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .help)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
@@ -133,10 +133,8 @@ class EmptyPrivateTabsView: UIView, EmptyPrivateTabView {
 
     @objc
     private func didTapLearnMore() {
-        let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-        if let langID = Locale.preferredLanguages.first {
-            let learnMoreRequest = URLRequest(url: "https://support.mozilla.org/1/mobile/\(appVersion ?? "0.0")/iOS/\(langID)/private-browsing-ios".asURL!)
-            delegate?.didTapLearnMore(urlRequest: learnMoreRequest)
-        }
+        guard let url = SupportUtils.URLForTopic("private-browsing-ios") else { return }
+        let request = URLRequest(url: url)
+        delegate?.didTapLearnMore(urlRequest: request)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
@@ -144,10 +144,8 @@ class ExperimentEmptyPrivateTabsView: UIView, EmptyPrivateTabView {
 
     @objc
     private func didTapLearnMore() {
-        let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-        if let langID = Locale.preferredLanguages.first {
-            let learnMoreRequest = URLRequest(url: "https://support.mozilla.org/1/mobile/\(appVersion ?? "0.0")/iOS/\(langID)/private-browsing-ios".asURL!)
-            delegate?.didTapLearnMore(urlRequest: learnMoreRequest)
-        }
+        guard let url = SupportUtils.URLForTopic("private-browsing-ios") else { return }
+        let request = URLRequest(url: url)
+        delegate?.didTapLearnMore(urlRequest: request)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/OpenSupportPageSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/OpenSupportPageSetting.swift
@@ -4,6 +4,7 @@
 
 import Common
 import Foundation
+import Shared
 
 /// Opens the SUMO page in a new tab
 class OpenSupportPageSetting: Setting {
@@ -27,7 +28,7 @@ class OpenSupportPageSetting: Setting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        guard let url = URL(string: "https://support.mozilla.org/products/ios") else { return }
+        guard let url = SupportUtils.URLForGetHelp else { return }
         settingsDelegate?.pressedOpenSupportPage(url: url)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12472)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27191)

## :bulb: Description
Noticed we were not using `SupportUtils` class for some of our support URLs, so went to fix that!

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
