### PR TITLE
 Refactor FXIOS-12765 [Swift 6 Migration] ContextMenuState Part 4

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -183,6 +183,7 @@ struct ContextMenuState {
         // TODO: FXIOS-12750 ContextMenuState should be synchronized to the main actor, and then we won't need to pass
         // this state across isolation boundaries...
         let windowUUID = windowUUID
+        let logger = logger
 
         return SingleActionViewModel(
             title: .FirefoxHomepage.ContextualMenu.SponsoredContent,
@@ -190,7 +191,7 @@ struct ContextMenuState {
             allowIconScaling: true,
             tapHandler: { _ in
                 guard let url = SupportUtils.URLForTopic("sponsor-privacy") else {
-                    self.logger.log(
+                    logger.log(
                         "Unable to retrieve URL for sponsor-privacy, return early",
                         level: .warning,
                         category: .homepage
@@ -303,7 +304,7 @@ struct ContextMenuState {
         return SingleActionViewModel(title: .RemoveBookmarkContextMenuTitle,
                                      iconString: StandardImageIdentifiers.Large.bookmarkSlash,
                                      allowIconScaling: true,
-                                     tapHandler: { _ in
+                                     tapHandler: { [bookmarkDelegate] _ in
             bookmarkDelegate.removeBookmark(urlString: site.url, title: site.title, site: site)
         })
     }
@@ -312,7 +313,7 @@ struct ContextMenuState {
         return SingleActionViewModel(title: .BookmarkContextMenuTitle,
                                      iconString: StandardImageIdentifiers.Large.bookmark,
                                      allowIconScaling: true,
-                                     tapHandler: { _ in
+                                     tapHandler: { [bookmarkDelegate] _ in
             // The method in BVC also handles the toast for this use case
             bookmarkDelegate.addBookmark(urlString: site.url, title: site.title, site: site)
         })


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12765)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27795)

## :bulb: Description
Continuing work of ContextMenuState Swift 6 fixes. Continued from Part 3 here: https://github.com/mozilla-mobile/firefox-ios/pull/27867

I noticed that after part 3 was merged, I was getting actual BUILD errors in Xcode 26 Beta 3 (??) on another branch. And these warnings didn't show up as live issues, I had to go into the report navigator to find them. 🙄 

@lmarceau Maybe for this one you can check it out and confirm it's actually passing in your Xcode 26 Beta 3? 😅 

cc @Cramsden Swift 6 migration

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
