### PR TITLE
 Refactor FXIOS-12796 [Swift 6 Migration] Fix `QRCodeCoordinator` and library `Coordinator` under-specified protocols

### DIFF
--- a/firefox-ios/Client/Coordinators/Library/DownloadsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/DownloadsCoordinator.swift
@@ -7,9 +7,11 @@ import Foundation
 protocol DownloadsNavigationHandler: AnyObject {
     /// Handles the possible navigations for a file.
     /// The source view is the view used to display a popover for the share controller.
+    @MainActor
     func handleFile(_ file: DownloadedFile, sourceView: UIView)
 
     /// Shows a UIDocumentInteractionController for the selected file.
+    @MainActor
     func showDocument(file: DownloadedFile)
 }
 

--- a/firefox-ios/Client/Coordinators/Library/HistoryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/HistoryCoordinator.swift
@@ -7,6 +7,7 @@ import Common
 import Shared
 
 protocol HistoryCoordinatorDelegate: AnyObject, LibraryPanelCoordinatorDelegate {
+    @MainActor
     func showRecentlyClosedTab()
 }
 

--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -8,12 +8,18 @@ import Foundation
 import enum MozillaAppServices.VisitType
 
 protocol LibraryCoordinatorDelegate: AnyObject, LibraryPanelDelegate, RecentlyClosedPanelDelegate {
+    @MainActor
     func didFinishLibrary(from coordinator: Coordinator)
 }
 
 protocol LibraryNavigationHandler: AnyObject {
+    @MainActor
     func start(panelType: LibraryPanelType, navigationController: UINavigationController)
+
+    @MainActor
     func shareLibraryItem(url: URL, sourceView: UIView)
+
+    @MainActor
     func setNavigationBarHidden(_ value: Bool)
 }
 

--- a/firefox-ios/Client/Coordinators/Library/LibraryPanelCoordinatorDelegate.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryPanelCoordinatorDelegate.swift
@@ -6,5 +6,6 @@ import Foundation
 
 /// Share navigation across the library panels
 protocol LibraryPanelCoordinatorDelegate: AnyObject {
+    @MainActor
     func shareLibraryItem(url: URL, sourceView: UIView)
 }

--- a/firefox-ios/Client/Coordinators/Library/ReadingListCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/ReadingListCoordinator.swift
@@ -7,6 +7,7 @@ import Foundation
 import enum MozillaAppServices.VisitType
 
 protocol ReadingListNavigationHandler: AnyObject, LibraryPanelCoordinatorDelegate {
+    @MainActor
     func openUrl(_ url: URL, visitType: VisitType)
 }
 

--- a/firefox-ios/Client/Coordinators/QRCode/QRCodeCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/QRCode/QRCodeCoordinator.swift
@@ -6,6 +6,7 @@ import Foundation
 
 protocol QRCodeDismissHandler: AnyObject {
     /// Dismisses the current presented QRCodeViewController
+    @MainActor
     func dismiss(_ completion: (() -> Void)?)
 }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -88,6 +88,7 @@ extension BookmarkItemData: BookmarksFolderCell {
         }
     }
 
+    @MainActor
     func didSelect(profile: Profile,
                    searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,

--- a/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
@@ -8,8 +8,13 @@ import Common
 import enum MozillaAppServices.VisitType
 
 protocol LibraryPanelDelegate: AnyObject {
+    @MainActor
     func libraryPanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)
+
+    @MainActor
     func libraryPanel(didSelectURL url: URL, visitType: VisitType)
+
+    @MainActor
     var libraryPanelWindowUUID: WindowUUID { get }
 }
 

--- a/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -16,6 +16,7 @@ private struct RecentlyClosedPanelUX {
 }
 
 protocol RecentlyClosedPanelDelegate: AnyObject {
+    @MainActor
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool)
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix under-specified protocol warnings in library `Coordinator`s and `QRCodeCoordinator`.

(For more context, see the [pinned slack thread](https://mozilla.slack.com/archives/C09235AH0P4/p1752268121089739) on under-specified protocols in the migration channel).

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
