### PR TITLE
Refactor FXIOS-27331 [TA 2025] Move library downloads panel probes to its own YAML file

### DIFF
--- a/firefox-ios/Client/Glean/probes/library.downloads_panel.yaml
+++ b/firefox-ios/Client/Glean/probes/library.downloads_panel.yaml
@@ -21,4 +21,16 @@ $tags:
 ###############################################################################
 
 # Add your new metrics and/or events here.
-
+downloads:
+  downloads_panel_row_tapped:
+    type: event
+    description: |
+      Records when a row is pressed in the downloads panel
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10777
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/10777
+      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-01-01"

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -1037,18 +1037,6 @@ downloads:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-01-01"
-  downloads_panel_row_tapped:
-    type: event
-    description: |
-      Records when a row is pressed in the downloads panel
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/10777
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/10777
-      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
   view_download_complete_toast:
     type: event
     description: |


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-27331)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27331)

## :bulb: Description
This PR separates the library downloads panel probes into their own specification file and adds a corresponding tag.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
