### PR TITLE
Refactor FXIOS-12485 [Toolbar] Don't hide toolbars on scroll when voice over is enabled

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -132,11 +132,13 @@ class TabScrollController: NSObject,
         return windowUUID
     }
 
-    // If scrollview contentSize height is bigger that device height plus delta
-    // New settings to disable bar autohide only for iPad
-    var isAbleToScroll: Bool {
-        return (UIScreen.main.bounds.size.height + 2 * UIConstants.ToolbarHeight) <
+    /// Returns true when the scrollview contentSize height is bigger than device height plus delta
+    /// and voice over is turned off
+    var shouldUpdateUIWhenScrolling: Bool {
+        let heightNeedsScrolling = (UIScreen.main.bounds.size.height + 2 * UIConstants.ToolbarHeight) <
             contentSize.height
+        let voiceOverOff = !UIAccessibility.isVoiceOverRunning
+        return heightNeedsScrolling && voiceOverOff
     }
 
     deinit {
@@ -208,7 +210,7 @@ class TabScrollController: NSObject,
             setScrollDirection(delta)
 
             lastPanTranslation = translation.y
-            if checkRubberbanding() && isAbleToScroll {
+            if checkRubberbanding() && shouldUpdateUIWhenScrolling {
                 scrollWithDelta(delta)
                 updateToolbarState()
             }
@@ -290,7 +292,7 @@ class TabScrollController: NSObject,
         context: UnsafeMutableRawPointer?
     ) {
         if keyPath == "contentSize" {
-            guard isAbleToScroll, toolbarsShowing else { return }
+            guard shouldUpdateUIWhenScrolling, toolbarsShowing else { return }
 
             showToolbars(animated: true)
         }
@@ -611,7 +613,7 @@ extension TabScrollController: UIScrollViewDelegate {
               !tabIsLoading(),
               !scrollReachBottom(),
               !tab.isFindInPageMode,
-              isAbleToScroll  else { return }
+              shouldUpdateUIWhenScrolling else { return }
 
         tab.shouldScrollToTop = false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12485)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27214)

## :bulb: Description
Turns off hiding toolbars when voice over is turned on.

## :movie_camera: Demos
-

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
