### PR TITLE
 Refactor FXIOS-12796 [Swift 6 Migration] Fix `ShareSheetCoordinator`'s under-specified protocols

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -8,6 +8,7 @@ import WebKit
 
 @objc
 protocol JSPromptAlertControllerDelegate: AnyObject {
+    @MainActor
     func promptAlertControllerDidDismiss(_ alertController: JSPromptAlertController)
 }
 

--- a/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -10,7 +10,10 @@ import SwiftUI
 import Common
 
 protocol DevicePickerViewControllerDelegate: AnyObject {
+    @MainActor
     func devicePickerViewControllerDidCancel(_ devicePickerViewController: DevicePickerViewController)
+
+    @MainActor
     func devicePickerViewController(
         _ devicePickerViewController: DevicePickerViewController,
         didPickDevices devices: [RemoteDevice]

--- a/firefox-ios/Client/Frontend/InstructionsView.swift
+++ b/firefox-ios/Client/Frontend/InstructionsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 import UIKit
 
 protocol InstructionsViewDelegate: AnyObject {
+    @MainActor
     func dismissInstructionsView()
 }
 

--- a/firefox-ios/Client/Frontend/Share/SendToDeviceHelper.swift
+++ b/firefox-ios/Client/Frontend/Share/SendToDeviceHelper.swift
@@ -32,6 +32,7 @@ class SendToDeviceHelper {
         self.delegate = delegate
     }
 
+    @MainActor
     func initialViewController() -> UIViewController {
         if !hasAccount() {
             // Display instructions to log in if user has no account

--- a/firefox-ios/Extensions/ShareTo/SendToDevice.swift
+++ b/firefox-ios/Extensions/ShareTo/SendToDevice.swift
@@ -30,6 +30,7 @@ class SendToDevice: DevicePickerViewControllerDelegate, InstructionsViewDelegate
         return themeManager.windowNonspecificTheme()
     }
 
+    @MainActor
     func initialViewController() -> UIViewController {
         let theme = currentTheme()
         guard let shareItem = sharedItem else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)


## :bulb: Description
Fix the under-specified protocols used by `ShareSheetCoordinator`.

<img width="1406" height="315" alt="Screenshot 2025-07-16 at 10 04 01 AM" src="https://github.com/user-attachments/assets/93db2e55-4e0a-4fa0-9fec-8d5c144cf595" />

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
