### PR TITLE
Refactor FXIOS-XXXX Fix misspelling of isDismissible across app code

### DIFF
--- a/firefox-ios/Client/Coordinators/BaseCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/BaseCoordinator.swift
@@ -11,7 +11,7 @@ open class BaseCoordinator: NSObject, Coordinator {
     var childCoordinators: [Coordinator] = []
     var router: Router
     var logger: Logger
-    var isDismissable: Bool { true }
+    var isDismissible: Bool { true }
     private var mainQueue: DispatchQueueInterface
 
     init(router: Router,
@@ -50,7 +50,7 @@ open class BaseCoordinator: NSObject, Coordinator {
 
         // Dismiss any child of the matching coordinator that handles a route
         for child in matchingCoordinator.childCoordinators {
-            guard child.isDismissable else { continue }
+            guard child.isDismissible else { continue }
 
             logger.log("Dismissing child of the matching coordinator", level: .debug, category: .coordinator)
             matchingCoordinator.router.dismiss()

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -54,7 +54,7 @@ class BrowserCoordinator: BaseCoordinator,
         return featureFlags.isFeatureEnabled(.deeplinkOptimizationRefactor, checking: .buildOnly)
     }
 
-    override var isDismissable: Bool { false }
+    override var isDismissible: Bool { false }
 
     init(router: Router,
          screenshotService: ScreenshotService,

--- a/firefox-ios/Client/Coordinators/Coordinator.swift
+++ b/firefox-ios/Client/Coordinators/Coordinator.swift
@@ -15,7 +15,7 @@ protocol Coordinator: AnyObject {
     /// cannot be dismissed for example due to state saving.
     /// This isn't ideal for this pattern, but was deemed necessary to keep existing behavior while
     /// moving away from previous pattern. By default, all coordinators should be dismissable.
-    var isDismissable: Bool { get }
+    var isDismissible: Bool { get }
 
     /// Will hold the Route the coordinator was asked to navigate to in case the path could not be handled yet.
     var savedRoute: Route? { get set }

--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -317,7 +317,7 @@ final class LaunchCoordinator: BaseCoordinator,
             introViewController.modalPresentationStyle = .formSheet
             // Disables dismissing the view by tapping outside the view, based on
             // Nimbus's configuration
-            if !introViewModel.isDismissable {
+            if !introViewModel.isDismissible {
                 introViewController.isModalInPresentation = true
             }
             router.present(introViewController, animated: true) {
@@ -345,7 +345,7 @@ final class LaunchCoordinator: BaseCoordinator,
                 height: ViewControllerConsts.PreferredSize.UpdateViewController.height)
             updateViewController.modalPresentationStyle = .formSheet
             // Nimbus's configuration
-            if !updateViewModel.isDismissable {
+            if !updateViewModel.isDismissible {
                 updateViewController.isModalInPresentation = true
             }
             router.present(updateViewController)

--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -26,7 +26,7 @@ class LibraryCoordinator: BaseCoordinator,
     private let tabManager: TabManager
     private var libraryViewController: LibraryViewController?
     weak var parentCoordinator: LibraryCoordinatorDelegate?
-    override var isDismissable: Bool { false }
+    override var isDismissible: Bool { false }
     private var windowUUID: WindowUUID { return tabManager.windowUUID }
 
     init(

--- a/firefox-ios/Client/Frontend/Onboarding/Models/IntroViewModel.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/IntroViewModel.swift
@@ -24,7 +24,7 @@ class IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
     var chosenOptions: OnboardingOptions = []
 
     var availableCards: [OnboardingCardViewController]
-    var isDismissable: Bool
+    var isDismissible: Bool
     var profile: Profile
     var telemetryUtility: OnboardingTelemetryProtocol
     private var cardModels: [OnboardingCardInfoModelProtocol]
@@ -40,7 +40,7 @@ class IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
         self.profile = profile
         self.telemetryUtility = telemetryUtility
         self.cardModels = model.cards
-        self.isDismissable = model.isDismissable
+        self.isDismissible = model.isDismissible
         self.availableCards = []
     }
 

--- a/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingKitViewModel.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingKitViewModel.swift
@@ -6,5 +6,5 @@ import Foundation
 
 struct OnboardingKitViewModel {
     let cards: [OnboardingKitCardInfoModel]
-    let isDismissable: Bool
+    let isDismissible: Bool
 }

--- a/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingViewModel.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingViewModel.swift
@@ -6,5 +6,5 @@ import Foundation
 
 struct OnboardingViewModel {
     let cards: [OnboardingCardInfoModel]
-    let isDismissable: Bool
+    let isDismissible: Bool
 }

--- a/firefox-ios/Client/Frontend/Onboarding/Models/UpdateViewModel.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/UpdateViewModel.swift
@@ -13,7 +13,7 @@ class UpdateViewModel: OnboardingViewModelProtocol,
     var profile: Profile
     var hasSyncableAccount: Bool?
     var availableCards: [OnboardingCardViewController]
-    var isDismissable: Bool
+    var isDismissible: Bool
     var telemetryUtility: OnboardingTelemetryProtocol
     let windowUUID: WindowUUID
     private var cardModels: [OnboardingCardInfoModelProtocol]
@@ -41,7 +41,7 @@ class UpdateViewModel: OnboardingViewModelProtocol,
         self.profile = profile
         self.telemetryUtility = telemetryUtility
         self.cardModels = model.cards
-        self.isDismissable = model.isDismissable
+        self.isDismissible = model.isDismissible
         self.availableCards = []
         self.windowUUID = windowUUID
     }

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingViewModelProtocol.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingViewModelProtocol.swift
@@ -7,7 +7,7 @@ import Common
 
 protocol OnboardingViewModelProtocol {
     var availableCards: [OnboardingCardViewController] { get }
-    var isDismissable: Bool { get }
+    var isDismissible: Bool { get }
     var profile: Profile { get }
     var telemetryUtility: OnboardingTelemetryProtocol { get }
 

--- a/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
@@ -112,7 +112,7 @@ class IntroViewController: UIViewController,
 
     private func setupLayout() {
         setupPageController()
-        if viewModel.isDismissable { setupCloseButton() }
+        if viewModel.isDismissible { setupCloseButton() }
     }
 
     private func setupPageController() {
@@ -129,7 +129,7 @@ class IntroViewController: UIViewController,
     }
 
     private func setupCloseButton() {
-        guard viewModel.isDismissable else { return }
+        guard viewModel.isDismissible else { return }
         view.addSubview(closeButton)
         view.bringSubviewToFront(closeButton)
         view.accessibilityElements = [closeButton, pageController.view as Any, pageControl]

--- a/firefox-ios/Client/Frontend/Onboarding/Views/UpdateViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/UpdateViewController.swift
@@ -88,7 +88,7 @@ class UpdateViewController: UIViewController,
             setupMultipleCardsConstraints()
         }
 
-        if viewModel.isDismissable { setupCloseButton() }
+        if viewModel.isDismissible { setupCloseButton() }
     }
 
     private func setupSingleInfoCard() {
@@ -122,7 +122,7 @@ class UpdateViewController: UIViewController,
     }
 
     private func setupCloseButton() {
-        guard viewModel.isDismissable else { return }
+        guard viewModel.isDismissible else { return }
         view.addSubview(closeButton)
         view.bringSubviewToFront(closeButton)
 

--- a/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -32,7 +32,7 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
 
         return OnboardingViewModel(
             cards: cards,
-            isDismissable: framework.dismissable)
+            isDismissible: framework.dismissable)
     }
 
     private func getOrderedOnboardingCards(

--- a/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingKitFeatureLayer.swift
+++ b/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingKitFeatureLayer.swift
@@ -31,7 +31,7 @@ class NimbusOnboardingKitFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
 
         return OnboardingKitViewModel(
             cards: cards,
-            isDismissable: framework.dismissable)
+            isDismissible: framework.dismissable)
     }
 
     private func getOrderedOnboardingCards(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
@@ -111,5 +111,5 @@ final class BaseCoordinatorTests: XCTestCase {
 }
 
 class NonDismissableCoordinator: BaseCoordinator {
-    override var isDismissable: Bool { false }
+    override var isDismissible: Bool { false }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
@@ -172,7 +172,7 @@ final class LaunchScreenViewModelTests: XCTestCase {
         ]
 
         return OnboardingViewModel(cards: cards,
-                                   isDismissable: true)
+                                   isDismissible: true)
     }
 
     func createCard(index: Int) -> OnboardingCardInfoModel {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockCoordinator.swift
@@ -12,7 +12,7 @@ class MockCoordinator: Coordinator {
     var router: Router
     var savedRoute: Route?
     var logger: Logger = MockLogger()
-    var isDismissable = true
+    var isDismissible = true
 
     var addChildCalled = 0
     var removedChildCalled = 0

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/NimbusOnboardingFeatureLayerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/NimbusOnboardingFeatureLayerTests.swift
@@ -44,7 +44,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
         let layer = NimbusOnboardingFeatureLayer(with: MockNimbusMessagingHelperUtility())
         let subject = layer.getOnboardingModel(for: .freshInstall)
 
-        XCTAssertTrue(subject.isDismissable)
+        XCTAssertTrue(subject.isDismissible)
     }
 
     func testLayer_dismissable_isFalse() {
@@ -52,7 +52,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
         let layer = NimbusOnboardingFeatureLayer(with: MockNimbusMessagingHelperUtility())
         let subject = layer.getOnboardingModel(for: .freshInstall)
 
-        XCTAssertFalse(subject.isDismissable)
+        XCTAssertFalse(subject.isDismissible)
     }
 
     // MARK: - Test A11yRoot

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
@@ -202,7 +202,7 @@ class UpdateViewModelTests: XCTestCase {
         ]
 
         return OnboardingViewModel(cards: withCards ? cards : [],
-                                   isDismissable: true)
+                                   isDismissible: true)
     }
 
     func createCard(index: Int) -> OnboardingCardInfoModel {


### PR DESCRIPTION
## :scroll: Tickets
N/A

## :bulb: Description
Fixes a misspelling of isDismissible which Xcode's spellchecker always underlines.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
