### PR TITLE
Bugfix FXIOS-12617 #27494 ⁃ App crashes on siri shortcut open new tab

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -51,6 +51,9 @@ public enum LoggerCategory: String {
     /// Related to redux library or integration
     case redux
 
+    /// Related to the settings
+    case settings
+
     /// Related to the setup of services on app launch.
     case setup
 

--- a/firefox-ios/Client/Frontend/Extensions/SiriShortcuts.swift
+++ b/firefox-ios/Client/Frontend/Extensions/SiriShortcuts.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import Intents
 import IntentsUI
@@ -44,9 +45,11 @@ class SiriShortcuts {
     }
 
     @MainActor
-    static func manageSiri(for activityType: SiriShortcuts.activityType, in viewController: UIViewController) {
-        INVoiceShortcutCenter.shared.getAllVoiceShortcuts { (voiceShortcuts, error) in
-            guard let voiceShortcuts = voiceShortcuts else { return }
+    static func manageSiri(for activityType: SiriShortcuts.activityType,
+                           in viewController: UIViewController,
+                           logger: Logger = DefaultLogger.shared) async {
+        do {
+            let voiceShortcuts = try await INVoiceShortcutCenter.shared.allVoiceShortcuts()
             let foundShortcut = voiceShortcuts.first(where: { (attempt) in
                 attempt.shortcut.userActivity?.activityType == activityType.rawValue
             })
@@ -56,6 +59,13 @@ class SiriShortcuts {
             } else {
                 self.displayAddToSiri(for: activityType, in: viewController)
             }
+        } catch {
+            logger.log(
+                "Could not get voice shortcurts: \(error.localizedDescription)",
+                level: .warning,
+                category: .settings,
+                extra: nil
+            )
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -53,7 +53,7 @@ class SiriOpenURLSetting: Setting {
     override func onClick(_ navigationController: UINavigationController?) {
         guard let controller = navigationController?.topViewController else { return }
         Task { @MainActor in
-            SiriShortcuts.manageSiri(for: SiriShortcuts.activityType.openURL, in: controller)
+            await SiriShortcuts.manageSiri(for: SiriShortcuts.activityType.openURL, in: controller)
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12617)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27494)

## :bulb: Description
Use the async/await version of SiriShortcuts + settings logger category 


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
