### PR TITLE
Add FXIOS-12573 [Homepage Rebuild] empty section layout for safety

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -401,4 +401,17 @@ final class HomepageSectionLayoutProvider {
 
         return section
     }
+
+    /// Returns an empty layout to avoid app crash when unable to section data
+    func makeEmptyLayoutSection() -> NSCollectionLayoutSection {
+        let zeroLayoutSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(0.0),
+            heightDimension: .absolute(0.0)
+        )
+        let emptyGroup = NSCollectionLayoutGroup.horizontal(
+            layoutSize: zeroLayoutSize,
+            subitems: [NSCollectionLayoutItem(layoutSize: zeroLayoutSize)]
+        )
+        return NSCollectionLayoutSection(group: emptyGroup)
+    }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -401,7 +401,12 @@ final class HomepageViewController: UIViewController,
                     category: .homepage,
                     extra: ["Section Index": "\(sectionIndex)"]
                 )
-                return nil
+
+                /// FXIOS-10131: Copied over from legacy homepage in that we want to create an empty layout
+                /// to avoid an app crash.
+                /// However, if we see this path getting hit, then something is wrong and
+                /// we should investigate the underlying issues. We should always be able to fetch the section.
+                return sectionProvider.makeEmptyLayoutSection()
             }
 
             return sectionProvider.createLayoutSection(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12573)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27383)

## :bulb: Description
In case we are unable to get the section when updating the layout, we want to show an empty layout instead of crashing. Basically, copied over what was in legacy homepage. In this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/22512), we added the fix. 

I still see the logs occurring for legacy homepage in Sentry:
`https://mozilla.sentry.io/issues/?environment=Production&project=6176941&query=The current section&statsPeriod=90d`

However, searching on the log for the new homepage `"Section should not have been nil, something went wrong"` returns 0 results. So it seems the underlying issue has been addressed in the homepage rebuild. Nevertheless, we can add this safety check, but if we do start seeing these logs, we would want to investigate. Added a comment to ensure this.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
