### PR TITLE
Refactor FXIOS-12583 [Swift 6 Migration] Tab.swift cleanup dead KVO code and fix deinit swift 6 issues

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,7 +57,6 @@ only_rules: # Only enforce these rules, ignore all others
   - void_return
   - file_header
   - redundant_type_annotation
-  - attributes
   - closing_brace
   - closure_end_indentation
   - contains_over_filter_count

--- a/firefox-ios/Client/AccountSyncHandler.swift
+++ b/firefox-ios/Client/AccountSyncHandler.swift
@@ -95,14 +95,14 @@ class AccountSyncHandler: TabEventHandler {
         for manager in tabManagers {
             // Set inactive tabs explicitly as inactive (initial state)
             for tab in manager.inactiveTabs {
-                if let remoteTab = Tab.toRemoteTab(tab, inactive: true) {
+                if let remoteTab = tab.toRemoteTab() {
                     storedTabsDict[tab.tabUUID] = remoteTab
                 }
             }
 
             // Active tabs override inactive ones if there's overlap
             for tab in manager.normalActiveTabs {
-                if let remoteTab = Tab.toRemoteTab(tab, inactive: false) {
+                if let remoteTab = tab.toRemoteTab() {
                     storedTabsDict[tab.tabUUID] = remoteTab
                 }
             }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -919,12 +919,9 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         return false
     }
 
-    private func deleteDownloadedDocuments(
-        docsURL: TemporaryDocumentSession,
-        backgroundDispatchQueue: DispatchQueueInterface = DispatchQueue.global(qos: .background)
-    ) {
+    private func deleteDownloadedDocuments(docsURL: TemporaryDocumentSession) {
         guard !docsURL.isEmpty else { return }
-        backgroundDispatchQueue.async { [fileManager] in
+        DispatchQueue.global(qos: .background).async { [fileManager] in
             docsURL.forEach { url in
                 try? fileManager.removeItem(at: url.key)
             }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -610,6 +610,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     deinit {
         deleteDownloadedDocuments(docsURL: temporaryDocumentsSession)
         webViewLoadingObserver?.invalidate()
+        webView?.navigationDelegate = nil
 
 #if DEBUG
         debugTabCount -= 1

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -427,6 +427,11 @@ class MockFileManager: FileManagerProtocol {
     var createDirectoryCalled = 0
     var contentOfDirectoryAtPathCalled = 0
 
+    /// Fires every time `removeItem(at: URL)` is called. This is useful for tests that fire this on a background thread
+    /// (e.g. in a deinit) and we want to wait for an expectation of a file removal to be fulfilled.
+    /// Closure contains the updated value of `removeItemAtURLCalled`.
+    var removeItemAtURLDispatch: ((Int) -> Void)?
+
     func fileExists(atPath path: String) -> Bool {
         fileExistsCalled += 1
         return fileExists
@@ -454,6 +459,7 @@ class MockFileManager: FileManagerProtocol {
 
     func removeItem(at url: URL) throws {
         removeItemAtURLCalled += 1
+        removeItemAtURLDispatch?(removeItemAtURLCalled)
     }
 
     func copyItem(at srcURL: URL, to dstURL: URL) throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12583)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27398)

## :bulb: Description

- Turn off swiftlint rule that's doesn't let us put annotations above properties (e.g. `@MainActor` above a property, or SwiftUI annotations like `@ViewBuilder`...)
- **Tab.swift** Remove backgroundDispatchQueue as a class member since it was only that way for unit testing.
- **Tab.swift** Pass in Sendable value type docsURL parameter instead of self to deleteDownloadedDocuments method called in the Tab deinit.
- **Tab.swift** Cleanup seemingly unused remote tab initializer and KVO observing?

cc @dataports 

### Testing
✏️  I believe the unit tests need some work, I'll fix these tomorrow!


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
