### PR TITLE
Bugfix FXIOS-12506 - Weird behavior of the URL bar after a specific scenario

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -117,18 +117,6 @@ class TabDisplayPanelViewController: UIViewController,
         }
     }
 
-//    override func viewWillDisappear(_ animated: Bool) {
-//        super.viewWillDisappear(animated)
-//        guard isToolbarRefactorEnabled, isTabTrayUIExperimentsEnabled else { return }
-//        store.dispatch(
-//            ToolbarAction(
-//                shouldAnimate: true,
-//                windowUUID: windowUUID,
-//                actionType: ToolbarActionType.animationStateChanged
-//            )
-//        )
-//    }
-
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         gradientLayer.frame = fadeView.bounds

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -117,17 +117,17 @@ class TabDisplayPanelViewController: UIViewController,
         }
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        guard isToolbarRefactorEnabled, isTabTrayUIExperimentsEnabled else { return }
-        store.dispatch(
-            ToolbarAction(
-                shouldAnimate: true,
-                windowUUID: windowUUID,
-                actionType: ToolbarActionType.animationStateChanged
-            )
-        )
-    }
+//    override func viewWillDisappear(_ animated: Bool) {
+//        super.viewWillDisappear(animated)
+//        guard isToolbarRefactorEnabled, isTabTrayUIExperimentsEnabled else { return }
+//        store.dispatch(
+//            ToolbarAction(
+//                shouldAnimate: true,
+//                windowUUID: windowUUID,
+//                actionType: ToolbarActionType.animationStateChanged
+//            )
+//        )
+//    }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -463,6 +463,7 @@ final class AddressToolbarContainer: UIView,
             delegate?.openSuggestions(searchTerm: locationText ?? "")
         } else {
             let action = ToolbarAction(searchTerm: locationText,
+                                       shouldAnimate: true,
                                        windowUUID: windowUUID,
                                        actionType: ToolbarActionType.didStartEditingUrl)
             store.dispatch(action)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12506)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27254)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

https://github.com/user-attachments/assets/eba12bc9-4534-4bab-aac4-477cc33c148c


</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
