### PR TITLE
Refactor FXIOS-12823 [Tab tray UI experiment] Re-enable drag and drop

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -974,6 +974,7 @@
 		8A6B799B2CDBCF3D003C3077 /* TopSitesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B79992CDBCE2E003C3077 /* TopSitesManagerTests.swift */; };
 		8A6B799D2CDBDAE4003C3077 /* MockContileProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B799C2CDBDAE4003C3077 /* MockContileProvider.swift */; };
 		8A6B79A02CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B799F2CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift */; };
+		8A6CDB472DF9E78400F11139 /* MockTabDisplayViewDragAndDropInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6CDB462DF9E78400F11139 /* MockTabDisplayViewDragAndDropInteraction.swift */; };
 		8A6E13982A71BA4E00A88FA8 /* TabWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */; };
 		8A6E63C52D4946760040D355 /* JumpBackInCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63C42D49466C0040D355 /* JumpBackInCell.swift */; };
 		8A6E63C72D4946B90040D355 /* JumpBackInSectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63C62D4946B40040D355 /* JumpBackInSectionState.swift */; };
@@ -8415,6 +8416,7 @@
 		8A6B79992CDBCE2E003C3077 /* TopSitesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesManagerTests.swift; sourceTree = "<group>"; };
 		8A6B799C2CDBDAE4003C3077 /* MockContileProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockContileProvider.swift; sourceTree = "<group>"; };
 		8A6B799F2CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGoogleTopSiteManager.swift; sourceTree = "<group>"; };
+		8A6CDB462DF9E78400F11139 /* MockTabDisplayViewDragAndDropInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabDisplayViewDragAndDropInteraction.swift; sourceTree = "<group>"; };
 		8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabWebViewTests.swift; sourceTree = "<group>"; };
 		8A6E63C42D49466C0040D355 /* JumpBackInCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInCell.swift; sourceTree = "<group>"; };
 		8A6E63C62D4946B40040D355 /* JumpBackInSectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInSectionState.swift; sourceTree = "<group>"; };
@@ -14023,6 +14025,7 @@
 		C889D7D22858C85200121E1D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				8A6CDB462DF9E78400F11139 /* MockTabDisplayViewDragAndDropInteraction.swift */,
 				8A01FE3F2DF0CE49002C483B /* MockDateProvider.swift */,
 				8A9F4F042DC8F4ED004644B9 /* MockRemoteTabs.swift */,
 				8A9F4F022DC8F4E6004644B9 /* MockPlaces.swift */,
@@ -18815,6 +18818,7 @@
 				21FA8FB22AE856EB0013B815 /* MockTabTrayCoordinatorDelegate.swift in Sources */,
 				8A87B4382CC1A92D003A9239 /* MockPocketManager.swift in Sources */,
 				C8699152289177F5007ACC5C /* WallpaperNetworkingTests.swift in Sources */,
+				8A6CDB472DF9E78400F11139 /* MockTabDisplayViewDragAndDropInteraction.swift in Sources */,
 				C818AD452A2100BA007F30BC /* OnboardingNotificationCardHelperTests.swift in Sources */,
 				E1AEC178286E0CF500062E29 /* LegacyHomepageViewControllerTests.swift in Sources */,
 				8A4EA0D42C01100200E4E4F1 /* MicrosurveySurfaceManagerTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -48,7 +48,7 @@ class TabTrayCoordinator: BaseCoordinator,
         let tabTrayViewController = TabTrayViewController(panelType: panelType, windowUUID: tabManager.windowUUID)
         router.setRootViewController(tabTrayViewController)
         self.tabTrayViewController = tabTrayViewController
-        tabTrayViewController.childPanelControllers = makeChildPanels()
+        tabTrayViewController.childPanelControllers = makeChildPanels(dragAndDropDelegate: tabTrayViewController)
         tabTrayViewController.childPanelThemes = makeChildPanelThemes()
         tabTrayViewController.delegate = self
         tabTrayViewController.navigationHandler = self
@@ -58,10 +58,14 @@ class TabTrayCoordinator: BaseCoordinator,
         tabTrayViewController?.setupOpenPanel(panelType: tabTraySection)
     }
 
-    private func makeChildPanels() -> [UINavigationController] {
+    private func makeChildPanels(dragAndDropDelegate: TabDisplayViewDragAndDropInteraction) -> [UINavigationController] {
         let windowUUID = tabManager.windowUUID
-        let regularTabsPanel = TabDisplayPanelViewController(isPrivateMode: false, windowUUID: windowUUID)
-        let privateTabsPanel = TabDisplayPanelViewController(isPrivateMode: true, windowUUID: windowUUID)
+        let regularTabsPanel = TabDisplayPanelViewController(isPrivateMode: false,
+                                                             windowUUID: windowUUID,
+                                                             dragAndDropDelegate: dragAndDropDelegate)
+        let privateTabsPanel = TabDisplayPanelViewController(isPrivateMode: true,
+                                                             windowUUID: windowUUID,
+                                                             dragAndDropDelegate: dragAndDropDelegate)
         let syncTabs = RemoteTabsPanel(windowUUID: windowUUID)
 
         let panels: [UIViewController]

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -76,13 +76,15 @@ class TabDisplayPanelViewController: UIViewController,
     init(isPrivateMode: Bool,
          windowUUID: WindowUUID,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
-         themeManager: ThemeManager = AppContainer.shared.resolve()) {
+         themeManager: ThemeManager = AppContainer.shared.resolve(),
+         dragAndDropDelegate: TabDisplayViewDragAndDropInteraction) {
         self.panelType = isPrivateMode ? .privateTabs : .tabs
         self.tabsState = TabsPanelState(windowUUID: windowUUID, isPrivateMode: isPrivateMode)
         self.notificationCenter = notificationCenter
         self.themeManager = themeManager
         self.windowUUID = windowUUID
         super.init(nibName: nil, bundle: nil)
+        tabDisplayView.dragAndDropDelegate = dragAndDropDelegate
     }
 
     required init?(coder: NSCoder) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -6,6 +6,11 @@ import Common
 import Redux
 import UIKit
 
+protocol TabDisplayViewDragAndDropInteraction: AnyObject {
+    func dragAndDropStarted()
+    func dragAndDropEnded()
+}
+
 class TabDisplayView: UIView,
                       ThemeApplicable,
                       UICollectionViewDelegate,
@@ -26,6 +31,7 @@ class TabDisplayView: UIView,
     private let windowUUID: WindowUUID
     private let inactiveTabsTelemetry = InactiveTabsTelemetry()
     var theme: Theme?
+    weak var dragAndDropDelegate: TabDisplayViewDragAndDropInteraction?
 
     lazy var dataSource =
     TabDisplayDiffableDataSource(
@@ -126,10 +132,8 @@ class TabDisplayView: UIView,
         collectionView.keyboardDismissMode = .onDrag
         collectionView.dragInteractionEnabled = true
         collectionView.delegate = self
-        if !isTabTrayUIExperimentsEnabled {
-            collectionView.dragDelegate = self
-            collectionView.dropDelegate = self
-        }
+        collectionView.dragDelegate = self
+        collectionView.dropDelegate = self
         collectionView.collectionViewLayout = createLayout()
         collectionView.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.collectionView
         return collectionView
@@ -461,5 +465,13 @@ extension TabDisplayView: UICollectionViewDragDelegate, UICollectionViewDropDele
         )
 
         store.dispatchLegacy(action)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, dragSessionWillBegin session: UIDragSession) {
+        dragAndDropDelegate?.dragAndDropStarted()
+    }
+
+    func collectionView(_ collectionView: UICollectionView, dragSessionDidEnd session: UIDragSession) {
+        dragAndDropDelegate?.dragAndDropEnded()
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -30,7 +30,8 @@ class TabTrayViewController: UIViewController,
                              StoreSubscriber,
                              FeatureFlaggable,
                              TabTraySelectorDelegate,
-                             TabTrayAnimationDelegate {
+                             TabTrayAnimationDelegate,
+                             TabDisplayViewDragAndDropInteraction {
     typealias SubscriberStateType = TabTrayState
     private struct UX {
         struct NavigationMenu {
@@ -64,6 +65,7 @@ class TabTrayViewController: UIViewController,
 
     private lazy var panelContainer: UIView = .build { _ in }
     private var pageViewController: UIPageViewController?
+    private weak var pageScrollView: UIScrollView?
     private var swipeFromIndex: Int?
     private lazy var themeAnimator = TabTrayThemeAnimator()
 
@@ -996,5 +998,15 @@ class TabTrayViewController: UIViewController,
 
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         swipeFromIndex = nil
+    }
+
+    // MARK: TabDisplayViewDragAndDropInteraction
+
+    func dragAndDropStarted() {
+        pageScrollView?.isScrollEnabled = false
+    }
+
+    func dragAndDropEnded() {
+        pageScrollView?.isScrollEnabled = true
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabDisplayViewDragAndDropInteraction.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabDisplayViewDragAndDropInteraction.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+class MockTabDisplayViewDragAndDropInteraction: TabDisplayViewDragAndDropInteraction {
+    var dragAndDropStartedCalled = 0
+    var dragAndDropEndedCalled = 0
+
+    func dragAndDropStarted() {
+        dragAndDropStartedCalled += 1
+    }
+
+    func dragAndDropEnded() {
+        dragAndDropEndedCalled += 1
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
@@ -50,7 +50,10 @@ final class TabDisplayPanelTests: XCTestCase {
         let subjectState = createSubjectState(isPrivateMode: isPrivateMode,
                                               emptyTabs: emptyTabs,
                                               emptyInactiveTabs: emptyInactiveTabs)
-        let subject = TabDisplayPanelViewController(isPrivateMode: isPrivateMode, windowUUID: .XCTestDefaultUUID)
+        let delegate = MockTabDisplayViewDragAndDropInteraction()
+        let subject = TabDisplayPanelViewController(isPrivateMode: isPrivateMode,
+                                                    windowUUID: .XCTestDefaultUUID,
+                                                    dragAndDropDelegate: delegate)
         subject.newState(state: subjectState)
 
         trackForMemoryLeaks(subject, file: file, line: line)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
@@ -145,8 +145,13 @@ final class TabTrayViewControllerTests: XCTestCase {
     }
 
     private func makeChildPanels() -> [UINavigationController] {
-        let regularTabsPanel = TabDisplayPanelViewController(isPrivateMode: false, windowUUID: .XCTestDefaultUUID)
-        let privateTabsPanel = TabDisplayPanelViewController(isPrivateMode: true, windowUUID: .XCTestDefaultUUID)
+        let delegate = MockTabDisplayViewDragAndDropInteraction()
+        let regularTabsPanel = TabDisplayPanelViewController(isPrivateMode: false,
+                                                             windowUUID: .XCTestDefaultUUID,
+                                                             dragAndDropDelegate: delegate)
+        let privateTabsPanel = TabDisplayPanelViewController(isPrivateMode: true,
+                                                             windowUUID: .XCTestDefaultUUID,
+                                                             dragAndDropDelegate: delegate)
         let syncTabs = RemoteTabsPanel(windowUUID: .XCTestDefaultUUID)
         return [
             ThemedNavigationController(rootViewController: regularTabsPanel, windowUUID: windowUUID),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12823)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27933)

## :bulb: Description
Andy told me we should re-enable drag and drop inside the tab tray UI experiment. It was disabled as a "just in case". The delegate code in this PR was added in [this ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12489) to fix a bug. This basically reverts commit 9563b5ceceff2b2a3f7d1492ec9437c5ff91fb2a.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [X] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
