### PR TITLE
Bugfix FXIOS-12496 [Tab tray UI experiment] Tabs' titles are incorrectly displayed in light theme

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -316,6 +316,9 @@ class TabDisplayView: UIView,
         self.theme = theme
         collectionView.backgroundColor = theme.colors.layer3
         collectionView.visibleCells.forEach { ($0 as? ThemeApplicable)?.applyTheme(theme: theme) }
+        collectionView.visibleSupplementaryViews(ofKind: TabTitleSupplementaryView.cellIdentifier)
+            .compactMap { $0 as? TabTitleSupplementaryView }
+            .forEach { $0.applyTheme(theme: theme) }
     }
 
     private func getSection(for sectionIndex: Int) -> TabDisplayViewSection {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12496)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27239)

## :bulb: Description
Make sure theme is applied properly on tab title supplementary views

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
