### PR TITLE
Bugfix FXIOS-12489 [Tab tray UI experiment] Disable swipe when drag and drop happens

### DIFF
--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -48,7 +48,7 @@ class TabTrayCoordinator: BaseCoordinator,
         let tabTrayViewController = TabTrayViewController(panelType: panelType, windowUUID: tabManager.windowUUID)
         router.setRootViewController(tabTrayViewController)
         self.tabTrayViewController = tabTrayViewController
-        tabTrayViewController.childPanelControllers = makeChildPanels()
+        tabTrayViewController.childPanelControllers = makeChildPanels(dragAndDropDelegate: tabTrayViewController)
         tabTrayViewController.childPanelThemes = makeChildPanelThemes()
         tabTrayViewController.delegate = self
         tabTrayViewController.navigationHandler = self
@@ -58,10 +58,14 @@ class TabTrayCoordinator: BaseCoordinator,
         tabTrayViewController?.setupOpenPanel(panelType: tabTraySection)
     }
 
-    private func makeChildPanels() -> [UINavigationController] {
+    private func makeChildPanels(dragAndDropDelegate: TabDisplayViewDragAndDropInteraction) -> [UINavigationController] {
         let windowUUID = tabManager.windowUUID
-        let regularTabsPanel = TabDisplayPanelViewController(isPrivateMode: false, windowUUID: windowUUID)
-        let privateTabsPanel = TabDisplayPanelViewController(isPrivateMode: true, windowUUID: windowUUID)
+        let regularTabsPanel = TabDisplayPanelViewController(isPrivateMode: false,
+                                                             windowUUID: windowUUID,
+                                                             dragAndDropDelegate: dragAndDropDelegate)
+        let privateTabsPanel = TabDisplayPanelViewController(isPrivateMode: true,
+                                                             windowUUID: windowUUID,
+                                                             dragAndDropDelegate: dragAndDropDelegate)
         let syncTabs = RemoteTabsPanel(windowUUID: windowUUID)
 
         let panels: [UIViewController]

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -76,13 +76,15 @@ class TabDisplayPanelViewController: UIViewController,
     init(isPrivateMode: Bool,
          windowUUID: WindowUUID,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
-         themeManager: ThemeManager = AppContainer.shared.resolve()) {
+         themeManager: ThemeManager = AppContainer.shared.resolve(),
+         dragAndDropDelegate: TabDisplayViewDragAndDropInteraction) {
         self.panelType = isPrivateMode ? .privateTabs : .tabs
         self.tabsState = TabsPanelState(windowUUID: windowUUID, isPrivateMode: isPrivateMode)
         self.notificationCenter = notificationCenter
         self.themeManager = themeManager
         self.windowUUID = windowUUID
         super.init(nibName: nil, bundle: nil)
+        tabDisplayView.dragAndDropDelegate = dragAndDropDelegate
     }
 
     required init?(coder: NSCoder) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -6,6 +6,11 @@ import Common
 import Redux
 import UIKit
 
+protocol TabDisplayViewDragAndDropInteraction: AnyObject {
+    func dragAndDropStarted()
+    func dragAndDropEnded()
+}
+
 class TabDisplayView: UIView,
                       ThemeApplicable,
                       UICollectionViewDelegate,
@@ -26,6 +31,7 @@ class TabDisplayView: UIView,
     private let windowUUID: WindowUUID
     private let inactiveTabsTelemetry = InactiveTabsTelemetry()
     var theme: Theme?
+    weak var dragAndDropDelegate: TabDisplayViewDragAndDropInteraction?
 
     lazy var dataSource =
     TabDisplayDiffableDataSource(
@@ -456,5 +462,13 @@ extension TabDisplayView: UICollectionViewDragDelegate, UICollectionViewDropDele
         )
 
         store.dispatch(action)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, dragSessionWillBegin session: UIDragSession) {
+        dragAndDropDelegate?.dragAndDropStarted()
+    }
+
+    func collectionView(_ collectionView: UICollectionView, dragSessionDidEnd session: UIDragSession) {
+        dragAndDropDelegate?.dragAndDropEnded()
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -30,7 +30,8 @@ class TabTrayViewController: UIViewController,
                              StoreSubscriber,
                              FeatureFlaggable,
                              TabTraySelectorDelegate,
-                             TabTrayAnimationDelegate {
+                             TabTrayAnimationDelegate,
+                             TabDisplayViewDragAndDropInteraction {
     typealias SubscriberStateType = TabTrayState
     private struct UX {
         struct NavigationMenu {
@@ -64,6 +65,7 @@ class TabTrayViewController: UIViewController,
 
     private lazy var panelContainer: UIView = .build { _ in }
     private var pageViewController: UIPageViewController?
+    private weak var pageScrollView: UIScrollView?
     private var swipeFromIndex: Int?
     private lazy var themeAnimator = TabTrayThemeAnimator()
 
@@ -718,6 +720,7 @@ class TabTrayViewController: UIViewController,
 
         if let scrollView = pageVC.view.subviews.first(where: { $0 is UIScrollView }) as? UIScrollView {
             scrollView.delegate = self
+            self.pageScrollView = scrollView
         }
 
         self.pageViewController = pageVC
@@ -994,5 +997,15 @@ class TabTrayViewController: UIViewController,
 
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         swipeFromIndex = nil
+    }
+
+    // MARK: TabDisplayViewDragAndDropInteraction
+
+    func dragAndDropStarted() {
+        pageScrollView?.isScrollEnabled = false
+    }
+
+    func dragAndDropEnded() {
+        pageScrollView?.isScrollEnabled = true
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12489)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27224)

## :bulb: Description
Disabling the swipe when we are drag and dropping a tab cell. It breaks the tab tray otherwise.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
