### PR TITLE
Add FXIOS-12611 [Homepage Redesign - Stories] Stories redesign feature flag

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -30,6 +30,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case homepageRebuild
     case homepageRedesign
     case homepageSearchBar
+    case homepageStoriesRedesign
     case inactiveTabs
     case loginsVerificationEnabled
     case menuRefactor
@@ -74,6 +75,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .hntContentFeedRefresh,
                 .hntTopSitesVisualRefresh,
                 .homepageRebuild,
+                .homepageStoriesRedesign,
                 .feltPrivacyFeltDeletion,
                 .feltPrivacySimplifiedUI,
                 .menuRefactor,
@@ -148,6 +150,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .homepageRebuild,
                 .homepageRedesign,
                 .homepageSearchBar,
+                .homepageStoriesRedesign,
                 .loginsVerificationEnabled,
                 .menuRefactor,
                 .menuRefactorHint,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -173,7 +173,7 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
-                    with: .hntTopSitesVisualRefresh,
+                    with: .homepageStoriesRedesign,
                     titleText: format(string: "Stories Redesign"),
                     statusText: format(string: "Toggle to enable homepage stories section redesign")
                 ) { [weak self] _ in

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -173,6 +173,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
+                    with: .hntTopSitesVisualRefresh,
+                    titleText: format(string: "Stories Redesign"),
+                    statusText: format(string: "Toggle to enable homepage stories section redesign")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .tabTrayUIExperiments,
                     titleText: format(string: "Tab Tray UI Experiment"),
                     statusText: format(string: "Toggle to use the new tab tray UI")

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -28,13 +28,6 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
             title: nil,
             children: [
                 FeatureFlagsBoolSetting(
-                    with: .addressBarMenu,
-                    titleText: format(string: "Enable New AddressBar Menu"),
-                    statusText: format(string: "Toggle to show the new address bar menu")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
                     with: .appearanceMenu,
                     titleText: format(string: "Appearance Menu"),
                     statusText: format(string: "Toggle to show the new apperance menu")
@@ -141,6 +134,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     with: .nativeErrorPage,
                     titleText: format(string: "Native Error Page"),
                     statusText: format(string: "Toggle to display natively created error pages")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .addressBarMenu,
+                    titleText: format(string: "New AddressBar Menu"),
+                    statusText: format(string: "Toggle to show the new address bar menu")
                 ) { [weak self] _ in
                     self?.reloadView()
                 },

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -65,6 +65,9 @@ final class NimbusFeatureFlagLayer {
         case .homepageSearchBar:
             return checkHomepageSearchBarFeature(from: nimbus)
 
+        case .homepageStoriesRedesign:
+            return checkHomepageStoriesRedesignFeature(from: nimbus)
+
         case .homepageRebuild:
             return checkHomepageFeature(from: nimbus)
 
@@ -233,6 +236,10 @@ final class NimbusFeatureFlagLayer {
 
     private func checkHomepageSearchBarFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.homepageRedesignFeature.value().searchBar
+    }
+
+    private func checkHomepageStoriesRedesignFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.homepageRedesignFeature.value().storiesRedesign
     }
 
     private func checkHomepageFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
@@ -14,14 +14,21 @@ features:
           If true, enables the search bar feature on homepage for users.
         type: Boolean
         default: false
-        
+      stories_redesign:
+        description: >
+          If true, enables the stories section redesign on homepage
+        type: Boolean
+        default: false
+
     defaults:
       - channel: beta
         value:
           enabled: false
           search_bar: false
+          stories_redesign: false
     
       - channel: developer
         value:
           enabled: false
           search_bar: false
+          stories_redesign: false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12611)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27453)

## :bulb: Description
- Add `stories_redesign` feature flag

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
