### PR TITLE
 Refactor FXIOS-12796 [Swift 6 Migration] Fix under-specified Coordinators Batch 1

### DIFF
--- a/firefox-ios/Client/Coordinators/ParentCoordinatorDelegate.swift
+++ b/firefox-ios/Client/Coordinators/ParentCoordinatorDelegate.swift
@@ -6,5 +6,6 @@ import Foundation
 
 protocol ParentCoordinatorDelegate: AnyObject {
     /// Notifies the parent coordinator that a child coordinator has finished his session.
+    @MainActor
     func didFinish(from childCoordinator: Coordinator)
 }

--- a/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
@@ -13,10 +13,19 @@ protocol PasswordManagerCoordinatorDelegate: AnyObject, ParentCoordinatorDelegat
 }
 
 protocol PasswordManagerFlowDelegate: AnyObject {
+    @MainActor
     func continueFromOnboarding()
+
+    @MainActor
     func showDevicePassCode()
+
+    @MainActor
     func pressedPasswordDetail(model: PasswordDetailViewControllerModel)
+
+    @MainActor
     func pressedAddPassword(completion: @escaping (LoginEntry) -> Void)
+
+    @MainActor
     func openURL(url: URL)
 }
 

--- a/firefox-ios/Client/Coordinators/QRCode/QRCodeNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/QRCode/QRCodeNavigationHandler.swift
@@ -7,10 +7,12 @@ import Foundation
 protocol QRCodeNavigationHandler: AnyObject {
     /// Shows the QRCodeViewController
     /// The root navigation controller is used when available to present the QRCodeViewController.
+    @MainActor
     func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController?)
 }
 
 extension QRCodeNavigationHandler {
+    @MainActor
     func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController? = nil) {
         showQRCode(delegate: delegate, rootNavigationController: rootNavigationController)
     }

--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -9,6 +9,7 @@ protocol TabTrayCoordinatorDelegate: AnyObject {
 }
 
 protocol TabTrayNavigationHandler: AnyObject {
+    @MainActor
     func start(panelType: TabTrayPanelType, navigationController: UINavigationController)
 }
 

--- a/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -47,7 +47,10 @@ class ETPSectionView: UIView {
 }
 
 protocol EnhancedTrackingProtectionMenuDelegate: AnyObject {
+    @MainActor
     func settingsOpenPage(settings: Route.SettingsSection)
+
+    @MainActor
     func didFinish()
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -9,7 +9,10 @@ import Redux
 import enum MozillaAppServices.VisitType
 
 protocol RemoteTabsPanelDelegate: AnyObject {
+    @MainActor
     func presentFirefoxAccountSignIn()
+
+    @MainActor
     func presentFxAccountSettings()
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -18,6 +18,7 @@ protocol TabTrayController: UIViewController,
 }
 
 protocol TabTrayViewControllerDelegate: AnyObject {
+    @MainActor
     func didFinish()
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuCoordinator.swift
@@ -6,6 +6,7 @@ import Foundation
 import Common
 
 protocol ContextMenuCoordinatorDelegate: AnyObject {
+    @MainActor
     func dismissFlow()
 }
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -30,7 +30,10 @@ struct TPMenuUX {
 }
 
 protocol TrackingProtectionMenuDelegate: AnyObject {
+    @MainActor
     func settingsOpenPage(settings: Route.SettingsSection)
+
+    @MainActor
     func didFinish()
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix under-specified protocols for several Coordinators.

(For more context, see the [pinned slack thread](https://mozilla.slack.com/archives/C09235AH0P4/p1752268121089739) on under-specified protocols in the migration channel).

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
