### PR TITLE
Bugfix FXIOS-12796 [Swift 6 Migration] Make ASTranslationModelsFetcher Sendable

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
@@ -37,7 +37,7 @@ protocol TranslationModelsFetching {
     func fetchModels(from sourceLang: String, to targetLang: String) -> Data?
 }
 
-final class ASTranslationModelsFetcher: TranslationModelsFetching {
+final class ASTranslationModelsFetcher: TranslationModelsFetching, Sendable {
     static let shared = ASTranslationModelsFetcher()
     // Pin versions to avoid using unsupported models
     private enum Constants {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Pretty straightforward, `ASTranslationModelsFetcher` can be `Sendable`

<img width="1245" height="336" alt="Screenshot 2025-07-18 at 11 55 07 AM" src="https://github.com/user-attachments/assets/e3a6e1e0-8912-4462-b86b-d3fa3cc5249b" />

cc: @ih-codes

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
