### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix `LaunchCoordinator`'s under-specified protocols

### DIFF
--- a/firefox-ios/Client/Coordinators/QRCode/QRCodeNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/QRCode/QRCodeNavigationHandler.swift
@@ -7,10 +7,12 @@ import Foundation
 protocol QRCodeNavigationHandler: AnyObject {
     /// Shows the QRCodeViewController
     /// The root navigation controller is used when available to present the QRCodeViewController.
+    @MainActor
     func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController?)
 }
 
 extension QRCodeNavigationHandler {
+    @MainActor
     func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController? = nil) {
         showQRCode(delegate: delegate, rootNavigationController: rootNavigationController)
     }

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingNavigationDelegate.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingNavigationDelegate.swift
@@ -5,5 +5,6 @@
 import Foundation
 
 protocol OnboardingNavigationDelegate: AnyObject {
+    @MainActor
     func finishOnboardingFlow()
 }

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
@@ -164,6 +164,7 @@ final class OnboardingService: FeatureFlaggable {
         askForNotificationPermission(from: cardName)
     }
 
+    @MainActor
     private func handleSyncSignIn(
         from cardName: String,
         with activityEventHelper: ActivityEventHelper,
@@ -184,12 +185,14 @@ final class OnboardingService: FeatureFlaggable {
         defaultApplicationHelper.openSettings()
     }
 
+    @MainActor
     private func handleOpenInstructionsPopup(from popupViewModel: OnboardingDefaultBrowserModelProtocol) {
         presentDefaultBrowserPopup(from: popupViewModel) { [weak self] in
             self?.navigationDelegate?.finishOnboardingFlow()
         }
     }
 
+    @MainActor
     private func handleReadPrivacyPolicy(from url: URL, completion: @escaping () -> Void) {
         presentPrivacyPolicy(from: url, completion: completion)
     }
@@ -199,6 +202,7 @@ final class OnboardingService: FeatureFlaggable {
         defaultApplicationHelper.openSettings()
     }
 
+    @MainActor
     private func handleEndOnboarding(with activityEventHelper: ActivityEventHelper) {
         introScreenManager?.didSeeIntroScreen()
         searchBarLocationSaver.saveUserSearchBarLocation(
@@ -231,6 +235,7 @@ final class OnboardingService: FeatureFlaggable {
         hasRegisteredForDefaultBrowserNotification = true
     }
 
+    @MainActor
     private func presentSignToSync(with params: FxALaunchParams, profile: Profile, completion: @escaping () -> Void) {
         guard let delegate = delegate else { return }
 
@@ -244,9 +249,10 @@ final class OnboardingService: FeatureFlaggable {
         delegate.present(signInVC, animated: true, completion: nil)
     }
 
+    @MainActor
     private func presentDefaultBrowserPopup(
         from popupViewModel: OnboardingDefaultBrowserModelProtocol,
-        completion: @escaping () -> Void
+        completion: @escaping @MainActor () -> Void
     ) {
         let popupVC = createDefaultBrowserPopupViewController(
             windowUUID: windowUUID,
@@ -257,6 +263,7 @@ final class OnboardingService: FeatureFlaggable {
         delegate?.present(popupVC, animated: false, completion: nil)
     }
 
+    @MainActor
     private func presentPrivacyPolicy(from url: URL, completion: @escaping () -> Void) {
         guard let delegate = delegate else { return }
         let privacyVC = createPrivacyPolicyViewController(
@@ -339,8 +346,10 @@ final class OnboardingService: FeatureFlaggable {
         return controller
     }
 
+    @MainActor
     @objc
     private func dismissSelector() {
+        assert(Thread.isMainThread, "Sometimes we have issues with @objc obeying @MainActor -- debug if this assert fails")
         delegate?.dismiss(animated: true, completion: nil)
     }
 }

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingServiceDelegate.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingServiceDelegate.swift
@@ -5,6 +5,9 @@
 import Foundation
 
 protocol OnboardingServiceDelegate: AnyObject {
+    @MainActor
     func dismiss(animated: Bool, completion: (() -> Void)?)
+
+    @MainActor
     func present(_ viewController: UIViewController, animated: Bool, completion: (() -> Void)?)
 }

--- a/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -9,6 +9,7 @@ import Shared
 import UIKit
 
 protocol SurveySurfaceViewControllerDelegate: AnyObject {
+    @MainActor
     func didFinish()
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix the under-specified protocol related to the  `LaunchCoordinator`.

(For more context, see the [pinned slack thread](https://mozilla.slack.com/archives/C09235AH0P4/p1752268121089739) on under-specified protocols in the migration channel).

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
