### PR TITLE
Refactor FXIOS-12609 Remove temporary `@unchecked Sendable` conformance from ShareSheetCoordinator

### DIFF
--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -10,9 +10,7 @@ import Storage
 class ShareSheetCoordinator: BaseCoordinator,
                              DevicePickerViewControllerDelegate,
                              InstructionsViewDelegate,
-                             JSPromptAlertControllerDelegate,
-                             // FXIOS-12609 Coordinators marked @unchecked Sendable should be @MainActor synchronized
-                             @unchecked Sendable {
+                             JSPromptAlertControllerDelegate {
     // MARK: - Properties
 
     private let tabManager: TabManager


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12609)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27441)

## :bulb: Description
Now that Coordinators are isolated to the main thread, we can remove temporary @unchecked Sendable conformance. (No need to test this code)

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
