### PR TITLE
Bugfix FXIOS-12816 ⁃ [Menu redesign] "Save as PDF" to Files does not complete any action — file not saved

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -664,14 +664,19 @@ class BrowserCoordinator: BaseCoordinator,
                           let outputURL = pdf.createOutputURL(withFileName: selectedTab.webView?.title ?? "") else {
                         return
                     }
-                    startShareSheetCoordinator(
-                        shareType: .file(url: outputURL),
-                        shareMessage: nil,
-                        sourceView: self.browserViewController.addressToolbarContainer,
-                        sourceRect: nil,
-                        toastContainer: self.browserViewController.contentContainer,
-                        popoverArrowDirection: .any
-                    )
+                    do {
+                        try data.write(to: outputURL)
+                        startShareSheetCoordinator(
+                            shareType: .file(url: outputURL),
+                            shareMessage: nil,
+                            sourceView: self.browserViewController.addressToolbarContainer,
+                            sourceRect: nil,
+                            toastContainer: self.browserViewController.contentContainer,
+                            popoverArrowDirection: .any
+                        )
+                    } catch {
+                        self.logger.log("PDF creation failed.", level: .warning, category: .webview)
+                    }
                 case .failure(let error):
                     // TODO: FXIOS-11542 [iOS Menu Redesign] - Handle saveAsPDF Menu option, error case
                     self.logger.log("Failed to get a valid data URL result, with error: \(error.localizedDescription)",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12816)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27916)

## :bulb: Description
Writing data to the output url before sharing it.

## :movie_camera: Demos

https://github.com/user-attachments/assets/461ae763-c724-42bc-968d-0e1c2b675a5a



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
