### PR TITLE
Bugfix FXIOS-12517 [Homepage Rebuild] fix UI bugs

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -158,7 +158,6 @@ final class HomepageViewController: UIViewController,
         Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
         store.dispatch(
             HomepageAction(
-                numberOfTopSitesPerRow: numberOfTilesPerRow(for: availableWidth),
                 windowUUID: windowUUID,
                 actionType: HomepageActionType.viewWillAppear
             )
@@ -178,6 +177,17 @@ final class HomepageViewController: UIViewController,
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         resetTrackedObjects()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        store.dispatch(
+            HomepageAction(
+                numberOfTopSitesPerRow: numberOfTilesPerRow(for: availableWidth),
+                windowUUID: windowUUID,
+                actionType: HomepageActionType.viewDidLayoutSubviews
+            )
+        )
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -158,6 +158,7 @@ final class HomepageViewController: UIViewController,
         Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
         store.dispatch(
             HomepageAction(
+                numberOfTopSitesPerRow: numberOfTilesPerRow(for: availableWidth),
                 windowUUID: windowUUID,
                 actionType: HomepageActionType.viewWillAppear
             )

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/SyncedTabCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/SyncedTabCell.swift
@@ -169,6 +169,15 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurra
         tabItemTitle.text = nil
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        contentView.layer.shadowPath = UIBezierPath(
+            roundedRect: contentView.bounds,
+            cornerRadius: HomepageViewModel.UX.generalCornerRadius
+        ).cgPath
+    }
+
     private func setupLayout() {
         tabImageContainer.addSubviews(tabHeroImage)
         syncedDeviceContainer.addSubviews(syncedDeviceImage, syncedDeviceLabel)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -40,6 +40,7 @@ enum HomepageActionType: ActionType {
     case traitCollectionDidChange
     case viewWillTransition
     case viewWillAppear
+    case viewDidLayoutSubviews
     case didSelectItem
     case embeddedHomepage
     case sectionSeen

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -59,7 +59,7 @@ struct TopSitesSectionState: StateType, Equatable {
             return handleUpdatedNumberOfRowsAction(action: action, state: state)
         case TopSitesActionType.toggleShowSectionSetting:
             return handleToggleShowSectionSettingAction(action: action, state: state)
-        case HomepageActionType.initialize, HomepageActionType.viewWillTransition, HomepageActionType.viewWillAppear:
+        case HomepageActionType.initialize, HomepageActionType.viewWillTransition, HomepageActionType.viewDidLayoutSubviews:
             return handleViewChangeAction(action: action, state: state)
         default:
             return defaultState(from: state)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -59,7 +59,7 @@ struct TopSitesSectionState: StateType, Equatable {
             return handleUpdatedNumberOfRowsAction(action: action, state: state)
         case TopSitesActionType.toggleShowSectionSetting:
             return handleToggleShowSectionSettingAction(action: action, state: state)
-        case HomepageActionType.initialize, HomepageActionType.viewWillTransition:
+        case HomepageActionType.initialize, HomepageActionType.viewWillTransition, HomepageActionType.viewWillAppear:
             return handleViewChangeAction(action: action, state: state)
         default:
             return defaultState(from: state)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -171,10 +171,22 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         subject.viewWillAppear(false)
 
         let actionCalled = try XCTUnwrap(
-            mockStore.dispatchedActions.last(where: { $0 is HomepageAction }) as? HomepageAction
+            mockStore.dispatchedActions.first(where: { $0 is HomepageAction }) as? HomepageAction
         )
         let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
         XCTAssertEqual(actionType, HomepageActionType.viewWillAppear)
+        XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+    }
+
+    func test_viewDidLayoutSubviews_triggersHomepageAction() throws {
+        let subject = createSubject()
+
+        subject.viewDidLayoutSubviews()
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.last(where: { $0 is HomepageAction }) as? HomepageAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
+        XCTAssertEqual(actionType, HomepageActionType.viewDidLayoutSubviews)
         XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -167,10 +167,11 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
 
     func test_viewWillAppear_triggersHomepageAction() throws {
         let subject = createSubject()
+
         subject.viewWillAppear(false)
 
         let actionCalled = try XCTUnwrap(
-            mockStore.dispatchedActions.first(where: { $0 is HomepageAction }) as? HomepageAction
+            mockStore.dispatchedActions.last(where: { $0 is HomepageAction }) as? HomepageAction
         )
         let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
         XCTAssertEqual(actionType, HomepageActionType.viewWillAppear)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
@@ -124,7 +124,7 @@ final class TopsSitesSectionStateTests: XCTestCase {
         XCTAssertEqual(newState.numberOfTilesPerRow, 8)
     }
 
-    func test_viewWillAppear_numberOfTilesPerRow_returnsExpectedState() {
+    func test_viewDidLayoutSubviews_numberOfTilesPerRow_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = topSiteReducer()
 
@@ -133,7 +133,7 @@ final class TopsSitesSectionStateTests: XCTestCase {
             HomepageAction(
                 numberOfTopSitesPerRow: 8,
                 windowUUID: .XCTestDefaultUUID,
-                actionType: HomepageActionType.viewWillAppear
+                actionType: HomepageActionType.viewDidLayoutSubviews
             )
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
@@ -106,7 +106,8 @@ final class TopsSitesSectionStateTests: XCTestCase {
         XCTAssertTrue(newState.shouldShowSection)
     }
 
-    func test_numberOfTilesPerRow_returnsExpectedState() {
+    // MARK: numberOfTilesPerRow
+    func test_viewWillTransition_numberOfTilesPerRow_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = topSiteReducer()
 
@@ -116,6 +117,40 @@ final class TopsSitesSectionStateTests: XCTestCase {
                 numberOfTopSitesPerRow: 8,
                 windowUUID: .XCTestDefaultUUID,
                 actionType: HomepageActionType.viewWillTransition
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.numberOfTilesPerRow, 8)
+    }
+
+    func test_viewWillAppear_numberOfTilesPerRow_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = topSiteReducer()
+
+        let newState = reducer(
+            initialState,
+            HomepageAction(
+                numberOfTopSitesPerRow: 8,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.viewWillAppear
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.numberOfTilesPerRow, 8)
+    }
+
+    func test_initialize_numberOfTilesPerRow_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = topSiteReducer()
+
+        let newState = reducer(
+            initialState,
+            HomepageAction(
+                numberOfTopSitesPerRow: 8,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.initialize
             )
         )
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12517)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27281)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12177)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26509)

## :bulb: Description
Addresses some UI bugs that were found.

**Unexpected shadow:**
- Orientation changes trigger layout changes, which can invalidate and not update the shadows accordingly, so need to make sure to update the shadowPath. We are doing this with other cells, but seems to miss it here.

**Top sites layout:**
- We only adjust layout on view will transition, but sometimes that doesn't get triggered so we also add the logic to adjust number of top sites when view appears. 

Please see issues for screen capture of issues. Running through the test steps in this branch, should no longer reproduce the issues. Please pull down to test and confirm! Thank you!

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
