### PR TITLE
Bugfix FXIOS-12796 [Swift 6 Migration] Unchecked Sendable prefs related classes

### DIFF
--- a/BrowserKit/Sources/Shared/NSUserDefaultsPrefs.swift
+++ b/BrowserKit/Sources/Shared/NSUserDefaultsPrefs.swift
@@ -5,7 +5,7 @@
 import Common
 import Foundation
 
-open class NSUserDefaultsPrefs: Prefs {
+open class NSUserDefaultsPrefs: Prefs, @unchecked Sendable {
     fileprivate let prefixWithDot: String
     fileprivate let userDefaults: UserDefaults
 

--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -247,7 +247,7 @@ public protocol Prefs: Sendable {
     func clearAll()
 }
 
-open class MockProfilePrefs: Prefs {
+open class MockProfilePrefs: Prefs, @unchecked Sendable {
     let prefix: String
 
     open func getBranchPrefix() -> String {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description

### MockProfilePrefs warnings
<img width="1287" height="588" alt="Screenshot 2025-07-18 at 11 10 43 AM" src="https://github.com/user-attachments/assets/c251b83c-847d-450f-9d47-ded3957cb2db" />

### NSUserDefaultsPrefs warnings
<img width="1234" height="255" alt="Screenshot 2025-07-18 at 11 18 37 AM" src="https://github.com/user-attachments/assets/6dcff7b2-a88f-4bef-8afa-940ebf96a998" />

Both I am proposing to fix with `@unchecked Sendable`. Apple marked `UserDefaults` as `@unchecked Sendable`:

<img width="513" height="121" alt="Screenshot 2025-07-18 at 11 14 35 AM" src="https://github.com/user-attachments/assets/a990e65e-c662-4ca2-9568-a02fb8055b6d" />

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
