### PR TITLE
Bugfix FXIOS-12919 ⁃ [Menu redesign] - Incorrect display of the CFR

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -612,12 +612,17 @@ class MainMenuViewController: UIViewController,
 
         // Don't display CFR for fresh installs for users that never saw before the photon main menu
         if InstallType.get() == .fresh {
-            if let photonMainMenuShown = profile.prefs.boolForKey(PrefsKeys.PhotonMainMenuShown),
-               photonMainMenuShown {
-                return viewProvider.shouldPresentContextualHint()
+            if isMenuRedesign {
+                viewProvider.markContextualHintPresented()
+                return false
+            } else {
+                if let photonMainMenuShown = profile.prefs.boolForKey(PrefsKeys.PhotonMainMenuShown),
+                   photonMainMenuShown {
+                    return viewProvider.shouldPresentContextualHint()
+                }
+                viewProvider.markContextualHintPresented()
+                return false
             }
-            viewProvider.markContextualHintPresented()
-            return false
         }
 
         if isMenuRedesign, isHomepage {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12919)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28160)

## :bulb: Description
Don't display Menu Redesign CFR on fresh installs

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
