### PR TITLE
Refactor FXIOS-7301 - Remove 2 closure_body_length violations from OnboardingMultipleChoiceCardView.swift, and ZoomLevelPickerView.swift

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,8 +103,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 37
-  error: 37
+  warning: 36
+  error: 36
 
 file_header:
   required_string: |

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,8 +103,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 36
-  error: 36
+  warning: 35
+  error: 35
 
 file_header:
   required_string: |

--- a/BrowserKit/Sources/OnboardingKit/Views/OnboardingMultipleChoiceCardView.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/OnboardingMultipleChoiceCardView.swift
@@ -82,6 +82,39 @@ public struct OnboardingMultipleChoiceCardView<VM: OnboardingCardInfoModelProtoc
         }
     }
 
+    private func scrollViewContent(geometry: GeometryProxy) -> some View {
+        // Determine scale factor based on current size vs base metrics
+        let widthScale = geometry.size.width / UX.CardView.baseWidth
+        let heightScale = geometry.size.height / UX.CardView.baseHeight
+        let scale = min(widthScale, heightScale)
+
+        return VStack {
+            VStack(spacing: UX.CardView.spacing * scale) {
+                Spacer()
+                titleView
+                Spacer()
+                OnboardingSegmentedControl<VM.OnboardingMultipleChoiceActionType>(
+                    selection: $selectedAction,
+                    items: viewModel.multipleChoiceButtons,
+                    windowUUID: windowUUID,
+                    themeManager: themeManager
+                )
+                .onChange(of: selectedAction) { newAction in
+                    onMultipleChoiceAction(newAction, viewModel.name)
+                }
+                Spacer()
+                primaryButton
+            }
+            .frame(height: geometry.size.height * UX.CardView.cardHeightRatio)
+            .padding(UX.CardView.verticalPadding * scale)
+            .background(
+                RoundedRectangle(cornerRadius: UX.CardView.cornerRadius)
+                    .fill(cardBackgroundColor)
+            )
+            .padding(.horizontal, UX.CardView.horizontalPadding * scale)
+        }
+    }
+
     var titleView: some View {
         Text(viewModel.title)
             .font(UX.CardView.titleFont)

--- a/BrowserKit/Sources/OnboardingKit/Views/OnboardingMultipleChoiceCardView.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/OnboardingMultipleChoiceCardView.swift
@@ -46,31 +46,7 @@ public struct OnboardingMultipleChoiceCardView<VM: OnboardingCardInfoModelProtoc
             let scale = min(widthScale, heightScale)
 
             ScrollView {
-                VStack {
-                    VStack(spacing: UX.CardView.spacing * scale) {
-                        Spacer()
-                        titleView
-                        Spacer()
-                        OnboardingSegmentedControl<VM.OnboardingMultipleChoiceActionType>(
-                            selection: $selectedAction,
-                            items: viewModel.multipleChoiceButtons,
-                            windowUUID: windowUUID,
-                            themeManager: themeManager
-                        )
-                        .onChange(of: selectedAction) { newAction in
-                            onMultipleChoiceAction(newAction, viewModel.name)
-                        }
-                        Spacer()
-                        primaryButton
-                    }
-                    .frame(height: geometry.size.height * UX.CardView.cardHeightRatio)
-                    .padding(UX.CardView.verticalPadding * scale)
-                    .background(
-                        RoundedRectangle(cornerRadius: UX.CardView.cornerRadius)
-                            .fill(cardBackgroundColor)
-                    )
-                    .padding(.horizontal, UX.CardView.horizontalPadding * scale)
-                }
+                scrollViewContent(geometry: geometry)
             }
             .onAppear {
                 applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -102,4 +102,41 @@ struct ZoomLevelPickerView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(backgroundColor)
     }
+
+    var pickerContent: some View {
+        HStack {
+            Text(pickerText)
+                .font(.body)
+                .foregroundColor(theme.colors.textPrimary.color)
+
+            Spacer()
+
+            // Right side - picker with current value
+            Menu {
+                Picker(selection: $selectedZoomLevel, label: EmptyView()) {
+                    ForEach(ZoomLevel.allCases, id: \.self) { item in
+                        Text(item.displayName)
+                            .tag(item)
+                    }
+                }
+                .onChange(of: selectedZoomLevel, perform: onZoomLevelChanged)
+                .pickerStyle(.inline)
+                .labelsHidden()
+            } label: {
+                HStack(spacing: UX.pickerLabelSpacing) {
+                    Text(selectedZoomLevel.displayName)
+                        .font(.body)
+                        .foregroundColor(theme.colors.textPrimary.color)
+
+                    Image(systemName: UX.chevronImageIdentifier)
+                        .renderingMode(.template)
+                        .font(.caption)
+                        .foregroundColor(theme.colors.textPrimary.color)
+                        .accessibilityHidden(true)
+                }
+            }
+        }
+        .padding(.horizontal, UX.sectionPadding)
+        .padding(.vertical, UX.verticalPadding)
+    }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -59,40 +59,7 @@ struct ZoomLevelPickerView: View {
                 .background(theme.colors.borderPrimary.color)
 
             // Picker content
-            HStack {
-                Text(pickerText)
-                    .font(.body)
-                    .foregroundColor(theme.colors.textPrimary.color)
-
-                Spacer()
-
-                // Right side - picker with current value
-                Menu {
-                    Picker(selection: $selectedZoomLevel, label: EmptyView()) {
-                        ForEach(ZoomLevel.allCases, id: \.self) { item in
-                            Text(item.displayName)
-                                .tag(item)
-                        }
-                    }
-                    .onChange(of: selectedZoomLevel, perform: onZoomLevelChanged)
-                    .pickerStyle(.inline)
-                    .labelsHidden()
-                } label: {
-                    HStack(spacing: UX.pickerLabelSpacing) {
-                        Text(selectedZoomLevel.displayName)
-                            .font(.body)
-                            .foregroundColor(theme.colors.textPrimary.color)
-
-                        Image(systemName: UX.chevronImageIdentifier)
-                            .renderingMode(.template)
-                            .font(.caption)
-                            .foregroundColor(theme.colors.textPrimary.color)
-                            .accessibilityHidden(true)
-                    }
-                }
-            }
-            .padding(.horizontal, UX.sectionPadding)
-            .padding(.vertical, UX.verticalPadding)
+            pickerContent
 
             // Bottom divider
             Divider()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 2 `closure_body_length` violations and decreases the threshold to 35.

I refactored `OnboardingMultipleChoiceCardView.swift` and `ZoomLevelPickerView.swift` by extracting logic into new functions and properties.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
