### PR TITLE
Add FXIOS-12682 ⁃ [Menu Redesign] More option transition to full menu

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -16,7 +16,7 @@ public final class MenuRedesignMainView: UIView,
     }
 
     public var closeButtonCallback: (() -> Void)?
-    public var onCalculatedHeight: ((CGFloat) -> Void)?
+    public var onCalculatedHeight: ((CGFloat, _ isExpanded: Bool) -> Void)?
 
     // MARK: - UI Elements
     private var tableView: MenuRedesignTableView = .build()
@@ -122,7 +122,7 @@ public final class MenuRedesignMainView: UIView,
            let isExpanded = expandedSection.isExpanded,
            isExpanded {
             let height = tableView.tableViewContentSize + UX.headerTopMargin
-            onCalculatedHeight?(height + siteProtectionHeader.frame.height)
+            onCalculatedHeight?(height + siteProtectionHeader.frame.height, true)
             layoutIfNeeded()
         } else {
             DispatchQueue.main.async { [weak self] in
@@ -131,7 +131,7 @@ public final class MenuRedesignMainView: UIView,
                 if let section = data.first(where: { $0.isHomepage }), section.isHomepage {
                     self.setHeightForHomepageMenu(height: height)
                 } else {
-                    onCalculatedHeight?(height + siteProtectionHeader.frame.height)
+                    onCalculatedHeight?(height + siteProtectionHeader.frame.height, false)
                 }
                 layoutIfNeeded()
             }
@@ -145,9 +145,10 @@ public final class MenuRedesignMainView: UIView,
                                      UX.closeButtonSize +
                                      UX.headerTopMarginWithButton +
                                      headerBannerHeight +
-                                     UX.headerTopMargin)
+                                     UX.headerTopMargin,
+                                     false)
         } else {
-            self.onCalculatedHeight?(height + UX.closeButtonSize + UX.headerTopMarginWithButton)
+            self.onCalculatedHeight?(height + UX.closeButtonSize + UX.headerTopMarginWithButton, false)
         }
     }
 

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -31,7 +31,6 @@ public final class MenuRedesignMainView: UIView,
 
     // MARK: - Properties
     private var isMenuDefaultBrowserBanner = false
-    private let isMenuExpanded = false
 
     // MARK: - UI Setup
     private func setupView(with data: [MenuSection], isHeaderBanner: Bool = true) {
@@ -118,10 +117,11 @@ public final class MenuRedesignMainView: UIView,
     }
 
     private func updateMenuHeight(for data: [MenuSection]) {
+        let expandedSection = data.first(where: { $0.isExpanded ?? false })
+        let isExpanded = expandedSection?.isExpanded ?? false
+
         // To avoid a glitch when expand the menu, we should not handle this action under DispatchQueue.main.async
-        if let expandedSection = data.first(where: { $0.isExpanded ?? false }),
-           let isExpanded = expandedSection.isExpanded,
-           isExpanded {
+        if isExpanded {
             let height = tableView.tableViewContentSize + UX.headerTopMargin
             onCalculatedHeight?(height + siteProtectionHeader.frame.height, isExpanded)
             layoutIfNeeded()
@@ -130,16 +130,16 @@ public final class MenuRedesignMainView: UIView,
                 guard let self else { return }
                 let height = tableView.tableViewContentSize + UX.headerTopMargin
                 if let section = data.first(where: { $0.isHomepage }), section.isHomepage {
-                    self.setHeightForHomepageMenu(height: height)
+                    self.setHeightForHomepageMenu(height: height, isExpanded: isExpanded)
                 } else {
-                    onCalculatedHeight?(height + siteProtectionHeader.frame.height, isMenuExpanded)
+                    onCalculatedHeight?(height + siteProtectionHeader.frame.height, isExpanded)
                 }
                 layoutIfNeeded()
             }
         }
     }
 
-    private func setHeightForHomepageMenu(height: CGFloat) {
+    private func setHeightForHomepageMenu(height: CGFloat, isExpanded: Bool) {
         if isMenuDefaultBrowserBanner {
             let headerBannerHeight = headerBanner.frame.height
             self.onCalculatedHeight?(height +
@@ -147,9 +147,9 @@ public final class MenuRedesignMainView: UIView,
                                      UX.headerTopMarginWithButton +
                                      headerBannerHeight +
                                      UX.headerTopMargin,
-                                     isMenuExpanded)
+                                     isExpanded)
         } else {
-            self.onCalculatedHeight?(height + UX.closeButtonSize + UX.headerTopMarginWithButton, isMenuExpanded)
+            self.onCalculatedHeight?(height + UX.closeButtonSize + UX.headerTopMarginWithButton, isExpanded)
         }
     }
 

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -31,6 +31,7 @@ public final class MenuRedesignMainView: UIView,
 
     // MARK: - Properties
     private var isMenuDefaultBrowserBanner = false
+    private let isMenuExpanded = false
 
     // MARK: - UI Setup
     private func setupView(with data: [MenuSection], isHeaderBanner: Bool = true) {
@@ -122,7 +123,7 @@ public final class MenuRedesignMainView: UIView,
            let isExpanded = expandedSection.isExpanded,
            isExpanded {
             let height = tableView.tableViewContentSize + UX.headerTopMargin
-            onCalculatedHeight?(height + siteProtectionHeader.frame.height, true)
+            onCalculatedHeight?(height + siteProtectionHeader.frame.height, isExpanded)
             layoutIfNeeded()
         } else {
             DispatchQueue.main.async { [weak self] in
@@ -131,7 +132,7 @@ public final class MenuRedesignMainView: UIView,
                 if let section = data.first(where: { $0.isHomepage }), section.isHomepage {
                     self.setHeightForHomepageMenu(height: height)
                 } else {
-                    onCalculatedHeight?(height + siteProtectionHeader.frame.height, false)
+                    onCalculatedHeight?(height + siteProtectionHeader.frame.height, isMenuExpanded)
                 }
                 layoutIfNeeded()
             }
@@ -146,9 +147,9 @@ public final class MenuRedesignMainView: UIView,
                                      UX.headerTopMarginWithButton +
                                      headerBannerHeight +
                                      UX.headerTopMargin,
-                                     false)
+                                     isMenuExpanded)
         } else {
-            self.onCalculatedHeight?(height + UX.closeButtonSize + UX.headerTopMarginWithButton, false)
+            self.onCalculatedHeight?(height + UX.closeButtonSize + UX.headerTopMarginWithButton, isMenuExpanded)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -124,8 +124,7 @@ class MainMenuViewController: UIViewController,
 
         if isMenuRedesign {
             menuRedesignContent.siteProtectionHeader.closeButtonCallback = { [weak self] in
-                guard let self else { return }
-                self.dispatchCloseMenuAction()
+                self?.dispatchCloseMenuAction()
             }
 
             menuRedesignContent.onCalculatedHeight = { [weak self] height, isExpanded in
@@ -144,23 +143,19 @@ class MainMenuViewController: UIViewController,
             }
 
             menuRedesignContent.siteProtectionHeader.siteProtectionsButtonCallback = { [weak self] in
-                guard let self else { return }
-                self.dispatchSiteProtectionAction()
+                self?.dispatchSiteProtectionAction()
             }
 
             menuRedesignContent.closeButtonCallback = { [weak self] in
-                guard let self else { return }
-                self.dispatchCloseMenuAction()
+                self?.dispatchCloseMenuAction()
             }
         } else {
             menuContent.accountHeaderView.closeButtonCallback = { [weak self] in
-                guard let self else { return }
-                self.dispatchCloseMenuAction()
+                self?.dispatchCloseMenuAction()
             }
 
             menuContent.accountHeaderView.mainButtonCallback = { [weak self] in
-                guard let self else { return }
-                self.dispatchSyncSignInAction()
+                self?.dispatchSyncSignInAction()
             }
         }
 
@@ -208,13 +203,12 @@ class MainMenuViewController: UIViewController,
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         coordinator.animate(alongsideTransition: { [weak self] _ in
-            guard let self else { return }
             // We should dismiss CFR when device is rotating
-            if UIDevice.current.orientation != lastOrientation {
-                lastOrientation = UIDevice.current.orientation
-                self.adjustLayout(isDeviceRotating: true)
+            if UIDevice.current.orientation != self?.lastOrientation {
+                self?.lastOrientation = UIDevice.current.orientation
+                self?.adjustLayout(isDeviceRotating: true)
             } else {
-                self.adjustLayout()
+                self?.adjustLayout()
             }
         }, completion: nil)
     }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -128,13 +128,18 @@ class MainMenuViewController: UIViewController,
                 self.dispatchCloseMenuAction()
             }
 
-            menuRedesignContent.onCalculatedHeight = { [weak self] height in
-                guard let self else { return }
+            menuRedesignContent.onCalculatedHeight = { [weak self] height, isExpanded in
                 if #available(iOS 16.0, *), UIDevice.current.userInterfaceIdiom == .phone {
                     let customDetent = UISheetPresentationController.Detent.custom { context in
                         return height
                     }
-                    self.sheetPresentationController?.detents = [customDetent]
+                    if isExpanded {
+                        self?.sheetPresentationController?.animateChanges({
+                            self?.sheetPresentationController?.detents = [customDetent]
+                        })
+                    } else {
+                        self?.sheetPresentationController?.detents = [customDetent]
+                    }
                 }
             }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12682)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27628)

## :bulb: Description
Added a transition when menu is expanded

## :movie_camera: Demos

https://github.com/user-attachments/assets/343de7d5-b7d3-4236-ab45-47ccc4380693



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
