### PR TITLE
Bugfix FXIOS-12765 [Xcode 26] Deprecated WKProcessPool

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
@@ -82,8 +82,8 @@ public struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvide
         // may safely share cookies.
         // The cookie store should only be created once, otherwise we can loose them. See FXIOS-11833
         configuration.websiteDataStore = parameters.isPrivate
-            ? DefaultWKEngineConfigurationProvider.nonPersistentStore
-            : DefaultWKEngineConfigurationProvider.defaultStore
+            ? Self.nonPersistentStore
+            : Self.defaultStore
 
         // Popup WKWebViewConfiguration can have the scheme already registered thus registering again
         // leads to crash


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12765)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27795)

## :bulb: Description
`WKProcessPool` is now [deprecated](https://developer.apple.com/documentation/webkit/wkprocesspool):
> Creating and using multiple instances of WKProcessPool no longer has any effect.

<img width="1245" height="615" alt="Screenshot 2025-07-18 at 10 43 53 AM" src="https://github.com/user-attachments/assets/e520b60f-ea75-493d-8160-cbe50cb11a4c" />

Since we are on iOS 15+, it seems it can be entirely removed. From what I found it seems isolation between private and normal tabs must be handled through `WKWebsiteDataStore` only. 

@yoanarios I tested the use cases I know with cookies, but if you can do as well a sanity check it would be highly appreciated 🙏 Hopefully this is our last WK configuration changes for now 😓 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
