### PR TITLE
Refactor FXIOS-12765 [Swift 6 Migration] Changing to selector based observer in ContentFittingScrollView

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/SwiftUI/ContentFittingScrollView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/SwiftUI/ContentFittingScrollView.swift
@@ -101,6 +101,8 @@ public struct ContentFittingScrollView<Content: View>: UIViewRepresentable {
             }
         }
 
+        // For Dynamic Type changes, we need to completely recreate the hosting controller
+        // because SwiftUI views don't always update their intrinsic size properly
         private func recreateHostingController() {
             guard let containerView = self.containerView,
                   let oldHostingController = self.hostingController else { return }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12765)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27795)

## :bulb: Description
On Xcode 26, we have the following warning located inside `ContentFittingScrollView`:

![Screenshot 2025-07-07 at 8 32 35 PM](https://github.com/user-attachments/assets/17fe9b1a-9469-4741-a197-a909e94bd0f1)

The closure is implicitly assumed to be `@Sendable` because the queue is `.main`, and Swift tries to enforce isolation. Inside this closure, we are capturing `self`, which is of type `Coordinator`. But `Coordinator` stores a property of type `UIHostingController<Content>`, and `Content` is a generic `UIView`, not marked `Sendable` (and I don't think it can be `Sendable` either).

I am proposing to use a selector based observer instead which avoids the issue, let me know if this cannot be used. I am not sure how to test this code @razvanlitianu. 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
