### PR TITLE
Bugfix FXIOS-12812 ⁃ [Menu redesign] Tapping “Website Dark Mode” in landscape sometimes opens the Passwords/History panel instead

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquaresViewContentCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquaresViewContentCell.swift
@@ -38,7 +38,7 @@ final class MenuSquaresViewContentCell: UITableViewCell, ReusableCell, ThemeAppl
     // We override this method, for handling taps on MenuSquareView views
     // This may be a temporary fix
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        if self.isHidden || self.alpha == 0 || !self.isUserInteractionEnabled {
+        if self.isHidden || self.alpha.isZero || !self.isUserInteractionEnabled {
             return nil
         }
         for subview in contentStackView.arrangedSubviews.reversed() {

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquaresViewContentCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquaresViewContentCell.swift
@@ -38,14 +38,16 @@ final class MenuSquaresViewContentCell: UITableViewCell, ReusableCell, ThemeAppl
     // We override this method, for handling taps on MenuSquareView views
     // This may be a temporary fix
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        guard self.bounds.contains(point) else { return nil }
-        for subview in contentStackView.arrangedSubviews {
+        if self.isHidden || self.alpha == 0 || !self.isUserInteractionEnabled {
+            return nil
+        }
+        for subview in contentStackView.arrangedSubviews.reversed() {
             let convertedPoint = self.convert(point, to: subview)
-            if let hitView = subview.hitTest(convertedPoint, with: event) {
-                return hitView
+            if let hit = subview.hitTest(convertedPoint, with: event) {
+                return hit
             }
         }
-        return super.hitTest(point, with: event)
+        return nil
     }
 
     private func setupUI() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12812)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27907)

## :bulb: Description
Changed the hitTest logic

## :movie_camera: Demos

https://github.com/user-attachments/assets/b4a7095f-bc95-48bb-b101-41e8a6cf89f5



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
