### PR TITLE
Bugfix FXIOS-12715 [Homepage Redesign] Stories section not visible

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketMiddleware.swift
@@ -23,7 +23,8 @@ final class PocketMiddleware {
     lazy var pocketSectionProvider: Middleware<AppState> = { state, action in
         switch action.actionType {
         case HomepageActionType.initialize,
-            HomepageMiddlewareActionType.enteredForeground:
+            HomepageMiddlewareActionType.enteredForeground,
+            PocketActionType.toggleShowSectionSetting:
             self.getPocketDataAndUpdateState(for: action)
         case PocketActionType.tapOnHomepagePocketCell:
             self.sendOpenPocketItemTelemetry(for: action)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
@@ -56,7 +56,33 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageMiddlewareActionType.enteredForeground
         )
 
-        let expectation = XCTestExpectation(description: "Pocket action entered foreground dispatched")
+        let expectation = XCTestExpectation(description: "Homepage action entered foreground dispatched")
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.pocketSectionProvider(AppState(), action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? PocketAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? PocketMiddlewareActionType)
+
+        XCTAssertEqual(actionType, PocketMiddlewareActionType.retrievedUpdatedStories)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertTrue(mockStore.dispatchedActions.first is PocketAction)
+        XCTAssertEqual(actionCalled.pocketStories?.count, 3)
+        XCTAssertEqual(pocketManager.getPocketItemsCalled, 1)
+    }
+
+    func test_toggleShowSectionSetting_getPocketData() throws {
+        let subject = createSubject(pocketManager: pocketManager)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: PocketActionType.toggleShowSectionSetting
+        )
+
+        let expectation = XCTestExpectation(description: "Pocket action toggled show section setting dispatched")
         mockStore.dispatchCalled = {
             expectation.fulfill()
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12715)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27697)

## :bulb: Description
Need to re-trigger fetching stories data when user is toggling the settings for showing and hiding stories section. The issue is due to the PocketState reseting to empty and so we need to refetch the pocket stories.

Note: This issue will need to test in release build and not dev build. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
