### PR TITLE
Add FXIOS-12467 [TA 2025] Add unit tests for the new settings.changed probe

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SettingsTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SettingsTelemetryTests.swift
@@ -44,6 +44,67 @@ final class SettingsTelemetryTests: XCTestCase {
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 
+    func testSettingChanged_recordsData() throws {
+        // The event and event extras type under test
+        let event = GleanMetrics.Settings.changed
+        typealias EventExtrasType = GleanMetrics.Settings.ChangedExtra
+
+        let expectedOption = "someUniqueSettingIdentifier"
+        let expectedNewValue = "Input"
+        let expectedOldValue = "Output"
+        let expectedMetricType = type(of: event)
+
+        let subject = createSubject()
+        subject.changedSetting(expectedOption, to: expectedNewValue, from: expectedOldValue)
+
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras[safe: 0] as? EventExtrasType
+        )
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>
+        )
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        // When `preferences.changed` is fully deprecated, this will record only 1 event.
+        // For now, this old event shadows the new `settings.changed`.
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 2)
+        XCTAssertEqual(savedExtras.setting, expectedOption)
+        XCTAssertEqual(savedExtras.changedTo, expectedNewValue)
+        XCTAssertEqual(savedExtras.changedFrom, expectedOldValue)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    // This test can be deleted once `preferences.changed` is expired and fully deprecated.
+    func testSettingChanged_recordsLegacyPreferencesChangedData() throws {
+        // The event and event extras type under test
+        let event = GleanMetrics.Preferences.changed
+        typealias EventExtrasType = GleanMetrics.Preferences.ChangedExtra
+
+        let expectedOption = "someUniqueSettingIdentifier"
+        let expectedNewValue = "Input"
+        let expectedOldValue = "Output"
+        let expectedMetricType = type(of: event)
+
+        let subject = createSubject()
+        subject.changedSetting(expectedOption, to: expectedNewValue, from: expectedOldValue)
+
+        // `preferences.changed` is recorded after `settings.changed`
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras[safe: 1] as? EventExtrasType
+        )
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents[safe: 1] as? EventMetricType<EventExtrasType>
+        )
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 2)
+        XCTAssertEqual(savedExtras.preference, expectedOption)
+        XCTAssertEqual(savedExtras.changedTo, expectedNewValue)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
     func createSubject() -> SettingsTelemetry {
         return SettingsTelemetry(gleanWrapper: mockGleanWrapper)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27177)

## :bulb: Description
As a followup to #27180, I am adding unit tests for the new `settings.changed` probe. I have also added a unit test which verifies that calling the new `SettingsTelemetry.changedSetting()` method also calls the (soon to be) retired `preferences.changed` probe.


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
