### PR TITLE
Refactor FXIOS-12502 [Toolbar] Add back baseline and default to version1 when used

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -1016,12 +1016,12 @@ struct AddressBarState: StateType, Equatable {
         let menuIcon = StandardImageIdentifiers.Large.moreHorizontalRound
 
         switch layout {
-        case .version1:
+        case .version1, .none:
             actions.append(contentsOf: [
                 menuAction(iconName: menuIcon, showWarningBadge: showWarningBadge),
                 tabsAction(numberOfTabs: numberOfTabs, isPrivateMode: toolbarState.isPrivateMode)
             ])
-        case .version2, .none:
+        case .version2:
             actions.append(contentsOf: [
                 tabsAction(numberOfTabs: numberOfTabs, isPrivateMode: toolbarState.isPrivateMode),
                 menuAction(iconName: menuIcon, showWarningBadge: showWarningBadge)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -194,12 +194,12 @@ struct NavigationBarState: StateType, Equatable {
         ]
 
         switch layout {
-        case .version1:
+        case .version1, .none:
             actions.append(middleAction)
             actions.append(menuAction(iconName: StandardImageIdentifiers.Large.moreHorizontalRound,
                                       showWarningBadge: showWarningBadge))
             actions.append(tabsAction(numberOfTabs: numberOfTabs, isPrivateMode: toolbarState.isPrivateMode))
-        case .version2, .none:
+        case .version2:
             actions.append(middleAction)
             actions.append(tabsAction(numberOfTabs: numberOfTabs, isPrivateMode: toolbarState.isPrivateMode))
             actions.append(menuAction(iconName: StandardImageIdentifiers.Large.moreHorizontalRound,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarLayoutStyle.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarLayoutStyle.swift
@@ -13,7 +13,7 @@ enum ToolbarLayoutStyle: String {
     static func style(from type: ToolbarLayoutType?) -> ToolbarLayoutStyle {
         guard let type else { return .version1 }
         switch type {
-        case .version1: return .version1
+        case .version1, .baseline: return .version1
         case .version2: return .version2
         }
     }

--- a/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceCardViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceCardViewController.swift
@@ -257,7 +257,7 @@ class OnboardingMultipleChoiceCardViewController: OnboardingCardViewController {
             .layout
 
         switch toolbarLayout {
-        case .version1, .version2:
+        case .version1, .version2, .baseline:
             let isToolbarBottomAction = buttonModel.action == .toolbarBottom
             let isToolbarTopAction = buttonModel.action == .toolbarTop
             if isToolbarBottomAction {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/NavigationBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/NavigationBarStateTests.swift
@@ -57,8 +57,8 @@ final class NavigationBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.actions[1].actionType, .forward)
         XCTAssertEqual(newState.actions[1].isEnabled, false)
         XCTAssertEqual(newState.actions[2].actionType, .search)
-        XCTAssertEqual(newState.actions[3].actionType, .tabs)
-        XCTAssertEqual(newState.actions[4].actionType, .menu)
+        XCTAssertEqual(newState.actions[3].actionType, .menu)
+        XCTAssertEqual(newState.actions[4].actionType, .tabs)
     }
 
     func test_urlDidChangeAction_returnsExpectedState() {

--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -71,6 +71,8 @@ enums:
   ToolbarLayoutType:
     description: The type of toolbar layout.
     variants:
+      baseline:
+        description: The default layout of the toolbars.
       version1:
         description: Shows the add new tab, menu and tabs button in the navigation toolbar. The share button is displayed in the address toolbar.
       version2:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12502)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27248)

## :bulb: Description
Adds back baseline layout variant and defaults to show version1 when baseline is used.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
