### PR TITLE
Bugfix FXIOS-12818 ⁃ [Menu redesign] “Set as default browser” banner reappears in menu every time, even after being dismissed

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -18,6 +18,7 @@ public final class MenuRedesignMainView: UIView,
     public var closeButtonCallback: (() -> Void)?
     public var onCalculatedHeight: ((CGFloat, _ isExpanded: Bool) -> Void)?
     public var bannerButtonCallback: (() -> Void)?
+    public var closeBannerButtonCallback: (() -> Void)?
 
     // MARK: - UI Elements
     private var tableView: MenuRedesignTableView = .build()
@@ -29,12 +30,17 @@ public final class MenuRedesignMainView: UIView,
     private var viewConstraints: [NSLayoutConstraint] = []
 
     // MARK: - Properties
+    // If default browser banner sub flag is enabled
     private var isMenuDefaultBrowserBanner = false
-    private var menuData: [MenuSection] = []
+    // If FF is the default browser
     private var isBrowserDefault = false
+    // If banner was already shown
     private var bannerShown = false
+    // If banner is currently visible
     private var isBannerVisible = false
+
     private var isPhoneLandscape = false
+    private var menuData: [MenuSection] = []
 
     // MARK: - UI Setup
     override public func layoutSubviews() {
@@ -110,10 +116,12 @@ public final class MenuRedesignMainView: UIView,
                              subtitle: String,
                              image: UIImage?,
                              isBannerFlagEnabled: Bool,
-                             isBrowserDefault: Bool) {
+                             isBrowserDefault: Bool,
+                             bannerShown: Bool) {
         headerBanner.setupDetails(title: title, subtitle: subtitle, image: image)
         isMenuDefaultBrowserBanner = isBannerFlagEnabled
         self.isBrowserDefault = isBrowserDefault
+        self.bannerShown = bannerShown
     }
 
     public func setupMenuMenuOrientation(isPhoneLandscape: Bool) {
@@ -172,6 +180,7 @@ public final class MenuRedesignMainView: UIView,
             self?.isBannerVisible = false
             self?.tableView.reloadData(isBannerVisible: self?.isBannerVisible ?? false)
             self?.updateMenuHeight(for: self?.menuData ?? [])
+            self?.closeBannerButtonCallback?()
         }
         headerBanner.bannerButtonCallback = { [weak self] in
             self?.bannerButtonTapped()

--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -214,6 +214,9 @@ public struct PrefsKeys {
     // Used to only show the felt deletion alert confirmation once, used for private mode
     public static let dataClearanceAlertShown = "dataClearanceAlertShownKey"
 
+    // Used to only show the Default Browser Banner, in Main Menu, until is dismissed by the user
+    public static let defaultBrowserBannerShown = "defaultBrowserBannerShownKey"
+
     public struct Usage {
         public static let profileId = "profileId"
     }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -63,6 +63,10 @@ class MainMenuViewController: UIViewController,
         return featureFlags.isFeatureEnabled(.menuDefaultBrowserBanner, checking: .buildOnly)
     }
 
+    private var bannerShown: Bool {
+        profile.prefs.boolForKey(PrefsKeys.defaultBrowserBannerShown) ?? false
+    }
+
     private var hasBeenExpanded = false
     private var currentCustomMenuHeight = 0.0
     private var isBrowserDefault = false
@@ -177,6 +181,10 @@ class MainMenuViewController: UIViewController,
 
             menuRedesignContent.bannerButtonCallback = { [weak self] in
                 self?.dispatchDefaultBrowserAction()
+            }
+
+            menuRedesignContent.closeBannerButtonCallback = { [weak self] in
+                self?.profile.prefs.setBool(true, forKey: PrefsKeys.defaultBrowserBannerShown)
             }
 
             menuRedesignContent.siteProtectionHeader.siteProtectionsButtonCallback = { [weak self] in
@@ -294,7 +302,8 @@ class MainMenuViewController: UIViewController,
                                          subtitle: .MainMenu.HeaderBanner.Subtitle,
                                          image: UIImage(named: ImageIdentifiers.foxDefaultBrowser),
                                          isBannerFlagEnabled: isMenuDefaultBrowserBanner,
-                                         isBrowserDefault: isBrowserDefault)
+                                         isBrowserDefault: isBrowserDefault,
+                                         bannerShown: bannerShown)
     }
 
     private func setupMenuOrientation() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12818)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27919)

## :bulb: Description
Set a pref key for showing the default browser banner only once

## :movie_camera: D

https://github.com/user-attachments/assets/3a6dd4b8-67c3-410f-8e09-cbd60c49a356


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
