### PR TITLE
Refactor FXIOS-27336 [TA 2025] Move password generator telemetry to its own YAML file

### DIFF
--- a/firefox-ios/Client/Glean/probes/autofill.password_generator.yaml
+++ b/firefox-ios/Client/Glean/probes/autofill.password_generator.yaml
@@ -21,4 +21,27 @@ $tags:
 ###############################################################################
 
 # Add your new metrics and/or events here.
-
+# Password Generator
+password_generator:
+  shown:
+    type: counter
+    description: |
+        The password generator bottom sheet was shown and is visible
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-01-01"
+  filled:
+    type: counter
+    description: |
+        The "use password button" of the password generator bottom sheet was clicked.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-01-01"

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -1062,31 +1062,6 @@ downloads:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-01-01"
 
-# Password Generator
-password_generator:
-  shown:
-    type: counter
-    description: |
-        The password generator bottom sheet was shown and is visible
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-  filled:
-    type: counter
-    description: |
-        The "use password button" of the password generator bottom sheet was clicked.
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-
 # Key Commands
 key_commands:
   press_key_command_action:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-27336)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27336)

## :bulb: Description
This PR separates the password generator probes into their own specification file and adds a corresponding tag.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
