### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] StartAtHomeMiddleware is main actor

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
@@ -6,6 +6,7 @@ import Common
 import Redux
 import Shared
 
+@MainActor
 final class StartAtHomeMiddleware {
     private let windowManager: WindowManager
     private let logger: Logger
@@ -23,31 +24,17 @@ final class StartAtHomeMiddleware {
     }
 
     lazy var startAtHomeProvider: Middleware<AppState> = { state, action in
-        // TODO: FXIOS-12557 We assume that we are isolated to the Main Actor
-        // because we dispatch to the main thread in the store. We will want
-        // to also isolate that to the @MainActor to remove this.
-        guard Thread.isMainThread else {
-            self.logger.log(
-                "Tab Manager Middleware is not being called from the main thread!",
-                level: .fatal,
-                category: .tabs
-            )
-            return
-        }
-
-        MainActor.assumeIsolated {
-            switch action.actionType {
-            case StartAtHomeActionType.didBrowserBecomeActive:
-                let shouldStartAtHome = self.startAtHomeCheck(windowUUID: action.windowUUID)
-                store.dispatchLegacy(
-                    StartAtHomeAction(
-                        shouldStartAtHome: shouldStartAtHome,
-                        windowUUID: action.windowUUID,
-                        actionType: StartAtHomeMiddlewareActionType.startAtHomeCheckCompleted
-                    )
+        switch action.actionType {
+        case StartAtHomeActionType.didBrowserBecomeActive:
+            let shouldStartAtHome = self.startAtHomeCheck(windowUUID: action.windowUUID)
+            store.dispatch(
+                StartAtHomeAction(
+                    shouldStartAtHome: shouldStartAtHome,
+                    windowUUID: action.windowUUID,
+                    actionType: StartAtHomeMiddlewareActionType.startAtHomeCheckCompleted
                 )
-            default: break
-            }
+            )
+        default: break
         }
     }
 
@@ -66,7 +53,6 @@ final class StartAtHomeMiddleware {
     /// based on user preferences and session state.
     ///
     /// - Returns: `true` if a homepage tab was selected and displayed, `false` otherwise.
-    @MainActor
     private func startAtHomeCheck(windowUUID: WindowUUID) -> Bool {
         let tabManager = tabManager(for: windowUUID)
         let startAtHomeManager = StartAtHomeHelper(
@@ -108,7 +94,6 @@ final class StartAtHomeMiddleware {
     ///   - privateMode: A Boolean indicating whether the tab is in private mode.
     ///   - profilePreferences: The user's profile preferences.
     /// - Returns: A tab configured to show the appropriate homepage content.
-    @MainActor
     private func createStartAtHomeTab(tabManager: TabManager,
                                       withExistingTab existingTab: Tab?,
                                       inPrivateMode privateMode: Bool,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
@@ -53,7 +53,14 @@ class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
         // TODO: if you need it
     }
 
-    func dispatch(_ action: Redux.Action) {}
+    /// We implemented the lock to ensure that this is thread safe
+    /// since actions can be dispatch in concurrent tasks
+    func dispatch(_ action: Redux.Action) {
+        lock.lock()
+        defer { lock.unlock() }
+        dispatchedActions.append(action)
+        dispatchCalled?()
+    }
 
     /// We implemented the lock to ensure that this is thread safe
     /// since actions can be dispatch in concurrent tasks

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHome/StartAtHomeMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHome/StartAtHomeMiddlewareTests.swift
@@ -40,6 +40,7 @@ final class StartAtHomeMiddlewareTests: XCTestCase, StoreTestUtility {
         super.tearDown()
     }
 
+    @MainActor
     func test_didBrowserBecomeActiveAction_withAfterFourHours_returnsTrueStartAtHomeCheck() throws {
         mockProfile.prefs.setString(StartAtHome.afterFourHours.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
         let subject = createSubject(with: mockProfile)
@@ -66,6 +67,7 @@ final class StartAtHomeMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionCalled.shouldStartAtHome, true)
     }
 
+    @MainActor
     func test_didBrowserBecomeActiveAction_withAlways_returnsTrueStartAtHomeCheck() throws {
         mockProfile.prefs.setString(StartAtHome.always.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
         let subject = createSubject(with: mockProfile)
@@ -92,6 +94,7 @@ final class StartAtHomeMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionCalled.shouldStartAtHome, true)
     }
 
+    @MainActor
     func test_didBrowserBecomeActiveAction_withDisabled_returnsFalseStartAtHomeCheck() throws {
         mockProfile.prefs.setString(StartAtHome.disabled.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
         let subject = createSubject(with: mockProfile)
@@ -119,6 +122,8 @@ final class StartAtHomeMiddlewareTests: XCTestCase, StoreTestUtility {
     }
 
     // MARK: - Helpers
+
+    @MainActor
     private func createSubject(with mockProfile: Profile = MockProfile()) -> StartAtHomeMiddleware {
         /// 9 Sep 2001 8:00 pm GMT + 0
         let testDate = Date(timeIntervalSince1970: 1_000_065_600)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- `StartAtHomeMiddleware` is now main actors
- Using `dispatch` instead of `dispatchLegacy` inside this middleware as well

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
