### PR TITLE
Add FXIOS-12540 [Telemetry Audit] Move toasts probes to their own toast.yaml file

### DIFF
--- a/firefox-ios/Client/Glean/gleanProbes.xcfilelist
+++ b/firefox-ios/Client/Glean/gleanProbes.xcfilelist
@@ -3,3 +3,4 @@ $(PROJECT_DIR)/Client/Glean/probes/app_icon.yaml
 $(PROJECT_DIR)/Client/Glean/probes/metrics.yaml
 $(PROJECT_DIR)/Client/Glean/probes/microsurvey.yaml
 $(PROJECT_DIR)/Client/Glean/probes/settings.yaml
+$(PROJECT_DIR)/Client/Glean/probes/toast.yaml

--- a/firefox-ios/Client/Glean/glean_index.yaml
+++ b/firefox-ios/Client/Glean/glean_index.yaml
@@ -10,4 +10,5 @@ metrics_files:
   - firefox-ios/Client/Glean/probes/metrics.yaml
   - firefox-ios/Client/Glean/probes/microsurvey.yaml
   - firefox-ios/Client/Glean/probes/settings.yaml
+  - firefox-ios/Client/Glean/probes/toast.yaml
   - firefox-ios/Storage/metrics.yaml

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -3506,41 +3506,6 @@ tabs_panel.close_all_tabs_sheet:
     metadata:
       tags:
         - TabsPanel
-
-# Toasts
-toasts.close_single_tab:
-  undo_tapped:
-    type: event
-    description: |
-      Records when the user selects undo after closing a tab.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-11714
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/25569
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-    metadata:
-      tags:
-        - Toasts
-        - TabsPanel
-
-toasts.close_all_tabs:
-  undo_tapped:
-    type: event
-    description: |
-      Records when the user selects undo after closing all tabs.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-11714
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/25569
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-    metadata:
-      tags:
-        - Toasts
-        - TabsPanel
   
 # Enhanced Tracking Protection metrics
 tracking_protection:

--- a/firefox-ios/Client/Glean/probes/toast.yaml
+++ b/firefox-ios/Client/Glean/probes/toast.yaml
@@ -1,0 +1,55 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the metrics that are recorded by the Glean SDK. They are
+# automatically converted to Swift code at build time using the `glean_parser`
+# PyPI package.
+
+# This file is organized (roughly) alphabetically by metric names
+# for easy navigation
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+$tags:
+  - Toasts
+
+###############################################################################
+# Documentation
+###############################################################################
+
+# Add your new metrics and/or events here.
+
+# Toasts
+toasts.close_single_tab:
+  undo_tapped:
+    type: event
+    description: |
+      Records when the user selects undo after closing a tab.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-11714
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25569
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-01-01"
+    metadata:
+      tags:
+        - TabsPanel
+
+toasts.close_all_tabs:
+  undo_tapped:
+    type: event
+    description: |
+      Records when the user selects undo after closing all tabs.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-11714
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25569
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-01-01"
+    metadata:
+      tags:
+        - TabsPanel

--- a/firefox-ios/Client/Glean/tags.yaml
+++ b/firefox-ios/Client/Glean/tags.yaml
@@ -43,8 +43,7 @@ TabsPanel:
   description: Corresponds to all things related to the tab panel.
 
 Toasts:
-  description: Corresponds to any events around toasts in the app. Toasts are the shortlived banners that 
-    appear when an action is taken.
+  description: Corresponds to the toast elements which can be shown over any screen in the app to provide feedback for user interaction and to sometimes revert user changes.
 
 TopSites:
   description: Corresponds to the [Feature:TopSites](https://mozilla-hub.atlassian.net/browse/FXIOS-3464)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12540)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27325)

## :bulb: Description
Move toasts related probes out of `metrics.yaml` to a separate file

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
