### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] ApplicationStateProvider and AppFxACommandsDelegate

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/firefox-ios/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -17,9 +17,9 @@ extension UIApplication {
 /// Sync will get the list of sent tabs, and try to display any in that list.
 /// Thus, push notifications are not needed to receive sent or closed tabs;
 /// they can be handled when the app performs a sync.
-class AppFxACommandsDelegate: FxACommandsDelegate, @unchecked Sendable {
+final class AppFxACommandsDelegate: FxACommandsDelegate, Sendable {
     private let app: ApplicationStateProvider
-    private var applicationHelper: ApplicationHelper
+    private let applicationHelper: ApplicationHelper
 
     init(app: ApplicationStateProvider,
          applicationHelper: ApplicationHelper = DefaultApplicationHelper()) {
@@ -29,19 +29,19 @@ class AppFxACommandsDelegate: FxACommandsDelegate, @unchecked Sendable {
 
     @MainActor
     func openSendTabs(for urls: [URL]) {
-        guard self.app.applicationState == .active else { return }
+        guard app.applicationState == .active else { return }
 
         for urlToOpen in urls {
             let urlString = URL.mozInternalScheme + "://open-url?url=\(urlToOpen)"
             guard let url = URL(string: urlString) else { continue }
 
-            self.applicationHelper.open(url)
+            applicationHelper.open(url)
         }
     }
 
     func closeTabs(for urls: [URL]) {
         Task {
-            await self.applicationHelper.closeTabs(urls)
+            await applicationHelper.closeTabs(urls)
         }
     }
 }

--- a/firefox-ios/Client/ApplicationHelper.swift
+++ b/firefox-ios/Client/ApplicationHelper.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Common
 
-protocol ApplicationHelper {
+protocol ApplicationHelper: Sendable {
     @MainActor
     func openSettings()
 

--- a/firefox-ios/Client/Protocols/ApplicationStateProvider.swift
+++ b/firefox-ios/Client/Protocols/ApplicationStateProvider.swift
@@ -9,4 +9,5 @@ protocol ApplicationStateProvider: Sendable {
     var applicationState: UIApplication.State { get }
 }
 
-extension UIApplication: ApplicationStateProvider {}
+// Since UIApplication is marked `@MainActor`, it is implicitly `Sendable`.
+extension UIApplication: @retroactive Sendable, ApplicationStateProvider {}

--- a/firefox-ios/Client/Protocols/ApplicationStateProvider.swift
+++ b/firefox-ios/Client/Protocols/ApplicationStateProvider.swift
@@ -4,7 +4,8 @@
 
 import UIKit
 
-protocol ApplicationStateProvider {
+protocol ApplicationStateProvider: Sendable {
+    @MainActor
     var applicationState: UIApplication.State { get }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppSendTabDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppSendTabDelegateTests.swift
@@ -95,6 +95,6 @@ final class AppFxACommandsTests: XCTestCase {
 }
 
 // MARK: MockApplicationStateProvider
-class MockApplicationStateProvider: ApplicationStateProvider {
+final class MockApplicationStateProvider: ApplicationStateProvider {
     var applicationState: UIApplication.State = .active
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockApplicationHelper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockApplicationHelper.swift
@@ -6,7 +6,7 @@ import UIKit
 import Common
 @testable import Client
 
-class MockApplicationHelper: ApplicationHelper {
+final class MockApplicationHelper: ApplicationHelper, @unchecked Sendable {
     var openSettingsCalled = 0
     var openURLCalled = 0
     var openURLInWindowCalled = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix @unchecked Sendable and actor isolation in ApplicationStateProvider, AppFxACommandsDelegate.

I just did a bit more work in this area since I saw another "conformance" mismatch warning. Then I got red of `@unchecked` Sendable because they are actually Sendable now.
<img width="1392" height="304" alt="Isolate Conformance of protocol" src="https://github.com/user-attachments/assets/897261a6-9703-45c0-b445-7ac2536e50da" />

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
