### PR TITLE
Refactor FXIOS-12716 [webcompat] Update uastring versions

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -172,7 +172,7 @@ public struct UserAgentBuilder {
     public static func defaultDesktopUserAgent() -> UserAgentBuilder {
         return UserAgentBuilder(
             product: UserAgent.product,
-            systemInfo: "(Macintosh; Intel Mac OS X 10.15)",
+            systemInfo: "(Macintosh; Intel Mac OS X 10_15_7)",
             platform: UserAgent.platform,
             platformDetails: UserAgent.platformDetails,
             extensions: "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")

--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -14,9 +14,6 @@ open class UserAgent {
     public static let platform = "AppleWebKit/605.1.15"
     public static let platformDetails = "(KHTML, like Gecko)"
 
-    // For iPad, we need to append this to the default UA for google.com to show correct page
-    public static let uaBitGoogleIpad = "Version/13.0.3"
-
     private static var defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
 
     private static func clientUserAgent(prefix: String) -> String {

--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -48,7 +48,7 @@ open class UserAgent {
 
     public static func desktopUserAgent() -> String {
         // swiftlint:disable line_length
-        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15"
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.7 Safari/605.1.15"
         // swiftlint:enable line_length
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
@@ -49,7 +49,7 @@ final class UserAgentBuilderTests: XCTestCase {
 
     func testDefaultDesktopUserAgent() {
         let builder = UserAgentBuilder.defaultDesktopUserAgent()
-        let systemInfo = "(Macintosh; Intel Mac OS X 10.15)"
+        let systemInfo = "(Macintosh; Intel Mac OS X 10_15_7)"
         let extensions = "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)"
         let testAgent = "\(UserAgent.product) \(systemInfo) \(UserAgent.platform) \(UserAgent.platformDetails) \(extensions)"
         XCTAssertEqual(builder.userAgent(), testAgent)

--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -160,9 +160,9 @@ class LegacyWebViewController: UIViewController, LegacyWebController {
         // Focus on iPad, which means there could be some edge cases right now.
 
         if UIDevice.current.userInterfaceIdiom == .pad {
-            configuration.applicationNameForUserAgent = "Version/16.0 Safari/605.1.15"
+            configuration.applicationNameForUserAgent = "Version/17.7 Safari/605.1.15"
         } else {
-            configuration.applicationNameForUserAgent = "FxiOS/\(AppInfo.majorVersion) Mobile/15E148 Version/16.0"
+            configuration.applicationNameForUserAgent = "FxiOS/\(AppInfo.majorVersion) Mobile/15E148 Version/17.7"
         }
 
         if #available(iOS 15.0, *) {


### PR DESCRIPTION
## :scroll: Tickets

#27698 
FXIOS-12716

## :bulb: Description

Updates the imaginary Safari version used to identify as in some cases and on some devices. Chosen values to blend in the most. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
