### PR TITLE
Refactor FXIOS-27070 [Swipe While Editing On Homepage] Prevent tab switching

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -88,6 +88,18 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
     func newState(state: ToolbarState) {
         toolbarState = state
         disablePanGestureIfTopAddressBar()
+        
+        // While the address bar is in editing mode (for example, when the user is
+        // typing on the homepage with a keyboard), the swipe gesture
+        // that switches between tabs should be disabled. Once editing ends we can
+        // safely re-enable the gesture
+        
+        if state.addressToolbar.isEditing {
+            disablePanGestureRecognizer()
+        } else {
+            enablePanGestureRecognizer()
+            enablePanGestureOnHomepageIfNeeded()
+        }
     }
 
     // MARK: - Pan Gesture Availability

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -88,12 +88,11 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
     func newState(state: ToolbarState) {
         toolbarState = state
         disablePanGestureIfTopAddressBar()
-        
+
         // While the address bar is in editing mode (for example, when the user is
         // typing on the homepage with a keyboard), the swipe gesture
         // that switches between tabs should be disabled. Once editing ends we can
         // safely re-enable the gesture
-        
         if state.addressToolbar.isEditing {
             disablePanGestureRecognizer()
         } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27070)

## :bulb: Description
Implement disabling the tab swipe gesture whenever the address bar is in editing mode (including keyboard scenerio)

## :movie_camera: Demos

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

https://github.com/user-attachments/assets/d9d5adfc-8776-486b-b0a6-9ad07e02044a
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
