### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix under-specified protocols for `LibraryPanel`

### DIFF
--- a/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
@@ -19,15 +19,26 @@ protocol LibraryPanelDelegate: AnyObject {
 }
 
 protocol LibraryPanel: UIViewController {
+    @MainActor
     var libraryPanelDelegate: LibraryPanelDelegate? { get set }
+
+    @MainActor
     var state: LibraryPanelMainState { get set }
+
+    @MainActor
     var bottomToolbarItems: [UIBarButtonItem] { get }
 
+    @MainActor
     func handleLeftTopButton()
+
+    @MainActor
     func handleRightTopButton()
+
+    @MainActor
     func shouldDismissOnDone() -> Bool
 }
 
+@MainActor
 extension LibraryPanel {
     var flexibleSpace: UIBarButtonItem {
         return UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/Legacy/LegacyBookmarksPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/Legacy/LegacyBookmarksPanelTests.swift
@@ -7,6 +7,7 @@ import Common
 
 @testable import Client
 
+@MainActor
 class LegacyBookmarksPanelTests: XCTestCase {
     override func setUp() {
         super.setUp()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/DownloadsPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/DownloadsPanelTests.swift
@@ -7,6 +7,7 @@ import Common
 
 @testable import Client
 
+@MainActor
 class DownloadsPanelTests: XCTestCase {
     let windowUUID: WindowUUID = .XCTestDefaultUUID
     override func setUp() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelTests.swift
@@ -7,6 +7,7 @@ import XCTest
 import Common
 @testable import Client
 
+@MainActor
 class HistoryPanelTests: XCTestCase {
     let windowUUID: WindowUUID = .XCTestDefaultUUID
     private var notificationCenter: MockNotificationCenter!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/ReadingListPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/ReadingListPanelTests.swift
@@ -6,6 +6,7 @@ import XCTest
 import Common
 @testable import Client
 
+@MainActor
 class ReadingListPanelTests: XCTestCase {
     let windowUUID: WindowUUID = .XCTestDefaultUUID
     override func setUp() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix the under-specified protocol warnings related to `LibraryPanel`.

<img width="1073" height="282" alt="Under Specified Conformance General Example" src="https://github.com/user-attachments/assets/dd6ccb75-8d1c-45d5-9fb1-45f40903ead1" />

(For more context, see the [pinned slack thread](https://mozilla.slack.com/archives/C09235AH0P4/p1752268121089739) on under-specified protocols in the migration channel).

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
