### PR TITLE
Refactor MTE-4495 Increase timeout for unit tests (Xcode 26.0 specific)

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1621,7 +1621,7 @@ workflows:
         - scheme: Fennec
         - configuration: Fennec_Testing
         - destination: platform=iOS Simulator,name=iPhone 16,OS=26.0
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" "-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2"'
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"
     - xcode-test-without-building@0.4.2:
         timeout: 6000
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1621,7 +1621,7 @@ workflows:
         - scheme: Fennec
         - configuration: Fennec_Testing
         - destination: platform=iOS Simulator,name=iPhone 16,OS=26.0
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
     - xcode-test-without-building@0.4.2:
         timeout: 6000
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1614,8 +1614,16 @@ workflows:
     - 2_certificate_and_profile
     - 3_provisioning_and_npm_installation
     steps:
-    - xcode-test@6.0.1:
-        timeout: 3000
+    - xcode-build-for_test@6.0.1:
+        timeout: 600
+        inputs:
+        - project_path: firefox-ios/Client.xcodeproj
+        - scheme: Fennec
+        - configuration: Fennec_Testing
+        - destination: platform=iOS Simulator,name=iPhone 16,OS=26.0
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" "-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2"'
+    - xcode-test-without-building@0.4.2:
+        timeout: 6000
         inputs:
         - project_path: firefox-ios/Client.xcodeproj
         - scheme: Fennec

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1614,7 +1614,7 @@ workflows:
     - 2_certificate_and_profile
     - 3_provisioning_and_npm_installation
     steps:
-    - xcode-build-for-test@6.0.1:
+    - xcode-build-for-test@3:
         timeout: 600
         inputs:
         - project_path: firefox-ios/Client.xcodeproj

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1614,15 +1614,7 @@ workflows:
     - 2_certificate_and_profile
     - 3_provisioning_and_npm_installation
     steps:
-    - xcode-build-for-test@3:
-        timeout: 600
-        inputs:
-        - project_path: firefox-ios/Client.xcodeproj
-        - scheme: Fennec
-        - configuration: Fennec_Testing
-        - destination: platform=iOS Simulator,name=iPhone 16,OS=26.0
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-    - xcode-test-without-building@0.4.2:
+    - xcode-test@6.0.1:
         timeout: 6000
         inputs:
         - project_path: firefox-ios/Client.xcodeproj

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1614,7 +1614,7 @@ workflows:
     - 2_certificate_and_profile
     - 3_provisioning_and_npm_installation
     steps:
-    - xcode-build-for_test@6.0.1:
+    - xcode-build-for-test@6.0.1:
         timeout: 600
         inputs:
         - project_path: firefox-ios/Client.xcodeproj


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4495)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Bumping the Xcode version to 26.0 (beta 3) makes the pipeline to timeout. The previous timeout was 3000 seconds (50 min):
https://app.bitrise.io/build/50d6bd4e-9537-43fa-a716-a914c31ac413

The PR divides up the build and the test into two different steps and bumps the tests to timeout at 6000 seconds (100 min).

Bitrise Pipeline on the updated workflow: https://app.bitrise.io/build/49d29dd0-f012-4ab6-aaa1-31c50763882d

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
