### PR TITLE
Fix FXIOS-12785 [Rust Login] use queue .async since we are already running on serial queue

### DIFF
--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -285,10 +285,10 @@ public class RustLogins: LoginsProtocol, KeyManager {
     public func reopenIfClosed() -> NSError? {
         var error: NSError?
 
-        queue.sync {
-            guard !isOpen else { return }
+        queue.async {
+            guard !self.isOpen else { return }
 
-            error = open()
+            error = self.open()
         }
 
         return error
@@ -297,10 +297,10 @@ public class RustLogins: LoginsProtocol, KeyManager {
     public func forceClose() -> NSError? {
         var error: NSError?
 
-        queue.sync {
-            guard isOpen else { return }
+        queue.async {
+            guard self.isOpen else { return }
 
-            error = close()
+            error = self.close()
         }
 
         return error


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12785)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Use queue.async instead of .sync, because dispatchqueue is a serial queue by default. Work will still be run one at a time without blocking the main thread (the caller of this function) in order to execute the queued work.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
