### PR TITLE
 Refactor FXIOS-12796 [Swift 6 Migration] (Big Refactor) `@MainActor` isolation of the app, starting from `ThemeApplicable`

### DIFF
--- a/BrowserKit/Sources/Common/Theming/ThemeApplicable.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeApplicable.swift
@@ -6,5 +6,6 @@ import Foundation
 
 // Used to pass in a theme to a view or cell to apply a theme
 public protocol ThemeApplicable {
+    @MainActor
     func applyTheme(theme: Theme)
 }

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public protocol ThemeManager {
+public protocol ThemeManager: Sendable {
     // Current theme
     func getCurrentTheme(for window: WindowUUID?) -> Theme
 

--- a/firefox-ios/Client/Application/WindowManager+DebugUtilities.swift
+++ b/firefox-ios/Client/Application/WindowManager+DebugUtilities.swift
@@ -8,6 +8,7 @@ import TabDataStore
 
 extension WindowManagerImplementation {
     /// For developer and internal debugging of Multi-window on iPad
+    @MainActor
     func _debugDiagnostics() -> String {
         func short(_ uuid: UUID) -> String { return String(uuid.uuidString.prefix(4)) }
         guard let del = (UIApplication.shared.delegate as? AppDelegate) else { return "<err>"}
@@ -52,6 +53,7 @@ extension WindowManagerImplementation {
 }
 
 /// Convenience. For developer and internal debugging
+@MainActor
 func _wndMgrDebug() -> String {
     let windowMgr: WindowManager = AppContainer.shared.resolve()
     return (windowMgr as? WindowManagerImplementation)?._debugDiagnostics() ?? "<err>"

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -44,6 +44,7 @@ protocol WindowManager {
 
     /// Signals the WindowManager that a window was closed.
     /// - Parameter uuid: the ID of the window.
+    @MainActor
     func windowWillClose(uuid: WindowUUID)
 
     /// Supplies the UUID for the next window the iOS app should open. This
@@ -60,10 +61,12 @@ protocol WindowManager {
     /// any one event is always associated with one window in specific.
     /// - Parameter event: the event that occurred and any associated metadata.
     /// - Parameter windowUUID: the UUID of the window triggering the event.
+    @MainActor
     func postWindowEvent(event: WindowEvent, windowUUID: WindowUUID)
 
     /// Performs a MultiWindowAction.
     /// - Parameter action: the action to perform.
+    @MainActor
     func performMultiWindowAction(_ action: MultiWindowAction)
 
     /// Returns the current window (if available) which hosts a specific tab.
@@ -145,6 +148,7 @@ final class WindowManagerImplementation: WindowManager {
         return Array(windows.keys) + (includingReserved ? reservedUUIDs : [])
     }
 
+    @MainActor
     func windowWillClose(uuid: WindowUUID) {
         postWindowEvent(event: .windowWillClose, windowUUID: uuid)
         updateWindow(nil, for: uuid)
@@ -236,6 +240,7 @@ final class WindowManagerImplementation: WindowManager {
         return result
     }
 
+    @MainActor
     func postWindowEvent(event: WindowEvent, windowUUID: WindowUUID) {
         windows.forEach { uuid, windowInfo in
             // Notify any interested Coordinators, in each window, of the
@@ -248,6 +253,7 @@ final class WindowManagerImplementation: WindowManager {
         }
     }
 
+    @MainActor
     func performMultiWindowAction(_ action: MultiWindowAction) {
         switch action {
         case .closeAllPrivateTabs:

--- a/firefox-ios/Client/ApplicationHelper.swift
+++ b/firefox-ios/Client/ApplicationHelper.swift
@@ -6,9 +6,18 @@ import Foundation
 import Common
 
 protocol ApplicationHelper {
+    @MainActor
     func openSettings()
+
+    @MainActor
     func open(_ url: URL)
+
+    @MainActor
     func open(_ url: URL, inWindow: WindowUUID)
+
+    // NOTE: I don't like how we can do this and then suddenly conforming methods are @MainActor without explicitly writing
+    // above each method...
+    @MainActor
     func closeTabs(_ urls: [URL]) async
 }
 

--- a/firefox-ios/Client/Coordinators/BaseCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/BaseCoordinator.swift
@@ -5,6 +5,7 @@
 import Common
 import Foundation
 
+@MainActor // maybe?
 open class BaseCoordinator: NSObject, Coordinator {
     var savedRoute: Route?
     var id = UUID()
@@ -42,8 +43,10 @@ open class BaseCoordinator: NSObject, Coordinator {
         return false
     }
 
+    @MainActor
     func handle(route: Route) { }
 
+    @MainActor
     @discardableResult
     func findAndHandle(route: Route) -> Coordinator? {
         guard let matchingCoordinator = find(route: route) else { return nil }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -14,6 +14,7 @@ import enum MozillaAppServices.VisitType
 import struct MozillaAppServices.CreditCard
 import ComponentLibrary
 
+@MainActor // maybe?
 class BrowserCoordinator: BaseCoordinator,
                           LaunchCoordinatorDelegate,
                           BrowserDelegate,
@@ -56,6 +57,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     override var isDismissable: Bool { false }
 
+    @MainActor
     init(router: Router,
          screenshotService: ScreenshotService,
          tabManager: TabManager,
@@ -115,7 +117,7 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     // MARK: - BrowserDelegate
-
+    @MainActor
     func showLegacyHomepage(
         inline: Bool,
         toastContainer: UIView,
@@ -140,6 +142,7 @@ class BrowserCoordinator: BaseCoordinator,
         screenshotService.screenshotableView = nil
     }
 
+    @MainActor
     func showHomepage(
         overlayManager: OverlayModeManager,
         isZeroSearch: Bool,
@@ -168,6 +171,7 @@ class BrowserCoordinator: BaseCoordinator,
         return homepageViewController ?? legacyHomepageViewController
     }
 
+    @MainActor
     func setHomepageVisibility(isVisible: Bool) {
         let homepage = homepageViewController ?? legacyHomepageViewController
         guard let homepage else { return }
@@ -184,6 +188,7 @@ class BrowserCoordinator: BaseCoordinator,
         )
     }
 
+    @MainActor
     func showPrivateHomepage(overlayManager: OverlayModeManager) {
         let privateHomepageController = PrivateHomepageViewController(
             windowUUID: windowUUID,
@@ -197,6 +202,7 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
+    @MainActor
     func navigateFromHomePanel(to url: URL, visitType: VisitType, isGoogleTopSite: Bool) {
         browserViewController.homePanel(didSelectURL: url, visitType: visitType, isGoogleTopSite: isGoogleTopSite)
     }
@@ -213,6 +219,7 @@ class BrowserCoordinator: BaseCoordinator,
         coordinator.start()
     }
 
+    @MainActor
     func showEditBookmark(parentFolder: FxBookmarkNode, bookmark: FxBookmarkNode) {
         let navigationController = DismissableNavigationViewController()
         let router = DefaultRouter(navigationController: navigationController)
@@ -234,6 +241,7 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     // MARK: - PrivateHomepageDelegate
+    @MainActor
     func homePanelDidRequestToOpenInNewTab(with url: URL, isPrivate: Bool, selectNewTab: Bool) {
         openInNewTab(url: url, isPrivate: isPrivate, selectNewTab: selectNewTab)
     }
@@ -243,6 +251,7 @@ class BrowserCoordinator: BaseCoordinator,
         browserViewController.tabManager.switchPrivacyMode()
     }
 
+    @MainActor
     func show(webView: WKWebView) {
         // Keep the webviewController in memory, update to newest webview when needed
         if let webviewController = webviewController {
@@ -274,6 +283,7 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
+    @MainActor
     private func getHomepage(inline: Bool,
                              toastContainer: UIView,
                              homepanelDelegate: HomePanelDelegate,
@@ -301,7 +311,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - ETPCoordinatorSSLStatusDelegate
 
-    var showHasOnlySecureContentInTrackingPanel: Bool {
+    @MainActor var showHasOnlySecureContentInTrackingPanel: Bool {
         if browserViewController.isToolbarRefactorEnabled {
             return browserViewController.tabManager.selectedTab?.currentWebView()?.hasOnlySecureContent ?? false
         }
@@ -394,6 +404,7 @@ class BrowserCoordinator: BaseCoordinator,
         startLaunch(with: launchType)
     }
 
+    @MainActor
     private func handleQRCode() {
         browserViewController.handleQRCode()
     }
@@ -406,6 +417,7 @@ class BrowserCoordinator: BaseCoordinator,
         windowManager.performMultiWindowAction(.closeAllPrivateTabs)
     }
 
+    @MainActor
     private func handle(homepanelSection section: Route.HomepanelSection) {
         switch section {
         case .bookmarks:
@@ -427,18 +439,22 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - Handle Deeplink Open URL / text
 
+    @MainActor
     private func handle(query: String, isPrivate: Bool) {
         browserViewController.handle(query: query, isPrivate: isPrivate)
     }
 
+    @MainActor
     private func handle(url: URL?, isPrivate: Bool, options: Set<Route.SearchOptions>? = nil) {
         browserViewController.handle(url: url, isPrivate: isPrivate, options: options)
     }
 
+    @MainActor
     private func handle(searchURL: URL?, tabId: String) {
         browserViewController.handle(url: searchURL, tabId: tabId)
     }
 
+    @MainActor
     private func handle(fxaParams: FxALaunchParams) {
         browserViewController.presentSignInViewController(fxaParams)
     }
@@ -447,6 +463,7 @@ class BrowserCoordinator: BaseCoordinator,
     /// - Parameters:
     ///   - shareType: The content to share.
     ///   - shareMessage: An optional textual message to accompany the shared content. May contain a Mail subject line.
+    @MainActor
     private func handleShareRoute(shareType: ShareType, shareMessage: ShareMessage?) {
         // FIXME: FXIOS-10829 Deep link shares should set a reasonable sourceView for iPad... or sourceView could be optional
         startShareSheetCoordinator(
@@ -466,6 +483,7 @@ class BrowserCoordinator: BaseCoordinator,
         return true
     }
 
+    @MainActor
     private func handleSettings(with section: Route.SettingsSection, onDismiss: (() -> Void)? = nil) {
         guard !childCoordinators.contains(where: { $0 is SettingsCoordinator }) else {
             return // route is handled with existing child coordinator
@@ -492,6 +510,7 @@ class BrowserCoordinator: BaseCoordinator,
         present(navigationController)
     }
 
+    @MainActor
     private func showLibrary(with homepanelSection: Route.HomepanelSection) {
         windowManager.postWindowEvent(event: .libraryOpened, windowUUID: windowUUID)
         if let libraryCoordinator = childCoordinators[LibraryCoordinator.self] {
@@ -524,6 +543,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - SettingsCoordinatorDelegate
 
+    @MainActor
     func openURLinNewTab(_ url: URL) {
         browserViewController.openURLInNewTab(url)
     }
@@ -533,6 +553,7 @@ class BrowserCoordinator: BaseCoordinator,
         remove(child: coordinator)
     }
 
+    @MainActor
     func openDebugTestTabs(count: Int) {
         guard let url = URL(string: "https://www.mozilla.org") else { return }
         browserViewController.debugOpen(numberOfNewTabs: count, at: url)
@@ -540,6 +561,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - LibraryCoordinatorDelegate
 
+    @MainActor
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
         browserViewController.openRecentlyClosedSiteInNewTab(url, isPrivate: isPrivate)
     }
@@ -570,12 +592,14 @@ class BrowserCoordinator: BaseCoordinator,
         remove(child: coordinator)
     }
 
+    @MainActor
     func settingsOpenPage(settings: Route.SettingsSection) {
         handleSettings(with: settings)
     }
 
     // MARK: - MainMenuCoordinatorDelegate
 
+    @MainActor
     func showMainMenu() {
         if featureFlags.isFeatureEnabled(.menuRedesign, checking: .buildOnly) {
             let mainMenuCoordinator = MainMenuCoordinator(router: router,
@@ -591,12 +615,14 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
+    @MainActor
     func openURLInNewTab(_ url: URL?) {
         if let url {
             browserViewController.openURLInNewTab(url, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false)
         }
     }
 
+    @MainActor
     func openNewTab(inPrivateMode isPrivate: Bool) {
         browserViewController.openNewTabFromMenu(
             focusLocationField: true,
@@ -604,25 +630,30 @@ class BrowserCoordinator: BaseCoordinator,
         )
     }
 
+    @MainActor
     func showLibraryPanel(_ panel: Route.HomepanelSection) {
         showLibrary(with: panel)
     }
 
+    @MainActor
     func showSettings(at destination: Route.SettingsSection) {
         presentWithModalDismissIfNeeded {
             self.handleSettings(with: destination, onDismiss: nil)
         }
     }
 
+    @MainActor
     func editBookmarkForCurrentTab() {
         guard let urlString = tabManager.selectedTab?.url?.absoluteString else { return }
         browserViewController.openBookmarkEditPanel(urlString: urlString)
     }
 
+    @MainActor
     func showFindInPage() {
         browserViewController.showFindInPage()
     }
 
+    @MainActor
     func updateZoomPageBarVisibility() {
         browserViewController.updateZoomPageBarVisibility(visible: true)
     }
@@ -630,6 +661,7 @@ class BrowserCoordinator: BaseCoordinator,
     /// Share the currently selected tab using the share sheet.
     ///
     /// Part of the MainMenuCoordinatorDelegate implementation, called from the New Menu > Tools > Share.
+    @MainActor
     func showShareSheetForCurrentlySelectedTab() {
         // We share the tab's displayURL to make sure we don't share reader mode localhost URLs
         guard let selectedTab = tabManager.selectedTab,
@@ -647,10 +679,12 @@ class BrowserCoordinator: BaseCoordinator,
         )
     }
 
+    @MainActor
     func presentSiteProtections() {
         showETPMenu(sourceView: browserViewController.addressToolbarContainer)
     }
 
+    @MainActor
     func presentSavePDFController() {
         guard let selectedTab = browserViewController.tabManager.selectedTab else { return }
         if selectedTab.mimeType == MIMEType.PDF {
@@ -687,6 +721,7 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
+    @MainActor
     func showPrintSheet() {
         if let tab = browserViewController.tabManager.selectedTab, let webView = tab.webView {
             let printInfo = UIPrintInfo(dictionary: nil)
@@ -698,6 +733,7 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
+    @MainActor
     private func makeMenuNavViewController() -> DismissableNavigationViewController? {
         if let mainMenuCoordinator = childCoordinators.first(where: { $0 is MainMenuCoordinator }) as? MainMenuCoordinator {
             mainMenuCoordinator.dismissMenuModal(animated: false)
@@ -724,6 +760,7 @@ class BrowserCoordinator: BaseCoordinator,
         return navigationController
     }
 
+    @MainActor
     func showSignInView(fxaParameters: FxASignInViewParameters?) {
         guard let fxaParameters else { return }
         browserViewController.presentSignInViewController(fxaParameters.launchParameters,
@@ -733,6 +770,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - SearchEngineSelectionCoordinatorDelegate
 
+    @MainActor
     func showSearchEngineSelection(forSourceView sourceView: UIView) {
         guard !childCoordinators.contains(where: { $0 is SearchEngineSelectionCoordinator }) else { return }
         let isEditing = store.state.screenState(ToolbarState.self,
@@ -768,6 +806,7 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     // MARK: - BrowserNavigationHandler
+    @MainActor
     func openInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
         browserViewController.homePanelDidRequestToOpenInNewTab(
             url,
@@ -793,6 +832,7 @@ class BrowserCoordinator: BaseCoordinator,
         )
     }
 
+    @MainActor
     func show(settings: Route.SettingsSection, onDismiss: (() -> Void)? = nil) {
         presentWithModalDismissIfNeeded {
             self.handleSettings(with: settings, onDismiss: onDismiss)
@@ -801,6 +841,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     /// Not all flows are handled by coordinators at the moment so we can't call router.dismiss for all
     /// This bridges to use the presentWithModalDismissIfNeeded method we have in older flows
+    @MainActor
     private func presentWithModalDismissIfNeeded(completion: @escaping () -> Void) {
         if let presentedViewController = router.navigationController.presentedViewController {
             presentedViewController.dismiss(animated: false, completion: {
@@ -811,6 +852,7 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
+    @MainActor
     func show(homepanelSection: Route.HomepanelSection) {
         showLibrary(with: homepanelSection)
     }
@@ -893,6 +935,7 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
+    @MainActor
     func showCreditCardAutofill(creditCard: CreditCard?,
                                 decryptedCard: UnencryptedCreditCardFields?,
                                 viewType state: CreditCardBottomSheetState,
@@ -909,17 +952,18 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     @MainActor
-    @preconcurrency
     func showSavedLoginAutofill(tabURL: URL, currentRequestId: String, field: FocusFieldType) {
         let bottomSheetCoordinator = makeCredentialAutofillCoordinator()
         bottomSheetCoordinator.showSavedLoginAutofill(tabURL: tabURL, currentRequestId: currentRequestId, field: field)
     }
 
+    @MainActor
     func showAddressAutofill(frame: WKFrameInfo?) {
         let bottomSheetCoordinator = makeAddressAutofillCoordinator()
         bottomSheetCoordinator.showAddressAutofill(frame: frame)
     }
 
+    @MainActor
     func showRequiredPassCode() {
         let bottomSheetCoordinator = makeCredentialAutofillCoordinator()
         bottomSheetCoordinator.showPassCodeController()
@@ -957,6 +1001,7 @@ class BrowserCoordinator: BaseCoordinator,
         return bottomSheetCoordinator
     }
 
+    @MainActor
     func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController?) {
         windowManager.postWindowEvent(event: .qrScannerOpened, windowUUID: windowUUID)
         var coordinator: QRCodeCoordinator
@@ -980,6 +1025,7 @@ class BrowserCoordinator: BaseCoordinator,
         coordinator.showQRCode(delegate: delegate)
     }
 
+    @MainActor
     func showTabTray(selectedPanel: TabTrayPanelType) {
         guard !childCoordinators.contains(where: { $0 is TabTrayCoordinator }) else {
             return // flow is already handled
@@ -1025,6 +1071,7 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     // This implementation of present is specifically for the animation on .tabTrayUIExperiments
+    @MainActor
     private func present(_ viewController: UIViewController,
                          customTransition: UIViewControllerTransitioningDelegate,
                          style: UIModalPresentationStyle) {
@@ -1040,11 +1087,13 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
+    @MainActor
     private func present(_ viewController: UIViewController) {
         browserViewController.willNavigateAway(from: tabManager.selectedTab)
         router.present(viewController)
     }
 
+    @MainActor
     func showBackForwardList() {
         guard let backForwardList = tabManager.selectedTab?.backForwardList else { return }
         let backForwardListVC = BackForwardListViewController(profile: profile,
@@ -1057,16 +1106,19 @@ class BrowserCoordinator: BaseCoordinator,
         present(backForwardListVC)
     }
 
+    @MainActor
     func showDocumentLoading() {
         browserViewController.showDocumentLoadingView()
     }
 
+    @MainActor
     func removeDocumentLoading() {
         browserViewController.removeDocumentLoadingView()
     }
 
     // MARK: Microsurvey
 
+    @MainActor
     func showMicrosurvey(model: MicrosurveyModel) {
         guard !childCoordinators.contains(where: { $0 is MicrosurveyCoordinator }) else {
             return
@@ -1093,6 +1145,7 @@ class BrowserCoordinator: BaseCoordinator,
         present(navigationController)
     }
 
+    @MainActor
     func showNativeErrorPage(overlayManager: OverlayModeManager) {
         let errorPageController = NativeErrorPageViewController(
             windowUUID: windowUUID,
@@ -1105,12 +1158,14 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
+    @MainActor
     private func setiPadLayoutDetents(for controller: UIViewController) {
         guard controller.shouldUseiPadSetup() else { return }
         controller.sheetPresentationController?.selectedDetentIdentifier = .large
     }
 
     // MARK: - Password Generator
+    @MainActor
     func showPasswordGenerator(tab: Tab, frame: WKFrameInfo) {
         let passwordGenVC = PasswordGeneratorViewController(windowUUID: windowUUID, currentTab: tab, currentFrame: frame)
 
@@ -1165,6 +1220,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - WindowEventCoordinator
 
+    @MainActor
     func coordinatorHandleWindowEvent(event: WindowEvent, uuid: WindowUUID) {
         switch event {
         case .windowWillClose:
@@ -1239,6 +1295,7 @@ class BrowserCoordinator: BaseCoordinator,
     /// - Parameters:
     ///   - coordinatorType: the type of coordinator.
     ///   - action: the action to perform. The Coordinator instance is supplied for convenience.
+    @MainActor
     private func performIfCoordinatorRootVCIsPresented<T: Coordinator>(_ coordinatorType: T.Type,
                                                                        action: (T) -> Void) {
         guard let expectedCoordinator = childCoordinators[coordinatorType] else { return }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -14,6 +14,7 @@ protocol BrowserDelegate: AnyObject {
     ///   - libraryPanelDelegate:  The library panel delegate for the homepage
     ///   - statusBarScrollDelegate: The delegate that takes care of the status bar overlay scroll
     ///   - overlayManager: The overlay manager for the homepage
+    @MainActor
     func showLegacyHomepage(
         inline: Bool,
         toastContainer: UIView,
@@ -24,6 +25,7 @@ protocol BrowserDelegate: AnyObject {
     )
 
     /// Show the new homepage to the user as part of the homepage rebuild project
+    @MainActor
     func showHomepage(
         overlayManager: OverlayModeManager,
         isZeroSearch: Bool,
@@ -32,6 +34,7 @@ protocol BrowserDelegate: AnyObject {
     )
 
     /// Returns a tool which can be used to get a snapshot of the homepage
+    @MainActor // does this need to be nonisolated?
     func homepageScreenshotTool() -> Screenshotable?
 
     /// Hides or shows the homepage.
@@ -39,19 +42,24 @@ protocol BrowserDelegate: AnyObject {
     /// Homepage is added to hierarchy when opening the app when swiping tabs is enabled.
     /// This method hide or show the homepage and it's needed when opening the app
     /// to avoid an homepage flash on the background.
+    @MainActor
     func setHomepageVisibility(isVisible: Bool)
 
     /// Show the private homepage to the user as part of felt privacy
+    @MainActor
     func showPrivateHomepage(overlayManager: OverlayModeManager)
 
     /// Show the webview to navigate
     /// - Parameter webView: When nil, will show the already existing webview
+    @MainActor
     func show(webView: WKWebView)
 
     /// This is called the browser is ready to start navigating,
     /// ensuring we are in the required state to perform deeplinks
+    @MainActor
     func browserHasLoaded()
 
     /// Show the Error page to the user
+    @MainActor
     func showNativeErrorPage(overlayManager: OverlayModeManager)
 }

--- a/firefox-ios/Client/Coordinators/Coordinator.swift
+++ b/firefox-ios/Client/Coordinators/Coordinator.swift
@@ -5,6 +5,7 @@
 import Common
 import Foundation
 
+@MainActor // maybe?
 protocol Coordinator: AnyObject {
     var id: UUID { get }
     var childCoordinators: [Coordinator] { get }
@@ -22,6 +23,7 @@ protocol Coordinator: AnyObject {
 
     /// Handle the Route, if able. This is implemented by each coordinator for Route they will handle.
     /// - Parameter route: The Route to navigate to
+    @MainActor
     func handle(route: Route)
 
     /// When the coordinator cannot handle this particular Route, it returns false.

--- a/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
@@ -42,6 +42,7 @@ class CredentialAutofillCoordinator: BaseCoordinator {
         return themeManager.getCurrentTheme(for: windowUUID)
     }
 
+    @MainActor
     func showCreditCardAutofill(creditCard: CreditCard?,
                                 decryptedCard: UnencryptedCreditCardFields?,
                                 viewType state: CreditCardBottomSheetState,
@@ -196,6 +197,7 @@ class CredentialAutofillCoordinator: BaseCoordinator {
         )
     }
 
+    @MainActor
     func showPassCodeController() {
         let passwordController = DevicePasscodeRequiredViewController(windowUUID: windowUUID)
         passwordController.profile = profile

--- a/firefox-ios/Client/Coordinators/Library/HistoryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/HistoryCoordinator.swift
@@ -7,9 +7,11 @@ import Common
 import Shared
 
 protocol HistoryCoordinatorDelegate: AnyObject, LibraryPanelCoordinatorDelegate {
+    @MainActor
     func showRecentlyClosedTab()
 }
 
+@MainActor
 class HistoryCoordinator: BaseCoordinator, HistoryCoordinatorDelegate {
     // MARK: - Properties
 

--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -12,11 +12,17 @@ protocol LibraryCoordinatorDelegate: AnyObject, LibraryPanelDelegate, RecentlyCl
 }
 
 protocol LibraryNavigationHandler: AnyObject {
+    @MainActor
     func start(panelType: LibraryPanelType, navigationController: UINavigationController)
+
+    @MainActor
     func shareLibraryItem(url: URL, sourceView: UIView)
+
+    @MainActor
     func setNavigationBarHidden(_ value: Bool)
 }
 
+@MainActor
 class LibraryCoordinator: BaseCoordinator,
                           LibraryPanelDelegate,
                           LibraryNavigationHandler,
@@ -29,6 +35,7 @@ class LibraryCoordinator: BaseCoordinator,
     override var isDismissable: Bool { false }
     private var windowUUID: WindowUUID { return tabManager.windowUUID }
 
+    @MainActor
     init(
         router: Router,
         profile: Profile = AppContainer.shared.resolve(),
@@ -40,6 +47,7 @@ class LibraryCoordinator: BaseCoordinator,
         initializeLibraryViewController()
     }
 
+    @MainActor
     private func initializeLibraryViewController() {
         let libraryViewController = LibraryViewController(profile: profile, tabManager: tabManager)
         router.setRootViewController(libraryViewController)
@@ -50,10 +58,12 @@ class LibraryCoordinator: BaseCoordinator,
         self.libraryViewController = libraryViewController
     }
 
+    @MainActor
     func start(with homepanelSection: Route.HomepanelSection) {
         libraryViewController?.setupOpenPanel(panelType: homepanelSection.libraryPanel)
     }
 
+    @MainActor
     private func makeChildPanels() -> [UINavigationController] {
         let bookmarksPanel: UIViewController
         if isBookmarkRefactorEnabled {
@@ -91,6 +101,7 @@ class LibraryCoordinator: BaseCoordinator,
         }
     }
 
+    @MainActor
     func shareLibraryItem(url: URL, sourceView: UIView) {
         if let coordinator = childCoordinators.first(where: { $0 is ShareSheetCoordinator }) as? ShareSheetCoordinator {
             // The share sheet extension coordinator wasn't correctly removed in the last share session. Attempt to recover.
@@ -118,6 +129,7 @@ class LibraryCoordinator: BaseCoordinator,
         coordinator.start(shareType: .site(url: url), shareMessage: nil, sourceView: sourceView)
     }
 
+    @MainActor
     private func makeBookmarksCoordinator(navigationController: UINavigationController) {
         guard !childCoordinators.contains(where: { $0 is BookmarksCoordinator }) else { return }
         let router = DefaultRouter(navigationController: navigationController)

--- a/firefox-ios/Client/Coordinators/Library/LibraryPanelCoordinatorDelegate.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryPanelCoordinatorDelegate.swift
@@ -6,5 +6,6 @@ import Foundation
 
 /// Share navigation across the library panels
 protocol LibraryPanelCoordinatorDelegate: AnyObject {
+    @MainActor
     func shareLibraryItem(url: URL, sourceView: UIView)
 }

--- a/firefox-ios/Client/Coordinators/Library/ReadingListCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/ReadingListCoordinator.swift
@@ -7,6 +7,7 @@ import Foundation
 import enum MozillaAppServices.VisitType
 
 protocol ReadingListNavigationHandler: AnyObject, LibraryPanelCoordinatorDelegate {
+    @MainActor
     func openUrl(_ url: URL, visitType: VisitType)
 }
 
@@ -30,10 +31,12 @@ class ReadingListCoordinator: BaseCoordinator, ReadingListNavigationHandler {
 
     // MARK: - ReadingListNavigationHandler
 
+    @MainActor
     func openUrl(_ url: URL, visitType: VisitType) {
         parentCoordinator?.libraryPanel(didSelectURL: url, visitType: visitType)
     }
 
+    @MainActor
     func shareLibraryItem(url: URL, sourceView: UIView) {
         navigationHandler?.shareLibraryItem(url: url, sourceView: sourceView)
     }

--- a/firefox-ios/Client/Coordinators/ParentCoordinatorDelegate.swift
+++ b/firefox-ios/Client/Coordinators/ParentCoordinatorDelegate.swift
@@ -6,5 +6,6 @@ import Foundation
 
 protocol ParentCoordinatorDelegate: AnyObject {
     /// Notifies the parent coordinator that a child coordinator has finished his session.
+    @MainActor
     func didFinish(from childCoordinator: Coordinator)
 }

--- a/firefox-ios/Client/Coordinators/QRCode/QRCodeCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/QRCode/QRCodeCoordinator.swift
@@ -6,9 +6,11 @@ import Foundation
 
 protocol QRCodeDismissHandler: AnyObject {
     /// Dismisses the current presented QRCodeViewController
+    @MainActor
     func dismiss(_ completion: (() -> Void)?)
 }
 
+@MainActor
 class QRCodeCoordinator: BaseCoordinator, QRCodeDismissHandler {
     private weak var parentCoordinator: ParentCoordinatorDelegate?
 

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -7,6 +7,7 @@ import Common
 import Shared
 import Storage
 
+@MainActor
 class ShareSheetCoordinator: BaseCoordinator,
                              DevicePickerViewControllerDelegate,
                              InstructionsViewDelegate,
@@ -43,6 +44,7 @@ class ShareSheetCoordinator: BaseCoordinator,
     // MARK: - Methods
 
     /// Presents the share sheet from the source view
+    @MainActor
     func start(
         shareType: ShareType,
         shareMessage: ShareMessage?,
@@ -81,6 +83,7 @@ class ShareSheetCoordinator: BaseCoordinator,
         }
     }
 
+    @MainActor // FIXME can we guarantee execution on the main thread or is this one of those gotchya situations?
     private func handleShareSheetCompletion(
         activityType: UIActivity.ActivityType?,
         shareType: ShareType,
@@ -160,6 +163,7 @@ class ShareSheetCoordinator: BaseCoordinator,
         router.present(alertController)
     }
 
+    @MainActor
     private func showToast(text: String) {
         SimpleToast().showAlertWithText(text,
                                         bottomContainer: self.alertContainer,

--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -191,6 +191,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     }
 
     /// Handle when a user hits the CTA of the surface, and forward the bookkeeping to the store.
+    @MainActor
     func onMessagePressed(_ message: GleanPlumbMessage, window: WindowUUID?, shouldExpire: Bool = true) {
         messagingStore.onMessagePressed(message, shouldExpire: shouldExpire)
 
@@ -208,6 +209,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
                                      extras: extras)
     }
 
+    @MainActor
     private func handleLinkAction(
         for message: GleanPlumbMessage,
         action: String,

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -13,6 +13,7 @@ import struct MozillaAppServices.Login
 class Authenticator {
     fileprivate static let MaxAuthenticationAttempts = 3
 
+    @MainActor
     static func handleAuthRequest(
         _ viewController: UIViewController,
         challenge: URLAuthenticationChallenge,
@@ -184,6 +185,7 @@ class Authenticator {
         }
     }
 
+    @MainActor
     fileprivate static func promptForUsernamePassword(
         _ viewController: UIViewController,
         credentials: URLCredential?,

--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -8,6 +8,7 @@ import WebKit
 
 @objc
 protocol JSPromptAlertControllerDelegate: AnyObject {
+    @MainActor // FIXME can we guarantee thread of callback with obj c interop?
     func promptAlertControllerDidDismiss(_ alertController: JSPromptAlertController)
 }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -22,6 +22,7 @@ protocol MainMenuCoordinatorDelegate: AnyObject {
     func showShareSheetForCurrentlySelectedTab()
 }
 
+@MainActor
 class MainMenuCoordinator: BaseCoordinator, FeatureFlaggable {
     weak var parentCoordinator: ParentCoordinatorDelegate?
     weak var navigationHandler: MainMenuCoordinatorDelegate?

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
@@ -10,10 +10,14 @@ protocol SearchEngineSelectionCoordinatorDelegate: AnyObject {
 }
 
 protocol SearchEngineSelectionCoordinator: AnyObject {
+    @MainActor
     func navigateToSearchSettings(animated: Bool)
+
+    @MainActor
     func dismissModal(animated: Bool)
 }
 
+@MainActor
 class DefaultSearchEngineSelectionCoordinator: BaseCoordinator,
                                                FeatureFlaggable,
                                                SearchEngineSelectionCoordinator {

--- a/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
@@ -5,6 +5,7 @@
 import Common
 import Foundation
 
+@MainActor
 struct SimpleToast: ThemeApplicable {
     struct UX {
         static let labelPadding: CGFloat = 16

--- a/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -10,7 +10,11 @@ import SwiftUI
 import Common
 
 protocol DevicePickerViewControllerDelegate: AnyObject {
+    // FIXME obj C interop can we guarantee for this picker main thread delegate callbacks?
+    @MainActor
     func devicePickerViewControllerDidCancel(_ devicePickerViewController: DevicePickerViewController)
+
+    @MainActor
     func devicePickerViewController(
         _ devicePickerViewController: DevicePickerViewController,
         didPickDevices devices: [RemoteDevice]

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuCoordinator.swift
@@ -6,9 +6,11 @@ import Foundation
 import Common
 
 protocol ContextMenuCoordinatorDelegate: AnyObject {
+    @MainActor
     func dismissFlow()
 }
 
+@MainActor
 final class ContextMenuCoordinator: BaseCoordinator, ContextMenuCoordinatorDelegate {
     weak var parentCoordinator: ParentCoordinatorDelegate?
 

--- a/firefox-ios/Client/Frontend/Home/HomepageSectionHandler.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageSectionHandler.swift
@@ -7,9 +7,11 @@ import Foundation
 // Protocol for each section in Firefox Home page view controller
 // to handle click and cell setup
 protocol HomepageSectionHandler {
+    @MainActor
     func configure(_ collectionView: UICollectionView,
                    at indexPath: IndexPath) -> UICollectionViewCell
 
+    @MainActor
     func configure(_ cell: UICollectionViewCell,
                    at indexPath: IndexPath) -> UICollectionViewCell
 
@@ -23,6 +25,7 @@ protocol HomepageSectionHandler {
 
 extension HomepageSectionHandler {
     // Default configure use the FirefoxHomeSectionType cellIdentifier, when there's only one cell type in that section
+    @MainActor
     func configure(_ collectionView: UICollectionView, at indexPath: IndexPath) -> UICollectionViewCell {
         guard let viewModel = self as? HomepageViewModelProtocol else { return UICollectionViewCell() }
 

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -70,6 +70,7 @@ extension HomepageHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 }
 
 extension HomepageHeaderViewModel: HomepageSectionHandler {
+    @MainActor
     func configure(_ cell: UICollectionViewCell, at indexPath: IndexPath) -> UICollectionViewCell {
         guard let headerCell = cell as? LegacyHomepageHeaderCell else { return UICollectionViewCell() }
         headerCell.configure(with: HomepageHeaderCellViewModel(showiPadSetup: showiPadSetup))

--- a/firefox-ios/Client/Frontend/InstructionsView.swift
+++ b/firefox-ios/Client/Frontend/InstructionsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 import UIKit
 
 protocol InstructionsViewDelegate: AnyObject {
+    @MainActor
     func dismissInstructionsView()
 }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -10,8 +10,10 @@ import class MozillaAppServices.BookmarkItemData
 
 /// Used to setup bookmarks and folder cell in Bookmarks panel, getting their viewModel
 protocol BookmarksFolderCell: BookmarksRefactorFeatureFlagProvider {
+    @MainActor
     func getViewModel() -> OneLineTableViewCellViewModel
 
+    @MainActor
     func didSelect(profile: Profile,
                    searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,
@@ -65,6 +67,7 @@ extension BookmarkFolderData: BookmarksFolderCell {
 }
 
 extension BookmarkItemData: BookmarksFolderCell {
+    @MainActor
     func getViewModel() -> OneLineTableViewCellViewModel {
         var title: String
         if self.title.isEmpty {
@@ -88,6 +91,7 @@ extension BookmarkItemData: BookmarksFolderCell {
         }
     }
 
+    @MainActor
     func didSelect(profile: Profile,
                    searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,

--- a/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
@@ -8,9 +8,13 @@ import Common
 import enum MozillaAppServices.VisitType
 
 protocol LibraryPanelDelegate: AnyObject {
+    @MainActor
     func libraryPanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)
+
+    @MainActor
     func libraryPanel(didSelectURL url: URL, visitType: VisitType)
-    var libraryPanelWindowUUID: WindowUUID { get }
+
+    @MainActor var libraryPanelWindowUUID: WindowUUID { get }
 }
 
 protocol LibraryPanel: UIViewController {

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
@@ -54,6 +54,7 @@ final class OnboardingService: FeatureFlaggable {
         self.searchBarLocationSaver = searchBarLocationSaver
     }
 
+    @MainActor // This is going to move lots of completion handlers to main actor
     func handleAction(
         _ action: OnboardingActions,
         from cardName: String,
@@ -162,6 +163,7 @@ final class OnboardingService: FeatureFlaggable {
         askForNotificationPermission(from: cardName)
     }
 
+    @MainActor
     private func handleSyncSignIn(
         from cardName: String,
         with activityEventHelper: ActivityEventHelper,
@@ -174,6 +176,7 @@ final class OnboardingService: FeatureFlaggable {
         presentSignToSync(with: fxaParams, profile: profile, completion: completion)
     }
 
+    @MainActor
     private func handleSetDefaultBrowser(with activityEventHelper: ActivityEventHelper) {
         activityEventHelper.chosenOptions.insert(.setAsDefaultBrowser)
         activityEventHelper.updateOnboardingUserActivationEvent()
@@ -181,20 +184,24 @@ final class OnboardingService: FeatureFlaggable {
         defaultApplicationHelper.openSettings()
     }
 
+    @MainActor
     private func handleOpenInstructionsPopup(from popupViewModel: OnboardingDefaultBrowserModelProtocol) {
         presentDefaultBrowserPopup(from: popupViewModel) { [weak self] in
             self?.navigationDelegate?.finishOnboardingFlow()
         }
     }
 
+    @MainActor
     private func handleReadPrivacyPolicy(from url: URL, completion: @escaping () -> Void) {
         presentPrivacyPolicy(from: url, completion: completion)
     }
 
+    @MainActor
     private func handleOpenIosFxSettings(from cardName: String) {
         defaultApplicationHelper.openSettings()
     }
 
+    @MainActor
     private func handleEndOnboarding(with activityEventHelper: ActivityEventHelper) {
         introScreenManager?.didSeeIntroScreen()
         searchBarLocationSaver.saveUserSearchBarLocation(
@@ -227,6 +234,7 @@ final class OnboardingService: FeatureFlaggable {
         hasRegisteredForDefaultBrowserNotification = true
     }
 
+    @MainActor
     private func presentSignToSync(with params: FxALaunchParams, profile: Profile, completion: @escaping () -> Void) {
         guard let delegate = delegate else { return }
 
@@ -240,6 +248,7 @@ final class OnboardingService: FeatureFlaggable {
         delegate.present(signInVC, animated: true, completion: nil)
     }
 
+    @MainActor
     private func presentDefaultBrowserPopup(
         from popupViewModel: OnboardingDefaultBrowserModelProtocol,
         completion: @escaping () -> Void
@@ -253,6 +262,7 @@ final class OnboardingService: FeatureFlaggable {
         delegate?.present(popupVC, animated: false, completion: nil)
     }
 
+    @MainActor
     private func presentPrivacyPolicy(from url: URL, completion: @escaping () -> Void) {
         guard let delegate = delegate else { return }
         let privacyVC = createPrivacyPolicyViewController(
@@ -264,6 +274,7 @@ final class OnboardingService: FeatureFlaggable {
         delegate.present(privacyVC, animated: true, completion: nil)
     }
 
+    @MainActor
     private func createSignInViewController(
         windowUUID: WindowUUID,
         params: FxALaunchParams,
@@ -290,6 +301,7 @@ final class OnboardingService: FeatureFlaggable {
         return controller
     }
 
+    @MainActor
     private func createDefaultBrowserPopupViewController(
         windowUUID: WindowUUID,
         from popupViewModel: OnboardingDefaultBrowserModelProtocol,
@@ -317,6 +329,7 @@ final class OnboardingService: FeatureFlaggable {
         return bottomSheetVC
     }
 
+    @MainActor
     private func createPrivacyPolicyViewController(
         windowUUID: WindowUUID,
         from url: URL,

--- a/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -106,7 +106,7 @@ final class SearchBarSettingsViewModel: FeatureFlaggable {
         return position
     }
 
-    var topSetting: CheckmarkSetting {
+    @MainActor var topSetting: CheckmarkSetting {
         return CheckmarkSetting(title: NSAttributedString(string: SearchBarPosition.top.getLocalizedTitle),
                                 subtitle: nil,
                                 accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.topSetting,
@@ -115,7 +115,7 @@ final class SearchBarSettingsViewModel: FeatureFlaggable {
         )
     }
 
-    var bottomSetting: CheckmarkSetting {
+    @MainActor var bottomSetting: CheckmarkSetting {
         return CheckmarkSetting(title: NSAttributedString(string: SearchBarPosition.bottom.getLocalizedTitle),
                                 subtitle: nil,
                                 accessibilityIdentifier: AccessibilityIdentifiers.Settings.SearchBar.bottomSetting,

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -27,6 +27,7 @@ extension UILabel {
 }
 
 // A base setting class that shows a title. You probably want to subclass this, not use it directly.
+@MainActor
 class Setting: NSObject {
     private var _title: NSAttributedString?
     private var _footerTitle: NSAttributedString?

--- a/firefox-ios/Client/Frontend/Share/SendToDeviceHelper.swift
+++ b/firefox-ios/Client/Frontend/Share/SendToDeviceHelper.swift
@@ -32,6 +32,7 @@ class SendToDeviceHelper {
         self.delegate = delegate
     }
 
+    @MainActor
     func initialViewController() -> UIViewController {
         if !hasAccount() {
             // Display instructions to log in if user has no account

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -32,6 +32,7 @@ struct LoginItem: Codable {
     var hostname: String
 }
 
+@MainActor
 class LoginsHelper: TabContentScript, FeatureFlaggable {
     private weak var tab: Tab?
     private let profile: Profile

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -30,12 +30,18 @@ func mostRecentTab(inTabs tabs: [Tab]) -> Tab? {
 }
 
 protocol TabContentScript {
-    static func name() -> String
+    static nonisolated func name() -> String
+
+    @MainActor
     func scriptMessageHandlerNames() -> [String]?
+
+    @MainActor
     func userContentController(
         _ userContentController: WKUserContentController,
         didReceiveScriptMessage message: WKScriptMessage
     )
+
+    @MainActor
     func prepareForDeinit()
 }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -768,7 +768,8 @@ class TabManagerImplementation: NSObject,
     }
 
     private func preserveTabs(forced: Bool) {
-        Task {
+        Task { @MainActor in
+            // FIXME sending self risks data races
             // FIXME FXIOS-10059 TabManagerImplementation's preserveTabs is called with a nil selectedTab
             let windowData = WindowData(id: windowUUID,
                                         activeTabId: self.selectedTabUUID ?? UUID(),

--- a/firefox-ios/Client/Utils/BackgroundTabLoader.swift
+++ b/firefox-ios/Client/Utils/BackgroundTabLoader.swift
@@ -37,7 +37,7 @@ final class DefaultBackgroundTabLoader: BackgroundTabLoader {
     }
 
     private func dequeueQueuedTabs() {
-        tabQueue.getQueuedTabs { [weak self] urls in
+        tabQueue.getQueuedTabs { @MainActor [weak self] urls in // FIXME why can't I annotate this?
             guard let self = self else { return }
             // This assumes that the DB returns rows in a sane order.
             guard !urls.isEmpty else { return }
@@ -51,10 +51,11 @@ final class DefaultBackgroundTabLoader: BackgroundTabLoader {
             // Clear after making an attempt to open. We're making a bet that
             // it's better to run the risk of perhaps opening twice on a crash,
             // rather than losing data.
-            self.tabQueue.clearQueuedTabs()
+            self.tabQueue.clearQueuedTabs() // FIXME should this be background?
         }
     }
 
+    @MainActor
     private func open(urls: [URL]) {
         for urlToOpen in urls {
             let urlString = URL.mozInternalScheme + "://open-url?url=\(urlToOpen)"

--- a/firefox-ios/Extensions/ShareTo/SendToDevice.swift
+++ b/firefox-ios/Extensions/ShareTo/SendToDevice.swift
@@ -30,6 +30,7 @@ class SendToDevice: DevicePickerViewControllerDelegate, InstructionsViewDelegate
         return themeManager.windowNonspecificTheme()
     }
 
+    @MainActor
     func initialViewController() -> UIViewController {
         let theme = currentTheme()
         guard let shareItem = sharedItem else {

--- a/firefox-ios/Storage/Queue.swift
+++ b/firefox-ios/Storage/Queue.swift
@@ -7,7 +7,7 @@ import Shared
 
 public protocol TabQueue {
     func addToQueue(_ tab: ShareItem) -> Success
-    func getQueuedTabs(completion: @escaping ([ShareItem]) -> Void)
+    func getQueuedTabs(completion: @escaping @MainActor ([ShareItem]) -> Void)
     @discardableResult
     func clearQueuedTabs() -> Success
 }

--- a/firefox-ios/Storage/SQL/SQLiteQueue.swift
+++ b/firefox-ios/Storage/SQL/SQLiteQueue.swift
@@ -21,14 +21,17 @@ open class SQLiteQueue: TabQueue {
         return ShareItem(url: url, title: "")
     }
 
-    open func getQueuedTabs(completion: @escaping ([ShareItem]) -> Void) {
+    open func getQueuedTabs(completion: @escaping @MainActor ([ShareItem]) -> Void) {
         let sql = "SELECT url FROM queue"
         let deferredResponse = db.runQuery(sql, args: nil, factory: self.factory) >>== { cursor in
             return deferMaybe(cursor.asArray())
         }
 
         deferredResponse.upon { result in
-            completion(result.successValue ?? [])
+            // FIXME Uhh is this ok?
+            DispatchQueue.main.async {
+                completion(result.successValue ?? [])
+            }
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
A monster PR with lots of `@MainActor` isolation across the entire app, starting from `ThemeApplicable`... 😰 

But it almost halved our warning count!!
<img width="324" height="50" alt="Screenshot 2025-07-11 at 2 32 12 PM" src="https://github.com/user-attachments/assets/3158a34b-93f2-4d70-91de-57f4e1f1e512" />

This took about an hour to work through one little xcode error at a time, to finally getting things compiling. The unit tests will undoubtedly need an update too before we can see if we get any failing UI tests. 😅  I only tested the app trivially but things seemed to... work? Only thing that maybe didn't was the sync spinner in Settings for logged in accounts (I got a priority inversion warning in the console too).

Leaving this as a draft because it's a little... uh, big of a change. And it's hard to test. 😬 

### Background information on the warnings we are fixing

`UIView`- and `UIViewController`-inheriting subclasses must conform to `@MainActor` as per the definitions from UIKit. That means if those classes also conform to _any_ protocols, those protocols must _explicitly_ define the isolation requirements of each property and method. To do otherwise results in an "[under-specified protocol](https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/commonproblems/#Under-Specified-Protocol)". 

Thus, when there is no explicit isolation, the compiler treats all under-specified protocol requirements as `nonisolated`. So when we have a class that inherits, for example, from `UIView` and conforms to an under-specified protocol, we see compiler warnings because the protocol's methods are treated as `nonisolated` but the class is synchronized to the main actor.

(check [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/27930) for an overview of the compiler warnings)

### Process
I worked through these main actor isolations starting with the `ThemeApplicable` protocol, as @lmarceau originally tried. I carried forward through all the build errors.

We might be able to do this work in smaller chunks, like if we instead start with the `NSObject`s inheriting classes (which function as UI logic), then the `UIViewController` / `UIView` subclasses level, and then moving up to `Coordinators`... But the cascade of errors makes this tricky.

Let's discuss more at our next chat on Monday. (see the multiple FIXME/TODO points inline with my changes...)

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
