### PR TITLE
Refactor FXIOS-7301 - Remove 3 closure_body_length violations from OnboardingSegmentedControl.swift, BrowserViewController+WebViewDelegates.swift, and MainMenuCoordinator.swift

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,8 +103,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 41
-  error: 41
+  warning: 39
+  error: 39
 
 file_header:
   required_string: |

--- a/BrowserKit/Sources/OnboardingKit/Views/OnboardingSegmentedControl.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/OnboardingSegmentedControl.swift
@@ -36,14 +36,7 @@ struct OnboardingSegmentedControl<Action: Equatable & Hashable>: View {
                     VStack(spacing: UX.SegmentedControl.outerVStackSpacing) {
                         let isSelected = item.action == selection
 
-                        if let img = item.image {
-                            Image(uiImage: img)
-                                .resizable()
-                                .colorMultiply(isSelected ? actionPrimary : noSelection)
-                                .aspectRatio(contentMode: .fit)
-                                .frame(height: UX.SegmentedControl.imageHeight)
-                                .accessibilityHidden(true)
-                        }
+                        itemImage(item: item, isSelected: isSelected)
 
                         VStack(spacing: UX.SegmentedControl.innerVStackSpacing) {
                             Text(item.title)

--- a/BrowserKit/Sources/OnboardingKit/Views/OnboardingSegmentedControl.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/OnboardingSegmentedControl.swift
@@ -85,6 +85,22 @@ struct OnboardingSegmentedControl<Action: Equatable & Hashable>: View {
         }
     }
 
+    private func itemContent(item: OnboardingMultipleChoiceButtonModel<Action>, isSelected: Bool) -> some View {
+        VStack(spacing: UX.SegmentedControl.innerVStackSpacing) {
+            Text(item.title)
+                .font(.footnote)
+                .foregroundColor(.primary)
+            Image(
+                isSelected
+                ? UX.SegmentedControl.radioButtonSelectedImage
+                : UX.SegmentedControl.radioButtonNotSelectedImage,
+                bundle: .module
+            )
+            .font(.system(size: UX.SegmentedControl.checkmarkFontSize))
+            .accessibilityHidden(true)
+        }
+    }
+
     private func applyTheme(theme: Theme) {
         actionPrimary = Color(theme.colors.actionPrimary)
         noSelection = Color(theme.colors.textOnDark)

--- a/BrowserKit/Sources/OnboardingKit/Views/OnboardingSegmentedControl.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/OnboardingSegmentedControl.swift
@@ -38,19 +38,7 @@ struct OnboardingSegmentedControl<Action: Equatable & Hashable>: View {
 
                         itemImage(item: item, isSelected: isSelected)
 
-                        VStack(spacing: UX.SegmentedControl.innerVStackSpacing) {
-                            Text(item.title)
-                                .font(.footnote)
-                                .foregroundColor(.primary)
-                            Image(
-                                isSelected
-                                ? UX.SegmentedControl.radioButtonSelectedImage
-                                : UX.SegmentedControl.radioButtonNotSelectedImage,
-                                bundle: .module
-                            )
-                            .font(.system(size: UX.SegmentedControl.checkmarkFontSize))
-                            .accessibilityHidden(true)
-                        }
+                        itemContent(item: item, isSelected: isSelected)
                     }
                     .padding(.vertical, UX.SegmentedControl.verticalPadding)
                     .frame(maxWidth: .infinity)

--- a/BrowserKit/Sources/OnboardingKit/Views/OnboardingSegmentedControl.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/OnboardingSegmentedControl.swift
@@ -80,6 +80,18 @@ struct OnboardingSegmentedControl<Action: Equatable & Hashable>: View {
         }
     }
 
+    @ViewBuilder
+    private func itemImage(item: OnboardingMultipleChoiceButtonModel<Action>, isSelected: Bool) -> some View {
+        if let img = item.image {
+            Image(uiImage: img)
+                .resizable()
+                .colorMultiply(isSelected ? actionPrimary : noSelection)
+                .aspectRatio(contentMode: .fit)
+                .frame(height: UX.SegmentedControl.imageHeight)
+                .accessibilityHidden(true)
+        }
+    }
+
     private func applyTheme(theme: Theme) {
         actionPrimary = Color(theme.colors.actionPrimary)
         noSelection = Color(theme.colors.textOnDark)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -861,6 +861,18 @@ extension BrowserViewController: WKNavigationDelegate {
         }
     }
 
+    private func handleDownloadError(tab: Tab?, request: URLRequest, error: (any Error)?) {
+        navigationHandler?.removeDocumentLoading()
+        logger.log("Failed to download Document",
+                   level: .warning,
+                   category: .webview,
+                   extra: [
+                    "error": error?.localizedDescription ?? "",
+                    "url": request.url?.absoluteString ?? "Unknown URL"])
+        guard let error, let webView = tab?.webView else { return }
+        showErrorPage(webView: webView, error: error)
+    }
+
     private func showErrorPage(webView: WKWebView, error: Error) {
         guard let url = webView.url else { return }
         if isNativeErrorPageEnabled {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -857,6 +857,16 @@ extension BrowserViewController: WKNavigationDelegate {
                      context: nil)
     }
 
+    private func handleDownloadStarted(tab: Tab?, request: URLRequest) {
+        observeValue(forKeyPath: KVOConstants.loading.rawValue,
+                     of: tab?.webView,
+                     change: [.newKey: true],
+                     context: nil)
+        if let url = request.url {
+            documentLogger.registerDownloadStart(url: url)
+        }
+    }
+
     private func showErrorPage(webView: WKWebView, error: Error) {
         guard let url = webView.url else { return }
         if isNativeErrorPageEnabled {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -853,6 +853,13 @@ extension BrowserViewController: WKNavigationDelegate {
         }
     }
 
+    private func handleDownloadProgressUpdate(progress: Double, tab: Tab?) {
+        observeValue(forKeyPath: KVOConstants.estimatedProgress.rawValue,
+                     of: tab?.webView,
+                     change: [.newKey: progress],
+                     context: nil)
+    }
+
     private func showErrorPage(webView: WKWebView, error: Error) {
         guard let url = webView.url else { return }
         if isNativeErrorPageEnabled {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -822,15 +822,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 self?.handleDownloadStarted(tab: tab, request: request)
             }
             tempPDF.onDownloadError = { error in
-                self?.navigationHandler?.removeDocumentLoading()
-                self?.logger.log("Failed to download Document",
-                                 level: .warning,
-                                 category: .webview,
-                                 extra: [
-                                    "error": error?.localizedDescription ?? "",
-                                    "url": request.url?.absoluteString ?? "Unknown URL"])
-                guard let error, let webView = tab?.webView else { return }
-                self?.showErrorPage(webView: webView, error: error)
+                self?.handleDownloadError(tab: tab, request: request, error: error)
             }
             tab?.enqueueDocument(tempPDF)
             if let url = request.url {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -819,13 +819,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 self?.handleDownloadProgressUpdate(progress: progress, tab: tab)
             }
             tempPDF.onDownloadStarted = {
-                self?.observeValue(forKeyPath: KVOConstants.loading.rawValue,
-                                   of: tab?.webView,
-                                   change: [.newKey: true],
-                                   context: nil)
-                if let url = request.url {
-                    self?.documentLogger.registerDownloadStart(url: url)
-                }
+                self?.handleDownloadStarted(tab: tab, request: request)
             }
             tempPDF.onDownloadError = { error in
                 self?.navigationHandler?.removeDocumentLoading()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -816,10 +816,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 cookies: cookies
             )
             tempPDF.onDownloadProgressUpdate = { progress in
-                self?.observeValue(forKeyPath: KVOConstants.estimatedProgress.rawValue,
-                                   of: tab?.webView,
-                                   change: [.newKey: progress],
-                                   context: nil)
+                self?.handleDownloadProgressUpdate(progress: progress, tab: tab)
             }
             tempPDF.onDownloadStarted = {
                 self?.observeValue(forKeyPath: KVOConstants.loading.rawValue,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -69,60 +69,7 @@ class MainMenuCoordinator: BaseCoordinator, FeatureFlaggable {
         router.dismiss(animated: animated, completion: { [weak self] in
             guard let self else { return }
 
-            switch destination.destination {
-            case .bookmarks:
-                self.navigationHandler?.showLibraryPanel(.bookmarks)
-
-            case .customizeHomepage:
-                self.navigationHandler?.showSettings(at: .homePage)
-
-            case .downloads:
-                self.navigationHandler?.showLibraryPanel(.downloads)
-
-            case .editBookmark:
-                self.navigationHandler?.editBookmarkForCurrentTab()
-
-            case .findInPage:
-                self.navigationHandler?.showFindInPage()
-
-            case .goToURL:
-                self.navigationHandler?.openURLInNewTab(destination.url)
-
-            case .history:
-                self.navigationHandler?.showLibraryPanel(.history)
-
-            case .newTab:
-                self.navigationHandler?.openNewTab(inPrivateMode: false)
-
-            case .newPrivateTab:
-                self.navigationHandler?.openNewTab(inPrivateMode: true)
-
-            case .passwords:
-                self.navigationHandler?.showSettings(at: .password)
-
-            case .settings:
-                self.navigationHandler?.showSettings(at: .general)
-
-            case .syncSignIn:
-                let fxaParameters = FxASignInViewParameters(
-                    launchParameters: FxALaunchParams(entrypoint: .browserMenu, query: [:]),
-                    flowType: .emailLoginFlow,
-                    referringPage: .appMenu
-                )
-                self.navigationHandler?.showSignInView(fxaParameters: fxaParameters)
-
-            case .printSheet:
-                self.navigationHandler?.showPrintSheet()
-
-            case .shareSheet:
-                self.navigationHandler?.showShareSheetForCurrentlySelectedTab()
-
-            case .saveAsPDF:
-                self.navigationHandler?.presentSavePDFController()
-
-            case .zoom:
-                self.navigationHandler?.updateZoomPageBarVisibility()
-            }
+            self.handleDestination(destination)
 
             removeCoordinatorFromParent()
         })

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -128,6 +128,63 @@ class MainMenuCoordinator: BaseCoordinator, FeatureFlaggable {
         })
     }
 
+    private func handleDestination(_ destination: MenuNavigationDestination) {
+        switch destination.destination {
+        case .bookmarks:
+            navigationHandler?.showLibraryPanel(.bookmarks)
+
+        case .customizeHomepage:
+            navigationHandler?.showSettings(at: .homePage)
+
+        case .downloads:
+            navigationHandler?.showLibraryPanel(.downloads)
+
+        case .editBookmark:
+            navigationHandler?.editBookmarkForCurrentTab()
+
+        case .findInPage:
+            navigationHandler?.showFindInPage()
+
+        case .goToURL:
+            navigationHandler?.openURLInNewTab(destination.url)
+
+        case .history:
+            navigationHandler?.showLibraryPanel(.history)
+
+        case .newTab:
+            navigationHandler?.openNewTab(inPrivateMode: false)
+
+        case .newPrivateTab:
+            navigationHandler?.openNewTab(inPrivateMode: true)
+
+        case .passwords:
+            navigationHandler?.showSettings(at: .password)
+
+        case .settings:
+            navigationHandler?.showSettings(at: .general)
+
+        case .syncSignIn:
+            let fxaParameters = FxASignInViewParameters(
+                launchParameters: FxALaunchParams(entrypoint: .browserMenu, query: [:]),
+                flowType: .emailLoginFlow,
+                referringPage: .appMenu
+            )
+            navigationHandler?.showSignInView(fxaParameters: fxaParameters)
+
+        case .printSheet:
+            navigationHandler?.showPrintSheet()
+
+        case .shareSheet:
+            navigationHandler?.showShareSheetForCurrentlySelectedTab()
+
+        case .saveAsPDF:
+            navigationHandler?.presentSavePDFController()
+
+        case .zoom:
+            navigationHandler?.updateZoomPageBarVisibility()
+        }
+    }
+
     // MARK: - Private helpers
 
     private func createMainMenuViewController() -> MainMenuViewController {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 3 `closure_body_length` violations and decreases the threshold to 39.

In `OnboardingSegmentedControl.swift`, I extracted a block of code into a new function instead of keeping it as a property body pattern, which couldn't work due to object reference requirements.

In `BrowserViewController+WebViewDelegates.swift`, I just moved some code blocks into new functions.

In `MainMenuCoordinator.swift`, I extracted an entire switch case statement into a function, which worked well because the function body length threshold is higher than the closure body length in default configuration.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
