### PR TITLE
Refactor FXIOS-12685 [Swift 6 Migration] Refactor Logger type to be a struct with `let` properties

### DIFF
--- a/BrowserKit/Sources/Common/Logger/DefaultLogger.swift
+++ b/BrowserKit/Sources/Common/Logger/DefaultLogger.swift
@@ -4,29 +4,27 @@
 
 import Foundation
 
-public class DefaultLogger: Logger {
+public struct DefaultLogger: Logger {
     public static let shared = DefaultLogger()
 
-    private var logger: SwiftyBeaverWrapper.Type
-    private var crashManager: CrashManager?
-    private var fileManager: LoggerFileManager
+    private let logger: SwiftyBeaverWrapper.Type
+    private let crashManager: CrashManager
+    private let fileManager: LoggerFileManager
 
     public var crashedLastLaunch: Bool {
-        return crashManager?.crashedLastLaunch ?? false
+        return crashManager.crashedLastLaunch
     }
 
     init(swiftyBeaverBuilder: SwiftyBeaverBuilder = DefaultSwiftyBeaverBuilder(),
-         fileManager: LoggerFileManager = DefaultLoggerFileManager()) {
-        self.fileManager = fileManager
+         fileManager: LoggerFileManager = DefaultLoggerFileManager(),
+         crashManager: CrashManager = DefaultCrashManager()) {
         self.logger = swiftyBeaverBuilder.setup(with: fileManager.getLogDestination())
-    }
-
-    public func configure(crashManager: CrashManager) {
+        self.fileManager = fileManager
         self.crashManager = crashManager
     }
 
     public func setup(sendCrashReports: Bool) {
-        crashManager?.setup(sendCrashReports: sendCrashReports)
+        crashManager.setup(sendCrashReports: sendCrashReports)
     }
 
     // TODO: FXIOS-7819 need to rethink if this should go to Sentry
@@ -67,10 +65,10 @@ public class DefaultLogger: Logger {
         // Log to sentry
         let extraEvents = bundleExtraEvents(extra: extra,
                                             description: description)
-        crashManager?.send(message: message,
-                           category: category,
-                           level: level,
-                           extraEvents: extraEvents)
+        crashManager.send(message: message,
+                          category: category,
+                          level: level,
+                          extraEvents: extraEvents)
     }
 
     public func copyLogsToDocuments() {

--- a/BrowserKit/Sources/Common/Logger/Logger.swift
+++ b/BrowserKit/Sources/Common/Logger/Logger.swift
@@ -8,7 +8,6 @@ public protocol Logger {
     var crashedLastLaunch: Bool { get }
 
     func setup(sendCrashReports: Bool)
-    func configure(crashManager: CrashManager)
     func logCustomError(error: Error)
 
     /// Log a new message to the logging system

--- a/BrowserKit/Tests/CommonTests/LoggerTests/LoggerTests.swift
+++ b/BrowserKit/Tests/CommonTests/LoggerTests/LoggerTests.swift
@@ -26,36 +26,31 @@ final class LoggerTests: XCTestCase {
     // MARK: - Log
 
     func testLog_debug() {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.configure(crashManager: crashManager)
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         subject.log("Debug log", level: .debug, category: .setup)
         XCTAssertEqual(MockSwiftyBeaver.debugCalled, 1)
     }
 
     func testLog_info() {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.configure(crashManager: crashManager)
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         subject.log("Info log", level: .info, category: .setup)
         XCTAssertEqual(MockSwiftyBeaver.infoCalled, 1)
     }
 
     func testLog_warning() {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.configure(crashManager: crashManager)
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         subject.log("Warning log", level: .warning, category: .setup)
         XCTAssertEqual(MockSwiftyBeaver.warningCalled, 1)
     }
 
     func testLog_fatal() {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.configure(crashManager: crashManager)
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         subject.log("Fatal log", level: .fatal, category: .setup)
         XCTAssertEqual(MockSwiftyBeaver.errorCalled, 1)
     }
 
     func testLog_informationCorrelate_withAllParams() throws {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.configure(crashManager: crashManager)
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         subject.log("Debug log",
                     level: .debug,
                     category: .setup,
@@ -67,8 +62,7 @@ final class LoggerTests: XCTestCase {
     }
 
     func testLog_informationCorrelate_withMessageAndDescriptionOnly() throws {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.configure(crashManager: crashManager)
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         subject.log("Debug log",
                     level: .debug,
                     category: .setup,
@@ -79,8 +73,7 @@ final class LoggerTests: XCTestCase {
     }
 
     func testLog_informationCorrelate_withMessageAndExtra() throws {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.configure(crashManager: crashManager)
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         subject.log("Debug log",
                     level: .debug,
                     category: .setup,
@@ -91,8 +84,7 @@ final class LoggerTests: XCTestCase {
     }
 
     func testLog_informationCorrelate_withMessageOnly() throws {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.configure(crashManager: crashManager)
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         subject.log("Debug log",
                     level: .debug,
                     category: .setup)
@@ -103,19 +95,8 @@ final class LoggerTests: XCTestCase {
 
     // MARK: - CrashManager
 
-    func testCrashManagerLog_withoutCrashManager_doesNotLog() {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.log("Debug log", level: .debug, category: .setup)
-        XCTAssertEqual(MockSwiftyBeaver.debugCalled, 1)
-
-        XCTAssertNil(crashManager.message)
-        XCTAssertNil(crashManager.category)
-        XCTAssertNil(crashManager.level)
-    }
-
     func testCrashManagerLog_fatalIsSent_informationCorrelate() throws {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.configure(crashManager: crashManager)
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         subject.log("Fatal log",
                     level: .fatal,
                     category: .setup,
@@ -130,14 +111,12 @@ final class LoggerTests: XCTestCase {
     }
 
     func testCrashManagerLog_sendCrashReportsNotCalled() {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.configure(crashManager: crashManager)
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         XCTAssertNil(crashManager.savedSendCrashReports)
     }
 
     func testCrashManagerLog_sendCrashReportsCalled() throws {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
-        subject.configure(crashManager: crashManager)
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         subject.setup(sendCrashReports: true)
 
         let savedSendCrashReports = try XCTUnwrap(crashManager.savedSendCrashReports)

--- a/BrowserKit/Tests/CommonTests/LoggerTests/LoggerTests.swift
+++ b/BrowserKit/Tests/CommonTests/LoggerTests/LoggerTests.swift
@@ -23,104 +23,195 @@ final class LoggerTests: XCTestCase {
         cleanUp()
     }
 
-    // MARK: - Log
+    // MARK: - Log to SwiftyBeaver and Sentry crash manager
 
     func testLog_debug() {
+        let logMessage = "Debug log"
+        let logLevel = LoggerLevel.debug
+        let logCategory = LoggerCategory.setup
+
         let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
-        subject.log("Debug log", level: .debug, category: .setup)
+        subject.log(logMessage, level: logLevel, category: logCategory)
+
         XCTAssertEqual(MockSwiftyBeaver.debugCalled, 1)
+
+        XCTAssertEqual(crashManager.message, logMessage)
+        XCTAssertEqual(crashManager.level, logLevel)
+        XCTAssertEqual(crashManager.category, logCategory)
     }
 
     func testLog_info() {
+        let logMessage = "Info log"
+        let logLevel = LoggerLevel.info
+        let logCategory = LoggerCategory.setup
+
         let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
-        subject.log("Info log", level: .info, category: .setup)
+        subject.log(logMessage, level: logLevel, category: logCategory)
+
         XCTAssertEqual(MockSwiftyBeaver.infoCalled, 1)
+
+        XCTAssertEqual(crashManager.message, logMessage)
+        XCTAssertEqual(crashManager.level, logLevel)
+        XCTAssertEqual(crashManager.category, logCategory)
     }
 
     func testLog_warning() {
+        let logMessage = "Warning log"
+        let logLevel = LoggerLevel.warning
+        let logCategory = LoggerCategory.setup
+
         let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
-        subject.log("Warning log", level: .warning, category: .setup)
+        subject.log(logMessage, level: logLevel, category: logCategory)
+
         XCTAssertEqual(MockSwiftyBeaver.warningCalled, 1)
+
+        XCTAssertEqual(crashManager.message, logMessage)
+        XCTAssertEqual(crashManager.level, logLevel)
+        XCTAssertEqual(crashManager.category, logCategory)
     }
 
     func testLog_fatal() {
+        let logMessage = "Fatal log"
+        let logLevel = LoggerLevel.fatal
+        let logCategory = LoggerCategory.setup
+
         let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
-        subject.log("Fatal log", level: .fatal, category: .setup)
+        subject.log(logMessage, level: logLevel, category: logCategory)
+
         XCTAssertEqual(MockSwiftyBeaver.errorCalled, 1)
+
+        XCTAssertEqual(crashManager.message, logMessage)
+        XCTAssertEqual(crashManager.level, logLevel)
+        XCTAssertEqual(crashManager.category, logCategory)
     }
 
     func testLog_informationCorrelate_withAllParams() throws {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
-        subject.log("Debug log",
-                    level: .debug,
-                    category: .setup,
-                    extra: ["example": "test"],
-                    description: "A description")
+        let logMessage = "Debug log"
+        let logLevel = LoggerLevel.debug
+        let logCategory = LoggerCategory.setup
+        let logExtraKey = "example"
+        let logExtraValue = "test"
+        let logExtra = [logExtraKey: logExtraValue]
+        let logDescription = "A description"
 
-        XCTAssertEqual(MockSwiftyBeaver.savedMessage, "Debug log - A description - example: test")
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
+        subject.log(
+            logMessage,
+            level: logLevel,
+            category: logCategory,
+            extra: logExtra,
+            description: logDescription
+        )
+
+        XCTAssertEqual(MockSwiftyBeaver.savedMessage, "\(logMessage) - \(logDescription) - \(logExtraKey): \(logExtraValue)")
         XCTAssertEqual(MockSwiftyBeaver.debugCalled, 1)
+
+        XCTAssertEqual(crashManager.message, logMessage)
+        XCTAssertEqual(crashManager.level, logLevel)
+        XCTAssertEqual(crashManager.category, logCategory)
+        XCTAssertEqual(crashManager.extraEvents, ["errorDescription": logDescription, logExtraKey: logExtraValue])
     }
 
     func testLog_informationCorrelate_withMessageAndDescriptionOnly() throws {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
-        subject.log("Debug log",
-                    level: .debug,
-                    category: .setup,
-                    description: "A description")
+        let logMessage = "Debug log"
+        let logLevel = LoggerLevel.debug
+        let logCategory = LoggerCategory.setup
+        let logDescription = "A description"
 
-        XCTAssertEqual(MockSwiftyBeaver.savedMessage, "Debug log - A description")
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
+        subject.log(
+            logMessage,
+            level: logLevel,
+            category: logCategory,
+            description: logDescription
+        )
+
+        XCTAssertEqual(MockSwiftyBeaver.savedMessage, "\(logMessage) - \(logDescription)")
         XCTAssertEqual(MockSwiftyBeaver.debugCalled, 1)
+
+        XCTAssertEqual(crashManager.message, logMessage)
+        XCTAssertEqual(crashManager.level, logLevel)
+        XCTAssertEqual(crashManager.category, logCategory)
+        XCTAssertEqual(crashManager.extraEvents, ["errorDescription": logDescription])
     }
 
     func testLog_informationCorrelate_withMessageAndExtra() throws {
+        let logMessage = "Debug log"
+        let logLevel = LoggerLevel.debug
+        let logCategory = LoggerCategory.setup
+        let logExtraKey = "example"
+        let logExtraValue = "test"
+        let logExtra = [logExtraKey: logExtraValue]
+
         let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
-        subject.log("Debug log",
-                    level: .debug,
-                    category: .setup,
-                    extra: ["example": "test"])
+        subject.log(
+            logMessage,
+            level: logLevel,
+            category: logCategory,
+            extra: logExtra
+        )
 
         XCTAssertEqual(MockSwiftyBeaver.savedMessage, "Debug log - example: test")
         XCTAssertEqual(MockSwiftyBeaver.debugCalled, 1)
+
+        XCTAssertEqual(crashManager.message, logMessage)
+        XCTAssertEqual(crashManager.level, logLevel)
+        XCTAssertEqual(crashManager.category, logCategory)
+        XCTAssertEqual(crashManager.extraEvents, [logExtraKey: logExtraValue])
     }
 
     func testLog_informationCorrelate_withMessageOnly() throws {
-        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
-        subject.log("Debug log",
-                    level: .debug,
-                    category: .setup)
+        let logMessage = "Debug log"
+        let logLevel = LoggerLevel.debug
+        let logCategory = LoggerCategory.setup
 
-        XCTAssertEqual(MockSwiftyBeaver.savedMessage, "Debug log")
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
+        subject.log(logMessage, level: logLevel, category: logCategory)
+
+        XCTAssertEqual(MockSwiftyBeaver.savedMessage, logMessage)
         XCTAssertEqual(MockSwiftyBeaver.debugCalled, 1)
+
+        XCTAssertEqual(crashManager.message, logMessage)
+        XCTAssertEqual(crashManager.level, logLevel)
+        XCTAssertEqual(crashManager.category, logCategory)
     }
 
     // MARK: - CrashManager
 
     func testCrashManagerLog_fatalIsSent_informationCorrelate() throws {
+        let logMessage = "Fatal log"
+        let logLevel = LoggerLevel.fatal
+        let logCategory = LoggerCategory.setup
+        let logExtraKey = "example"
+        let logExtraValue = "test"
+        let logExtra = [logExtraKey: logExtraValue]
+        let logDescription = "A description"
+
         let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
-        subject.log("Fatal log",
-                    level: .fatal,
-                    category: .setup,
-                    extra: ["example": "test"],
-                    description: "A description")
+        subject.log(
+            logMessage,
+            level: logLevel,
+            category: logCategory,
+            extra: logExtra,
+            description: logDescription
+        )
 
         XCTAssertEqual(crashManager.message, "Fatal log")
         XCTAssertEqual(crashManager.category, .setup)
         XCTAssertEqual(crashManager.level, .fatal)
-        let extra = try XCTUnwrap(crashManager.extraEvents)
-        XCTAssertEqual(extra, ["example": "test", "errorDescription": "A description"])
+        XCTAssertEqual(crashManager.extraEvents, ["errorDescription": logDescription, logExtraKey: logExtraValue])
     }
 
-    func testCrashManagerLog_sendCrashReportsNotCalled() {
+    func testCrashManagerLog_sendCrashReportsNotCalled_onInit() {
         let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
-        XCTAssertNil(crashManager.savedSendCrashReports)
+        XCTAssertEqual(crashManager.savedSendCrashReportsCalled, 0)
     }
 
-    func testCrashManagerLog_sendCrashReportsCalled() throws {
+    func testCrashManagerLog_sendCrashReportsCalled_onSetup() throws {
         let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder, crashManager: crashManager)
         subject.setup(sendCrashReports: true)
 
-        let savedSendCrashReports = try XCTUnwrap(crashManager.savedSendCrashReports)
-        XCTAssertTrue(savedSendCrashReports)
+        XCTAssertEqual(crashManager.savedSendCrashReportsCalled, 1)
     }
 }
 
@@ -180,9 +271,9 @@ class MockSwiftyBeaver: SwiftyBeaverWrapper {
 class MockCrashManager: CrashManager {
     var crashedLastLaunch = false
 
-    var savedSendCrashReports: Bool?
+    var savedSendCrashReportsCalled = 0
     func setup(sendCrashReports: Bool) {
-        savedSendCrashReports = sendCrashReports
+        savedSendCrashReportsCalled += 1
     }
 
     var message: String?

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -72,8 +72,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         // before any Application Services component gets used.
         Viaduct.shared.useReqwestBackend()
 
-        // Configure logger so we can start tracking logs early
-        logger.configure(crashManager: DefaultCrashManager())
         initializeRustErrors(logger: logger)
         logger.log("willFinishLaunchingWithOptions begin",
                    level: .info,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLogger.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLogger.swift
@@ -12,7 +12,6 @@ class MockLogger: Logger {
     var savedExtra: [String: String]?
 
     func setup(sendCrashReports: Bool) {}
-    func configure(crashManager: Common.CrashManager) {}
     func copyLogsToDocuments() {}
     func logCustomError(error: Error) {}
     func deleteCachedLogFiles() {}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12685)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27639)

## :bulb: Description

I noticed that the Logger singleton type would probably need a little love after working on #27638.

- Refactor the `DefaultLogger` type into a struct. 
- Make its properties `let`s which are set on `init`. 
- Now we can remove unnecessary setup from AppDelegate using unneeded `configure` method.
- Updated unit tests (see first unit test commit)
- Then rewrote a lot of the unit tests to do more thorough checks on the Sentry side of things (see 2nd unit test commit)

### Testing

Please just double check that the logger is called on init of the AppDelegate, seeing as that setup line was removed (seems unnecessary to me since the AppDelegate init also inits the shared Logger instance...).

We should see logs continue to go through the `DefaultLogger` to Sentry's `send` method.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
