### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] HomepageRebuild - SectionLayout + DimensionCalculator

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -12571,7 +12571,6 @@
 			isa = PBXGroup;
 			children = (
 				EDDB13862D3184EB00C4B165 /* Site+createSponsoredSite.swift */,
-				8AD3AFC22D143EF000CFC887 /* HomepageDimensionImplementation.swift */,
 				8A454D3E2CB9B8A0009436D9 /* TopSitesSectionState.swift */,
 				8A454D422CB9B8F5009436D9 /* TopSitesManager.swift */,
 				8A454D402CB9B8AA009436D9 /* TopSitesAction.swift */,
@@ -12813,6 +12812,7 @@
 				8ABDBAA42CB6BF3A00B51F63 /* Pocket */,
 				8A7D08E22CAAF7C30035999C /* HomepageViewController.swift */,
 				8AA0A6622CAC40AA00AC7EB3 /* HomepageDiffableDataSource.swift */,
+				8AD3AFC22D143EF000CFC887 /* HomepageDimensionImplementation.swift */,
 				8AA0A6642CAC6B7100AC7EB3 /* HomepageSectionLayoutProvider.swift */,
 				8AF347DC2CADD0E100624036 /* Redux */,
 			);

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDimensionImplementation.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDimensionImplementation.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+@MainActor
 struct HomepageDimensionCalculator {
     static func isCompactLayout(
         traitCollection: UITraitCollection,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -6,6 +6,7 @@ import Foundation
 import Common
 
 /// Holds section layout logic for the new homepage as part of the rebuild project
+@MainActor
 final class HomepageSectionLayoutProvider: FeatureFlaggable {
     struct UX {
         static let standardInset: CGFloat = 16
@@ -16,6 +17,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         static let standardSingleItemHeight: CGFloat = 100
         static let sectionHeaderHeight: CGFloat = 34
 
+        @MainActor
         static func leadingInset(
             traitCollection: UITraitCollection,
             interfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
@@ -40,7 +42,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             static let numberOfItemsInColumn = 3
             static let fractionalWidthiPhonePortrait: CGFloat = 0.90
             static let fractionalWidthiPhoneLandscape: CGFloat = 0.46
-            static let interItemSpacing = NSCollectionLayoutSpacing.fixed(8)
+            @MainActor static let interItemSpacing = NSCollectionLayoutSpacing.fixed(8)
 
             // Redesigned stories constants
             static let redesignNumberOfItemsInColumn = 1
@@ -51,6 +53,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
             // The dimension of a cell
             // Fractions for iPhone to only show a slight portion of the next column
+            @MainActor
             static func getWidthDimension(device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
                                           isLandscape: Bool = UIWindow.isLandscape) -> NSCollectionLayoutDimension {
                 if device == .pad {
@@ -62,6 +65,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
                 }
             }
 
+            @MainActor
             static func getAbsoluteCellWidth(device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
                                              isLandscape: Bool = UIWindow.isLandscape,
                                              collectionViewWidth: CGFloat) -> CGFloat {
@@ -89,6 +93,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             static let syncedItemCompactHeight: CGFloat = 182
             static let maxItemsPerGroup = 2
 
+            @MainActor
             static func getWidthDimension(
                 for device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
                 layoutType: JumpBackInSectionLayoutConfiguration.LayoutType

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDimensionCalculatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDimensionCalculatorTests.swift
@@ -6,6 +6,7 @@ import XCTest
 
 @testable import Client
 
+@MainActor
 class HomepageDimensionCalculatorTests: XCTestCase {
     struct UX {
         struct DeviceSize {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
In the Homepage Rebuild folder, saw some warnings related to `HomepageSectionLayoutProvider` and `HomepageDimensionCalculator` related to 
```
Main actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode
```
Added `@MainActor` to both of these types since they are used to generate the UI for the homepage and should run on main thread. 

| HomepageSectionLayoutProvider Errors | HomepageDimensionCalculator Errors |
| - | - |
|<img width="1022" height="1389" alt="image" src="https://github.com/user-attachments/assets/4b859c2f-d5ae-4350-9818-935ab14a340d" /> | <img width="1016" height="536" alt="image" src="https://github.com/user-attachments/assets/50f20ef5-a344-4774-a1cb-1e404a37040d" />|

Note: Updated tests and moved `HomepageDimensionCalculator` outside of top sites folder since its more generic.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
