### PR TITLE
Bugfix MTE-4812 Disable non related tests from perf test plan

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
@@ -404,6 +404,7 @@
         "ShareToolbarTests",
         "SiteLoadTest",
         "SiteLoadTest\/testLoadSite()",
+        "StoryTests",
         "SwipingTabsTests",
         "SyncUITests",
         "SyncUITests\/testCreateAnAccountLink()",

--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -127,6 +127,7 @@
         "ShareMenuTests",
         "ShareToolbarTests",
         "SiteLoadTest",
+        "StoryTests",
         "SwipingTabsTests",
         "SyncUITests",
         "TabCounterTests",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -425,6 +425,7 @@
         "ShareMenuTests",
         "ShareToolbarTests",
         "SiteLoadTest",
+        "StoryTests",
         "SwipingTabsTests",
         "SyncUITests",
         "SyncUITests\/testCreateAnAccountLink()",

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
@@ -146,6 +146,7 @@
         "ShareMenuTests",
         "ShareToolbarTests",
         "SiteLoadTest",
+        "StoryTests",
         "SwipingTabsTests",
         "SyncUITests",
         "TabCounterTests",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4812)


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Performance test workflows are not running due to an error caused for unrelated test suites added to their test plans

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
