### PR TITLE
Add github action that creates ios milestone on test rail

### DIFF
--- a/.github/workflows/firefox-ios-testrail-milestones.yml
+++ b/.github/workflows/firefox-ios-testrail-milestones.yml
@@ -1,4 +1,4 @@
-name: TestRail Milestone
+name: Create TestRail Milestone
 
 on:
   release:
@@ -24,3 +24,5 @@ jobs:
           testrail-host: ${{ secrets.TESTRAIL_HOST }}
           testrail-username: ${{ secrets.TESTRAIL_USERNAME }}
           testrail-api-key: ${{ secrets.TESTRAIL_PASSWORD }}
+          slack_webhook_url: ${{ secrets.WEBHOOK_SLACK_MOBILE_TESTENG_RELEASES_CHANNEL }}
+          slack_webhook_url_error_channel: ${{ secrets.WEBHOOK_SLACK_MOBILE_ALERTS_IOS_CHANNEL }}

--- a/.github/workflows/firefox-ios-testrail-milestones.yml
+++ b/.github/workflows/firefox-ios-testrail-milestones.yml
@@ -1,0 +1,26 @@
+name: TestRail Milestone
+
+on:
+  release:
+    types: [published]  # Trigger only when a release is published
+
+jobs:
+  handle-new-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Print Release Info
+        run: |
+          echo "New release published!"
+          echo "Tag: ${{ github.event.release.tag_name }}"
+          echo "Release Name: ${{ github.event.release.name }}"
+          echo "Body: ${{ github.event.release.body }}"
+          echo "Published at: ${{ github.event.release.published_at }}"
+      - name: Run the reusable action from testops-tools
+        uses: mozilla-mobile/testops-tools/.github/actions/firefox-ios-milestone@main
+        with:
+          release-name: ${{ github.event.release.name }}
+          release-tag: ${{ github.event.release.tag_name }}
+          testrail-host: ${{ secrets.TESTRAIL_HOST }}
+          testrail-username: ${{ secrets.TESTRAIL_USERNAME }}
+          testrail-api-key: ${{ secrets.TESTRAIL_PASSWORD }}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4758)

## :bulb: Description
Currently, for every release, we manually create a milestone in TestRail before executing the test cases.
This PR introduces a GitHub Action that triggers another action in the testops-tools repository, which automatically creates the milestone in TestRail and assigns all relevant test cases to it.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
