### PR TITLE
Bugfix FXIOS-12630 The app crashes when adding the article in reader mode and then adding it to home screen

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -179,9 +179,13 @@ final class HomepageViewController: UIViewController,
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+
+        let numberOfTilesPerRow = numberOfTilesPerRow(for: availableWidth)
+        guard homepageState.topSitesState.numberOfTilesPerRow != numberOfTilesPerRow else { return }
+
         store.dispatchLegacy(
             HomepageAction(
-                numberOfTopSitesPerRow: numberOfTilesPerRow(for: availableWidth),
+                numberOfTopSitesPerRow: numberOfTilesPerRow,
                 windowUUID: windowUUID,
                 actionType: HomepageActionType.viewDidLayoutSubviews
             )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -94,7 +94,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
     func test_scrollToTop_updatesStatusBarScrollDelegate_andSetsCollectionViewOffset() {
         let mockStatusBarScrollDelegate = MockStatusBarScrollDelegate()
         let homepageVC = createSubject(statusBarScrollDelegate: mockStatusBarScrollDelegate)
-       let wallpaperConfiguration = WallpaperConfiguration(hasImage: true)
+        let wallpaperConfiguration = WallpaperConfiguration(hasImage: true)
         let newState = HomepageState.reducer(
             HomepageState(windowUUID: .XCTestDefaultUUID),
             WallpaperAction(
@@ -198,6 +198,17 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
         XCTAssertEqual(actionType, HomepageActionType.viewDidLayoutSubviews)
         XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+    }
+
+    func test_viewDidLayoutSubviews_withoutTopSitesChange_triggersNothing() throws {
+        let subject = createSubject()
+
+        subject.viewDidLayoutSubviews()
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.last(where: { $0 is HomepageAction }) as? HomepageAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
+        XCTAssertNotEqual(actionType, HomepageActionType.viewDidLayoutSubviews)
     }
 
     func test_viewDidAppear_triggersHomepageAction() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -178,8 +178,18 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
     }
 
-    func test_viewDidLayoutSubviews_triggersHomepageAction() throws {
+    func test_viewDidLayoutSubviews_withTopSitesChange_triggersHomepageAction() throws {
         let subject = createSubject()
+
+        let newState = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            HomepageAction(
+                numberOfTopSitesPerRow: 10,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.viewDidLayoutSubviews
+            )
+        )
+        subject.newState(state: newState)
 
         subject.viewDidLayoutSubviews()
         let actionCalled = try XCTUnwrap(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12630)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27525)

## :bulb: Description
The crash was caused by an endless loop of dispatches of `HomepageActionType.viewDidLayoutSubviewsOnly`. We now only dispatch if the number of top sites changes.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
