### PR TITLE
Remove FXIOS-12138 #26409 ⁃ [Toast audit] Remove toast from Settings > password for action delete password

### DIFF
--- a/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
@@ -82,9 +82,6 @@ class PasswordManagerCoordinator: BaseCoordinator,
     func pressedPasswordDetail(model: PasswordDetailViewControllerModel) {
         let viewController = PasswordDetailViewController(viewModel: model, windowUUID: windowUUID)
         viewController.coordinator = self
-        viewController.deleteHandler = { [weak self] in
-            self?.passwordManager?.showToast()
-        }
         router.push(viewController)
     }
 

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -168,12 +168,6 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         dismiss(animated: true)
     }
 
-    func showToast() {
-        SimpleToast().showAlertWithText(.LoginListDeleteToast,
-                                        bottomContainer: view,
-                                        theme: themeManager.getCurrentTheme(for: windowUUID))
-    }
-
     lazy var editButton = UIBarButtonItem(barButtonSystemItem: .edit,
                                           target: self,
                                           action: #selector(beginEditing))
@@ -334,7 +328,6 @@ private extension PasswordManagerListViewController {
                         self.cancelSelection()
                         self.loadLogins()
                         self.sendLoginsDeletedTelemetry()
-                        self.showToast()
                     }
                 }
             }, hasSyncedLogins: yes.successValue ?? true)

--- a/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -19,7 +19,6 @@ class PasswordDetailViewController: SensitiveViewController, Themeable {
     var notificationCenter: NotificationProtocol
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
-    var deleteHandler: (() -> Void)?
 
     private lazy var tableView: UITableView = .build { [weak self] tableView in
         guard let self = self else { return }
@@ -345,7 +344,6 @@ extension PasswordDetailViewController {
                 self.viewModel.profile.logins.deleteLogin(id: self.viewModel.login.id) { _ in
                     DispatchQueue.main.async { [weak self] in
                         _ = self?.navigationController?.popViewController(animated: true)
-                        self?.deleteHandler?()
                     }
                 }
             }, hasSyncedLogins: yes.successValue ?? true)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12138)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26409)

## :bulb: Description
- Remove the toast shown after Password is deleted and remove handlers to show the toast


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
