### PR TITLE
FXIOS-27064 Navigation arrows become active after a restart

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -853,6 +853,12 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         // Only preserve tabs after the restore has finished
         guard tabRestoreHasFinished else { return }
 
+        guard let url = selectedTab?.url else { return }
+
+        if url.isFxHomeUrl {
+            return
+        }
+
         saveSessionData(forTab: selectedTab)
         preserveTabs(forced: true)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-27064)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27064)

## :bulb: Description
- Fix for navigation arrows getting active after restart and home page getting appended after each launch

# Before
https://github.com/user-attachments/assets/fbd35e9a-c5be-408f-86a0-8bdcdbbd076b

# After
https://github.com/user-attachments/assets/056fc732-19ba-4d2b-82db-3beae48a3ee9


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
