### PR TITLE
Add FXIOS-12901 [Swift 6 Migration] Fix Swift concurrency warnings for static properties in FontFamily struct

### DIFF
--- a/BrowserKit/Sources/Common/ReaderMode/ReaderModeFontType.swift
+++ b/BrowserKit/Sources/Common/ReaderMode/ReaderModeFontType.swift
@@ -5,7 +5,7 @@
 import Foundation
 import UIKit
 
-public enum ReaderModeFontType: String {
+public enum ReaderModeFontType: String, Sendable {
     case serif = "serif"
     case serifBold = "serif-bold"
     case sansSerif = "sans-serif"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12901)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28125)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Multiple static properties in the FontFamily struct are generating concurrency-safety warnings because the ReaderModeFontType enum is not marked as Sendable. This affects font family definitions used throughout the app.
<img width="1920" height="330" alt="image" src="https://github.com/user-attachments/assets/939914b8-959e-4b09-b301-1dbf560f9868" />

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
