### PR TITLE
Bugfix FXIOS-12513 - [Memory Leaks] - The sha256 property in the Data+Extension file leaks memory on each use

### DIFF
--- a/BrowserKit/Sources/Shared/Extensions/Data+Extension.swift
+++ b/BrowserKit/Sources/Shared/Extensions/Data+Extension.swift
@@ -10,7 +10,9 @@ extension Data {
         let length = Int(CC_SHA256_DIGEST_LENGTH)
         let digest = UnsafeMutablePointer<UInt8>.allocate(capacity: length)
         CC_SHA256((self as NSData).bytes, CC_LONG(self.count), digest)
-        return Data(bytes: UnsafePointer<UInt8>(digest), count: length)
+        let data = Data(bytes: UnsafePointer<UInt8>(digest), count: length)
+        digest.deallocate()
+        return data
     }
 
     public func hmacSha256WithKey(_ key: Data) -> Data {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12513)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27271)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR fixes a memory leak in the `Data().sha256` extension.
Previously, the implementation used an unsafe pointer for the digest buffer but did not deallocate it, causing a memory leak each time the property was accessed.
The updated code ensures that the allocated memory is properly deallocated after use, preventing heap growth and improving memory management.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
