### PR TITLE
Add FXIOS-12445 Add fx-accounts ping and firefox account UID string

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1974,6 +1974,7 @@
 		ED5835FE2D2D98DB000C188A /* PinnedSiteInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BD95B2878AA74000FE773 /* PinnedSiteInfo.swift */; };
 		ED67B2962D0C921600BDC599 /* ShareTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED67B2952D0C921600BDC599 /* ShareTelemetry.swift */; };
 		ED67B2982D0C940C00BDC599 /* ShareTelemetryActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED67B2972D0C940C00BDC599 /* ShareTelemetryActivityItemProvider.swift */; };
+		ED6C23102DFB4F39005EDE1D /* UserTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6C230F2DFB4F36005EDE1D /* UserTelemetryTests.swift */; };
 		ED6C8DAC2CE6A4BB00D7F7F3 /* Sentry-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = ED6C8DAB2CE6A4BB00D7F7F3 /* Sentry-Dynamic */; };
 		ED6D46E02D3573F80045E4ED /* TitleActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED67B2932D0B80E200BDC599 /* TitleActivityItemProviderTests.swift */; };
 		ED6F82C32D6E539200FC1098 /* UIColor+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6F82C22D6E539200FC1098 /* UIColor+Color.swift */; };
@@ -10328,6 +10329,7 @@
 		ED67B2932D0B80E200BDC599 /* TitleActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleActivityItemProviderTests.swift; sourceTree = "<group>"; };
 		ED67B2952D0C921600BDC599 /* ShareTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTelemetry.swift; sourceTree = "<group>"; };
 		ED67B2972D0C940C00BDC599 /* ShareTelemetryActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTelemetryActivityItemProvider.swift; sourceTree = "<group>"; };
+		ED6C230F2DFB4F36005EDE1D /* UserTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTelemetryTests.swift; sourceTree = "<group>"; };
 		ED6F82C22D6E539200FC1098 /* UIColor+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Color.swift"; sourceTree = "<group>"; };
 		ED6F82FA2D6E6C3400FC1098 /* AppIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconView.swift; sourceTree = "<group>"; };
 		ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreForMiddleware.swift; sourceTree = "<group>"; };
@@ -13003,6 +13005,7 @@
 		8AC225632B6D3F9600CDA7FD /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				ED6C230F2DFB4F36005EDE1D /* UserTelemetryTests.swift */,
 				0ABCD45C2D356006005D704A /* TermsOfServiceTelemetryTests.swift */,
 				0A686B3B2CDB70DC0090E146 /* MainMenuTelemetryTests.swift */,
 				613489A42D9443610009AF01 /* ToastTelemetryTests.swift */,
@@ -18574,6 +18577,7 @@
 				8A9D31642D1355EE00171502 /* MockFxBookmarkNode.swift in Sources */,
 				8A827E302C20C7F5008D5E3C /* MicrosurveyMiddlewareTests.swift in Sources */,
 				8A9D31622D13545A00171502 /* EditFolderViewModelTests.swift in Sources */,
+				ED6C23102DFB4F39005EDE1D /* UserTelemetryTests.swift in Sources */,
 				21B548992B1E7FDF00DC1DF8 /* InactiveTabsManagerTests.swift in Sources */,
 				8AF6D4DF2A856A9000B0474B /* MockContileNetworking.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1958,6 +1958,7 @@
 		ED07C0EF2CCAE856006C0627 /* SearchEngineSelectionMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0EE2CCAE856006C0627 /* SearchEngineSelectionMiddleware.swift */; };
 		ED07C0F22CCAFED1006C0627 /* SearchEngineSelectionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0F02CCAFEC2006C0627 /* SearchEngineSelectionStateTests.swift */; };
 		ED07C0F52CCB020B006C0627 /* SearchEngineSelectionMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0F32CCB0200006C0627 /* SearchEngineSelectionMiddlewareTests.swift */; };
+		ED232EA02DFA3BF30046DA47 /* UserTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED232E9F2DFA3BF00046DA47 /* UserTelemetry.swift */; };
 		ED26BFD72DE5260700FB2B3F /* glean_index.yaml in Resources */ = {isa = PBXBuildFile; fileRef = ED26BFD62DE5260700FB2B3F /* glean_index.yaml */; };
 		ED28DAC92C45A95F00D2641C /* TabScrollBehaviorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */; };
 		ED33E3572D0A4CE9002265A7 /* URLActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED33E3562D0A4CE9002265A7 /* URLActivityItemProviderTests.swift */; };
@@ -10308,6 +10309,7 @@
 		ED07C0EE2CCAE856006C0627 /* SearchEngineSelectionMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionMiddleware.swift; sourceTree = "<group>"; };
 		ED07C0F02CCAFEC2006C0627 /* SearchEngineSelectionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionStateTests.swift; sourceTree = "<group>"; };
 		ED07C0F32CCB0200006C0627 /* SearchEngineSelectionMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionMiddlewareTests.swift; sourceTree = "<group>"; };
+		ED232E9F2DFA3BF00046DA47 /* UserTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTelemetry.swift; sourceTree = "<group>"; };
 		ED264785844AD63AD616A882 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		ED26BFD62DE5260700FB2B3F /* glean_index.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = glean_index.yaml; sourceTree = "<group>"; };
 		ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollBehaviorModel.swift; sourceTree = "<group>"; };
@@ -14995,6 +14997,7 @@
 				C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */,
 				C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */,
 				61CEFF5D2DA8BC78000B88A7 /* TabsPanelTelemetry.swift */,
+				ED232E9F2DFA3BF00046DA47 /* UserTelemetry.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -17646,6 +17649,7 @@
 				8A8D12142DD671DC00E0B8BB /* TabTrayPanelSwipePalette.swift in Sources */,
 				8C2447EC2DFADF6800BD2C91 /* OnboardingNavigationDelegate.swift in Sources */,
 				E18EA56F28AD3279003F97FC /* UIDevice+Extension.swift in Sources */,
+				ED232EA02DFA3BF30046DA47 /* UserTelemetry.swift in Sources */,
 				8A46F5AD2C9E4389005B6422 /* RemoteSettingsFetchConfig.swift in Sources */,
 				CDB3BE8724746787009320EE /* FirefoxAccountSignInViewController.swift in Sources */,
 				8A471183287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift in Sources */,

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -111,9 +111,13 @@ final class AppLaunchUtil {
             }
         }
 
-        RustFirefoxAccounts.startup(prefs: profile.prefs) { _ in
+        RustFirefoxAccounts.startup(prefs: profile.prefs) { manager in
             self.logger.log("RustFirefoxAccounts started", level: .info, category: .sync)
             AppEventQueue.signal(event: .accountManagerInitialized)
+
+            if let accountUid = manager.accountProfile()?.uid {
+                UserTelemetry().setFirefoxAccountID(uid: accountUid)
+            }
         }
 
         // Add swizzle on UIViewControllers to automatically log when there's a new view appearing or disappearing

--- a/firefox-ios/Client/Glean/gleanProbes.xcfilelist
+++ b/firefox-ios/Client/Glean/gleanProbes.xcfilelist
@@ -20,3 +20,4 @@ $(PROJECT_DIR)/Client/Glean/probes/toast.yaml
 $(PROJECT_DIR)/Client/Glean/probes/tracking_protection.yaml
 $(PROJECT_DIR)/Client/Glean/probes/toolbar.yaml
 $(PROJECT_DIR)/Client/Glean/probes/zoom_bar.yaml
+$(PROJECT_DIR)/Client/Glean/probes/user.yaml

--- a/firefox-ios/Client/Glean/glean_index.yaml
+++ b/firefox-ios/Client/Glean/glean_index.yaml
@@ -27,4 +27,5 @@ metrics_files:
   - firefox-ios/Client/Glean/probes/zoom_bar.yaml
   - firefox-ios/Client/Glean/probes/tracking_protection.yaml
   - firefox-ios/Client/Glean/probes/toolbar.yaml
+  - firefox-ios/Client/Glean/probes/user.yaml
   - firefox-ios/Storage/metrics.yaml

--- a/firefox-ios/Client/Glean/pings.yaml
+++ b/firefox-ios/Client/Glean/pings.yaml
@@ -29,6 +29,22 @@ first-session:
   notification_emails:
     - fx-ios-data-stewards@mozilla.com
 
+fx-accounts:
+  description: |
+    A ping for information about Mozilla Account usage. Sent at the same cadence
+    as the baseline ping.
+  include_client_id: true
+  send_if_empty: false
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/FXIOS-12445
+  data_reviews:
+    - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+  notification_emails:
+    - fx-ios-data-stewards@mozilla.com
+  metadata:
+    ping_schedule:
+      - baseline
+
 fx-suggest:
   description: |
     A ping representing a single event occurring with or to a Firefox Suggestion.

--- a/firefox-ios/Client/Glean/pings.yaml
+++ b/firefox-ios/Client/Glean/pings.yaml
@@ -41,9 +41,6 @@ fx-accounts:
     - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
   notification_emails:
     - fx-ios-data-stewards@mozilla.com
-  metadata:
-    ping_schedule:
-      - baseline
 
 fx-suggest:
   description: |

--- a/firefox-ios/Client/Glean/pings.yaml
+++ b/firefox-ios/Client/Glean/pings.yaml
@@ -33,12 +33,14 @@ fx-accounts:
   description: |
     A ping for information about Mozilla Account usage. Sent at the same cadence
     as the baseline ping.
+
+    Owner: @jdavis
   include_client_id: true
   send_if_empty: false
   bugs:
     - https://mozilla-hub.atlassian.net/browse/FXIOS-12445
   data_reviews:
-    - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    - https://github.com/mozilla-mobile/firefox-ios/pull/27296
   notification_emails:
     - fx-ios-data-stewards@mozilla.com
 
@@ -172,3 +174,5 @@ nimbus:
   notification_emails:
     - chumphreys@mozilla.com
     - project-nimbus@mozilla.com
+
+# Test

--- a/firefox-ios/Client/Glean/pings.yaml
+++ b/firefox-ios/Client/Glean/pings.yaml
@@ -174,5 +174,3 @@ nimbus:
   notification_emails:
     - chumphreys@mozilla.com
     - project-nimbus@mozilla.com
-
-# Test

--- a/firefox-ios/Client/Glean/probes/user.yaml
+++ b/firefox-ios/Client/Glean/probes/user.yaml
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the metrics that are recorded by the Glean SDK. They are
+# automatically converted to Swift code at build time using the `glean_parser`
+# PyPI package.
+
+# This file is organized (roughly) alphabetically by metric names
+# for easy navigation
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+$tags:
+  - User
+
+###############################################################################
+# Documentation
+###############################################################################
+
+user.client_association:
+  uid:
+    type: string
+    description: |
+      The Mozilla Account UID associated with the user.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-12445
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    data_sensitivity:
+      - highly_sensitive
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-accounts

--- a/firefox-ios/Client/Glean/probes/user.yaml
+++ b/firefox-ios/Client/Glean/probes/user.yaml
@@ -24,10 +24,12 @@ user.client_association:
     type: string
     description: |
       The Mozilla Account UID associated with the user.
+
+      Owner: @jdavis
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-12445
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/27296
     data_sensitivity:
       - highly_sensitive
     notification_emails:

--- a/firefox-ios/Client/Glean/tags.yaml
+++ b/firefox-ios/Client/Glean/tags.yaml
@@ -90,6 +90,9 @@ TopSites:
 
 TrackingProtection:
   description: Corresponds to the enhanced tracking protection bottom sheet which can be displayed over a webpage.
+  
+User:
+  description: Corresponds to user properties and settings.
 
 ZoomBar:
   description: Corresponds to any event around zoom bar. Shown from the app menu.

--- a/firefox-ios/Client/Telemetry/UserTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/UserTelemetry.swift
@@ -16,5 +16,8 @@ struct UserTelemetry {
     /// - Parameter option: A unique identifier for the selected row. Identifies the row tapped, not the screen shown.
     func setFirefoxAccountID(uid: String) {
         gleanWrapper.recordString(for: GleanMetrics.UserClientAssociation.uid, value: uid)
+
+        // We send the `fx-accounts` ping now that the payload data has been set
+        GleanMetrics.Pings.shared.fxAccounts.submit()
     }
 }

--- a/firefox-ios/Client/Telemetry/UserTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/UserTelemetry.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+struct UserTelemetry {
+    private let gleanWrapper: GleanWrapper
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
+    /// Recorded when a user taps a row on the settings screen (or one of its subscreens) to drill deeper into the settings.
+    /// - Parameter option: A unique identifier for the selected row. Identifies the row tapped, not the screen shown.
+    func setFirefoxAccountID(uid: String) {
+        gleanWrapper.recordString(for: GleanMetrics.UserClientAssociation.uid, value: uid)
+    }
+}

--- a/firefox-ios/Client/Telemetry/UserTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/UserTelemetry.swift
@@ -12,8 +12,9 @@ struct UserTelemetry {
         self.gleanWrapper = gleanWrapper
     }
 
-    /// Recorded when a user taps a row on the settings screen (or one of its subscreens) to drill deeper into the settings.
-    /// - Parameter option: A unique identifier for the selected row. Identifies the row tapped, not the screen shown.
+    /// Records the UID of a user signed into their Firefox Account on a special `fx-accounts` ping. Once the UID is
+    /// recorded, the ping is immediately submitted.
+    /// - Parameter uid: The user's Firefox Account UID.
     func setFirefoxAccountID(uid: String) {
         gleanWrapper.recordString(for: GleanMetrics.UserClientAssociation.uid, value: uid)
 

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -371,6 +371,11 @@ extension FxAWebViewModel {
         profile.rustFxA.accountManager?.finishAuthentication(authData: auth) { _ in
             self.profile.syncManager?.onAddedAccount()
 
+            // Set the user's Firefox account UID if available
+            if let accountUid = self.profile.rustFxA.accountManager?.accountProfile()?.uid {
+                UserTelemetry().setFirefoxAccountID(uid: accountUid)
+            }
+
             // only ask for notification permission if it's not onboarding related (e.g. settings)
             // or if the onboarding flow is missing the notifications card
             guard self.shouldAskForNotificationPermission else { return }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanWrapper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanWrapper.swift
@@ -26,6 +26,7 @@ class MockGleanWrapper: GleanWrapper {
     var submitPingCalled = 0
     var savedEvents: [Any] = []
     var savedExtras: [Any] = []
+    var savedValues: [Any] = []
     var savedLabel: Any?
     var savedPing: Any?
 
@@ -62,6 +63,7 @@ class MockGleanWrapper: GleanWrapper {
 
     func recordString(for metric: StringMetricType, value: String) {
         savedEvents.append(metric)
+        savedValues.append(value)
         recordStringCalled += 1
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/UserTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/UserTelemetryTests.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+import XCTest
+
+@testable import Client
+
+final class UserTelemetryTests: XCTestCase {
+    let mockFirefoxAccountId = "8a583618afa8468684cac629d899e0af" // FxA uses uuid v4 format
+    var mockGleanWrapper: MockGleanWrapper!
+
+    override func setUp() {
+        super.setUp()
+
+        mockGleanWrapper = MockGleanWrapper()
+    }
+
+    func testSetFirefoxAccountID_recordsData() throws {
+        let expectedMetricType = type(of: GleanMetrics.UserClientAssociation.uid)
+        let expectedValue = mockFirefoxAccountId
+
+        let subject = createSubject()
+        subject.setFirefoxAccountID(uid: expectedValue)
+
+        let savedValue = try XCTUnwrap(
+            mockGleanWrapper.savedValues.first as? String
+        )
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents.first as? StringMetricType
+        )
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordStringCalled, 1)
+        XCTAssertEqual(savedValue, expectedValue)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func createSubject() -> UserTelemetry {
+        return UserTelemetry(gleanWrapper: mockGleanWrapper)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12445)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27133)

## :bulb: Description
This PR adds a new `fx-accounts` ping which is sent any time the app launches with a user on an authenticated account, or after a user logs in to their Firefox account.

### Testing Notes

**To test `fx-accounts` after logging into your firefox sync account:**

- Launch the app and make sure you're logged out
- Run `xcrun simctl openurl booted "firefox://glean?logPings=true&debugViewTag=YOURTAG&sendPing=metrics"` from your terminal with the [Glean Debugger Dashboard](https://glean-debug-view-dev-237806.firebaseapp.com/) `debugViewTag` of your choice
- Log into your sync account
- Check the ping data on the Glean Debugger Dashboard: `https://glean-debug-view-dev-237806.firebaseapp.com/pings/YOURTAG` for the `debugViewTag` of your choice

**To test `fx-accounts` sending on startup:**

- Compile and build the app once
- Quit the app
- Run `xcrun simctl openurl booted "firefox://glean?logPings=true&debugViewTag=YOURTAG&sendPing=metrics"` from your terminal with the [Glean Debugger Dashboard](https://glean-debug-view-dev-237806.firebaseapp.com/) `debugViewTag` of your choice
- This will launch the app and immediately submit the `fx-accounts` ping (happens very early in startup)
- Check the ping data on the Glean Debugger Dashboard: `https://glean-debug-view-dev-237806.firebaseapp.com/pings/YOURTAG` for the `debugViewTag` of your choice

In both cases, you should see something like this in the `fx-accounts` ping:
```
"metrics": {
    "string": {
      "user.client_association.uid": "8a583618afa8468684cac629d899e0af"
    }
  },
```

💡 In the Glean Debugger Dashboard, the new `fx-accounts` ping will currently have a little info bubble beside it. That's because it's new; Glean will recognize it later.

Unit tests to follow shortly in another commit.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
