### PR TITLE
Refactor FXIOS-12765 [Swift 6 Migration] Remove whatsNewTopic from codebase since its not used

### DIFF
--- a/BrowserKit/Sources/Shared/AppInfo.swift
+++ b/BrowserKit/Sources/Shared/AppInfo.swift
@@ -34,19 +34,6 @@ extension AppInfo {
         return prefix + "." + bundleIdentifier
     }
 
-    // Return the MozWhatsNewTopic key from the Info.plist
-    public static var whatsNewTopic: String? {
-        // By default we don't want to add dot version to what's new section. Set
-        // this to true if you'd like to add dot version for whats new article.
-        let shouldAddDotVersion = false
-        let appVersionSplit = AppInfo.appVersion.components(separatedBy: ".")
-        let majorAppVersion = appVersionSplit[0]
-        var dotVersion = ""
-        if appVersionSplit.count > 1, appVersionSplit[0] != "0" { dotVersion = appVersionSplit[1] }
-        let topic = "whats-new-ios-\(majorAppVersion)\(shouldAddDotVersion ? dotVersion : "")"
-        return topic
-    }
-
     public static let debugPrefIsChinaEdition = "debugPrefIsChinaEdition"
 
     public static var isChinaEdition: Bool = {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12765)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27795)

## :bulb: Description
There was a warning under `AppInfo` in `BrowserKit`.

![Screenshot 2025-07-07 at 8 23 35 PM](https://github.com/user-attachments/assets/d42ed8c6-f768-4f17-8ca6-0eac996f8845)

But this code is not even used, so I'm proposing to remove it.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
