### PR TITLE
Fix [MTE-4688]-testLongTapRecentlySavedLink test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -424,6 +424,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
         app.launch()
         validateLongTapOptionsFromBookmarkLink()
         forceRestartApp()
+        app.launch()
         if #available(iOS 18, *) {
             XCUIDevice.shared.orientation = .landscapeLeft
             validateLongTapOptionsFromBookmarkLink()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4688

## :bulb: Description
Small fix for testLongTapRecentlySavedLink test