### PR TITLE
Refactor FXIOS-12591 -  [Swift 6 Migration] - Fix nonisolated(unsafe) static property in ReaderModeHandlers file

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -108,7 +108,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
 
         // Set up a web server that serves us static content.
         // Do this early so that it is ready when the UI is presented.
-        webServerUtil = WebServerUtil(profile: profile)
+        webServerUtil = WebServerUtil(readerModeHandler: ReaderModeHandlers(), profile: profile)
         webServerUtil?.setUpWebServer()
 
         menuBuilderHelper = MenuBuilderHelper()

--- a/firefox-ios/Client/Application/WebServerUtil.swift
+++ b/firefox-ios/Client/Application/WebServerUtil.swift
@@ -7,25 +7,24 @@ import Foundation
 import GCDWebServers
 import Shared
 
-class WebServerUtil {
-    private var readerModeHander: ReaderModeHandlersProtocol
-    private var webServer: WebServerProtocol
-    private var profile: Profile
+final class WebServerUtil {
+    private let readerModeHander: ReaderModeHandlersProtocol
+    private let webServer: WebServerProtocol
+    private let profile: Profile
 
-    init(readerModeHander: ReaderModeHandlersProtocol = ReaderModeHandlers(),
+    init(readerModeHandler: some ReaderModeHandlersProtocol,
          webServer: WebServer = WebServer.sharedInstance,
          profile: Profile) {
-        self.readerModeHander = readerModeHander
+        self.readerModeHander = readerModeHandler
         self.webServer = webServer
         self.profile = profile
     }
 
+    @MainActor
     func setUpWebServer() {
         guard !webServer.server.isRunning else { return }
 
-        Task {
-            await readerModeHander.register(webServer, profile: profile)
-        }
+        readerModeHander.register(webServer, profile: profile)
         let responders: [(String, InternalSchemeResponse)] =
              [(AboutHomeHandler.path, AboutHomeHandler()),
               (AboutLicenseHandler.path, AboutLicenseHandler()),

--- a/firefox-ios/Client/Application/WebServerUtil.swift
+++ b/firefox-ios/Client/Application/WebServerUtil.swift
@@ -23,8 +23,9 @@ class WebServerUtil {
     func setUpWebServer() {
         guard !webServer.server.isRunning else { return }
 
-        readerModeHander.register(webServer, profile: profile)
-
+        Task {
+            await readerModeHander.register(webServer, profile: profile)
+        }
         let responders: [(String, InternalSchemeResponse)] =
              [(AboutHomeHandler.path, AboutHomeHandler()),
               (AboutLicenseHandler.path, AboutLicenseHandler()),

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4274,7 +4274,7 @@ extension BrowserViewController: TabManagerDelegate {
             privateModeButton.setSelected(selectedTab.isPrivate, animated: true)
         }
         readerModeCache = selectedTab.isPrivate ? MemoryReaderModeCache.shared : DiskReaderModeCache.shared
-        ReaderModeHandlers.readerModeCache = readerModeCache
+        ReaderModeHandlers.setCache(readerModeCache)
 
         scrollController.tab = selectedTab
 

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -8,17 +8,17 @@ import GCDWebServers
 import Shared
 import WebEngine
 
-protocol ReaderModeHandlersProtocol: Actor {
+protocol ReaderModeHandlersProtocol {
+    @MainActor
     func register(_ webServer: WebServerProtocol, profile: Profile)
 }
 
-actor ReaderModeHandlers: ReaderModeHandlersProtocol {
-    private static var _readerModeCache: ReaderModeCache = DiskReaderModeCache.shared
-    private static let queue = DispatchQueue(label: "org.mozilla.ios.Fennec.readerModeHandlersQueue")
+@MainActor
+struct ReaderModeHandlers: ReaderModeHandlersProtocol {
+    private static var readerModeCache: ReaderModeCache = DiskReaderModeCache.shared
 
-    static var readerModeCache: ReaderModeCache {
-        get { queue.sync { _readerModeCache } }
-        set { queue.sync { _readerModeCache = newValue } }
+    static func setCache(_ cache: ReaderModeCache) {
+        readerModeCache = cache
     }
 
     func register(_ webServer: WebServerProtocol, profile: Profile) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12591)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27411)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Makes `ReaderModeHandlers` an `actor` and use queue for thread-safety access.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
