### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Isolate TabsSectionManager and InactiveTabManager to the MainActor

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/InactiveTabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/InactiveTabsSectionManager.swift
@@ -5,10 +5,12 @@
 import Foundation
 
 protocol InactiveTabsSectionManagerDelegate: AnyObject {
+    @MainActor
     func deleteInactiveTab(for index: Int)
 }
 
-class InactiveTabsSectionManager {
+@MainActor
+final class InactiveTabsSectionManager {
     struct UX {
         static let margin: CGFloat = 15.0
         static let headerEstimatedHeight: CGFloat = 48

--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -4,9 +4,11 @@
 
 import Foundation
 
-class TabsSectionManager: FeatureFlaggable {
+@MainActor
+final class TabsSectionManager: FeatureFlaggable {
     struct UX {
         // On iPad we can set to have bigger tabs, on iPhone we need smaller ones
+        @MainActor
         static let cellEstimatedWidth: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 250 : 170
         static let cellAbsoluteHeight: CGFloat = 200
         static let cardSpacing: CGFloat = 16


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Isolate TabManager and InactiveTabManager to the MainActor
Error Number: 2860->2802

## Errors
<img width="372" height="876" alt="Screenshot 2025-07-17 at 9 47 33 PM" src="https://github.com/user-attachments/assets/1d732ecb-0b14-4942-bb95-2b283dfb45a7" />
<img width="354" height="890" alt="Screenshot 2025-07-17 at 9 47 44 PM" src="https://github.com/user-attachments/assets/7340749f-c2e0-4a1c-ae88-6f4c0ecc10b6" />

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
