### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix `SettingsCoordinator`'s under-specified protocols

### DIFF
--- a/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
@@ -8,7 +8,10 @@ import Common
 import struct MozillaAppServices.LoginEntry
 
 protocol PasswordManagerCoordinatorDelegate: AnyObject, ParentCoordinatorDelegate {
+    @MainActor
     func settingsOpenURLInNewTab(_ url: URL)
+
+    @MainActor
     func didFinishPasswordManager(from: PasswordManagerCoordinator)
 }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -12,6 +12,7 @@ import class MozillaAppServices.BookmarkItemData
 protocol BookmarksFolderCell: BookmarksRefactorFeatureFlagProvider {
     func getViewModel() -> OneLineTableViewCellViewModel
 
+    @MainActor
     func didSelect(profile: Profile,
                    searchEnginesManager: SearchEnginesManager,
                    windowUUID: WindowUUID,

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
@@ -7,6 +7,7 @@ import Common
 
 /// Child settings pages appearance actions
 protocol AppearanceSettingsDelegate: AnyObject {
+    @MainActor
     func pressedPageZoom()
 }
 

--- a/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
@@ -7,7 +7,10 @@ import Shared
 
 /// Child settings pages browsing actions
 protocol BrowsingSettingsDelegate: AnyObject {
+    @MainActor
     func pressedMailApp()
+
+    @MainActor
     func pressedAutoPlay()
 }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/About/AboutSettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/About/AboutSettingsDelegate.swift
@@ -5,7 +5,12 @@
 import Foundation
 
 protocol AboutSettingsDelegate: AnyObject {
+    @MainActor
     func pressedRateApp()
+
+    @MainActor
     func pressedLicense(url: URL, title: NSAttributedString)
+
+    @MainActor
     func pressedYourRights(url: URL, title: NSAttributedString)
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/Account/AccountSettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/AccountSettingsDelegate.swift
@@ -6,9 +6,18 @@ import Foundation
 
 /// Child settings pages account actions
 protocol AccountSettingsDelegate: AnyObject {
+    @MainActor
     func pressedConnectSetting()
+
+    @MainActor
     func pressedAdvancedAccountSetting()
+
+    @MainActor
     func pressedToShowSyncContent()
+
+    @MainActor
     func pressedToShowFirefoxAccount()
+
+    @MainActor
     func askedToOpen(url: URL?, withTitle title: NSAttributedString?)
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -16,13 +16,28 @@ protocol SettingsFlowDelegate: AnyObject,
                                AccountSettingsDelegate,
                                AboutSettingsDelegate,
                                SupportSettingsDelegate {
+    @MainActor
     func showDevicePassCode()
+
+    @MainActor
     func showCreditCardSettings()
+
+    @MainActor
     func showExperiments()
+
+    @MainActor
     func showFirefoxSuggest()
+
+    @MainActor
     func openDebugTestTabs(count: Int)
+
+    @MainActor
     func showDebugFeatureFlags()
+
+    @MainActor
     func showPasswordManager(shouldShowOnboarding: Bool)
+
+    @MainActor
     func didFinishShowingSettings()
 }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/General/GeneralSettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/GeneralSettingsDelegate.swift
@@ -6,13 +6,30 @@ import Foundation
 
 /// Child settings pages general actions
 protocol GeneralSettingsDelegate: AnyObject {
+    @MainActor
     func pressedCustomizeAppIcon()
+
+    @MainActor
     func pressedHome()
+
+    @MainActor
     func pressedNewTab()
+
+    @MainActor
     func pressedSearchEngine()
+
+    @MainActor
     func pressedSiri()
+
+    @MainActor
     func pressedToolbar()
+
+    @MainActor
     func pressedTheme()
+
+    @MainActor
     func pressedBrowsing()
+
+    @MainActor
     func pressedAutoFillsPasswords()
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/PrivacySettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/PrivacySettingsDelegate.swift
@@ -6,11 +6,24 @@ import Foundation
 
 /// Child settings pages privacy actions
 protocol PrivacySettingsDelegate: AnyObject {
+    @MainActor
     func pressedAddressAutofill()
+
+    @MainActor
     func pressedCreditCard()
+
+    @MainActor
     func pressedClearPrivateData()
+
+    @MainActor
     func pressedContentBlocker()
+
+    @MainActor
     func pressedPasswords()
+
+    @MainActor
     func pressedNotifications()
+
+    @MainActor
     func askedToOpen(url: URL?, withTitle title: NSAttributedString?)
 }

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -806,7 +806,10 @@ class WithoutAccountSetting: AccountSetting {
 
 @objc
 protocol SettingsDelegate: AnyObject {
+    @MainActor
     func settingsOpenURLInNewTab(_ url: URL)
+
+    @MainActor
     func didFinish()
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix the under-specified protocol warnings related to `SettingsCoordinator`.

<img width="1417" height="319" alt="Under-specified Protocol" src="https://github.com/user-attachments/assets/66e45bf3-807d-4242-8288-d05d57ae8ac7" />

(For more context, see the [pinned slack thread](https://mozilla.slack.com/archives/C09235AH0P4/p1752268121089739) on under-specified protocols in the migration channel).

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
