### PR TITLE
 Refactor FXIOS-12796 [Swift 6 Migration] Move Device Check out of LaunchType functions

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -81,8 +81,8 @@ class BrowserCoordinator: BaseCoordinator,
 
     func start(with launchType: LaunchType?) {
         router.push(browserViewController, animated: false)
-
-        if let launchType = launchType, launchType.canLaunch(fromType: .BrowserCoordinator) {
+        let isIphone = UIDevice.current.userInterfaceIdiom == .phone
+        if let launchType = launchType, launchType.canLaunch(fromType: .BrowserCoordinator, isIphone: isIphone) {
             startLaunch(with: launchType)
         }
     }

--- a/firefox-ios/Client/Coordinators/Launch/LaunchType.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchType.swift
@@ -30,7 +30,7 @@ enum LaunchType {
     ///   - isIphone: True when the current device is of type iPhone
     /// - Returns: true if the launch type can be launched from a particular coordinator or not
     func canLaunch(fromType type: LaunchCoordinatorType,
-                   isIphone: Bool = UIDevice.current.userInterfaceIdiom == .phone) -> Bool {
+                   isIphone: Bool) -> Bool {
         switch type {
         case .BrowserCoordinator:
             return !isFullScreenAvailable(isIphone: isIphone)
@@ -42,7 +42,7 @@ enum LaunchType {
     /// We show full screen launch types from scene coordinator, other launch type are shown from browser coordinator
     /// - Parameter isIphone: True when the current device is of type iPhone
     /// - Returns: if the launch type needs to be full screen or not
-    func isFullScreenAvailable(isIphone: Bool = UIDevice.current.userInterfaceIdiom == .phone) -> Bool {
+    func isFullScreenAvailable(isIphone: Bool) -> Bool {
         switch self {
         case .termsOfService:
             return true

--- a/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -77,14 +77,16 @@ class SceneCoordinator: BaseCoordinator,
         let profile: Profile = AppContainer.shared.resolve()
         let introManager = IntroScreenManager(prefs: profile.prefs)
         let launchType = LaunchType.intro(manager: introManager)
-        return launchType.canLaunch(fromType: .SceneCoordinator)
+        let isIphone = UIDevice.current.userInterfaceIdiom == .phone
+        return launchType.canLaunch(fromType: .SceneCoordinator, isIphone: isIphone)
     }
 
     private func showIntroOnboardingIfNeeded() {
         let profile: Profile = AppContainer.shared.resolve()
         let introManager = IntroScreenManager(prefs: profile.prefs)
         let launchType = LaunchType.intro(manager: introManager)
-        if launchType.canLaunch(fromType: .SceneCoordinator) {
+        let isIphone = UIDevice.current.userInterfaceIdiom == .phone
+        if launchType.canLaunch(fromType: .SceneCoordinator, isIphone: isIphone) {
             startLaunch(with: launchType)
         }
     }
@@ -92,7 +94,8 @@ class SceneCoordinator: BaseCoordinator,
     // MARK: - LaunchFinishedLoadingDelegate
 
     func launchWith(launchType: LaunchType) {
-        guard launchType.canLaunch(fromType: .SceneCoordinator) else {
+        let isIphone = UIDevice.current.userInterfaceIdiom == .phone
+        guard launchType.canLaunch(fromType: .SceneCoordinator, isIphone: isIphone) else {
             startBrowser(with: launchType)
             return
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Project Errors: 3042 -> 3040
Move the device check out of the LaunchType functions
<img width="636" height="124" alt="Screenshot 2025-07-15 at 9 26 42 PM" src="https://github.com/user-attachments/assets/7c856292-2f4f-42c0-b6cd-d0f944693aa0" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
