### PR TITLE
 Refactor FXIOS-12796, FXIOS-12789 [Swift 6 Migration] Fix `BrowserCoordinator`'s under-specified protocols

### DIFF
--- a/firefox-ios/Client/Application/WindowEventCoordinator.swift
+++ b/firefox-ios/Client/Application/WindowEventCoordinator.swift
@@ -31,5 +31,6 @@ enum WindowEvent {
 /// to key window lifecycle events, such as cleaning up when a window is closed.
 protocol WindowEventCoordinator {
     /// Notifies the coordinator that its parent window/scene is being removed.
+    @MainActor
     func coordinatorHandleWindowEvent(event: WindowEvent, uuid: WindowUUID)
 }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -14,15 +14,18 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     /// - Parameter settings: The settings route we're trying to get to
     /// - Parameter onDismiss: An optional closure that is executed when the settings page is dismissed.
     /// This closure takes no parameters and returns no value.
+    @MainActor
     func show(settings: Route.SettingsSection, onDismiss: (() -> Void)?)
 
     /// Asks to show a enhancedTrackingProtection page, can be a general
     /// enhancedTrackingProtection page or a child page
+    @MainActor
     func showEnhancedTrackingProtection(sourceView: UIView)
 
     /// Shows the specified section of the home panel.
     ///
     /// - Parameter homepanelSection: The section to be displayed.
+    @MainActor
     func show(homepanelSection: Route.HomepanelSection)
 
     /// Shows the share sheet.
@@ -33,6 +36,7 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     /// - Parameter sourceRect: An optional rect to use for ipad popover presentation.
     /// - Parameter toastContainer: The view in which is displayed the toast results from actions in the share extension.
     /// - Parameter popoverArrowDirection: The arrow direction for the view controller presented as popover.
+    @MainActor
     func showShareSheet(shareType: ShareType,
                         shareMessage: ShareMessage?,
                         sourceView: UIView,
@@ -41,6 +45,7 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
                         popoverArrowDirection: UIPopoverArrowDirection)
 
     /// Shows a CreditCardAutofill view to select credit cards in order to autofill cards forms.
+    @MainActor
     func showCreditCardAutofill(creditCard: CreditCard?,
                                 decryptedCard: UnencryptedCreditCardFields?,
                                 viewType state: CreditCardBottomSheetState,
@@ -49,45 +54,60 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 
     /// Displays an autofill interface for saved logins, allowing the user to select from stored login credentials
     /// to autofill login forms on the specified web page.
+    @MainActor
     func showSavedLoginAutofill(tabURL: URL, currentRequestId: String, field: FocusFieldType)
 
     /// Shows an AddressAutofill view for selecting addresses in order to autofill forms.
+    @MainActor
     func showAddressAutofill(frame: WKFrameInfo?)
 
     /// Shows authentication view controller to authorize access to sensitive data.
+    @MainActor
     func showRequiredPassCode()
 
     /// Shows the Tab Tray View Controller.
+    @MainActor
     func showTabTray(selectedPanel: TabTrayPanelType)
 
     /// Shows the Back Forward List View Controller.
+    @MainActor
     func showBackForwardList()
 
+    @MainActor
     func showMicrosurvey(model: MicrosurveyModel)
 
+    @MainActor
     func showPasswordGenerator(tab: Tab, frame: WKFrameInfo)
 
     /// Shows the app menu
+    @MainActor
     func showMainMenu()
 
     /// Shows the toolbar's search engine selection bottom sheet (iPhone) or popup (iPad)
+    @MainActor
     func showSearchEngineSelection(forSourceView sourceView: UIView)
 
     /// Navigates from home page to a new link
+    @MainActor
     func navigateFromHomePanel(to url: URL, visitType: VisitType, isGoogleTopSite: Bool)
 
     /// Navigates to our custom context menu (Photon Action Sheet)
+    @MainActor
     func showContextMenu(for configuration: ContextMenuConfiguration)
 
     /// Navigates to the edit bookmark view
+    @MainActor
     func showEditBookmark(parentFolder: FxBookmarkNode, bookmark: FxBookmarkNode)
 
+    @MainActor
     func openInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool)
 
     /// Shows the Document loading view on screen
+    @MainActor
     func showDocumentLoading()
 
     /// Removes the Document loading view from screen
+    @MainActor
     func removeDocumentLoading()
 }
 

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -112,6 +112,7 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 }
 
 extension BrowserNavigationHandler {
+    @MainActor
     func show(settings: Route.SettingsSection) {
         show(settings: settings, onDismiss: nil)
     }

--- a/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
@@ -12,7 +12,8 @@ protocol EnhancedTrackingProtectionCoordinatorDelegate: AnyObject {
 }
 
 protocol ETPCoordinatorSSLStatusDelegate: AnyObject {
-    @MainActor var showHasOnlySecureContentInTrackingPanel: Bool { get }
+    @MainActor
+    var showHasOnlySecureContentInTrackingPanel: Bool { get }
 }
 
 class EnhancedTrackingProtectionCoordinator: BaseCoordinator,

--- a/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
@@ -12,7 +12,7 @@ protocol EnhancedTrackingProtectionCoordinatorDelegate: AnyObject {
 }
 
 protocol ETPCoordinatorSSLStatusDelegate: AnyObject {
-    var showHasOnlySecureContentInTrackingPanel: Bool { get }
+    @MainActor var showHasOnlySecureContentInTrackingPanel: Bool { get }
 }
 
 class EnhancedTrackingProtectionCoordinator: BaseCoordinator,

--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -10,7 +10,10 @@ import SwiftUI
 import ComponentLibrary
 
 protocol LaunchCoordinatorDelegate: AnyObject {
+    @MainActor
     func didFinishTermsOfService(from coordinator: LaunchCoordinator)
+
+    @MainActor
     func didFinishLaunch(from coordinator: LaunchCoordinator)
 }
 

--- a/firefox-ios/Client/Coordinators/QRCode/QRCodeNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/QRCode/QRCodeNavigationHandler.swift
@@ -7,10 +7,12 @@ import Foundation
 protocol QRCodeNavigationHandler: AnyObject {
     /// Shows the QRCodeViewController
     /// The root navigation controller is used when available to present the QRCodeViewController.
+    @MainActor
     func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController?)
 }
 
 extension QRCodeNavigationHandler {
+    @MainActor
     func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController? = nil) {
         showQRCode(delegate: delegate, rootNavigationController: rootNavigationController)
     }

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -8,8 +8,13 @@ import Redux
 import SwiftUI
 
 protocol SettingsCoordinatorDelegate: AnyObject {
+    @MainActor
     func openURLinNewTab(_ url: URL)
+
+    @MainActor
     func openDebugTestTabs(count: Int)
+
+    @MainActor
     func didFinishSettings(from coordinator: SettingsCoordinator)
 }
 

--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -5,6 +5,7 @@
 import Common
 
 protocol TabTrayCoordinatorDelegate: AnyObject {
+    @MainActor
     func didDismissTabTray(from coordinator: TabTrayCoordinator)
 }
 

--- a/firefox-ios/Client/DispatchQueueHelper.swift
+++ b/firefox-ios/Client/DispatchQueueHelper.swift
@@ -7,9 +7,11 @@ import Foundation
 // Only push the task async if we are not already on the main thread.
 // Unless you want another event to fire before your work happens.
 // This is better than using DispatchQueue.main.async to ensure main thread
-func ensureMainThread(execute work: @escaping @convention(block) () -> Swift.Void) {
+func ensureMainThread(execute work: @escaping @MainActor @convention(block) () -> Swift.Void) {
     if Thread.isMainThread {
-        work()
+        MainActor.assumeIsolated {
+            work()
+        }
     } else {
         DispatchQueue.main.async {
             work()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -127,7 +127,7 @@ class WebContextMenuActionsProvider {
             title: .ContextMenuShareLink,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.share),
             identifier: UIAction.Identifier("linkContextMenu.share")
-        ) { _ in
+        ) { @MainActor _ in
             guard let tab = tabManager[webView],
                   let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper
             else { return }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -117,6 +117,7 @@ class WebContextMenuActionsProvider {
         })
     }
 
+    @MainActor
     func addShare(url: URL,
                   tabManager: TabManager,
                   webView: WKWebView,
@@ -127,7 +128,7 @@ class WebContextMenuActionsProvider {
             title: .ContextMenuShareLink,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.share),
             identifier: UIAction.Identifier("linkContextMenu.share")
-        ) { @MainActor _ in
+        ) { _ in
             guard let tab = tabManager[webView],
                   let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper
             else { return }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -6,19 +6,41 @@ import Common
 import Foundation
 
 protocol MainMenuCoordinatorDelegate: AnyObject {
+    @MainActor
     func editBookmarkForCurrentTab()
+
+    @MainActor
     func openURLInNewTab(_ url: URL?)
+
+    @MainActor
     func openNewTab(inPrivateMode: Bool)
+
+    @MainActor
     func showLibraryPanel(_ panel: Route.HomepanelSection)
+
+    @MainActor
     func showSettings(at destination: Route.SettingsSection)
+
+    @MainActor
     func showFindInPage()
+
+    @MainActor
     func showSignInView(fxaParameters: FxASignInViewParameters?)
+
+    @MainActor
     func updateZoomPageBarVisibility()
+
+    @MainActor
     func presentSavePDFController()
+
+    @MainActor
     func presentSiteProtections()
+
+    @MainActor
     func showPrintSheet()
 
     /// Open the share sheet to share the currently selected `Tab`.
+    @MainActor
     func showShareSheetForCurrentlySelectedTab()
 }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -657,6 +657,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
     /// Share the URL of a downloaded file (e.g. either a user-downloaded file being viewed in the webView, or a link with a
     /// non-HTML MIME type currently opened in the webView, such as a PDF).
     /// NOTE: Called from getShareFileAction (files in the browser) and getShareAction (websites)
+    @MainActor
     private func share(fileURL: URL, buttonView: UIView) {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
         navigationHandler?.showShareSheet(

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
@@ -6,11 +6,15 @@ import Common
 import Foundation
 
 protocol SearchEngineSelectionCoordinatorDelegate: AnyObject {
+    @MainActor
     func showSettings(at destination: Route.SettingsSection)
 }
 
 protocol SearchEngineSelectionCoordinator: AnyObject {
+    @MainActor
     func navigateToSearchSettings(animated: Bool)
+
+    @MainActor
     func dismissModal(animated: Bool)
 }
 

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -9,7 +9,9 @@ import Shared
 
 // Delegate for coordinator to be able to handle navigation
 protocol PrivateHomepageDelegate: AnyObject {
+    @MainActor
     func homePanelDidRequestToOpenInNewTab(with url: URL, isPrivate: Bool, selectNewTab: Bool)
+
     @MainActor
     func switchMode()
 }

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -112,11 +112,15 @@ protocol TabManager: AnyObject {
     /// Commits the pending changes to the persistent store.
     func commitChanges()
 
+    @MainActor
     func notifyCurrentTabDidFinishLoading()
+
     @MainActor
     func restoreTabs(_ forced: Bool)
+
     func expireLoginAlerts()
     @discardableResult
+
     @MainActor
     func switchPrivacyMode() -> SwitchPrivacyModeResult
 

--- a/firefox-ios/Client/TabManagement/TabManagerDelegate.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerDelegate.swift
@@ -8,14 +8,28 @@ import WebKit
 // MARK: - TabManagerDelegate
 protocol TabManagerDelegate: AnyObject {
     // Must be called on the main thread
+    @MainActor
     func tabManager(_ tabManager: TabManager, didSelectedTabChange selectedTab: Tab, previousTab: Tab?, isRestoring: Bool)
+
+    @MainActor
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, placeNextToParentTab: Bool, isRestoring: Bool)
+
+    @MainActor
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool)
 
+    @MainActor
     func tabManagerDidRestoreTabs(_ tabManager: TabManager)
+
+    @MainActor
     func tabManagerDidAddTabs(_ tabManager: TabManager)
+
+    @MainActor
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?)
+
+    @MainActor
     func tabManagerUpdateCount()
+
+    @MainActor
     func tabManagerTabDidFinishLoading()
 }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -311,7 +311,7 @@ class TabManagerImplementation: NSObject,
         tab.close()
 
         // Notify of tab removal
-        ensureMainThread { [unowned self] in
+        ensureMainThread { @MainActor [unowned self] in
             delegates.forEach { $0.get()?.tabManager(self, didRemoveTab: tab, isRestoring: !tabRestoreHasFinished) }
             TabEvent.post(.didClose, for: tab)
         }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -822,6 +822,7 @@ class TabManagerImplementation: NSObject,
         saveSessionData(forTab: selectedTab)
     }
 
+    @MainActor
     func notifyCurrentTabDidFinishLoading() {
         delegates.forEach {
             $0.get()?.tabManagerTabDidFinishLoading()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -117,6 +117,7 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(selectedTab.isPrivate)
     }
 
+    @MainActor
     func testDidSelectedTabChange_appliesExpectedUIModeToAllUIElements_whenToolbarRefactorDisabled() {
         let subject = createSubject()
         let topTabsViewController = TopTabsViewController(tabManager: tabManager, profile: profile)
@@ -132,6 +133,7 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertFalse(subject.toolbar.privateModeBadge.badge.isHidden)
     }
 
+    @MainActor
     func testDidSelectedTabChange_appliesExpectedUIModeToTopTabsViewController_whenToolbarRefactorEnabled() {
         let subject = createSubject()
         let topTabsViewController = TopTabsViewController(tabManager: tabManager, profile: profile)
@@ -148,6 +150,7 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(subject.toolbar.privateModeBadge.badge.isHidden)
     }
 
+    @MainActor
     func test_didSelectedTabChange_fromHomepageToHomepage_triggersAppropriateDispatchAction() throws {
         let subject = createSubject()
         let testTab = Tab(profile: profile, isPrivate: true, windowUUID: .XCTestDefaultUUID)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

Also incidentally will fix FXIOS-12789 once I get my next fix pushed up.

## :bulb: Description
Fix the under-specified protocol warnings related to `BrowserCoordinator`.

(For more context, see the [pinned slack thread](https://mozilla.slack.com/archives/C09235AH0P4/p1752268121089739) on under-specified protocols in the migration channel).

cc @Cramsden @lmarceau 
## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
