### PR TITLE
Refactor FXIOS-12135 Turn off experiments for sync integration tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -13,7 +13,7 @@ private let historyItemSavedOnDesktop = "https://www.example.com/"
 private let loginEntry = "https://accounts.google.com"
 private let tabOpenInDesktop = "https://example.com/"
 
-class IntegrationTests: BaseTestCase {
+class IntegrationTests: FeatureFlaggedTestBase {
     let testWithDB = ["testFxASyncHistory"]
     let testFxAChinaServer = ["testFxASyncPageUsingChinaFxA"]
 
@@ -93,6 +93,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncHistory () {
+        app.launch()
         // History is generated using the DB so go directly to Sign in
         // Sign into Mozilla Account
         navigator.goto(BrowserTabMenu)
@@ -103,6 +104,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncPageUsingChinaFxA () {
+        app.launch()
         // History is generated using the DB so go directly to Sign in
         // Sign into Mozilla Account
         navigator.goto(BrowserTabMenu)
@@ -116,6 +118,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncBookmark () {
+        app.launch()
         // Bookmark is added by the DB
         // Sign into Mozilla Account
         navigator.openURL(testingURL)
@@ -130,6 +133,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncBookmarkDesktop () {
+        app.launch()
         // Sign into Mozilla Account
         signInFxAccounts()
 
@@ -140,6 +144,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncTabs () {
+        app.launch()
         signInFxAccounts()
 
         // We only sync tabs if the user is signed in
@@ -167,6 +172,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncLogins () {
+        app.launch()
         navigator.openURL("gmail.com")
         waitUntilPageLoad()
 
@@ -187,6 +193,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncHistoryDesktop () {
+        app.launch()
         // Sign into Mozilla Account
         signInFxAccounts()
 
@@ -199,6 +206,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncPasswordDesktop () {
+        app.launch()
         // Sign into Mozilla Account
         signInFxAccounts()
 
@@ -220,7 +228,9 @@ class IntegrationTests: BaseTestCase {
         XCTAssertTrue(app.tables.cells.staticTexts[loginEntry].exists, "The login saved on desktop is not synced")
     }
 
-    func testFxASyncTabsDesktop () {
+    func testFxASyncTabsDesktop_tabTrayExperimentOff() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "tab-tray-ui-experiments")
+        app.launch()
         // Sign into Mozilla Account
         signInFxAccounts()
 
@@ -240,6 +250,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxADisconnectConnect() {
+        app.launch()
         // Sign into Mozilla Account
         signInFxAccounts()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12135)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
`test_sync_bookmark_from_device` fails because of a UI change introduced by an experiment on tab tray. Let's not using the experiment for the test for now.

Test run using the branch on MacStadium:
https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/result_1066/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/results/index.html?sort=result

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
