### PR TITLE
Bugfix FXIOS-12792 ⁃ [Menu Redesign] The menu cannot be closed via swiping down while being in landscape mode

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -21,9 +21,7 @@ public final class MenuRedesignMainView: UIView,
 
     // MARK: - UI Elements
     private var tableView: MenuRedesignTableView = .build()
-    private lazy var closeButton: CloseButton = .build { button in
-        button.addTarget(self, action: #selector(self.closeTapped), for: .touchUpInside)
-    }
+
     public var headerBanner: HeaderBanner = .build()
 
     public var siteProtectionHeader: MenuSiteProtectionsHeader = .build()
@@ -50,25 +48,11 @@ public final class MenuRedesignMainView: UIView,
         self.addSubview(tableView)
         if let section = data.first(where: { $0.isHomepage }), section.isHomepage {
             self.siteProtectionHeader.removeFromSuperview()
-            if isPhoneLandscape {
-                self.addSubview(closeButton)
-                viewConstraints.append(contentsOf: [
-                    closeButton.topAnchor.constraint(equalTo: self.topAnchor, constant: UX.headerTopMargin),
-                    closeButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -UX.horizontalMargin),
-                    closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
-                    closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize)
-                ])
-            } else {
-                self.closeButton.removeFromSuperview()
-            }
-
-            let topAnchor = isPhoneLandscape ? closeButton.bottomAnchor : self.topAnchor
-
             if isHeaderBanner, isMenuDefaultBrowserBanner, !isBrowserDefault, !bannerShown {
                 isBannerVisible = true
                 self.addSubview(headerBanner)
                 viewConstraints.append(contentsOf: [
-                    headerBanner.topAnchor.constraint(equalTo: topAnchor, constant: UX.headerTopMargin),
+                    headerBanner.topAnchor.constraint(equalTo: self.topAnchor, constant: UX.headerTopMargin),
                     headerBanner.leadingAnchor.constraint(equalTo: self.leadingAnchor),
                     headerBanner.trailingAnchor.constraint(equalTo: self.trailingAnchor),
 
@@ -82,7 +66,7 @@ public final class MenuRedesignMainView: UIView,
                 isBannerVisible = false
                 headerBanner.removeFromSuperview()
                 viewConstraints.append(contentsOf: [
-                    tableView.topAnchor.constraint(equalTo: topAnchor,
+                    tableView.topAnchor.constraint(equalTo: self.topAnchor,
                                                    constant: UX.headerTopMarginWithButton),
                     tableView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
                     tableView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
@@ -92,7 +76,6 @@ public final class MenuRedesignMainView: UIView,
         } else if !data.isEmpty {
             isBannerVisible = false
             headerBanner.removeFromSuperview()
-            self.closeButton.removeFromSuperview()
             self.addSubview(siteProtectionHeader)
             viewConstraints.append(contentsOf: [
                 siteProtectionHeader.topAnchor.constraint(equalTo: self.topAnchor, constant: UX.headerTopMargin),
@@ -116,9 +99,6 @@ public final class MenuRedesignMainView: UIView,
                                               siteProtectionHeaderIdentifier: String,
                                               headerBannerCloseButtonA11yIdentifier: String,
                                               headerBannerCloseButtonA11yLabel: String) {
-        let closeButtonViewModel = CloseButtonViewModel(a11yLabel: closeButtonA11yLabel,
-                                                        a11yIdentifier: closeButtonA11yIdentifier)
-        closeButton.configure(viewModel: closeButtonViewModel)
         headerBanner.setupAccessibility(closeButtonA11yLabel: headerBannerCloseButtonA11yLabel,
                                         closeButtonA11yId: headerBannerCloseButtonA11yIdentifier)
         siteProtectionHeader.setupAccessibility(closeButtonA11yLabel: closeButtonA11yLabel,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -577,8 +577,18 @@ class BrowserCoordinator: BaseCoordinator,
     // MARK: - MainMenuCoordinatorDelegate
 
     func showMainMenu() {
-        guard let menuNavViewController = makeMenuNavViewController() else { return }
-        present(menuNavViewController)
+        if featureFlags.isFeatureEnabled(.menuRedesign, checking: .buildOnly) {
+            let mainMenuCoordinator = MainMenuCoordinator(router: router,
+                                                          windowUUID: tabManager.windowUUID,
+                                                          profile: profile)
+            mainMenuCoordinator.parentCoordinator = self
+            mainMenuCoordinator.navigationHandler = self
+            add(child: mainMenuCoordinator)
+            mainMenuCoordinator.startWithNavController()
+        } else {
+            guard let menuNavViewController = makeMenuNavViewController() else { return }
+            present(menuNavViewController)
+        }
     }
 
     func openURLInNewTab(_ url: URL?) {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -134,25 +134,6 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
             isHomepage: tabInfo.isHomepage,
             options: [
             MenuElement(
-                title: .MainMenu.PanelLinkSection.History,
-                iconName: Icons.history,
-                isEnabled: true,
-                isActive: false,
-                a11yLabel: .MainMenu.PanelLinkSection.AccessibilityLabels.History,
-                a11yHint: "",
-                a11yId: AccessibilityIdentifiers.MainMenu.history,
-                action: {
-                    store.dispatchLegacy(
-                        MainMenuAction(
-                            windowUUID: uuid,
-                            actionType: MainMenuActionType.tapNavigateToDestination,
-                            navigationDestination: MenuNavigationDestination(.history),
-                            telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)
-                        )
-                    )
-                }
-            ),
-            MenuElement(
                 title: .MainMenu.PanelLinkSection.Bookmarks,
                 iconName: Icons.bookmarksTray,
                 isEnabled: true,
@@ -166,6 +147,25 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
                             windowUUID: uuid,
                             actionType: MainMenuActionType.tapNavigateToDestination,
                             navigationDestination: MenuNavigationDestination(.bookmarks),
+                            telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.PanelLinkSection.History,
+                iconName: Icons.history,
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: .MainMenu.PanelLinkSection.AccessibilityLabels.History,
+                a11yHint: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.history,
+                action: {
+                    store.dispatchLegacy(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.tapNavigateToDestination,
+                            navigationDestination: MenuNavigationDestination(.history),
                             telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)
                         )
                     )

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -39,6 +39,20 @@ class MainMenuCoordinator: BaseCoordinator, FeatureFlaggable {
         super.init(router: router)
     }
 
+    func startWithNavController() {
+        let mainMenuViewController = createMainMenuViewController()
+
+        let mainMenuNavController = UINavigationController(rootViewController: mainMenuViewController)
+        mainMenuNavController.isNavigationBarHidden = true
+
+        if let sheetPresentationController = mainMenuNavController.sheetPresentationController {
+            sheetPresentationController.detents = [.medium(), .large()]
+        }
+        mainMenuNavController.sheetPresentationController?.prefersEdgeAttachedInCompactHeight = true
+        mainMenuNavController.sheetPresentationController?.prefersGrabberVisible = true
+        router.present(mainMenuNavController, animated: true, completion: nil)
+    }
+
     func start() {
         router.setRootViewController(
             createMainMenuViewController(),

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -160,7 +160,7 @@ class MainMenuViewController: UIViewController,
                 let customHeight: CGFloat = self?.currentCustomMenuHeight ?? 0
                 if (height > customHeight + UX.menuHeightTolerance) || (height < customHeight - UX.menuHeightTolerance) {
                     self?.currentCustomMenuHeight = height
-                    if #available(iOS 16.0, *), UIDevice.current.userInterfaceIdiom == .phone {
+                    if #available(iOS 16.0, *) {
                         let customDetent = UISheetPresentationController.Detent.custom { context in
                             return height
                         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12792)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27858)

## :bulb: Description
Changed the presentation mode for Menu
Changed the horizontal menu options order

https://github.com/user-attachments/assets/62dc0acb-5fc4-4799-a74b-d60fec01bd28

https://github.com/user-attachments/assets/d0764a0d-f217-4d72-99bd-b57ed09063db



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
