### PR TITLE
Remove FXIOS-12452 [Telemetry Audit] unneeded preferences telemetry

### DIFF
--- a/firefox-ios/Client/Glean/probes/settings.yaml
+++ b/firefox-ios/Client/Glean/probes/settings.yaml
@@ -52,24 +52,6 @@ preferences:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-01-01"
-  new_tab_experience:
-    type: string
-    description: |
-      The name of the view that the user wants to see on new tabs.
-      For example History, Homepage or Blank. It is used to measure
-      usage of this feature, to see how effective feature promotion
-      campaigns are and to establish a baseline number for when we
-      introduce the new Activity Stream features.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-      - https://github.com/mozilla-mobile/firefox-ios/pull/9673
-      - https://github.com/mozilla-mobile/firefox-ios/pull/12334
-      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
   home_page_setting:
     type: string
     description: |
@@ -89,20 +71,6 @@ preferences:
     type: boolean
     description: |
       Measures the state of the "Save Logins" preference.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-      - https://github.com/mozilla-mobile/firefox-ios/pull/9673
-      - https://github.com/mozilla-mobile/firefox-ios/pull/12334
-      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-  show_clipboard_bar:
-    type: boolean
-    description: |
-      Measures the state of the "Show Clipboard Bar" preference.
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
     data_reviews:
@@ -157,53 +125,6 @@ preferences:
       - https://github.com/mozilla-mobile/firefox-ios/pull/9673
       - https://github.com/mozilla-mobile/firefox-ios/pull/12334
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-  jump_back_in:
-    type: boolean
-    description: |
-      An indication of whether the Jump back in section
-      is enabled to be displayed.
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/14908
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/15583
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-  recently_visited:
-    type: boolean
-    description: |
-      An indication of whether the Recently visited section
-      is enabled to be displayed.
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/14908
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/15583
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-  recently_saved:
-    type: boolean
-    description: |
-      An indication of whether the recently saved section
-      is enabled to be displayed.
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/14908
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/15583
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-01-01"
-  pocket:
-    type: boolean
-    description: |
-      An indication of whether Pocket is enabled to be displayed.
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/14908
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/15583
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-01-01"

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -229,13 +229,6 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         // FxA Account Login status
         GleanMetrics.Preferences.fxaLoggedIn.set(profile.hasSyncableAccount())
 
-        // Record New Tab setting
-        if let newTabChoice = prefs.stringForKey(NewTabAccessors.HomePrefKey) {
-            GleanMetrics.Preferences.newTabExperience.set(newTabChoice)
-        } else {
-            GleanMetrics.Preferences.newTabExperience.set(NewTabAccessors.Default.rawValue)
-        }
-
         // Record `Home` setting, where Firefox Home is "Home", a custom URL is "other" and blank is "Blank".
         let homePageSetting = NewTabAccessors.getHomePage(prefs)
         switch homePageSetting {
@@ -258,13 +251,6 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
             GleanMetrics.Preferences.saveLogins.set(saveLogins)
         } else {
             GleanMetrics.Preferences.saveLogins.set(true)
-        }
-
-        // Show clipboard bar
-        if let showClipboardBar = prefs.boolForKey(PrefsKeys.ShowClipboardBar) {
-            GleanMetrics.Preferences.showClipboardBar.set(showClipboardBar)
-        } else {
-            GleanMetrics.Preferences.showClipboardBar.set(false)
         }
 
         // Close private tabs
@@ -303,17 +289,6 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
             // https://mozilla.github.io/glean/book/reference/metrics/index.html#label-format)
             GleanMetrics.WallpaperAnalytics.themedWallpaper[currentWallpaper.id.lowercased()].add()
         }
-
-        // Homepage section preferences
-        let isJumpBackInEnabled = !featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
-        GleanMetrics.Preferences.jumpBackIn.set(isJumpBackInEnabled)
-
-        let isBookmarksEnabled = !featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
-        GleanMetrics.Preferences.recentlySaved.set(isBookmarksEnabled)
-
-        let isFeatureEnabled = prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.ASPocketStories) ?? true
-        let isPocketEnabled = isFeatureEnabled && PocketProvider.islocaleSupported(Locale.current.identifier)
-        GleanMetrics.Preferences.pocket.set(isPocketEnabled)
 
         let startAtHomeOption: StartAtHome = featureFlags.getCustomState(for: .startAtHome) ?? .afterFourHours
         GleanMetrics.Preferences.openingScreen.set(startAtHomeOption.rawValue)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12452)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27158)

## :bulb: Description
Remove unneeded telemetry based on the conversations in the ticket. 

- preferences.jump_back_in
- preferences.new_tab_experience
- preferences.pocket
- preferences.recently_saved
- preferences.recently_visited
- preferences.show_clipboard_bar

Kept the following for now:
- preferences.opening_screen
- preferences.home_page_setting

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
