### PR TITLE
Refactor FXIOS-12746 [Tab tray] Adjust padding below each tab row to match design

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -10,7 +10,7 @@ class TabsSectionManager: FeatureFlaggable {
         static let cellEstimatedWidth: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 250 : 170
         static let cellAbsoluteHeight: CGFloat = 200
         static let cardSpacing: CGFloat = 16
-        static let experimentCardSpacing: CGFloat = 40
+        static let experimentCardSpacing: CGFloat = 52
         static let experimentA11yCardSpacing: CGFloat = 72
         static let standardInset: CGFloat = 18
         static let iPadInset: CGFloat = 50


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12746)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27759)

## :bulb: Description
Updates space between each tab row.

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-11 at 11 42 30" src="https://github.com/user-attachments/assets/7d262975-d936-4b56-83a7-aa0691f85878" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-11 at 11 40 17" src="https://github.com/user-attachments/assets/6acfdeb1-1cec-40f0-a834-656615634c3a" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
