### PR TITLE
Several fixes [MTE-4688] - on new failed tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -424,6 +424,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
         app.launch()
         validateLongTapOptionsFromBookmarkLink()
         forceRestartApp()
+        app.launch()
         if #available(iOS 18, *) {
             XCUIDevice.shared.orientation = .landscapeLeft
             validateLongTapOptionsFromBookmarkLink()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -128,7 +128,10 @@ class DragAndDropTests: FeatureFlaggedTestBase {
         }
     }
 
-    func testRearrangeTabsTabTrayLandscape_tabTrayExperimentOn() {
+    func testRearrangeTabsTabTrayLandscape_tabTrayExperimentOn() throws {
+        guard iPad() else {
+            throw XCTSkip("Drag and drop is only applicable for iPad with tab tray enabled")
+        }
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "tab-tray-ui-experiments")
         app.launch()
         // Set the device in landscape mode
@@ -184,7 +187,10 @@ class DragAndDropTests: FeatureFlaggedTestBase {
         }
     }
 
-    func testDragAndDropHomeTabTabsTray_tabTrayExperimentOn() {
+    func testDragAndDropHomeTabTabsTray_tabTrayExperimentOn() throws {
+        guard iPad() else {
+            throw XCTSkip("Drag and drop is only applicable for iPad with tab tray enabled")
+        }
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "tab-tray-ui-experiments")
         app.launch()
         navigator.openNewURL(urlString: secondWebsite.url)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4688

## :bulb: Description
Small fix for testLongTapRecentlySavedLink test
Removed 2 drag and drop tests from running on iPhone. This functionality has been removed for the tray experiment on.