### PR TITLE
Remove FXIOS-12705 [Messaging] Remove default browser message

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
@@ -48,6 +48,12 @@ class GleanPlumbMessageManagerTests: XCTestCase {
                 "messaging": [
                     "messages": [
                         "default-browser": [
+                            "title": "Default Browser/DefaultBrowserCard.Title",
+                            "text": "Default Browser/DefaultBrowserCard.Description",
+                            "button-label": "Default Browser/DefaultBrowserCard.Button.v2",
+                            "surface": "new-tab-card",
+                            "style": "FALLBACK",
+                            "action": "MAKE_DEFAULT_BROWSER_WITH_TUTORIAL",
                             "trigger-if-all": ["ALWAYS"],
                             "except-if-any": []
                         ]

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -23,19 +23,19 @@ import:
         # This message displays on the homescreen, asking the user to set Firefox as the default.
         # It is triggered after a minimum of 4 launches of the app.
         - value:
-            messages:
-              # default-browser:
-              #   surface: new-tab-card
-              #   style: FALLBACK
-              #   trigger-if-all:
-              #     - SUPPORTS_DEFAULT_BROWSER
-              #     - ON_FOURTH_LAUNCH_THIS_YEAR
-              #   except-if-any:
-              #     - I_AM_DEFAULT_BROWSER
-              #   title: Default Browser/DefaultBrowserCard.Title
-              #   text: Default Browser/DefaultBrowserCard.Description
-              #   button-label: Default Browser/DefaultBrowserCard.Button.v2
-              #   action: MAKE_DEFAULT_BROWSER_WITH_TUTORIAL
+            # messages:
+            # default-browser:
+            #   surface: new-tab-card
+            #   style: FALLBACK
+            #   trigger-if-all:
+            #     - SUPPORTS_DEFAULT_BROWSER
+            #     - ON_FOURTH_LAUNCH_THIS_YEAR
+            #   except-if-any:
+            #     - I_AM_DEFAULT_BROWSER
+            #   title: Default Browser/DefaultBrowserCard.Title
+            #   text: Default Browser/DefaultBrowserCard.Description
+            #   button-label: Default Browser/DefaultBrowserCard.Button.v2
+            #   action: MAKE_DEFAULT_BROWSER_WITH_TUTORIAL
             triggers:
               ON_FOURTH_LAUNCH_THIS_YEAR: "'app_cycle.foreground'|eventSum('Years', 1, 0) > 3"
 

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -24,18 +24,18 @@ import:
         # It is triggered after a minimum of 4 launches of the app.
         - value:
             messages:
-              default-browser:
-                surface: new-tab-card
-                style: FALLBACK
-                trigger-if-all:
-                  - SUPPORTS_DEFAULT_BROWSER
-                  - ON_FOURTH_LAUNCH_THIS_YEAR
-                except-if-any:
-                  - I_AM_DEFAULT_BROWSER
-                title: Default Browser/DefaultBrowserCard.Title
-                text: Default Browser/DefaultBrowserCard.Description
-                button-label: Default Browser/DefaultBrowserCard.Button.v2
-                action: MAKE_DEFAULT_BROWSER_WITH_TUTORIAL
+              # default-browser:
+              #   surface: new-tab-card
+              #   style: FALLBACK
+              #   trigger-if-all:
+              #     - SUPPORTS_DEFAULT_BROWSER
+              #     - ON_FOURTH_LAUNCH_THIS_YEAR
+              #   except-if-any:
+              #     - I_AM_DEFAULT_BROWSER
+              #   title: Default Browser/DefaultBrowserCard.Title
+              #   text: Default Browser/DefaultBrowserCard.Description
+              #   button-label: Default Browser/DefaultBrowserCard.Button.v2
+              #   action: MAKE_DEFAULT_BROWSER_WITH_TUTORIAL
             triggers:
               ON_FOURTH_LAUNCH_THIS_YEAR: "'app_cycle.foreground'|eventSum('Years', 1, 0) > 3"
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12705)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27675)

## :bulb: Description
Removing the evergreen message on the homepage for default browser. (I may need to add to this PR, as I can't currently test on Xcode, so using Bitrise to see if test are failing.)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
