### PR TITLE
Refactor FXIOS-12583 [Swift 6 Migration] Mark immutable properties of `DefaultTabDataStore` as nonisolated

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -36,6 +36,7 @@ public actor DefaultTabDataStore: TabDataStore {
     }
 
     nonisolated private let logger: Logger
+    // Note: The underlying shared `FileManager` of `DefaultTabFileManager` is safe to access from multiple threads
     nonisolated private let fileManager: TabFileManager
     private let throttleTime: UInt64
     private var windowDataToSave: WindowData?

--- a/BrowserKit/Sources/TabDataStore/TabFileManager.swift
+++ b/BrowserKit/Sources/TabDataStore/TabFileManager.swift
@@ -64,6 +64,9 @@ public struct DefaultTabFileManager: TabFileManager {
         static let backup = "window-data-backup"
     }
 
+    /// As per Apple docs, the `FileManager.default` shared FileManager can safely be called from multiple threads. But if
+    /// we need to use any delegate methods, we should create our own FileManager instance.
+    /// Ref: https://developer.apple.com/documentation/foundation/filemanager#Threading-Considerations
     let fileManager: FileManager
     let logger: Logger
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12583)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27398)

## :bulb: Description
To resolve some Swift 6 errors, I've marked 2 immutable properties of the `DefaultTabDataStore` `actor` as `nonisolated`.

![Screenshot 2025-06-27 at 12 07 54 PM](https://github.com/user-attachments/assets/5e7afc42-7748-41c6-823c-b1e7a39db57c)

Since both the `logger` and `fileManager` are immutable `let` properties, it appears we can safely indicate to the compiler they are `nonisolated` (hence no need to create a followup ticket). However, they both contain classes under the hood so that's probably why the compiler didn't synthesize these automatically...

The underlying `TabFileManager` concrete type of `DefaultTabFileManager` appears to rely on the shared `FileManager`, which the Apple docs state is [thread safe](https://developer.apple.com/documentation/foundation/filemanager#Threading-Considerations). Thus I'm hoping here that it's safe for us to read from the `fileManager` in `fetchWindowDataUUIDs()`, considering this function was deliberately marked `nonisolated` itself to conform with protocol requirements. 🤔 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
