### PR TITLE
Bugfix FXIOS-12811 ⁃ [Menu redesign] The strikethrough line on the Tracking Protection shield icon is not red for unsafe pages

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSiteProtectionsHeader.swift
@@ -142,11 +142,23 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         closeButton.layer.cornerRadius = 0.5 * UX.closeButtonSize
     }
 
-    public func setupDetails(title: String?, subtitle: String?, image: String?, state: String, stateImage: String) {
+    public func setupDetails(
+        title: String?,
+        subtitle: String?,
+        image: String?,
+        state: String,
+        stateImage: String,
+        shouldUseRenderMode: Bool
+    ) {
         titleLabel.text = title
         subtitleLabel.text = subtitle
         siteProtectionsLabel.text = state
-        siteProtectionsIcon.image = UIImage(named: stateImage)?.withRenderingMode(.alwaysTemplate) ?? UIImage()
+        let siteProtectionsImage: UIImage = if shouldUseRenderMode {
+            UIImage(named: stateImage)?.withRenderingMode(.alwaysTemplate) ?? UIImage()
+        } else {
+            UIImage(named: stateImage) ?? UIImage()
+        }
+        siteProtectionsIcon.image = siteProtectionsImage
 
         let image = FaviconImageViewModel(siteURLString: image,
                                           faviconCornerRadius: UX.favIconSize / 2)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -502,12 +502,14 @@ class MainMenuViewController: UIViewController,
     private func updateSiteProtectionsHeaderWith(siteProtectionsData: SiteProtectionsData) {
         var state = String.MainMenu.SiteProtection.ProtectionsOn
         var stateImage = StandardImageIdentifiers.Small.shieldCheckmarkFill
+        var shouldUseRenderMode = false
 
         switch siteProtectionsData.state {
         case .notSecure:
             state = String.MainMenu.SiteProtection.ConnectionNotSecure
             stateImage = StandardImageIdentifiers.Small.shieldSlashFillMulticolor
-        case .on: break
+        case .on:
+            shouldUseRenderMode = true
         case .off:
             state = String.MainMenu.SiteProtection.ProtectionsOff
             stateImage = StandardImageIdentifiers.Small.shieldSlashFillMulticolor
@@ -518,7 +520,8 @@ class MainMenuViewController: UIViewController,
             subtitle: siteProtectionsData.subtitle,
             image: siteProtectionsData.image,
             state: state,
-            stateImage: stateImage)
+            stateImage: stateImage,
+            shouldUseRenderMode: shouldUseRenderMode)
     }
 
     // MARK: - A11y


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12811)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27906)

## :bulb: Description
Fixed the site protections icon

## :movie_camera: Demos
<img width="1206" height="2622" alt="IMG_7709" src="https://github.com/user-attachments/assets/bd8f891c-08c2-462a-8624-378e523c473f" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
