### PR TITLE
Add FXIOS-12396 Default Zoom Feature tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ZoomPageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ZoomPageManagerTests.swift
@@ -126,6 +126,44 @@ class ZoomPageManagerTests: XCTestCase {
         // When the tab is set we check if there is zoom level and set it
         XCTAssertEqual(zoomStore.findZoomLevelCalledCount, 1)
     }
+    
+    func testZoomLevelWhenTabIsNill_DefaultZoomLimit() {
+        let subject = createSubject()
+        
+        XCTAssertEqual(subject.getZoomLevel(), ZoomConstants.defaultZoomLimit)
+    }
+    
+    func testZoomLevelWhenTabIsNill_WhenZoomInIsCalledDefaultZoomLimit() {
+        let subject = createSubject()
+        
+        XCTAssertEqual(subject.zoomIn(), ZoomConstants.defaultZoomLimit)
+        XCTAssertEqual(zoomStore.findZoomLevelCalledCount, 0)
+    }
+    
+    func testZoomLevelWhenTabUrlIsNill_WhenZoomInIsCalledDefaultZoomLimit() {
+        let subject = createSubject()
+        let tab = Tab(profile: profile, windowUUID: windowUUID)
+        subject.tabDidGainFocus(tab)
+        
+        XCTAssertEqual(subject.zoomIn(), ZoomConstants.defaultZoomLimit)
+        XCTAssertEqual(zoomStore.findZoomLevelCalledCount, 0)
+    }
+    
+    func testZoomLevelWhenTabIsNill_WhenZoomOutIsCalledDefaultZoomLimit() {
+        let subject = createSubject()
+        
+        XCTAssertEqual(subject.zoomOut(), ZoomConstants.defaultZoomLimit)
+        XCTAssertEqual(zoomStore.findZoomLevelCalledCount, 0)
+    }
+    
+    func testZoomLevelWhenTabUrlIsNill_WhenZoomOutIsCalledDefaultZoomLimit() {
+        let subject = createSubject()
+        let tab = Tab(profile: profile, windowUUID: windowUUID)
+        subject.tabDidGainFocus(tab)
+        
+        XCTAssert(subject.zoomOut() == ZoomConstants.defaultZoomLimit)
+        XCTAssert(zoomStore.findZoomLevelCalledCount == 0)
+    }
 
     // MARK: - Private
     private func createSubject() -> ZoomPageManager {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12396)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27039)

## :bulb: Description
Tests for the default zoom feature added to ZoomPageManagerTests

## :movie_camera: Demos

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ x] I filled in the ticket numbers and a description of my work
- [x ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x ] I ensured unit tests pass and wrote tests for new code
- [ x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x ] If needed, I updated documentation and added comments to complex code
- [ x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
