### PR TITLE
 Refactor FXIOS-12796 [Swift 6 Migration] Make LoggerFileManager Sendable

### DIFF
--- a/BrowserKit/Sources/Common/Protocols/FileManagerProtocol.swift
+++ b/BrowserKit/Sources/Common/Protocols/FileManagerProtocol.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public protocol FileManagerProtocol {
+public protocol FileManagerProtocol: Sendable {
     func fileExists(atPath path: String) -> Bool
     func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL]
     func contentsOfDirectory(atPath path: String) throws -> [String]

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -437,7 +437,7 @@ class MockURLAuthenticationChallengeSender: NSObject, URLAuthenticationChallenge
     func cancel(_ challenge: URLAuthenticationChallenge) {}
 }
 
-class MockFileManager: FileManagerProtocol {
+final class MockFileManager: FileManagerProtocol, @unchecked Sendable {
     var fileExistsCalled = 0
     var fileExists = false
     var urlsForDirectoryCalled = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Makes the `LoggerFileManager` `Sendable`, as required for the `DefaultLogger` implementation.

I made the helper method `static` so we could instantiate `let` properties on init instead of making a `var`.

<img width="1419" height="395" alt="DefaultLogger requires Sendable LoggerFileManager" src="https://github.com/user-attachments/assets/00d1248b-77df-482b-b3b5-1f294989b3da" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
