### PR TITLE
Localize FXIOS-26661 Clean up unused strings

### DIFF
--- a/firefox-ios/Shared/Supporting Files/bg.lproj/TabLocation.strings
+++ b/firefox-ios/Shared/Supporting Files/bg.lproj/TabLocation.strings
@@ -1,3 +1,0 @@
-/* Accessibility label for the shopping button in url bar */
-"TabLocation.Shopping.A11y.Label.v120" = "Проверка на отзиви";
-

--- a/firefox-ios/Shared/Supporting Files/es.lproj/TabLocation.strings
+++ b/firefox-ios/Shared/Supporting Files/es.lproj/TabLocation.strings
@@ -25,12 +25,8 @@
 /* Large content title for the share button. This title is displayed when using accessible font sizes is enabled */
 "TabLocation.ShareButton.AccessibilityLabel.v122" = "Compartir";
 
-/* Accessibility label for the shopping button in url bar */
-"TabLocation.Shopping.A11y.Label.v120" = "Verificador de reseñas";
-
 /* Large content title for the tabs button. The argument is the number of open tabs or an infinity symbol. This title is displayed when using accessible font sizes is enabled. */
 "TabsButton.Accessibility.LargeContentTitle.v122" = "Mostrar pestañas: %@";
 
 /* Large content title for the button shown in editing mode to remove this site from the top sites panel. */
 "TopSites.RemoveButton.LargeContentTitle.v122" = "Eliminar página";
-

--- a/firefox-ios/Shared/Supporting Files/ur.lproj/Edit Card.strings
+++ b/firefox-ios/Shared/Supporting Files/ur.lproj/Edit Card.strings
@@ -1,3 +1,0 @@
-/* Title label for the view where user can edit their credit card info */
-"CreditCard.EditCard.EditCreditCardTitle.v113" = "کریڈٹ کارڈ میں ترمیم کریں";
-

--- a/firefox-ios/Shared/Supporting Files/ur.lproj/FirefoxSync.strings
+++ b/firefox-ios/Shared/Supporting Files/ur.lproj/FirefoxSync.strings
@@ -1,3 +1,0 @@
-/* Toggle for credit cards syncing setting */
-"FirefoxSync.CreditCardsEngine.v115" = "کریڈٹ کارڈز";
-

--- a/firefox-ios/Shared/az.lproj/Today.strings
+++ b/firefox-ios/Shared/az.lproj/Today.strings
@@ -1,3 +1,0 @@
-/* Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands */
-"TodayWidget.DropDownMenuItemNewSearch" = "Yeni axtarış";
-

--- a/firefox-ios/Shared/en.lproj/Localizable.strings
+++ b/firefox-ios/Shared/en.lproj/Localizable.strings
@@ -445,18 +445,6 @@
 /* Button to not update the user's password */
 "LoginsHelper.DontUpdate.Button" = "Don’t Update";
 
-/* Prompt for saving a login. The first parameter is the username being saved. The second parameter is the hostname of the site. */
-"LoginsHelper.PromptSaveLogin.Title" = "Save login %1$@ for %2$@?";
-
-/* Prompt for saving a password with no username. The parameter is the hostname of the site. */
-"LoginsHelper.PromptSavePassword.Title" = "Save password for %@?";
-
-/* Prompt for updating a login. The first parameter is the hostname for which the password will be updated for. */
-"LoginsHelper.PromptUpdateLogin.Title.OneArg" = "Update login for %@?";
-
-/* Prompt for updating a login. The first parameter is the username for which the password will be updated for. The second parameter is the hostname of the site. */
-"LoginsHelper.PromptUpdateLogin.Title.TwoArg" = "Update login %1$@ for %2$@?";
-
 /* Button to save the user's password */
 "LoginsHelper.SaveLogin.Button" = "Save Login";
 
@@ -1090,9 +1078,6 @@
 /* The button to undo the delete all tabs */
 "Tabs.DeleteAllUndo.Button" = "Undo";
 
-/* The label indicating that all the tabs were closed */
-"Tabs.DeleteAllUndo.Title" = "%d tab(s) closed";
-
 /* Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Firefox reader mode from another app. */
 "The page could not be displayed in Reader View." = "The page could not be displayed in Reader View.";
 
@@ -1209,4 +1194,3 @@
 
 /* Relative date for yesterday. */
 "yesterday" = "yesterday";
-

--- a/firefox-ios/Shared/tzm.lproj/Today.strings
+++ b/firefox-ios/Shared/tzm.lproj/Today.strings
@@ -1,6 +1,3 @@
-/* Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands */
-"TodayWidget.DropDownMenuItemNewSearch" = "ⴰⵔⵣⵣⵓ ⴰⵎⴰⵢⵏⵓ";
-
 /* Open New Tab button label */
 "TodayWidget.NewSearchButtonLabelV1" = "ⵔⵣⵓ ⴳ ⴼⴰⵢⵔⴼⵓⴽⵙ";
 
@@ -21,4 +18,3 @@
 
 /* Search in private tab */
 "TodayWidget.SearchInPrivateTabLabelV2" = "ⵔⵣⵓ ⴳ ⵓⵙⴽⵙⵍ ⵓⵙⵍⵉⴳ";
-


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26661)

## :bulb: Description
Doing some experiments with [string catalogs](https://www.fline.dev/the-missing-string-catalogs-faq-for-xcode-15/) instead of legacy `.strings`, and these strings were exported without source text.

The 4 en strings were replaced by a v122 version, and are still exposed for localization.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
