### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] HomepageRebuild - HomepageDiffableDatasource

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -34,7 +34,7 @@ final class HomepageDiffableDataSource:
         }
     }
 
-    enum HomeItem: Hashable {
+    enum HomeItem: Hashable, Sendable {
         case messageCard(MessageCardConfiguration)
         case topSite(TopSiteConfiguration, TextColor?)
         case topSiteEmpty

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInTabConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInTabConfiguration.swift
@@ -5,7 +5,12 @@
 import Foundation
 import Common
 
-struct JumpBackInTabConfiguration: Equatable, Hashable, CustomStringConvertible, CustomDebugStringConvertible {
+// TODO: FXIOS-12817 Fix @unchecked Sendable to due non-Sendable type 'Tab'
+struct JumpBackInTabConfiguration: @unchecked Sendable,
+                                   Equatable,
+                                   Hashable,
+                                   CustomStringConvertible,
+                                   CustomDebugStringConvertible {
     let tab: Tab
     let titleText: String
     let descriptionText: String

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketStoryConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketStoryConfiguration.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// Converts the pocket story model to be presentable for the `PocketStandardCell` view
-class PocketStoryConfiguration: Equatable, Hashable {
+final class PocketStoryConfiguration: Sendable, Equatable, Hashable {
     private let story: PocketStory
 
     init(story: PocketStory) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
In the Homepage Rebuild folder, saw some warnings related to `HomepageDiffableDatasource` in which `HomepageItem` does not conform to the Sendable protocol. 

| Main Error | Sub Errors |
| - | - |
| <img width="624" height="746" alt="image" src="https://github.com/user-attachments/assets/78261ab7-aff1-4ab9-8f16-559a1066f708" /> | <img width="616" height="110" alt="image" src="https://github.com/user-attachments/assets/46d891d7-e564-4140-860b-47ded87698dd" /> |

Updated `PocketStoryConfiguration` to be Sendable and made it `final`. `JumpBackInTabConfiguration` relies on `Tab` being Sendable, so add unchecked for now.
<img width="612" height="37" alt="image" src="https://github.com/user-attachments/assets/2114898d-6dbb-4710-954f-8cdb6257018f" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
