### PR TITLE
Refactor FXIOS-12583 [Swift 6 Migration] Make ShareSheetCoordinator @unchecked Sendable

### DIFF
--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -10,7 +10,9 @@ import Storage
 class ShareSheetCoordinator: BaseCoordinator,
                              DevicePickerViewControllerDelegate,
                              InstructionsViewDelegate,
-                             JSPromptAlertControllerDelegate {
+                             JSPromptAlertControllerDelegate,
+                             // FXIOS-12609 Coordinators marked @unchecked Sendable should be @MainActor synchronized
+                             @unchecked Sendable {
     // MARK: - Properties
 
     private let tabManager: TabManager


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12583)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27398)

## :bulb: Description
Just one little baby Swift 6 migration for ShareSheetCoordinator.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
