### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] removeTopSites warning

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
@@ -228,9 +228,16 @@ final class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
     // MARK: - Context menu actions
     func removeTopSite(_ site: Site) async {
         googleTopSiteManager.removeGoogleTopSite(site: site)
-        let result = await topSiteHistoryManager.remove(pinnedSite: site)
-        guard case .success = result else { return }
-        hideURLFromTopSites(site)
+        do {
+            try await topSiteHistoryManager.remove(pinnedSite: site)
+            hideURLFromTopSites(site)
+        } catch {
+            logger.log(
+                "Removing pinned site threw an error - \(error.localizedDescription)",
+                level: .warning,
+                category: .homepage
+            )
+        }
     }
 
     func pinTopSite(_ site: Site) {
@@ -239,7 +246,7 @@ final class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
 
     func unpinTopSite(_ site: Site) async {
         googleTopSiteManager.removeGoogleTopSite(site: site)
-        _ = await topSiteHistoryManager.remove(pinnedSite: site)
+        try? await topSiteHistoryManager.remove(pinnedSite: site)
     }
 
     private func hideURLFromTopSites(_ site: Site) {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
@@ -51,7 +51,6 @@ final class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
     private let topSiteHistoryManager: TopSiteHistoryManagerProvider
     private let searchEnginesManager: SearchEnginesManagerProvider
     private let unifiedAdsProvider: UnifiedAdsProviderInterface
-    private let dispatchQueue: DispatchQueueInterface
     private let notification: NotificationProtocol
 
     private let maxTopSites: Int
@@ -65,7 +64,6 @@ final class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
         topSiteHistoryManager: TopSiteHistoryManagerProvider,
         searchEnginesManager: SearchEnginesManagerProvider,
         logger: Logger = DefaultLogger.shared,
-        dispatchQueue: DispatchQueueInterface = DispatchQueue.main,
         notification: NotificationProtocol = NotificationCenter.default,
         maxTopSites: Int = 4 * 14 // Max rows * max tiles on the largest screen plus some padding
     ) {
@@ -76,7 +74,6 @@ final class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
         self.topSiteHistoryManager = topSiteHistoryManager
         self.searchEnginesManager = searchEnginesManager
         self.logger = logger
-        self.dispatchQueue = dispatchQueue
         self.notification = notification
         self.maxTopSites = maxTopSites
     }
@@ -249,8 +246,7 @@ final class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
         topSiteHistoryManager.removeDefaultTopSitesTile(site: site)
         // We make sure to remove all history for URL so it doesn't show anymore in the
         // top sites, this is the approach that Android takes too.
-        let dispatchQueue = dispatchQueue as? DispatchQueue ?? .main
-        profile.places.deleteVisitsFor(url: site.url).uponQueue(dispatchQueue) { [weak self] _ in
+        profile.places.deleteVisitsFor(url: site.url).uponQueue(.main) { [weak self] _ in
             self?.notification.post(name: .TopSitesUpdated, withObject: nil)
         }
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
@@ -32,14 +32,14 @@ protocol TopSitesManagerInterface {
 
     /// Removes the site out of the top sites.
     /// If site is pinned it removes it from pinned and top sites list.
-    func removeTopSite(_ site: Site)
+    func removeTopSite(_ site: Site) async
 
     /// Adds the top site as a pinned tile in the top sites lists.
     func pinTopSite(_ site: Site)
 
     /// Unpin removes the top site from the location it's in.
     /// The site still can appear in the top sites as unpin.
-    func unpinTopSite(_ site: Site)
+    func unpinTopSite(_ site: Site) async
 }
 
 /// Manager to fetch the top sites data, the data gets updated from notifications on specific user actions
@@ -229,28 +229,29 @@ final class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
     }
 
     // MARK: - Context menu actions
-    func removeTopSite(_ site: Site) {
-        unpinTopSite(site)
-        dispatchQueue.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            self?.hideURLFromTopSites(site)
-        }
+    func removeTopSite(_ site: Site) async {
+        googleTopSiteManager.removeGoogleTopSite(site: site)
+        let result = await topSiteHistoryManager.remove(pinnedSite: site)
+        guard case .success = result else { return }
+        hideURLFromTopSites(site)
     }
 
     func pinTopSite(_ site: Site) {
         profile.pinnedSites.addPinnedTopSite(site)
     }
 
-    func unpinTopSite(_ site: Site) {
+    func unpinTopSite(_ site: Site) async {
         googleTopSiteManager.removeGoogleTopSite(site: site)
-        topSiteHistoryManager.removeTopSite(site: site)
+        _ = await topSiteHistoryManager.remove(pinnedSite: site)
     }
 
     private func hideURLFromTopSites(_ site: Site) {
         topSiteHistoryManager.removeDefaultTopSitesTile(site: site)
         // We make sure to remove all history for URL so it doesn't show anymore in the
         // top sites, this is the approach that Android takes too.
-        profile.places.deleteVisitsFor(url: site.url).uponQueue(.main) { [weak self] _ in
-            self?.notification.post(name: .TopSitesUpdated, withObject: self)
+        let dispatchQueue = dispatchQueue as? DispatchQueue ?? .main
+        profile.places.deleteVisitsFor(url: site.url).uponQueue(dispatchQueue) { [weak self] _ in
+            self?.notification.post(name: .TopSitesUpdated, withObject: nil)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -63,14 +63,10 @@ final class TopSitesMiddleware: FeatureFlaggable {
             self.homepageTelemetry.sendContextMenuOpenedEventForTopSites(for: .pin)
 
         case ContextMenuActionType.tappedOnUnpinTopSite:
-            guard let site = self.getSite(for: action) else { return }
-            self.topSitesManager.unpinTopSite(site)
-            self.homepageTelemetry.sendContextMenuOpenedEventForTopSites(for: .unpin)
+            self.handleTappedOnUnpinSites(for: action)
 
         case ContextMenuActionType.tappedOnRemoveTopSite:
-            guard let site = self.getSite(for: action) else { return }
-            self.topSitesManager.removeTopSite(site)
-            self.homepageTelemetry.sendContextMenuOpenedEventForTopSites(for: .remove)
+            self.handleTappedOnRemoveTopSites(for: action)
 
         case ContextMenuActionType.tappedOnOpenNewPrivateTab:
             self.sendOpenInPrivateTelemetry(for: action)
@@ -83,6 +79,22 @@ final class TopSitesMiddleware: FeatureFlaggable {
         default:
             break
         }
+    }
+
+    private func handleTappedOnRemoveTopSites(for action: Action) {
+        guard let site = self.getSite(for: action) else { return }
+        Task { @MainActor in
+            await self.topSitesManager.removeTopSite(site)
+        }
+        self.homepageTelemetry.sendContextMenuOpenedEventForTopSites(for: .remove)
+    }
+
+    private func handleTappedOnUnpinSites(for action: Action) {
+        guard let site = self.getSite(for: action) else { return }
+        Task { @MainActor in
+            await self.topSitesManager.unpinTopSite(site)
+        }
+        self.homepageTelemetry.sendContextMenuOpenedEventForTopSites(for: .unpin)
     }
 
     private func getSite(for action: Action) -> Site? {

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
@@ -9,7 +9,7 @@ import Storage
 protocol TopSiteHistoryManagerProvider {
     func getTopSites(completion: @escaping ([Site]?) -> Void)
     func removeDefaultTopSitesTile(site: Site)
-    func removeTopSite(site: Site)
+    func remove(pinnedSite: Site) async -> Result<Void, Error>
 }
 
 // Manages the top site
@@ -32,6 +32,14 @@ class TopSiteHistoryManager: TopSiteHistoryManagerProvider {
         topSitesProvider.getTopSites { [weak self] result in
             guard self != nil else { return }
             completion(result)
+        }
+    }
+
+    func remove(pinnedSite: Site) async -> Result<Void, Error> {
+        do {
+            return try await profile.pinnedSites.remove(pinnedSite: pinnedSite)
+        } catch {
+            return .failure(error)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
@@ -9,7 +9,7 @@ import Storage
 protocol TopSiteHistoryManagerProvider {
     func getTopSites(completion: @escaping ([Site]?) -> Void)
     func removeDefaultTopSitesTile(site: Site)
-    func remove(pinnedSite: Site) async -> Result<Void, Error>
+    func remove(pinnedSite: Site) async throws
 }
 
 // Manages the top site
@@ -35,12 +35,8 @@ class TopSiteHistoryManager: TopSiteHistoryManagerProvider {
         }
     }
 
-    func remove(pinnedSite: Site) async -> Result<Void, Error> {
-        do {
-            return try await profile.pinnedSites.remove(pinnedSite: pinnedSite)
-        } catch {
-            return .failure(error)
-        }
+    func remove(pinnedSite: Site) async throws {
+        try await profile.pinnedSites.remove(pinnedSite: pinnedSite)
     }
 
     // TODO: FXIOS-10245 Remove when we nuke legacy homepage from the codebase

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
@@ -43,6 +43,7 @@ class TopSiteHistoryManager: TopSiteHistoryManagerProvider {
         }
     }
 
+    // TODO: FXIOS-10245 Remove when we nuke legacy homepage from the codebase
     func removeTopSite(site: Site) {
         profile.pinnedSites.removeFromPinnedTopSites(site)
     }

--- a/firefox-ios/Storage/PinnedSites.swift
+++ b/firefox-ios/Storage/PinnedSites.swift
@@ -8,7 +8,7 @@ import Shared
 public protocol PinnedSites {
     // Pinning top sites
     // Without Deferred
-    func remove(pinnedSite site: Site) async throws -> Result<Void, Error>
+    func remove(pinnedSite site: Site) async throws
 
     // With Deferred
     @discardableResult

--- a/firefox-ios/Storage/PinnedSites.swift
+++ b/firefox-ios/Storage/PinnedSites.swift
@@ -7,6 +7,10 @@ import Shared
 /// A protocol to manage pinned sites in BrowserDB
 public protocol PinnedSites {
     // Pinning top sites
+    // Without Deferred
+    func remove(pinnedSite site: Site) async throws -> Result<Void, Error>
+
+    // With Deferred
     @discardableResult
     func removeFromPinnedTopSites(_ site: Site) -> Success
     @discardableResult

--- a/firefox-ios/Storage/SQL/SQLitePinnedSites.swift
+++ b/firefox-ios/Storage/SQL/SQLitePinnedSites.swift
@@ -53,7 +53,7 @@ extension BrowserDBSQLite: PinnedSites {
 
     /// Helper method that converts using the deferred types to result
     /// and adopts modern swift concurrency to avoid refactoring the database level
-    func awaitDatabaseRun(for commands: [(String, Args)]) async -> Result<Void, Error> {
+    private func awaitDatabaseRun(for commands: [(String, Args)]) async -> Result<Void, Error> {
         await withCheckedContinuation { continuation in
             database.run(commands).upon { result in
                 switch result {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
@@ -44,9 +44,8 @@ class MockTopSiteHistoryManager: TopSiteHistoryManagerProvider {
         self.sites = sites
     }
 
-    func remove(pinnedSite: Storage.Site) async -> Result<Void, any Error> {
+    func remove(pinnedSite: Storage.Site) async throws {
         removePinnedSiteCalled()
-        return .success(())
     }
 
     func getTopSites(completion: @escaping ([Site]?) -> Void) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
@@ -11,6 +11,7 @@ class MockTopSiteHistoryManager: TopSiteHistoryManagerProvider {
     private let sites: [Site]?
     var removeDefaultTopSitesTileCalledCount = 0
     var removeTopSiteCalledCount = 0
+    var removePinnedSiteCalled: () -> Void = {}
 
     static var defaultSuccessData: [Site] {
         return [
@@ -41,6 +42,11 @@ class MockTopSiteHistoryManager: TopSiteHistoryManagerProvider {
 
     init(sites: [Site]? = []) {
         self.sites = sites
+    }
+
+    func remove(pinnedSite: Storage.Site) async -> Result<Void, any Error> {
+        removePinnedSiteCalled()
+        return .success(())
     }
 
     func getTopSites(completion: @escaping ([Site]?) -> Void) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
@@ -12,7 +12,7 @@ final class MockTopSitesManager: TopSitesManagerInterface {
     var recalculateTopSitesCalledCount = 0
     var pinTopSiteCalledCount = 0
 
-    // We add these completions since this method is called in an asynchronous
+    // We add these completions since this method is called asynchronously
     var removeTopSiteCalled: () -> Void = {}
     var unpinTopSiteCalled: () -> Void = {}
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
@@ -10,12 +10,11 @@ import XCTest
 
 final class MockTopSitesManager: TopSitesManagerInterface {
     var recalculateTopSitesCalledCount = 0
-
-    var removeTopSiteCalledCount = 0
     var pinTopSiteCalledCount = 0
-    var unpinTopSiteCalledCount = 0
 
-    private let lock = NSLock()
+    // We add these completions since this method is called in an asynchronous
+    var removeTopSiteCalled: () -> Void = {}
+    var unpinTopSiteCalled: () -> Void = {}
 
     func getOtherSites() async -> [TopSiteConfiguration] {
         return createSites(count: 15, subtitle: ": otherSites")
@@ -27,7 +26,6 @@ final class MockTopSitesManager: TopSitesManagerInterface {
     }
 
     func recalculateTopSites(otherSites: [TopSiteConfiguration], sponsoredSites: [Site]) -> [TopSiteConfiguration] {
-        // We add this completion since this method is called in an asynchronous
         recalculateTopSitesCalledCount += 1
         XCTAssertTrue(Thread.isMainThread)
         return createSites(subtitle: ": total top sites")
@@ -43,15 +41,15 @@ final class MockTopSitesManager: TopSitesManagerInterface {
         return sites
     }
 
-    func removeTopSite(_ site: Site) {
-        removeTopSiteCalledCount += 1
+    func removeTopSite(_ site: Site) async {
+        removeTopSiteCalled()
     }
 
     func pinTopSite(_ site: Site) {
         pinTopSiteCalledCount += 1
     }
 
-    func unpinTopSite(_ site: Site) {
-        unpinTopSiteCalledCount += 1
+    func unpinTopSite(_ site: Site) async {
+        unpinTopSiteCalled()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
@@ -322,23 +322,37 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: .XCTestDefaultUUID,
             actionType: ContextMenuActionType.tappedOnUnpinTopSite
         )
+        let unpinTopSiteExpectation = XCTestExpectation(
+            description: "Unpin top sites method is called from top site manager"
+        )
+        mockTopSitesManager.unpinTopSiteCalled = {
+            unpinTopSiteExpectation.fulfill()
+        }
 
         subject.topSitesProvider(appState, action)
 
         try checkContextMenuMetricsCalled(withExtra: "unpin")
 
-        XCTAssertEqual(mockTopSitesManager.unpinTopSiteCalledCount, 1)
+        wait(for: [unpinTopSiteExpectation], timeout: 1)
     }
 
     func test_tappedOnUnpinTopSite_withoutSite_doesNotCallUnpinTopSite() {
         let subject = createSubject(topSitesManager: mockTopSitesManager)
         let action = TopSitesAction(windowUUID: .XCTestDefaultUUID, actionType: ContextMenuActionType.tappedOnUnpinTopSite)
 
+        let unpinTopSiteExpectation = XCTestExpectation(
+            description: "Unpin top sites method is called from top site manager"
+        )
+        unpinTopSiteExpectation.isInverted = true
+        mockTopSitesManager.unpinTopSiteCalled = {
+            unpinTopSiteExpectation.fulfill()
+        }
+
         subject.topSitesProvider(appState, action)
 
         XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)
-        XCTAssertEqual(mockTopSitesManager.unpinTopSiteCalledCount, 0)
+        wait(for: [unpinTopSiteExpectation], timeout: 1)
     }
 
     func test_tappedOnRemoveTopSite_withSite_callsRemoveTopSite() throws {
@@ -350,22 +364,38 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ContextMenuActionType.tappedOnRemoveTopSite
         )
 
+        let removeTopSiteExpectation = XCTestExpectation(
+            description: "Remove top sites method is called from top site manager"
+        )
+        mockTopSitesManager.removeTopSiteCalled = {
+            removeTopSiteExpectation.fulfill()
+        }
+
         subject.topSitesProvider(appState, action)
 
         try checkContextMenuMetricsCalled(withExtra: "remove")
 
-        XCTAssertEqual(mockTopSitesManager.removeTopSiteCalledCount, 1)
+        wait(for: [removeTopSiteExpectation], timeout: 1)
     }
 
     func test_tappedOnRemoveTopSite_withoutSite_doesNotCallRemoveTopSite() {
         let subject = createSubject(topSitesManager: mockTopSitesManager)
         let action = TopSitesAction(windowUUID: .XCTestDefaultUUID, actionType: ContextMenuActionType.tappedOnRemoveTopSite)
 
+        let removeTopSiteExpectation = XCTestExpectation(
+            description: "Remove top sites method is called from top site manager"
+        )
+        removeTopSiteExpectation.isInverted = true
+
+        mockTopSitesManager.removeTopSiteCalled = {
+            removeTopSiteExpectation.fulfill()
+        }
+
         subject.topSitesProvider(appState, action)
 
         XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)
-        XCTAssertEqual(mockTopSitesManager.removeTopSiteCalledCount, 0)
+        wait(for: [removeTopSiteExpectation], timeout: 1)
     }
 
     func test_tappedOnOpenNewPrivateTabAction_sendTelemetryData() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
@@ -5,13 +5,14 @@
 import Shared
 import Storage
 import XCTest
+import Common
 
 @testable import Client
 
 final class TopSitesManagerTests: XCTestCase {
     private var profile: MockProfile!
+    private var mockNotificationCenter: MockNotificationCenter!
     private var dispatchQueue: MockDispatchQueue?
-    private var mockNotificationCenter: MockNotificationCenter?
     override func setUp() {
         super.setUp()
         profile = MockProfile()
@@ -21,9 +22,9 @@ final class TopSitesManagerTests: XCTestCase {
     }
 
     override func tearDown() {
-        mockNotificationCenter = nil
         dispatchQueue = nil
         profile = nil
+        mockNotificationCenter = nil
         super.tearDown()
     }
 
@@ -349,7 +350,7 @@ final class TopSitesManagerTests: XCTestCase {
     }
 
     // MARK: Context menu actions
-    func test_unpinTopSite_callsProperMethods() throws {
+    func test_unpinTopSite_callsProperMethods() async throws {
         let mockGoogleTopSiteManager = MockGoogleTopSiteManager()
         let mockTopSiteHistoryManager = MockTopSiteHistoryManager()
         let subject = try createSubject(
@@ -357,25 +358,49 @@ final class TopSitesManagerTests: XCTestCase {
             topSiteHistoryManager: mockTopSiteHistoryManager
         )
         let site = Site.createBasicSite(url: "www.example.com", title: "Example Pinned Site")
-        subject.unpinTopSite(site)
+        let unpinnedSiteExpectation = XCTestExpectation(
+            description: "Remove top sites method is called from top site manager"
+        )
+
+        mockTopSiteHistoryManager.removePinnedSiteCalled = {
+            unpinnedSiteExpectation.fulfill()
+        }
+        await subject.unpinTopSite(site)
 
         XCTAssertEqual(mockGoogleTopSiteManager.removeGoogleTopSiteCalledCount, 1)
-        XCTAssertEqual(mockTopSiteHistoryManager.removeTopSiteCalledCount, 1)
+        await fulfillment(of: [unpinnedSiteExpectation], timeout: 1)
     }
 
-    func test_removeTopSite_callsProperMethods() throws {
+    func test_removeTopSite_callsProperMethods() async throws {
         let mockGoogleTopSiteManager = MockGoogleTopSiteManager()
         let mockTopSiteHistoryManager = MockTopSiteHistoryManager()
         let subject = try createSubject(
             googleTopSiteManager: mockGoogleTopSiteManager,
-            topSiteHistoryManager: mockTopSiteHistoryManager
+            topSiteHistoryManager: mockTopSiteHistoryManager,
         )
         let site = Site.createBasicSite(url: "www.example.com", title: "Example Pinned Site")
-        subject.removeTopSite(site)
+        let removePinnedSiteExpectation = XCTestExpectation(
+            description: "Remove top sites method is called from top site manager"
+        )
+
+        let postCalledExpectation = XCTestExpectation(
+            description: "Notification post method is called from top site manager"
+        )
+
+        mockTopSiteHistoryManager.removePinnedSiteCalled = {
+            removePinnedSiteExpectation.fulfill()
+        }
+
+        mockNotificationCenter.postCalled = { name in
+            guard name == .TopSitesUpdated else { return }
+            postCalledExpectation.fulfill()
+        }
+
+        await subject.removeTopSite(site)
 
         XCTAssertEqual(mockGoogleTopSiteManager.removeGoogleTopSiteCalledCount, 1)
-        XCTAssertEqual(mockTopSiteHistoryManager.removeTopSiteCalledCount, 1)
         XCTAssertEqual(mockTopSiteHistoryManager.removeDefaultTopSitesTileCalledCount, 1)
+        await fulfillment(of: [removePinnedSiteExpectation, postCalledExpectation], timeout: 1)
     }
 
     func test_pinTopSite_callsProperMethods() throws {
@@ -464,6 +489,7 @@ final class TopSitesManagerTests: XCTestCase {
     ) throws -> TopSitesManager {
         let mockProfile = try XCTUnwrap(injectedProfile ?? profile)
         let mockQueue = try XCTUnwrap(dispatchQueue)
+        let mockNotificationCenter = try XCTUnwrap(mockNotificationCenter)
         let subject = TopSitesManager(
             profile: mockProfile,
             contileProvider: contileProvider,
@@ -472,7 +498,7 @@ final class TopSitesManagerTests: XCTestCase {
             topSiteHistoryManager: topSiteHistoryManager,
             searchEnginesManager: searchEngineManager,
             dispatchQueue: mockQueue,
-            notification: try XCTUnwrap(mockNotificationCenter),
+            notification: mockNotificationCenter,
             maxTopSites: maxCount
         )
         trackForMemoryLeaks(subject, file: file, line: line)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
@@ -373,7 +373,7 @@ final class TopSitesManagerTests: XCTestCase {
         let mockTopSiteHistoryManager = MockTopSiteHistoryManager()
         let subject = try createSubject(
             googleTopSiteManager: mockGoogleTopSiteManager,
-            topSiteHistoryManager: mockTopSiteHistoryManager,
+            topSiteHistoryManager: mockTopSiteHistoryManager
         )
         let site = Site.createBasicSite(url: "www.example.com", title: "Example Pinned Site")
         let removePinnedSiteExpectation = XCTestExpectation(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
@@ -12,17 +12,14 @@ import Common
 final class TopSitesManagerTests: XCTestCase {
     private var profile: MockProfile!
     private var mockNotificationCenter: MockNotificationCenter!
-    private var dispatchQueue: MockDispatchQueue?
     override func setUp() {
         super.setUp()
         profile = MockProfile()
-        dispatchQueue = MockDispatchQueue()
         mockNotificationCenter = MockNotificationCenter()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
     override func tearDown() {
-        dispatchQueue = nil
         profile = nil
         mockNotificationCenter = nil
         super.tearDown()
@@ -488,7 +485,6 @@ final class TopSitesManagerTests: XCTestCase {
         line: UInt = #line
     ) throws -> TopSitesManager {
         let mockProfile = try XCTUnwrap(injectedProfile ?? profile)
-        let mockQueue = try XCTUnwrap(dispatchQueue)
         let mockNotificationCenter = try XCTUnwrap(mockNotificationCenter)
         let subject = TopSitesManager(
             profile: mockProfile,
@@ -497,7 +493,6 @@ final class TopSitesManagerTests: XCTestCase {
             googleTopSiteManager: googleTopSiteManager,
             topSiteHistoryManager: topSiteHistoryManager,
             searchEnginesManager: searchEngineManager,
-            dispatchQueue: mockQueue,
             notification: mockNotificationCenter,
             maxTopSites: maxCount
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNotificationCenter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNotificationCenter.swift
@@ -6,6 +6,7 @@ import Foundation
 import Common
 
 final class MockNotificationCenter: NotificationProtocol, @unchecked Sendable {
+    var postCalled: (NSNotification.Name) -> Void = { _ in }
     var postCallCount = 0
     var addObserverCallCount = 0
     var removeObserverCallCount = 0
@@ -28,6 +29,7 @@ final class MockNotificationCenter: NotificationProtocol, @unchecked Sendable {
         savePostObject = anObject
         saveUserInfo = info
         postCallCount += 1
+        postCalled(aName)
         self.notifiableListener?.handleNotifications(Notification(name: aName))
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockablePinnedSites.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockablePinnedSites.swift
@@ -8,6 +8,7 @@ import Shared
 
 /// A class that adheres to all the requirements for a profile's pinned sites
 class MockablePinnedSites: PinnedSites {
+    func remove(pinnedSite site: Storage.Site) async throws -> Result<Void, any Error> { return .success(()) }
     var addPinnedTopSiteCalledCount = 0
     func removeFromPinnedTopSites(_ site: Site) -> Success { fatalError() }
     func isPinnedTopSite(_ url: String) -> Deferred<Maybe<Bool>> { fatalError()}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockablePinnedSites.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockablePinnedSites.swift
@@ -8,7 +8,7 @@ import Shared
 
 /// A class that adheres to all the requirements for a profile's pinned sites
 class MockablePinnedSites: PinnedSites {
-    func remove(pinnedSite site: Storage.Site) async throws -> Result<Void, any Error> { return .success(()) }
+    func remove(pinnedSite site: Storage.Site) async throws { }
     var addPinnedTopSiteCalledCount = 0
     func removeFromPinnedTopSites(_ site: Site) -> Success { fatalError() }
     func isPinnedTopSite(_ url: String) -> Deferred<Maybe<Bool>> { fatalError()}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -82,6 +82,60 @@ class PhotonActionSheetTests: FeatureFlaggedTestBase {
         mozWaitForElementToNotExist(cell)
     }
 
+    func testPinToShortcuts_andThenRemovingShortcuts_topSitesVisualRefreshFlagEnabled() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "hnt-top-sites-visual-refresh-feature")
+        app.launch()
+        navigator.openURL(path(forTestPage: "test-example.html"))
+        waitUntilPageLoad()
+        navigator.performAction(Action.PinToTopSitesPAM)
+        navigator.nowAt(BrowserTab)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+
+        let itemCell = app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
+        let shortcutCell = itemCell.staticTexts["Example Domain"]
+        mozWaitForElementToExist(shortcutCell)
+        if #available(iOS 17, *) {
+            mozWaitForElementToExist(app.links["Pinned: Example Domain"].images[StandardImageIdentifiers.Large.pinFill])
+        } else {
+            // No identifier is available for iOS 17 amd below
+            mozWaitForElementToExist(app.links["Pinned: Example Domain"].images.element(boundBy: 1))
+        }
+
+        let pinnedShortcutCell = app.collectionViews.links["Pinned: Example Domain"]
+        pinnedShortcutCell.press(forDuration: 2)
+        app.tables.cells.buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
+
+        mozWaitForElementToNotExist(pinnedShortcutCell)
+        mozWaitForElementToNotExist(shortcutCell)
+    }
+
+    func testPinToShortcuts_andThenRemovingShortcuts_topSitesVisualRefreshFlagDisabled() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hnt-top-sites-visual-refresh-feature")
+        app.launch()
+        navigator.openURL(path(forTestPage: "test-example.html"))
+        waitUntilPageLoad()
+        navigator.performAction(Action.PinToTopSitesPAM)
+        navigator.nowAt(BrowserTab)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+
+        let itemCell = app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
+        let shortcutCell = itemCell.staticTexts["Example Domain"]
+        mozWaitForElementToExist(shortcutCell)
+        if #available(iOS 17, *) {
+            mozWaitForElementToExist(app.links["Pinned: Example Domain"].images[StandardImageIdentifiers.Small.pinBadgeFill])
+        } else {
+            // No identifier is available for iOS 17 amd below
+            mozWaitForElementToExist(app.links["Pinned: Example Domain"].images.element(boundBy: 1))
+        }
+
+        let pinnedShortcutCell = app.collectionViews.links["Pinned: Example Domain"]
+        pinnedShortcutCell.press(forDuration: 2)
+        app.tables.cells.buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
+
+        mozWaitForElementToNotExist(shortcutCell)
+        mozWaitForElementToNotExist(pinnedShortcutCell)
+    }
+
     private func openNewShareSheet() {
         app.launch()
         navigator.openURL("example.com")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -109,6 +109,7 @@ class PhotonActionSheetTests: FeatureFlaggedTestBase {
         mozWaitForElementToNotExist(shortcutCell)
     }
 
+    // https://mozilla.testrail.io/index.php?/cases/view/3102521
     func testPinToShortcuts_andThenRemovingShortcuts_topSitesVisualRefreshFlagDisabled() {
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hnt-top-sites-visual-refresh-feature")
         app.launch()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Refactor `TopSitesManager.swift` to use modern swift concurrency to eliminate Swift 6 warnings (see error below). In this PR, I remove the `dispatchQueue` and opted to using `async / await`. We needed to modify the current `remove` method in `SQLitePinnedSites` file so that we convert from returning deferred type to `Result` type. 

Note: To test this, its recommended that you have a list of top sites and not just a fresh install. We have cases if you try to remove the top site, it will re-appear and not be removed and this happens in legacy as well.

**Error Message**

<img width="1142" height="140" alt="image" src="https://github.com/user-attachments/assets/2a8bbafb-f615-4d25-9988-02b32642035a" />

## :movie_camera: Demos

https://github.com/user-attachments/assets/9eb10d13-d104-4595-bac3-8c7da2df1c64

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
