### PR TITLE
 Refactor FXIOS-12765 [Swift 6 Migration] Mark closures in the `UserNotificationCenterProtocol` as `Sendable`

### DIFF
--- a/firefox-ios/Client/UserNotificationCenterProtocol.swift
+++ b/firefox-ios/Client/UserNotificationCenterProtocol.swift
@@ -5,16 +5,17 @@
 import Foundation
 import UserNotifications
 
-// Protocol with UNUserNotificationCenter methods so we can mock UNUserNotificationCenter for unit testing
+/// Protocol for `UNUserNotificationCenter` methods so we can mock `UNUserNotificationCenter` for unit testing. We do this
+/// because the `init` method is marked unavailable for subclasses of the `UNUserNotificationCenter` (can't override it).
 protocol UserNotificationCenterProtocol {
-    func getNotificationSettings(completionHandler: @escaping (UNNotificationSettings) -> Void)
+    func getNotificationSettings(completionHandler: @escaping @Sendable (UNNotificationSettings) -> Void)
     func requestAuthorization(options: UNAuthorizationOptions,
-                              completionHandler: @escaping (Bool, Error?) -> Void)
-    func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: ((Error?) -> Void)?)
-    func getPendingNotificationRequests(completionHandler: @escaping ([UNNotificationRequest]) -> Void)
+                              completionHandler: @escaping @Sendable (Bool, Error?) -> Void)
+    func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: (@Sendable (Error?) -> Void)?)
+    func getPendingNotificationRequests(completionHandler: @escaping @Sendable ([UNNotificationRequest]) -> Void)
     func removePendingNotificationRequests(withIdentifiers identifiers: [String])
     func removeAllPendingNotificationRequests()
-    func getDeliveredNotifications(completionHandler: @escaping ([UNNotification]) -> Void)
+    func getDeliveredNotifications(completionHandler: @escaping @Sendable ([UNNotification]) -> Void)
     func removeDeliveredNotifications(withIdentifiers identifiers: [String])
     func removeAllDeliveredNotifications()
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12765)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27795)

## :bulb: Description
We were seeing errors with our conformance to `UserNotificationCenterProtocol` because the underlying `UNUserNotificationCenter` methods have `Sendable` closures now.

Side note:
On my branch, this takes our Xcode 26 Beta 2 general warning count down to 18 (at least if the ContextMenuState warnings magically vanish when you open the file, as they seem to do for everyone!).

cc @Cramsden Swift 6 migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
