### PR TITLE
Bugfix FXIOS-12679 ⁃ Bookmarks, Downloads and Passwords all open history panel

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignTableView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignTableView.swift
@@ -163,9 +163,13 @@ final class MenuRedesignTableView: UIView,
         didSelectRowAt indexPath: IndexPath
     ) {
         tableView.deselectRow(at: indexPath, animated: false)
+        let section = menuData[indexPath.section]
 
-        if let action = menuData[indexPath.section].options[indexPath.row].action {
-            action()
+        // We handle the actions for horizontalTabs, in MenuSquaresViewContentCell
+        if !section.isHorizontalTabsSection {
+            if let action = section.options[indexPath.row].action {
+                action()
+            }
         }
     }
 

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquareCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquareCell.swift
@@ -40,11 +40,14 @@ final class MenuSquareView: UIView, ThemeApplicable {
 
     // MARK: - Properties
     var model: MenuElement?
+    var cellTapCallback: (() -> Void)?
 
     // MARK: - Initializers
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        self.addGestureRecognizer(tapGesture)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -101,6 +104,11 @@ final class MenuSquareView: UIView, ThemeApplicable {
             ),
             icon.heightAnchor.constraint(equalToConstant: UX.iconSize)
         ])
+    }
+
+    @objc
+    private func handleTap() {
+        cellTapCallback?()
     }
 
     // MARK: - Theme Applicable

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquaresViewContentCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquaresViewContentCell.swift
@@ -27,10 +27,24 @@ final class MenuSquaresViewContentCell: UITableViewCell, ReusableCell, ThemeAppl
         menuData = []
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
+        selectionStyle = .none
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // We override this method, for handling taps on MenuSquareView views
+    // This may be a temporary fix
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard self.bounds.contains(point) else { return nil }
+        for subview in contentStackView.arrangedSubviews {
+            let convertedPoint = self.convert(point, to: subview)
+            if let hitView = subview.hitTest(convertedPoint, with: event) {
+                return hitView
+            }
+        }
+        return super.hitTest(point, with: event)
     }
 
     private func setupUI() {
@@ -46,6 +60,10 @@ final class MenuSquaresViewContentCell: UITableViewCell, ReusableCell, ThemeAppl
 
     func reloadData(with data: [MenuSection]) {
         menuData = data
+        setupHorizontalTabs()
+    }
+
+    private func setupHorizontalTabs() {
         contentStackView.removeAllArrangedViews()
         guard let horizontalTabsSection else { return }
         for option in horizontalTabsSection.options {
@@ -53,6 +71,9 @@ final class MenuSquaresViewContentCell: UITableViewCell, ReusableCell, ThemeAppl
                 guard let self else { return }
                 view.configureCellWith(model: option)
                 if let theme { view.applyTheme(theme: theme) }
+                view.cellTapCallback = {
+                    option.action?()
+                }
             }
             contentStackView.addArrangedSubview(squareView)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12679)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27625)

## :bulb: Description
Handle tap for horizontal tabs

## :movie_camera: Demos

https://github.com/user-attachments/assets/b0d5a572-f8a5-4a91-a8c6-153123bb748d



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
