### PR TITLE
Add FXIOS-12641 ⁃ [Menu Redesign] Handle Menu UI for different accessibility sizes

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuAccountCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuAccountCell.swift
@@ -10,7 +10,6 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private struct UX {
         static let contentMargin: CGFloat = 16
         static let iconSize: CGFloat = 24
-        static let largeIconSize: CGFloat = 48
         static let contentSpacing: CGFloat = 3
         static let noDescriptionContentSpacing: CGFloat = 0
         static let cornerRadius: CGFloat = 16
@@ -25,11 +24,12 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     private var descriptionLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.caption1.scaledFont()
+        label.numberOfLines = 0
     }
 
     private var contentStackView: UIStackView = .build { stackView in
         stackView.axis = .vertical
-        stackView.distribution = .fillProportionally
+        stackView.distribution = .fill
     }
 
     private var iconImageView: UIImageView = .build()
@@ -117,13 +117,6 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
             iconImageView.widthAnchor.constraint(equalToConstant: UX.iconSize),
             iconImageView.heightAnchor.constraint(equalToConstant: UX.iconSize)
         ])
-        adjustLayout(isAccessibilityCategory: UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory)
-    }
-
-    private func adjustLayout(isAccessibilityCategory: Bool) {
-        let iconSize = isAccessibilityCategory ? UX.largeIconSize : UX.iconSize
-        iconImageView.widthAnchor.constraint(equalToConstant: iconSize).isActive = true
-        iconImageView.heightAnchor.constraint(equalToConstant: iconSize).isActive = true
     }
 
     private func configureCornerRadiusForCellPosition() {

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignCell.swift
@@ -10,7 +10,6 @@ final class MenuRedesignCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private struct UX {
         static let contentMargin: CGFloat = 16
         static let iconSize: CGFloat = 24
-        static let largeIconSize: CGFloat = 48
         static let contentSpacing: CGFloat = 3
         static let noDescriptionContentSpacing: CGFloat = 0
         static let cornerRadius: CGFloat = 16
@@ -25,11 +24,12 @@ final class MenuRedesignCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     private var descriptionLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.caption1.scaledFont()
+        label.numberOfLines = 0
     }
 
     private var contentStackView: UIStackView = .build { stackView in
         stackView.axis = .vertical
-        stackView.distribution = .fillProportionally
+        stackView.distribution = .fill
     }
 
     private var iconImageView: UIImageView = .build()
@@ -96,13 +96,6 @@ final class MenuRedesignCell: UITableViewCell, ReusableCell, ThemeApplicable {
             iconImageView.widthAnchor.constraint(equalToConstant: UX.iconSize),
             iconImageView.heightAnchor.constraint(equalToConstant: UX.iconSize)
         ])
-        adjustLayout(isAccessibilityCategory: UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory)
-    }
-
-    private func adjustLayout(isAccessibilityCategory: Bool) {
-        let iconSize = isAccessibilityCategory ? UX.largeIconSize : UX.iconSize
-        iconImageView.widthAnchor.constraint(equalToConstant: iconSize).isActive = true
-        iconImageView.heightAnchor.constraint(equalToConstant: iconSize).isActive = true
     }
 
     private func configureCornerRadiusForCellPosition() {

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -44,7 +44,7 @@ public final class MenuRedesignMainView: UIView,
                 closeButton.topAnchor.constraint(equalTo: self.topAnchor, constant: UX.headerTopMargin),
                 closeButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -UX.horizontalMargin),
                 closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
-                closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
+                closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize)
             ])
 
             if isHeaderBanner && isMenuDefaultBrowserBanner {

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSiteProtectionsHeader.swift
@@ -32,6 +32,7 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         stack.distribution = .fillProportionally
         stack.axis = .vertical
         stack.spacing = UX.contentLabelsSpacing
+        stack.isAccessibilityElement = true
     }
 
     private var favicon: FaviconImageView = .build { favicon in
@@ -42,11 +43,13 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
     private let titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Bold.callout.scaledFont()
         label.adjustsFontForContentSizeCategory = true
+        label.isAccessibilityElement = false
     }
 
     private let subtitleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.footnote.scaledFont()
         label.adjustsFontForContentSizeCategory = true
+        label.isAccessibilityElement = false
     }
 
     private lazy var closeButton: CloseButton = .build { button in
@@ -78,6 +81,7 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.adjustsFontForContentSizeCategory = true
+        label.accessibilityTraits = .button
     }
 
     private var siteProtectionsIcon: UIImageView = .build { imageView in
@@ -154,6 +158,7 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         let closeButtonViewModel = CloseButtonViewModel(a11yLabel: closeButtonA11yLabel,
                                                         a11yIdentifier: closeButtonA11yId)
         closeButton.configure(viewModel: closeButtonViewModel)
+        contentLabels.accessibilityLabel = "\(titleLabel.text ?? "") \(subtitleLabel.text ?? "")"
     }
 
     @objc

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquareCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquareCell.swift
@@ -5,7 +5,6 @@
 import Common
 import UIKit
 
-// TODO: FXIOS-12302 Create the UI for different accessibility sizes, for horizontal options section
 final class MenuSquareView: UIView, ThemeApplicable {
     private struct UX {
         static let iconSize: CGFloat = 24
@@ -17,6 +16,7 @@ final class MenuSquareView: UIView, ThemeApplicable {
         static let contentViewHorizontalMargin: CGFloat = 4
         static let cornerRadius: CGFloat = 16
         static let backgroundAlpha: CGFloat = 0.8
+        static let hyphenationFactor: Float = 1.0
     }
 
     // MARK: - UI Elements
@@ -25,7 +25,7 @@ final class MenuSquareView: UIView, ThemeApplicable {
     private var contentStackView: UIStackView = .build { stack in
         stack.axis = .vertical
         stack.spacing = UX.contentViewSpacing
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
     }
 
     private var icon: UIImageView = .build { view in
@@ -33,9 +33,8 @@ final class MenuSquareView: UIView, ThemeApplicable {
     }
 
     private var titleLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.caption2.scaledFont()
-        label.numberOfLines = 1
-        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
     }
 
     // MARK: - Properties
@@ -61,7 +60,7 @@ final class MenuSquareView: UIView, ThemeApplicable {
 
     func configureCellWith(model: MenuElement) {
         self.model = model
-        self.titleLabel.text = model.title
+        self.setTitle(with: model.title)
         self.icon.image = UIImage(named: model.iconName)?.withRenderingMode(.alwaysTemplate)
         self.backgroundContentView.layer.cornerRadius = UX.backgroundViewCornerRadius
         self.isAccessibilityElement = true
@@ -96,11 +95,27 @@ final class MenuSquareView: UIView, ThemeApplicable {
                 constant: -UX.contentViewHorizontalMargin
             ),
             contentStackView.bottomAnchor.constraint(
-                equalTo: backgroundContentView.bottomAnchor,
+                lessThanOrEqualTo: backgroundContentView.bottomAnchor,
                 constant: -UX.contentViewBottomMargin
             ),
             icon.heightAnchor.constraint(equalToConstant: UX.iconSize)
         ])
+    }
+
+    private func setTitle(with title: String) {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.hyphenationFactor = UX.hyphenationFactor
+        paragraphStyle.alignment = .center
+
+        let attributedText = NSAttributedString(
+            string: title,
+            attributes: [
+                .paragraphStyle: paragraphStyle,
+                .font: FXFontStyles.Regular.caption2.scaledFont()
+            ]
+        )
+
+        titleLabel.attributedText = attributedText
     }
 
     // MARK: - Theme Applicable

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -252,7 +252,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
                     needsReAuth: tabInfo.accountData.needsReAuth,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: "",
+                    a11yLabel: "\(tabInfo.accountData.title) \(tabInfo.accountData.subtitle ?? "")",
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.signIn,
                     action: {
@@ -416,7 +416,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
             isEnabled: true,
             isActive: isActive,
             a11yLabel: .MainMenu.ToolsSection.AccessibilityLabels.DesktopSite,
-            a11yHint: "",
+            a11yHint: isActive ? .MainMenu.On : .MainMenu.Off,
             a11yId: AccessibilityIdentifiers.MainMenu.desktopSite,
             infoTitle: isActive ? .MainMenu.On : .MainMenu.Off,
             action: {
@@ -448,7 +448,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
             isEnabled: true,
             isActive: false,
             a11yLabel: isExpanded ? A11y.LessOptions : A11y.MoreOptions,
-            a11yHint: "",
+            a11yHint: isExpanded ? A11y.ExpandedHint : A11y.CollapsedHint,
             a11yId: AccessibilityIdentifiers.MainMenu.moreLess,
             action: {
                 store.dispatchLegacy(
@@ -485,8 +485,8 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
             iconName: "",
             isEnabled: true,
             isActive: tabInfo.zoomLevel != regularZoom,
-            a11yLabel: String(format: .MainMenu.Submenus.Tools.AccessibilityLabels.Zoom, "\(zoomSymbol)\(zoomLevel)"),
-            a11yHint: "",
+            a11yLabel: .MainMenu.ToolsSection.AccessibilityLabels.PageZoom,
+            a11yHint: "\(zoomSymbol)\(zoomLevel)",
             a11yId: AccessibilityIdentifiers.MainMenu.zoom,
             isOptional: true,
             infoTitle: "\(zoomLevel)",
@@ -509,15 +509,14 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         typealias A11y = String.MainMenu.Submenus.Tools.AccessibilityLabels
 
         let nightModeIsOn = NightModeHelper.isActivated()
-        let a11yLabel = nightModeIsOn ? A11y.NightModeOff : A11y.NightModeOn
 
         return MenuElement(
             title: .MainMenu.Submenus.Tools.WebsiteDarkMode,
             iconName: "",
             isEnabled: true,
             isActive: nightModeIsOn,
-            a11yLabel: a11yLabel,
-            a11yHint: "",
+            a11yLabel: .MainMenu.ToolsSection.AccessibilityLabels.WebsiteDarkMode,
+            a11yHint: nightModeIsOn ? .MainMenu.On : .MainMenu.Off,
             a11yId: AccessibilityIdentifiers.MainMenu.nightMode,
             isOptional: true,
             infoTitle: nightModeIsOn ? .MainMenu.On : .MainMenu.Off,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -120,6 +120,9 @@ final class MainMenuMiddleware: FeatureFlaggable {
         case MainMenuDetailsActionType.tapDismissView:
             telemetry.closeButtonTapped(isHomepage: isHomepage)
 
+        case MainMenuActionType.tapMoreOptions:
+            handleTapMoreOptions(action: action)
+
         default: break
         }
     }
@@ -247,6 +250,15 @@ final class MainMenuMiddleware: FeatureFlaggable {
                            subtitle: subtitle,
                            warningIcon: warningIcon,
                            iconURL: iconURL)
+    }
+
+    private func handleTapMoreOptions(action: MainMenuAction) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            UIAccessibility.post(
+                notification: .announcement,
+                argument: String.MainMenu.ToolsSection.AccessibilityLabels.ExpandedHint
+            )
+        }
     }
 
     private func handleTelemetryFor(for navigationDestination: MainMenuNavigationDestination,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -472,7 +472,7 @@ class MainMenuViewController: UIViewController,
                 menuRedesignContent.setupAccessibilityIdentifiers(
                     menuA11yId: AccessibilityIdentifiers.MainMenu.mainMenu,
                     menuA11yLabel: .MainMenu.TabsSection.AccessibilityLabels.MainMenu,
-                    closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButton,
+                    closeButtonA11yLabel: .MainMenu.AccessibilityLabels.CloseButton,
                     closeButtonA11yIdentifier: AccessibilityIdentifiers.MainMenu.HeaderView.closeButton,
                     siteProtectionHeaderIdentifier: AccessibilityIdentifiers.MainMenu.SiteProtectionsHeaderView.header)
             } else {

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4303,6 +4303,11 @@ extension String {
                 tableName: "MainMenu",
                 value: "Dimmed",
                 comment: "On the main menu, the accessibility label hint for any action/option inside the menu, that is disabled. For example: 'Save to Reading List' option, from Menu, in some cases is disabled and the voice over should indicate that. 'Save To Reading List dimmed'")
+            public static let CloseButton = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.CloseButton.142",
+                tableName: "MainMenu",
+                value: "Close Menu",
+                comment: "The accessibility label for the close button in the Main menu.")
         }
 
         public struct SiteProtection {
@@ -4488,6 +4493,16 @@ extension String {
                     tableName: "MainMenu",
                     value: "Desktop Site",
                     comment: "On the main menu, the accessibility label for the action that will switch a site user agent value, if available.")
+                public static let PageZoom = MZLocalizedString(
+                    key: "MainMenu.ToolsSection.AccessibilityLabels.PageZoom.Title.v142",
+                    tableName: "MainMenu",
+                    value: "Page Zoom",
+                    comment: "On the main menu, the accessibility label for the action that will open the page zoom tool.")
+                public static let WebsiteDarkMode = MZLocalizedString(
+                    key: "MainMenu.ToolsSection.AccessibilityLabels.WebsiteDarkMode.Title.v142",
+                    tableName: "MainMenu",
+                    value: "Website Dark Mode",
+                    comment: "On the main menu, the accessibility label for the action that will switch dark mode to on or off.")
                 public static let FindInPage = MZLocalizedString(
                     key: "MainMenu.ToolsSection.AccessibilityLabels.FindInPage.v132",
                     tableName: "MainMenu",
@@ -4513,6 +4528,16 @@ extension String {
                     tableName: "MainMenu",
                     value: "Less",
                     comment: "On the main menu, the accessibility label for the action that will hide some menu options in the current section of the menu.")
+                public static let CollapsedHint = MZLocalizedString(
+                    key: "MainMenu.ToolsSection.AccessibilityLabels.CollapsedHint.v142",
+                    tableName: "MainMenu",
+                    value: "Collapsed",
+                    comment: "On the main menu, the accessibility label hint for the action that will show more menu options in the current section of the menu.")
+                public static let ExpandedHint = MZLocalizedString(
+                    key: "MainMenu.ToolsSection.AccessibilityLabels.ExpandedHint.v142",
+                    tableName: "MainMenu",
+                    value: "Expanded",
+                    comment: "On the main menu, the accessibility label hint for the action that will show more menu options in the current section of the menu. Hint will be called when menu is expanded.")
             }
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12641)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27556)

## :bulb: Description
Handle UI for different accessibility text sizes

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
