### PR TITLE
 Refactor FXIOS-12796 [Swift 6 Migration] SiteImageView Package - isolate global instance of requestQueue

### DIFF
--- a/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
@@ -18,7 +18,7 @@ public class DefaultSiteImageHandler: SiteImageHandler {
     /// reference to the same `DefaultSiteImageHandler` so we could properly queue and throttle requests to get favicon
     /// URLs, download images, etc. Since that's a large architectural change, for now lets use a static queue so we can
     /// prevent too many duplicate calls to remotely fetching URLs and images. (FXIOS-9830, revised FXIOS-9427 bugfix)
-    private(set) static var requestQueue: [String: Task<UIImage, Never>] = [:]
+    @MainActor private(set) static var requestQueue: [String: Task<UIImage, Never>] = [:]
 
     public static func factory() -> DefaultSiteImageHandler {
         return DefaultSiteImageHandler()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Synchronize access to the global instance of requestQueue to protect mutable state. This works because the only method to set it (`getFaviconImage`) is already `@MainActor` synchronized as well.

<img width="1398" height="416" alt="Screenshot 2025-07-11 at 12 27 17 PM" src="https://github.com/user-attachments/assets/e4c96459-7e14-47af-88ed-ab9fc4a98b36" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
