### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] FakeReduxMiddleware and MainMenuMiddleware are main actor

### DIFF
--- a/BrowserKit/Tests/ReduxTests/ReduxIntegrationTests.swift
+++ b/BrowserKit/Tests/ReduxTests/ReduxIntegrationTests.swift
@@ -5,6 +5,8 @@
 import XCTest
 
 @testable import Redux
+
+@MainActor
 let store = Store(state: FakeReduxState(),
                   reducer: FakeReduxState.reducer,
                   middlewares: [FakeReduxMiddleware().fakeProvider])

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
@@ -6,6 +6,7 @@ import Foundation
 
 @testable import Redux
 
+@MainActor
 class FakeReduxMiddleware {
     lazy var fakeProvider: Middleware<FakeReduxState> = { state, action in
         switch action.actionType {
@@ -14,7 +15,7 @@ class FakeReduxMiddleware {
             let action = FakeReduxAction(counterValue: initialValue,
                                          windowUUID: windowUUID,
                                          actionType: FakeReduxActionType.initialValueLoaded)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case FakeReduxActionType.increaseCounter:
             let existingValue = state.counter
@@ -22,7 +23,7 @@ class FakeReduxMiddleware {
             let action = FakeReduxAction(counterValue: newValue,
                                          windowUUID: windowUUID,
                                          actionType: FakeReduxActionType.counterIncreased)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case FakeReduxActionType.decreaseCounter:
             let existingValue = state.counter
@@ -30,7 +31,7 @@ class FakeReduxMiddleware {
             let action = FakeReduxAction(counterValue: newValue,
                                          windowUUID: windowUUID,
                                          actionType: FakeReduxActionType.counterDecreased)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         default:
            break

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxViewController.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxViewController.swift
@@ -31,7 +31,7 @@ class FakeReduxViewController: UIViewController, StoreSubscriber {
         store.subscribe(self)
 
         let action = FakeReduxAction(windowUUID: windowUUID, actionType: FakeReduxActionType.requestInitialValue)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     func unsubscribeFromRedux() {
@@ -47,18 +47,18 @@ class FakeReduxViewController: UIViewController, StoreSubscriber {
 
     func increaseCounter() {
         let action = FakeReduxAction(windowUUID: windowUUID, actionType: FakeReduxActionType.increaseCounter)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     func decreaseCounter() {
         let action = FakeReduxAction(windowUUID: windowUUID, actionType: FakeReduxActionType.decreaseCounter)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     func setPrivateMode(to value: Bool) {
         let action = FakeReduxAction(privateMode: value,
                                      windowUUID: windowUUID,
                                      actionType: FakeReduxActionType.setPrivateModeTo)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
@@ -24,6 +24,7 @@ final class MainMenuMiddlewareTests: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testDismissMenuAction() throws {
         let mockStore = Store(
             state: AppState(),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- `MainMenuMiddleware` and `FakeReduxMiddleware` are now main actors
- Using `dispatch` instead of `dispatchLegacy` inside those middlewares as well

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
