### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Make AppEvents `Sendable`

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -5,8 +5,8 @@
 import Foundation
 import Common
 
-/// Base event type protocol. Conforming types must be hashable.
-public protocol AppEventType: Hashable { }
+/// Base event type protocol. Conforming types must be Hashable.
+public protocol AppEventType: Hashable, Sendable { }
 
 public enum AppEvent: AppEventType {
     // MARK: - Global App Events


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Add explicit `Sendable` conformance to a public type that was already implicitly `Sendable`. This is a requirement for public types.

This little beauty takes our warning count from 2,772 down to 2,734, fixing 38 errors. 👩‍🍳 

Example warnings:
<img width="1431" height="499" alt="Screenshot 2025-07-17 at 2 53 55 PM" src="https://github.com/user-attachments/assets/ca6a2104-1465-49f8-a72c-31a9d814e6cd" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
