### PR TITLE
Add FXIOS-12902 [Swift 6 Migration] Fix Swift concurrency warning for non-Sendable closure parameter in addObserver function

### DIFF
--- a/BrowserKit/Sources/Common/Utilities/Notifiable.swift
+++ b/BrowserKit/Sources/Common/Utilities/Notifiable.swift
@@ -14,7 +14,7 @@ public protocol NotificationProtocol: Sendable {
     @discardableResult
     func addObserver(name: NSNotification.Name?,
                      queue: OperationQueue?,
-                     using block: @escaping (Notification) -> Void) -> NSObjectProtocol?
+                     using block: @Sendable @escaping (Notification) -> Void) -> NSObjectProtocol?
     func removeObserver(_ observer: Any)
 }
 
@@ -32,7 +32,7 @@ extension NotificationCenter: NotificationProtocol {
 
     public func addObserver(name: NSNotification.Name?,
                             queue: OperationQueue?,
-                            using block: @escaping (Notification) -> Void) -> NSObjectProtocol? {
+                            using block: @Sendable @escaping (Notification) -> Void) -> NSObjectProtocol? {
         self.addObserver(forName: name,
                          object: nil,
                          queue: queue,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12902)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28127)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Fix Swift concurrency warning for non-Sendable closure parameter in addObserver function.
<img width="1920" height="355" alt="image" src="https://github.com/user-attachments/assets/59b4f619-6b68-4e65-a7bb-cab4ed6eac5c" />

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
