### PR TITLE
Add FXIOS-12135 Tab tray experiment on for test_sync_tabs_from_desktop

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_integration.py
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_integration.py
@@ -27,9 +27,13 @@ def test_sync_logins_from_desktop(tps, xcodebuild):
     tps.run('test_password_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncPasswordDesktop')
 
-def test_sync_tabs_from_desktop(tps, xcodebuild):
+def test_sync_tabs_from_desktop_tabTrayExperimentOn(tps, xcodebuild):
     tps.run('test_tabs_desktop.js')
-    xcodebuild.test('XCUITests/IntegrationTests/testFxASyncTabsDesktop')
+    xcodebuild.test('XCUITests/IntegrationTests/testFxASyncTabsDesktop_tabTrayExperimentOn')
+
+def test_sync_tabs_from_desktop_tabTrayExperimentOff(tps, xcodebuild):
+    tps.run('test_tabs_desktop.js')
+    xcodebuild.test('XCUITests/IntegrationTests/testFxASyncTabsDesktop_tabTrayExperimentOff')
 
 def test_sync_disconnect_connect_fxa(tps, xcodebuild):
     tps.run('test_bookmark_login.js')

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -228,6 +228,27 @@ class IntegrationTests: FeatureFlaggedTestBase {
         XCTAssertTrue(app.tables.cells.staticTexts[loginEntry].exists, "The login saved on desktop is not synced")
     }
 
+    func testFxASyncTabsDesktop_tabTrayExperimentOn() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "tab-tray-ui-experiments")
+        app.launch()
+        // Sign into Mozilla Account
+        signInFxAccounts()
+
+        // Wait for initial sync to complete
+        waitForInitialSyncComplete()
+
+        // Check synced Tabs
+        app.buttons["Done"].waitAndTap()
+        navigator.nowAt(HomePanelsScreen)
+        navigator.goto(TabTray)
+        navigator.performAction(Action.ToggleExperimentSyncMode)
+
+        // Need to swipe to get the data on the screen on focus
+        app.swipeDown()
+        mozWaitForElementToExist(app.tables.otherElements["profile1"])
+        XCTAssertTrue(app.tables.staticTexts[tabOpenInDesktop].exists, "The tab is not synced")
+    }
+
     func testFxASyncTabsDesktop_tabTrayExperimentOff() {
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "tab-tray-ui-experiments")
         app.launch()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12135)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Let me turn on the tab tray experiment for sync integration tests as well.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

Test run for `test_sync_tabs_from_desktop_tabTrayExperimentOff`. Ditto for `test_sync_tabs_from_desktop_tabTrayExperimentOn`:
```
$ pipenv run pytest test_integration.py::test_sync_tabs_from_desktop_tabTrayExperimentOff
============================================================ test session starts ============================================================
platform darwin -- Python 3.12.6, pytest-8.3.3, pluggy-1.5.0 -- /Users/cso/.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.12.6', 'Platform': 'macOS-15.5-arm64-arm-64bit', 'Packages': {'pytest': '8.3.3', 'pluggy': '1.5.0'}, 'Plugins': {'html': '4.1.1', 'fxa-mte': '1.6.0', 'metadata': '3.1.1'}, 'JAVA_HOME': '/Applications/Android Studio.app/Contents/jbr/Contents/Home'}
rootdir: /Users/cso/workspace/firefox-ios/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests
configfile: pytest.ini
plugins: html-4.1.1, fxa-mte-1.6.0, metadata-3.1.1
collected 1 item                                                                                                                            

test_integration.py::test_sync_tabs_from_desktop_tabTrayExperimentOff 
-------------------------------------------------------------- live log setup ---------------------------------------------------------------
INFO     mozdownload.scraper:scraper.py:462 Retrieving the build status file from https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/
INFO     mozdownload.scraper:scraper.py:509 Retrieving list of builds from https://archive.mozilla.org/pub/firefox/nightly/2025/06/
INFO     mozdownload.scraper:scraper.py:363 Found 1 build: 2025-06-26-21-43-51-mozilla-central
INFO     mozdownload.scraper:scraper.py:543 Selected build: 2025-06-26-21-43-51-mozilla-central
INFO     mozdownload.scraper:scraper.py:292 File has already been downloaded: /Users/cso/workspace/firefox-ios/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/.pytest_cache/d/firefox/2025-06-26-21-43-51-mozilla-central-firefox-142.0a1.en-US.mac.dmg
INFO     mozdownload.scraper:scraper.py:292 File has already been downloaded: /Users/cso/workspace/firefox-ios/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/.pytest_cache/d/tps-FFDeHkiYQ7i6Kzx5Lj6JMQ/tps.xpi
INFO     root:plugin.py:96 Created: FxAccount(email='pytest-964830a580@restmail.net', password='NKqLHRIm')
INFO     root:plugin.py:103 Verified: FxAccount(email='pytest-964830a580@restmail.net', password='NKqLHRIm')
--------------------------------------------------------------- live log call ---------------------------------------------------------------
INFO     root:tps.py:34 Running: /private/var/folders/z8/_38sh9qn5p7cx5hbbk4_rt640000gn/T/pytest-of-cso/pytest-25/firefox0/Firefox Nightly.app/Contents/MacOS/firefox -marionette -headless
INFO     root:tps.py:35 Using profile at: /var/folders/z8/_38sh9qn5p7cx5hbbk4_rt640000gn/T/tmpo31g6zpx.mozrunner
INFO     root:xcrun.py:14 Running: xcrun simctl shutdown all
INFO     root:xcrun.py:14 Running: xcrun simctl erase all
INFO     root:xcodebuild.py:57 Running: xcodebuild test -scheme Fennec -destination platform=iOS Simulator,name=iPhone 16,OS=18.2 -only-testing:XCUITests/IntegrationTests/testFxASyncTabsDesktop_tabTrayExperimentOff -testPlan SyncIntegrationTestPlan
PASSED                                                                                                                                [100%]
------------------------------------------------------------- live log teardown -------------------------------------------------------------
INFO     root:plugin.py:60 Removed: FxAccount(email='pytest-964830a580@restmail.net', password='NKqLHRIm')


============================================================= warnings summary ==============================================================
../../../../../../.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/mozdevice/adb.py:7
  /Users/cso/.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/mozdevice/adb.py:7: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
    import pipes

../../../../../../.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/mozrunner/devices/emulator.py:11
  /Users/cso/.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/mozrunner/devices/emulator.py:11: DeprecationWarning: 'telnetlib' is deprecated and slated for removal in Python 3.13
    from telnetlib import Telnet

../../../../../../.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/mozrunner/utils.py:19
  /Users/cso/.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/mozrunner/utils.py:19: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

../../../../../../.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/pkg_resources/__init__.py:3154
../../../../../../.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/pkg_resources/__init__.py:3154
../../../../../../.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/pkg_resources/__init__.py:3154
../../../../../../.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/pkg_resources/__init__.py:3154
  /Users/cso/.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/pkg_resources/__init__.py:3154: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

conftest.py:142
  /Users/cso/workspace/firefox-ios/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/conftest.py:142: PytestDeprecationWarning: The hookimpl pytest_runtest_makereport uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(hookwrapper=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    @pytest.mark.hookwrapper

test_integration.py::test_sync_tabs_from_desktop_tabTrayExperimentOff
  /Users/cso/.local/share/virtualenvs/SyncIntegrationTests-nkT8pc_I/lib/python3.12/site-packages/pytest_html/plugin.py:133: DeprecationWarning: The 'report.extra' attribute is deprecated and will be removed in a future release, use 'report.extras' instead.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- Generated html report: file:///Users/cso/workspace/firefox-ios/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/results/index.html -
================================================= 1 passed, 9 warnings in 195.40s (0:03:15) =================================================
```

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
