### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Isolate `TabToolbarHelper` and ensure safety of `@objc` selector methods

### DIFF
--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -192,9 +192,8 @@ open class TabToolbarHelper: NSObject {
     @objc
     func didClickBack() {
         // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
-        guard Thread.isMainThread else {
+        if !Thread.isMainThread {
             assertionFailure("This must be called main thread")
-            return
         }
 
         toolbar.tabToolbarDelegate?.tabToolbarDidPressBack(toolbar, button: toolbar.backButton)
@@ -204,9 +203,8 @@ open class TabToolbarHelper: NSObject {
     @objc
     func didLongPressBack(_ recognizer: UILongPressGestureRecognizer) {
         // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
-        guard Thread.isMainThread else {
+        if !Thread.isMainThread {
             assertionFailure("This must be called main thread")
-            return
         }
 
         if recognizer.state == .began {
@@ -219,9 +217,8 @@ open class TabToolbarHelper: NSObject {
     @objc
     func didClickTabs() {
         // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
-        guard Thread.isMainThread else {
+        if !Thread.isMainThread {
             assertionFailure("This must be called main thread")
-            return
         }
 
         toolbar.tabToolbarDelegate?.tabToolbarDidPressTabs(toolbar, button: toolbar.tabsButton)
@@ -230,9 +227,8 @@ open class TabToolbarHelper: NSObject {
     @objc
     func didLongPressTabs(_ recognizer: UILongPressGestureRecognizer) {
         // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
-        guard Thread.isMainThread else {
+        if !Thread.isMainThread {
             assertionFailure("This must be called main thread")
-            return
         }
 
         if recognizer.state == .began {
@@ -244,9 +240,8 @@ open class TabToolbarHelper: NSObject {
     @objc
     func didClickForward() {
         // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
-        guard Thread.isMainThread else {
+        if !Thread.isMainThread {
             assertionFailure("This must be called main thread")
-            return
         }
 
         toolbar.tabToolbarDelegate?.tabToolbarDidPressForward(toolbar, button: toolbar.forwardButton)
@@ -256,9 +251,8 @@ open class TabToolbarHelper: NSObject {
     @objc
     func didLongPressForward(_ recognizer: UILongPressGestureRecognizer) {
         // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
-        guard Thread.isMainThread else {
+        if !Thread.isMainThread {
             assertionFailure("This must be called main thread")
-            return
         }
 
         if recognizer.state == .began {
@@ -271,9 +265,8 @@ open class TabToolbarHelper: NSObject {
     @objc
     func didClickMenu() {
         // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
-        guard Thread.isMainThread else {
+        if !Thread.isMainThread {
             assertionFailure("This must be called main thread")
-            return
         }
 
         toolbar.tabToolbarDelegate?.tabToolbarDidPressMenu(toolbar, button: toolbar.appMenuButton)
@@ -282,9 +275,8 @@ open class TabToolbarHelper: NSObject {
     @objc
     func didClickLibrary() {
         // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
-        guard Thread.isMainThread else {
+        if !Thread.isMainThread {
             assertionFailure("This must be called main thread")
-            return
         }
 
         toolbar.tabToolbarDelegate?.tabToolbarDidPressBookmarks(toolbar, button: toolbar.appMenuButton)
@@ -293,9 +285,8 @@ open class TabToolbarHelper: NSObject {
     @objc
     func didClickAddNewTab() {
         // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
-        guard Thread.isMainThread else {
+        if !Thread.isMainThread {
             assertionFailure("This must be called main thread")
-            return
         }
 
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .addNewTabButton)
@@ -308,9 +299,8 @@ open class TabToolbarHelper: NSObject {
     @objc
     func didPressMultiStateButton() {
         // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
-        guard Thread.isMainThread else {
+        if !Thread.isMainThread {
             assertionFailure("This must be called main thread")
-            return
         }
 
         switch middleButtonState {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -50,7 +50,7 @@ enum MiddleButtonState {
     case fire
 }
 
-@objcMembers
+@MainActor
 open class TabToolbarHelper: NSObject {
     let toolbar: TabToolbarProtocol
     let ImageSearch = UIImage.templateImageNamed(StandardImageIdentifiers.Large.search)
@@ -94,6 +94,7 @@ open class TabToolbarHelper: NSObject {
 
     init(toolbar: TabToolbarProtocol) {
         self.toolbar = toolbar
+
         super.init()
 
         toolbar.addUILargeContentViewInteraction(interaction: uiLargeContentViewInteraction)
@@ -188,12 +189,26 @@ open class TabToolbarHelper: NSObject {
         }
     }
 
+    @objc
     func didClickBack() {
+        // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
+        guard Thread.isMainThread else {
+            assertionFailure("This must be called main thread")
+            return
+        }
+
         toolbar.tabToolbarDelegate?.tabToolbarDidPressBack(toolbar, button: toolbar.backButton)
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .navigateTabHistoryBack)
     }
 
+    @objc
     func didLongPressBack(_ recognizer: UILongPressGestureRecognizer) {
+        // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
+        guard Thread.isMainThread else {
+            assertionFailure("This must be called main thread")
+            return
+        }
+
         if recognizer.state == .began {
             toolbar.tabToolbarDelegate?.tabToolbarDidLongPressBack(toolbar, button: toolbar.backButton)
             uiLargeContentViewInteraction.gestureRecognizerForExclusionRelationship.state = .cancelled
@@ -201,23 +216,51 @@ open class TabToolbarHelper: NSObject {
         }
     }
 
+    @objc
     func didClickTabs() {
+        // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
+        guard Thread.isMainThread else {
+            assertionFailure("This must be called main thread")
+            return
+        }
+
         toolbar.tabToolbarDelegate?.tabToolbarDidPressTabs(toolbar, button: toolbar.tabsButton)
     }
 
+    @objc
     func didLongPressTabs(_ recognizer: UILongPressGestureRecognizer) {
+        // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
+        guard Thread.isMainThread else {
+            assertionFailure("This must be called main thread")
+            return
+        }
+
         if recognizer.state == .began {
             toolbar.tabToolbarDelegate?.tabToolbarDidLongPressTabs(toolbar, button: toolbar.tabsButton)
             uiLargeContentViewInteraction.gestureRecognizerForExclusionRelationship.state = .cancelled
         }
     }
 
+    @objc
     func didClickForward() {
+        // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
+        guard Thread.isMainThread else {
+            assertionFailure("This must be called main thread")
+            return
+        }
+
         toolbar.tabToolbarDelegate?.tabToolbarDidPressForward(toolbar, button: toolbar.forwardButton)
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .navigateTabHistoryForward)
     }
 
+    @objc
     func didLongPressForward(_ recognizer: UILongPressGestureRecognizer) {
+        // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
+        guard Thread.isMainThread else {
+            assertionFailure("This must be called main thread")
+            return
+        }
+
         if recognizer.state == .began {
             toolbar.tabToolbarDelegate?.tabToolbarDidLongPressForward(toolbar, button: toolbar.forwardButton)
             uiLargeContentViewInteraction.gestureRecognizerForExclusionRelationship.state = .cancelled
@@ -225,15 +268,36 @@ open class TabToolbarHelper: NSObject {
         }
     }
 
+    @objc
     func didClickMenu() {
+        // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
+        guard Thread.isMainThread else {
+            assertionFailure("This must be called main thread")
+            return
+        }
+
         toolbar.tabToolbarDelegate?.tabToolbarDidPressMenu(toolbar, button: toolbar.appMenuButton)
     }
 
+    @objc
     func didClickLibrary() {
+        // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
+        guard Thread.isMainThread else {
+            assertionFailure("This must be called main thread")
+            return
+        }
+
         toolbar.tabToolbarDelegate?.tabToolbarDidPressBookmarks(toolbar, button: toolbar.appMenuButton)
     }
 
+    @objc
     func didClickAddNewTab() {
+        // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
+        guard Thread.isMainThread else {
+            assertionFailure("This must be called main thread")
+            return
+        }
+
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .addNewTabButton)
         toolbar.tabToolbarDelegate?.tabToolbarDidPressAddNewTab(
             toolbar,
@@ -241,7 +305,14 @@ open class TabToolbarHelper: NSObject {
         )
     }
 
+    @objc
     func didPressMultiStateButton() {
+        // For @objc methods, we want to guard against concurrency abuse via direct calls with .perform()
+        guard Thread.isMainThread else {
+            assertionFailure("This must be called main thread")
+            return
+        }
+
         switch middleButtonState {
         case .home:
             toolbar.tabToolbarDelegate?.tabToolbarDidPressHome(toolbar, button: toolbar.multiStateButton)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import Common
 import Shared
 
+@MainActor
 class TabToolbarHelperTests: XCTestCase {
     let backButtonImage = UIImage.templateImageNamed(StandardImageIdentifiers.Large.back)?
         .imageFlippedForRightToLeftLayoutDirection()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
We had lots of warnings for main actor isolated state being modified in nonisolated methods inside the `TabToolbarHelper`.

<img width="1429" height="699" alt="Screenshot 2025-07-18 at 11 37 45 AM" src="https://github.com/user-attachments/assets/959f454d-0b1c-40f4-8975-76b6a4679f4b" />

To fix this, I annotated the type with `@MainActor` to isolate it.

As well, apparently [it has previously been possible](https://blog.hobbyistsoftware.com/2022/11/mainactor-the-rules/) to call `@objc` selector methods directly with `.perform()` to bypass `@MainActor` isolation (see article under heading `– Selectors`). Thus, I added extra safety checks into these methods. 🤔 

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
