### PR TITLE
Bugfix FXIOS-7301 swiftlint closure count

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
@@ -54,18 +54,22 @@ final class HomepageMiddleware: FeatureFlaggable {
             }
             self.homepageTelemetry.sendSectionLabeledCounter(for: type)
 
-        case HomepageActionType.initialize, HomepageActionType.viewWillTransition,
-            ToolbarActionType.cancelEdit:
-            store.dispatchLegacy(
-                HomepageAction(
-                    isSearchBarEnabled: self.shouldShowSearchBar(),
-                    windowUUID: action.windowUUID,
-                    actionType: HomepageMiddlewareActionType.configuredSearchBar
-                )
-            )
+        case HomepageActionType.initialize, HomepageActionType.viewWillTransition, ToolbarActionType.cancelEdit:
+            self.handleSearchBarConfigurationAction(action: action)
+
         default:
             break
         }
+    }
+
+    private func handleSearchBarConfigurationAction(action: Action) {
+        store.dispatchLegacy(
+            HomepageAction(
+                isSearchBarEnabled: self.shouldShowSearchBar(),
+                windowUUID: action.windowUUID,
+                actionType: HomepageMiddlewareActionType.configuredSearchBar
+            )
+        )
     }
 
     private func shouldShowSearchBar(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
Fix SwiftLint closure issue. Introduced in https://github.com/mozilla-mobile/firefox-ios/pull/27549 and other PRs got merged before, but bitrise CI passed for that PR.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
