### PR TITLE
Add FXIOS-12758 [Summarizer] Add initial LiteLLMClient

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -63,6 +63,9 @@ public enum LoggerCategory: String {
     /// Related to storage (keychain, SQL database, store of different types, etc).
     case storage
 
+    /// Related to the AI summarizer.
+    case summarizer
+
     /// Related to sync accounts, sync management, application services.
     case sync
 

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1409,6 +1409,7 @@
 		BA4BB9A42D7FF754006BD137 /* DarkModeToggleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BB9A32D7FF74D006BD137 /* DarkModeToggleView.swift */; };
 		BA7A14842C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7A14832C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift */; };
 		BA8E197F2BF2FB1900590B5F /* AddressFormManager.js in Resources */ = {isa = PBXBuildFile; fileRef = BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */; };
+		BA9EBA1C2E1BDDF300A11D91 /* LiteLLMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9EBA1B2E1BDDEE00A11D91 /* LiteLLMClient.swift */; };
 		BACE70062DC110CA00E6102C /* ASTranslationModelsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE70052DC110C700E6102C /* ASTranslationModelsFetcher.swift */; };
 		BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
@@ -9192,6 +9193,7 @@
 		BA7A14832C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAddressWebViewManager.swift; sourceTree = "<group>"; };
 		BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AddressFormManager.js; sourceTree = "<group>"; };
 		BA904A3B89BC820A7A802D55 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/Storage.strings"; sourceTree = "<group>"; };
+		BA9EBA1B2E1BDDEE00A11D91 /* LiteLLMClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiteLLMClient.swift; sourceTree = "<group>"; };
 		BAA64356B54F1CD258764620 /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		BACE70052DC110C700E6102C /* ASTranslationModelsFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTranslationModelsFetcher.swift; sourceTree = "<group>"; };
 		BAF14FEC94CB9DA4E08BA60C /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Storage.strings; sourceTree = "<group>"; };
@@ -13680,6 +13682,14 @@
 			path = AppearanceSettings;
 			sourceTree = "<group>";
 		};
+		BA9EBA1A2E1BDDE400A11D91 /* Summary */ = {
+			isa = PBXGroup;
+			children = (
+				BA9EBA1B2E1BDDEE00A11D91 /* LiteLLMClient.swift */,
+			);
+			path = Summary;
+			sourceTree = "<group>";
+		};
 		C22753422A3CA25100B9C0D1 /* WebsiteDataManagement */ = {
 			isa = PBXGroup;
 			children = (
@@ -15514,6 +15524,7 @@
 		F84B21F11A0910F600AAB793 /* Frontend */ = {
 			isa = PBXGroup;
 			children = (
+				BA9EBA1A2E1BDDE400A11D91 /* Summary */,
 				8A1A93572B757C7B0069C190 /* LottieFiles */,
 				392ED7D51D0AEEEE009D9B62 /* Accessors */,
 				E692E3271C46E62D009D1240 /* AuthenticationManager */,
@@ -17364,6 +17375,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BA9EBA1C2E1BDDF300A11D91 /* LiteLLMClient.swift in Sources */,
 				8A4AC0EC28C929D700439F83 /* URLSessionProtocol.swift in Sources */,
 				C2A72A672A76938C002ACCE2 /* DownloadsCoordinator.swift in Sources */,
 				5FC276552894AEFF00AF2721 /* LibraryPanelHelper.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Summary/LiteLLMClient.swift
+++ b/firefox-ios/Client/Frontend/Summary/LiteLLMClient.swift
@@ -46,7 +46,6 @@ private struct Delta: Codable {
     let content: String?
 }
 
-
 /// Errors produced by LiteLLMClient, with user-friendly descriptions.
 public enum LLMClientError: LocalizedError {
     case requestCreationFailed
@@ -154,7 +153,7 @@ public class LiteLLMClient: NSObject {
 
         var payload: [String: Any] = [
             "model": model,
-            "messages": messages.map { ["role":  $0.role.rawValue, "content": $0.content] },
+            "messages": messages.map { ["role": $0.role.rawValue, "content": $0.content] },
             "max_tokens": maxTokens
         ]
 

--- a/firefox-ios/Client/Frontend/Summary/LiteLLMClient.swift
+++ b/firefox-ios/Client/Frontend/Summary/LiteLLMClient.swift
@@ -1,0 +1,236 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+/// Defines the role of an LLM message, catching typos at compile time.
+enum LiteLLMRole: String, Codable {
+    case system, user, assistant
+}
+
+/// Represents a single message exchanged with the LLM.
+public struct LiteLLMMessage: Codable {
+    let role: LiteLLMRole
+    let content: String
+}
+
+private struct LiteLLMResponse: Codable {
+    let id: String
+    let choices: [LiteLLMChoice]
+}
+
+private struct LiteLLMChoice: Codable {
+    let index: Int
+    let message: LiteLLMMessage?
+    let delta: LiteLLMMessage?
+    let finishReason: String?
+}
+
+private struct StreamResponse: Codable {
+    let id: String
+    let created: Int
+    let model: String
+    let object: String
+    let choices: [StreamChoice]
+}
+
+private struct StreamChoice: Codable {
+    let index: Int
+    let delta: Delta
+}
+
+private struct Delta: Codable {
+    let role: String?
+    let content: String?
+}
+
+
+/// Errors produced by LiteLLMClient, with user-friendly descriptions.
+public enum LLMClientError: LocalizedError {
+    case requestCreationFailed
+    case invalidResponse
+    case noContent
+    case decodingFailed
+    case networkError(underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .requestCreationFailed:
+            return "Unable to prepare the request. Please try again later."
+        case .invalidResponse:
+            return "Received an unexpected response from the server."
+        case .noContent:
+            return "The server returned no message."
+        case .decodingFailed:
+            return "Failed to read the server's response."
+        case .networkError:
+            return "Network error occurred. Check your connection and try again."
+        }
+    }
+}
+
+/// Delegate protocol for streaming chat completions.
+public protocol LiteLLMStreamDelegate: AnyObject {
+    /// Called when a new chunk of content is received.
+    func liteLLMClient(_ client: LiteLLMClient, didReceive text: String)
+    /// Called when the stream ends or errors out.
+    func liteLLMClient(_ client: LiteLLMClient, didFinishWith error: Error?)
+}
+
+/// A lightweight client for interacting with a chat completions endpoint.
+public class LiteLLMClient: NSObject {
+    /// NOTE: OpenAI like APIs including LiteLLM don't use websockets for streaming mode
+    /// but instead use Server Sent Events (SSE) to send chunked responses.
+    private static let sseEventDelimiter = "\n\n"
+    private static let sseDataPrefix = "data: "
+    private static let sseDoneSignal = "[DONE]"
+
+    private var logger: Logger = DefaultLogger.shared
+    private let apiKey: String
+    private let baseURL: URL
+    private lazy var session: URLSession = {
+        let config = URLSessionConfiguration.default
+        return URLSession(configuration: config, delegate: self, delegateQueue: nil)
+    }()
+
+    /// Delegate to receive streaming updates.
+    public weak var streamDelegate: LiteLLMStreamDelegate?
+
+    /// Initializes the client.
+    /// - Parameters:
+    ///   - apiKey: Your API key for authentication.
+    ///   - baseURL: Base URL of the server.
+    public init(apiKey: String, baseURL: URL) {
+        self.apiKey = apiKey
+        self.baseURL = baseURL
+    }
+
+    /// Sends a chat completion request.
+    /// - Parameters:
+    ///   - messages: Array of `ChatMessage`.
+    ///   - model: Model identifier.
+    ///   - maxTokens: Maximum tokens to generate.
+    ///   - stream: Whether to stream the response (`true`) or not (`false`).
+    ///   - completion: Completion handler for non-streaming requests. Ignored if `stream` is `true`.
+    public func requestChatCompletion(
+        messages: [LiteLLMMessage],
+        model: String = "fake-openai-endpoint-5",
+        maxTokens: Int = 1000,
+        stream: Bool = false,
+        completion: ((Result<String, Error>) -> Void)? = nil
+    ) {
+        do {
+            let request = try makeRequest(messages: messages, model: model, maxTokens: maxTokens, stream: stream)
+            if stream {
+                session.dataTask(with: request).resume()
+            } else {
+                URLSession.shared.dataTask(with: request) { data, _, error in
+                    self.handleResponse(data: data, error: error, completion: completion)
+                }.resume()
+            }
+        } catch {
+            if stream {
+                streamDelegate?.liteLLMClient(self, didFinishWith: LLMClientError.requestCreationFailed)
+            } else {
+                completion?(.failure(LLMClientError.requestCreationFailed))
+            }
+        }
+    }
+
+    // MARK: - Private Helpers
+    private func makeRequest(
+        messages: [LiteLLMMessage],
+        model: String,
+        maxTokens: Int,
+        stream: Bool
+    ) throws -> URLRequest {
+        let endpoint = baseURL.appendingPathComponent("chat/completions")
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        var payload: [String: Any] = [
+            "model": model,
+            "messages": messages.map { ["role":  $0.role.rawValue, "content": $0.content] },
+            "max_tokens": maxTokens
+        ]
+
+        if stream {
+            request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
+            request.addValue("keep-alive", forHTTPHeaderField: "Connection")
+            payload["stream"] = true
+        }
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        return request
+    }
+
+    private func handleResponse(
+        data: Data?,
+        error: Error?,
+        completion: ((Result<String, Error>) -> Void)?
+    ) {
+        // Network-level errors
+        if let err = error {
+            completion?(.failure(LLMClientError.networkError(underlying: err)))
+            return
+        }
+        // Missing or invalid data
+        guard let data = data else {
+            completion?(.failure(LLMClientError.invalidResponse))
+            return
+        }
+        // Parse JSON and extract content
+        do {
+            let response = try JSONDecoder().decode(LiteLLMResponse.self, from: data)
+            guard let content = response.choices.first?.message?.content else {
+                completion?(.failure(LLMClientError.noContent))
+                return
+            }
+            completion?(.success(content))
+        } catch {
+            completion?(.failure(LLMClientError.decodingFailed))
+        }
+    }
+}
+
+extension LiteLLMClient: URLSessionDataDelegate {
+    public func urlSession(_ session: URLSession,
+                           dataTask: URLSessionDataTask,
+                           didReceive data: Data) {
+        guard let text = String(data: data, encoding: .utf8) else { return }
+
+        for raw in text.components(separatedBy: Self.sseEventDelimiter) {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.hasPrefix(Self.sseDataPrefix) else { continue }
+            let payload = String(trimmed.dropFirst(Self.sseDataPrefix.count))
+
+            if payload == Self.sseDoneSignal {
+                streamDelegate?.liteLLMClient(self, didFinishWith: nil)
+                return
+            }
+
+            decodeAndForward(payload)
+        }
+    }
+
+    public func urlSession(_ session: URLSession,
+                           task: URLSessionTask,
+                           didCompleteWithError error: Error?) {
+        streamDelegate?.liteLLMClient(self, didFinishWith: error)
+    }
+
+    private func decodeAndForward(_ jsonString: String) {
+        guard
+            let data = jsonString.data(using: .utf8),
+            let chunk = try? JSONDecoder().decode(StreamResponse.self, from: data)
+        else { return }
+
+        if let content = chunk.choices.first?.delta.content {
+            streamDelegate?.liteLLMClient(self, didReceive: content)
+        }
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12758)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27778)

## :bulb: Description
This PR:
- Adds an initial `LiteLLMClient` to connect to openai like APIs.
- Adds both streaming and non-streaming modes.
- Adds support for different prompt roles ( to prevent prompt injection )

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
