### PR TITLE
 Refactor FXIOS-12796 [Swift 6 Migration] Fix `MicrosurveyCoordinator`'s under-specified protocols

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyCoordinator.swift
@@ -7,7 +7,9 @@ import Foundation
 import Shared
 
 protocol MicrosurveyCoordinatorDelegate: AnyObject {
+    @MainActor
     func dismissFlow()
+
     @MainActor
     func showPrivacy(with content: String?)
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix the under-specified protocol in `MicrosurveyCoordinator`.

<img width="1414" height="267" alt="MicrosurveyCoordinator" src="https://github.com/user-attachments/assets/2696f41a-178e-4069-90b9-b3dc19ca83cf" />

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
