### PR TITLE
Refactor FXIOS-27330 [TA 2025] Move bookmarks panel probes to its own YAML file

### DIFF
--- a/firefox-ios/Client/Glean/probes/library.bookmarks_panel.yaml
+++ b/firefox-ios/Client/Glean/probes/library.bookmarks_panel.yaml
@@ -21,4 +21,32 @@ $tags:
 ###############################################################################
 
 # Add your new metrics and/or events here.
-
+bookmarks:
+  view_list:
+    type: labeled_counter
+    description: |
+      Counts the number of times the bookmarks list is opened
+      from either the Home Panel tab button or the App Menu.
+    labels:
+      - app-menu
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9673
+      - https://github.com/mozilla-mobile/firefox-ios/pull/12334
+      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-01-01"
+  folder_add:
+    type: event
+    description: |
+      A user added a new bookmark folder.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/15620
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15833
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-01-01"

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -438,23 +438,6 @@ app_menu:
 
 # Bookmark metrics
 bookmarks:
-  view_list:
-    type: labeled_counter
-    description: |
-      Counts the number of times the bookmarks list is opened
-      from either the Home Panel tab button or the App Menu.
-    labels:
-      - app-menu
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-      - https://github.com/mozilla-mobile/firefox-ios/pull/9673
-      - https://github.com/mozilla-mobile/firefox-ios/pull/12334
-      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
   add:
     type: labeled_counter
     description: |
@@ -567,17 +550,6 @@ bookmarks:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-01-01"
     unit: quantity of mobile bookmarks
-  folder_add:
-    type: event
-    description: |
-      A user added a new bookmark folder.
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/15620
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/15833
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
 
 # Context menus
 context_menu:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-27330)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27330)

## :bulb: Description
This PR separates the bookmark panel probes into their own specification file and adds a corresponding tag.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
