### PR TITLE
Refactor FXIOS-12765 [Xcode 26] Silence ContextMenuState and TabEventHandler warnings 

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -16,11 +16,12 @@ protocol BookmarksHandlerDelegate: AnyObject {
     func removeBookmark(urlString: String, title: String?, site: Site?)
 }
 
+// TODO: FXIOS-12781 Make ContextMenuState actually sendable
 /// State to populate actions for the `PhotonActionSheet` view
 /// Ideally, we want that view to subscribe to the store and update its state following the redux pattern
 /// For now, we will instantiate this state and populate the associated view model instead to avoid
 /// increasing scope of homepage rebuild project.
-struct ContextMenuState {
+struct ContextMenuState: @unchecked Sendable {
     var site: Site?
     var actions: [[PhotonRowActions]] = [[]]
 

--- a/firefox-ios/Client/TabManagement/TabEventHandler.swift
+++ b/firefox-ios/Client/TabManagement/TabEventHandler.swift
@@ -186,7 +186,7 @@ private class ObserverWrapper: NSObject {
 }
 
 extension TabEventHandler {
-    // TODO: FXIOS-12782 Using a weakHandler here is a cheat to silence sendable warnings. 
+    // TODO: FXIOS-12782 Using a weakHandler here is a cheat to silence sendable warnings.
     /// Implementations of handles should use this method to register for events.
     /// `TabObservers` should be preserved for unregistering later.
     func register(_ observer: AnyObject, forTabEvents events: TabEventLabel...) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12765)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This is by no means a cute or effective fix but does silence warnings so that I can build again. Follow up tickets were created to dig into these issues more. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
