### PR TITLE
Bugfix FXIOS-12814 ⁃ [Menu redesign] "<" element in Tracking Protection and More buttons is incorrect in Arabic

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignCell.swift
@@ -69,7 +69,9 @@ final class MenuRedesignCell: UITableViewCell, ReusableCell, ThemeApplicable {
         self.titleLabel.text = model.title
         self.descriptionLabel.text = model.description
         self.contentStackView.spacing = model.description != nil ? UX.contentSpacing : UX.noDescriptionContentSpacing
-        self.iconImageView.image = UIImage(named: model.iconName)?.withRenderingMode(.alwaysTemplate)
+        self.iconImageView.image = UIImage(named: model.iconName)?
+            .withRenderingMode(.alwaysTemplate)
+            .imageFlippedForRightToLeftLayoutDirection()
         self.isAccessibilityElement = true
         self.isUserInteractionEnabled = !model.isEnabled ? false : true
         self.accessibilityIdentifier = model.a11yId

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSiteProtectionsHeader.swift
@@ -90,7 +90,10 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
 
     private var siteProtectionsMoreSettingsIcon: UIImageView = .build { imageView in
         let imageName = StandardImageIdentifiers.Large.chevronRight
-        imageView.image = UIImage(named: imageName)?.withRenderingMode(.alwaysTemplate) ?? UIImage()
+        let image = UIImage(named: imageName)?
+            .withRenderingMode(.alwaysTemplate)
+            .imageFlippedForRightToLeftLayoutDirection() ?? UIImage()
+        imageView.image = image
         imageView.contentMode = .scaleAspectFit
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12814)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27912)

## :bulb: Description
Applied imageFlippedForRightToLeftLayoutDirection for images

## :movie_camera: Demos
<img width="750" height="1334" alt="Simulator Screenshot - iPhone 7 - 2025-07-15 at 10 57 46" src="https://github.com/user-attachments/assets/5063ad35-5eae-46da-864b-07bbdcb426c1" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
