### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix UIDeviceInterface warning

### DIFF
--- a/firefox-ios/Client/Protocols/UIDeviceInterface.swift
+++ b/firefox-ios/Client/Protocols/UIDeviceInterface.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 protocol UIDeviceInterface {
-    var userInterfaceIdiom: UIUserInterfaceIdiom { get }
+    @MainActor var userInterfaceIdiom: UIUserInterfaceIdiom { get }
 }
 
 extension UIDevice: UIDeviceInterface {}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Easy one! As you demo yesterday @ih-codes. `userInterfaceIdiom` variable [has a conformance](https://developer.apple.com/documentation/uikit/uidevice/userinterfaceidiom) to the `@MainActor`, and I'm just adding it in.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
