### PR TITLE
Bugfix FXIOS-12680 #27626 ⁃ Don't display the Make Default Banner if the user has set up Firefox as default

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -31,8 +31,8 @@ public final class MenuRedesignMainView: UIView,
 
     // MARK: - Properties
     private var isMenuDefaultBrowserBanner = false
-
     private var isBrowserDefault = false
+    private var bannerShown = false
 
     // MARK: - UI Setup
     private func setupView(with data: [MenuSection], isHeaderBanner: Bool = true) {
@@ -49,7 +49,7 @@ public final class MenuRedesignMainView: UIView,
                 closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
             ])
 
-            if isHeaderBanner, isMenuDefaultBrowserBanner, !isBrowserDefault {
+            if isHeaderBanner, isMenuDefaultBrowserBanner, !isBrowserDefault, !bannerShown {
                 self.addSubview(headerBanner)
                 viewConstraints.append(contentsOf: [
                     headerBanner.topAnchor.constraint(equalTo: closeButton.bottomAnchor, constant: UX.headerTopMargin),
@@ -108,10 +108,10 @@ public final class MenuRedesignMainView: UIView,
     public func setupDetails(title: String,
                              subtitle: String,
                              image: UIImage?,
-                             isBannerEnabled: Bool,
+                             isBannerFlagEnabled: Bool,
                              isBrowserDefault: Bool) {
         headerBanner.setupDetails(title: title, subtitle: subtitle, image: image)
-        isMenuDefaultBrowserBanner = isBannerEnabled
+        isMenuDefaultBrowserBanner = isBannerFlagEnabled
         self.isBrowserDefault = isBrowserDefault
     }
 
@@ -161,6 +161,7 @@ public final class MenuRedesignMainView: UIView,
     private func handleBannerCallback(with data: [MenuSection]) {
         headerBanner.closeButtonCallback = { [weak self] in
             self?.setupView(with: data, isHeaderBanner: false)
+            self?.bannerShown = true
         }
     }
 

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -32,6 +32,8 @@ public final class MenuRedesignMainView: UIView,
     // MARK: - Properties
     private var isMenuDefaultBrowserBanner = false
 
+    private var isBrowserDefault = false
+
     // MARK: - UI Setup
     private func setupView(with data: [MenuSection], isHeaderBanner: Bool = true) {
         self.removeConstraints(viewConstraints)
@@ -47,7 +49,7 @@ public final class MenuRedesignMainView: UIView,
                 closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
             ])
 
-            if isHeaderBanner && isMenuDefaultBrowserBanner {
+            if isHeaderBanner, isMenuDefaultBrowserBanner, !isBrowserDefault {
                 self.addSubview(headerBanner)
                 viewConstraints.append(contentsOf: [
                     headerBanner.topAnchor.constraint(equalTo: closeButton.bottomAnchor, constant: UX.headerTopMargin),
@@ -103,9 +105,14 @@ public final class MenuRedesignMainView: UIView,
         siteProtectionHeader.accessibilityIdentifier = siteProtectionHeaderIdentifier
     }
 
-    public func setupDetails(title: String, subtitle: String, image: UIImage?, isBannerEnabled: Bool) {
+    public func setupDetails(title: String,
+                             subtitle: String,
+                             image: UIImage?,
+                             isBannerEnabled: Bool,
+                             isBrowserDefault: Bool) {
         headerBanner.setupDetails(title: title, subtitle: subtitle, image: image)
         isMenuDefaultBrowserBanner = isBannerEnabled
+        self.isBrowserDefault = isBrowserDefault
     }
 
     // MARK: - Interface

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
@@ -30,7 +30,7 @@ final class MainMenuAction: Action {
         siteProtectionsData: SiteProtectionsData? = nil,
         telemetryInfo: TelemetryInfo? = nil,
         isExpanded: Bool? = nil,
-        isBrowserDefault: Bool = false,
+        isBrowserDefault: Bool = false
     ) {
         self.navigationDestination = navigationDestination
         self.detailsViewToShow = changeMenuViewTo

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
@@ -16,6 +16,7 @@ final class MainMenuAction: Action {
     var siteProtectionsData: SiteProtectionsData?
     var telemetryInfo: TelemetryInfo?
     var isExpanded: Bool?
+    var isBrowserDefault: Bool
 
     init(
         windowUUID: WindowUUID,
@@ -28,7 +29,8 @@ final class MainMenuAction: Action {
         accountIcon: UIImage? = nil,
         siteProtectionsData: SiteProtectionsData? = nil,
         telemetryInfo: TelemetryInfo? = nil,
-        isExpanded: Bool? = nil
+        isExpanded: Bool? = nil,
+        isBrowserDefault: Bool = false,
     ) {
         self.navigationDestination = navigationDestination
         self.detailsViewToShow = changeMenuViewTo
@@ -39,6 +41,7 @@ final class MainMenuAction: Action {
         self.siteProtectionsData = siteProtectionsData
         self.telemetryInfo = telemetryInfo
         self.isExpanded = isExpanded
+        self.isBrowserDefault = isBrowserDefault
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
@@ -66,6 +69,7 @@ enum MainMenuMiddlewareActionType: ActionType {
     case requestTabInfo
     case requestTabInfoForSiteProtectionsHeader
     case updateAccountHeader
+    case updateBannerVisibility
 }
 
 enum MainMenuDetailsActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -159,23 +159,36 @@ final class MainMenuMiddleware: FeatureFlaggable {
     }
 
     private func handleDidInstantiateViewAction(action: MainMenuAction) {
-        guard !isMenuRedesignOn else { return }
-        guard let accountData = getAccountData() else {
-            dispatchUpdateAccountHeader(action: action)
-            return
-        }
-
-        if let iconURL = accountData.iconURL {
-            GeneralizedImageFetcher().getImageFor(url: iconURL) { [weak self] image in
-                guard let self else { return }
-                self.dispatchUpdateAccountHeader(
-                    accountData: accountData,
-                    action: action,
-                    icon: image)
+        if !isMenuRedesignOn {
+            guard let accountData = getAccountData() else {
+                dispatchUpdateAccountHeader(action: action)
+                return
+            }
+            
+            if let iconURL = accountData.iconURL {
+                GeneralizedImageFetcher().getImageFor(url: iconURL) { [weak self] image in
+                    guard let self else { return }
+                    self.dispatchUpdateAccountHeader(
+                        accountData: accountData,
+                        action: action,
+                        icon: image)
+                }
+            } else {
+                dispatchUpdateAccountHeader(accountData: accountData, action: action)
             }
         } else {
-            dispatchUpdateAccountHeader(accountData: accountData, action: action)
+            dispatchUpdateBannerVisibility(action: action)
         }
+    }
+
+    private func dispatchUpdateBannerVisibility(action: MainMenuAction) {
+        store.dispatchLegacy(
+            MainMenuAction(
+                windowUUID: action.windowUUID,
+                actionType: MainMenuMiddlewareActionType.updateBannerVisibility,
+                isBrowserDefault: DefaultBrowserUtil.isBrowserDefault
+            )
+        )
     }
 
     private func dispatchUpdateAccountHeader(

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -164,7 +164,6 @@ final class MainMenuMiddleware: FeatureFlaggable {
                 dispatchUpdateAccountHeader(action: action)
                 return
             }
-            
             if let iconURL = accountData.iconURL {
                 GeneralizedImageFetcher().getImageFor(url: iconURL) { [weak self] image in
                     guard let self else { return }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -79,6 +79,7 @@ struct MainMenuState: ScreenState, Equatable {
 
     var accountData: AccountData?
     var accountIcon: UIImage?
+    var isBrowserDefault: Bool
 
     var siteProtectionsData: SiteProtectionsData?
 
@@ -107,7 +108,8 @@ struct MainMenuState: ScreenState, Equatable {
             shouldDismiss: mainMenuState.shouldDismiss,
             accountData: mainMenuState.accountData,
             accountIcon: mainMenuState.accountIcon,
-            siteProtectionsData: mainMenuState.siteProtectionsData
+            siteProtectionsData: mainMenuState.siteProtectionsData,
+            isBrowserDefault: mainMenuState.isBrowserDefault
         )
     }
 
@@ -121,7 +123,8 @@ struct MainMenuState: ScreenState, Equatable {
             shouldDismiss: false,
             accountData: nil,
             accountIcon: nil,
-            siteProtectionsData: nil
+            siteProtectionsData: nil,
+            isBrowserDefault: false
         )
     }
 
@@ -134,7 +137,8 @@ struct MainMenuState: ScreenState, Equatable {
         shouldDismiss: Bool = false,
         accountData: AccountData?,
         accountIcon: UIImage?,
-        siteProtectionsData: SiteProtectionsData?
+        siteProtectionsData: SiteProtectionsData?,
+        isBrowserDefault: Bool
     ) {
         self.windowUUID = windowUUID
         self.menuElements = menuElements
@@ -145,6 +149,7 @@ struct MainMenuState: ScreenState, Equatable {
         self.accountData = accountData
         self.accountIcon = accountIcon
         self.siteProtectionsData = siteProtectionsData
+        self.isBrowserDefault = isBrowserDefault
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -162,6 +167,8 @@ struct MainMenuState: ScreenState, Equatable {
             return handleViewDidLoadAction(state: state)
         case MainMenuMiddlewareActionType.updateAccountHeader:
             return handleUpdateAccountHeaderAction(state: state, action: action)
+        case MainMenuMiddlewareActionType.updateBannerVisibility:
+            return handleUpdateBannerVisibilityAction(state: state, action: action)
         case MainMenuActionType.updateSiteProtectionsHeader:
             return handleUpdateSiteProtectionsHeaderAction(state: state, action: action)
         case MainMenuActionType.updateCurrentTabInfo:
@@ -197,7 +204,8 @@ struct MainMenuState: ScreenState, Equatable {
             currentTabInfo: state.currentTabInfo,
             accountData: state.accountData,
             accountIcon: state.accountIcon,
-            siteProtectionsData: state.siteProtectionsData
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
         )
     }
 
@@ -208,7 +216,8 @@ struct MainMenuState: ScreenState, Equatable {
             currentTabInfo: state.currentTabInfo,
             accountData: state.accountData,
             accountIcon: state.accountIcon,
-            siteProtectionsData: state.siteProtectionsData
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
         )
     }
 
@@ -221,7 +230,22 @@ struct MainMenuState: ScreenState, Equatable {
             currentTabInfo: state.currentTabInfo,
             accountData: action.accountData,
             accountIcon: action.accountIcon,
-            siteProtectionsData: state.siteProtectionsData
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
+        )
+    }
+
+    private static func handleUpdateBannerVisibilityAction(state: MainMenuState, action: Action) -> MainMenuState {
+        guard let action = action as? MainMenuAction else { return defaultState(from: state) }
+
+        return MainMenuState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuElements,
+            currentTabInfo: state.currentTabInfo,
+            accountData: state.accountData,
+            accountIcon: state.accountIcon,
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: action.isBrowserDefault
         )
     }
 
@@ -234,7 +258,8 @@ struct MainMenuState: ScreenState, Equatable {
             currentTabInfo: state.currentTabInfo,
             accountData: state.accountData,
             accountIcon: state.accountIcon,
-            siteProtectionsData: action.siteProtectionsData
+            siteProtectionsData: action.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
         )
     }
 
@@ -253,7 +278,8 @@ struct MainMenuState: ScreenState, Equatable {
             currentTabInfo: currentTabInfo,
             accountData: state.accountData,
             accountIcon: state.accountIcon,
-            siteProtectionsData: state.siteProtectionsData
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
         )
     }
 
@@ -274,7 +300,8 @@ struct MainMenuState: ScreenState, Equatable {
             currentTabInfo: state.currentTabInfo,
             accountData: state.accountData,
             accountIcon: state.accountIcon,
-            siteProtectionsData: state.siteProtectionsData
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
         )
     }
 
@@ -288,7 +315,8 @@ struct MainMenuState: ScreenState, Equatable {
             submenuDestination: action.detailsViewToShow,
             accountData: state.accountData,
             accountIcon: state.accountIcon,
-            siteProtectionsData: state.siteProtectionsData
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
         )
     }
 
@@ -302,7 +330,8 @@ struct MainMenuState: ScreenState, Equatable {
             navigationDestination: action.navigationDestination,
             accountData: state.accountData,
             accountIcon: state.accountIcon,
-            siteProtectionsData: state.siteProtectionsData
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
         )
     }
 
@@ -314,7 +343,8 @@ struct MainMenuState: ScreenState, Equatable {
             shouldDismiss: true,
             accountData: state.accountData,
             accountIcon: state.accountIcon,
-            siteProtectionsData: state.siteProtectionsData
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
         )
     }
 
@@ -326,7 +356,8 @@ struct MainMenuState: ScreenState, Equatable {
             shouldDismiss: true,
             accountData: state.accountData,
             accountIcon: state.accountIcon,
-            siteProtectionsData: state.siteProtectionsData
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
         )
     }
 
@@ -338,7 +369,8 @@ struct MainMenuState: ScreenState, Equatable {
             navigationDestination: MenuNavigationDestination(.editBookmark),
             accountData: state.accountData,
             accountIcon: state.accountIcon,
-            siteProtectionsData: state.siteProtectionsData
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
         )
     }
 
@@ -350,7 +382,8 @@ struct MainMenuState: ScreenState, Equatable {
             navigationDestination: MenuNavigationDestination(.zoom),
             accountData: state.accountData,
             accountIcon: state.accountIcon,
-            siteProtectionsData: state.siteProtectionsData
+            siteProtectionsData: state.siteProtectionsData,
+            isBrowserDefault: state.isBrowserDefault
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -63,6 +63,7 @@ class MainMenuViewController: UIViewController,
     }
 
     private var hasBeenExpanded = false
+    private var isBrowserDefault = false
 
     // Used to save the last screen orientation
     private var lastOrientation: UIDeviceOrientation
@@ -250,8 +251,8 @@ class MainMenuViewController: UIViewController,
         menuRedesignContent.setupDetails(title: String(format: .MainMenu.HeaderBanner.Title, AppName.shortName.rawValue),
                                          subtitle: .MainMenu.HeaderBanner.Subtitle,
                                          image: UIImage(named: ImageIdentifiers.foxDefaultBrowser),
-                                         isBannerEnabled: isMenuDefaultBrowserBanner,
-                                         isBrowserDefault: DefaultBrowserUtil.isBrowserDefault)
+                                         isBannerFlagEnabled: isMenuDefaultBrowserBanner,
+                                         isBrowserDefault: isBrowserDefault)
     }
 
     private func setupHintView() {
@@ -334,6 +335,8 @@ class MainMenuViewController: UIViewController,
 
     func newState(state: MainMenuState) {
         menuState = state
+
+        isBrowserDefault = menuState.isBrowserDefault
 
         if let accountData = menuState.accountData {
             updateHeaderWith(accountData: accountData, icon: menuState.accountIcon)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -250,7 +250,8 @@ class MainMenuViewController: UIViewController,
         menuRedesignContent.setupDetails(title: String(format: .MainMenu.HeaderBanner.Title, AppName.shortName.rawValue),
                                          subtitle: .MainMenu.HeaderBanner.Subtitle,
                                          image: UIImage(named: ImageIdentifiers.foxDefaultBrowser),
-                                         isBannerEnabled: isMenuDefaultBrowserBanner)
+                                         isBannerEnabled: isMenuDefaultBrowserBanner,
+                                         isBrowserDefault: DefaultBrowserUtil.isBrowserDefault)
     }
 
     private func setupHintView() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12680)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27626)

## :bulb: Description
Don't display the banner if the FF is default browser

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
