### PR TITLE
Add FXIOS-12462 [Telemetry Audit] Remove pocket actions and send to device telemetry

### DIFF
--- a/firefox-ios/Client/Frontend/Share/SendToDeviceActivity.swift
+++ b/firefox-ios/Client/Frontend/Share/SendToDeviceActivity.swift
@@ -14,11 +14,6 @@ class SendToDeviceActivity: CustomAppActivity {
     override func prepare(withActivityItems activityItems: [Any]) {}
 
     override func perform() {
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .tap,
-                                     object: .shareSheet,
-                                     value: .shareSendToDevice,
-                                     extras: nil)
         activityDidFinish(true)
     }
 }

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -37,27 +37,7 @@ class ShareManager: NSObject, FeatureFlaggable {
 
         activityViewController.excludedActivityTypes = excludingActivities
 
-        activityViewController.completionWithItemsHandler = { activityType, completed, returnedItems, activityError in
-            guard completed else {
-                completionHandler(completed, activityType)
-                return
-            }
-
-            // Add telemetry for Pocket extension activityTypes
-            if activityType?.rawValue == ActivityIdentifiers.pocketIconExtension {
-                TelemetryWrapper.recordEvent(category: .action,
-                                             method: .tap,
-                                             object: .shareSheet,
-                                             value: .sharePocketIcon,
-                                             extras: nil)
-            } else if activityType?.rawValue == ActivityIdentifiers.pocketActionExtension {
-                TelemetryWrapper.recordEvent(category: .action,
-                                             method: .tap,
-                                             object: .shareSheet,
-                                             value: .shareSaveToPocket,
-                                             extras: nil)
-            }
-
+        activityViewController.completionWithItemsHandler = { activityType, completed, _, _ in
             completionHandler(completed, activityType)
         }
 

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -4692,45 +4692,6 @@ toolbar:
 # Share sheet specific metrics
 
 share_sheet:
-  send_device_tapped:
-    type: event
-    description: |
-      Counts the number of times a user taps send to device
-      button from Share Sheet actions
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-5226
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/12526
-      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-  pocket_action_tapped:
-    type: event
-    description: |
-      Counts the number of times a user taps Pocket icon
-      from Share Sheet apps available
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-5226
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/12552
-      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-  save_to_pocket_tapped:
-    type: event
-    description: |
-      Counts the number of times a user taps Save to Pocket
-      from Share Sheet actions
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-5226
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/12552
-      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
   shared_to:
     type: event
     description: |

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -587,9 +587,6 @@ extension TelemetryWrapper {
         case readingListPanel = "reading-list-panel"
         case shareExtension = "share-extension"
         case shareMenu = "share-menu"
-        case shareSendToDevice = "share-send-to-device"
-        case sharePocketIcon = "share-pocket-icon"
-        case shareSaveToPocket = "save-to-pocket-share-action"
         case tabTray = "tab-tray"
         case topTabs = "top-tabs"
         case themeModeManually = "theme-manually"
@@ -1729,13 +1726,6 @@ extension TelemetryWrapper {
                     messageSurface: messageSurface
                 )
             )
-        // MARK: - Share sheet actions
-        case (.action, .tap, .shareSheet, .shareSendToDevice, _):
-            GleanMetrics.ShareSheet.sendDeviceTapped.record()
-        case (.action, .tap, .shareSheet, .sharePocketIcon, _):
-            GleanMetrics.ShareSheet.pocketActionTapped.record()
-        case (.action, .tap, .shareSheet, .shareSaveToPocket, _):
-            GleanMetrics.ShareSheet.saveToPocketTapped.record()
 
         // MARK: - App Errors
         case(.information, .error, .app, .largeFileWrite, let extras):


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12462)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27168)

## :bulb: Description
Removed 

share_sheet.pocket_action_tapped
share_sheet.save_to_pocket_tapped
share_sheet.send_device_tapped

and related code 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
