### PR TITLE
BugFix FXIOS-12263 gradient background flash on Private homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -125,7 +125,7 @@ final class PrivateHomepageViewController: UIViewController,
 
     override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {
         coordinator.animate { _ in
-            self.gradient.frame = self.view.bounds
+            self.gradient.frame = CGRect(origin: .zero, size: size)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -14,12 +14,11 @@ protocol PrivateHomepageDelegate: AnyObject {
 }
 
 // Displays the view for the private homepage when users create a new tab in private browsing
-final class PrivateHomepageViewController:
-    UIViewController,
-    ContentContainable,
-    Screenshotable,
-    Themeable,
-    FeatureFlaggable {
+final class PrivateHomepageViewController: UIViewController,
+                                           ContentContainable,
+                                           Screenshotable,
+                                           Themeable,
+                                           FeatureFlaggable {
     enum UX {
         static let scrollContainerStackSpacing: CGFloat = 24
         static let defaultScrollContainerPadding: CGFloat = 16
@@ -124,6 +123,12 @@ final class PrivateHomepageViewController:
         applyTheme()
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {
+        coordinator.animate { _ in
+            self.gradient.frame = self.view.bounds
+        }
+    }
+
     deinit {
         // TODO: FXIOS-11187 - Investigate further on privateMessageCardCell memory leaking during viewing private tab.
         scrollView.removeFromSuperview()
@@ -135,6 +140,7 @@ final class PrivateHomepageViewController:
         scrollContainer.accessibilityElements = [homepageHeaderCell.contentView, privateMessageCardCell]
 
         setupGradient(gradient)
+        gradient.frame = view.bounds
         view.layer.addSublayer(gradient)
         view.addSubview(scrollView)
         scrollView.addSubview(scrollContainer)
@@ -194,11 +200,6 @@ final class PrivateHomepageViewController:
         constraint?.isActive = false
         constraint?.constant = updatedConstant
         constraint?.isActive = true
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        gradient.frame = view.bounds
     }
 
     func applyTheme() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12263)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26715)

## :bulb: Description
Bugfix private homepage gradient background flashing when keyboard is popping in.

## :movie_camera: Demos

https://github.com/user-attachments/assets/dfb0e329-8df1-44b7-a964-0b0059d8f638

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
