### PR TITLE
BugFix [Swift 6] FXIOS-12583 region based warnings on LaunchScreenViewControllers and in LoginStorage

### DIFF
--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
@@ -48,7 +48,7 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
 
         Task {
             try await delayStart()
-            await startLoading()
+            startLoading()
         }
     }
 
@@ -64,8 +64,8 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
     }
 
     // MARK: - Loading
-    func startLoading() async {
-        await viewModel.startLoading()
+    func startLoading() {
+        viewModel.startLoading()
     }
 
     // MARK: - Setup

--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewModel.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewModel.swift
@@ -47,8 +47,8 @@ class LaunchScreenViewModel {
         profile.prefs.setBool(true, forKey: PrefsKeys.splashScreenShownKey)
     }
 
-    func startLoading(appVersion: String = AppInfo.appVersion) async {
-        await loadLaunchType(appVersion: appVersion)
+    func startLoading(appVersion: String = AppInfo.appVersion) {
+        loadLaunchType(appVersion: appVersion)
     }
 
     func loadNextLaunchType() {
@@ -62,7 +62,7 @@ class LaunchScreenViewModel {
         }
     }
 
-    private func loadLaunchType(appVersion: String) async {
+    private func loadLaunchType(appVersion: String) {
         var launchOrder = [LaunchType]()
 
         if introScreenManager.shouldShowIntroScreen {
@@ -72,7 +72,7 @@ class LaunchScreenViewModel {
 
             launchOrder.append(.intro(manager: introScreenManager))
         } else if updateViewModel.shouldShowUpdateSheet(appVersion: appVersion),
-                  await updateViewModel.hasSyncableAccount() {
+                  updateViewModel.containsSyncableAccount() {
             launchOrder.append(.update(viewModel: updateViewModel))
         } else if surveySurfaceManager.shouldShowSurveySurface {
             launchOrder.append(.survey(manager: surveySurfaceManager))

--- a/firefox-ios/Client/Frontend/Autofill/LoginStorage.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginStorage.swift
@@ -7,6 +7,7 @@ import Storage
 import struct MozillaAppServices.Login
 
 protocol LoginStorage {
+    @MainActor
     func listLogins() async throws -> [Login]
 }
 

--- a/firefox-ios/Client/Frontend/Onboarding/Models/UpdateViewModel.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/UpdateViewModel.swift
@@ -80,7 +80,7 @@ class UpdateViewModel: OnboardingViewModelProtocol,
         }
     }
 
-    func hasSyncableAccount() async -> Bool {
+    func containsSyncableAccount() -> Bool {
         let hasSync = profile.hasAccount()
         hasSyncableAccount = hasSync
         return hasSync

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
@@ -42,11 +42,11 @@ final class LaunchScreenViewModelTests: XCTestCase {
         XCTAssertEqual(delegate.finishedLoadingLaunchOrderCalled, 0)
     }
 
-    func testLaunchType_intro() async {
+    func testLaunchType_intro() {
         profile.prefs.setInt(1, forKey: PrefsKeys.TermsOfServiceAccepted)
         let subject = createSubject()
         subject.delegate = delegate
-        await subject.startLoading(appVersion: "112.0")
+        subject.startLoading(appVersion: "112.0")
 
         XCTAssertEqual(delegate.launchBrowserCalled, 0)
         XCTAssertEqual(delegate.finishedLoadingLaunchOrderCalled, 1)
@@ -60,14 +60,14 @@ final class LaunchScreenViewModelTests: XCTestCase {
         XCTAssertEqual(delegate.launchWithTypeCalled, 1)
     }
 
-    func testLaunchType_termsOfService() async {
+    func testLaunchType_termsOfService() {
         FxNimbus.shared.features.tosFeature.with(initializer: { _, _ in
             TosFeature(status: true)
         })
 
         let subject = createSubject()
         subject.delegate = delegate
-        await subject.startLoading(appVersion: "112.0")
+        subject.startLoading(appVersion: "112.0")
 
         XCTAssertEqual(delegate.launchBrowserCalled, 0)
         XCTAssertEqual(delegate.finishedLoadingLaunchOrderCalled, 1)
@@ -81,13 +81,13 @@ final class LaunchScreenViewModelTests: XCTestCase {
         XCTAssertEqual(delegate.launchWithTypeCalled, 1)
     }
 
-    func testLaunchType_update() async {
+    func testLaunchType_update() {
         profile.prefs.setString("112.0", forKey: PrefsKeys.AppVersion.Latest)
         profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
 
         let subject = createSubject()
         subject.delegate = delegate
-        await subject.startLoading(appVersion: "113.0")
+        subject.startLoading(appVersion: "113.0")
 
         XCTAssertEqual(delegate.launchBrowserCalled, 0)
         XCTAssertEqual(delegate.finishedLoadingLaunchOrderCalled, 1)
@@ -101,7 +101,7 @@ final class LaunchScreenViewModelTests: XCTestCase {
         XCTAssertEqual(delegate.launchWithTypeCalled, 1)
     }
 
-    func testLaunchType_survey() async {
+    func testLaunchType_survey() {
         profile.prefs.setString("112.0", forKey: PrefsKeys.AppVersion.Latest)
         profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
         let message = createMessage()
@@ -109,7 +109,7 @@ final class LaunchScreenViewModelTests: XCTestCase {
 
         let subject = createSubject()
         subject.delegate = delegate
-        await subject.startLoading(appVersion: "112.0")
+        subject.startLoading(appVersion: "112.0")
 
         XCTAssertEqual(delegate.launchBrowserCalled, 0)
         XCTAssertEqual(delegate.finishedLoadingLaunchOrderCalled, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLaunchScreenManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLaunchScreenManager.swift
@@ -30,7 +30,7 @@ class MockLaunchScreenViewModel: LaunchScreenViewModel {
         super.init(windowUUID: windowUUID)
     }
 
-    override func startLoading(appVersion: String) async {
+    override func startLoading(appVersion: String) {
         startLoadingCalled += 1
         if let mockLaunchType = mockLaunchType {
             delegate?.launchWith(launchType: mockLaunchType)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
@@ -24,6 +24,13 @@ class UpdateViewModelTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: PrefsKeys.NimbusUserEnabledFeatureTestsOverride)
     }
 
+    func testContainsSyncableAccounts_returnsMockValue() {
+        profile.hasSyncableAccountMock = true
+        let subject = createSubject()
+
+        XCTAssertTrue(subject.containsSyncableAccount())
+    }
+
     // MARK: Enable cards
     func testEnabledCards_ForHasSyncAccount() {
         profile.hasSyncableAccountMock = true
@@ -171,6 +178,12 @@ class UpdateViewModelTests: XCTestCase {
     }
 
     // MARK: - Private Helpers
+    /// <#Description#>
+    /// - Parameters:
+    ///   - hasOnboardingCards: <#hasOnboardingCards description#>
+    ///   - file: <#file description#>
+    ///   - line: <#line description#>
+    /// - Returns: <#description#>
     func createSubject(
         hasOnboardingCards: Bool = true,
         file: StaticString = #filePath,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
@@ -178,12 +178,6 @@ class UpdateViewModelTests: XCTestCase {
     }
 
     // MARK: - Private Helpers
-    /// <#Description#>
-    /// - Parameters:
-    ///   - hasOnboardingCards: <#hasOnboardingCards description#>
-    ///   - file: <#file description#>
-    ///   - line: <#line description#>
-    /// - Returns: <#description#>
     func createSubject(
         hasOnboardingCards: Bool = true,
         file: StaticString = #filePath,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12583)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27398)

## :bulb: Description
Fix region based isolation warning in `LaunchScreenViewController` and `LoginStorage`. To fix the issue on the controller i noticed we could remove the async chain until the end, so i just made chain sync. 
@OrlaM do you know if there was a reason to have it async ?

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
