### PR TITLE
Fix [Release Automation] Replace references to staging in test params for taskgraph

### DIFF
--- a/taskcluster/test/params/cron-beta-releases.yml
+++ b/taskcluster/test/params/cron-beta-releases.yml
@@ -1,5 +1,5 @@
 base_ref: origin/main
-base_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+base_repository: https://github.com/mozilla-mobile/firefox-ios
 base_rev: 6a5ff6fb20e56f7963c81509a8933d7019028e16
 build_date: 1747826577
 build_number: 1
@@ -17,7 +17,7 @@ files_changed:
 filters:
 - target_tasks_method
 head_ref: main
-head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+head_repository: https://github.com/mozilla-mobile/firefox-ios
 head_rev: 3943c2420bd7eb7357e067c9f469346264d6bd5e
 head_tag: ''
 level: '1'
@@ -26,7 +26,7 @@ next_version: null
 optimize_strategies: null
 optimize_target_tasks: true
 owner: cron@noreply.mozilla.org
-project: staging-firefox-ios
+project: firefox-ios
 pull_request_number: null
 pushdate: 0
 pushlog_id: '0'

--- a/taskcluster/test/params/release-promote-beta.yml
+++ b/taskcluster/test/params/release-promote-beta.yml
@@ -1,5 +1,5 @@
 base_ref: origin/main
-base_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+base_repository: https://github.com/mozilla-mobile/firefox-ios
 base_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 build_date: 1740597206
 build_number: 3
@@ -14,7 +14,7 @@ files_changed: []
 filters:
 - target_tasks_method
 head_ref: refs/heads/main
-head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+head_repository: https://github.com/mozilla-mobile/firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 head_tag: firefox-v137.0b1
 level: '1'
@@ -23,7 +23,7 @@ next_version: 137.0b2
 optimize_strategies: null
 optimize_target_tasks: true
 owner: nobody@mozilla.com
-project: staging-firefox-ios
+project: firefox-ios
 pull_request_number: null
 pushdate: 0
 pushlog_id: '0'

--- a/taskcluster/test/params/release-promote.yml
+++ b/taskcluster/test/params/release-promote.yml
@@ -1,5 +1,5 @@
 base_ref: origin/main
-base_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+base_repository: https://github.com/mozilla-mobile/firefox-ios
 base_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 build_date: 1740597206
 build_number: 3
@@ -14,7 +14,7 @@ files_changed: []
 filters:
 - target_tasks_method
 head_ref: refs/heads/main
-head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+head_repository: https://github.com/mozilla-mobile/firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 head_tag: firefox-v137.0
 level: '1'
@@ -23,7 +23,7 @@ next_version: '137.1'
 optimize_strategies: null
 optimize_target_tasks: true
 owner: nobody@mozilla.com
-project: staging-firefox-ios
+project: firefox-ios
 pull_request_number: null
 pushdate: 0
 pushlog_id: '0'

--- a/taskcluster/test/params/release-push-beta.yml
+++ b/taskcluster/test/params/release-push-beta.yml
@@ -1,5 +1,5 @@
 base_ref: origin/main
-base_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+base_repository: https://github.com/mozilla-mobile/firefox-ios
 base_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 build_date: 1740597206
 build_number: 3
@@ -14,7 +14,7 @@ files_changed: []
 filters:
 - target_tasks_method
 head_ref: refs/heads/main
-head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+head_repository: https://github.com/mozilla-mobile/firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 head_tag: firefox-v137.0b1
 level: '1'
@@ -23,7 +23,7 @@ next_version: 137.0b2
 optimize_strategies: null
 optimize_target_tasks: true
 owner: nobody@mozilla.com
-project: staging-firefox-ios
+project: firefox-ios
 pull_request_number: null
 pushdate: 0
 pushlog_id: '0'

--- a/taskcluster/test/params/release-push.yml
+++ b/taskcluster/test/params/release-push.yml
@@ -1,5 +1,5 @@
 base_ref: origin/main
-base_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+base_repository: https://github.com/mozilla-mobile/firefox-ios
 base_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 build_date: 1740597206
 build_number: 3
@@ -14,7 +14,7 @@ files_changed: []
 filters:
 - target_tasks_method
 head_ref: refs/heads/main
-head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+head_repository: https://github.com/mozilla-mobile/firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 head_tag: firefox-v137.0
 level: '1'
@@ -23,7 +23,7 @@ next_version: '137.1'
 optimize_strategies: null
 optimize_target_tasks: true
 owner: nobody@mozilla.com
-project: staging-firefox-ios
+project: firefox-ios
 pull_request_number: null
 pushdate: 0
 pushlog_id: '0'

--- a/taskcluster/test/params/release-ship-beta.yml
+++ b/taskcluster/test/params/release-ship-beta.yml
@@ -1,5 +1,5 @@
 base_ref: origin/main
-base_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+base_repository: https://github.com/mozilla-mobile/firefox-ios
 base_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 build_date: 1740597206
 build_number: 3
@@ -14,7 +14,7 @@ files_changed: []
 filters:
 - target_tasks_method
 head_ref: refs/heads/main
-head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+head_repository: https://github.com/mozilla-mobile/firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 head_tag: firefox-v137b1
 level: '1'
@@ -23,7 +23,7 @@ next_version: 137.0.1
 optimize_strategies: null
 optimize_target_tasks: true
 owner: nobody@mozilla.com
-project: staging-firefox-ios
+project: firefox-ios
 pull_request_number: null
 pushdate: 0
 pushlog_id: '0'

--- a/taskcluster/test/params/release-ship.yml
+++ b/taskcluster/test/params/release-ship.yml
@@ -1,5 +1,5 @@
 base_ref: origin/main
-base_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+base_repository: https://github.com/mozilla-mobile/firefox-ios
 base_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 build_date: 1740597206
 build_number: 3
@@ -14,7 +14,7 @@ files_changed: []
 filters:
 - target_tasks_method
 head_ref: refs/heads/main
-head_repository: https://github.com/mozilla-mobile/staging-firefox-ios
+head_repository: https://github.com/mozilla-mobile/firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 head_tag: firefox-v137.0
 level: '1'
@@ -23,7 +23,7 @@ next_version: '137.1'
 optimize_strategies: null
 optimize_target_tasks: true
 owner: nobody@mozilla.com
-project: staging-firefox-ios
+project: firefox-ios
 pull_request_number: null
 pushdate: 0
 pushlog_id: '0'


### PR DESCRIPTION
## :bulb: Description
This should fix the taskgraph tests on main. Technically only `cron-beta-releases` needed that change as the test would get the list of branches of the non staging repo but then would try to get the version of that branch on the staging one. But there's no value in keeping any of those params referencing staging so I just made them all use the original repository.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
