### PR TITLE
Add FXIOS-12583 [Swift 6 Migration] Make profile unchecked sendable

### DIFF
--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -214,7 +214,8 @@ extension Profile {
     }
 }
 
-open class BrowserProfile: Profile {
+open class BrowserProfile: Profile,
+                           @unchecked Sendable {
     private let logger: Logger
     private lazy var directory: String = {
         do {

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -214,6 +214,7 @@ extension Profile {
     }
 }
 
+// TODO: Removed unchecked flag with FXIOS-12610
 open class BrowserProfile: Profile,
                            @unchecked Sendable {
     private let logger: Logger

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -60,7 +60,7 @@ public protocol FxACommandsDelegate: AnyObject {
     func closeTabs(for urls: [URL])
 }
 
-struct ProfileFileAccessor: FileAccessor {
+struct ProfileFileAccessor: FileAccessor, Sendable {
     public var rootPath: String
 
     init(localName: String, logger: Logger = DefaultLogger.shared) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserProfile.swift
@@ -6,4 +6,4 @@ import Foundation
 
 @testable import Client
 
-class MockBrowserProfile: BrowserProfile {}
+class MockBrowserProfile: BrowserProfile, @unchecked Sendable {}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12583)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27398)

## :bulb: Description
Make profile unchecked sendable

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
