### PR TITLE
Bugfix FXIOS-12721 ⁃ Shaky menu movemenu when launched after opening a new tab

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -31,8 +31,14 @@ public final class MenuRedesignMainView: UIView,
 
     // MARK: - Properties
     private var isMenuDefaultBrowserBanner = false
+    private var menuData: [MenuSection] = []
 
     // MARK: - UI Setup
+    override public func layoutSubviews() {
+        super.layoutSubviews()
+        updateMenuHeight(for: menuData)
+    }
+
     private func setupView(with data: [MenuSection], isHeaderBanner: Bool = true) {
         self.removeConstraints(viewConstraints)
         viewConstraints.removeAll()
@@ -113,7 +119,7 @@ public final class MenuRedesignMainView: UIView,
         setupView(with: data)
         tableView.reloadTableView(with: data)
         handleBannerCallback(with: data)
-        updateMenuHeight(for: data)
+        menuData = data
     }
 
     private func updateMenuHeight(for data: [MenuSection]) {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -63,6 +63,7 @@ class MainMenuViewController: UIViewController,
     }
 
     private var hasBeenExpanded = false
+    private var currentCustomMenuHeight = 0.0
 
     // Used to save the last screen orientation
     private var lastOrientation: UIDeviceOrientation
@@ -128,16 +129,19 @@ class MainMenuViewController: UIViewController,
             }
 
             menuRedesignContent.onCalculatedHeight = { [weak self] height, isExpanded in
-                if #available(iOS 16.0, *), UIDevice.current.userInterfaceIdiom == .phone {
-                    let customDetent = UISheetPresentationController.Detent.custom { context in
-                        return height
-                    }
-                    if isExpanded {
-                        self?.sheetPresentationController?.animateChanges({
+                if let customHeight = self?.currentCustomMenuHeight, height > customHeight {
+                    self?.currentCustomMenuHeight = height
+                    if #available(iOS 16.0, *), UIDevice.current.userInterfaceIdiom == .phone {
+                        let customDetent = UISheetPresentationController.Detent.custom { context in
+                            return height
+                        }
+                        if isExpanded {
+                            self?.sheetPresentationController?.animateChanges({
+                                self?.sheetPresentationController?.detents = [customDetent]
+                            })
+                        } else {
                             self?.sheetPresentationController?.detents = [customDetent]
-                        })
-                    } else {
-                        self?.sheetPresentationController?.detents = [customDetent]
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12721)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27708)

## :bulb: Description
Updated the logic to set the custom height for menu

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
