### PR TITLE
 Refactor FXIOS-12583 [Swift 6 Migration] SearchViewModel, RustFirefoxSuggest

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -827,7 +827,9 @@ class SearchViewController: SiteTableViewController,
             reloadSearchEngines()
         case .SponsoredAndNonSponsoredSuggestionsChanged:
             guard !viewModel.searchQuery.isEmpty else { return }
-            _ = viewModel.loadFirefoxSuggestions()
+            Task {
+                await viewModel.loadFirefoxSuggestions()
+            }
         default:
             break
         }

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
@@ -212,6 +212,9 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
         })
     }
 
+    /// Provides suggestions from external suggestion providers other than the local ones (history, bookmarks, etc.). For now
+    /// this includes suggestions from `amp` (sponsored ads) and `wikipedia`. Application Services supports the other ones.
+    /// This behaviour is currently geo-locked to the US, so to debug locally ensure your simulator region is set to US.
     @MainActor
     func loadFirefoxSuggestions() async {
         let includeNonSponsored = shouldShowNonSponsoredSuggestions

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -80,10 +80,11 @@ struct ProfileFileAccessor: FileAccessor, Sendable {
     }
 }
 
+// TODO: FXIOS-12610 Profile should be refactored so it is **not** `Sendable`
 /**
  * A Profile manages access to the user's data.
  */
-protocol Profile: AnyObject {
+protocol Profile: AnyObject, Sendable {
     var autofill: RustAutofill { get }
     var places: RustPlaces { get }
     var prefs: Prefs { get }

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -12,8 +12,7 @@ import enum MozillaAppServices.SuggestionProvider
 import struct MozillaAppServices.SuggestIngestionConstraints
 import struct MozillaAppServices.SuggestionQuery
 
-@preconcurrency
-public protocol RustFirefoxSuggestProtocol {
+public protocol RustFirefoxSuggestProtocol: Sendable {
     /// Downloads and stores new Firefox Suggest suggestions.
     func ingest(emptyOnly: Bool) async throws
 
@@ -33,8 +32,7 @@ public protocol RustFirefoxSuggestProtocol {
 
 /// Wraps the synchronous Rust `SuggestStore` binding to execute
 /// blocking operations on a dispatch queue.
-@preconcurrency
-public class RustFirefoxSuggest: RustFirefoxSuggestProtocol {
+public final class RustFirefoxSuggest: RustFirefoxSuggestProtocol, Sendable {
     private let store: SuggestStore
 
     // Using a pair of serial queues lets read and write operations run

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
@@ -109,17 +109,18 @@ class MockFiles: FileAccessor {
     }
 }
 
-open class MockProfile: Client.Profile {
+// TODO: FXIOS-12610 Profile should be refactored so it is **not** `Sendable`.
+final class MockProfile: Client.Profile, @unchecked Sendable {
     public var rustFxA: RustFirefoxAccounts {
         return RustFirefoxAccounts.shared
     }
 
     // Read/Writeable properties for mocking
 
-    public var files: FileAccessor
-    public var syncManager: ClientSyncManager?
-    public var firefoxSuggest: RustFirefoxSuggestProtocol?
-    public var remoteSettingsService: RemoteSettingsService?
+    public let files: FileAccessor
+    public let syncManager: ClientSyncManager?
+    public let firefoxSuggest: RustFirefoxSuggestProtocol?
+    public let remoteSettingsService: RemoteSettingsService?
 
     fileprivate let name = "mockaccount"
 
@@ -130,13 +131,14 @@ open class MockProfile: Client.Profile {
     init(
         databasePrefix: String = "mock",
         firefoxSuggest: RustFirefoxSuggestProtocol? = nil,
-        remoteSettingService: RemoteSettingsService? = nil,
+        remoteSettingsService: RemoteSettingsService? = nil,
         injectedPinnedSites: MockablePinnedSites? = nil
     ) {
         files = MockFiles()
         syncManager = ClientSyncManagerSpy()
         self.databasePrefix = databasePrefix
         self.firefoxSuggest = firefoxSuggest
+        self.remoteSettingsService = remoteSettingsService
         self.injectedPinnedSites = injectedPinnedSites
 
         do {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/MockRustFirefoxSuggest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/MockRustFirefoxSuggest.swift
@@ -6,9 +6,10 @@ import Foundation
 import Storage
 import MozillaAppServices
 
-class MockRustFirefoxSuggest: RustFirefoxSuggestProtocol {
+final class MockRustFirefoxSuggest: RustFirefoxSuggestProtocol {
     func ingest(emptyOnly: Bool) async throws {
     }
+
     func query(
         _ keyword: String,
         providers: [SuggestionProvider],

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/SearchViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/SearchViewModelTests.swift
@@ -79,6 +79,7 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertTrue(subject.hasFirefoxSuggestions)
     }
 
+    @MainActor
     func testFirefoxSuggestionReturnsNoSuggestions() async throws {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -89,16 +90,17 @@ final class SearchViewModelTests: XCTestCase {
         searchEnginesManager.shouldShowSponsoredSuggestions = false
 
         let subject = createSubject()
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
         XCTAssertEqual(subject.firefoxSuggestions.count, 0)
 
         // Providers set to false, so regardless of the prefs, we shouldn't see anything
         searchEnginesManager.shouldShowFirefoxSuggestions = true
         searchEnginesManager.shouldShowSponsoredSuggestions = true
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
         XCTAssertEqual(subject.firefoxSuggestions.count, 0)
     }
 
+    @MainActor
     func testFirefoxSuggestionReturnsNoSuggestionsWhenSuggestionSettingsFalse() async throws {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -110,11 +112,12 @@ final class SearchViewModelTests: XCTestCase {
 
         let subject = createSubject()
 
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
         XCTAssertEqual(subject.firefoxSuggestions.count, 0)
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
+    @MainActor
     func testFirefoxSuggestionReturnsSponsoredAndNonSponsored() async throws {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -124,7 +127,7 @@ final class SearchViewModelTests: XCTestCase {
         searchEnginesManager.shouldShowFirefoxSuggestions = true
         searchEnginesManager.shouldShowSponsoredSuggestions = true
         let subject = createSubject()
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
 
         XCTAssertEqual(subject.firefoxSuggestions.count, 2)
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 1)
@@ -205,61 +208,67 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(subject.filteredRemoteClientTabs.count, 3)
     }
 
+    @MainActor
     func testSponsoredSuggestionsAreNotShownInPrivateBrowsingMode() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
         searchEnginesManager.shouldShowFirefoxSuggestions = true
         searchEnginesManager.shouldShowSponsoredSuggestions = true
 
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
         XCTAssertTrue(subject.firefoxSuggestions.isEmpty)
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
+    @MainActor
     func testNonSponsoredSuggestionsAreNotShownInPrivateBrowsingMode() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
 
         searchEnginesManager.shouldShowFirefoxSuggestions = true
         searchEnginesManager.shouldShowSponsoredSuggestions = true
 
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
 
         XCTAssertTrue(subject.firefoxSuggestions.isEmpty)
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
+    @MainActor
     func testNonSponsoredAndSponsoredSuggestionsInPrivateModeWithPrivateSuggestionsOn() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
 
         searchEnginesManager.shouldShowFirefoxSuggestions = true
         searchEnginesManager.shouldShowSponsoredSuggestions = true
         searchEnginesManager.shouldShowPrivateModeFirefoxSuggestions = true
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
 
         XCTAssertTrue(subject.firefoxSuggestions.isEmpty)
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
+    @MainActor
     func testNonSponsoredInPrivateModeWithPrivateSuggestionsOn() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
         searchEnginesManager.shouldShowFirefoxSuggestions = true
         searchEnginesManager.shouldShowSponsoredSuggestions = false
         searchEnginesManager.shouldShowPrivateModeFirefoxSuggestions = true
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
 
         XCTAssertTrue(subject.firefoxSuggestions.isEmpty)
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
+    @MainActor
     func testNonSponsoredAndSponsoredSuggestionsAreNotShownInPrivateBrowsingMode() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
 
         searchEnginesManager.shouldShowPrivateModeFirefoxSuggestions = false
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
 
         XCTAssertTrue(subject.firefoxSuggestions.isEmpty)
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
+    @MainActor
     func testLoad_forFirefoxSuggestions_doesNotTriggerReloadForSameSuggestions() async throws {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -269,8 +278,8 @@ final class SearchViewModelTests: XCTestCase {
         searchEnginesManager.shouldShowFirefoxSuggestions = true
         searchEnginesManager.shouldShowSponsoredSuggestions = true
         let subject = createSubject()
-        await subject.loadFirefoxSuggestions()?.value
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
+        await subject.loadFirefoxSuggestions()
 
         XCTAssertEqual(subject.firefoxSuggestions.count, 2)
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 1)
@@ -300,6 +309,7 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 1)
     }
 
+    @MainActor
     func testFirefoxSuggestionReturnsSponsored() async {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -309,12 +319,13 @@ final class SearchViewModelTests: XCTestCase {
         searchEnginesManager.shouldShowFirefoxSuggestions = false
         searchEnginesManager.shouldShowSponsoredSuggestions = true
         let subject = createSubject()
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
 
         XCTAssertEqual(subject.firefoxSuggestions[0].title, "Mozilla")
         XCTAssertEqual(subject.firefoxSuggestions.count, 1)
     }
 
+    @MainActor
     func testFirefoxSuggestionReturnsNonSponsored() async {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -324,7 +335,7 @@ final class SearchViewModelTests: XCTestCase {
         searchEnginesManager.shouldShowFirefoxSuggestions = true
         searchEnginesManager.shouldShowSponsoredSuggestions = false
         let subject = createSubject()
-        await subject.loadFirefoxSuggestions()?.value
+        await subject.loadFirefoxSuggestions()
 
         XCTAssertEqual(subject.firefoxSuggestions[0].title, "California")
         XCTAssertEqual(subject.firefoxSuggestions.count, 1)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12583)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27398)

## :bulb: Description
Addressed some warnings in the SearchViewModel's `loadFirefoxSuggestions()` method.

I annotated the method `@MainActor` and made it `async` to simplify the concurrency a bit. Seemed kinda weird how it returned a `Task`, which was ignored at call sites... I assume in scenarios like this the Task would just fire upon creation?


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
