### PR TITLE
Bugfix FXIOS- 12827 - [Swift 6 Migration] - Fix thread safety issue in DefaultHeroImageFetcher - LPMetadataProvider must run on main thread

### DIFF
--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/HeroImageFetcher/HeroImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/HeroImageFetcher/HeroImageFetcher.swift
@@ -28,7 +28,9 @@ final class DefaultHeroImageFetcher: HeroImageFetcher {
                         metadataProvider: LPMetadataProvider = LPMetadataProvider()
     ) async throws -> UIImage {
         do {
-            let metadata = try await metadataProvider.startFetchingMetadata(for: siteURL)
+            let metadata = try await Task { @MainActor in
+                try await metadataProvider.startFetchingMetadata(for: siteURL)
+            }.value
             guard let imageProvider = metadata.imageProvider else {
                 throw SiteImageError.unableToDownloadImage("Metadata image provider could not be retrieved.")
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12827)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27950)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- `LPMetadataProvider` requires main thread execution due to internal `WebKit` usage.
- Wrap `startFetchingMetadata` call in `@MainActor` task to prevent crashes.

### 📷  Screenshot

<details>
<summary>Error</summary>

<img width="2626" height="1306" alt="image" src="https://github.com/user-attachments/assets/9e142389-d73d-46ca-a405-78f20da064ae" />

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
