### PR TITLE
 Refactor FXIOS-12765 [Swift 6 Migration] ContextMenuState Part 3

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -108,6 +108,10 @@ struct ContextMenuState {
     /// This action removes the tile out of the top sites.
     /// If site is pinned, it removes it from pinned and remove from top sites in general.
     private func getRemoveTopSiteAction(site: Site) -> PhotonRowActions {
+        // TODO: FXIOS-12750 ContextMenuState should be synchronized to the main actor, and then we won't need to pass
+        // this state across isolation boundaries...
+        let windowUUID = windowUUID
+
         return SingleActionViewModel(
             title: .RemoveContextMenuTitle,
             iconString: StandardImageIdentifiers.Large.cross,
@@ -122,6 +126,10 @@ struct ContextMenuState {
     }
 
     private func getPinTopSiteAction(site: Site) -> PhotonRowActions {
+        // TODO: FXIOS-12750 ContextMenuState should be synchronized to the main actor, and then we won't need to pass
+        // this state across isolation boundaries...
+        let windowUUID = windowUUID
+
         return SingleActionViewModel(
             title: .PinTopsiteActionTitle2,
             iconString: StandardImageIdentifiers.Large.pin,
@@ -138,6 +146,10 @@ struct ContextMenuState {
     /// This unpin action removes the top site from the location it's in.
     /// The tile can still appear in the top sites as unpinned.
     private func getRemovePinTopSiteAction(site: Site) -> PhotonRowActions {
+        // TODO: FXIOS-12750 ContextMenuState should be synchronized to the main actor, and then we won't need to pass
+        // this state across isolation boundaries...
+        let windowUUID = windowUUID
+
         return SingleActionViewModel(
             title: .UnpinTopsiteActionTitle2,
             iconString: StandardImageIdentifiers.Large.pinSlash,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12765)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27795)

## :bulb: Description
Continuing work of ContextMenuState Swift 6 fixes. Continued from Part 2 here: https://github.com/mozilla-mobile/firefox-ios/pull/27805

Not sure why these warnings didn't crop up until Beta 3.

cc @Cramsden Swift 6 migration

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
