### PR TITLE
Bugfix FXIOS-12791 - iPad toolbar is set to the bottom if was previously set on iPhone

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -614,7 +614,7 @@ class BrowserViewController: UIViewController,
     }
 
     private func updateAddressToolbarContainerPosition(for traitCollection: UITraitCollection) {
-        guard searchBarPosition == .bottom, isToolbarRefactorEnabled else { return }
+        guard searchBarPosition == .bottom, isToolbarRefactorEnabled, isSearchBarLocationFeatureEnabled else { return }
 
         let isNavToolbar = toolbarHelper.shouldShowNavigationToolbar(for: traitCollection)
         let newPosition: SearchBarPosition = isNavToolbar ? .bottom : .top

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
@@ -61,7 +61,7 @@ extension HistoryPanel: UISearchBarDelegate {
         var snapshot = NSDiffableDataSourceSnapshot<HistoryPanelSections, HistoryItem>()
         snapshot.appendSections([HistoryPanelSections.searchResults])
         snapshot.appendItems(
-            self.viewModel.searchResultSites.map( { HistoryItem.site($0) })
+            self.viewModel.searchResultSites.map({ HistoryItem.site($0) })
         )
 
         self.diffableDataSource?.apply(snapshot, animatingDifferences: false)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12791)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27854)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- This bug is related to https://github.com/mozilla-mobile/firefox-ios/pull/27691. 
- I've added an additional flag to make sure it does not run for iPads.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
