### PR TITLE
Refactor FXIOS-12765 [Swift 6 Migration] Non-sendable type capture inside PhotonActionSheetProtocol

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -76,8 +76,10 @@ extension PhotonActionSheetProtocol {
             accessibilityId: AccessibilityIdentifiers.Photon.pasteAction
         )
 
-        let copyAddressAction = SingleActionViewModel(title: .CopyAddressTitle,
-                                                      iconString: StandardImageIdentifiers.Large.link) { _ in
+        let copyAddressAction = SingleActionViewModel(
+            title: .CopyAddressTitle,
+            iconString: StandardImageIdentifiers.Large.link
+        ) { [tabManager] _ in
             let currentURL = tabManager.selectedTab?.currentURL()
             if let url = tabManager.selectedTab?.canonicalURL?.displayURL ?? currentURL {
                 UIPasteboard.general.url = url


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12765)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27795)

## :bulb: Description
Capturing `TabManager` into the closure rather than self to fix the error in `PhotonActionSheetProtocol`:

![Screenshot 2025-07-07 at 12 43 48 PM](https://github.com/user-attachments/assets/cdd1e3ac-2a23-4ce5-8546-7b7d4711e3d6)

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
