### PR TITLE
Improve [MTE-4803] - microsurvey test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -58,6 +58,11 @@ final class MicrosurveyTests: FeatureFlaggedTestBase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2776933
     func testCloseButtonDismissesMicrosurveyPrompt_tabTrayExperimentOff() {
+        // Workaround: The microsurvey prompt may not appear on the first run due to retained app state or missing triggers.
+        // To ensure the prompt is shown, the app is terminated and relaunched to make sure the
+        // microsurvey is triggered again.
+        app.terminate()
+        app.launch()
         generateTriggerForMicrosurvey()
         waitForElementsToExist(
             [

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -58,7 +58,8 @@ final class MicrosurveyTests: FeatureFlaggedTestBase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2776933
     func testCloseButtonDismissesMicrosurveyPrompt_tabTrayExperimentOff() {
-        // Workaround: The microsurvey prompt may not appear on the first run due to retained app state or missing triggers.
+        // Workaround: The microsurvey prompt may not appear on the first run due to retained app
+        // state or missing triggers.
         // To ensure the prompt is shown, the app is terminated and relaunched to make sure the
         // microsurvey is triggered again.
         app.terminate()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4803

## :bulb: Description
testCloseButtonDismissesMicrosurveyPrompt_tabTrayExperimentOff test fails constantly, because on the first run the microsurvey prompt doesn't appear.
As an workaround i have added a relaunch to make sure the prompt is triggered and launch arguments are applied.
