### PR TITLE
Suppress Sendability warnings on unit test mock classes.

### DIFF
--- a/BrowserKit/Tests/CommonTests/LoggerTests/LoggerFileManagerTests.swift
+++ b/BrowserKit/Tests/CommonTests/LoggerTests/LoggerFileManagerTests.swift
@@ -73,7 +73,7 @@ final class LoggerFileManagerTests: XCTestCase {
 }
 
 // MARK: - MockFileManager
-private final class MockFileManager: FileManagerProtocol {
+private final class MockFileManager: FileManagerProtocol, @unchecked Sendable {
     let fileExists = false
     func fileExists(atPath path: String) -> Bool {
         return fileExists

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLFetcherTests.swift
@@ -7,11 +7,11 @@ import XCTest
 
 class FaviconURLFetcherTests: XCTestCase {
     var subject: DefaultFaviconURLFetcher!
-    var networkMock: HTMLDataRequestMock!
+    var networkMock: MockHTMLDataRequest!
 
     override func setUp() {
         super.setUp()
-        networkMock = HTMLDataRequestMock()
+        networkMock = MockHTMLDataRequest()
         subject = DefaultFaviconURLFetcher(network: networkMock)
     }
 

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLHandlerTests.swift
@@ -9,12 +9,12 @@ class FaviconURLHandlerTests: XCTestCase {
     let siteURL = URL(string: "https://www.firefox.com")!
     let faviconURL = URL(string: "https://www.firefox.com/image")!
 
-    var mockFetcher: FaviconURLFetcherMock!
+    var mockFetcher: MockFaviconURLFetcher!
     var mockCache: FaviconURLCacheMock!
 
     override func setUp() {
         super.setUp()
-        mockFetcher = FaviconURLFetcherMock()
+        mockFetcher = MockFaviconURLFetcher()
         mockCache = FaviconURLCacheMock()
     }
 

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/URLCacheFileManagerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/URLCacheFileManagerTests.swift
@@ -34,7 +34,7 @@ class URLCacheFileManagerTests: XCTestCase {
     }
 }
 
-class MockFileManager: FileManagerProtocol {
+final class MockFileManager: FileManagerProtocol, @unchecked Sendable {
     var urls = [URL(string: "firefox")!]
     var fileExists = true
     var fileExistsCalledCount = 0

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/FaviconFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/FaviconFetcherTests.swift
@@ -52,7 +52,7 @@ final class FaviconFetcherTests: XCTestCase {
 }
 
 // MARK: - MockSiteImageDownloader
-private class MockSiteImageDownloader: SiteImageDownloader {
+private final class MockSiteImageDownloader: SiteImageDownloader, @unchecked Sendable {
     var logger: Logger = DefaultLogger.shared
     var timeoutDelay: Double = 10
 

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
@@ -363,7 +363,7 @@ private extension ImageHandlerTests {
 }
 
 // MARK: - MockHeroImageFetcher
-private class MockHeroImageFetcher: HeroImageFetcher {
+private final class MockHeroImageFetcher: HeroImageFetcher, @unchecked Sendable {
     var image: UIImage?
     var fetchHeroImageSucceedCalled = 0
     var fetchHeroImageFailedCalled = 0
@@ -382,7 +382,7 @@ private class MockHeroImageFetcher: HeroImageFetcher {
 }
 
 // MARK: - MockSiteImageCache
-private class MockSiteImageCache: SiteImageCache {
+private final class MockSiteImageCache: SiteImageCache, @unchecked Sendable {
     var image: UIImage?
     var getImageFromCacheSucceedCalled = 0
     var getImageFromCacheFailedCalled = 0
@@ -413,7 +413,7 @@ private class MockSiteImageCache: SiteImageCache {
 }
 
 // MARK: - MockFaviconFetcher
-private class MockFaviconFetcher: FaviconFetcher {
+private final class MockFaviconFetcher: FaviconFetcher, @unchecked Sendable {
     var image: UIImage?
     var fetchImageSucceedCalled = 0
     var fetchImageFailedCalled = 0

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/LetterImageGeneratorTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/LetterImageGeneratorTests.swift
@@ -195,7 +195,6 @@ extension CGImage {
         let x = Int(point.x)
         let y = Int(point.y)
         let width = self.width
-        let height = self.height
         let index = width * y + x
 
         guard let pixelData = self.dataProvider?.data,

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageCacheTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageCacheTests.swift
@@ -87,7 +87,7 @@ final class SiteImageCacheTests: XCTestCase {
     }
 }
 
-private class MockDefaultImageCache: DefaultImageCache {
+private final class MockDefaultImageCache: DefaultImageCache, @unchecked Sendable {
     var image: UIImage?
     var retrievalError: KingfisherError?
     var capturedRetrievalKey: String?

--- a/BrowserKit/Tests/SiteImageViewTests/Mocks/FaviconURLFetcherMock.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/Mocks/FaviconURLFetcherMock.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import SiteImageView
 
-class FaviconURLFetcherMock: FaviconURLFetcher {
+final class MockFaviconURLFetcher: FaviconURLFetcher, @unchecked Sendable {
     var url: URL?
     var error: (any Error)?
     var fetchFaviconURLCalledCount = 0

--- a/BrowserKit/Tests/SiteImageViewTests/Mocks/HTMLDataRequestMock.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/Mocks/HTMLDataRequestMock.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import SiteImageView
 
-class HTMLDataRequestMock: HTMLDataRequest {
+final class MockHTMLDataRequest: HTMLDataRequest, @unchecked Sendable {
     var fetchDataForURLCount = 0
     var data: Data?
     var error: (any Error)?

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageHandlerTests.swift
@@ -196,7 +196,7 @@ final class SiteImageHandlerTests: XCTestCase {
 }
 
 // MARK: - MockFaviconURLHandler
-private class MockFaviconURLHandler: FaviconURLHandler {
+private final class MockFaviconURLHandler: FaviconURLHandler, @unchecked Sendable {
     var faviconURL: URL?
     var cacheKey: String?
     var getFaviconURLCalled = 0
@@ -231,7 +231,7 @@ private class MockFaviconURLHandler: FaviconURLHandler {
 }
 
 // MARK: - MockImageHandler
-private class MockImageHandler: ImageHandler {
+private final class MockImageHandler: ImageHandler, @unchecked Sendable {
     var faviconImage = UIImage()
     var heroImage: UIImage?
     var fetchFaviconCalledCount = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
This PR suppresses Sendability warnings on unit test mock classes.

I also updated a few mock names so `Mock` is a prefix rather than suffix.

I noticed a bunch of these in Bitrise. After Bitrise runs on this PR, I will try to lower our Xcode 16.2 warning threshold again.

Example issues:
```
⚠️  /Users/[REDACTED]/git/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/FaviconFetcherTests.swift:55:15: non-final class 'MockSiteImageDownloader' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in the Swift 6 language mode
private class MockSiteImageDownloader: SiteImageDownloader {
        ^

⚠️  /Users/[REDACTED]/git/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift:385:15: non-final class 'MockSiteImageCache' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in the Swift 6 language mode
private class MockSiteImageCache: SiteImageCache {
        ^

⚠️  /Users/[REDACTED]/git/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift:386:9: stored property 'image' of 'Sendable'-conforming class 'MockSiteImageCache' is mutable; this is an error in the Swift 6 language mode
    var image: UIImage?
              ^
...
```

We'll chat on Monday, but I think the best thing we can do for our mocks with mutable state right now is conform to `@unchecked Sendable`, since that is how they're already behaving anyway.

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
