### PR TITLE
Bugfix FXIOS-12804 [Homepage Redesign - Stories] Story cell sizing cleanup

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -74,9 +74,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
                     fractionalWidth = UX.PocketConstants.redesignedFractionalWidthiPhonePortrait
                 }
 
-                return ((collectionViewWidth - UX.standardInset)
-                       * fractionalWidth)
-                       + UX.PocketConstants.storiesSpacing
+                return collectionViewWidth * fractionalWidth
             }
         }
 
@@ -246,13 +244,13 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(cellHeight)
+            heightDimension: .fractionalHeight(1.0)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .absolute(cellWidth),
-            heightDimension: .estimated(cellHeight)
+            heightDimension: .absolute(cellHeight)
         )
 
         let subItems = Array(repeating: item, count: UX.PocketConstants.redesignNumberOfItemsInColumn)
@@ -261,7 +259,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             top: 0,
             leading: 0,
             bottom: 0,
-            trailing: UX.PocketConstants.storiesSpacing)
+            trailing: 0)
 
         let section = NSCollectionLayoutSection(group: group)
 
@@ -276,8 +274,9 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         section.contentInsets = NSDirectionalEdgeInsets(top: 0,
                                                         leading: leadingInset,
                                                         bottom: UX.standardInset,
-                                                        trailing: 0)
+                                                        trailing: UX.standardInset)
         section.orthogonalScrollingBehavior = .continuous
+        section.interGroupSpacing = UX.PocketConstants.storiesSpacing
         return section
     }
 
@@ -506,7 +505,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
     // performance impacts were seen with this O(n) function (where n = number of cells needing to be created, currently 9)
     // TODO: FXIOS-12727 - Investigate replacing this code with `uniformAcrossSiblings` API in iOS 17+
     private func getTallestStoryCellHeight(cellWidth: CGFloat) -> CGFloat {
-        guard let  state = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID) else { return 0 }
+        guard let state = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID) else { return 0 }
         var storyCells: [StoryCell] = []
         for story in state.pocketState.pocketData {
             let cell = StoryCell()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12804)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27890)

## :bulb: Description
- Fixes an issue where stories cells were not always one uniform size due to cell width miscalculation

### 📝 Notes
- Add insets to the trailing edge of the section
- Replace story group trailing insets with section `interGroupSpacing`

| Before | After |
| - | - |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-09 at 22 07 49" src="https://github.com/user-attachments/assets/1bce5b31-45fb-4b35-9811-76a4dacb4b96" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-09 at 22 07 07" src="https://github.com/user-attachments/assets/97994881-502d-4d1a-9af7-27bcae924f7b" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
