### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix under-specified protocols - FindInPage delegates, TabContentScript, KeyboardHelperDelegate

### DIFF
--- a/BrowserKit/Sources/Shared/KeyboardHelper.swift
+++ b/BrowserKit/Sources/Shared/KeyboardHelper.swift
@@ -45,11 +45,22 @@ public struct KeyboardState {
 }
 
 public protocol KeyboardHelperDelegate: AnyObject {
+    @MainActor
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState)
+
+    @MainActor
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState)
+
+    @MainActor
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState)
+
+    @MainActor
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillChangeWithState state: KeyboardState)
+
+    @MainActor
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidChangeWithState state: KeyboardState)
+
+    @MainActor
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidHideWithState state: KeyboardState)
 }
 
@@ -135,6 +146,7 @@ open class KeyboardHelper: NSObject {
         delegates.append(WeakKeyboardDelegate(delegate))
     }
 
+    @MainActor
     @objc
     private func keyboardWillShow(_ notification: Notification) {
         if let userInfo = notification.userInfo {
@@ -145,6 +157,7 @@ open class KeyboardHelper: NSObject {
         }
     }
 
+    @MainActor
     @objc
     private func keyboardDidShow(_ notification: Notification) {
         if let userInfo = notification.userInfo {
@@ -155,6 +168,7 @@ open class KeyboardHelper: NSObject {
         }
     }
 
+    @MainActor
     @objc
     private func keyboardWillHide(_ notification: Notification) {
         if let userInfo = notification.userInfo {
@@ -165,6 +179,7 @@ open class KeyboardHelper: NSObject {
         }
     }
 
+    @MainActor
     @objc
     private func keyboardDidHide(_ notification: Notification) {
         if let userInfo = notification.userInfo {
@@ -175,6 +190,7 @@ open class KeyboardHelper: NSObject {
         }
     }
 
+    @MainActor
     @objc
     private func keyboardWillChange(_ notification: Notification) {
         if let userInfo = notification.userInfo {
@@ -186,6 +202,7 @@ open class KeyboardHelper: NSObject {
         }
     }
 
+    @MainActor
     @objc
     private func keyboardDidChange(_ notification: Notification) {
         if let userInfo = notification.userInfo {

--- a/firefox-ios/Client/Frontend/Browser/FindInPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/FindInPageBar.swift
@@ -6,9 +6,16 @@ import Common
 import UIKit
 
 protocol FindInPageBarDelegate: AnyObject {
+    @MainActor
     func findInPage(_ findInPage: FindInPageBar, didTextChange text: String)
+
+    @MainActor
     func findInPage(_ findInPage: FindInPageBar, didFindPreviousWithText text: String)
+
+    @MainActor
     func findInPage(_ findInPage: FindInPageBar, didFindNextWithText text: String)
+
+    @MainActor
     func findInPageDidPressClose(_ findInPage: FindInPageBar)
 }
 

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
@@ -7,7 +7,10 @@ import Foundation
 import WebKit
 
 protocol FindInPageHelperDelegate: AnyObject {
+    @MainActor
     func findInPageHelper(_ findInPageHelper: FindInPageHelper, didUpdateCurrentResult currentResult: Int)
+
+    @MainActor
     func findInPageHelper(_ findInPageHelper: FindInPageHelper, didUpdateTotalResults totalResults: Int)
 }
 
@@ -29,6 +32,7 @@ class FindInPageHelper: TabContentScript {
         return ["findInPageHandler"]
     }
 
+    @MainActor
     func userContentController(
         _ userContentController: WKUserContentController,
         didReceiveScriptMessage message: WKScriptMessage

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -32,10 +32,13 @@ func mostRecentTab(inTabs tabs: [Tab]) -> Tab? {
 protocol TabContentScript {
     static func name() -> String
     func scriptMessageHandlerNames() -> [String]?
+
+    @MainActor
     func userContentController(
         _ userContentController: WKUserContentController,
         didReceiveScriptMessage message: WKScriptMessage
     )
+
     func prepareForDeinit()
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
@@ -119,6 +119,7 @@ class FormAutofillHelperTests: XCTestCase {
         XCTAssertEqual(json["tel"] as? String, "+16509030800")
     }
 
+    @MainActor
     func testUserContentControllerDidReceiveScriptMessage_withAddressHandler() {
         // Arrange
         let formAutofillHelper = FormAutofillHelper(tab: tab)
@@ -307,6 +308,7 @@ class FormAutofillHelperTests: XCTestCase {
         XCTAssertTrue(handlerNames!.contains(FormAutofillHelper.HandlerName.addressFormTelemetryMessageHandler.rawValue))
     }
 
+    @MainActor
     func testUserContentControllerDidReceiveScriptMessage_withCreditCardHandler() {
         let formAutofillHelper = FormAutofillHelper(tab: tab)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description

Fix under-specified protocols in FindInPage related delegates, TabContentScript, KeyboardHelperDelegate.

<img width="1417" height="319" alt="Underspecified Delegate" src="https://github.com/user-attachments/assets/e40dcdb7-2ced-4b75-943f-84f39c77a69b" />

(For more context, see the [pinned slack thread](https://mozilla.slack.com/archives/C09235AH0P4/p1752268121089739) on under-specified protocols in the migration channel).

cc @Cramsden @lmarceau 


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
