### PR TITLE
Bugfix FXIOS-12836 - [Minimal Address Bar] - Color inconsistency when scrolling with address bar positioned at top

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
@@ -44,7 +44,7 @@ public struct AddressToolbarUXConfiguration {
         )
     }
 
-    func addressToolbarBackgroundColor(theme: any Theme) -> UIColor {
+    func addressToolbarBackgroundColor(theme: some Theme) -> UIColor {
         let backgroundColor = isLocationTextCentered ? theme.colors.layerSurfaceLow : theme.colors.layer1
         if shouldBlur {
             return backgroundColor.withAlphaComponent(backgroundAlpha)
@@ -53,9 +53,9 @@ public struct AddressToolbarUXConfiguration {
         return backgroundColor
     }
 
-    func locationContainerBackgroundColor(theme: any Theme) -> UIColor {
+    func locationContainerBackgroundColor(theme: some Theme) -> UIColor {
+        if scrollAlpha.isZero { return .clear }
         let backgroundColor = isLocationTextCentered ? theme.colors.layerSurfaceMedium : theme.colors.layerSearch
-        if scrollAlpha == 0 { return backgroundColor.withAlphaComponent(scrollAlpha) }
         return backgroundColor
     }
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
@@ -54,7 +54,7 @@ public struct AddressToolbarUXConfiguration {
     }
 
     func locationContainerBackgroundColor(theme: some Theme) -> UIColor {
-        if scrollAlpha.isZero { return .clear }
+        guard !scrollAlpha.isZero else { return .clear }
         let backgroundColor = isLocationTextCentered ? theme.colors.layerSurfaceMedium : theme.colors.layerSearch
         return backgroundColor
     }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -121,12 +121,12 @@ public class BrowserAddressToolbar: UIView,
                           isUnifiedSearchEnabled: Bool,
                           animated: Bool) {
         [navigationActionStack, leadingPageActionStack, pageActionStack, browserActionStack].forEach {
-            $0.isHidden = config.uxConfiguration.scrollAlpha == 0
+            $0.isHidden = config.uxConfiguration.scrollAlpha.isZero
         }
         self.toolbarDelegate = toolbarDelegate
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
-        self.previousConfiguration = config
         addressBarPosition = toolbarPosition
+        previousConfiguration = config
         configureUX(config: config.uxConfiguration, toolbarPosition: toolbarPosition)
         updateSpacing(uxConfig: config.uxConfiguration, leading: leadingSpace, trailing: trailingSpace)
         configure(config: config,
@@ -488,8 +488,11 @@ public class BrowserAddressToolbar: UIView,
     // MARK: - ThemeApplicable
     public func applyTheme(theme: Theme) {
         let colors = theme.colors
-        backgroundColor = previousConfiguration?.uxConfiguration
-            .addressToolbarBackgroundColor(theme: theme)
+        // Set background color to clear when address bar is positioned at top to avoid
+        // double opacity effects. The status bar overlay already provides the necessary
+        // alpha gradient that matches the bottom navigation bar's appearance.
+        backgroundColor = addressBarPosition == .top ? .clear :
+        previousConfiguration?.uxConfiguration.addressToolbarBackgroundColor(theme: theme)
         locationContainer.backgroundColor = previousConfiguration?.uxConfiguration
             .locationContainerBackgroundColor(theme: theme)
         locationDividerView.backgroundColor = colors.layer1

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationContainer.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationContainer.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Common
 
-class LocationContainer: UIView, ThemeApplicable {
+final class LocationContainer: UIView, ThemeApplicable {
     private enum UX {
         static let shadowRadius: CGFloat = 14
         static let shadowOpacity: Float = 1

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1383,7 +1383,7 @@ class BrowserViewController: UIViewController,
             statusBarOverlay.topAnchor.constraint(equalTo: view.topAnchor),
             statusBarOverlay.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             statusBarOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            statusBarOverlay.heightAnchor.constraint(equalToConstant: view.safeAreaInsets.top)
+            statusBarOverlay.bottomAnchor.constraint(equalTo: header.bottomAnchor)
         ])
         NSLayoutConstraint.activate(statusBarOverlayConstraints)
 

--- a/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
@@ -18,7 +18,7 @@ protocol BrowserStatusBarScrollDelegate: AnyObject {
 /// - On homepage with bottom URL bar, the status bar overlay alpha changes when the user scrolls.
 /// - In all other cases apart from this one, the status bar should be opaque
 /// - With top tabs, the status bar overlay has a different color than without it
-class StatusBarOverlay: UIView,
+final class StatusBarOverlay: UIView,
                         ThemeApplicable,
                         StatusBarScrollDelegate,
                         SearchBarLocationProvider,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12836)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27978)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Changed 1 constraint for the `statusBarOverlay`.
- Changed `any Theme` → `some Theme` for compile-time dispatch.
- Added `final` to non-subclassed classes for static dispatch optimizations.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| ![before](https://github.com/user-attachments/assets/8f6bb447-f9e6-4a87-ba35-f66dbbbc94e5) | ![after](https://github.com/user-attachments/assets/0fcce281-1632-4958-a393-de9e0054dd71) |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
