### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] OpenQLPreviewHelper + WKNavigationDelegate warnings

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -448,10 +448,11 @@ extension BrowserViewController: WKNavigationDelegate {
     // This is the place where we decide what to do with a new navigation action. There are a number of special schemes
     // and http(s) urls that need to be handled in a different way. All the logic for that is inside this delegate
     // method.
+    @MainActor
     func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationAction: WKNavigationAction,
-        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
     ) {
         // prevent the App from opening universal links
         // https://stackoverflow.com/questions/38450586/prevent-universal-links-from-opening-in-wkwebview-uiwebview
@@ -667,10 +668,11 @@ extension BrowserViewController: WKNavigationDelegate {
         handleDownloadFiles(downloadHelper: downloadHelper)
     }
 
+    @MainActor
     func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationResponse: WKNavigationResponse,
-        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+        decisionHandler: @escaping @MainActor (WKNavigationResponsePolicy) -> Void
     ) {
         let response = navigationResponse.response
         let responseURL = response.url
@@ -1017,10 +1019,11 @@ extension BrowserViewController: WKNavigationDelegate {
         }
     }
 
+    @MainActor
     func webView(
         _ webView: WKWebView,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        completionHandler: @escaping @MainActor (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
         guard challenge.protectionSpace.authenticationMethod != NSURLAuthenticationMethodServerTrust else {
             handleServerTrust(
@@ -1053,7 +1056,7 @@ extension BrowserViewController: WKNavigationDelegate {
             challenge: challenge,
             loginsHelper: loginsHelper
         ) { res in
-            self.mainQueue.async {
+            Task { @MainActor in
                 switch res {
                 case .success(let credentials):
                     completionHandler(.useCredential, credentials.credentials)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1267,9 +1267,10 @@ private extension BrowserViewController {
         return false
     }
 
-    func handleServerTrust(challenge: URLAuthenticationChallenge,
-                           dispatchQueue: DispatchQueueInterface,
-                           completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    func handleServerTrust(
+        challenge: URLAuthenticationChallenge,
+        dispatchQueue: DispatchQueueInterface,
+        completionHandler: @escaping @MainActor (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
         dispatchQueue.async {
             // If this is a certificate challenge, see if the certificate has previously been

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1280,13 +1280,13 @@ private extension BrowserViewController {
                   let cert = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
                   self.profile.certStore.containsCertificate(cert[0], forOrigin: origin)
             else {
-                self.mainQueue.async {
+                Task { @MainActor in
                     completionHandler(.performDefaultHandling, nil)
                 }
                 return
             }
 
-            self.mainQueue.async {
+            Task { @MainActor in
                 completionHandler(.useCredential, URLCredential(trust: trust))
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1023,7 +1023,7 @@ extension BrowserViewController: WKNavigationDelegate {
     func webView(
         _ webView: WKWebView,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping @MainActor (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        completionHandler: @escaping @Sendable @MainActor (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
         guard challenge.protectionSpace.authenticationMethod != NSURLAuthenticationMethodServerTrust else {
             handleServerTrust(
@@ -1270,7 +1270,7 @@ private extension BrowserViewController {
     func handleServerTrust(
         challenge: URLAuthenticationChallenge,
         dispatchQueue: DispatchQueueInterface,
-        completionHandler: @escaping @MainActor (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        completionHandler: @escaping @Sendable @MainActor (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
         dispatchQueue.async {
             // If this is a certificate challenge, see if the certificate has previously been

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -360,7 +360,6 @@ class BrowserViewController: UIViewController,
     weak var pendingDownloadWebView: WKWebView?
 
     let downloadQueue: DownloadQueue
-    let mainQueue: DispatchQueueInterface
     let userInitiatedQueue: DispatchQueueInterface
 
     private let bookmarksSaver: BookmarksSaver
@@ -397,7 +396,6 @@ class BrowserViewController: UIViewController,
         documentLogger: DocumentLogger = AppContainer.shared.resolve(),
         appAuthenticator: AppAuthenticationProtocol = AppAuthenticator(),
         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
-        mainQueue: DispatchQueueInterface = DispatchQueue.main,
         userInitiatedQueue: DispatchQueueInterface = DispatchQueue.global(qos: .userInitiated)
     ) {
         self.profile = profile
@@ -416,7 +414,6 @@ class BrowserViewController: UIViewController,
         self.bookmarksHandler = profile.places
         self.zoomManager = ZoomPageManager(windowUUID: tabManager.windowUUID)
         self.tabsPanelTelemetry = TabsPanelTelemetry(gleanWrapper: gleanWrapper, logger: logger)
-        self.mainQueue = mainQueue
         self.userInitiatedQueue = userInitiatedQueue
 
         super.init(nibName: nil, bundle: nil)

--- a/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenQLPreviewHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenQLPreviewHelper.swift
@@ -5,7 +5,7 @@
 import Foundation
 import QuickLook
 
-class OpenQLPreviewHelper: NSObject, QLPreviewControllerDataSource, QLPreviewControllerDelegate {
+final class OpenQLPreviewHelper: NSObject, QLPreviewControllerDataSource, QLPreviewControllerDelegate {
     private var previewItem = NSURL()
     private let presenter: Presenter
     private let previewController: QLPreviewController
@@ -49,18 +49,22 @@ class OpenQLPreviewHelper: NSObject, QLPreviewControllerDataSource, QLPreviewCon
         }
     }
 
+    // MARK: - QLPreviewControllerDelegate
+
+    @MainActor
     func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
         return 1
     }
 
+    @MainActor
     func previewController(_ controller: QLPreviewController,
                            previewItemAt index: Int) -> QLPreviewItem {
         return previewItem
     }
 
-    // MARK: - QLPreviewControllerDelegate
-
-    func previewControllerDidDismiss(_ controller: QLPreviewController) {
-        completionHandler?()
+    nonisolated func previewControllerDidDismiss(_ controller: QLPreviewController) {
+        Task { @MainActor in
+            self.completionHandler?()
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -32,6 +32,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         profile = nil
         tabManager = nil
         fileManager = nil
+        DependencyHelperMock().reset()
         super.tearDown()
     }
 
@@ -50,6 +51,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
     }
 
     // MARK: - Decide policy for navigation action
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_cancelWhenTabNotInTabManager() {
         let subject = createSubject()
         let url = URL(string: "https://example.com")!
@@ -62,6 +64,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_cancelFacetimeScheme() {
         let subject = createSubject()
         let url = URL(string: "facetime://testuser")!
@@ -75,6 +78,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_cancelFacetimeAudioScheme() {
         let subject = createSubject()
         let url = URL(string: "facetime-audio://testuser")!
@@ -88,6 +92,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_cancelTelScheme() {
         let subject = createSubject()
         let url = URL(string: "tel://3484563742")!
@@ -101,6 +106,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_cancelAppStoreScheme() {
         let subject = createSubject()
         let url = URL(string: "itms-apps://test-app")!
@@ -114,6 +120,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_cancelAppStoreURL() {
         let subject = createSubject()
         let url = URL(string: "https://apps.apple.com/test-app")!
@@ -127,6 +134,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_allowsAnyWebsite_withNormalTabs() {
         let subject = createSubject()
         let tab = createTab()
@@ -140,6 +148,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_allowsAnyWebsiteBlockingUniversalLink_whenOptionEnabled() {
         let subject = createSubject()
         let tab = createTab()
@@ -154,6 +163,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_allowsAnyWebsite_andBlockUniversalLinksWithPrivateTab() {
         let subject = createSubject()
         let tab = createTab(isPrivate: true)
@@ -167,6 +177,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_addRequestToPending() {
         let subject = createSubject()
         let tab = createTab()
@@ -180,6 +191,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_allowsLoading_whenBlobSchemeWithNavigationTypeOther() {
         let subject = createSubject()
         let tab = createTab()
@@ -193,6 +205,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_cancelLoading_withBlobScheme() {
         let subject = createSubject()
         let tab = createTab()
@@ -206,6 +219,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_cancelLoading_whenLoadingLocalPDFurlPreviouslyDeleted() {
         let subject = createSubject()
         let tab = createTab()
@@ -222,6 +236,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationAction_allowsLoading_whenLoadingLocalPDFurlPreviouslyDownloaded() {
         let subject = createSubject()
         let tab = createTab()
@@ -237,6 +252,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
     }
 
     // MARK: - Decide policy for navigation response
+    @MainActor
     func testWebViewDecidePolicyForNavigationResponse_cancelLoading_whenResponseIsPDFThatWasntDownloadedPreviously() {
         let subject = createSubject()
         let tab = createTab()
@@ -256,6 +272,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDecidePolicyForNavigationResponse_allowsLoading_whenResponseIsLocalPDFFileAlreadyDownloaded() {
         let subject = createSubject()
         let tab = createTab()
@@ -280,6 +297,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
 
     // MARK: - Authentication
 
+    @MainActor
     func testWebViewDidReceiveChallenge_MethodServerTrust() {
         let subject = createSubject()
 
@@ -292,6 +310,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDidReceiveChallenge_MethodHTTPDigest() {
         let subject = createSubject()
 
@@ -304,6 +323,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDidReceiveChallenge_MethodHTTPNTLM() {
         let subject = createSubject()
 
@@ -316,6 +336,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testWebViewDidReceiveChallenge_MethodHTTPBasic() {
         let subject = createSubject()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -353,7 +353,6 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         let subject = BrowserViewController(
             profile: profile,
             tabManager: tabManager,
-            mainQueue: MockDispatchQueue(),
             userInitiatedQueue: MockDispatchQueue()
         )
         trackForMemoryLeaks(subject)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description

### OpenQLPreviewHelper
Started by looking into this `OpenQLPreviewHelper` warning, which seemed similar to the other one that was fixed. 

<img width="1887" height="636" alt="Screenshot 2025-07-11 at 4 10 17 PM" src="https://github.com/user-attachments/assets/262333d9-20ee-48c0-905d-9a3e3dca2352" />

Two of the delegate calls were indeed marked now as `@MainActor` ([1](https://developer.apple.com/documentation/quicklook/qlpreviewcontrollerdatasource/previewcontroller(_:previewitemat:)), [2](https://developer.apple.com/documentation/quicklook/qlpreviewcontrollerdatasource/numberofpreviewitems(in:))).

The warning was still not going away even with those changes, and I found out the `previewControllerDidDismiss` was at cause (if I commented it the conformance warning was going away. I am proposing to make the `previewControllerDidDismiss` nonisolated to fix it, which means the `completionHandler` needs to be isolated
<img width="1918" height="332" alt="Screenshot 2025-07-11 at 4 13 43 PM" src="https://github.com/user-attachments/assets/d6fc3646-54ad-421f-9bd0-f060f7262599" />

### WKNavigationDelegate
By testing the `OpenQLPreviewHelper`, I stumbled on warnings that seemed small enough to include here too. The `WKNavigation` delegate calls are missing `@MainActor` annotations to match (in 3 places):

<img width="1884" height="427" alt="Screenshot 2025-07-11 at 3 40 47 PM" src="https://github.com/user-attachments/assets/1058eeb8-2fd0-40ff-9d9e-bdfc7a602248" />

Those completion handler were an throwing errors on 16.2 so I needed to include a fix for this too:

<img width="1887" height="365" alt="Screenshot 2025-07-11 at 4 14 21 PM" src="https://github.com/user-attachments/assets/bfcc4552-971f-452e-ba8d-1b282a54ff14" />

I can open those fixes in another PR if you think it's better that way! Let me know

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
