### PR TITLE
Add FXIOS-12706  [Homepage Redesign - Stories] Hide homepage section settings

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -123,7 +123,10 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         // Section ordering
         sectionItems.append(TopSitesSettings(settings: self))
 
-        if let profile {
+        let shouldHideSections = featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly)
+                              && featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
+
+        if let profile, !shouldHideSections {
             let jumpBackInSetting = BoolSetting(
                 prefs: profile.prefs,
                 theme: themeManager.getCurrentTheme(for: windowUUID),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12706)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27676)

## :bulb: Description
- Hide the bookmarks and jump back in section settings in homepage settings when the `homepage-rebuild-feature` and `stories_redesign` features are enabled

## :movie_camera: Demos

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 16 - 2025-07-08 at 15 35 05](https://github.com/user-attachments/assets/220db28f-e710-4d61-8225-1414a372c2c9) | ![Simulator Screenshot - iPhone 16 - 2025-07-08 at 15 36 17](https://github.com/user-attachments/assets/aa09be67-1e8b-450d-afde-7ce0ba1e4fc4) |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
