### PR TITLE
Bugfix FXIOS-12631 - [Toolbar Redesign] - The safelisted blue dot is not visible or partially visible when tracking protections is off

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -490,7 +490,7 @@ final class LocationView: UIView,
     }
 
     private func setLockIconImage() {
-        guard let lockIconImageName else { return }
+        guard let lockIconImageName, !lockIconImageName.isEmpty else { return }
         var lockImage: UIImage?
 
         if let safeListedURLImageName {
@@ -501,7 +501,8 @@ final class LocationView: UIView,
             }
 
             if let dotImage = UIImage(named: safeListedURLImageName)?.withTintColor(safeListedURLImageColor) {
-                let image = lockImage?.overlayWith(image: dotImage, modifier: 0.4, origin: CGPoint(x: 13.5, y: 13))
+                let origin = isURLTextFieldCentered ? CGPoint(x: 10, y: 10) : CGPoint(x: 13.5, y: 13)
+                let image = lockImage?.overlayWith(image: dotImage, modifier: 0.4, origin: origin)
                 lockIconButton.setImage(image, for: .normal)
             }
         } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12631)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27526)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Adjust position of blue dot.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| ![screenshot](https://github.com/user-attachments/assets/e60dd0ab-4407-48d4-a29d-c1f288466278) | ![demo](https://github.com/user-attachments/assets/46c9c471-f489-4f72-bd00-bbdb3cce9623) |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
