### PR TITLE
Add FXIOS-12843 [Swift 6 Migration] Test that annotating `OnboardingService`'s `handleAction()` with `@MainActor` does not cause issues

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
@@ -54,7 +54,6 @@ final class OnboardingService: FeatureFlaggable {
         self.searchBarLocationSaver = searchBarLocationSaver
     }
 
-    // TODO: FXIOS-12843 Test that calling these completion handlers on the main thread does not cause issues for each action
     @MainActor
     func handleAction(
         _ action: OnboardingActions,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingServiceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingServiceTests.swift
@@ -163,6 +163,7 @@ final class OnboardingServiceTests: XCTestCase {
             cards: [],
             with: activityEventHelper
         ) { result in
+            self.assertOnMainThread()
             expectation.fulfill()
         }
 
@@ -186,10 +187,12 @@ final class OnboardingServiceTests: XCTestCase {
             from: "testCard",
             cards: [],
             with: activityEventHelper
-        ) { _ in }
+        ) { _ in
+            self.assertOnMainThread()
+        }
 
         // Wait for async completion
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        DispatchQueue.main.async {
             expectation.fulfill()
         }
 
@@ -213,10 +216,8 @@ final class OnboardingServiceTests: XCTestCase {
             from: "testCard",
             cards: [],
             with: activityEventHelper
-        ) { _ in }
-
-        // Wait for async completion
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        ) { _ in
+            self.assertOnMainThread()
             expectation.fulfill()
         }
 
@@ -241,6 +242,7 @@ final class OnboardingServiceTests: XCTestCase {
             cards: [],
             with: activityEventHelper
         ) { result in
+            self.assertOnMainThread()
             if case .success(let tabAction) = result {
                 resultTabAction = tabAction
             }
@@ -270,6 +272,7 @@ final class OnboardingServiceTests: XCTestCase {
             cards: [],
             with: activityEventHelper
         ) { result in
+            self.assertOnMainThread()
             if case .success(let tabAction) = result {
                 resultTabAction = tabAction
             }
@@ -299,6 +302,7 @@ final class OnboardingServiceTests: XCTestCase {
             cards: [],
             with: activityEventHelper
         ) { result in
+            self.assertOnMainThread()
             if case .success(let tabAction) = result {
                 resultTabAction = tabAction
             }
@@ -320,6 +324,7 @@ final class OnboardingServiceTests: XCTestCase {
     func testHandleAction_SyncSignIn_UpdatesActivityEventHelper() {
         // Given
         let activityEventHelper = MockActivityEventHelper()
+        let expectation = XCTestExpectation(description: "Completion called")
 
         // When
         sut.handleAction(
@@ -327,7 +332,20 @@ final class OnboardingServiceTests: XCTestCase {
             from: "testCard",
             cards: [],
             with: activityEventHelper
-        ) { _ in }
+        ) { _ in
+            self.assertOnMainThread()
+            expectation.fulfill()
+        }
+
+        guard let presented = mockDelegate.presentedViewController else {
+            XCTFail("Expected a view controller to be presented")
+            return
+        }
+        presented.dismiss(animated: false, completion: nil)
+        presented.beginAppearanceTransition(false, animated: false)
+        presented.endAppearanceTransition()
+
+        wait(for: [expectation], timeout: 1.0)
 
         // Then
         XCTAssertTrue(activityEventHelper.chosenOptions.contains(.syncSignIn))
@@ -351,6 +369,7 @@ final class OnboardingServiceTests: XCTestCase {
             cards: [],
             with: activityEventHelper
         ) { _ in
+            self.assertOnMainThread()
             expectation.fulfill()
         }
 
@@ -376,6 +395,7 @@ final class OnboardingServiceTests: XCTestCase {
             cards: [],
             with: activityEventHelper
         ) { _ in
+            self.assertOnMainThread()
             expectation.fulfill()
         }
 
@@ -399,6 +419,7 @@ final class OnboardingServiceTests: XCTestCase {
             cards: [],
             with: activityEventHelper
         ) { _ in
+            self.assertOnMainThread()
             expectation.fulfill()
         }
 
@@ -417,6 +438,7 @@ final class OnboardingServiceTests: XCTestCase {
         let activityEventHelper = MockActivityEventHelper()
         let testURL = URL(string: "https://example.com/privacy")!
         let mockCard = createMockCard(name: "testCard", url: testURL)
+        let expectation = XCTestExpectation(description: "Completion called")
 
         // When
         sut.handleAction(
@@ -424,7 +446,20 @@ final class OnboardingServiceTests: XCTestCase {
             from: "testCard",
             cards: [mockCard],
             with: activityEventHelper
-        ) { _ in }
+        ) { _ in
+            self.assertOnMainThread()
+            expectation.fulfill()
+        }
+
+        guard let presented = mockDelegate.presentedViewController else {
+            XCTFail("Expected a view controller to be presented")
+            return
+        }
+        presented.dismiss(animated: false, completion: nil)
+        presented.beginAppearanceTransition(false, animated: false)
+        presented.endAppearanceTransition()
+
+        wait(for: [expectation], timeout: 1.0)
 
         // Then
         XCTAssertTrue(mockDelegate.presentCalled)
@@ -444,6 +479,7 @@ final class OnboardingServiceTests: XCTestCase {
             cards: [],
             with: activityEventHelper
         ) { _ in
+            self.assertOnMainThread()
             expectation.fulfill()
         }
 
@@ -476,6 +512,18 @@ final class OnboardingServiceTests: XCTestCase {
             a11yIdRoot: "onboarding_customizationToolbar",
             imageID: "toolbar",
             instructionsPopup: nil
+        )
+    }
+
+    private func assertOnMainThread(
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            Thread.isMainThread,
+            "Not on main thread",
+            file: file,
+            line: line
         )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12843)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27987)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The updated tests now ensure that the completion handler is executed on the main thread, as the handleAction function is marked with the main actor.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
