### PR TITLE
Add FXIOS-12571 [HNT - Search Bar] accessibility label + trait

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SearchBar/SearchBarCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SearchBar/SearchBarCell.swift
@@ -34,6 +34,8 @@ class SearchBarCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
     private func setupAccessibility() {
         isAccessibilityElement = true
         accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell
+        accessibilityTraits.insert(.button)
+        accessibilityLabel = .TabLocationURLPlaceholder
     }
 
     private func setupView() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12572)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27381)

## :bulb: Description
Add a11y label and trait for the search bar in the middle.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
