### PR TITLE
Bugfix FXIOS-12729 #27721 ⁃ Tab/Address bar autohide/autoreveal is incredibly annoying

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -16,7 +16,7 @@ final class TabScrollController: NSObject,
         static let minimalAddressBarAnimationDuration: CGFloat = 0.4
         static let heightOffset: CGFloat = 14
         static let minimumScrollThreshold: CGFloat = 20
-        static let minimumScrollVelocity: CGFloat = 300
+        static let minimumScrollVelocity: CGFloat = 100
     }
 
     private var isMinimalAddressBarEnabled: Bool {
@@ -243,8 +243,7 @@ final class TabScrollController: NSObject,
             let delta = lastPanTranslation - translation.y
             setScrollDirection(delta)
 
-            guard let containerView = scrollView?.superview,
-                  !shouldRespondToScrollGesture(gesture, delta: delta, in: containerView) else {
+            guard shouldRespondToScrollGesture(gesture, delta: delta, in: containerView) else {
                 return
             }
 


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-12729](https://mozilla-hub.atlassian.net/browse/FXIOS-12729)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27721)

[FXIOS-12559](https://mozilla-hub.atlassian.net/browse/FXIOS-12559)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27360)

## :bulb: Description
- These are two small improvements while a long term solution is implemented.
1- First added a threshold that takes into account velocity and translation to avoid toggling the toolbar from short interactions.
2- Update `hasScrollableContent` to take into account the toolbar height to fix the bug where the toolbar was not hiding for short webpages ([FXIOS-12559](https://mozilla-hub.atlassian.net/browse/FXIOS-12559))

## :movie_camera: Demos
It's hard to see the changes, but I added a video to show that small and slow scroll actions don't trigger a show/hide toolbar. I recommend testing to get a better feeling of the change
https://github.com/user-attachments/assets/38ff0fcb-4451-4d3d-9feb-c46d86d82acf

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)


[FXIOS-12729]: https://mozilla-hub.atlassian.net/browse/FXIOS-12729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-12559]: https://mozilla-hub.atlassian.net/browse/FXIOS-12559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-12559]: https://mozilla-hub.atlassian.net/browse/FXIOS-12559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ