### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix ThemeApplicable warnings part 1

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorButtonModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorButtonModel.swift
@@ -14,7 +14,8 @@ struct TabTraySelectorButtonModel {
     let cornerRadius: CGFloat
 }
 
-final class TabTraySelectorButton: UIButton, ThemeApplicable {
+@MainActor
+final class TabTraySelectorButton: UIButton, @MainActor ThemeApplicable {
     private var foregroundColorNormal: UIColor = .clear
     private var foregroundColorHighlighted: UIColor = .clear
     private var backgroundColorNormal: UIColor = .clear

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -19,8 +19,9 @@ struct TabTraySelectorUX {
     static let stackViewLeadingTrailingPadding: CGFloat = 8
 }
 
-class TabTraySelectorView: UIView,
-                           ThemeApplicable {
+@MainActor
+final class TabTraySelectorView: UIView,
+                                 @MainActor ThemeApplicable {
     weak var delegate: TabTraySelectorDelegate?
 
     private var theme: Theme

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
@@ -13,7 +13,8 @@ protocol EmptyPrivateTabsViewDelegate: AnyObject {
 }
 
 // View we display when there are no private tabs created
-class EmptyPrivateTabsView: UIView, EmptyPrivateTabView {
+@MainActor
+class EmptyPrivateTabsView: UIView, @MainActor EmptyPrivateTabView {
     struct UX {
         static let paddingInBetweenItems: CGFloat = 15
         static let verticalPadding: CGFloat = 20

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
@@ -13,7 +13,8 @@ protocol EmptyPrivateTabView: UIView, ThemeApplicable {
 }
 
 // View we display when there are no private tabs created
-class ExperimentEmptyPrivateTabsView: UIView, EmptyPrivateTabView {
+@MainActor
+final class ExperimentEmptyPrivateTabsView: UIView, @MainActor EmptyPrivateTabView {
     struct UX {
         static let paddingInBetweenItems: CGFloat = 15
         static let verticalPadding: CGFloat = 20

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
@@ -12,7 +12,8 @@ protocol RemoteTabsEmptyViewProtocol: UIView, ThemeApplicable {
                    delegate: RemoteTabsEmptyViewDelegate?)
 }
 
-class ExperimentRemoteTabsEmptyView: UIView, RemoteTabsEmptyViewProtocol {
+@MainActor
+final class ExperimentRemoteTabsEmptyView: UIView, @MainActor RemoteTabsEmptyViewProtocol {
     struct UX {
         static let paddingInBetweenItems: CGFloat = 15
         static let verticalPadding: CGFloat = 20

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -9,7 +9,10 @@ import Shared
 import SiteImageView
 
 /// Tab cell used in the tab tray under the .tabTrayUIExperiments Nimbus experiment
-class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
+@MainActor
+final class ExperimentTabCell: UICollectionViewCell,
+                               @MainActor ThemeApplicable,
+                               ReusableCell {
     struct UX {
         static let selectedBorderWidth: CGFloat = 3.0
         static let unselectedBorderWidth: CGFloat = 1

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsCell.swift
@@ -6,7 +6,10 @@ import Common
 import SiteImageView
 import UIKit
 
-class InactiveTabsCell: UICollectionViewListCell, ReusableCell, ThemeApplicable {
+@MainActor
+final class InactiveTabsCell: UICollectionViewListCell,
+                              ReusableCell,
+                              @MainActor ThemeApplicable {
     struct UX {
         static let imageSize: CGFloat = 28
         static let labelTopBottomMargin: CGFloat = 11

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsFooterView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsFooterView.swift
@@ -6,7 +6,10 @@ import Common
 import ComponentLibrary
 import UIKit
 
-class InactiveTabsFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable {
+@MainActor
+final class InactiveTabsFooterView: UICollectionReusableView,
+                                    ReusableCell,
+                                    @MainActor ThemeApplicable {
     struct UX {
         static let buttonImagePadding: CGFloat = 11
         static let iPadOffset: CGFloat = 100

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsHeaderView.swift
@@ -5,7 +5,10 @@
 import Common
 import Foundation
 
-class InactiveTabsHeaderView: UICollectionReusableView, ReusableCell, ThemeApplicable {
+@MainActor
+final class InactiveTabsHeaderView: UICollectionReusableView,
+                                    ReusableCell,
+                                    @MainActor ThemeApplicable {
     private struct UX {
         static let titleMinimumScaleFactor: CGFloat = 0.7
         static let verticalPadding: CGFloat = 19

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
@@ -13,7 +13,8 @@ protocol RemoteTabsEmptyViewDelegate: AnyObject {
     func remotePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)
 }
 
-class RemoteTabsEmptyView: UIView, RemoteTabsEmptyViewProtocol {
+@MainActor
+final class RemoteTabsEmptyView: UIView, @MainActor RemoteTabsEmptyViewProtocol {
     struct UX {
         static let verticalPadding: CGFloat = 40
         static let horizontalPadding: CGFloat = 24

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -12,7 +12,10 @@ protocol TabCellDelegate: AnyObject {
     func tabCellDidClose(for tabUUID: TabUUID)
 }
 
-class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
+@MainActor
+final class TabCell: UICollectionViewCell,
+                     @MainActor ThemeApplicable,
+                     ReusableCell {
     struct UX {
         static let borderWidth: CGFloat = 3.0
         static let cornerRadius: CGFloat = 16

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -6,14 +6,15 @@ import Common
 import Redux
 import UIKit
 
-class TabDisplayView: UIView,
-                      ThemeApplicable,
-                      UICollectionViewDelegate,
-                      UICollectionViewDelegateFlowLayout,
-                      TabCellDelegate,
-                      SwipeAnimatorDelegate,
-                      InactiveTabsSectionManagerDelegate,
-                      FeatureFlaggable {
+@MainActor
+final class TabDisplayView: UIView,
+                            @MainActor ThemeApplicable,
+                            UICollectionViewDelegate,
+                            UICollectionViewDelegateFlowLayout,
+                            TabCellDelegate,
+                            SwipeAnimatorDelegate,
+                            InactiveTabsSectionManagerDelegate,
+                            FeatureFlaggable {
     struct UX {
         static let cornerRadius: CGFloat = 6.0
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTitleSupplementaryView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTitleSupplementaryView.swift
@@ -6,7 +6,10 @@ import Common
 import SiteImageView
 
 /// A supplementary view shown below the `ExperimentTabCell` containing the tab favicon and title
-final class TabTitleSupplementaryView: UICollectionReusableView, ThemeApplicable, ReusableCell {
+@MainActor
+final class TabTitleSupplementaryView: UICollectionReusableView,
+                                       @MainActor ThemeApplicable,
+                                       ReusableCell {
     struct UX {
         static let tabViewFooterSpacing: CGFloat = 4
         static let faviconSize = CGSize(width: 16, height: 16)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
We have 105 warnings of the type `Conformance of 'X' to protocol 'ThemeApplicable' crosses into main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode`.

<img width="2539" height="705" alt="Screenshot 2025-07-11 at 1 11 02 PM" src="https://github.com/user-attachments/assets/0d36578f-bbdd-42eb-9401-112d4ed846a0" />

I went first with an approach of making `ThemeApplicable` and `ThemeManager` `@MainActor` but this was basically breaking our whole application lol (every where we used those protocols needs to be main actor... otherwise its an error and not just a warning). 

So I tried to follow instead [Apple guidelines](https://docs.swift.org/compiler/documentation/diagnostics/conformance-isolation/) on how to fix this type of error,  I went with the first listed approach there to:

> If all of the operations used to satisfy the protocol’s requirements are on the same global actor (such as the main actor), the conformance itself can be isolated to that global actor. This allows the conformance to be used inside code running on that actor, but it cannot be used concurrently. A conformance can be isolated to a global actor the same way as anything else in the language, e.g.,

```
@MainActor
struct MyData: @MainActor P {
  func f() { }
}
```

The approach seems to enable gradual non-breaking changes, so I think it makes sense. Theme changes should be on the main thread and UI related work is also main thread. So I am proposing to fix only warnings in the tab tray views/cells area with this PR (around 10 warnings), if this is breaking something we'll know really quickly 😆 If this is approved, I'll slowly chip at the rest of the same `ThemeApplicable` warnings.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
