### PR TITLE
Bugfix FXIOS-12730 - [Toolbar Translucency] - Address bar and toolbar colors do not match when becoming visible after scrolling with "Find in Page" open

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
@@ -21,6 +21,7 @@ extension BrowserViewController {
         guard let webView = tabManager.selectedTab?.webView else { return }
 
         if isVisible {
+            webView.scrollView.keyboardDismissMode = .none
             webView.isFindInteractionEnabled = true
             webView.findInteraction?.searchText = searchText ?? ""
             webView.findInteraction?.presentFindNavigator(showingReplace: false)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1644,7 +1644,7 @@ class BrowserViewController: UIViewController,
         }
 
         if let tab = tabManager.selectedTab, tab.isFindInPageMode {
-            scrollController.hideToolbars(animated: true, isFindInPageMode: true)
+            scrollController.hideToolbars(animated: true)
         } else {
             adjustBottomSearchBarForKeyboard()
         }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -275,7 +275,7 @@ final class TabScrollController: NSObject,
             completion: nil)
     }
 
-    func hideToolbars(animated: Bool, isFindInPageMode: Bool = false) {
+    func hideToolbars(animated: Bool) {
         guard toolbarState != .collapsed else { return }
 
         toolbarState = .collapsed
@@ -598,8 +598,6 @@ private extension TabScrollController {
             } else {
                 overKeyboardContainerOffset = overKeyboardOffset
             }
-            overKeyboardContainer?.updateAlphaForSubviews(alpha)
-            overKeyboardContainer?.superview?.layoutIfNeeded()
 
             header?.updateAlphaForSubviews(alpha)
             header?.superview?.layoutIfNeeded()
@@ -668,7 +666,7 @@ extension TabScrollController: UIScrollViewDelegate {
             if scrollDirection == .up {
                 showToolbars(animated: true)
             } else {
-                hideToolbars(animated: true, isFindInPageMode: tab.isFindInPageMode)
+                hideToolbars(animated: true)
             }
 
             // this action controls the address toolbar's border position,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12730)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27725)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- To solve this bug, I took inspiration from Safari where the keyboard is not dismissible on scroll.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
