### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Add main actor conformance to Swipe Animator and TabDisplayView related Protocols

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SwipeAnimator.swift
+++ b/firefox-ios/Client/Frontend/Browser/SwipeAnimator.swift
@@ -22,12 +22,14 @@ private let DefaultParameters =
         minExitVelocity: 800,
         recenterAnimationDuration: 0.15)
 
+@MainActor
 protocol SwipeAnimatorDelegate: AnyObject {
     func swipeAnimator(_ animator: SwipeAnimator)
     func swipeAnimatorIsAnimateAwayEnabled(_ animator: SwipeAnimator) -> Bool
 }
 
-class SwipeAnimator: NSObject {
+@MainActor
+final class SwipeAnimator: NSObject {
     weak var delegate: SwipeAnimatorDelegate?
     weak var animatingView: UIView?
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -9,6 +9,7 @@ import SiteImageView
 import enum MozillaAppServices.VisitType
 
 protocol CollapsibleTableViewSection: AnyObject {
+    @MainActor
     func hideTableViewSection(_ section: Int)
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -9,10 +9,13 @@ import Shared
 import SiteImageView
 
 protocol TabCellDelegate: AnyObject {
+    @MainActor
     func tabCellDidClose(for tabUUID: TabUUID)
 }
 
-class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
+final class TabCell: UICollectionViewCell,
+                     ThemeApplicable,
+                     ReusableCell {
     struct UX {
         static let borderWidth: CGFloat = 3.0
         static let cornerRadius: CGFloat = 16

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabPeekViewController.swift
@@ -7,7 +7,7 @@ import Common
 import WebKit
 import Redux
 
-class TabPeekViewController: UIViewController,
+final class TabPeekViewController: UIViewController,
                              StoreSubscriber {
     typealias SubscriberStateType = TabPeekState
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Adding some main actor conformance to Tab files I know are view related and should only be run on the main actor.

## Warnings Screenshots
<img width="363" height="1003" alt="Screenshot 2025-07-21 at 4 05 46 PM" src="https://github.com/user-attachments/assets/5fe02545-c3e3-4e49-9b64-a475f51c89b1" />
<img width="1742" height="307" alt="Screenshot 2025-07-21 at 4 02 46 PM" src="https://github.com/user-attachments/assets/063201ee-54b0-4885-a5dd-8890b7a16dfe" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
