### PR TITLE
Bugfix FXIOS-12881 ⁃ [Menu redesign] [Accessibility] - Incorrect announcement of more submenu with voice over

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignMainView.swift
@@ -128,6 +128,18 @@ public final class MenuRedesignMainView: UIView,
         self.isPhoneLandscape = isPhoneLandscape
     }
 
+    public func announceAccessibility(expandedHint: String) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            UIAccessibility.post(notification: .announcement, argument: expandedHint)
+            if let section = self?.menuData.first,
+               let optionalElementIndex = section.options.firstIndex(where: { $0.isOptional }) {
+                if let firstCell = self?.tableView.tableView.visibleCells[optionalElementIndex] {
+                    UIAccessibility.post(notification: .layoutChanged, argument: firstCell)
+                }
+            }
+        }
+    }
+
     // MARK: - Interface
     public func reloadDataView(with data: [MenuSection]) {
         setupView(with: data)

--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignTableView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuRedesignTableView.swift
@@ -18,7 +18,7 @@ final class MenuRedesignTableView: UIView,
         static let distanceBetweenSections: CGFloat = 16
     }
 
-    private var tableView: UITableView
+    public var tableView: UITableView
     private var menuData: [MenuSection]
     private var theme: Theme?
     private var isBannerVisible = false

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
@@ -18,6 +18,7 @@ final class MainMenuAction: Action {
     var isExpanded: Bool?
     var isBrowserDefault: Bool
     var isPhoneLandscape: Bool
+    var moreCellTapped: Bool
 
     init(
         windowUUID: WindowUUID,
@@ -32,7 +33,8 @@ final class MainMenuAction: Action {
         telemetryInfo: TelemetryInfo? = nil,
         isExpanded: Bool? = nil,
         isBrowserDefault: Bool = false,
-        isPhoneLandscape: Bool = false
+        isPhoneLandscape: Bool = false,
+        moreCellTapped: Bool = false
     ) {
         self.navigationDestination = navigationDestination
         self.detailsViewToShow = changeMenuViewTo
@@ -45,6 +47,7 @@ final class MainMenuAction: Action {
         self.isExpanded = isExpanded
         self.isBrowserDefault = isBrowserDefault
         self.isPhoneLandscape = isPhoneLandscape
+        self.moreCellTapped = moreCellTapped
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
@@ -75,6 +78,7 @@ enum MainMenuMiddlewareActionType: ActionType {
     case updateAccountHeader
     case updateBannerVisibility
     case updateMenuAppearance
+    case updateMenuCells
 }
 
 enum MainMenuDetailsActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -156,9 +156,6 @@ final class MainMenuMiddleware: FeatureFlaggable {
         case MainMenuDetailsActionType.tapDismissView:
             telemetry.closeButtonTapped(isHomepage: isHomepage)
 
-        case MainMenuActionType.tapMoreOptions:
-            handleTapMoreOptions(action: action)
-
         default: break
         }
     }
@@ -316,15 +313,6 @@ final class MainMenuMiddleware: FeatureFlaggable {
                            subtitle: subtitle,
                            warningIcon: warningIcon,
                            iconURL: iconURL)
-    }
-
-    private func handleTapMoreOptions(action: MainMenuAction) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            UIAccessibility.post(
-                notification: .announcement,
-                argument: String.MainMenu.ToolsSection.AccessibilityLabels.ExpandedHint
-            )
-        }
     }
 
     private func handleTelemetryFor(for navigationDestination: MainMenuNavigationDestination,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -81,6 +81,7 @@ struct MainMenuState: ScreenState, Equatable {
     var accountIcon: UIImage?
     var isBrowserDefault: Bool
     var isPhoneLandscape: Bool
+    var moreCellTapped: Bool
 
     var siteProtectionsData: SiteProtectionsData?
 
@@ -111,7 +112,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: mainMenuState.accountIcon,
             siteProtectionsData: mainMenuState.siteProtectionsData,
             isBrowserDefault: mainMenuState.isBrowserDefault,
-            isPhoneLandscape: mainMenuState.isPhoneLandscape
+            isPhoneLandscape: mainMenuState.isPhoneLandscape,
+            moreCellTapped: mainMenuState.moreCellTapped
         )
     }
 
@@ -127,7 +129,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: nil,
             siteProtectionsData: nil,
             isBrowserDefault: false,
-            isPhoneLandscape: false
+            isPhoneLandscape: false,
+            moreCellTapped: false
         )
     }
 
@@ -142,7 +145,8 @@ struct MainMenuState: ScreenState, Equatable {
         accountIcon: UIImage?,
         siteProtectionsData: SiteProtectionsData?,
         isBrowserDefault: Bool,
-        isPhoneLandscape: Bool
+        isPhoneLandscape: Bool,
+        moreCellTapped: Bool
     ) {
         self.windowUUID = windowUUID
         self.menuElements = menuElements
@@ -155,6 +159,7 @@ struct MainMenuState: ScreenState, Equatable {
         self.siteProtectionsData = siteProtectionsData
         self.isBrowserDefault = isBrowserDefault
         self.isPhoneLandscape = isPhoneLandscape
+        self.moreCellTapped = moreCellTapped
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -213,7 +218,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -226,7 +232,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -241,7 +248,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: action.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -256,7 +264,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: action.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -271,7 +280,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: action.isPhoneLandscape
+            isPhoneLandscape: action.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -286,7 +296,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: action.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -307,7 +318,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -330,7 +342,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: true
         )
     }
 
@@ -346,7 +359,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -362,7 +376,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -376,7 +391,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -390,7 +406,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -404,7 +421,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 
@@ -418,7 +436,8 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon,
             siteProtectionsData: state.siteProtectionsData,
             isBrowserDefault: state.isBrowserDefault,
-            isPhoneLandscape: state.isPhoneLandscape
+            isPhoneLandscape: state.isPhoneLandscape,
+            moreCellTapped: false
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -432,6 +432,11 @@ class MainMenuViewController: UIViewController,
         changeDetentIfNecessary()
         removeHintViewIfNecessary()
         reloadTableView(with: menuState.menuElements)
+
+        if menuState.moreCellTapped {
+            let expandedHint = String.MainMenu.ToolsSection.AccessibilityLabels.ExpandedHint
+            menuRedesignContent.announceAccessibility(expandedHint: expandedHint)
+        }
     }
 
     private func dispatchCloseMenuAction() {

--- a/firefox-ios/nimbus-features/menuRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/menuRefactorFeature.yaml
@@ -43,5 +43,4 @@ features:
           menu-hint: true
           menu-redesign: false
           menu-default-browser-banner: false
-          menu-redesign-hint: false
           menu-redesign-hint: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12881)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28083)

## :bulb: Description
Moved the voice over to the next element when menu is expanded

## :movie_camera: Demos

https://github.com/user-attachments/assets/c67cfdab-f2c9-4bfa-a385-cb18a597d580


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
