### PR TITLE
Remove FXIOS-12463 [Telemetry Audit] Delete Phase 1: Misc. telemetry probes

### DIFF
--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -2199,35 +2199,9 @@ homepage:
       tags:
         - Homepage
 
-
-# Metrics related to the history panel of the library
-library:
-  panel_pressed:
-    type: labeled_counter
-    description: |
-      Counts the number of times a specific library panel
-      button is tapped for Bookmarks, History, Reading List,
-      Downloads and Synced tabs
-    labels:
-      - bookmarks-panel
-      - history-panel
-      - reading-panel
-      - downloads-panel
-      - sync-panel
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/8035
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/8152
-      - https://github.com/mozilla-mobile/firefox-ios/pull/9673
-      - https://github.com/mozilla-mobile/firefox-ios/pull/12334
-      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-
 # Library
 library.history_panel:
-  cleared_history: 
+  cleared_history:
     type: event
     description: |
       A user deleted history entries from a certain timeframe
@@ -5059,21 +5033,6 @@ adjust:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-01-01"
-migration:
-  image_sd_cache_cleanup:
-    type: counter
-    description: |
-        Counts the number of times a user runs the
-        sd web image library cache cleanup
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/10903
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/11169
-      - https://github.com/mozilla-mobile/firefox-ios/pull/12334
-      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
 
 places_history_migration:
   duration:
@@ -5941,7 +5900,7 @@ testing:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-17"
-    no_lint: 
+    no_lint:
       - COMMON_PREFIX
   test_event_2:
     type: event
@@ -5955,5 +5914,5 @@ testing:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-18"
-    no_lint: 
+    no_lint:
       - COMMON_PREFIX

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -1353,9 +1353,6 @@ extension TelemetryWrapper {
         case (.action, .tap, .newPrivateTab, .pocketSite, _):
             GleanMetrics.Pocket.openInPrivateTab.record()
 
-        // MARK: Library Panel
-        case (.action, .tap, .libraryPanel, let type?, _):
-            GleanMetrics.Library.panelPressed[type.rawValue].add()
         // History Panel related
         case (.action, .navigate, .navigateToGroupHistory, _, _):
             GleanMetrics.History.groupList.add()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12463)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27169)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Deleted the below telemetry probes
`library.panel_pressed`
`migration.image_sd_cache_cleanup`

Did not find these two probes
`firefox_home_page.history_impressions`
`homepage.private_mode_toggle`

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
