### PR TITLE
Bugfix FXIOS-12614 [Content Feed] no longer consider "discover" pocket cell

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -109,10 +109,6 @@ class PocketViewModel {
 
         pocketStoriesViewModels.append(pocketStoryViewModel)
     }
-
-    private func showDiscoverMore() {
-        onTapTileAction?(PocketProvider.MoreStoriesURL)
-    }
 }
 
 // MARK: HomeViewModelProtocol

--- a/firefox-ios/Providers/Pocket/PocketProvider.swift
+++ b/firefox-ios/Providers/Pocket/PocketProvider.swift
@@ -26,14 +26,6 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
     private var prefs: Prefs
 
     static let GlobalFeed = "https://getpocket.cdn.mozilla.net/v3/firefox/global-recs"
-    static let MoreStoriesURL = {
-        switch Locale.current.identifier {
-        case "de_DE":
-            return URL(string: "https://getpocket.com/de/explore?src=ff_ios")!
-        default:
-            return URL(string: "https://getpocket.com/explore?src=ff_ios&cdn=0")!
-        }
-    }()
 
     // Allow endPoint to be overridden for testing
     init(endPoint: String = PocketProvider.GlobalFeed,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12614)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27469)

## :bulb: Description
- Prevents legacy homepage from crashing by no longer considering the recently removed "Discover more" pocket cell in the section count

Caused by #27297, which has been backported to v140. v140 RC has been created, so this will need to go in v140.1 and the crash will still exist in v140. Issue should be contained to first-run users and users with experimentation disabled as this only affects the legacy homepage, and the homepage rebuild has been rolled out to 100% of users via nimbus.


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
