### PR TITLE
FXIOS-12623 [Sync Settings] Update sync logic after sync settings change

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -173,8 +173,8 @@ class SyncContentSettingsViewController: SettingsTableViewController, FeatureFla
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    override func viewDidLoad() {
+        super.viewDidLoad()
         self.profile?.syncManager?.reportOpenSyncSettingsMenuTelemetry()
     }
 

--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -173,9 +173,14 @@ class SyncContentSettingsViewController: SettingsTableViewController, FeatureFla
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        self.profile?.syncManager?.reportOpenSyncSettingsMenuTelemetry()
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         if !enginesToSyncOnExit.isEmpty {
-            _ = self.profile?.syncManager?.syncNamedCollections(
+            self.profile?.syncManager?.syncPostSyncSettingsChange(
                 why: .enabledChange,
                 names: Array(enginesToSyncOnExit)
             )

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -37,7 +37,9 @@ public protocol SyncManager {
 
     func syncTabs() -> Deferred<Maybe<SyncResult>>
     func syncHistory() -> Deferred<Maybe<SyncResult>>
-    func syncNamedCollections(why: SyncReason, names: [String]) -> Success
+    func syncNamedCollections(why: SyncReason, names: [String]) -> Deferred<Maybe<SyncResult>>
+    func syncPostSyncSettingsChange(why: SyncReason, names: [String])
+    func reportOpenSyncSettingsMenuTelemetry()
     @discardableResult
     func syncEverything(why: SyncReason) -> Success
 

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -665,13 +665,7 @@ public class RustSyncManager: NSObject, SyncManager {
     }
 
     private func retrySyncAfterDelay(why: SyncReason, names: [String]) {
-        // If the timer property is set and is valid, we reset it. This will prevent the sync
-        // from being executed too often. It will run `self.syncBackOffDelay` seconds
-        // after the previous sync.
-        if self.syncBackOffTimer != nil && self.syncBackOffTimer?.isValid ?? false {
-            self.syncBackOffTimer?.invalidate()
-            self.syncBackOffTimer = nil
-        }
+        self.syncBackOffTimer?.invalidate()
 
         self.syncBackOffTimer = Timer.scheduledTimer(withTimeInterval: self.syncBackOffDelay,
                                                      repeats: false) { _ in

--- a/firefox-ios/Sync/RustSyncManagerAPI.swift
+++ b/firefox-ios/Sync/RustSyncManagerAPI.swift
@@ -82,6 +82,19 @@ open class RustSyncManagerAPI {
         }
     }
 
+    public func reportOpenSyncSettingsMenuTelemetry() {
+        DispatchQueue.global().async {
+            SyncManagerComponent.reportOpenSyncSettingsMenuTelemetry()
+        }
+    }
+
+    public func reportSaveSyncSettingsTelemetry(enabledEngines: [String], disabledEngines: [String]) {
+        DispatchQueue.global().async {
+            SyncManagerComponent.reportSaveSyncSettingsTelemetry(enabledEngines: enabledEngines,
+                                                                 disabledEngines: disabledEngines)
+        }
+    }
+
     public func getAvailableEngines(completion: @escaping ([String]) -> Void) {
         DispatchQueue.global().async { [unowned self] in
             let engines = self.api.getAvailableEngines()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
@@ -37,10 +37,15 @@ open class ClientSyncManagerSpy: ClientSyncManager {
     open func syncEverything(why: SyncReason) -> Success { return succeed() }
 
     var syncNamedCollectionsCalled = 0
-    open func syncNamedCollections(why: SyncReason, names: [String]) -> Success {
+    open func syncNamedCollections(why: SyncReason, names: [String]) -> Deferred<Maybe<SyncResult>> {
         syncNamedCollectionsCalled += 1
-        return succeed()
+        return emptySyncResult
     }
+    var syncPostSyncSettingsChangeCalled = 0
+    open func syncPostSyncSettingsChange(why: SyncReason, names: [String]) {
+        syncPostSyncSettingsChangeCalled += 1
+    }
+    open func reportOpenSyncSettingsMenuTelemetry() {}
     open func beginTimedSyncs() {}
     open func endTimedSyncs() {}
     open func applicationDidBecomeActive() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12623)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27510)

## :bulb: Description
Updates sync settings logic to add a retry if the sync that is fired after changes is backed off. Also adds telemetry to track when the user opens the sync settings menu and any engines they enable/disable. Changes include:
- Adding a `syncPostSyncSettingsChange` function which reports the open sync settings menu telemetry (via `reportSaveSyncSettingsTelemetry`), calls `syncNamedCollections`, and retries the `syncNamedCollections` if the first call resulted in a sync back off.
- Changing the return type of `syncNamedCollections` since the return value is unused in all callers and `syncPostSyncSettingsChange` needs the sync status to determine if a sync back off occurred.
- Adding wrapper functions for the `reportOpenSyncSettingsMenuTelemetry` and `reportSaveSyncSettingsTelemetry` telemetry functions to report when a user opens the sync settings menu or changes settings within it.


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
