### PR TITLE
Add FXIOS-12439 [Tab Tray UI Experiment] Make ExperimentTabCell constraint match Figma

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTitleSupplementaryView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTitleSupplementaryView.swift
@@ -10,7 +10,7 @@ final class TabTitleSupplementaryView: UICollectionReusableView, ThemeApplicable
     struct UX {
         static let tabViewFooterSpacing: CGFloat = 4
         static let faviconSize = CGSize(width: 16, height: 16)
-        static let viewPosition: CGFloat = 23
+        static let bottomAnchorText: CGFloat = 8
     }
 
     private lazy var footerView: UIStackView = .build { stackView in
@@ -42,7 +42,7 @@ final class TabTitleSupplementaryView: UICollectionReusableView, ThemeApplicable
         faviconContainer.addSubview(favicon)
 
         NSLayoutConstraint.activate([
-            footerView.topAnchor.constraint(equalTo: topAnchor, constant: UX.viewPosition),
+            footerView.topAnchor.constraint(equalTo: bottomAnchor, constant: UX.bottomAnchorText),
             footerView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
             footerView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
             footerView.centerXAnchor.constraint(equalTo: centerXAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12439)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27122)

## :bulb: Description
Adjust TabTitleSupplementaryView so that ExperimentTabCell constraints are the same as in Figma. 

## :movie_camera: Demos
### Before
![before](https://github.com/user-attachments/assets/3cfdd768-3f73-4c4d-b928-445eabb50248)
<img height=500 src="https://github.com/user-attachments/assets/6cf29c56-8c8e-40c2-8b04-4f91e0cc91aa"/>

### After
![after](https://github.com/user-attachments/assets/e80aee14-f06b-4e7a-bf18-2d031faa8e62)
<img height=500 src="https://github.com/user-attachments/assets/179fd5bf-51e8-44d9-9312-1a0c65afb999"/>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
