### PR TITLE
Refactor FXIOS-12521 [Tab tray UI experiment] Change selector to be centered

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -29,6 +29,7 @@ class TabTraySelectorView: UIView,
     private var buttonTitles: [String]
     private var selectionBackgroundWidthConstraint: NSLayoutConstraint?
     private var stackViewOffsetConstraint: NSLayoutConstraint?
+    private let edgeFadeGradientLayer = CAGradientLayer()
 
     private lazy var selectionBackgroundView: UIView = .build { view in
         view.layer.cornerRadius = TabTraySelectorUX.cornerRadius
@@ -55,6 +56,11 @@ class TabTraySelectorView: UIView,
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateEdgeFadeMask()
+    }
+
     func updateSelectionProgress(fromIndex: Int, toIndex: Int, progress: CGFloat) {
         updateSelectionBackground(from: fromIndex, to: toIndex, progress: abs(progress), animated: false)
         simulateFontWeightTransition(from: fromIndex, to: toIndex, progress: abs(progress))
@@ -68,6 +74,7 @@ class TabTraySelectorView: UIView,
     private func setup() {
         addSubview(selectionBackgroundView)
         addSubview(stackView)
+        layer.mask = edgeFadeGradientLayer
 
         for (index, title) in buttonTitles.enumerated() {
             let button = createButton(with: index, title: title)
@@ -261,6 +268,17 @@ class TabTraySelectorView: UIView,
         selectionBackgroundWidthConstraint?.constant = interpolatedWidth
 
         layoutIfNeeded()
+    }
+
+    private func updateEdgeFadeMask() {
+        edgeFadeGradientLayer.frame = bounds
+        edgeFadeGradientLayer.colors = [UIColor.clear.cgColor,
+                                        UIColor.black.cgColor,
+                                        UIColor.black.cgColor,
+                                        UIColor.clear.cgColor]
+        edgeFadeGradientLayer.locations = [0.0, 0.05, 0.95, 1.0]
+        edgeFadeGradientLayer.startPoint = CGPoint(x: 0, y: 0.5)
+        edgeFadeGradientLayer.endPoint = CGPoint(x: 1, y: 0.5)
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -718,6 +718,8 @@ class TabTrayViewController: UIViewController,
 
         if let scrollView = pageVC.view.subviews.first(where: { $0 is UIScrollView }) as? UIScrollView {
             scrollView.delegate = self
+            // TODO: FXIOS-12431 - Uncomment this when the tab tray selector view is swipable
+//            scrollView.isScrollEnabled = false
         }
 
         self.pageViewController = pageVC


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12521)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27290)

## :bulb: Description
- Changing so we center the tab tray selector on the selected button. Tried with a collection view, and we were essentially removing all existing code to start anew with a new set of problems. After discussion with Orla, we wanted to try this animation with minimal changes since existing code is working. Less changes the better? 
- Took the opportunity to remove some unused code related to dynamic type notification. We are using large content viewer and not scaling the font anymore.
- There's also now a fade when text is too long and appears off screen.

## :movie_camera: Demos

<details>
<summary>Centering elements</summary>

https://github.com/user-attachments/assets/e2a32b31-8cf4-4642-bbde-27b3e52d5371

</details>

<details>
<summary>Large content viewer</summary>

https://github.com/user-attachments/assets/88131acd-e918-405c-b43f-b71bdcb49ac8

</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [X] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
