### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Add main actor conformance to UIImage+extension method

### DIFF
--- a/firefox-ios/Client/Extensions/UIImage+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIImage+Extension.swift
@@ -5,6 +5,7 @@
 import UIKit
 
 extension UIImage {
+    @MainActor
     func overlayWith(image: UILabel) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(CGSize(width: size.width, height: size.height), false, 0.0)
         draw(in: CGRect(origin: CGPoint.zero, size: size))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Easy little fix.
<img width="1409" height="373" alt="Screenshot 2025-07-21 at 3 46 12 PM" src="https://github.com/user-attachments/assets/1cd71d30-bd02-4ea0-b8e1-bf9197821ae4" />

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
