### PR TITLE
Bugfix FXIOS-12482 [Video Player] Videos should be inlined by default when desktop mode is on

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/WebcompatAtDocumentStart/FullscreenHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/WebcompatAtDocumentStart/FullscreenHelper.js
@@ -52,6 +52,7 @@ if (!isFullScreenEnabled && isFullscreenVideosSupported && !/mobile/i.test(navig
 /// This is a good default because it makes videos less intrusive.
 /// Calling `requestFullscreen()` on the video element still works as expected and
 /// the user can still enter full screen by interacting with the video controls.
+/// FXIOS-12482 has more details on this issue.
 if (!/mobile/i.test(navigator.userAgent)) {
   const forceInline = (video) => {
     const inlineAttributes = ["playsinline", "webkit-playsinline"];


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12482)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27209)

## :bulb: Description
This PR:
- Adds override to force inline mode in videos when desktop mode is on.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
