### PR TITLE
Add FXIOS-12855 [Summarizer] Add page content extractor

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1410,6 +1410,8 @@
 		BA7A14842C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7A14832C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift */; };
 		BA8E197F2BF2FB1900590B5F /* AddressFormManager.js in Resources */ = {isa = PBXBuildFile; fileRef = BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */; };
 		BACE70062DC110CA00E6102C /* ASTranslationModelsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE70052DC110C700E6102C /* ASTranslationModelsFetcher.swift */; };
+		BAEB9EB22E2869C400F9F482 /* SummarizationChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEB9EB12E2869BE00F9F482 /* SummarizationChecker.swift */; };
+		BAEB9EB42E28726A00F9F482 /* SummarizationCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEB9EB32E28726100F9F482 /* SummarizationCheckerTests.swift */; };
 		BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
 		BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */; };
@@ -9194,6 +9196,8 @@
 		BA904A3B89BC820A7A802D55 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/Storage.strings"; sourceTree = "<group>"; };
 		BAA64356B54F1CD258764620 /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		BACE70052DC110C700E6102C /* ASTranslationModelsFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTranslationModelsFetcher.swift; sourceTree = "<group>"; };
+		BAEB9EB12E2869BE00F9F482 /* SummarizationChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizationChecker.swift; sourceTree = "<group>"; };
+		BAEB9EB32E28726100F9F482 /* SummarizationCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizationCheckerTests.swift; sourceTree = "<group>"; };
 		BAF14FEC94CB9DA4E08BA60C /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Storage.strings; sourceTree = "<group>"; };
 		BAF74394B38CDAE36910B788 /* eu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/Shared.strings; sourceTree = "<group>"; };
 		BAFB47EE839E6EE784CA9C34 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
@@ -13680,6 +13684,14 @@
 			path = AppearanceSettings;
 			sourceTree = "<group>";
 		};
+		BAEB9EB02E28699F00F9F482 /* Summary */ = {
+			isa = PBXGroup;
+			children = (
+				BAEB9EB12E2869BE00F9F482 /* SummarizationChecker.swift */,
+			);
+			path = Summary;
+			sourceTree = "<group>";
+		};
 		C22753422A3CA25100B9C0D1 /* WebsiteDataManagement */ = {
 			isa = PBXGroup;
 			children = (
@@ -15339,6 +15351,7 @@
 		F84B21D61A090F8100AAB793 /* ClientTests */ = {
 			isa = PBXGroup;
 			children = (
+				BAEB9EB32E28726100F9F482 /* SummarizationCheckerTests.swift */,
 				EDADF7822D70D59900C39295 /* AppIconSelection */,
 				8A171A6029F82AD90085770E /* Application */,
 				B23620492B7EAF2C000B1DE7 /* Autofill */,
@@ -15514,6 +15527,7 @@
 		F84B21F11A0910F600AAB793 /* Frontend */ = {
 			isa = PBXGroup;
 			children = (
+				BAEB9EB02E28699F00F9F482 /* Summary */,
 				8A1A93572B757C7B0069C190 /* LottieFiles */,
 				392ED7D51D0AEEEE009D9B62 /* Accessors */,
 				E692E3271C46E62D009D1240 /* AuthenticationManager */,
@@ -17433,6 +17447,7 @@
 				8AD40FCB27BADC4B00672675 /* StatefulButton.swift in Sources */,
 				C84655E62887398700861B4A /* WallpaperCollection.swift in Sources */,
 				EBF47E701F7979DF00899189 /* TelemetryWrapper.swift in Sources */,
+				BAEB9EB22E2869C400F9F482 /* SummarizationChecker.swift in Sources */,
 				8AD40FCF27BADC6B00672675 /* URLTextField.swift in Sources */,
 				31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */,
 				8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */,
@@ -18389,6 +18404,7 @@
 				E4CD9F1D1A6D9C2800318571 /* WebServerTests.swift in Sources */,
 				C869916528918C8E007ACC5C /* WallpaperURLSessionMock.swift in Sources */,
 				961577942A39008100391E8D /* SponsoredTileDataUtilityTests.swift in Sources */,
+				BAEB9EB42E28726A00F9F482 /* SummarizationCheckerTests.swift in Sources */,
 				8A093D812A4B58330099ABA5 /* MockSettingsFlowDelegate.swift in Sources */,
 				431C0D1E25C9DC4D00395CE4 /* DefaultBrowserOnboardingTests.swift in Sources */,
 				5AD3B6782CF650DF00AFA1FE /* DefaultBrowserUitTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Summary/SummarizationChecker.swift
+++ b/firefox-ios/Client/Frontend/Summary/SummarizationChecker.swift
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import WebKit
+import Foundation
+
+/// Model for all the reasons summarization might be dissallowed.
+public enum SummarizationReason: String, Decodable {
+  case documentNotReady, documentNotReadable, contentTooLong
+}
+
+/// Model for the JS `checkSummarization()` result
+/// See UserScripts/MainFrame/AtDocumentStart/Summarizer.js for more context
+public struct SummarizationCheckResult: Decodable {
+    public let canSummarize: Bool
+    public let reason: SummarizationReason?
+    public let wordCount: Int
+
+    /// Convenience initializer for constructing a failure result.
+    static func failure(_ error: SummarizationCheckError) -> SummarizationCheckResult {
+        SummarizationCheckResult(canSummarize: false, reason: nil, wordCount: 0)
+    }
+}
+
+/// Possible errors encountered when evaluating or parsing the JS result.
+public enum SummarizationCheckError: Error {
+    /// Thrown when `evaluateJavaScript` itself fails.
+    case jsEvaluationFailed(Error)
+    /// Thrown when the raw JS result is not valid JSON.
+    case invalidJSON
+    /// Thrown when decoding the JSON into a model fails.
+    case decodingFailed(Error)
+
+    var description: String {
+        switch self {
+        case .jsEvaluationFailed(let error):
+            return "JavaScript evaluation failed: \(error.localizedDescription)"
+        case .invalidJSON:
+            return "Invalid JSON from page script"
+        case .decodingFailed(let error):
+            return "Decoding failed: \(error.localizedDescription)"
+        }
+    }
+}
+
+public final class SummarizationChecker {
+    /// Calls `checkSummarization(maxWords:)` in the web page and returns a typed result.
+    /// - Parameters:
+    ///   - webView: The WKWebView instance with the JS already injected.
+    ///   - maxWords: The maximum allowed words before summarization is disallowed.
+    /// - Returns: A `SummarizationCheckResult`, even on error.
+    public static func check(on webView: WKWebView, maxWords: Int) async -> SummarizationCheckResult {
+        let jsCall = "checkSummarization(\(maxWords));"
+        do {
+            let rawResult = try await webView.evaluateJavaScript(jsCall, in: nil, contentWorld: .defaultClient)
+            guard let rawResult = rawResult else { return SummarizationCheckResult.failure(.invalidJSON) }
+            return try parse(rawResult)
+        } catch {
+            return SummarizationCheckResult.failure(.jsEvaluationFailed(error))
+        }
+    }
+
+    /// Parses the raw JS evaluation result into `SummarizationCheckResult`.
+    public static func parse(_ rawResult: Any) throws -> SummarizationCheckResult {
+        guard JSONSerialization.isValidJSONObject(rawResult) else { throw SummarizationCheckError.invalidJSON }
+        do {
+            let data = try JSONSerialization.data(withJSONObject: rawResult)
+            return try JSONDecoder().decode(SummarizationCheckResult.self, from: data)
+        } catch {
+            throw SummarizationCheckError.decodingFailed(error)
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
@@ -1,0 +1,80 @@
+/* vim: set ts=2 sts=2 sw=2 et tw=80: */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+"use strict";
+import { Readability } from "@mozilla/readability";
+
+// TODO(FXIOS-xxx): the max input is 5000 words, but we need to take into account the prompt length.
+// Once we have a final prompt length, we can adjust this value.
+// This should be 5000 - <prompt length>.
+const MAX_DOCUMENT_LENGTH_IN_WORDS = 5000;
+
+const extractContent = () => {
+  const uri = {
+    spec: document.location.href,
+    host: document.location.host,
+    prePath: document.location.protocol + "//" + document.location.host,
+    scheme: document.location.protocol.substr(
+      0,
+      document.location.protocol.indexOf(":")
+    ),
+    pathBase:
+      document.location.protocol +
+      "//" +
+      document.location.host +
+      location.pathname.substr(0, location.pathname.lastIndexOf("/") + 1),
+  };
+
+  const docStr = new XMLSerializer().serializeToString(document);
+
+  const DOMPurify = require("dompurify");
+  const clean = DOMPurify.sanitize(docStr, { WHOLE_DOCUMENT: true });
+  const doc = new DOMParser().parseFromString(clean, "text/html");
+  const readability = new Readability(uri, doc);
+  const readabilityResult = readability.parse();
+  return readabilityResult.textContent ?? readabilityResult.content;
+};
+
+/**
+ * Checks document summarization eligibility.
+ * Returns an object with `canSummarize`, `reason`, and `wordCount`.
+ * @param {number} maxWords - Maximum number of words allowed for summarization.
+ * @returns {{ canSummarize: boolean, reason: string, wordCount: number }}
+ */
+const checkSummarization = (maxWords = MAX_DOCUMENT_LENGTH_IN_WORDS) => {
+  // 0. Document should be ready before we do anything.
+  if (document.readyState === "loading") {
+    return {
+      canSummarize: false,
+      reason: "DocumentNotReady",
+      wordCount: 0,
+    };
+  }
+
+  // 1. Readerability check
+  if (!isProbablyReaderable(document)) {
+    return {
+      canSummarize: false,
+      reason: "DocumentNotReadeable",
+      wordCount: 0,
+    };
+  }
+
+  // 2. Extract and count words
+  const text = extractContent();
+  const wordCount = text.trim().split(/\s+/).filter(Boolean).length;
+
+  if (wordCount > maxWords) {
+    return {
+      canSummarize: false,
+      reason: "ContentTooLong",
+      wordCount,
+    };
+  }
+
+  return { canSummarize: true, reason: null, wordCount };
+};
+
+window.checkSummarization = checkSummarization;

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
@@ -6,11 +6,6 @@
 "use strict";
 import { Readability } from "@mozilla/readability";
 
-// TODO(FXIOS-xxx): the max input is 5000 words, but we need to take into account the prompt length.
-// Once we have a final prompt length, we can adjust this value.
-// This should be 5000 - <prompt length>.
-const MAX_DOCUMENT_LENGTH_IN_WORDS = 5000;
-
 const extractContent = () => {
   const uri = {
     spec: document.location.href,
@@ -48,7 +43,7 @@ const checkSummarization = (maxWords = MAX_DOCUMENT_LENGTH_IN_WORDS) => {
   if (document.readyState === "loading") {
     return {
       canSummarize: false,
-      reason: "DocumentNotReady",
+      reason: "documentNotReady",
       wordCount: 0,
     };
   }
@@ -57,7 +52,7 @@ const checkSummarization = (maxWords = MAX_DOCUMENT_LENGTH_IN_WORDS) => {
   if (!isProbablyReaderable(document)) {
     return {
       canSummarize: false,
-      reason: "DocumentNotReadeable",
+      reason: "documentNotReadeable",
       wordCount: 0,
     };
   }
@@ -69,7 +64,7 @@ const checkSummarization = (maxWords = MAX_DOCUMENT_LENGTH_IN_WORDS) => {
   if (wordCount > maxWords) {
     return {
       canSummarize: false,
-      reason: "ContentTooLong",
+      reason: "contentTooLong",
       wordCount,
     };
   }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SummarizationCheckerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SummarizationCheckerTests.swift
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+@testable import Client
+import XCTest
+
+final class SummarizationCheckerTests: XCTestCase {
+  func testSummarizationCheckerCanSummarizeTrue() throws {
+    let jsStub: [String: Any] = [
+      "canSummarize": true,
+      "wordCount": 42,
+    ]
+
+    let result = try SummarizationChecker.parse(jsStub)
+    XCTAssertTrue(result.canSummarize)
+    XCTAssertNil(result.reason)
+    XCTAssertEqual(result.wordCount, 42)
+  }
+
+  /// JS stub for a page that is not reader‑readable.
+  func testSummarizationCheckerCanSummarizeFalseDocumentNotReady() throws {
+    let jsStub: [String: Any] = [
+      "canSummarize": false,
+      "reason": "documentNotReady",
+      "wordCount": 0,
+    ]
+
+    let result = try SummarizationChecker.parse(jsStub)
+    XCTAssertFalse(result.canSummarize)
+    XCTAssertEqual(result.reason, .documentNotReady)
+    XCTAssertEqual(result.wordCount, 0)
+  }
+
+  /// JS stub for a page that is not reader‑readable.
+  func testSummarizationCheckerCanSummarizeFalseNotReadable() throws {
+    let jsStub: [String: Any] = [
+      "canSummarize": false,
+      "reason": "documentNotReadable",
+      "wordCount": 0,
+    ]
+
+    let result = try SummarizationChecker.parse(jsStub)
+    XCTAssertFalse(result.canSummarize)
+    XCTAssertEqual(result.reason, .documentNotReadable)
+    XCTAssertEqual(result.wordCount, 0)
+  }
+
+  /// JS stub for a page that is too long to summarize.
+  func testSummarizationCheckerCanSummarizeFalseContentTooLong() throws {
+    let jsStub: [String: Any] = [
+      "canSummarize": false,
+      "reason": "contentTooLong",
+      "wordCount": 9001,
+    ]
+
+    let result = try SummarizationChecker.parse(jsStub)
+    XCTAssertFalse(result.canSummarize)
+    XCTAssertEqual(result.reason, .contentTooLong)
+    XCTAssertEqual(result.wordCount, 9001)
+  }
+
+  /// When a required key is missing, decoding should throw `.decodingFailed`.
+  func testSummarizationCheckerMissingField() {
+    // Missing `wordCount`
+    let jsStub: [String: Any] = [
+      "canSummarize": true
+    ]
+
+    XCTAssertThrowsError(try SummarizationChecker.parse(jsStub)) { error in
+      guard case .decodingFailed = error as? SummarizationCheckError else {
+        return XCTFail("Expected .decodingFailed, got \(error)")
+      }
+    }
+  }
+
+  /// When the `reason` value doesn’t map to any enum case, decoding should throw `.decodingFailed`.
+  func testSummarizationCheckerUnknownReason() {
+    let jsStub: [String: Any] = [
+      "canSummarize": false,
+      "reason": "fooReason",
+      "wordCount": 0,
+    ]
+
+    XCTAssertThrowsError(try SummarizationChecker.parse(jsStub)) { error in
+      guard case .decodingFailed = error as? SummarizationCheckError else {
+        return XCTFail("Expected .decodingFailed, got \(error)")
+      }
+    }
+  }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12855)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28021)

## :bulb: Description
This PR:
- Adds `Summarizer.js` which is injected in the top frame of each page and exposes a method `checkSummarization`. `checkSummarization` checks 3 things:
    - is the document ready to be interacted with ?
    - is the document readable ?
    - does the document word count exceed the max word count ?
- Adds a class `SummarizationChecker` that runs `checkSummarization` on a given webview and returns an appropriate result. 
- Adds test for `SummarizationChecker.parse`.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
