### PR TITLE
Add FXIOS-12563 [HNT - Search Bar] search bar feature flag

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -28,7 +28,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case hntSponsoredShortcuts
     case hntTopSitesVisualRefresh
     case homepageRebuild
-    case homepageNewTab
+    case homepageRedesign
     case homepageSearchBar
     case inactiveTabs
     case loginsVerificationEnabled
@@ -146,7 +146,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .hntCusomizationSection,
                 .hntTopSitesVisualRefresh,
                 .homepageRebuild,
-                .homepageNewTab,
+                .homepageRedesign,
                 .homepageSearchBar,
                 .loginsVerificationEnabled,
                 .menuRefactor,

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -28,6 +28,8 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case hntSponsoredShortcuts
     case hntTopSitesVisualRefresh
     case homepageRebuild
+    case homepageNewTab
+    case homepageSearchBar
     case inactiveTabs
     case loginsVerificationEnabled
     case menuRefactor
@@ -144,6 +146,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .hntCusomizationSection,
                 .hntTopSitesVisualRefresh,
                 .homepageRebuild,
+                .homepageNewTab,
+                .homepageSearchBar,
                 .loginsVerificationEnabled,
                 .menuRefactor,
                 .menuRefactorHint,

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -59,11 +59,11 @@ final class NimbusFeatureFlagLayer {
         case .hntTopSitesVisualRefresh:
             return checkHntTopSitesVisualRefreshFeature(from: nimbus)
 
-        case .homepageNewTab:
-            return checkHomepageNewTabFeature(from: nimbus)
+        case .homepageRedesign:
+            return checkHomepageRedesignFeature(from: nimbus)
 
         case .homepageSearchBar:
-            return checkHomepageNewTabSearchBarFeature(from: nimbus)
+            return checkHomepageSearchBarFeature(from: nimbus)
 
         case .homepageRebuild:
             return checkHomepageFeature(from: nimbus)
@@ -227,12 +227,12 @@ final class NimbusFeatureFlagLayer {
         return nimbus.features.hntTopSitesVisualRefreshFeature.value().enabled
     }
 
-    private func checkHomepageNewTabFeature(from nimbus: FxNimbus) -> Bool {
-        return nimbus.features.homepageNewTabFeature.value().enabled
+    private func checkHomepageRedesignFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.homepageRedesignFeature.value().enabled
     }
 
-    private func checkHomepageNewTabSearchBarFeature(from nimbus: FxNimbus) -> Bool {
-        return nimbus.features.homepageNewTabFeature.value().searchBar
+    private func checkHomepageSearchBarFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.homepageRedesignFeature.value().searchBar
     }
 
     private func checkHomepageFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -59,6 +59,12 @@ final class NimbusFeatureFlagLayer {
         case .hntTopSitesVisualRefresh:
             return checkHntTopSitesVisualRefreshFeature(from: nimbus)
 
+        case .homepageNewTab:
+            return checkHomepageNewTabFeature(from: nimbus)
+
+        case .homepageSearchBar:
+            return checkHomepageNewTabSearchBarFeature(from: nimbus)
+
         case .homepageRebuild:
             return checkHomepageFeature(from: nimbus)
 
@@ -219,6 +225,14 @@ final class NimbusFeatureFlagLayer {
 
     private func checkHntTopSitesVisualRefreshFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.hntTopSitesVisualRefreshFeature.value().enabled
+    }
+
+    private func checkHomepageNewTabFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.homepageNewTabFeature.value().enabled
+    }
+
+    private func checkHomepageNewTabSearchBarFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.homepageNewTabFeature.value().searchBar
     }
 
     private func checkHomepageFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/nimbus-features/homepageNewTabFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageNewTabFeature.yaml
@@ -1,0 +1,27 @@
+# The configuration for the homepageNewTabFeature feature
+features:
+  homepage-new-tab-feature:
+    description: >
+      This feature is for managing the roll out of the Homepage New Tab feature
+    variables:
+      enabled:
+        description: >
+          Enables the feature
+        type: Boolean
+        default: false
+      search_bar:
+        description: >
+          If true, enables the search bar feature on homepage for users.
+        type: Boolean
+        default: false
+        
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+          search_bar: false
+    
+      - channel: developer
+        value:
+          enabled: false
+          search_bar: false

--- a/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
@@ -1,12 +1,12 @@
-# The configuration for the homepageNewTabFeature feature
+# The configuration for the homepageRedesignFeature feature
 features:
-  homepage-new-tab-feature:
+  homepage-redesign-feature:
     description: >
-      This feature is for managing the roll out of the Homepage New Tab feature
+      This feature is for managing the roll out of the Homepage New Tab Redesign feature.
     variables:
       enabled:
         description: >
-          Enables the feature
+          Enables the feature.
         type: Boolean
         default: false
       search_bar:

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -27,8 +27,8 @@ include:
   - nimbus-features/hntJumpBackInSectionFeature.yaml
   - nimbus-features/hntSponsoredShortcutsFeature.yaml
   - nimbus-features/hntTopSitesVisualRefresh.yaml
-  - nimbus-features/homepageNewTabFeature.yaml
   - nimbus-features/homepageRebuildFeature.yaml
+  - nimbus-features/homepageRedesignFeature.yaml
   - nimbus-features/loginsVerificationEnabled.yaml
   - nimbus-features/menuRefactorFeature.yaml
   - nimbus-features/messagingFeature.yaml

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -27,6 +27,7 @@ include:
   - nimbus-features/hntJumpBackInSectionFeature.yaml
   - nimbus-features/hntSponsoredShortcutsFeature.yaml
   - nimbus-features/hntTopSitesVisualRefresh.yaml
+  - nimbus-features/homepageNewTabFeature.yaml
   - nimbus-features/homepageRebuildFeature.yaml
   - nimbus-features/loginsVerificationEnabled.yaml
   - nimbus-features/menuRefactorFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12563)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27365)

## :bulb: Description
Add main homepage new tab feature flag and search bar sub-flag.

Note: Did not add to debug menu because no immediate need for it. Can add later.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
