### PR TITLE
Bugfix FXIOS-12499 [Toolbar] Shadow around address bar is cut off at the top and bottom

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -559,15 +559,17 @@ class BrowserViewController: UIViewController,
             let offset = scrollOffset ?? statusBarOverlay.scrollOffset
             topBlurView.alpha = isFxHomeTab ? offset : 1
 
-            // move addressToolbarContainer view to the front so the address toolbar shadow doesn't get clipped
+            // move views to the front so the address toolbar shadow doesn't get clipped
             overKeyboardContainer.bringSubviewToFront(addressToolbarContainer)
+            view.bringSubviewToFront(overKeyboardContainer)
         } else {
             header.isClearBackground = enableBlur
             overKeyboardContainer.isClearBackground = false
             topBlurView.alpha = 1
 
-            // move addressToolbarContainer view to the front so the address toolbar shadow doesn't get clipped
+            // move views to the front so the address toolbar shadow doesn't get clipped
             header.bringSubviewToFront(addressToolbarContainer)
+            view.bringSubviewToFront(header)
         }
 
         bottomContainer.isClearBackground = showNavToolbar && enableBlur


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12499)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27245)

## :bulb: Description
Move toolbar containing views to the front so the address toolbar shadow doesn't get clipped.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
