### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix mozPublicScheme and mozInternalScheme global mutable state

### DIFF
--- a/BrowserKit/Sources/Shared/Extensions/URLExtensions.swift
+++ b/BrowserKit/Sources/Shared/Extensions/URLExtensions.swift
@@ -209,7 +209,7 @@ extension URL {
 // MARK: - Exported URL Schemes
 
 extension URL {
-    public static var mozPublicScheme: String = {
+    public static let mozPublicScheme: String = {
         guard let string = Bundle.main.object(
             forInfoDictionaryKey: "MozPublicURLScheme"
         ) as? String, !string.isEmpty else {
@@ -219,7 +219,7 @@ extension URL {
         return string
     }()
 
-    public static var mozInternalScheme: String = {
+    public static let mozInternalScheme: String = {
         guard let string = Bundle.main.object(
             forInfoDictionaryKey: "MozInternalURLScheme"
         ) as? String, !string.isEmpty else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix static `mozPublicScheme` and `mozInternalScheme` global mutable state.

<img width="1420" height="158" alt="Screenshot 2025-07-17 at 1 15 46 PM" src="https://github.com/user-attachments/assets/bd7dcc1d-ba4a-46dc-96b1-14ec1123de5a" />


cc @Cramsden @lmarceau 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
