### PR TITLE
Bugfix FXIOS-12640 [Toolbar] Status bar overlay black when translucency is disabled

### DIFF
--- a/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
@@ -35,10 +35,6 @@ class StatusBarOverlay: UIView,
     var notificationCenter: NotificationProtocol = NotificationCenter.default
     var hasTopTabs = false
 
-    private var isToolbarRefactorEnabled: Bool {
-        toolbarHelper.isToolbarRefactorEnabled
-    }
-
     /// Returns a value between 0 and 1 which indicates how far the user has scrolled.
     /// This is used as the alpha of the status bar background.
     /// 0 = no status bar background shown
@@ -80,17 +76,9 @@ class StatusBarOverlay: UIView,
 
     func resetState(isHomepage: Bool) {
         savedIsHomepage = isHomepage
-
-        // We only need no status bar for one edge case
-        var needsNoStatusBar = isHomepage && isBottomSearchBar
-        if !isToolbarRefactorEnabled {
-            needsNoStatusBar = needsNoStatusBar && wallpaperManager.currentWallpaper.hasImage
-        }
+        let needsNoStatusBar = needsNoStatusBar(isHomepage: isHomepage)
         scrollOffset = needsNoStatusBar ? 0 : 1
-
-        let translucencyBackgroundAlpha = toolbarHelper.backgroundAlpha()
-        let alpha = scrollOffset > translucencyBackgroundAlpha ? translucencyBackgroundAlpha : scrollOffset
-        backgroundColor = savedBackgroundColor?.withAlphaComponent(alpha)
+        updateStatusBarAlpha(isHomepage: isHomepage, needsNoStatusBar: needsNoStatusBar)
     }
 
     func showOverlay(animated: Bool) {
@@ -125,22 +113,20 @@ class StatusBarOverlay: UIView,
         }
     }
 
-    // MARK: - ThemeApplicable
+    // MARK: - Helper
 
-    func applyTheme(theme: Theme) {
-        savedBackgroundColor = (hasTopTabs || isToolbarRefactorEnabled) ? theme.colors.layerSurfaceLow : theme.colors.layer1
-        let translucencyBackgroundAlpha = toolbarHelper.backgroundAlpha()
-
-        // We only need no status bar for one edge case
-        let isHomepage = savedIsHomepage ?? false
+    private func needsNoStatusBar(isHomepage: Bool) -> Bool {
         let isWallpaperedHomepage = isHomepage && wallpaperManager.currentWallpaper.hasImage
-        var needsNoStatusBar: Bool
 
-        if isToolbarRefactorEnabled {
-            needsNoStatusBar = isHomepage && isBottomSearchBar
+        if toolbarHelper.shouldBlur() {
+            return isHomepage && isBottomSearchBar
         } else {
-            needsNoStatusBar = isWallpaperedHomepage && isBottomSearchBar
+            return isWallpaperedHomepage && isBottomSearchBar
         }
+    }
+
+    private func updateStatusBarAlpha(isHomepage: Bool, needsNoStatusBar: Bool) {
+        let translucencyBackgroundAlpha = toolbarHelper.backgroundAlpha()
 
         if needsNoStatusBar {
             let alpha = scrollOffset > translucencyBackgroundAlpha ? translucencyBackgroundAlpha : scrollOffset
@@ -148,6 +134,16 @@ class StatusBarOverlay: UIView,
         } else {
             backgroundColor = savedBackgroundColor?.withAlphaComponent(translucencyBackgroundAlpha)
         }
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        savedBackgroundColor = (hasTopTabs || toolbarHelper.isToolbarRefactorEnabled) ?
+                                    theme.colors.layerSurfaceLow : theme.colors.layer1
+        let isHomepage: Bool = savedIsHomepage ?? false
+        let needsNoStatusBar = needsNoStatusBar(isHomepage: isHomepage)
+        updateStatusBarAlpha(isHomepage: isHomepage, needsNoStatusBar: needsNoStatusBar)
     }
 
     // MARK: - StatusBarScrollDelegate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StatusBarOverlayTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StatusBarOverlayTests.swift
@@ -12,6 +12,7 @@ class StatusBarOverlayTests: XCTestCase {
     private var profile: MockProfile!
     private var wallpaperManager: WallpaperManagerMock!
     private var notificationCenter: MockNotificationCenter!
+    private var toolbarHelper: ToolbarHelperInterface!
 
     override func setUp() {
         super.setUp()
@@ -28,16 +29,20 @@ class StatusBarOverlayTests: XCTestCase {
         self.notificationCenter = nil
     }
 
-    func testInitialState_isOpaque() throws {
-        let subject = createSubject()
+    // MARK: Translucency enabled
+
+    func testInitialState_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
 
         XCTAssertFalse(subject.hasTopTabs)
         let backgroundColor = try XCTUnwrap(subject.backgroundColor)
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0.8).cgColor)
     }
 
-    func testOnHomepage_withoutWallpaperWithBottomURLBar_isOpaque() throws {
-        let subject = createSubject()
+    func testOnHomepage_withoutWallpaperWithBottomURLBar_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
         profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
 
         subject.resetState(isHomepage: true)
@@ -46,8 +51,9 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0).cgColor)
     }
 
-    func testOnHomepage_withoutWallpaperWithTopURLBar_isOpaque() throws {
-        let subject = createSubject()
+    func testOnHomepage_withoutWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
         profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
 
         subject.resetState(isHomepage: true)
@@ -56,8 +62,9 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0.8).cgColor)
     }
 
-    func testOnHomepage_withWallpaperWithBottomURLBar_notOpaque() throws {
-        let subject = createSubject()
+    func testOnHomepage_withWallpaperWithBottomURLBar_translucencyOn_notOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
         profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
         wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
                                                       textColor: nil,
@@ -70,8 +77,9 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0).cgColor)
     }
 
-    func testOnHomepage_withWallpaperWithTopURLBar_isOpaque() throws {
-        let subject = createSubject()
+    func testOnHomepage_withWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
         profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
         wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
                                                       textColor: nil,
@@ -84,8 +92,9 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0.8).cgColor)
     }
 
-    func testOnWebpage_withoutWallpaperWithBottomURLBar_isOpaque() throws {
-        let subject = createSubject()
+    func testOnWebpage_withoutWallpaperWithBottomURLBar_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
         profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
 
         subject.resetState(isHomepage: false)
@@ -94,8 +103,9 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0.8).cgColor)
     }
 
-    func testOnWebpage_withoutWallpaperWithTopURLBar_isOpaque() throws {
-        let subject = createSubject()
+    func testOnWebpage_withoutWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
         profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
 
         subject.resetState(isHomepage: false)
@@ -104,8 +114,9 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0.8).cgColor)
     }
 
-    func testOnWebpage_withWallpaperWithBottomURLBar_isOpaque() throws {
-        let subject = createSubject()
+    func testOnWebpage_withWallpaperWithBottomURLBar_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
         profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
         wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
                                                       textColor: nil,
@@ -118,8 +129,9 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0.8).cgColor)
     }
 
-    func testOnWebpage_withWallpaperWithTopURLBar_isOpaque() throws {
-        let subject = createSubject()
+    func testOnWebpage_withWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
         profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
         wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
                                                       textColor: nil,
@@ -132,8 +144,9 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0.8).cgColor)
     }
 
-    func testHasTopTabs_onHomepageWithoutWallpaperWithTopURLBar_isOpaque() throws {
-        let subject = createSubject(hasTopTabs: true)
+    func testHasTopTabs_onHomepageWithoutWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
         profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
 
         subject.resetState(isHomepage: true)
@@ -142,9 +155,9 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0.8).cgColor)
     }
 
-    func testHasTopTabs_onHomepageWithWallpaperWithTopURLBar_isOpaque() throws {
-        let subject = createSubject(hasTopTabs: true)
-        subject.hasTopTabs = true
+    func testHasTopTabs_onHomepageWithWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
         profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
         wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
                                                       textColor: nil,
@@ -157,9 +170,9 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0.8).cgColor)
     }
 
-    func testHasTopTabs_onWebpageWithoutWallpaperWithTopURLBar_isOpaque() throws {
-        let subject = createSubject(hasTopTabs: true)
-        subject.hasTopTabs = true
+    func testHasTopTabs_onWebpageWithoutWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
         profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
 
         subject.resetState(isHomepage: false)
@@ -168,9 +181,9 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0.8).cgColor)
     }
 
-    func testHasTopTabs_onWebpageWithWallpaperWithTopURLBar_isOpaque() throws {
-        let subject = createSubject(hasTopTabs: true)
-        subject.hasTopTabs = true
+    func testHasTopTabs_onWebpageWithWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: true)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
         profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
         wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
                                                       textColor: nil,
@@ -183,13 +196,392 @@ class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0.8).cgColor)
     }
 
-    private func createSubject(hasTopTabs: Bool = false) -> StatusBarOverlay {
+    // MARK: Translucency enabled
+
+    func testInitialState_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+
+        XCTAssertFalse(subject.hasTopTabs)
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnHomepage_withoutWallpaperWithBottomURLBar_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(1).cgColor)
+    }
+
+    func testOnHomepage_withoutWallpaperWithTopURLBar_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnHomepage_withWallpaperWithBottomURLBar_translucencyOff_notOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0).cgColor)
+    }
+
+    func testOnHomepage_withWallpaperWithTopURLBar_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnWebpage_withoutWallpaperWithBottomURLBar_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnWebpage_withoutWallpaperWithTopURLBar_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnWebpage_withWallpaperWithBottomURLBar_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnWebpage_withWallpaperWithTopURLBar_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testHasTopTabs_onHomepageWithoutWallpaperWithTopURLBar_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testHasTopTabs_onHomepageWithWallpaperWithTopURLBar_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testHasTopTabs_onWebpageWithoutWallpaperWithTopURLBar_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testHasTopTabs_onWebpageWithWallpaperWithTopURLBar_translucencyOff_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isTranslucencyEnabled: false)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    // MARK: Reduce Transparency
+
+    func testInitialState_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+
+        XCTAssertFalse(subject.hasTopTabs)
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnHomepage_withoutWallpaperWithBottomURLBar_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(1).cgColor)
+    }
+
+    func testOnHomepage_withoutWallpaperWithTopURLBar_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnHomepage_withWallpaperWithBottomURLBar_reduceTransparency_notOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.withAlphaComponent(0).cgColor)
+    }
+
+    func testOnHomepage_withWallpaperWithTopURLBar_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnWebpage_withoutWallpaperWithBottomURLBar_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnWebpage_withoutWallpaperWithTopURLBar_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnWebpage_withWallpaperWithBottomURLBar_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testOnWebpage_withWallpaperWithTopURLBar_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testHasTopTabs_onHomepageWithoutWallpaperWithTopURLBar_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testHasTopTabs_onHomepageWithWallpaperWithTopURLBar_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testHasTopTabs_onWebpageWithoutWallpaperWithTopURLBar_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    func testHasTopTabs_onWebpageWithWallpaperWithTopURLBar_reduceTransparency_isOpaque() throws {
+        let toolbarHelper = createToolbarMock(isReduceTransparencyEnabled: true)
+        let subject = createSubject(hasTopTabs: true, toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        wallpaperManager.currentWallpaper = Wallpaper(id: "A Custom Wallpaper",
+                                                      textColor: nil,
+                                                      cardColor: nil,
+                                                      logoTextColor: nil)
+
+        subject.resetState(isHomepage: false)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layer3.cgColor)
+    }
+
+    // MARK: Helper
+
+    private func createSubject(hasTopTabs: Bool = false,
+                               toolbarHelper: ToolbarHelperInterface = ToolbarHelper()) -> StatusBarOverlay {
         let subject = StatusBarOverlay(frame: .zero,
                                        notificationCenter: notificationCenter,
-                                       wallpaperManager: wallpaperManager)
+                                       wallpaperManager: wallpaperManager,
+                                       toolbarHelper: toolbarHelper)
         subject.hasTopTabs = hasTopTabs
         subject.applyTheme(theme: LightTheme())
         trackForMemoryLeaks(subject)
         return subject
+    }
+
+    private func createToolbarMock(
+        isTranslucencyEnabled: Bool = true,
+        isReduceTransparencyEnabled: Bool = false) -> ToolbarHelperInterface {
+        let toolbarHelper = ToolbarHelperMock()
+        toolbarHelper.isToolbarTranslucencyEnabled = isTranslucencyEnabled
+        toolbarHelper.isReduceTransparencyEnabled = isReduceTransparencyEnabled
+        return toolbarHelper
+    }
+}
+
+private class ToolbarHelperMock: ToolbarHelperInterface {
+    private enum UX {
+        static let backgroundAlphaForBlur: CGFloat = 0.8
+    }
+
+    var isToolbarRefactorEnabled = true
+    var isToolbarTranslucencyEnabled = true
+    var isReduceTransparencyEnabled = false
+
+    func shouldShowNavigationToolbar(for traitCollection: UITraitCollection) -> Bool {
+        return traitCollection.verticalSizeClass != .compact
+               && traitCollection.horizontalSizeClass != .regular
+    }
+
+    func shouldShowTopTabs(for traitCollection: UITraitCollection) -> Bool {
+        return traitCollection.verticalSizeClass == .regular
+               && traitCollection.horizontalSizeClass == .regular
+    }
+
+    func shouldBlur() -> Bool {
+        return isToolbarRefactorEnabled &&
+            isToolbarTranslucencyEnabled &&
+            !isReduceTransparencyEnabled
+    }
+
+    func backgroundAlpha() -> CGFloat {
+        guard shouldBlur() else { return 1.0 }
+
+        return UX.backgroundAlphaForBlur
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12640)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27554)

## :bulb: Description
Added a check for translucency enabled and also used the same logic for resetting the status bar overlay.

## :movie_camera: Demos

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-25 at 15 36 49](https://github.com/user-attachments/assets/89261dd4-4c7e-4836-9639-b20e3c70f1bf) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-25 at 15 33 02](https://github.com/user-attachments/assets/84256aa9-fb5b-435a-b2b9-1687a3da060f) |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
