### PR TITLE
Refactor FXIOS-12469 [TA 2025] Update MockGleanWrapper functionality to test extras from multiple events fired in a single test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/AppIconSelection/AppIconSelectionTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/AppIconSelection/AppIconSelectionTelemetryTests.swift
@@ -32,10 +32,10 @@ final class AppIconSelectionTelemetryTests: XCTestCase {
         subject.selectedIcon(expectedNewAppIcon, previousIcon: expectedOldAppIcon)
 
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? EventExtrasType
+            mockGleanWrapper.savedExtras.first as? EventExtrasType
         )
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>
         )
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/UnifiedAdsCallbackTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/UnifiedAdsCallbackTelemetryTests.swift
@@ -68,11 +68,11 @@ class UnifiedAdsCallbackTelemetryTests: XCTestCase {
             return
         }
         XCTAssertEqual(asAnyHashable(savedPing), asAnyHashable(GleanMetrics.Pings.shared.topsitesImpression))
-        XCTAssertEqual(gleanWrapper.savedEvents?.count, 2)
+        XCTAssertEqual(gleanWrapper.savedEvents.count, 2)
 
         // Ensuring we call the right metrics type
         let firstSavedMetric = try XCTUnwrap(
-            gleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.TopSites.ContileImpressionExtra>
+            gleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.TopSites.ContileImpressionExtra>
         )
         let expectedFirstMetricType = type(of: GleanMetrics.TopSites.contileImpression)
         let firstResultMetricType = type(of: firstSavedMetric)
@@ -80,7 +80,7 @@ class UnifiedAdsCallbackTelemetryTests: XCTestCase {
                                                  resultMetric: firstResultMetricType)
         XCTAssert(firstResultMetricType == expectedFirstMetricType, debugMessage.text)
 
-        let secondSavedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[1] as? StringMetricType)
+        let secondSavedMetric = try XCTUnwrap(gleanWrapper.savedEvents[safe: 1] as? StringMetricType)
         let expectedSecondMetricType = type(of: GleanMetrics.TopSites.contileAdvertiser)
         let secondResultMetricType = type(of: secondSavedMetric)
         let secondDebugMessage = TelemetryDebugMessage(expectedMetric: expectedSecondMetricType,
@@ -102,11 +102,11 @@ class UnifiedAdsCallbackTelemetryTests: XCTestCase {
             return
         }
         XCTAssertEqual(asAnyHashable(savedPing), asAnyHashable(GleanMetrics.Pings.shared.topsitesImpression))
-        XCTAssertEqual(gleanWrapper.savedEvents?.count, 2)
+        XCTAssertEqual(gleanWrapper.savedEvents.count, 2)
 
         // Ensuring we call the right metrics type
         let firstSavedMetric = try XCTUnwrap(
-            gleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.TopSites.ContileClickExtra>
+            gleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.TopSites.ContileClickExtra>
         )
         let expectedFirstMetricType = type(of: GleanMetrics.TopSites.contileClick)
         let firstResultMetricType = type(of: firstSavedMetric)
@@ -114,7 +114,7 @@ class UnifiedAdsCallbackTelemetryTests: XCTestCase {
                                                  resultMetric: firstResultMetricType)
         XCTAssert(firstResultMetricType == expectedFirstMetricType, debugMessage.text)
 
-        let secondSavedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[1] as? StringMetricType)
+        let secondSavedMetric = try XCTUnwrap(gleanWrapper.savedEvents[safe: 1] as? StringMetricType)
         let expectedSecondMetricType = type(of: GleanMetrics.TopSites.contileAdvertiser)
         let secondResultMetricType = type(of: secondSavedMetric)
         let secondDebugMessage = TelemetryDebugMessage(expectedMetric: expectedSecondMetricType,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
@@ -53,7 +53,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.homepageProvider(AppState(), action)
 
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents?[0] as? EventMetricType<NoExtras>)
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let expectedMetricType = type(of: GleanMetrics.Homepage.viewed)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -71,7 +71,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.homepageProvider(AppState(), action)
 
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents?[0] as? EventMetricType<NoExtras>)
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let expectedMetricType = type(of: GleanMetrics.Homepage.viewed)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -91,10 +91,10 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.homepageProvider(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Homepage.ItemTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Homepage.ItemTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Homepage.itemTapped)
         let resultMetricType = type(of: savedMetric)
@@ -117,10 +117,10 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.homepageProvider(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Homepage.ItemTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Homepage.ItemTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Homepage.itemTapped)
         let resultMetricType = type(of: savedMetric)
@@ -143,10 +143,10 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.homepageProvider(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Homepage.ItemTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Homepage.ItemTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Homepage.itemTapped)
         let resultMetricType = type(of: savedMetric)
@@ -169,10 +169,10 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.homepageProvider(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Homepage.ItemTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Homepage.ItemTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Homepage.itemTapped)
         let resultMetricType = type(of: savedMetric)
@@ -195,10 +195,10 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.homepageProvider(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Homepage.ItemTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Homepage.ItemTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Homepage.itemTapped)
         let resultMetricType = type(of: savedMetric)
@@ -220,7 +220,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.homepageProvider(AppState(), action)
 
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents?[0] as? LabeledMetricType<CounterMetricType>)
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? LabeledMetricType<CounterMetricType>)
         let expectedMetricType = type(of: GleanMetrics.Homepage.sectionViewed)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
@@ -86,7 +86,7 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.pocketSectionProvider(AppState(), action)
 
         let firstSavedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? LabeledMetricType<CounterMetricType>
+            mockGleanWrapper.savedEvents.first as? LabeledMetricType<CounterMetricType>
         )
         let expectedFirstMetricType = type(of: GleanMetrics.Pocket.openStoryOrigin)
         let firstResultMetricType = type(of: firstSavedMetric)
@@ -95,7 +95,7 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
             resultMetric: firstResultMetricType
         )
 
-        let secondSavedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents?[1] as? LabeledMetricType<CounterMetricType>)
+        let secondSavedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? LabeledMetricType<CounterMetricType>)
         let expectedSecondMetricType = type(of: GleanMetrics.Pocket.openStoryPosition)
         let secondResultMetricType = type(of: secondSavedMetric)
         let secondDebugMessage = TelemetryDebugMessage(
@@ -103,7 +103,7 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
             resultMetric: secondResultMetricType
         )
 
-        XCTAssertEqual(mockGleanWrapper.savedEvents?.count, 2)
+        XCTAssertEqual(mockGleanWrapper.savedEvents.count, 2)
         XCTAssertEqual(mockGleanWrapper.recordLabelCalled, 2)
         XCTAssert(firstResultMetricType == expectedFirstMetricType, debugMessage.text)
         XCTAssert(secondResultMetricType == expectedSecondMetricType, secondDebugMessage.text)
@@ -117,7 +117,7 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         subject.pocketSectionProvider(AppState(), action)
 
-        XCTAssertEqual(mockGleanWrapper.savedEvents?.count, 0)
+        XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordLabelCalled, 0)
     }
 
@@ -127,7 +127,7 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.pocketSectionProvider(AppState(), action)
 
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents?[0] as? CounterMetricType)
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? CounterMetricType)
         let expectedMetricType = type(of: GleanMetrics.Pocket.sectionImpressions)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -145,7 +145,7 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         subject.pocketSectionProvider(AppState(), action)
 
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents?[0] as? EventMetricType<NoExtras>)
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let expectedMetricType = type(of: GleanMetrics.Pocket.openInPrivateTab)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -163,7 +163,7 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         subject.pocketSectionProvider(AppState(), action)
 
-        XCTAssertEqual(mockGleanWrapper.savedEvents?.count, 0)
+        XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
@@ -181,7 +181,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         try checkTopSitesPressedMetrics(label: "zero-search", position: "0", tileType: "sponsored")
 
-        XCTAssertEqual(mockGleanWrapper.savedEvents?.count, 2)
+        XCTAssertEqual(mockGleanWrapper.savedEvents.count, 2)
         XCTAssertEqual(mockGleanWrapper.recordLabelCalled, 1)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
         XCTAssertEqual(sponsoredTelemetry.sendClickTelemetryCalled, 1)
@@ -210,7 +210,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         try checkTopSitesPressedMetrics(label: "zero-search", position: "0", tileType: "sponsored")
 
-        XCTAssertEqual(mockGleanWrapper.savedEvents?.count, 2)
+        XCTAssertEqual(mockGleanWrapper.savedEvents.count, 2)
         XCTAssertEqual(mockGleanWrapper.recordLabelCalled, 1)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
         XCTAssertEqual(unifiedAdsTelemetry.sendClickTelemetryCalled, 1)
@@ -242,7 +242,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         try checkTopSitesPressedMetrics(label: "origin-other", position: "1", tileType: "suggested")
 
-        XCTAssertEqual(mockGleanWrapper.savedEvents?.count, 2)
+        XCTAssertEqual(mockGleanWrapper.savedEvents.count, 2)
         XCTAssertEqual(mockGleanWrapper.recordLabelCalled, 1)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
         XCTAssertEqual(sponsoredTelemetry.sendClickTelemetryCalled, 0)
@@ -264,7 +264,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.topSitesProvider(appState, action)
 
-        XCTAssertEqual(mockGleanWrapper.savedEvents?.count, 0)
+        XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordLabelCalled, 0)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)
         XCTAssertEqual(unifiedAdsTelemetry.sendImpressionTelemetryCalled, 0)
@@ -298,7 +298,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.topSitesProvider(appState, action)
 
-        XCTAssertEqual(mockGleanWrapper.savedEvents?.count, 0)
+        XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)
         XCTAssertEqual(mockTopSitesManager.pinTopSiteCalledCount, 0)
     }
@@ -325,7 +325,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.topSitesProvider(appState, action)
 
-        XCTAssertEqual(mockGleanWrapper.savedEvents?.count, 0)
+        XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)
         XCTAssertEqual(mockTopSitesManager.unpinTopSiteCalledCount, 0)
     }
@@ -352,7 +352,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.topSitesProvider(appState, action)
 
-        XCTAssertEqual(mockGleanWrapper.savedEvents?.count, 0)
+        XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)
         XCTAssertEqual(mockTopSitesManager.removeTopSiteCalledCount, 0)
     }
@@ -366,7 +366,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         subject.topSitesProvider(AppState(), action)
 
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents?[0] as? EventMetricType<NoExtras>)
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let expectedMetricType = type(of: GleanMetrics.TopSites.openInPrivateTab)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -414,10 +414,10 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
     private func checkContextMenuMetricsCalled(withExtra extra: String) throws {
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.TopSites.ContextualMenuExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.TopSites.ContextualMenuExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.TopSites.ContextualMenuExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.TopSites.ContextualMenuExtra
         )
         let expectedMetricType = type(of: GleanMetrics.TopSites.contextualMenu)
         let resultMetricType = type(of: savedMetric)
@@ -430,7 +430,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
     private func checkTopSitesPressedMetrics(label: String, position: String, tileType: String) throws {
         let firstSavedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? LabeledMetricType<CounterMetricType>
+            mockGleanWrapper.savedEvents.first as? LabeledMetricType<CounterMetricType>
         )
 
         let expectedFirstMetricType = type(of: GleanMetrics.TopSites.pressedTileOrigin)
@@ -441,10 +441,10 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         )
 
         let secondSavedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[1] as? EventMetricType<GleanMetrics.TopSites.TilePressedExtra>
+            mockGleanWrapper.savedEvents[safe: 1] as? EventMetricType<GleanMetrics.TopSites.TilePressedExtra>
         )
         let secondSavedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.TopSites.TilePressedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.TopSites.TilePressedExtra
         )
         let expectedSecondMetricType = type(of: GleanMetrics.TopSites.tilePressed)
         let secondResultMetricType = type(of: secondSavedMetric)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarksTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarksTelemetryTests.swift
@@ -26,7 +26,7 @@ final class BookmarksTelemetryTests: XCTestCase {
     func testRecordBookmark_WhenAddedBookmark_ThenGleanIsCalled() throws {
         subject?.addBookmark(eventLabel: .bookmarksPanel)
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[0] as? LabeledMetricType<CounterMetricType>)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? LabeledMetricType<CounterMetricType>)
         let expectedMetricType = type(of: GleanMetrics.Bookmarks.add)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -37,7 +37,7 @@ final class BookmarksTelemetryTests: XCTestCase {
     func testRecordBookmark_WhenDeletedBookmark_ThenGleanIsCalled() throws {
         subject?.deleteBookmark(eventLabel: .bookmarksPanel)
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[0] as? LabeledMetricType<CounterMetricType>)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? LabeledMetricType<CounterMetricType>)
         let expectedMetricType = type(of: GleanMetrics.Bookmarks.delete)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -48,7 +48,7 @@ final class BookmarksTelemetryTests: XCTestCase {
     func testRecordBookmark_WhenOpenedSite_ThenGleanIsCalled() throws {
         subject?.openBookmarksSite(eventLabel: .bookmarksPanel)
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[0] as? LabeledMetricType<CounterMetricType>)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? LabeledMetricType<CounterMetricType>)
         let expectedMetricType = type(of: GleanMetrics.Bookmarks.open)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -59,7 +59,7 @@ final class BookmarksTelemetryTests: XCTestCase {
     func testRecordBookmark_WhenEditedSite_ThenGleanIsCalled() throws {
         subject?.editBookmark(eventLabel: .bookmarksPanel)
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[0] as? LabeledMetricType<CounterMetricType>)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? LabeledMetricType<CounterMetricType>)
         let expectedMetricType = type(of: GleanMetrics.Bookmarks.edit)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -70,7 +70,7 @@ final class BookmarksTelemetryTests: XCTestCase {
     func testRecordBookmark_WhenAddedFolder_ThenGleanIsCalled() throws {
         subject?.addBookmarkFolder()
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[0] as? EventMetricType<NoExtras>)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let expectedMetricType = type(of: GleanMetrics.Bookmarks.folderAdd)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanWrapper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanWrapper.swift
@@ -24,8 +24,8 @@ class MockGleanWrapper: GleanWrapper {
     var cancelTimingCalled = 0
     var stopAndAccumulateCalled = 0
     var submitPingCalled = 0
-    var savedEvents: [Any]? = []
-    var savedExtras: Any?
+    var savedEvents: [Any] = []
+    var savedExtras: [Any] = []
     var savedLabel: Any?
     var savedPing: Any?
 
@@ -45,77 +45,77 @@ class MockGleanWrapper: GleanWrapper {
 
     func recordEvent<ExtraObject>(for metric: EventMetricType<ExtraObject>,
                                   extras: EventExtras) where ExtraObject: EventExtras {
-        savedExtras = extras
-        savedEvents?.append(metric)
+        savedExtras.append(extras)
+        savedEvents.append(metric)
         recordEventCalled += 1
     }
 
     func recordEvent<NoExtras>(for metric: EventMetricType<NoExtras>) where NoExtras: EventExtras {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         recordEventNoExtraCalled += 1
     }
 
     func incrementCounter(for metric: CounterMetricType) {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         incrementCounterCalled += 1
     }
 
     func recordString(for metric: StringMetricType, value: String) {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         recordStringCalled += 1
     }
 
     func recordLabel(for metric: LabeledMetricType<CounterMetricType>, label: String) {
         savedLabel = label
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         recordLabelCalled += 1
     }
 
     func setBoolean(for metric: BooleanMetricType, value: Bool) {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         setBooleanCalled += 1
     }
 
     func recordQuantity(for metric: QuantityMetricType, value: Int64) {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         recordQuantityCalled += 1
     }
 
     func recordLabeledQuantity(for metric: LabeledMetricType<QuantityMetricType>, label: String, value: Int64) {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         recordLabeledQuantityCalled += 1
     }
 
     func recordUrl(for metric: UrlMetricType, value: String) {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         recordUrlCalled += 1
     }
 
     func incrementNumerator(for metric: RateMetricType, amount: Int32) {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         incrementNumeratorCalled += 1
     }
 
     func incrementDenominator(for metric: RateMetricType, amount: Int32) {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         incrementDenominatorCalled += 1
     }
 
     func startTiming(for metric: TimingDistributionMetricType) -> GleanTimerId {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         startTimingCalled += 1
         return savedTimerId
     }
 
     func cancelTiming(for metric: TimingDistributionMetricType,
                       timerId: GleanTimerId) {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         cancelTimingCalled += 1
     }
 
     func stopAndAccumulateTiming(for metric: TimingDistributionMetricType,
                                  timerId: GleanTimerId) {
-        savedEvents?.append(metric)
+        savedEvents.append(metric)
         stopAndAccumulateCalled += 1
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PrivateBrowsingTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PrivateBrowsingTelemetryTests.swift
@@ -21,10 +21,10 @@ final class PrivateBrowsingTelemetryTests: XCTestCase {
         subject.sendDataClearanceTappedTelemetry(didConfirm: true)
 
         let savedEvent = try XCTUnwrap(
-            gleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.PrivateBrowsing.DataClearanceIconTappedExtra>
+            gleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.PrivateBrowsing.DataClearanceIconTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            gleanWrapper.savedExtras as? GleanMetrics.PrivateBrowsing.DataClearanceIconTappedExtra
+            gleanWrapper.savedExtras.first as? GleanMetrics.PrivateBrowsing.DataClearanceIconTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.PrivateBrowsing.dataClearanceIconTapped)
         let resultMetricType = type(of: savedEvent)
@@ -41,10 +41,10 @@ final class PrivateBrowsingTelemetryTests: XCTestCase {
         subject.sendDataClearanceTappedTelemetry(didConfirm: false)
 
         let savedEvent = try XCTUnwrap(
-            gleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.PrivateBrowsing.DataClearanceIconTappedExtra>
+            gleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.PrivateBrowsing.DataClearanceIconTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            gleanWrapper.savedExtras as? GleanMetrics.PrivateBrowsing.DataClearanceIconTappedExtra
+            gleanWrapper.savedExtras.first as? GleanMetrics.PrivateBrowsing.DataClearanceIconTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.PrivateBrowsing.dataClearanceIconTapped)
         let resultMetricType = type(of: savedEvent)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SettingsTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SettingsTelemetryTests.swift
@@ -31,10 +31,10 @@ final class SettingsTelemetryTests: XCTestCase {
         subject.optionSelected(option: .AppIconSelection)
 
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? EventExtrasType
+            mockGleanWrapper.savedExtras.first as? EventExtrasType
         )
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>
         )
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryActivityItemProviderTests.swift
@@ -43,7 +43,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
 
         XCTAssertTrue(itemForActivity is NSNull, "Should never share content")
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
-        XCTAssertNotNil(mockGleanWrapper.savedEvents?.first as? EventMetricType<GleanMetrics.ShareSheet.SharedToExtra>)
+        XCTAssertNotNil(mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.ShareSheet.SharedToExtra>)
     }
 
     func testWithShareType_hasShareMessage_callTelemetryOnly() throws {
@@ -64,7 +64,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
 
         XCTAssertTrue(itemForActivity is NSNull, "Should never share content")
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
-        XCTAssertNotNil(mockGleanWrapper.savedEvents?.first as? EventMetricType<GleanMetrics.ShareSheet.SharedToExtra>)
+        XCTAssertNotNil(mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.ShareSheet.SharedToExtra>)
     }
 
     // MARK: - Sent from Firefox experiment
@@ -92,7 +92,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
             createStubActivityViewController(),
             itemForActivityType: testActivityType
         )
-        let eventExtra = try XCTUnwrap(mockGleanWrapper.savedExtras as? GleanMetrics.ShareSheet.SharedToExtra)
+        let eventExtra = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? GleanMetrics.ShareSheet.SharedToExtra)
 
         XCTAssertTrue(itemForActivity is NSNull, "Should never share content")
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
@@ -123,7 +123,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
             createStubActivityViewController(),
             itemForActivityType: testActivityType
         )
-        let eventExtra = try XCTUnwrap(mockGleanWrapper.savedExtras as? GleanMetrics.ShareSheet.SharedToExtra)
+        let eventExtra = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? GleanMetrics.ShareSheet.SharedToExtra)
 
         XCTAssertTrue(itemForActivity is NSNull, "Should never share content")
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
@@ -154,7 +154,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
             createStubActivityViewController(),
             itemForActivityType: testActivityType
         )
-        let eventExtra = try XCTUnwrap(mockGleanWrapper.savedExtras as? GleanMetrics.ShareSheet.SharedToExtra)
+        let eventExtra = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? GleanMetrics.ShareSheet.SharedToExtra)
 
         XCTAssertTrue(itemForActivity is NSNull, "Should never share content")
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
@@ -185,7 +185,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
             createStubActivityViewController(),
             itemForActivityType: testActivityType
         )
-        let eventExtra = try XCTUnwrap(mockGleanWrapper.savedExtras as? GleanMetrics.ShareSheet.SharedToExtra)
+        let eventExtra = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? GleanMetrics.ShareSheet.SharedToExtra)
 
         XCTAssertTrue(itemForActivity is NSNull, "Should never share content")
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SponsoredTileTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SponsoredTileTelemetryTests.swift
@@ -43,7 +43,7 @@ class SponsoredTileTelemetryTests: XCTestCase {
             return
         }
         XCTAssertEqual(asAnyHashable(savedPing), asAnyHashable(GleanMetrics.Pings.shared.topsitesImpression))
-        XCTAssertEqual(gleanWrapper.savedEvents?.count, 4)
+        XCTAssertEqual(gleanWrapper.savedEvents.count, 4)
     }
 
     // MARK: Click
@@ -66,7 +66,7 @@ class SponsoredTileTelemetryTests: XCTestCase {
             return
         }
         XCTAssertEqual(asAnyHashable(savedPing), asAnyHashable(GleanMetrics.Pings.shared.topsitesImpression))
-        XCTAssertEqual(gleanWrapper.savedEvents?.count, 4)
+        XCTAssertEqual(gleanWrapper.savedEvents.count, 4)
     }
 
     // MARK: Helper methods

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/InactiveTabsTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/InactiveTabsTelemetryTests.swift
@@ -26,7 +26,7 @@ final class InactiveTabsTelemetryTests: XCTestCase {
     func testRecordInactiveTab_WhenSectionShown_ThenGleanIsCalled() throws {
         subject?.sectionShown()
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[0] as? CounterMetricType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? CounterMetricType)
         let expectedMetricType = type(of: GleanMetrics.InactiveTabsTray.inactiveTabShown)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -37,7 +37,7 @@ final class InactiveTabsTelemetryTests: XCTestCase {
     func testRecordInactiveTab_WhenClosedAllTabs_ThenGleanIsCalled() throws {
         subject?.closedAllTabs()
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[0] as? CounterMetricType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? CounterMetricType)
         let expectedMetricType = type(of: GleanMetrics.InactiveTabsTray.inactiveTabsCloseAllBtn)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -48,7 +48,7 @@ final class InactiveTabsTelemetryTests: XCTestCase {
     func testRecordInactiveTab_WhenTabOpened_ThenGleanIsCalled() throws {
         subject?.tabOpened()
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[0] as? CounterMetricType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? CounterMetricType)
         let expectedMetricType = type(of: GleanMetrics.InactiveTabsTray.openInactiveTab)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -59,7 +59,7 @@ final class InactiveTabsTelemetryTests: XCTestCase {
     func testRecordInactiveTab_WhenTabSwipedClosed_ThenGleanIsCalled() throws {
         subject?.tabSwipedToClose()
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[0] as? CounterMetricType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? CounterMetricType)
         let expectedMetricType = type(of: GleanMetrics.InactiveTabsTray.inactiveTabSwipeClose)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -71,7 +71,7 @@ final class InactiveTabsTelemetryTests: XCTestCase {
         subject?.sectionToggled(hasExpanded: true)
 
         let savedMetric = try XCTUnwrap(
-            gleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.InactiveTabsTray.ToggleInactiveTabTrayExtra>
+            gleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.InactiveTabsTray.ToggleInactiveTabTrayExtra>
         )
         let expectedMetricType = type(of: GleanMetrics.InactiveTabsTray.toggleInactiveTabTray)
         let resultMetricType = type(of: savedMetric)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ContextMenuTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ContextMenuTelemetryTests.swift
@@ -34,8 +34,8 @@ final class ContextMenuTelemetryTests: XCTestCase {
 
         subject?.optionSelected(option: expectedOption, origin: expectedOrigin)
 
-        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
@@ -54,8 +54,8 @@ final class ContextMenuTelemetryTests: XCTestCase {
 
         subject?.shown(origin: expectedOrigin)
 
-        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
@@ -73,8 +73,8 @@ final class ContextMenuTelemetryTests: XCTestCase {
 
         subject?.dismissed(origin: expectedOrigin)
 
-        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/HistoryDeletionUtilityTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/HistoryDeletionUtilityTelemetryTests.swift
@@ -28,10 +28,10 @@ final class HistoryDeletionUtilityTelemetryTests: XCTestCase {
         subject.clearedHistory(expectedDateOption)
 
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? EventExtrasType
+            mockGleanWrapper.savedExtras.first as? EventExtrasType
         )
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>
         )
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/MainMenuTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/MainMenuTelemetryTests.swift
@@ -30,10 +30,10 @@ final class MainMenuTelemetryTests: XCTestCase {
         subject?.mainMenuOptionTapped(with: true, and: "test_option")
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.AppMenu.MainMenuOptionSelectedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.AppMenu.MainMenuOptionSelectedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.AppMenu.mainMenuOptionSelected)
         let resultMetricType = type(of: savedMetric)
@@ -49,10 +49,10 @@ final class MainMenuTelemetryTests: XCTestCase {
         subject?.saveSubmenuOptionTapped(with: true, and: "test_option")
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.AppMenu.SaveMenuOptionSelectedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.SaveMenuOptionSelectedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.AppMenu.SaveMenuOptionSelectedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.AppMenu.SaveMenuOptionSelectedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.AppMenu.saveMenuOptionSelected)
         let resultMetricType = type(of: savedMetric)
@@ -68,10 +68,10 @@ final class MainMenuTelemetryTests: XCTestCase {
         subject?.toolsSubmenuOptionTapped(with: true, and: "test_option")
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.AppMenu.ToolsMenuOptionSelectedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.ToolsMenuOptionSelectedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.AppMenu.ToolsMenuOptionSelectedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.AppMenu.ToolsMenuOptionSelectedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.AppMenu.toolsMenuOptionSelected)
         let resultMetricType = type(of: savedMetric)
@@ -87,10 +87,10 @@ final class MainMenuTelemetryTests: XCTestCase {
         subject?.closeButtonTapped(isHomepage: true)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.AppMenu.CloseButtonExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.CloseButtonExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.AppMenu.CloseButtonExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.AppMenu.CloseButtonExtra
         )
         let expectedMetricType = type(of: GleanMetrics.AppMenu.closeButton)
         let resultMetricType = type(of: savedMetric)
@@ -105,10 +105,10 @@ final class MainMenuTelemetryTests: XCTestCase {
         subject?.menuDismissed(isHomepage: true)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.AppMenu.MenuDismissedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MenuDismissedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.AppMenu.MenuDismissedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.AppMenu.MenuDismissedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.AppMenu.menuDismissed)
         let resultMetricType = type(of: savedMetric)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ToastTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ToastTelemetryTests.swift
@@ -24,7 +24,7 @@ final class ToastTelemetryTests: XCTestCase {
         subject.undoClosedSingleTab()
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?.first as? EventMetricType<NoExtras>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>
         )
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
@@ -41,7 +41,7 @@ final class ToastTelemetryTests: XCTestCase {
         subject.undoClosedAllTabs()
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?.first as? EventMetricType<NoExtras>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>
         )
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/ZoomTelemetryTests.swift
@@ -31,8 +31,8 @@ final class ZoomTelemetryTests: XCTestCase {
 
         subject?.zoomIn(zoomLevel: expectedZoomLevel)
 
-        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
@@ -49,8 +49,8 @@ final class ZoomTelemetryTests: XCTestCase {
 
         subject?.zoomOut(zoomLevel: expectedZoomLevel)
 
-        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
@@ -65,7 +65,7 @@ final class ZoomTelemetryTests: XCTestCase {
 
         subject?.resetZoomLevel()
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<NoExtras>)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
@@ -79,7 +79,7 @@ final class ZoomTelemetryTests: XCTestCase {
 
         subject?.closeZoomBar()
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<NoExtras>)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
@@ -95,8 +95,8 @@ final class ZoomTelemetryTests: XCTestCase {
 
         subject?.updateDefaultZoomLevel(zoomLevel: expectedZoomLevel)
 
-        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
@@ -113,8 +113,8 @@ final class ZoomTelemetryTests: XCTestCase {
 
         subject?.deleteZoomDomainLevel(value: expectedIndex)
 
-        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<EventExtrasType>)
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
@@ -129,7 +129,7 @@ final class ZoomTelemetryTests: XCTestCase {
 
         subject?.resetDomainZoomLevel()
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?.first as? EventMetricType<NoExtras>)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -196,10 +196,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didTapButton(buttonType: .home, expectedActionType: GeneralBrowserActionType.goToHomepage)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.HomeButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.HomeButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.HomeButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.HomeButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.homeButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -214,10 +214,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didTapButton(buttonType: .newTab, expectedActionType: GeneralBrowserActionType.addNewTab)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.OneTapNewTabButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.OneTapNewTabButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.OneTapNewTabButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.OneTapNewTabButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.oneTapNewTabButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -232,10 +232,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didTapButton(buttonType: .qrCode, expectedActionType: GeneralBrowserActionType.showQRcodeReader)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.QrScanButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.QrScanButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.QrScanButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.QrScanButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.qrScanButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -269,10 +269,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(secondActionType, GeneralBrowserActionType.showQRcodeReader)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.QrScanButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.QrScanButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.QrScanButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.QrScanButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.qrScanButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -287,10 +287,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didTapButton(buttonType: .back, expectedActionType: GeneralBrowserActionType.navigateBack)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.BackButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.BackButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.BackButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.BackButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.backButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -305,10 +305,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didTapButton(buttonType: .forward, expectedActionType: GeneralBrowserActionType.navigateForward)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.ForwardButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.ForwardButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.ForwardButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.ForwardButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.forwardButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -337,10 +337,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, GeneralBrowserActionType.showTabTray)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.TabTrayButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.TabTrayButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.TabTrayButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.TabTrayButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.tabTrayButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -357,10 +357,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             expectedActionType: GeneralBrowserActionType.showTrackingProtectionDetails)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.SiteInfoButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.SiteInfoButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.SiteInfoButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.SiteInfoButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.siteInfoButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -390,10 +390,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, GeneralBrowserActionType.showMenu)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.AppMenuButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.AppMenuButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.AppMenuButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.AppMenuButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.appMenuButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -421,10 +421,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didTapButton(buttonType: .readerMode, expectedActionType: GeneralBrowserActionType.showReaderMode)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.ReaderModeButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.ReaderModeButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.ReaderModeButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.ReaderModeButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.readerModeButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -440,10 +440,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didTapButton(buttonType: .reload, expectedActionType: GeneralBrowserActionType.reloadWebsite)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.RefreshButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.RefreshButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.RefreshButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.RefreshButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.refreshButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -462,10 +462,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didTapButton(buttonType: .share, expectedActionType: GeneralBrowserActionType.showShare)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.ShareButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.ShareButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.ShareButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.ShareButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.shareButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -493,10 +493,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, ToolbarActionType.didStartEditingUrl)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.SearchButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.SearchButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.SearchButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.SearchButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.searchButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -511,10 +511,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didTapButton(buttonType: .dataClearance, expectedActionType: GeneralBrowserActionType.clearData)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.DataClearanceButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.DataClearanceButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.DataClearanceButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.DataClearanceButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.dataClearanceButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -529,10 +529,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didLongPressButton(buttonType: .back, expectedActionType: GeneralBrowserActionType.showBackForwardList)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.BackLongPressExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.BackLongPressExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.BackLongPressExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.BackLongPressExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.backLongPress)
         let resultMetricType = type(of: savedMetric)
@@ -547,10 +547,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didLongPressButton(buttonType: .forward, expectedActionType: GeneralBrowserActionType.showBackForwardList)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.ForwardLongPressExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.ForwardLongPressExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.ForwardLongPressExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.ForwardLongPressExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.forwardLongPress)
         let resultMetricType = type(of: savedMetric)
@@ -565,10 +565,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         try didLongPressButton(buttonType: .tabs, expectedActionType: GeneralBrowserActionType.showTabsLongPressActions)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.TabTrayLongPressExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.TabTrayLongPressExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.TabTrayLongPressExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.TabTrayLongPressExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.tabTrayLongPress)
         let resultMetricType = type(of: savedMetric)
@@ -607,10 +607,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
                                expectedActionType: GeneralBrowserActionType.showNewTabLongPressActions)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.OneTapNewTabLongPressExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.OneTapNewTabLongPressExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.OneTapNewTabLongPressExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.OneTapNewTabLongPressExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.oneTapNewTabLongPress)
         let resultMetricType = type(of: savedMetric)
@@ -661,10 +661,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, ToolbarActionType.clearSearch)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Toolbar.ClearSearchButtonTappedExtra>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.ClearSearchButtonTappedExtra>
         )
         let savedExtras = try XCTUnwrap(
-            mockGleanWrapper.savedExtras as? GleanMetrics.Toolbar.ClearSearchButtonTappedExtra
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.ClearSearchButtonTappedExtra
         )
         let expectedMetricType = type(of: GleanMetrics.Toolbar.clearSearchButtonTapped)
         let resultMetricType = type(of: savedMetric)
@@ -685,7 +685,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
 
         let savedMetric = try XCTUnwrap(
-            mockGleanWrapper.savedEvents?[0] as? EventMetricType<NoExtras>
+            mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>
         )
         let expectedMetricType = type(of: GleanMetrics.Awesomebar.dragLocationBar)
         let resultMetricType = type(of: savedMetric)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12469)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates our `MockGleanWrapper` to allow telemetry unit tests to capture extras from multiple events by making the `extras` an array. Also removes the unnecessary optional on the wrapper's `events` array.

Updated all the tests for these changes (trivial text replacements).

This is in preparation of being able to add unit tests for code that fires multiple events where we want to inspect the extras.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)