### PR TITLE
Refactor FXIOS-12581 [Swift 6 Migration] Make LoginStorage protocol @MainActor

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/LoginStorage.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginStorage.swift
@@ -6,6 +6,7 @@ import Storage
 
 import struct MozillaAppServices.Login
 
+@MainActor
 protocol LoginStorage {
     func listLogins() async throws -> [Login]
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12581)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27398)

## :bulb: Description
We are accessing `self.loginStorage.listLogins()` from within the @MainActor-isolated context `LoginListViewModel.fetchLogins()` while `loginStorage.listLogins()` is not actor-isolated. This cross-actor access is unsafe, I am proposing we fix it by making the `loginStorage.listLogins()` protocol `@MainActor`.

![Screenshot 2025-06-19 at 2 02 00 PM](https://github.com/user-attachments/assets/4e2f99f2-18a5-40df-af47-6e2618f755a6)

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
