### PR TITLE
Add FXIOS-12495 ⁃ [Menu Redesign] Apply latest design for menu cells and menu

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuAccountCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuAccountCell.swift
@@ -41,8 +41,8 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
         return model?.iconImage != nil && (model?.needsReAuth == nil || model?.needsReAuth == false)
     }
 
-    var isFirstCell = false
-    var isLastCell = false
+    private var isFirstCell = false
+    private var isLastCell = false
 
     // MARK: - Initializers
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -62,19 +62,7 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
             iconImageView.layer.cornerRadius = 0
         }
         iconImageView.clipsToBounds = shouldConfigureImageView
-
-        self.clipsToBounds = true
-        if isFirstCell && isLastCell {
-            self.layer.cornerRadius = UX.cornerRadius
-            self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner,
-                                        .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-        } else if isFirstCell {
-            self.layer.cornerRadius = UX.cornerRadius
-            self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-        } else if isLastCell {
-            self.layer.cornerRadius = UX.cornerRadius
-            self.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-        }
+        configureCornerRadiusForCellPosition()
     }
 
     override func prepareForReuse() {
@@ -136,6 +124,18 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
         let iconSize = isAccessibilityCategory ? UX.largeIconSize : UX.iconSize
         iconImageView.widthAnchor.constraint(equalToConstant: iconSize).isActive = true
         iconImageView.heightAnchor.constraint(equalToConstant: iconSize).isActive = true
+    }
+
+    private func configureCornerRadiusForCellPosition() {
+        guard isFirstCell || isLastCell else { return }
+        self.clipsToBounds = true
+        layer.cornerRadius = UX.cornerRadius
+        layer.maskedCorners = {
+            var corners: CACornerMask = []
+            if isFirstCell { corners.formUnion([.layerMinXMinYCorner, .layerMaxXMinYCorner]) }
+            if isLastCell { corners.formUnion([.layerMinXMaxYCorner, .layerMaxXMaxYCorner]) }
+            return corners
+        }()
     }
 
     // MARK: - Theme Applicable

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuAccountCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuAccountCell.swift
@@ -13,6 +13,8 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
         static let largeIconSize: CGFloat = 48
         static let contentSpacing: CGFloat = 3
         static let noDescriptionContentSpacing: CGFloat = 0
+        static let cornerRadius: CGFloat = 16
+        static let backgroundAlpha: CGFloat = 0.8
     }
 
     // MARK: - UI Elements
@@ -39,6 +41,9 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
         return model?.iconImage != nil && (model?.needsReAuth == nil || model?.needsReAuth == false)
     }
 
+    var isFirstCell = false
+    var isLastCell = false
+
     // MARK: - Initializers
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -57,15 +62,32 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
             iconImageView.layer.cornerRadius = 0
         }
         iconImageView.clipsToBounds = shouldConfigureImageView
+
+        self.clipsToBounds = true
+        if isFirstCell && isLastCell {
+            self.layer.cornerRadius = UX.cornerRadius
+            self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner,
+                                        .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        } else if isFirstCell {
+            self.layer.cornerRadius = UX.cornerRadius
+            self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        } else if isLastCell {
+            self.layer.cornerRadius = UX.cornerRadius
+            self.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        }
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
         iconImageView.image = nil
+        isFirstCell = false
+        isLastCell = false
     }
 
-    func configureCellWith(model: MenuElement, theme: Theme) {
+    func configureCellWith(model: MenuElement, theme: Theme, isFirstCell: Bool, isLastCell: Bool) {
         self.model = model
+        self.isFirstCell = isFirstCell
+        self.isLastCell = isLastCell
         titleLabel.text = model.title
         descriptionLabel.text = model.description
         contentStackView.spacing = model.description != nil ? UX.contentSpacing : UX.noDescriptionContentSpacing
@@ -119,7 +141,7 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
     // MARK: - Theme Applicable
     func applyTheme(theme: Theme) {
         guard let model else { return }
-        backgroundColor = theme.colors.layer2
+        backgroundColor = theme.colors.layer2.withAlphaComponent(UX.backgroundAlpha)
         if let needsReAuth = model.needsReAuth, needsReAuth {
             descriptionLabel.textColor = theme.colors.textCritical
         } else if model.iconImage != nil {

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuInfoCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuInfoCell.swift
@@ -12,6 +12,7 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
         static let infoLabelHorizontalMargin: CGFloat = 8
         static let infoLabelVerticalPadding: CGFloat = 7
         static let infoLabelHorizontalPadding: CGFloat = 14
+        static let backgroundAlpha: CGFloat = 0.8
     }
 
     // MARK: - UI Elements
@@ -94,7 +95,7 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
     // MARK: - Theme Applicable
     func applyTheme(theme: Theme) {
         guard let model else { return }
-        backgroundColor = theme.colors.layer2
+        backgroundColor = theme.colors.layer2.withAlphaComponent(UX.backgroundAlpha)
         if model.isActive {
             titleLabel.textColor = theme.colors.textAccent
             infoLabelView.textColor = theme.colors.textPrimary

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignCell.swift
@@ -34,8 +34,8 @@ final class MenuRedesignCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     private var iconImageView: UIImageView = .build()
 
-    var isFirstCell = false
-    var isLastCell = false
+    private var isFirstCell = false
+    private var isLastCell = false
 
     // MARK: - Properties
     var model: MenuElement?
@@ -52,18 +52,7 @@ final class MenuRedesignCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        self.clipsToBounds = true
-        if isFirstCell && isLastCell {
-            self.layer.cornerRadius = UX.cornerRadius
-            self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner,
-                                        .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-        } else if isFirstCell {
-            self.layer.cornerRadius = UX.cornerRadius
-            self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-        } else if isLastCell {
-            self.layer.cornerRadius = UX.cornerRadius
-            self.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-        }
+        configureCornerRadiusForCellPosition()
     }
 
     override func prepareForReuse() {
@@ -114,6 +103,18 @@ final class MenuRedesignCell: UITableViewCell, ReusableCell, ThemeApplicable {
         let iconSize = isAccessibilityCategory ? UX.largeIconSize : UX.iconSize
         iconImageView.widthAnchor.constraint(equalToConstant: iconSize).isActive = true
         iconImageView.heightAnchor.constraint(equalToConstant: iconSize).isActive = true
+    }
+
+    private func configureCornerRadiusForCellPosition() {
+        guard isFirstCell || isLastCell else { return }
+        self.clipsToBounds = true
+        layer.cornerRadius = UX.cornerRadius
+        layer.maskedCorners = {
+            var corners: CACornerMask = []
+            if isFirstCell { corners.formUnion([.layerMinXMinYCorner, .layerMaxXMinYCorner]) }
+            if isLastCell { corners.formUnion([.layerMinXMaxYCorner, .layerMaxXMaxYCorner]) }
+            return corners
+        }()
     }
 
     // MARK: - Theme Applicable

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignCell.swift
@@ -13,6 +13,8 @@ final class MenuRedesignCell: UITableViewCell, ReusableCell, ThemeApplicable {
         static let largeIconSize: CGFloat = 48
         static let contentSpacing: CGFloat = 3
         static let noDescriptionContentSpacing: CGFloat = 0
+        static let cornerRadius: CGFloat = 16
+        static let backgroundAlpha: CGFloat = 0.8
     }
 
     // MARK: - UI Elements
@@ -32,6 +34,9 @@ final class MenuRedesignCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     private var iconImageView: UIImageView = .build()
 
+    var isFirstCell = false
+    var isLastCell = false
+
     // MARK: - Properties
     var model: MenuElement?
 
@@ -45,13 +50,33 @@ final class MenuRedesignCell: UITableViewCell, ReusableCell, ThemeApplicable {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.clipsToBounds = true
+        if isFirstCell && isLastCell {
+            self.layer.cornerRadius = UX.cornerRadius
+            self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner,
+                                        .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        } else if isFirstCell {
+            self.layer.cornerRadius = UX.cornerRadius
+            self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        } else if isLastCell {
+            self.layer.cornerRadius = UX.cornerRadius
+            self.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        }
+    }
+
     override func prepareForReuse() {
         super.prepareForReuse()
         iconImageView.image = nil
+        isFirstCell = false
+        isLastCell = false
     }
 
-    func configureCellWith(model: MenuElement, theme: Theme) {
+    func configureCellWith(model: MenuElement, theme: Theme, isFirstCell: Bool, isLastCell: Bool) {
         self.model = model
+        self.isFirstCell = isFirstCell
+        self.isLastCell = isLastCell
         self.titleLabel.text = model.title
         self.descriptionLabel.text = model.description
         self.contentStackView.spacing = model.description != nil ? UX.contentSpacing : UX.noDescriptionContentSpacing
@@ -94,7 +119,7 @@ final class MenuRedesignCell: UITableViewCell, ReusableCell, ThemeApplicable {
     // MARK: - Theme Applicable
     func applyTheme(theme: Theme) {
         guard let model else { return }
-        backgroundColor = theme.colors.layer2
+        backgroundColor = theme.colors.layer2.withAlphaComponent(UX.backgroundAlpha)
         if model.isActive {
             titleLabel.textColor = theme.colors.textAccent
             descriptionLabel.textColor = theme.colors.textSecondary

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -90,19 +90,19 @@ public final class MenuRedesignMainView: UIView,
         if let expandedSection = data.first(where: { $0.isExpanded ?? false }),
            let isExpanded = expandedSection.isExpanded,
            isExpanded {
-            let height = self.tableView.tableViewContentSize + UX.headerTopMargin
-            onCalculatedHeight?(height + self.siteProtectionHeader.frame.height)
-            self.layoutIfNeeded()
+            let height = tableView.tableViewContentSize + UX.headerTopMargin
+            onCalculatedHeight?(height + siteProtectionHeader.frame.height)
+            layoutIfNeeded()
         } else {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
-                let height = self.tableView.tableViewContentSize + UX.headerTopMargin
+                let height = tableView.tableViewContentSize + UX.headerTopMargin
                 if let section = data.first(where: { $0.isHomepage }), section.isHomepage {
-                    self.onCalculatedHeight?(height + UX.closeButtonSize + UX.headerTopMarginWithButton)
+                    onCalculatedHeight?(height + UX.closeButtonSize + UX.headerTopMarginWithButton)
                 } else {
-                    self.onCalculatedHeight?(height + self.siteProtectionHeader.frame.height)
+                    onCalculatedHeight?(height + siteProtectionHeader.frame.height)
                 }
-                self.layoutIfNeeded()
+                layoutIfNeeded()
             }
         }
     }

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignTableView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignTableView.swift
@@ -20,7 +20,9 @@ final class MenuRedesignTableView: UIView,
     private var menuData: [MenuSection]
     private var theme: Theme?
 
-    var updateHeaderLineView: ((_ isHidden: Bool) -> Void)?
+    public var tableViewContentSize: CGFloat {
+        tableView.contentSize.height
+    }
 
     override init(frame: CGRect) {
         tableView = UITableView(frame: .zero, style: .insetGrouped)
@@ -117,7 +119,10 @@ final class MenuRedesignTableView: UIView,
                 return UITableViewCell()
             }
             if let theme {
-                cell.configureCellWith(model: rowOption, theme: theme)
+                let numberOfRows = tableView.numberOfRows(inSection: indexPath.section)
+                let isFirst = indexPath.row == 0
+                let isLast = indexPath.row == numberOfRows - 1
+                cell.configureCellWith(model: rowOption, theme: theme, isFirstCell: isFirst, isLastCell: isLast)
                 cell.applyTheme(theme: theme)
             }
             return cell
@@ -144,7 +149,10 @@ final class MenuRedesignTableView: UIView,
             return UITableViewCell()
         }
         if let theme {
-            cell.configureCellWith(model: rowOption, theme: theme)
+            let numberOfRows = tableView.numberOfRows(inSection: indexPath.section)
+            let isFirst = indexPath.row == 0
+            let isLast = indexPath.row == numberOfRows - 1
+            cell.configureCellWith(model: rowOption, theme: theme, isFirstCell: isFirst, isLastCell: isLast)
             cell.applyTheme(theme: theme)
         }
         return cell
@@ -183,14 +191,6 @@ final class MenuRedesignTableView: UIView,
             menuData = data
         }
         tableView.reloadData()
-    }
-
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if scrollView.contentOffset.y >= UX.topPadding {
-            updateHeaderLineView?(false)
-        } else {
-            updateHeaderLineView?(true)
-        }
     }
 
     // MARK: - Theme Applicable

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSiteProtectionsHeader.swift
@@ -19,8 +19,10 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         static let siteProtectionsContentHorizontalPadding: CGFloat = 10
         static let siteProtectionsContentVerticalPadding: CGFloat = 6
         static let siteProtectionsIcon: CGFloat = 16
+        static let protectionIconMargin: CGFloat = 2
         static let siteProtectionsMoreSettingsIcon: CGFloat = 20
         static let siteProtectionsContentSpacing: CGFloat = 4
+        static let closeButtonBackgroundAlpha: CGFloat = 0.8
     }
 
     public var closeButtonCallback: (() -> Void)?
@@ -126,7 +128,10 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
 
             siteProtectionsContent.topAnchor.constraint(equalTo: contentLabels.bottomAnchor,
                                                         constant: UX.siteProtectionsContentTopMargin),
-            siteProtectionsContent.leadingAnchor.constraint(equalTo: favicon.trailingAnchor),
+            siteProtectionsContent.leadingAnchor.constraint(
+                equalTo: favicon.trailingAnchor,
+                constant: UX.horizontalContentMargin - UX.siteProtectionsContentHorizontalPadding - UX.protectionIconMargin
+            ),
             siteProtectionsContent.trailingAnchor.constraint(lessThanOrEqualTo: closeButton.leadingAnchor),
             siteProtectionsContent.bottomAnchor.constraint(equalTo: self.bottomAnchor),
         ])
@@ -165,7 +170,7 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         titleLabel.textColor = theme.colors.textPrimary
         subtitleLabel.textColor = theme.colors.textSecondary
         closeButton.tintColor = theme.colors.iconSecondary
-        closeButton.backgroundColor = theme.colors.layer2
+        closeButton.backgroundColor = theme.colors.layer2.withAlphaComponent(UX.closeButtonBackgroundAlpha)
         siteProtectionsLabel.textColor = theme.colors.textSecondary
         siteProtectionsContent.layer.borderColor = theme.colors.actionSecondaryHover.cgColor
         siteProtectionsIcon.tintColor = theme.colors.iconSecondary

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquareCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquareCell.swift
@@ -15,6 +15,8 @@ final class MenuSquareView: UIView, ThemeApplicable {
         static let contentViewTopMargin: CGFloat = 12
         static let contentViewBottomMargin: CGFloat = 8
         static let contentViewHorizontalMargin: CGFloat = 4
+        static let cornerRadius: CGFloat = 16
+        static let backgroundAlpha: CGFloat = 0.8
     }
 
     // MARK: - UI Elements
@@ -47,6 +49,14 @@ final class MenuSquareView: UIView, ThemeApplicable {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) not yet supported")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.layer.cornerRadius = UX.cornerRadius
+        self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner,
+                                    .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        self.clipsToBounds = true
     }
 
     func configureCellWith(model: MenuElement) {
@@ -97,7 +107,7 @@ final class MenuSquareView: UIView, ThemeApplicable {
     func applyTheme(theme: Theme) {
         backgroundColor = .clear
         contentStackView.backgroundColor = .clear
-        backgroundContentView.backgroundColor = theme.colors.layer2
+        backgroundContentView.backgroundColor = theme.colors.layer2.withAlphaComponent(UX.backgroundAlpha)
         icon.tintColor = theme.colors.iconPrimary
         titleLabel.textColor = theme.colors.textSecondary
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -1030,17 +1030,17 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
 
     private func getSiteProtectionState(for selectedTab: Tab) -> SiteProtectionsState {
         let isContentBlockingConfigEnabled = profile.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? true
+        guard let url = selectedTab.url,
+              !ContentBlocker.shared.isSafelisted(url: url),
+              isContentBlockingConfigEnabled else { return .off }
+
         let hasSecureContent = selectedTab.currentWebView()?.hasOnlySecureContent ?? false
 
         if !hasSecureContent {
             return .notSecure
         }
 
-        if isContentBlockingConfigEnabled {
-            return .on
-        }
-
-        return .off
+        return .on
     }
 
     // MARK: - Homepage Related Actions


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12495)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27238)

## :bulb: Description
- Changed the alignment of the Site Protections button icon
- Set the Site Protection button text, based on the site protection and global protection feature
- Set the modal height automatically, based on the content size (for iOS 16 or above)
- Added blur and transparent background for menu and for the cells

## :movie_camera: Demos
![IMG_6348](https://github.com/user-attachments/assets/04157ecf-ac67-4aed-a269-8b6de87d0a4b)


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
