### PR TITLE
Bugfix FXIOS-12796 [Swift 6 Migration] Call to MainActor isolated applicationHelper.open inside AppFxACommandsDelegate

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/firefox-ios/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -20,25 +20,22 @@ extension UIApplication {
 class AppFxACommandsDelegate: FxACommandsDelegate, @unchecked Sendable {
     private let app: ApplicationStateProvider
     private var applicationHelper: ApplicationHelper
-    private var mainQueue: DispatchQueueInterface
 
     init(app: ApplicationStateProvider,
-         applicationHelper: ApplicationHelper = DefaultApplicationHelper(),
-         mainQueue: DispatchQueueInterface = DispatchQueue.main) {
+         applicationHelper: ApplicationHelper = DefaultApplicationHelper()) {
         self.app = app
         self.applicationHelper = applicationHelper
-        self.mainQueue = mainQueue
     }
 
+    @MainActor
     func openSendTabs(for urls: [URL]) {
-        mainQueue.async {
-            guard self.app.applicationState == .active else { return }
+        guard self.app.applicationState == .active else { return }
 
-            for urlToOpen in urls {
-                let urlString = URL.mozInternalScheme + "://open-url?url=\(urlToOpen)"
-                guard let url = URL(string: urlString) else { continue }
-                self.applicationHelper.open(url)
-            }
+        for urlToOpen in urls {
+            let urlString = URL.mozInternalScheme + "://open-url?url=\(urlToOpen)"
+            guard let url = URL(string: urlString) else { continue }
+
+            self.applicationHelper.open(url)
         }
     }
 

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -674,6 +674,7 @@ open class BrowserProfile: Profile,
                     }
                 }
                 if !receivedTabURLs.isEmpty {
+                    // TODO: FXIOS-12854 pollForCommands completionHandler should be marked as @MainActor
                     Task { @MainActor in
                         self.fxaCommandsDelegate?.openSendTabs(for: receivedTabURLs)
                     }

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -57,6 +57,7 @@ public protocol SyncManager {
 /// This exists to pass in external context: e.g., the UIApplication can
 /// expose notification functionality in this way.
 public protocol FxACommandsDelegate: AnyObject {
+    @MainActor
     func openSendTabs(for urls: [URL])
     func closeTabs(for urls: [URL])
 }
@@ -673,7 +674,9 @@ open class BrowserProfile: Profile,
                     }
                 }
                 if !receivedTabURLs.isEmpty {
-                    self.fxaCommandsDelegate?.openSendTabs(for: receivedTabURLs)
+                    Task { @MainActor in
+                        self.fxaCommandsDelegate?.openSendTabs(for: receivedTabURLs)
+                    }
                 }
 
                 if !closedTabURLs.isEmpty {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppSendTabDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppSendTabDelegateTests.swift
@@ -5,7 +5,6 @@
 import XCTest
 @testable import Client
 
-@preconcurrency
 final class AppFxACommandsTests: XCTestCase {
     private var applicationStateProvider: MockApplicationStateProvider!
     private var applicationHelper: MockApplicationHelper!
@@ -22,6 +21,7 @@ final class AppFxACommandsTests: XCTestCase {
         self.applicationHelper = nil
     }
 
+    @MainActor
     func testOpenSendTabs_inactiveState_doesntCallDeeplink() {
         applicationStateProvider.applicationState = .inactive
         let url = URL(string: "https://mozilla.com")!
@@ -31,6 +31,7 @@ final class AppFxACommandsTests: XCTestCase {
         XCTAssertEqual(applicationHelper.openURLCalled, 0)
     }
 
+    @MainActor
     func testOpenSendTabs_backgroundState_doesntCallDeeplink() {
         applicationStateProvider.applicationState = .background
         let url = URL(string: "https://mozilla.com")!
@@ -40,6 +41,7 @@ final class AppFxACommandsTests: XCTestCase {
         XCTAssertEqual(applicationHelper.openURLCalled, 0)
     }
 
+    @MainActor
     func testOpenSendTabs_activeWithOneURL_callsDeeplink() {
         let url = URL(string: "https://mozilla.com")!
         let subject = createSubject()
@@ -50,6 +52,7 @@ final class AppFxACommandsTests: XCTestCase {
         XCTAssertEqual(applicationHelper.lastOpenURL, expectedURL)
     }
 
+    @MainActor
     func testOpenSendTabs_activeWithMultipleURLs_callsDeeplink() {
         let url = URL(string: "https://mozilla.com")!
         let subject = createSubject()
@@ -62,13 +65,11 @@ final class AppFxACommandsTests: XCTestCase {
     func testCloseSendTabs_activeWithOneURL_callsDeeplink() async {
         let url = URL(string: "https://mozilla.com")!
         let subject = createSubject()
-        let expectation = XCTestExpectation(description: "Close tabs called")
-        subject.closeTabs(for: [url])
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            expectation.fulfill()
-            XCTAssertEqual(self.applicationHelper.closeTabsCalled, 1)
+        let task = Task {
+            subject.closeTabs(for: [url])
         }
-        await fulfillment(of: [expectation])
+        await task.value
+        XCTAssertEqual(applicationHelper.closeTabsCalled, 1)
     }
 
     func testCloseSendTabs_activeWithMultipleURLs_callsDeeplink() async {
@@ -76,21 +77,18 @@ final class AppFxACommandsTests: XCTestCase {
         let url2 = URL(string: "https://example.com/1")!
         let url3 = URL(string: "https://example.com/2")!
         let subject = createSubject()
-        let expectation = XCTestExpectation(description: "Close tabs called multiple times")
-        subject.closeTabs(for: [url1, url2, url3])
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            expectation.fulfill()
-            XCTAssertEqual(self.applicationHelper.closeTabsCalled, 1)
+        let task = Task {
+            subject.closeTabs(for: [url1, url2, url3])
         }
-        await fulfillment(of: [expectation])
+        await task.value
+        XCTAssertEqual(applicationHelper.closeTabsCalled, 1)
     }
 
     // MARK: - Helper methods
 
     func createSubject() -> AppFxACommandsDelegate {
         let subject = AppFxACommandsDelegate(app: applicationStateProvider,
-                                             applicationHelper: applicationHelper,
-                                             mainQueue: MockDispatchQueue())
+                                             applicationHelper: applicationHelper)
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
`ApplicationHelper.open` method is now `@MainActor` which causes this warning under the `AppFxACommandsDelegate`.

<img width="1923" height="767" alt="Screenshot 2025-07-16 at 2 09 05 PM" src="https://github.com/user-attachments/assets/26df8855-98f9-44e9-b31b-a83220e1f92a" />

### Fix proposal
I was thinking at first to just wrap the call into a `Task { @MainActor` like this:
```
Task { @MainActor in
    self.applicationHelper.open(url)
}
```

However, this makes testing more difficult, and if I recall correctly, we said it's best practice in Swift concurrency to surface Task creation as high in the call hierarchy as possible.

So instead I am making `openSendTabs(for urls: [URL])` `@MainActor`, both on the protocol and the class implementation (the more verbose way that we discussed).

### Testing
There was an `@preconcurrency` added at the top of the test class, I am removing it and await the `Task` instead of using a `DispatchQueue` with an expectation, in the following tests:
- `testOpenSendTabs_activeWithMultipleURLs_callsDeeplink`
- `testCloseSendTabs_activeWithMultipleURLs_callsDeeplink`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
