### PR TITLE
Add FXIOS-12740 [Homepage Redesign] Updated homepage layout 

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -102,8 +102,7 @@ final class HomepageDiffableDataSource:
             snapshot.appendItems(topSites, toSection: .topSites(textColor, numberOfCellsPerRow))
         }
 
-        // TODO add to pocket state
-        if featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly) {
+        if state.shouldShowSpacer {
             snapshot.appendSections([.spacer])
             snapshot.appendItems([.spacer], toSection: .spacer)
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -23,6 +23,7 @@ final class HomepageDiffableDataSource:
         case bookmarks(TextColor?)
         case pocket(TextColor?)
         case customizeHomepage
+        case spacer
 
         var canHandleLongPress: Bool {
             switch self {
@@ -44,6 +45,7 @@ final class HomepageDiffableDataSource:
         case bookmark(BookmarkConfiguration)
         case pocket(PocketStoryConfiguration)
         case customizeHomepage
+        case spacer
 
         static var cellTypes: [ReusableCell.Type] {
             return [
@@ -57,7 +59,8 @@ final class HomepageDiffableDataSource:
                 BookmarksCell.self,
                 PocketStandardCell.self,
                 StoryCell.self,
-                CustomizeHomepageSectionCell.self
+                CustomizeHomepageSectionCell.self,
+                EmptyHomepageCell.self
             ]
         }
 
@@ -97,6 +100,12 @@ final class HomepageDiffableDataSource:
         if let (topSites, numberOfCellsPerRow) = getTopSites(with: state.topSitesState, and: textColor) {
             snapshot.appendSections([.topSites(textColor, numberOfCellsPerRow)])
             snapshot.appendItems(topSites, toSection: .topSites(textColor, numberOfCellsPerRow))
+        }
+
+        // TODO add to pocket state
+        if featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly) {
+            snapshot.appendSections([.spacer])
+            snapshot.appendItems([.spacer], toSection: .spacer)
         }
 
         if state.searchState.shouldShowSearchBar {
@@ -185,3 +194,5 @@ final class HomepageDiffableDataSource:
         return state.bookmarks.compactMap { .bookmark($0) }
     }
 }
+
+class EmptyHomepageCell: UICollectionViewCell, ReusableCell { }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -60,7 +60,7 @@ final class HomepageDiffableDataSource:
                 PocketStandardCell.self,
                 StoryCell.self,
                 CustomizeHomepageSectionCell.self,
-                EmptyHomepageCell.self
+                HomepageSpacerCell.self
             ]
         }
 
@@ -195,4 +195,4 @@ final class HomepageDiffableDataSource:
     }
 }
 
-class EmptyHomepageCell: UICollectionViewCell, ReusableCell { }
+class HomepageSpacerCell: UICollectionViewCell, ReusableCell { }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -15,7 +15,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         static let iPadInset: CGFloat = 50
         static let spacingBetweenSections: CGFloat = 62
         static let standardSingleItemHeight: CGFloat = 100
-        static let sectionHeaderHeight: CGFloat = 34
+        static let sectionHeaderHeight: CGFloat = 75
 
         @MainActor
         static func leadingInset(
@@ -506,9 +506,11 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
     private func createSpacerSectionLayout(for environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
         let collectionViewHeight = environment.container.contentSize.height
-        let spacerHeight = collectionViewHeight - getShortcutsSectionHeight()
-                                                - getStoriesSectionHeight(environment: environment)
-                                                - getSearchBarSectionHeight()
+        // Dimensions of <= 0.0 cause runtime warnings, so use a minimum height of 0.1
+        let spacerHeight = max(0.1, collectionViewHeight - getShortcutsSectionHeight(environment: environment)
+                                                         - getStoriesSectionHeight(environment: environment)
+                                                         - getSearchBarSectionHeight(environment: environment)
+        )
 
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
                                               heightDimension: .absolute(spacerHeight))
@@ -532,7 +534,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         return NSCollectionLayoutSection(group: emptyGroup)
     }
 
-    private func getShortcutsSectionHeight() -> CGFloat {
+    private func getShortcutsSectionHeight(environment: NSCollectionLayoutEnvironment) -> CGFloat {
         guard let state = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID) else { return 0 }
         var totalHeight: CGFloat = 0
         let topSitesState = state.topSitesState
@@ -560,10 +562,11 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         totalHeight += CGFloat(rowsShown - 1) * UX.standardSpacing
 
         // Add header height
-        let header = LabelButtonHeaderView()
+        let header = LabelButtonHeaderView(frame: CGRect(width: 200, height: 200))
         header.configure(state: topSitesState.sectionHeaderState, textColor: .black, theme: LightTheme())
+        let containerWidth = environment.container.contentSize.width
         let size = header.systemLayoutSizeFitting(
-            CGSize(width: 0, height: UIView.layoutFittingCompressedSize.height),
+            CGSize(width: containerWidth, height: UIView.layoutFittingCompressedSize.height),
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
@@ -587,10 +590,11 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         totalHeight += max(getTallestStoryCellHeight(cellWidth: cellWidth), UX.PocketConstants.redesignedMinimumCellHeight)
 
         // Add header height
-        let header = LabelButtonHeaderView()
+        let header = LabelButtonHeaderView(frame: CGRect(width: 200, height: 200))
         header.configure(state: storiesState.sectionHeaderState, textColor: .black, theme: LightTheme())
+        let containerWidth = environment.container.contentSize.width
         let size = header.systemLayoutSizeFitting(
-            CGSize(width: 0, height: UIView.layoutFittingCompressedSize.height),
+            CGSize(width: containerWidth, height: UIView.layoutFittingCompressedSize.height),
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
@@ -602,14 +606,15 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         return totalHeight
     }
 
-    private func getSearchBarSectionHeight() -> CGFloat {
+    private func getSearchBarSectionHeight(environment: NSCollectionLayoutEnvironment) -> CGFloat {
         guard let state = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID),
                   state.searchState.shouldShowSearchBar else { return 0 }
         var totalHeight: CGFloat = 0
 
         let searchBarCell = SearchBarCell()
+        let containerWidth = environment.container.contentSize.width
         let size = searchBarCell.systemLayoutSizeFitting(
-            CGSize(width: 0, height: UIView.layoutFittingCompressedSize.height),
+            CGSize(width: containerWidth, height: UIView.layoutFittingCompressedSize.height),
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -87,6 +87,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             static let minCards = 4
             static let redesignedTopSitesBottomSpacingLandscape: CGFloat = 16
 
+            @MainActor
             static func getBottomInset() -> CGFloat {
                 if UIDevice.current.orientation.isLandscape {
                     return redesignedTopSitesBottomSpacingLandscape

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -124,6 +124,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
     private var isStoriesRedesignEnabled: Bool {
         return featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
     }
+    var spacerHeight = 0.0
 
     init(windowUUID: WindowUUID, logger: Logger = DefaultLogger.shared) {
         self.windowUUID = windowUUID
@@ -169,6 +170,8 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             )
         case .bookmarks:
             return createBookmarksSectionLayout(for: traitCollection)
+        case .spacer:
+            return createSpacerSectionLayout(for: traitCollection)
         }
     }
 
@@ -491,8 +494,19 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         return section
     }
 
+    private func createSpacerSectionLayout(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        let spacerH = max(1, spacerHeight)
+
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(spacerH))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: itemSize, subitems: [item])
+        let sectionLayout = NSCollectionLayoutSection(group: group)
+        sectionLayout.interGroupSpacing = 0
+        return sectionLayout
+    }
+
     /// Returns an empty layout to avoid app crash when unable to section data
-    func makeEmptyLayoutSection() -> NSCollectionLayoutSection {
+    static func makeEmptyLayoutSection() -> NSCollectionLayoutSection {
         let zeroLayoutSize = NSCollectionLayoutSize(
             widthDimension: .absolute(0.0),
             heightDimension: .absolute(0.0)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -538,10 +538,12 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         guard let state = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID) else { return 0 }
         var totalHeight: CGFloat = 0
         let topSitesState = state.topSitesState
+        let rows = topSitesState.numberOfRows
         let cols = topSitesState.numberOfTilesPerRow
+        let maxCells = rows * cols
 
         // Build flat array of configured cells
-        let allCells = topSitesState.topSitesData.enumerated().compactMap { index, data in
+        let allCells = topSitesState.topSitesData.prefix(maxCells).map { data in
             let cell = TopSiteCell()
             cell.configure(data, position: 0, theme: LightTheme(), textColor: .black)
             return cell

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -179,7 +179,7 @@ final class HomepageViewController: UIViewController,
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-
+        collectionView?.collectionViewLayout.invalidateLayout()
         let numberOfTilesPerRow = numberOfTilesPerRow(for: availableWidth)
         guard homepageState.topSitesState.numberOfTilesPerRow != numberOfTilesPerRow else { return }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -15,6 +15,7 @@ struct HomepageTelemetryExtras {
 
 final class HomepageAction: Action {
     let isSearchBarEnabled: Bool?
+    let shouldShowSpacer: Bool?
     let showiPadSetup: Bool?
     let numberOfTopSitesPerRow: Int?
     let telemetryExtras: HomepageTelemetryExtras?
@@ -22,6 +23,7 @@ final class HomepageAction: Action {
 
     init(
         isSearchBarEnabled: Bool? = nil,
+        shouldShowSpacer: Bool? = nil,
         numberOfTopSitesPerRow: Int? = nil,
         showiPadSetup: Bool? = nil,
         telemetryExtras: HomepageTelemetryExtras? = nil,
@@ -30,6 +32,7 @@ final class HomepageAction: Action {
         actionType: any ActionType
     ) {
         self.isSearchBarEnabled = isSearchBarEnabled
+        self.shouldShowSpacer = shouldShowSpacer
         self.numberOfTopSitesPerRow = numberOfTopSitesPerRow
         self.showiPadSetup = showiPadSetup
         self.telemetryExtras = telemetryExtras
@@ -56,4 +59,5 @@ enum HomepageMiddlewareActionType: ActionType {
     case bookmarksUpdated
     case enteredForeground
     case configuredSearchBar
+    case configuredSpacer
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
@@ -57,6 +57,7 @@ final class HomepageMiddleware: FeatureFlaggable {
         case HomepageActionType.initialize, HomepageActionType.viewWillTransition,
             ToolbarActionType.cancelEdit, GeneralBrowserActionType.navigateBack:
             self.dispatchSearchBarConfigurationAction(action: action)
+            self.dispatchSpacerConfigurationAction(action: action)
 
         default:
             break
@@ -73,6 +74,16 @@ final class HomepageMiddleware: FeatureFlaggable {
         )
     }
 
+    private func dispatchSpacerConfigurationAction(action: Action) {
+        store.dispatchLegacy(
+            HomepageAction(
+                shouldShowSpacer: self.shouldShowSpacer(),
+                windowUUID: action.windowUUID,
+                actionType: HomepageMiddlewareActionType.configuredSpacer
+            )
+        )
+    }
+
     private func shouldShowSearchBar(
         for device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
         and isLandscape: Bool = UIWindow.isLandscape
@@ -84,6 +95,10 @@ final class HomepageMiddleware: FeatureFlaggable {
             return false
         }
         return true
+    }
+
+    private func shouldShowSpacer(for device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) -> Bool {
+        return device == .phone && featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
     }
 
     // MARK: - Notifications

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -195,7 +195,7 @@ struct HomepageState: ScreenState, Equatable {
             pocketState: PocketState.reducer(state.pocketState, action),
             wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
             isZeroSearch: state.isZeroSearch,
-            shouldTriggerImpression: true,
+            shouldTriggerImpression: false,
             shouldShowSpacer: isSpacerEnabled
         )
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -29,6 +29,7 @@ struct HomepageState: ScreenState, Equatable {
     /// This needs to be set properly for telemetry and the contextual pop overs that appears on homepage
     let isZeroSearch: Bool
     let shouldTriggerImpression: Bool
+    let shouldShowSpacer: Bool
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let homepageState = store.state.screenState(
@@ -51,7 +52,8 @@ struct HomepageState: ScreenState, Equatable {
             pocketState: homepageState.pocketState,
             wallpaperState: homepageState.wallpaperState,
             isZeroSearch: homepageState.isZeroSearch,
-            shouldTriggerImpression: homepageState.shouldTriggerImpression
+            shouldTriggerImpression: homepageState.shouldTriggerImpression,
+            shouldShowSpacer: homepageState.shouldShowSpacer
         )
     }
 
@@ -67,7 +69,8 @@ struct HomepageState: ScreenState, Equatable {
             pocketState: PocketState(windowUUID: windowUUID),
             wallpaperState: WallpaperState(windowUUID: windowUUID),
             isZeroSearch: false,
-            shouldTriggerImpression: false
+            shouldTriggerImpression: false,
+            shouldShowSpacer: false
         )
     }
 
@@ -82,7 +85,8 @@ struct HomepageState: ScreenState, Equatable {
         pocketState: PocketState,
         wallpaperState: WallpaperState,
         isZeroSearch: Bool,
-        shouldTriggerImpression: Bool
+        shouldTriggerImpression: Bool,
+        shouldShowSpacer: Bool
     ) {
         self.windowUUID = windowUUID
         self.headerState = headerState
@@ -95,6 +99,7 @@ struct HomepageState: ScreenState, Equatable {
         self.wallpaperState = wallpaperState
         self.isZeroSearch = isZeroSearch
         self.shouldTriggerImpression = shouldTriggerImpression
+        self.shouldShowSpacer = shouldShowSpacer
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -114,6 +119,8 @@ struct HomepageState: ScreenState, Equatable {
             return handleEmbeddedHomepageAction(state: state, action: action, isZeroSearch: isZeroSearch)
         case GeneralBrowserActionType.didSelectedTabChangeToHomepage:
             return handleDidTabChangeToHomepageAction(state: state, action: action)
+        case HomepageMiddlewareActionType.configuredSpacer:
+            return handleSpacerInitialization(action: action, state: state)
         default:
             return defaultState(from: state, action: action)
         }
@@ -131,7 +138,8 @@ struct HomepageState: ScreenState, Equatable {
             pocketState: PocketState.reducer(state.pocketState, action),
             wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
             isZeroSearch: state.isZeroSearch,
-            shouldTriggerImpression: false
+            shouldTriggerImpression: false,
+            shouldShowSpacer: state.shouldShowSpacer
         )
     }
 
@@ -149,7 +157,8 @@ struct HomepageState: ScreenState, Equatable {
             pocketState: PocketState.reducer(state.pocketState, action),
             wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
             isZeroSearch: isZeroSearch,
-            shouldTriggerImpression: false
+            shouldTriggerImpression: false,
+            shouldShowSpacer: state.shouldShowSpacer
         )
     }
 
@@ -165,7 +174,29 @@ struct HomepageState: ScreenState, Equatable {
             pocketState: PocketState.reducer(state.pocketState, action),
             wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
             isZeroSearch: state.isZeroSearch,
-            shouldTriggerImpression: true
+            shouldTriggerImpression: true,
+            shouldShowSpacer: state.shouldShowSpacer
+        )
+    }
+
+    private static func handleSpacerInitialization(action: Action, state: Self) -> HomepageState {
+        guard let isSpacerEnabled = (action as? HomepageAction)?.shouldShowSpacer else {
+            return defaultState(from: state)
+        }
+
+        return HomepageState(
+            windowUUID: state.windowUUID,
+            headerState: HeaderState.reducer(state.headerState, action),
+            messageState: MessageCardState.reducer(state.messageState, action),
+            topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
+            searchState: SearchBarState.reducer(state.searchState, action),
+            jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
+            bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
+            pocketState: PocketState.reducer(state.pocketState, action),
+            wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
+            isZeroSearch: state.isZeroSearch,
+            shouldTriggerImpression: true,
+            shouldShowSpacer: isSpacerEnabled
         )
     }
 
@@ -201,7 +232,8 @@ struct HomepageState: ScreenState, Equatable {
             pocketState: pocketState,
             wallpaperState: wallpaperState,
             isZeroSearch: state.isZeroSearch,
-            shouldTriggerImpression: false
+            shouldTriggerImpression: false,
+            shouldShowSpacer: state.shouldShowSpacer
         )
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
@@ -48,15 +48,9 @@ class LabelButtonHeaderView: UICollectionReusableView,
 
     var notificationCenter: NotificationProtocol = NotificationCenter.default
 
-    private var stackViewLeadingConstraint: NSLayoutConstraint?
-
     // MARK: - Initializers
     override init(frame: CGRect) {
         super.init(frame: frame)
-        stackView.addArrangedSubview(titleLabel)
-        stackView.addArrangedSubview(moreButton)
-        addSubview(stackView)
-
         setupLayout()
         setupNotifications(forObserver: self,
                            observing: [.DynamicFontChanged])
@@ -67,12 +61,9 @@ class LabelButtonHeaderView: UICollectionReusableView,
         stackView.addArrangedSubview(moreButton)
         addSubview(stackView)
 
-        stackViewLeadingConstraint = stackView.leadingAnchor.constraint(equalTo: leadingAnchor,
-                                                                        constant: UX.leadingInset)
-        stackViewLeadingConstraint?.isActive = true
-
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: UX.topSpacing),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.leadingInset),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.bottomSpace),
         ])

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
@@ -250,12 +250,20 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         wait(for: [dispatchExpectation], timeout: 1)
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? HomepageAction)
-        let actionsType = try XCTUnwrap(actionCalled.actionType as? HomepageMiddlewareActionType)
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [HomepageAction])
+        let configuredSearchBarAction = try XCTUnwrap(actionsCalled.first(where: {
+            $0.actionType as? HomepageMiddlewareActionType == .configuredSearchBar
+        }))
+        let configuredSearchBarActionCount = actionsCalled.filter {
+            ($0.actionType as? HomepageMiddlewareActionType) == .configuredSearchBar
+        }.count
+        let configuredSearchBarActionType = try XCTUnwrap(
+            configuredSearchBarAction.actionType as? HomepageMiddlewareActionType
+        )
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertEqual(actionsType, .configuredSearchBar)
-        XCTAssertEqual(actionCalled.isSearchBarEnabled, true)
+        XCTAssertEqual(configuredSearchBarActionCount, 1)
+        XCTAssertEqual(configuredSearchBarActionType, .configuredSearchBar)
+        XCTAssertEqual(configuredSearchBarAction.isSearchBarEnabled, true)
     }
 
     func test_initializeAction_doesNotConfigureSearchBar() throws {
@@ -276,12 +284,20 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         wait(for: [dispatchExpectation], timeout: 1)
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? HomepageAction)
-        let actionsType = try XCTUnwrap(actionCalled.actionType as? HomepageMiddlewareActionType)
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [HomepageAction])
+        let configuredSearchBarAction = try XCTUnwrap(actionsCalled.first(where: {
+            $0.actionType as? HomepageMiddlewareActionType == .configuredSearchBar
+        }))
+        let configuredSearchBarActionCount = actionsCalled.filter {
+            ($0.actionType as? HomepageMiddlewareActionType) == .configuredSearchBar
+        }.count
+        let configuredSearchBarActionType = try XCTUnwrap(
+            configuredSearchBarAction.actionType as? HomepageMiddlewareActionType
+        )
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertEqual(actionsType, .configuredSearchBar)
-        XCTAssertEqual(actionCalled.isSearchBarEnabled, false)
+        XCTAssertEqual(configuredSearchBarActionCount, 1)
+        XCTAssertEqual(configuredSearchBarActionType, .configuredSearchBar)
+        XCTAssertEqual(configuredSearchBarAction.isSearchBarEnabled, false)
     }
 
     func test_viewWillTransitionAction_configuresSearchBar() throws {
@@ -302,12 +318,20 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         wait(for: [dispatchExpectation], timeout: 1)
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? HomepageAction)
-        let actionsType = try XCTUnwrap(actionCalled.actionType as? HomepageMiddlewareActionType)
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [HomepageAction])
+        let configuredSearchBarAction = try XCTUnwrap(actionsCalled.first(where: {
+            $0.actionType as? HomepageMiddlewareActionType == .configuredSearchBar
+        }))
+        let configuredSearchBarActionCount = actionsCalled.filter {
+            ($0.actionType as? HomepageMiddlewareActionType) == .configuredSearchBar
+        }.count
+        let configuredSearchBarActionType = try XCTUnwrap(
+            configuredSearchBarAction.actionType as? HomepageMiddlewareActionType
+        )
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertEqual(actionsType, .configuredSearchBar)
-        XCTAssertEqual(actionCalled.isSearchBarEnabled, true)
+        XCTAssertEqual(configuredSearchBarActionCount, 1)
+        XCTAssertEqual(configuredSearchBarActionType, .configuredSearchBar)
+        XCTAssertEqual(configuredSearchBarAction.isSearchBarEnabled, true)
     }
 
     func test_viewWillTransitionAction_doesNotConfigureSearchBar() throws {
@@ -328,12 +352,20 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         wait(for: [dispatchExpectation], timeout: 1)
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? HomepageAction)
-        let actionsType = try XCTUnwrap(actionCalled.actionType as? HomepageMiddlewareActionType)
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [HomepageAction])
+        let configuredSearchBarAction = try XCTUnwrap(actionsCalled.first(where: {
+            $0.actionType as? HomepageMiddlewareActionType == .configuredSearchBar
+        }))
+        let configuredSearchBarActionCount = actionsCalled.filter {
+            ($0.actionType as? HomepageMiddlewareActionType) == .configuredSearchBar
+        }.count
+        let configuredSearchBarActionType = try XCTUnwrap(
+            configuredSearchBarAction.actionType as? HomepageMiddlewareActionType
+        )
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertEqual(actionsType, .configuredSearchBar)
-        XCTAssertEqual(actionCalled.isSearchBarEnabled, false)
+        XCTAssertEqual(configuredSearchBarActionCount, 1)
+        XCTAssertEqual(configuredSearchBarActionType, .configuredSearchBar)
+        XCTAssertEqual(configuredSearchBarAction.isSearchBarEnabled, false)
     }
 
     func test_toolbarCancelEditAction_configuresSearchBar() throws {
@@ -354,12 +386,20 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         wait(for: [dispatchExpectation], timeout: 1)
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? HomepageAction)
-        let actionsType = try XCTUnwrap(actionCalled.actionType as? HomepageMiddlewareActionType)
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [HomepageAction])
+        let configuredSearchBarAction = try XCTUnwrap(actionsCalled.first(where: {
+            $0.actionType as? HomepageMiddlewareActionType == .configuredSearchBar
+        }))
+        let configuredSearchBarActionCount = actionsCalled.filter {
+            ($0.actionType as? HomepageMiddlewareActionType) == .configuredSearchBar
+        }.count
+        let configuredSearchBarActionType = try XCTUnwrap(
+            configuredSearchBarAction.actionType as? HomepageMiddlewareActionType
+        )
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertEqual(actionsType, .configuredSearchBar)
-        XCTAssertEqual(actionCalled.isSearchBarEnabled, true)
+        XCTAssertEqual(configuredSearchBarActionCount, 1)
+        XCTAssertEqual(configuredSearchBarActionType, .configuredSearchBar)
+        XCTAssertEqual(configuredSearchBarAction.isSearchBarEnabled, true)
     }
 
     func test_toolbarCancelEditAction_doesNotConfigureSearchBar() throws {
@@ -379,12 +419,20 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         wait(for: [dispatchExpectation], timeout: 1)
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? HomepageAction)
-        let actionsType = try XCTUnwrap(actionCalled.actionType as? HomepageMiddlewareActionType)
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [HomepageAction])
+        let configuredSearchBarAction = try XCTUnwrap(actionsCalled.first(where: {
+            $0.actionType as? HomepageMiddlewareActionType == .configuredSearchBar
+        }))
+        let configuredSearchBarActionCount = actionsCalled.filter {
+            ($0.actionType as? HomepageMiddlewareActionType) == .configuredSearchBar
+        }.count
+        let configuredSearchBarActionType = try XCTUnwrap(
+            configuredSearchBarAction.actionType as? HomepageMiddlewareActionType
+        )
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertEqual(actionsType, .configuredSearchBar)
-        XCTAssertEqual(actionCalled.isSearchBarEnabled, false)
+        XCTAssertEqual(configuredSearchBarActionCount, 1)
+        XCTAssertEqual(configuredSearchBarActionType, .configuredSearchBar)
+        XCTAssertEqual(configuredSearchBarAction.isSearchBarEnabled, false)
     }
 
     func test_navigateBackAction_configuresSearchBar() throws {
@@ -405,12 +453,20 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         wait(for: [dispatchExpectation], timeout: 1)
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? HomepageAction)
-        let actionsType = try XCTUnwrap(actionCalled.actionType as? HomepageMiddlewareActionType)
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [HomepageAction])
+        let configuredSearchBarAction = try XCTUnwrap(actionsCalled.first(where: {
+            $0.actionType as? HomepageMiddlewareActionType == .configuredSearchBar
+        }))
+        let configuredSearchBarActionCount = actionsCalled.filter {
+            ($0.actionType as? HomepageMiddlewareActionType) == .configuredSearchBar
+        }.count
+        let configuredSearchBarActionType = try XCTUnwrap(
+            configuredSearchBarAction.actionType as? HomepageMiddlewareActionType
+        )
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertEqual(actionsType, .configuredSearchBar)
-        XCTAssertEqual(actionCalled.isSearchBarEnabled, true)
+        XCTAssertEqual(configuredSearchBarActionCount, 1)
+        XCTAssertEqual(configuredSearchBarActionType, .configuredSearchBar)
+        XCTAssertEqual(configuredSearchBarAction.isSearchBarEnabled, true)
     }
 
     func test_navigateBackAction_doesNotConfigureSearchBar() throws {
@@ -430,12 +486,20 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         wait(for: [dispatchExpectation], timeout: 1)
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? HomepageAction)
-        let actionsType = try XCTUnwrap(actionCalled.actionType as? HomepageMiddlewareActionType)
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [HomepageAction])
+        let configuredSearchBarAction = try XCTUnwrap(actionsCalled.first(where: {
+            $0.actionType as? HomepageMiddlewareActionType == .configuredSearchBar
+        }))
+        let configuredSearchBarActionCount = actionsCalled.filter {
+            ($0.actionType as? HomepageMiddlewareActionType) == .configuredSearchBar
+        }.count
+        let configuredSearchBarActionType = try XCTUnwrap(
+            configuredSearchBarAction.actionType as? HomepageMiddlewareActionType
+        )
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertEqual(actionsType, .configuredSearchBar)
-        XCTAssertEqual(actionCalled.isSearchBarEnabled, false)
+        XCTAssertEqual(configuredSearchBarActionCount, 1)
+        XCTAssertEqual(configuredSearchBarActionType, .configuredSearchBar)
+        XCTAssertEqual(configuredSearchBarAction.isSearchBarEnabled, false)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12740)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27737)

## :bulb: Description
- Updates the homepage layout to create space between the shortcuts section and the other sections, allowing for the search bar to be positioned ideally.

### 🧑‍💻 Technical details
- This  full-screen-layout without-having-a-full-screen-of-content is accomplished by adding a `spacer` section to the homepage, who's height is the size of the `UICollectionView` minus the size of all of the other sections which are comprised of content, headers/footers, vertical item/group/section spacing, and vertical item/group/section insets.

- The spacer is hidden on iPad, where the stories section appears right below the shortcuts section

### 📝 Follow-ups  
To avoid this PR getting to big, I created some follow-up work:
- Add unit tests ([FXIOS-12863](https://mozilla-hub.atlassian.net/browse/FXIOS-12863))
- Improve layout transition when showing/hiding address bar ([FXIOS-12865](https://mozilla-hub.atlassian.net/browse/FXIOS-12865))

| Before | After |
| - | - |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-17 at 10 39 52" src="https://github.com/user-attachments/assets/69367580-5c45-4b3b-a752-90ff0b0f8736" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-17 at 10 36 38" src="https://github.com/user-attachments/assets/ddf4bbae-6d9d-4318-aa36-2c50e9e300d1" /> |


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)


[FXIOS-12863]: https://mozilla-hub.atlassian.net/browse/FXIOS-12863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FXIOS-12865]: https://mozilla-hub.atlassian.net/browse/FXIOS-12865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ