### PR TITLE
Bugfix FXIOS-12703 [Homepage Redesign - Stories] Always show homepage sections on legacy homepage

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -78,14 +78,17 @@ public struct PrefsKeys {
 
     // For ease of use, please list keys alphabetically.
     public struct FeatureFlags {
-        public static let BookmarksSection = "BookmarksSectionUserPrefsKey"
         public static let DebugSuffixKey = "DebugKey"
         public static let FirefoxSuggest = "FirefoxSuggest"
         public static let InactiveTabs = "InactiveTabsUserPrefsKey"
-        public static let JumpBackInSection = "JumpBackInSectionUserPrefsKey"
         public static let SearchBarPosition = "SearchBarPositionUsersPrefsKey"
         public static let SponsoredShortcuts = "SponsoredShortcutsUserPrefsKey"
         public static let StartAtHome = "StartAtHomeUserPrefsKey"
+    }
+
+    public struct HomepageSettings {
+        public static let BookmarksSection = "BookmarksSectionUserPrefsKey"
+        public static let JumpBackInSection = "JumpBackInSectionUserPrefsKey"
     }
 
     public struct SearchSettings {

--- a/firefox-ios/Client/Frontend/Home/Bookmarks/BookmarksViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/Bookmarks/BookmarksViewModel.swift
@@ -111,8 +111,7 @@ extension BookmarksViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var isEnabled: Bool {
-        return !featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
-            || !featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly)
+        return profile.prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection) ?? true
     }
 
     var hasData: Bool {

--- a/firefox-ios/Client/Frontend/Home/Bookmarks/BookmarksViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/Bookmarks/BookmarksViewModel.swift
@@ -112,6 +112,7 @@ extension BookmarksViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
     var isEnabled: Bool {
         return !featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
+            || !featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly)
     }
 
     var hasData: Bool {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksSectionState.swift
@@ -21,9 +21,11 @@ struct BookmarksSectionState: StateType, Equatable, Hashable {
     )
 
     init(profile: Profile = AppContainer.shared.resolve(), windowUUID: WindowUUID) {
-        let shouldShowSection = !LegacyFeatureFlagsManager.shared.isFeatureEnabled(.homepageStoriesRedesign,
-                                                                                   checking: .buildOnly)
-                             && (profile.prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection) ?? true)
+        let isStoriesRedesignEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(.homepageStoriesRedesign,
+                                                                                         checking: .buildOnly)
+        let isBookmarksSectionPrefEnabled = profile.prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection) ?? true
+        let shouldShowSection = !isStoriesRedesignEnabled && isBookmarksSectionPrefEnabled
+
         self.init(
             windowUUID: windowUUID,
             bookmarks: [],

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksSectionState.swift
@@ -23,6 +23,7 @@ struct BookmarksSectionState: StateType, Equatable, Hashable {
     init(profile: Profile = AppContainer.shared.resolve(), windowUUID: WindowUUID) {
         let shouldShowSection = !LegacyFeatureFlagsManager.shared.isFeatureEnabled(.homepageStoriesRedesign,
                                                                                    checking: .buildOnly)
+                             && (profile.prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection) ?? true)
         self.init(
             windowUUID: windowUUID,
             bookmarks: [],

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksSectionState.swift
@@ -24,7 +24,7 @@ struct BookmarksSectionState: StateType, Equatable, Hashable {
         let isStoriesRedesignEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(.homepageStoriesRedesign,
                                                                                          checking: .buildOnly)
         let isBookmarksSectionPrefEnabled = profile.prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection) ?? true
-        let shouldShowSection = !isStoriesRedesignEnabled && isBookmarksSectionPrefEnabled
+        let shouldShowSection = isStoriesRedesignEnabled ? false : isBookmarksSectionPrefEnabled
 
         self.init(
             windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
@@ -27,9 +27,11 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
         windowUUID: WindowUUID
     ) {
         // TODO: FXIOS-11412 / 11226 - Move profile dependency and show section also based on feature flags
-        let shouldShowSection = !LegacyFeatureFlagsManager.shared.isFeatureEnabled(.homepageStoriesRedesign,
-                                                                                   checking: .buildOnly)
-                             && profile.prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection) ?? true
+        let isStoriesRedesignEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(.homepageStoriesRedesign,
+                                                                                         checking: .buildOnly)
+        let isJumpBackInSectionPrefEnabled = profile.prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection) ?? true
+        let shouldShowSection = !isStoriesRedesignEnabled && isJumpBackInSectionPrefEnabled
+
         self.init(
             windowUUID: windowUUID,
             jumpBackInTabs: [],

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
@@ -30,7 +30,7 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
         let isStoriesRedesignEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(.homepageStoriesRedesign,
                                                                                          checking: .buildOnly)
         let isJumpBackInSectionPrefEnabled = profile.prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection) ?? true
-        let shouldShowSection = !isStoriesRedesignEnabled && isJumpBackInSectionPrefEnabled
+        let shouldShowSection = isStoriesRedesignEnabled ? false : isJumpBackInSectionPrefEnabled
 
         self.init(
             windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
@@ -29,6 +29,7 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
         // TODO: FXIOS-11412 / 11226 - Move profile dependency and show section also based on feature flags
         let shouldShowSection = !LegacyFeatureFlagsManager.shared.isFeatureEnabled(.homepageStoriesRedesign,
                                                                                    checking: .buildOnly)
+                             && profile.prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection) ?? true
         self.init(
             windowUUID: windowUUID,
             jumpBackInTabs: [],

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -309,6 +309,7 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
 
     var isEnabled: Bool {
         let isEnabled = !featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
+                     || !featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly)
         return !isPrivate && isEnabled
     }
 

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -308,8 +308,7 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     }
 
     var isEnabled: Bool {
-        let isEnabled = !featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
-                     || !featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly)
+        let isEnabled = profile.prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection) ?? true
         return !isPrivate && isEnabled
     }
 

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -127,7 +127,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             let jumpBackInSetting = BoolSetting(
                 prefs: profile.prefs,
                 theme: themeManager.getCurrentTheme(for: windowUUID),
-                prefKey: PrefsKeys.FeatureFlags.JumpBackInSection,
+                prefKey: PrefsKeys.HomepageSettings.JumpBackInSection,
                 defaultValue: true,
                 titleText: .Settings.Homepage.CustomizeFirefoxHome.JumpBackIn
             ) { value in
@@ -144,7 +144,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             let bookmarksSetting = BoolSetting(
                 prefs: profile.prefs,
                 theme: themeManager.getCurrentTheme(for: windowUUID),
-                prefKey: PrefsKeys.FeatureFlags.BookmarksSection,
+                prefKey: PrefsKeys.HomepageSettings.BookmarksSection,
                 defaultValue: true,
                 titleText: .Settings.Homepage.CustomizeFirefoxHome.Bookmarks
             ) { value in

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -128,7 +128,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
                 prefs: profile.prefs,
                 theme: themeManager.getCurrentTheme(for: windowUUID),
                 prefKey: PrefsKeys.FeatureFlags.JumpBackInSection,
-                defaultValue: !featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly),
+                defaultValue: true,
                 titleText: .Settings.Homepage.CustomizeFirefoxHome.JumpBackIn
             ) { value in
                 store.dispatchLegacy(
@@ -145,7 +145,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
                 prefs: profile.prefs,
                 theme: themeManager.getCurrentTheme(for: windowUUID),
                 prefKey: PrefsKeys.FeatureFlags.BookmarksSection,
-                defaultValue: !featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly),
+                defaultValue: true,
                 titleText: .Settings.Homepage.CustomizeFirefoxHome.Bookmarks
             ) { value in
                 store.dispatchLegacy(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Redux
+import Shared
 import Storage
 import XCTest
 
@@ -106,15 +107,47 @@ final class JumpBackInSectionStateTests: XCTestCase {
         XCTAssertFalse(newState.shouldShowSection)
     }
 
-    func test_sectionShown_returnsExpectedState() {
+    func test_storiesDisabled_returnsExpectedState() {
         setupNimbusHomepageRedesignTesting(storiesRedesignEnabled: false)
 
         let initialState = createSubject()
         XCTAssertTrue(initialState.shouldShowSection)
     }
 
-    func test_sectionHidden_returnsExpectedState() {
+    func test_storiesEnabled_returnsExpectedState() {
         setupNimbusHomepageRedesignTesting(storiesRedesignEnabled: true)
+
+        let initialState = createSubject()
+        XCTAssertFalse(initialState.shouldShowSection)
+    }
+
+    func test_storiesDisabled_prefDisabled_returnsExpectedState() {
+        setupNimbusHomepageRedesignTesting(storiesRedesignEnabled: false)
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.JumpBackInSection)
+
+        let initialState = createSubject()
+        XCTAssertFalse(initialState.shouldShowSection)
+    }
+
+    func test_storiesDisabled_prefEnabled_returnsExpectedState() {
+        setupNimbusHomepageRedesignTesting(storiesRedesignEnabled: false)
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.HomepageSettings.JumpBackInSection)
+
+        let initialState = createSubject()
+        XCTAssertTrue(initialState.shouldShowSection)
+    }
+
+    func test_storiesEnabled_prefDisabled_returnsExpectedState() {
+        setupNimbusHomepageRedesignTesting(storiesRedesignEnabled: true)
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.JumpBackInSection)
+
+        let initialState = createSubject()
+        XCTAssertFalse(initialState.shouldShowSection)
+    }
+
+    func test_storiesEnabled_prefEnabled_returnsExpectedState() {
+        setupNimbusHomepageRedesignTesting(storiesRedesignEnabled: true)
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.HomepageSettings.JumpBackInSection)
 
         let initialState = createSubject()
         XCTAssertFalse(initialState.shouldShowSection)
@@ -122,7 +155,7 @@ final class JumpBackInSectionStateTests: XCTestCase {
 
     // MARK: - Private
     private func createSubject() -> JumpBackInSectionState {
-        return JumpBackInSectionState(windowUUID: .XCTestDefaultUUID)
+        return JumpBackInSectionState(profile: mockProfile, windowUUID: .XCTestDefaultUUID)
     }
 
     private func jumpBackInSectionReducer() -> Reducer<JumpBackInSectionState> {

--- a/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
@@ -16,7 +16,7 @@ features:
         default: false
       stories_redesign:
         description: >
-          If true, enables the stories section redesign on homepage
+          If true, enables the stories section redesign on homepage, which also includes the removal of other sections (i.e. jump back in, bookmarks)
         type: Boolean
         default: false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12703)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27673)

## :bulb: Description
- This prevents an issue where we weren't showing the bookmarks and jump back in sections on the legacy homepage when `stories_redesign` was enabled

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
