### PR TITLE
Add FXIOS-12621 [HNT - Search Bar] zero state to search button on toolbar

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -64,6 +64,7 @@ enum GeneralBrowserActionType: ActionType {
     case clearData
     case showPasswordGenerator
     case didSelectedTabChangeToHomepage
+    case enteredZeroSearchScreen
 }
 
 class GeneralBrowserMiddlewareAction: Action {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -131,6 +131,8 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             return reduceStateForNavigationBrowserAction(action: action, state: state)
         } else if let action = action as? StartAtHomeAction {
             return reduceStateForStartAtHomeAction(action: action, state: state)
+        } else if let action = action as? ToolbarMiddlewareAction {
+            return reduceStateForToolbarAction(action: action, state: state)
         } else {
             return BrowserViewControllerState(
                 searchScreenState: state.searchScreenState,
@@ -180,6 +182,27 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         switch action.actionType {
         case StartAtHomeMiddlewareActionType.startAtHomeCheckCompleted:
             return resolveStateForStartAtHome(action: action, state: state)
+        default:
+            return defaultState(from: state, action: action)
+        }
+    }
+
+    static func reduceStateForToolbarAction(
+        action: ToolbarMiddlewareAction,
+        state: BrowserViewControllerState
+    ) -> BrowserViewControllerState {
+        switch action.actionType {
+        case ToolbarMiddlewareActionType.didTapButton:
+            guard action.isHomepageSearchBarEnabled ?? false else {
+                return defaultState(from: state, action: action)
+            }
+            return BrowserViewControllerState(
+                searchScreenState: state.searchScreenState,
+                windowUUID: state.windowUUID,
+                browserViewType: state.browserViewType,
+                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
+                navigationDestination: NavigationDestination(.zeroSearch)
+            )
         default:
             return defaultState(from: state, action: action)
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1118,6 +1118,7 @@ class BrowserViewController: UIViewController,
         )
     }
 
+    // TODO: FXIOS-12632 Refactor how we determine when to hide / show toolbar
     /// If we are showing the homepage search bar, then we should hide the address toolbar
     private func shouldHideToolbar() -> Bool {
         let shouldShowSearchBar = store.state.screenState(
@@ -2609,6 +2610,11 @@ class BrowserViewController: UIViewController,
         case .tabTray(let panelType):
             navigationHandler?.showTabTray(selectedPanel: panelType)
         case .zeroSearch:
+            store.dispatchLegacy(
+                GeneralBrowserAction(
+                    windowUUID: windowUUID,
+                    actionType: GeneralBrowserActionType.enteredZeroSearchScreen)
+            )
             overlayManager.openNewTab(url: nil, newTabSettings: .topSites)
             configureZeroSearchView()
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/NavigationToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/NavigationToolbarContainerModel.swift
@@ -60,11 +60,20 @@ struct NavigationToolbarContainerModel: Equatable {
         } : nil
     }
 
+    /// Handles user action for tapping on one of the buttons on the navigation toolbar.
+    /// In the case of tapping on search, we want to handle it differently for when we show homepage search bar feature.
     private static func getOnSelected(action: ToolbarActionConfiguration, windowUUID: WindowUUID) -> ((UIButton) -> Void)? {
         return { button in
+            let shouldShowSearchBar = store.state.screenState(
+                HomepageState.self,
+                for: .homepage,
+                window: windowUUID
+            )?.searchState.shouldShowSearchBar ?? false
+            let isHomepageSearchBarEnabled = shouldShowSearchBar && action.actionType == .search
             let action = ToolbarMiddlewareAction(buttonType: action.actionType,
                                                  buttonTapped: button,
                                                  gestureType: .tap,
+                                                 isHomepageSearchBarEnabled: isHomepageSearchBarEnabled,
                                                  windowUUID: windowUUID,
                                                  actionType: ToolbarMiddlewareActionType.didTapButton)
             store.dispatchLegacy(action)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -114,17 +114,20 @@ class ToolbarMiddlewareAction: Action {
     let buttonTapped: UIButton?
     let gestureType: ToolbarButtonGesture?
     let scrollOffset: CGPoint?
+    let isHomepageSearchBarEnabled: Bool?
 
     init(buttonType: ToolbarActionConfiguration.ActionType? = nil,
          buttonTapped: UIButton? = nil,
          gestureType: ToolbarButtonGesture? = nil,
          scrollOffset: CGPoint? = nil,
+         isHomepageSearchBarEnabled: Bool? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
         self.buttonType = buttonType
         self.buttonTapped = buttonTapped
         self.gestureType = gestureType
         self.scrollOffset = scrollOffset
+        self.isHomepageSearchBarEnabled = isHomepageSearchBarEnabled
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SearchBar/SearchBarState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SearchBar/SearchBarState.swift
@@ -36,7 +36,7 @@ struct SearchBarState: StateType, Equatable {
         switch action.actionType {
         case HomepageMiddlewareActionType.configuredSearchBar:
             return handleSearchBarInitialization(action: action, state: state)
-        case NavigationBrowserActionType.tapOnHomepageSearchBar:
+        case GeneralBrowserActionType.enteredZeroSearchScreen:
             return handleHidingSearchBar(action: action, state: state)
         default:
             return defaultState(from: state)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -223,19 +223,6 @@ final class BrowserViewControllerStateTests: XCTestCase {
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
-    func test_tapOnHomepageSearchBar_navigationBrowserAction_returnsExpectedState() {
-        let initialState = createSubject()
-        let reducer = browserViewControllerReducer()
-
-        XCTAssertNil(initialState.navigationDestination)
-
-        let action = getNavigationBrowserAction(for: .tapOnHomepageSearchBar, destination: .zeroSearch)
-        let newState = reducer(initialState, action)
-
-        XCTAssertEqual(newState.navigationDestination?.destination, .zeroSearch)
-        XCTAssertEqual(newState.navigationDestination?.url, nil)
-    }
-
     // MARK: StartAtHomeAction
 
     func test_shouldStartAtHome_withStartAtHomeAction_returnsTrue() {
@@ -267,6 +254,56 @@ final class BrowserViewControllerStateTests: XCTestCase {
         let newState = reducer(initialState, action)
 
         XCTAssertFalse(newState.shouldStartAtHome)
+    }
+
+    // MARK: - Zero Search State
+
+    func test_tapOnHomepageSearchBar_navigationBrowserAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.navigationDestination)
+
+        let action = getNavigationBrowserAction(for: .tapOnHomepageSearchBar, destination: .zeroSearch)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.navigationDestination?.destination, .zeroSearch)
+        XCTAssertEqual(newState.navigationDestination?.url, nil)
+    }
+
+    func test_didTapButtonToolbarAction_withHomepageSearch_navigateToZeroSearch() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.navigationDestination)
+
+        let action = ToolbarMiddlewareAction(
+            isHomepageSearchBarEnabled: true,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
+        )
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.navigationDestination?.destination, .zeroSearch)
+        XCTAssertEqual(newState.navigationDestination?.url, nil)
+    }
+
+    func test_didTapButtonToolbarAction_withoutHomepageSearch_doesNotNavigateToZeroSearch() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.navigationDestination)
+
+        XCTAssertNil(initialState.navigationDestination)
+
+        let action = ToolbarMiddlewareAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
+        )
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.navigationDestination?.destination, nil)
+        XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -229,6 +229,71 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, StartAtHomeActionType.didBrowserBecomeActive)
     }
 
+    // MARK: - Zero Search State
+
+    func test_tapOnHomepageSearchBarAction_withBVCState_triggersGeneralBrowserAction() throws {
+        let subject = createSubject()
+
+        let newState = BrowserViewControllerState.reducer(
+            BrowserViewControllerState(windowUUID: .XCTestDefaultUUID),
+            NavigationBrowserAction(
+                navigationDestination: NavigationDestination(.zeroSearch),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: NavigationBrowserActionType.tapOnHomepageSearchBar
+            )
+        )
+        subject.newState(state: newState)
+
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.last(where: { $0 is GeneralBrowserAction }) as? GeneralBrowserAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? GeneralBrowserActionType)
+        XCTAssertEqual(actionType, GeneralBrowserActionType.enteredZeroSearchScreen)
+        XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+    }
+
+    func test_didTapButtonToolbarAction_withHomepageSearchEnabled_triggersGeneralBrowserAction() throws {
+        let subject = createSubject()
+
+        let newState = BrowserViewControllerState.reducer(
+            BrowserViewControllerState(windowUUID: .XCTestDefaultUUID),
+            ToolbarMiddlewareAction(
+                isHomepageSearchBarEnabled: true,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: ToolbarMiddlewareActionType.didTapButton
+            )
+        )
+        subject.newState(state: newState)
+
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.last(where: { $0 is GeneralBrowserAction }) as? GeneralBrowserAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? GeneralBrowserActionType)
+        XCTAssertEqual(actionType, GeneralBrowserActionType.enteredZeroSearchScreen)
+        XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+    }
+
+    func test_didTapButtonToolbarAction_withoutHomepageSearchEnabled_doesNotTriggersGeneralBrowserAction() throws {
+        let subject = createSubject()
+
+        let newState = BrowserViewControllerState.reducer(
+            BrowserViewControllerState(windowUUID: .XCTestDefaultUUID),
+            ToolbarMiddlewareAction(
+                isHomepageSearchBarEnabled: false,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: ToolbarMiddlewareActionType.didTapButton
+            )
+        )
+        subject.newState(state: newState)
+
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.last(where: { $0 is GeneralBrowserAction }) as? GeneralBrowserAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? GeneralBrowserActionType)
+        XCTAssertEqual(actionType, GeneralBrowserActionType.enteredZeroSearchScreen)
+        XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+    }
+
     private func createSubject() -> BrowserViewController {
         let subject = BrowserViewController(profile: profile,
                                             tabManager: tabManager,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/SearchBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/SearchBarStateTests.swift
@@ -50,16 +50,15 @@ final class SearchBarStateTests: XCTestCase {
         XCTAssertFalse(newState.shouldShowSearchBar)
     }
 
-    func test_tapOnHomepageSearchBarAction_returnsExpectedState() {
+    func test_enteredZeroSearchState_withGeneralBrowserAction_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = searchBarReducer()
 
         let newState = reducer(
             initialState,
-            NavigationBrowserAction(
-                navigationDestination: NavigationDestination(.zeroSearch),
+            GeneralBrowserAction(
                 windowUUID: .XCTestDefaultUUID,
-                actionType: NavigationBrowserActionType.tapOnHomepageSearchBar
+                actionType: GeneralBrowserActionType.enteredZeroSearchScreen
             )
         )
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12621)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27506)

## :bulb: Description
Tapping on search button on navigation toolbar should show zero search similar to tapping on the search bar in the middle of the homepage.

Note: Showing / hiding the address toolbar will be added in a separate ticket; this PR is mainly to add in that tapping shows the new zero search state.

## :movie_camera: Demos

https://github.com/user-attachments/assets/ef07572a-9738-4a30-9765-0f586bd66e5e

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
