### PR TITLE
BugFix FX-26694: Ensure only connections button uses voiceover

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -274,6 +274,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
     private func setupConnectionStatusView() {
         connectionView.addSubviews(connectionImage, connectionLabel, connectionDetailArrow, connectionButton)
         view.addSubview(connectionView)
+        setupConnectionAccessibilityConfiguration()
 
         let connectionConstraints = [
             connectionView.leadingAnchor.constraint(
@@ -428,6 +429,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
 
         siteDomainLabel.text = viewModel.websiteTitle
         connectionLabel.text = viewModel.connectionStatusString
+        connectionButton.accessibilityLabel = viewModel.connectionStatusString
         toggleSwitch.isOn = viewModel.isSiteETPEnabled
         toggleLabel.text = .TrackingProtectionEnableTitle
         toggleStatusLabel.text = toggleSwitch.isOn ? .ETPOn : .ETPOff
@@ -498,6 +500,15 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
                 }
             }
         }
+    }
+
+    private func setupConnectionAccessibilityConfiguration() {
+        connectionView.isAccessibilityElement = false
+        connectionImage.isAccessibilityElement = false
+        connectionLabel.isAccessibilityElement = false
+        connectionDetailArrow.isAccessibilityElement = false
+        connectionButton.isAccessibilityElement = true
+        connectionButton.accessibilityTraits = .button
     }
 
     private func currentTheme() -> Theme {

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionConnectionStatusView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionConnectionStatusView.swift
@@ -17,6 +17,7 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
         image.contentMode = .scaleAspectFit
         image.clipsToBounds = true
         image.layer.masksToBounds = true
+        image.isAccessibilityElement = false
     }
 
     private let connectionStatusLabel: UILabel = .build { label in
@@ -31,6 +32,7 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
             .withRenderingMode(.alwaysTemplate)
             .imageFlippedForRightToLeftLayoutDirection()
         image.transform = CGAffineTransform(rotationAngle: .pi)
+        image.isAccessibilityElement = false
     }
 
     private let connectionButton: UIButton = .build()
@@ -52,6 +54,7 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
     private func setupViews() {
         self.addSubviews(connectionStatusImage, connectionStatusLabel, connectionDetailArrow)
         self.addSubviews(connectionButton)
+        setupAccessibilityConfiguration()
     }
 
     private func updateLayout(isAccessibilityCategory: Bool) {
@@ -141,4 +144,11 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
         connectionStatusImage.tintColor = theme.colors.iconSecondary
         connectionDetailArrow.isHidden = !isConnectionSecure
     }
+    
+    private func setupAccessibilityConfiguration() {
+        self.isAccessibilityElement = false
+        connectionButton.isAccessibilityElement = true
+        connectionButton.accessibilityTraits = .button
+    }
 }
+

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionConnectionStatusView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionConnectionStatusView.swift
@@ -17,7 +17,6 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
         image.contentMode = .scaleAspectFit
         image.clipsToBounds = true
         image.layer.masksToBounds = true
-        image.isAccessibilityElement = false
     }
 
     private let connectionStatusLabel: UILabel = .build { label in
@@ -32,7 +31,6 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
             .withRenderingMode(.alwaysTemplate)
             .imageFlippedForRightToLeftLayoutDirection()
         image.transform = CGAffineTransform(rotationAngle: .pi)
-        image.isAccessibilityElement = false
     }
 
     private let connectionButton: UIButton = .build()
@@ -54,7 +52,6 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
     private func setupViews() {
         self.addSubviews(connectionStatusImage, connectionStatusLabel, connectionDetailArrow)
         self.addSubviews(connectionButton)
-        setupAccessibilityConfiguration()
     }
 
     private func updateLayout(isAccessibilityCategory: Bool) {
@@ -143,11 +140,5 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
         connectionButton.accessibilityLabel = text
         connectionStatusImage.tintColor = theme.colors.iconSecondary
         connectionDetailArrow.isHidden = !isConnectionSecure
-    }
-
-    private func setupAccessibilityConfiguration() {
-        self.isAccessibilityElement = false
-        connectionButton.isAccessibilityElement = true
-        connectionButton.accessibilityTraits = .button
     }
 }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionConnectionStatusView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionConnectionStatusView.swift
@@ -144,11 +144,10 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
         connectionStatusImage.tintColor = theme.colors.iconSecondary
         connectionDetailArrow.isHidden = !isConnectionSecure
     }
-    
+
     private func setupAccessibilityConfiguration() {
         self.isAccessibilityElement = false
         connectionButton.isAccessibilityElement = true
         connectionButton.accessibilityTraits = .button
     }
 }
-


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12252)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26694)

## :bulb: Description
Ensure that only the connection button is an accessibility element by setting isAccessibilityElement = false for all other elements.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
