### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Migrate redux Actions from class inheritance to Sendable structs

### DIFF
--- a/BrowserKit/Sources/Redux/Action.swift
+++ b/BrowserKit/Sources/Redux/Action.swift
@@ -6,15 +6,12 @@ import Foundation
 import Common
 
 /// Used to describe an action that can be dispatched by the redux store
-open class Action: CustomDebugStringConvertible {
-    public var windowUUID: WindowUUID
-    public var actionType: ActionType
+public protocol Action: CustomDebugStringConvertible {
+    var windowUUID: WindowUUID { get }
+    var actionType: ActionType { get }
+}
 
-    public init(windowUUID: WindowUUID, actionType: ActionType) {
-        self.windowUUID = windowUUID
-        self.actionType = actionType
-    }
-
+extension Action {
     func displayString() -> String {
         let className = String(describing: Self.self)
         return "\(className) \(actionType)"
@@ -22,9 +19,8 @@ open class Action: CustomDebugStringConvertible {
 
     public var debugDescription: String {
         let className = String(describing: type(of: self))
-        let memAddr = Unmanaged.passUnretained(self).toOpaque()
-        return "<\(className): \(memAddr)> Type: \(actionType) Window: \(windowUUID.uuidString.prefix(4))"
+        return "<\(className)> Type: \(actionType) Window: \(windowUUID.uuidString.prefix(4))"
     }
 }
 
-public protocol ActionType {}
+public protocol ActionType: Sendable {}

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxAction.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxAction.swift
@@ -3,10 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 
 @testable import Redux
 
-class FakeReduxAction: Action {
+struct FakeReduxAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let counterValue: Int?
     let privateMode: Bool?
 
@@ -14,10 +17,10 @@ class FakeReduxAction: Action {
          privateMode: Bool? = nil,
          windowUUID: UUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.counterValue = counterValue
         self.privateMode = privateMode
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -7,7 +7,9 @@ import Redux
 import Common
 import WebKit
 
-class GeneralBrowserAction: Action {
+struct GeneralBrowserAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let selectedTabURL: URL?
     let isPrivateBrowsing: Bool?
     let toastType: ToastType?
@@ -24,6 +26,8 @@ class GeneralBrowserAction: Action {
          frame: WKFrameInfo? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.selectedTabURL = selectedTabURL
         self.isPrivateBrowsing = isPrivateBrowsing
         self.toastType = toastType
@@ -31,8 +35,6 @@ class GeneralBrowserAction: Action {
         self.showOverlay = showOverlay
         self.isNativeErrorPage = isNativeErrorPage
         self.frame = frame
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
     }
 }
 
@@ -68,7 +70,9 @@ enum GeneralBrowserActionType: ActionType {
     case didUnhideToolbar
 }
 
-class GeneralBrowserMiddlewareAction: Action {
+struct GeneralBrowserMiddlewareAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let scrollOffset: CGPoint?
     let toolbarPosition: SearchBarPosition?
 
@@ -76,10 +80,10 @@ class GeneralBrowserMiddlewareAction: Action {
          toolbarPosition: SearchBarPosition? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.scrollOffset = scrollOffset
         self.toolbarPosition = toolbarPosition
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
@@ -7,15 +7,17 @@ import Foundation
 import Redux
 
 /// Actions that are related to navigation from the user perspective
-class NavigationBrowserAction: Action {
+struct NavigationBrowserAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let navigationDestination: NavigationDestination
 
     init(navigationDestination: NavigationDestination,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.navigationDestination = navigationDestination
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
@@ -6,7 +6,9 @@ import Common
 import Foundation
 import Redux
 
-final class MainMenuAction: Action {
+struct MainMenuAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     var tabID: TabUUID?
     var navigationDestination: MenuNavigationDestination?
     var currentTabInfo: MainMenuTabInfo?
@@ -36,6 +38,8 @@ final class MainMenuAction: Action {
         isPhoneLandscape: Bool = false,
         moreCellTapped: Bool = false
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.navigationDestination = navigationDestination
         self.detailsViewToShow = changeMenuViewTo
         self.currentTabInfo = currentTabInfo
@@ -48,7 +52,6 @@ final class MainMenuAction: Action {
         self.isBrowserDefault = isBrowserDefault
         self.isPhoneLandscape = isPhoneLandscape
         self.moreCellTapped = moreCellTapped
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionAction.swift
@@ -6,7 +6,9 @@ import Common
 import Foundation
 import Redux
 
-final class SearchEngineSelectionAction: Action {
+struct SearchEngineSelectionAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let searchEngines: [SearchEngineModel]?
     let selectedSearchEngine: SearchEngineModel?
 
@@ -16,9 +18,10 @@ final class SearchEngineSelectionAction: Action {
         searchEngines: [SearchEngineModel]? = nil,
         selectedSearchEngine: SearchEngineModel? = nil
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.searchEngines = searchEngines
         self.selectedSearchEngine = selectedSearchEngine
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeAction.swift
@@ -5,15 +5,19 @@
 import Common
 import Redux
 
-final class StartAtHomeAction: Action {
+struct StartAtHomeAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let shouldStartAtHome: Bool?
+
     init(
         shouldStartAtHome: Bool? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.shouldStartAtHome = shouldStartAtHome
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsManagerAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsManagerAction.swift
@@ -11,18 +11,22 @@ struct RemoteTabConfiguration {
     let tab: RemoteTab
 }
 
-final class RemoteTabsAction: Action {
-    var mostRecentSyncedTab: RemoteTabConfiguration?
+struct RemoteTabsAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+    let mostRecentSyncedTab: RemoteTabConfiguration?
 
     init(
         mostRecentSyncedTab: RemoteTabConfiguration? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.mostRecentSyncedTab = mostRecentSyncedTab
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
+
 enum RemoteTabsActionType: ActionType {
     case fetchRecentTab
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
@@ -9,7 +9,9 @@ import Storage
 import struct MozillaAppServices.Device
 
 /// Defines actions sent to Redux for Sync tab in tab tray
-class RemoteTabsPanelAction: Action {
+struct RemoteTabsPanelAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let clientAndTabs: [ClientAndTabs]?
     let reason: RemoteTabsPanelEmptyStateReason?
     let url: URL?
@@ -23,13 +25,13 @@ class RemoteTabsPanelAction: Action {
          devices: [Device]? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.clientAndTabs = clientAndTabs
         self.reason = reason
         self.url = url
         self.targetDeviceId = targetDeviceId
         self.devices = devices
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
@@ -5,16 +5,19 @@
 import Common
 import Redux
 
-final class TabManagerAction: Action {
-    var recentTabs: [Tab]?
+struct TabManagerAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+    let recentTabs: [Tab]?
 
     init(
         recentTabs: [Tab]? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.recentTabs = recentTabs
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -11,7 +11,9 @@ struct MoveTabData {
     let isPrivate: Bool
 }
 
-class TabPanelViewAction: Action {
+struct TabPanelViewAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let panelType: TabTrayPanelType?
     let isPrivateModeActive: Bool?
     let urlRequest: URLRequest?
@@ -35,6 +37,8 @@ class TabPanelViewAction: Action {
          deleteTabPeriod: TabsDeletionPeriod? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.panelType = panelType
         self.isPrivateModeActive = isPrivateModeActive
         self.urlRequest = urlRequest
@@ -45,8 +49,6 @@ class TabPanelViewAction: Action {
         self.shareSheetURL = shareSheetURL
         self.isInactiveTab = isInactiveTab
         self.deleteTabPeriod = deleteTabPeriod
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
     }
 }
 
@@ -72,7 +74,9 @@ enum TabPanelViewActionType: ActionType {
     case selectTab
 }
 
-class TabPanelMiddlewareAction: Action {
+struct TabPanelMiddlewareAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let tabDisplayModel: TabDisplayModel?
     let inactiveTabModels: [InactiveTabsModel]?
     let toastType: ToastType??
@@ -84,12 +88,12 @@ class TabPanelMiddlewareAction: Action {
          scrollBehavior: TabScrollBehavior? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.tabDisplayModel = tabDisplayModel
         self.inactiveTabModels = inactiveTabModels
         self.toastType = toastType
         self.scrollBehavior = scrollBehavior
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
     }
 }
 
@@ -103,12 +107,15 @@ enum TabPanelMiddlewareActionType: ActionType {
     case scrollToTab
 }
 
-final class ScreenshotAction: Action {
+struct ScreenshotAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let tab: Tab
 
     init(windowUUID: WindowUUID, tab: Tab, actionType: any ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.tab = tab
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
@@ -5,7 +5,9 @@
 import Redux
 import Common
 
-class TabPeekAction: Action {
+struct TabPeekAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let tabUUID: TabUUID?
     let tabPeekModel: TabPeekModel?
 
@@ -13,10 +15,10 @@ class TabPeekAction: Action {
          tabPeekModel: TabPeekModel? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.tabUUID = tabUUID
         self.tabPeekModel = tabPeekModel
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
@@ -5,7 +5,9 @@
 import Redux
 import Common
 
-class TabTrayAction: Action {
+struct TabTrayAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let panelType: TabTrayPanelType?
     let tabTrayModel: TabTrayModel?
     let hasSyncableAccount: Bool?
@@ -15,11 +17,11 @@ class TabTrayAction: Action {
          hasSyncableAccount: Bool? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.panelType = panelType
         self.tabTrayModel = tabTrayModel
         self.hasSyncableAccount = hasSyncableAccount
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TopTabsAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TopTabsAction.swift
@@ -3,9 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Redux
+import Common
 
 /// Actions related to top tabs shown on large device layout (i.e. iPad)
-class TopTabsAction: Action { }
+struct TopTabsAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+}
 
 enum  TopTabsActionType: ActionType {
     case didTapNewTab

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -6,7 +6,9 @@ import Common
 import Redux
 import ToolbarKit
 
-final class ToolbarAction: Action {
+struct ToolbarAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let toolbarPosition: SearchBarPosition?
     let toolbarLayout: ToolbarLayoutStyle?
     let isTranslucent: Bool?
@@ -56,6 +58,8 @@ final class ToolbarAction: Action {
          shouldAnimate: Bool? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.toolbarPosition = toolbarPosition
         self.toolbarLayout = toolbarLayout
         self.isTranslucent = isTranslucent
@@ -79,7 +83,6 @@ final class ToolbarAction: Action {
         self.isNewTabFeatureEnabled = isNewTabFeatureEnabled
         self.canShowDataClearanceAction = canShowDataClearanceAction
         self.shouldAnimate = shouldAnimate
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 
@@ -113,7 +116,9 @@ enum ToolbarActionType: ActionType {
     case translucencyDidChange
 }
 
-final class ToolbarMiddlewareAction: Action {
+struct ToolbarMiddlewareAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let buttonType: ToolbarActionConfiguration.ActionType?
     let buttonTapped: UIButton?
     let gestureType: ToolbarButtonGesture?
@@ -125,11 +130,12 @@ final class ToolbarMiddlewareAction: Action {
          scrollOffset: CGPoint? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.buttonType = buttonType
         self.buttonTapped = buttonTapped
         self.gestureType = gestureType
         self.scrollOffset = scrollOffset
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/FeltPrivacy/PrivateModeAction.swift
+++ b/firefox-ios/Client/Frontend/FeltPrivacy/PrivateModeAction.swift
@@ -6,15 +6,17 @@ import Foundation
 import Redux
 import Common
 
-class PrivateModeAction: Action {
+struct PrivateModeAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let isPrivate: Bool?
 
     init(isPrivate: Bool? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.isPrivate = isPrivate
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksAction.swift
@@ -6,7 +6,9 @@ import Foundation
 import Redux
 import Common
 
-final class BookmarksAction: Action {
+struct BookmarksAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let bookmarks: [BookmarkConfiguration]?
     var isEnabled: Bool?
 
@@ -15,9 +17,10 @@ final class BookmarksAction: Action {
          windowUUID: WindowUUID,
          actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.bookmarks = bookmarks
         self.isEnabled = isEnabled
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuAction.swift
@@ -7,7 +7,9 @@ import Foundation
 import Redux
 import Storage
 
-final class ContextMenuAction: Action {
+struct ContextMenuAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let section: HomepageSection?
     let site: Site?
 
@@ -17,9 +19,10 @@ final class ContextMenuAction: Action {
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.section = section
         self.site = site
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInAction.swift
@@ -5,7 +5,9 @@
 import Common
 import Redux
 
-final class JumpBackInAction: Action {
+struct JumpBackInAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let isEnabled: Bool?
     let tab: Tab?
 
@@ -15,9 +17,10 @@ final class JumpBackInAction: Action {
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.isEnabled = isEnabled
         self.tab = tab
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoAction.swift
@@ -11,7 +11,9 @@ struct OpenPocketTelemetryConfig {
     let position: Int
 }
 
-final class MerinoAction: Action {
+struct MerinoAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let merinoStories: [MerinoStoryConfiguration]?
     let isEnabled: Bool?
     let telemetryConfig: OpenPocketTelemetryConfig?
@@ -23,10 +25,11 @@ final class MerinoAction: Action {
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.merinoStories = merinoStories
         self.isEnabled = isEnabled
         self.telemetryConfig = telemetryConfig
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardAction.swift
@@ -6,15 +6,18 @@ import Foundation
 import Redux
 import Common
 
-final class MessageCardAction: Action {
+struct MessageCardAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let messageCardConfiguration: MessageCardConfiguration?
 
     init(messageCardConfiguration: MessageCardConfiguration? = nil,
          windowUUID: WindowUUID,
          actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.messageCardConfiguration = messageCardConfiguration
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -13,7 +13,9 @@ struct HomepageTelemetryExtras {
     let topSitesTelemetryConfig: TopSitesTelemetryConfig?
 }
 
-final class HomepageAction: Action {
+struct HomepageAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let isSearchBarEnabled: Bool?
     let shouldShowSpacer: Bool?
     let showiPadSetup: Bool?
@@ -31,13 +33,14 @@ final class HomepageAction: Action {
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.isSearchBarEnabled = isSearchBarEnabled
         self.shouldShowSpacer = shouldShowSpacer
         self.numberOfTopSitesPerRow = numberOfTopSitesPerRow
         self.showiPadSetup = showiPadSetup
         self.telemetryExtras = telemetryExtras
         self.isZeroSearch = isZeroSearch
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesAction.swift
@@ -11,7 +11,9 @@ struct TopSitesTelemetryConfig {
     let topSiteConfiguration: TopSiteConfiguration
 }
 
-final class TopSitesAction: Action {
+struct TopSitesAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let topSites: [TopSiteConfiguration]?
     let numberOfRows: Int?
     let isEnabled: Bool?
@@ -25,11 +27,12 @@ final class TopSitesAction: Action {
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.isEnabled = isEnabled
         self.topSites = topSites
         self.numberOfRows = numberOfRows
         self.telemetryConfig = telemetryConfig
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperAction.swift
@@ -6,15 +6,18 @@ import Foundation
 import Redux
 import Common
 
-final class WallpaperAction: Action {
+struct WallpaperAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let wallpaperConfiguration: WallpaperConfiguration
 
     init(wallpaperConfiguration: WallpaperConfiguration,
          windowUUID: WindowUUID,
          actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.wallpaperConfiguration = wallpaperConfiguration
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
@@ -6,13 +6,20 @@ import Foundation
 import Redux
 import Common
 
-final class MicrosurveyPromptAction: Action { }
+struct MicrosurveyPromptAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+}
 
-final class MicrosurveyPromptMiddlewareAction: Action {
+struct MicrosurveyPromptMiddlewareAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let microsurveyModel: MicrosurveyModel?
+
     init(microsurveyModel: MicrosurveyModel? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.microsurveyModel = microsurveyModel
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
@@ -6,14 +6,17 @@ import Foundation
 import Redux
 import Common
 
-final class MicrosurveyAction: Action {
+struct MicrosurveyAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let userSelection: String?
     let surveyId: String
 
     init(surveyId: String, userSelection: String? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.surveyId = surveyId
         self.userSelection = userSelection
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageAction.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageAction.swift
@@ -5,7 +5,9 @@
 import Redux
 import Common
 
-final class NativeErrorPageAction: Action {
+struct NativeErrorPageAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let networkError: NSError?
     let nativePageErrorModel: ErrorPageModel?
 
@@ -15,9 +17,10 @@ final class NativeErrorPageAction: Action {
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.networkError = networkError
         self.nativePageErrorModel = nativePageErrorModel
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorAction.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorAction.swift
@@ -7,7 +7,10 @@ import Redux
 import Common
 import WebKit
 
-final class PasswordGeneratorAction: Action {
+struct PasswordGeneratorAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+
     // Used in the middlwares
     let currentFrame: WKFrameInfo?
 
@@ -21,10 +24,11 @@ final class PasswordGeneratorAction: Action {
          currentFrame: WKFrameInfo? = nil,
          password: String? = nil,
          origin: String? = nil) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.currentFrame = currentFrame
         self.password = password
         self.origin = origin
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
@@ -5,7 +5,9 @@
 import Common
 import Redux
 
-class ThemeSettingsViewAction: Action {
+struct ThemeSettingsViewAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let useSystemAppearance: Bool?
     let automaticBrightnessEnabled: Bool?
     let manualThemeType: ThemeType?
@@ -19,24 +21,27 @@ class ThemeSettingsViewAction: Action {
          systemBrightness: Float? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.useSystemAppearance = useSystemAppearance
         self.automaticBrightnessEnabled = automaticBrightnessEnabled
         self.manualThemeType = manualThemeType
         self.userBrightness = userBrightness
         self.systemBrightness = systemBrightness
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
     }
 }
 
-class ThemeSettingsMiddlewareAction: Action {
+struct ThemeSettingsMiddlewareAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let themeSettingsState: ThemeSettingsState?
 
     init(themeSettingsState: ThemeSettingsState? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
         self.themeSettingsState = themeSettingsState
-        super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionAction.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionAction.swift
@@ -4,8 +4,12 @@
 
 import Foundation
 import Redux
+import Common
 
-final class TrackingProtectionAction: Action { }
+struct TrackingProtectionAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+}
 
 enum TrackingProtectionActionType: ActionType {
     case toggleTrackingProtectionStatus
@@ -20,7 +24,10 @@ enum TrackingProtectionActionType: ActionType {
     case updateConnectionStatus
 }
 
-final class TrackingProtectionMiddlewareAction: Action { }
+struct TrackingProtectionMiddlewareAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+}
 
 enum TrackingProtectionMiddlewareActionType: ActionType {
     case dismissTrackingProtection

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
@@ -6,16 +6,10 @@ import Foundation
 import Redux
 import Common
 
-class ScreenAction: Action {
+struct ScreenAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
     let screen: AppScreen
-
-    init(windowUUID: WindowUUID,
-         actionType: ActionType,
-         screen: AppScreen) {
-        self.screen = screen
-        super.init(windowUUID: windowUUID,
-                   actionType: actionType)
-    }
 }
 
 enum AppScreen {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
This PR refactors the redux `Action` and its inheriting subclasses. These types contain immutable data and it follows that they should be thread safe and `Sendable`. So we can refactor to rewrite these types as `Sendable` structs conforming to a protocol `Action` instead.

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
