### PR TITLE
Bugfix FXIOS-12567 [Top Sites Visual Refresh] Top site cell background and clipping issues when using a wallpaper

### DIFF
--- a/firefox-ios/Client/Extensions/UIView+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIView+Extension.swift
@@ -29,13 +29,14 @@ extension UIView {
     ///
     /// - Parameter style: The strength of the blur desired
     func addBlurEffect(using style: UIBlurEffect.Style) {
-        guard !UIAccessibility.isReduceTransparencyEnabled else { return }
+        guard !UIAccessibility.isReduceTransparencyEnabled, shouldAddBlur else { return }
 
         let blurEffect = UIBlurEffect(style: style)
         let blurEffectView = UIVisualEffectView(effect: blurEffect)
         blurEffectView.clipsToBounds = true
         blurEffectView.isUserInteractionEnabled = false
         blurEffectView.translatesAutoresizingMaskIntoConstraints = false
+        blurEffectView.layer.cornerRadius = layer.cornerRadius
         insertSubview(blurEffectView, at: 0)
 
         NSLayoutConstraint.activate([

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -31,7 +31,7 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
 
     private var rootContainer: UIView = .build { view in
         view.backgroundColor = .clear
-        view.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
+        view.layer.cornerRadius = UX.faviconCornerRadius
     }
 
     private lazy var imageView: FaviconImageView = {
@@ -295,7 +295,7 @@ extension TopSiteCell: Blurrable {
     func adjustBlur(theme: Theme) {
         if shouldApplyWallpaperBlur {
             rootContainer.layoutIfNeeded()
-            rootContainer.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
+            rootContainer.addBlurEffect(using: .systemThickMaterial)
         } else {
             // If blur is disabled set background color
             rootContainer.removeVisualEffectView()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12567)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27372)

## :bulb: Description
- Fixes issue with favicon backgrounds and pin icons when a wallpaper is applied

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 16 - 2025-06-18 at 15 21 20](https://github.com/user-attachments/assets/61296d82-e932-4941-b0ed-28b42f8764a1) | ![Simulator Screenshot - iPhone 16 - 2025-06-18 at 15 20 04](https://github.com/user-attachments/assets/bd9abc9a-4d0b-4505-b461-ec99ab27db4b) | 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
