### PR TITLE
Refactor FXIOS-12581 [Swift 6 migration] manageSiri is now @MainActor

### DIFF
--- a/firefox-ios/Client/Frontend/Extensions/SiriShortcuts.swift
+++ b/firefox-ios/Client/Frontend/Extensions/SiriShortcuts.swift
@@ -43,6 +43,7 @@ class SiriShortcuts {
         viewController.present(editViewController, animated: true, completion: nil)
     }
 
+    @MainActor
     static func manageSiri(for activityType: SiriShortcuts.activityType, in viewController: UIViewController) {
         INVoiceShortcutCenter.shared.getAllVoiceShortcuts { (voiceShortcuts, error) in
             DispatchQueue.main.async {

--- a/firefox-ios/Client/Frontend/Extensions/SiriShortcuts.swift
+++ b/firefox-ios/Client/Frontend/Extensions/SiriShortcuts.swift
@@ -46,17 +46,15 @@ class SiriShortcuts {
     @MainActor
     static func manageSiri(for activityType: SiriShortcuts.activityType, in viewController: UIViewController) {
         INVoiceShortcutCenter.shared.getAllVoiceShortcuts { (voiceShortcuts, error) in
-            DispatchQueue.main.async {
-                guard let voiceShortcuts = voiceShortcuts else { return }
-                let foundShortcut = voiceShortcuts.first(where: { (attempt) in
-                    attempt.shortcut.userActivity?.activityType == activityType.rawValue
-                })
+            guard let voiceShortcuts = voiceShortcuts else { return }
+            let foundShortcut = voiceShortcuts.first(where: { (attempt) in
+                attempt.shortcut.userActivity?.activityType == activityType.rawValue
+            })
 
-                if let foundShortcut = foundShortcut {
-                    self.displayEditSiri(for: foundShortcut, in: viewController)
-                } else {
-                    self.displayAddToSiri(for: activityType, in: viewController)
-                }
+            if let foundShortcut = foundShortcut {
+                self.displayEditSiri(for: foundShortcut, in: viewController)
+            } else {
+                self.displayAddToSiri(for: activityType, in: viewController)
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -51,7 +51,8 @@ class SiriOpenURLSetting: Setting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        if let controller = navigationController?.topViewController {
+        guard let controller = navigationController?.topViewController else { return }
+        Task { @MainActor in
             SiriShortcuts.manageSiri(for: SiriShortcuts.activityType.openURL, in: controller)
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12581)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27398)

## :bulb: Description
`manageSiri` is now `@MainActor`, the error was:

![Screenshot 2025-06-19 at 1 59 31 PM](https://github.com/user-attachments/assets/c563fb24-aa97-4340-9454-7c2aa3afd4ab)

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
