### PR TITLE
Add FXIOS-12554 ⁃ [Menu Redesign] Handle Telemetry for menu

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -309,7 +309,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
                                 windowUUID: uuid,
                                 actionType: MainMenuActionType.tapNavigateToDestination,
                                 navigationDestination: MenuNavigationDestination(
-                                    .saveAsPDF,
+                                    .saveAsPDFV2,
                                     url: tabInfo.canonicalURL
                                 ),
                                 telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)
@@ -332,7 +332,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
                                 windowUUID: uuid,
                                 actionType: MainMenuActionType.tapNavigateToDestination,
                                 navigationDestination: MenuNavigationDestination(
-                                    .printSheet,
+                                    .printSheetV2,
                                     url: tabInfo.canonicalURL
                                 ),
                                 telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -119,13 +119,13 @@ class MainMenuCoordinator: BaseCoordinator, FeatureFlaggable {
             )
             navigationHandler?.showSignInView(fxaParameters: fxaParameters)
 
-        case .printSheet:
+        case .printSheet, .printSheetV2:
             navigationHandler?.showPrintSheet()
 
         case .shareSheet:
             navigationHandler?.showShareSheetForCurrentlySelectedTab()
 
-        case .saveAsPDF:
+        case .saveAsPDF, .saveAsPDFV2:
             navigationHandler?.presentSavePDFController()
 
         case .zoom:
@@ -133,6 +133,9 @@ class MainMenuCoordinator: BaseCoordinator, FeatureFlaggable {
 
         case .siteProtections:
             self.navigationHandler?.presentSiteProtections()
+
+        case .defaultBrowser:
+            DefaultApplicationHelper().openSettings()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -41,6 +41,8 @@ final class MainMenuMiddleware: FeatureFlaggable {
         static let nightModeTurnOn = "night_mode_turn_on"
         static let nightModeTurnOff = "night_mode_turn_off"
         static let back = "back"
+        static let siteProtections = "site_protections"
+        static let defaultBrowserSettings = "default_browser_settings"
     }
 
     private let logger: Logger
@@ -93,20 +95,35 @@ final class MainMenuMiddleware: FeatureFlaggable {
         case MainMenuDetailsActionType.tapZoom:
             telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
 
+        case MainMenuActionType.tapZoom:
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
+
         case MainMenuDetailsActionType.tapReportBrokenSite:
             telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
 
         case MainMenuDetailsActionType.tapAddToBookmarks:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
 
+        case MainMenuActionType.tapAddToBookmarks:
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
+
         case MainMenuDetailsActionType.tapEditBookmark:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
+
+        case MainMenuActionType.tapEditBookmark:
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
 
         case MainMenuDetailsActionType.tapAddToShortcuts:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
 
+        case MainMenuActionType.tapAddToShortcuts:
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
+
         case MainMenuDetailsActionType.tapRemoveFromShortcuts:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
+
+        case MainMenuActionType.tapRemoveFromShortcuts:
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
 
         case MainMenuDetailsActionType.tapAddToReadingList:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
@@ -114,8 +131,11 @@ final class MainMenuMiddleware: FeatureFlaggable {
         case MainMenuDetailsActionType.tapRemoveFromReadingList:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
 
-        case MainMenuDetailsActionType.tapToggleNightMode, MainMenuActionType.tapToggleNightMode:
+        case MainMenuDetailsActionType.tapToggleNightMode:
             handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
+
+        case MainMenuActionType.tapToggleNightMode:
+            handleTapToggleWebSiteDarkModeAction(action: action, isHomepage: isHomepage)
 
         case MainMenuDetailsActionType.tapBackToMainMenu:
             handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
@@ -242,6 +262,12 @@ final class MainMenuMiddleware: FeatureFlaggable {
         telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: option)
     }
 
+    private func handleTapToggleWebSiteDarkModeAction(action: MainMenuAction, isHomepage: Bool) {
+        guard let isActionOn = action.telemetryInfo?.isActionOn else { return }
+        let option = isActionOn ? TelemetryAction.nightModeTurnOn : TelemetryAction.nightModeTurnOff
+        telemetry.mainMenuOptionTapped(with: isHomepage, and: option)
+    }
+
     private func handleTapBackToMainMenuAction(action: MainMenuAction, isHomepage: Bool) {
         guard let submenuType = action.telemetryInfo?.submenuType else { return }
         if submenuType == .save {
@@ -327,11 +353,17 @@ final class MainMenuMiddleware: FeatureFlaggable {
         case .printSheet:
             telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.print)
 
+        case .printSheetV2:
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.print)
+
         case .shareSheet:
             telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.share)
 
         case .saveAsPDF:
             telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveAsPDF)
+
+        case .saveAsPDFV2:
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.saveAsPDF)
 
         case .syncSignIn:
             telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.signInAccount)
@@ -342,8 +374,11 @@ final class MainMenuMiddleware: FeatureFlaggable {
         case .zoom:
             self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
 
-        case .siteProtections: break
-            // TODO: FXIOS-12554 [Menu Redesign] Handle Telemetry for menu
+        case .siteProtections:
+            self.telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.siteProtections)
+
+        case .defaultBrowser:
+            self.telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.defaultBrowserSettings)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MenuNavigationDestination.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MenuNavigationDestination.swift
@@ -7,6 +7,7 @@ import Foundation
 enum MainMenuNavigationDestination: Equatable, CaseIterable {
     case bookmarks
     case customizeHomepage
+    case defaultBrowser
     case downloads
     case editBookmark
     case findInPage
@@ -19,8 +20,10 @@ enum MainMenuNavigationDestination: Equatable, CaseIterable {
     case siteProtections
     case syncSignIn
     case printSheet
+    case printSheetV2
     case shareSheet
     case saveAsPDF
+    case saveAsPDFV2
     case zoom
 }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -175,8 +175,8 @@ class MainMenuViewController: UIViewController,
                 }
             }
 
-            menuRedesignContent.bannerButtonCallback = {
-                DefaultApplicationHelper().openSettings()
+            menuRedesignContent.bannerButtonCallback = { [weak self] in
+                self?.dispatchDefaultBrowserAction()
             }
 
             menuRedesignContent.siteProtectionHeader.siteProtectionsButtonCallback = { [weak self] in
@@ -452,6 +452,17 @@ class MainMenuViewController: UIViewController,
                 windowUUID: self.windowUUID,
                 actionType: MainMenuActionType.tapNavigateToDestination,
                 navigationDestination: MenuNavigationDestination(.siteProtections),
+                currentTabInfo: menuState.currentTabInfo
+            )
+        )
+    }
+
+    private func dispatchDefaultBrowserAction() {
+        store.dispatchLegacy(
+            MainMenuAction(
+                windowUUID: self.windowUUID,
+                actionType: MainMenuActionType.tapNavigateToDestination,
+                navigationDestination: MenuNavigationDestination(.defaultBrowser),
                 currentTabInfo: menuState.currentTabInfo
             )
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12554)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27348)

## :bulb: Description
Added necessary telemetry for Menu

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
