### PR TITLE
Remove [MTE-4708] - pocket test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -47,7 +47,6 @@ class JumpBackInTests: FeatureFlaggedTestBase {
         // Open a new tab
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        closeKeyboard()
 
         // "Jump Back In" section is displayed
         mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
@@ -96,20 +96,4 @@ class PocketTests: BaseTestCase {
             ]
         )
     }
-
-    // https://mozilla.testrail.io/index.php?/cases/view/2855361
-    func testValidateLearnMoreButton() {
-        navigator.goto(NewTabScreen)
-        mozWaitForElementToExist(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
-        // Learn more link is displayed under the stories
-        app.swipeUp()
-        let collectionView = AccessibilityIdentifiers.FirefoxHomepage.collectionView
-        let learnMoreLink = app.collectionViews[collectionView].staticTexts["Learn more"]
-        let pocketTitle = AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket
-        let addressBar = AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField
-        mozWaitForElementToExist(learnMoreLink)
-        XCTAssertTrue(learnMoreLink.isBelow(element: app.staticTexts[pocketTitle]))
-        learnMoreLink.waitAndTap()
-        mozWaitForValueContains(app.textFields[addressBar], value: "mozilla.org")
-    }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4708

## :bulb: Description
Small fix for testJumpBackInSection by removing the close keyboard action
Removed testValidateLearnMoreButton test because learn more was part of pocket and this was replaced by stories.