### PR TITLE
Add FXIOS-12673 ⁃ [Menu Redesign] Handle Menu banner UI for different accessibility sizes

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/HeaderBanner.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/HeaderBanner.swift
@@ -19,29 +19,43 @@ public final class HeaderBanner: UIView, ThemeApplicable {
         static let foxImageHeight: CGFloat = 53
         static let foxImageWidth: CGFloat = 77
         static let backgroundAlpha: CGFloat = 0.8
+        static let labelsVerticalMargin: CGFloat = 8
         static let crossLarge = StandardImageIdentifiers.Large.cross
     }
 
     public var closeButtonCallback: (() -> Void)?
+    public var bannerButtonCallback: (() -> Void)?
 
     private lazy var headerView: UIView = .build { view in
         view.layer.cornerRadius = UX.cornerRadius
     }
 
-    private lazy var headerLabelsContainer: UIStackView = .build { stack in
+    private lazy var headerLabelsContainer: UIStackView = .build { [weak self] stack in
         stack.alignment = .leading
         stack.axis = .vertical
         stack.spacing = UX.headerLabelDistance
+        stack.distribution = .fill
+        stack.isAccessibilityElement = true
+        stack.accessibilityTraits = .button
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self?.bannerButtonTapped))
+        stack.addGestureRecognizer(tapGesture)
+        stack.isUserInteractionEnabled = true
     }
 
     private let titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        label.isAccessibilityElement = false
     }
 
     private let subtitleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.caption1.scaledFont()
         label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        label.isAccessibilityElement = false
     }
 
     private let foxImage: UIImageView = .build { imageView in
@@ -80,7 +94,10 @@ public final class HeaderBanner: UIView, ThemeApplicable {
                 equalTo: headerView.leadingAnchor,
                 constant: UX.horizontalMargin
             ),
-            headerLabelsContainer.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+            headerLabelsContainer.topAnchor.constraint(equalTo: headerView.topAnchor,
+                                                       constant: UX.labelsVerticalMargin),
+            headerLabelsContainer.bottomAnchor.constraint(equalTo: headerView.bottomAnchor,
+                                                          constant: -UX.labelsVerticalMargin),
             headerLabelsContainer.trailingAnchor.constraint(
                 equalTo: foxImage.leadingAnchor,
                 constant: -UX.horizontalMargin
@@ -94,7 +111,7 @@ public final class HeaderBanner: UIView, ThemeApplicable {
             closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
             closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
 
-            foxImage.topAnchor.constraint(equalTo: closeButton.topAnchor),
+            foxImage.topAnchor.constraint(greaterThanOrEqualTo: closeButton.topAnchor),
             foxImage.bottomAnchor.constraint(equalTo: headerView.bottomAnchor),
             foxImage.trailingAnchor.constraint(equalTo: closeButton.trailingAnchor),
             foxImage.heightAnchor.constraint(equalToConstant: UX.foxImageHeight),
@@ -106,6 +123,7 @@ public final class HeaderBanner: UIView, ThemeApplicable {
         titleLabel.text = title
         subtitleLabel.text = subtitle
         foxImage.image = image
+        headerLabelsContainer.accessibilityLabel = "\(title) \(subtitle)"
     }
 
     public func setupAccessibility(closeButtonA11yLabel: String,
@@ -118,6 +136,11 @@ public final class HeaderBanner: UIView, ThemeApplicable {
     @objc
     func closeButtonTapped() {
         closeButtonCallback?()
+    }
+
+    @objc
+    func bannerButtonTapped() {
+        bannerButtonCallback?()
     }
 
     public func applyTheme(theme: Theme) {

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -17,6 +17,7 @@ public final class MenuRedesignMainView: UIView,
 
     public var closeButtonCallback: (() -> Void)?
     public var onCalculatedHeight: ((CGFloat, _ isExpanded: Bool) -> Void)?
+    public var bannerButtonCallback: (() -> Void)?
 
     // MARK: - UI Elements
     private var tableView: MenuRedesignTableView = .build()
@@ -100,12 +101,14 @@ public final class MenuRedesignMainView: UIView,
                                               menuA11yLabel: String,
                                               closeButtonA11yLabel: String,
                                               closeButtonA11yIdentifier: String,
-                                              siteProtectionHeaderIdentifier: String) {
+                                              siteProtectionHeaderIdentifier: String,
+                                              headerBannerCloseButtonA11yIdentifier: String,
+                                              headerBannerCloseButtonA11yLabel: String) {
         let closeButtonViewModel = CloseButtonViewModel(a11yLabel: closeButtonA11yLabel,
                                                         a11yIdentifier: closeButtonA11yIdentifier)
         closeButton.configure(viewModel: closeButtonViewModel)
-        headerBanner.setupAccessibility(closeButtonA11yLabel: closeButtonA11yLabel,
-                                        closeButtonA11yId: closeButtonA11yIdentifier)
+        headerBanner.setupAccessibility(closeButtonA11yLabel: headerBannerCloseButtonA11yLabel,
+                                        closeButtonA11yId: headerBannerCloseButtonA11yIdentifier)
         siteProtectionHeader.setupAccessibility(closeButtonA11yLabel: closeButtonA11yLabel,
                                                 closeButtonA11yId: closeButtonA11yIdentifier)
         siteProtectionHeader.accessibilityIdentifier = siteProtectionHeaderIdentifier
@@ -171,12 +174,20 @@ public final class MenuRedesignMainView: UIView,
             self?.setupView(with: data, isHeaderBanner: false)
             self?.bannerShown = true
         }
+        headerBanner.bannerButtonCallback = { [weak self] in
+            self?.bannerButtonTapped()
+        }
     }
 
     // MARK: - Callbacks
     @objc
     private func closeTapped() {
         closeButtonCallback?()
+    }
+
+    @objc
+    private func bannerButtonTapped() {
+        bannerButtonCallback?()
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -77,6 +77,10 @@ struct AccessibilityIdentifiers {
             static let header = "MainMenu.SiteProtectionHeader"
         }
 
+        struct HeaderBanner {
+            static let closeButton = "MainMenu.HeaderBanner.CloseMenuButton"
+        }
+
         struct HeaderView {
             static let mainButton = "MainMenu.MainButton"
             static let closeButton = "MainMenu.CloseMenuButton"

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -147,6 +147,10 @@ class MainMenuViewController: UIViewController,
                 }
             }
 
+            menuRedesignContent.bannerButtonCallback = {
+                DefaultApplicationHelper().openSettings()
+            }
+
             menuRedesignContent.siteProtectionHeader.siteProtectionsButtonCallback = { [weak self] in
                 self?.dispatchSiteProtectionAction()
             }
@@ -481,7 +485,9 @@ class MainMenuViewController: UIViewController,
                     menuA11yLabel: .MainMenu.TabsSection.AccessibilityLabels.MainMenu,
                     closeButtonA11yLabel: .MainMenu.AccessibilityLabels.CloseButton,
                     closeButtonA11yIdentifier: AccessibilityIdentifiers.MainMenu.HeaderView.closeButton,
-                    siteProtectionHeaderIdentifier: AccessibilityIdentifiers.MainMenu.SiteProtectionsHeaderView.header)
+                    siteProtectionHeaderIdentifier: AccessibilityIdentifiers.MainMenu.SiteProtectionsHeaderView.header,
+                    headerBannerCloseButtonA11yIdentifier: AccessibilityIdentifiers.MainMenu.HeaderBanner.closeButton,
+                    headerBannerCloseButtonA11yLabel: .MainMenu.AccessibilityLabels.DismissBanner)
             } else {
                 menuContent.setupAccessibilityIdentifiers(
                     closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButton,

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4308,6 +4308,11 @@ extension String {
                 tableName: "MainMenu",
                 value: "Close Menu",
                 comment: "The accessibility label for the close button in the Main menu.")
+            public static let DismissBanner = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.DismissBanner.142",
+                tableName: "MainMenu",
+                value: "Dismiss banner",
+                comment: "The accessibility label for the dismiss button, for header banner, on top of the menu.")
         }
 
         public struct SiteProtection {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12673)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27612)

## :bulb: Description
Added accessbility sizes for Menu banner

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
