### PR TITLE
Add FXIOS-12725 [Homepage Redesign] new l10n strings

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SearchBar/SearchBarCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SearchBar/SearchBarCell.swift
@@ -21,7 +21,7 @@ class SearchBarCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
     }
 
     private lazy var placeholderLabel: UILabel = .build { view in
-        view.text = .TabLocationURLPlaceholder
+        view.text = .FirefoxHomepage.SearchBar.PlaceholderTitle
         view.font = FXFontStyles.Regular.body.scaledFont()
         view.textAlignment = .center
         view.numberOfLines = 0
@@ -38,7 +38,7 @@ class SearchBarCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
         isAccessibilityElement = true
         accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell
         accessibilityTraits.insert(.button)
-        accessibilityLabel = .TabLocationURLPlaceholder
+        accessibilityLabel = .FirefoxHomepage.SearchBar.PlaceholderTitle
     }
 
     private func setupView() {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -17,9 +17,8 @@ struct TopSitesSectionState: StateType, Equatable {
     let numberOfTilesPerRow: Int
     let shouldShowSection: Bool
 
-    // TODO: FXIOS-12725 - Add new l10n strings
     let sectionHeaderState = SectionHeaderConfiguration(
-        title: .Settings.Homepage.Shortcuts.ShortcutsPageTitle,
+        title: .FirefoxHomepage.Shortcuts.SectionTitle,
         a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.topSites
     )
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1048,6 +1048,11 @@ extension String {
         public struct RecentlySaved { }
 
         public struct Shortcuts {
+            public static let SectionTitle = MZLocalizedString(
+                key: "FirefoxHomepage.Shortcuts.SectionTitle.v142",
+                tableName: "FirefoxHomepage",
+                value: "Shortcuts",
+                comment: "This is the section title for the Shortcuts section on Firefox Homepage.")
             public static let Sponsored = MZLocalizedString(
                 key: "FirefoxHomepage.Shortcuts.Sponsored.v100",
                 tableName: nil,
@@ -1060,6 +1065,14 @@ extension String {
                 value: "Pinned: %@",
                 comment: "Accessibility label for shortcuts tile on the Firefox home page, indicating that the tile is a pinned tile. %@ is the title of the website."
             )
+        }
+
+        public struct SearchBar {
+            public static let PlaceholderTitle = MZLocalizedString(
+                key: "FirefoxHomepage.SearchBar.PlaceholderTitle.v142",
+                tableName: "FirefoxHomepage",
+                value: "Search or enter address",
+                comment: "This is the placeholder text that is at the center of the search bar on the Firefox Homepage.")
         }
 
         public struct YourLibrary { }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12725)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27714)

## :bulb: Description
Previously, we used existing strings so we can have translated strings for v141, but we eventually want separate strings and so this PR adds a new string for the search bar in the middle as well as the shortcuts heading.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
