### PR TITLE
Refactor FXIOS-7301 - Remove 2 closure_body_length violations from DownloadLiveActivity.swift, and WebView.swift

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,8 +103,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 38
-  error: 38
+  warning: 37
+  error: 37
 
 file_header:
   required_string: |

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -322,27 +322,7 @@ struct DownloadLiveActivity: Widget {
             } compactLeading: {
                 compactLeadingContent
             } compactTrailing: {
-                let circleProgressPercentage = min(
-                    liveDownload.state.containsOnlyEncodedFiles ? 1.0 : liveDownload.state.totalProgress, 1.0
-                )
-                ZStack {
-                    Circle()
-                        .stroke(lineWidth: UX.DynamicIsland.lineWidth)
-                        .foregroundColor(.gray)
-                        .opacity(0.3)
-                        .frame(width: UX.DynamicIsland.circleWidth, height: UX.DynamicIsland.circleWidth)
-                        .padding(.leading, 2)
-                        .padding(.trailing, 1)
-                    Circle()
-                        .trim(from: 0.0, to: circleProgressPercentage)
-                        .stroke(style: StrokeStyle(lineWidth: UX.DynamicIsland.lineWidth))
-                        .rotationEffect(.degrees(UX.DynamicIsland.rotation))
-                        .animation(.linear, value: min(liveDownload.state.totalProgress, 1.0))
-                        .foregroundStyle(.orange)
-                        .frame(width: UX.DynamicIsland.circleWidth, height: UX.DynamicIsland.circleWidth)
-                }
-                .padding(.leading, UX.DynamicIsland.downloadPaddingLeading)
-                .padding(.trailing, UX.DynamicIsland.downloadPaddingTrailing)
+                compactTrailingContent(liveDownload: liveDownload)
             } minimal: {
                 minimalViewBuilder(liveDownload: liveDownload)
             }

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -355,4 +355,14 @@ struct DownloadLiveActivity: Widget {
             .widgetURL(URL(string: URL.mozInternalScheme + "://deep-link?url=/homepanel/downloads"))
         }
     }
+
+    var compactLeadingContent: some View {
+        Image(StandardImageIdentifiers.Large.download)
+            .renderingMode(.template)
+            .resizable()
+            .scaledToFit()
+            .frame(width: UX.DynamicIsland.downloadIconSize, height: UX.DynamicIsland.downloadIconSize)
+            .foregroundStyle(.orange)
+            .padding([.leading, .trailing], 2)
+    }
 }

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -359,4 +359,28 @@ struct DownloadLiveActivity: Widget {
             .foregroundStyle(.orange)
             .padding([.leading, .trailing], 2)
     }
+
+    private func compactTrailingContent(liveDownload: ActivityViewContext<DownloadLiveActivityAttributes>) -> some View {
+        let circleProgressPercentage = min(
+            liveDownload.state.containsOnlyEncodedFiles ? 1.0 : liveDownload.state.totalProgress, 1.0
+        )
+        return ZStack {
+            Circle()
+                .stroke(lineWidth: UX.DynamicIsland.lineWidth)
+                .foregroundColor(.gray)
+                .opacity(0.3)
+                .frame(width: UX.DynamicIsland.circleWidth, height: UX.DynamicIsland.circleWidth)
+                .padding(.leading, 2)
+                .padding(.trailing, 1)
+            Circle()
+                .trim(from: 0.0, to: circleProgressPercentage)
+                .stroke(style: StrokeStyle(lineWidth: UX.DynamicIsland.lineWidth))
+                .rotationEffect(.degrees(UX.DynamicIsland.rotation))
+                .animation(.linear, value: min(liveDownload.state.totalProgress, 1.0))
+                .foregroundStyle(.orange)
+                .frame(width: UX.DynamicIsland.circleWidth, height: UX.DynamicIsland.circleWidth)
+        }
+        .padding(.leading, UX.DynamicIsland.downloadPaddingLeading)
+        .padding(.trailing, UX.DynamicIsland.downloadPaddingTrailing)
+    }
 }

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -320,13 +320,7 @@ struct DownloadLiveActivity: Widget {
                 centerExpandedRegion(liveDownload: liveDownload)
                 trailingExpandedRegion(liveDownload: liveDownload)
             } compactLeading: {
-                Image(StandardImageIdentifiers.Large.download)
-                    .renderingMode(.template)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: UX.DynamicIsland.downloadIconSize, height: UX.DynamicIsland.downloadIconSize)
-                    .foregroundStyle(.orange)
-                    .padding([.leading, .trailing], 2)
+                compactLeadingContent
             } compactTrailing: {
                 let circleProgressPercentage = min(
                     liveDownload.state.containsOnlyEncodedFiles ? 1.0 : liveDownload.state.totalProgress, 1.0

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/UI Components/WebView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/UI Components/WebView.swift
@@ -167,4 +167,29 @@ struct PrivacyPolicyView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.white.opacity(0.8))
     }
+
+    var errorContent: some View {
+        VStack {
+            Image(systemName: "wifi.slash")
+                .resizable()
+                .frame(width: 50, height: 50)
+                .foregroundColor(.gray)
+                .padding()
+            
+            Text(errorMessage)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+                .padding()
+            
+            Button(action: {
+                viewModel.reload()
+            }) {
+                Text(retryButtonText)
+            }
+            .buttonStyle(PrimaryButtonStyle())
+            .padding(Constants.buttonPadding)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.white.opacity(0.8))
+    }
 }

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/UI Components/WebView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/UI Components/WebView.swift
@@ -123,13 +123,7 @@ struct PrivacyPolicyView: View {
                 WebView(url: url, viewModel: viewModel)
 
                 if viewModel.state == .loading {
-                    VStack {
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle())
-                            .padding()
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color.white.opacity(0.8))
+                    loadingContent
                 }
 
                 if viewModel.state == .error {

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/UI Components/WebView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/UI Components/WebView.swift
@@ -163,4 +163,14 @@ struct PrivacyPolicyView: View {
             .ignoresSafeArea(edges: [.bottom])
         }
     }
+
+    var loadingContent: some View {
+        VStack {
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle())
+                .padding()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.white.opacity(0.8))
+    }
 }

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/UI Components/WebView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/UI Components/WebView.swift
@@ -127,28 +127,7 @@ struct PrivacyPolicyView: View {
                 }
 
                 if viewModel.state == .error {
-                    VStack {
-                        Image(systemName: "wifi.slash")
-                            .resizable()
-                            .frame(width: 50, height: 50)
-                            .foregroundColor(.gray)
-                            .padding()
-
-                        Text(errorMessage)
-                            .font(.headline)
-                            .multilineTextAlignment(.center)
-                            .padding()
-
-                        Button(action: {
-                            viewModel.reload()
-                        }) {
-                            Text(retryButtonText)
-                        }
-                        .buttonStyle(PrimaryButtonStyle())
-                        .padding(Constants.buttonPadding)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color.white.opacity(0.8))
+                    errorContent
                 }
             }
             .navigationBarItems(trailing: Button(doneButtonText) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 2 `closure_body_length` violations and decreases the threshold to 37.

I refactored `DownloadLiveActivity.swift` (Firefox) and `WebView.swift` (Focus) by extracting logic into new functions and properties.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
