### PR TITLE
FXIOS-26846 Unexpected grey loading bar appears when refreshing a blank new tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -200,6 +200,7 @@ class TabScrollController: NSObject,
         }
 
         guard !tabIsLoading() else { return }
+        guard !(tab?.isFxHomeTab ?? false) else { return }
 
         tab?.shouldScrollToTop = false
 
@@ -613,6 +614,7 @@ extension TabScrollController: UIScrollViewDelegate {
               !tabIsLoading(),
               !scrollReachBottom(),
               !tab.isFindInPageMode,
+              !tab.isFxHomeTab,
               shouldUpdateUIWhenScrolling else { return }
 
         tab.shouldScrollToTop = false

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -312,7 +312,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     var isFxHomeTab: Bool {
         // Check if there is a url or last known url
         let url = url ?? lastKnownUrl
-        guard let url = url else { return false }
+        guard let url = url else { return true }
 
         // Make sure the url is of type home page
         if url.absoluteString.hasPrefix("internal://"),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12326)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26846)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

# Before
https://github.com/user-attachments/assets/866169b5-ded9-4160-92be-f3f12755aa03

# After
https://github.com/user-attachments/assets/41a95bb5-5420-493e-8bd2-83fe0ffab833


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
