### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] Merino and wallpaper middlewares are main actor

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoMiddleware.swift
@@ -7,6 +7,7 @@ import MozillaAppServices
 import Redux
 import Shared
 
+@MainActor
 final class MerinoMiddleware {
     private let merinoManager: MerinoManagerProvider
     private let homepageTelemetry: HomepageTelemetry
@@ -42,7 +43,7 @@ final class MerinoMiddleware {
     private func getPocketDataAndUpdateState(for action: Action) {
         Task {
             let merinoStories = await merinoManager.getMerinoItems()
-            store.dispatchLegacy(
+            store.dispatch(
                 MerinoAction(
                     merinoStories: merinoStories,
                     windowUUID: action.windowUUID,

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -4,6 +4,7 @@
 
 import Redux
 
+@MainActor
 class WallpaperMiddleware {
     private let wallpaperManager: WallpaperManagerInterface
     private var wallpaperConfiguration: WallpaperConfiguration {
@@ -31,7 +32,7 @@ class WallpaperMiddleware {
                 windowUUID: action.windowUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
             )
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         default:
             break
         }
@@ -45,7 +46,7 @@ class WallpaperMiddleware {
                 windowUUID: action.windowUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidChange
             )
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         default:
             break
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
@@ -53,7 +53,12 @@ class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
         // TODO: if you need it
     }
 
-    func dispatch(_ action: Redux.Action) {}
+    func dispatch(_ action: Redux.Action) {
+        lock.lock()
+        defer { lock.unlock() }
+        dispatchedActions.append(action)
+        dispatchCalled?()
+    }
 
     /// We implemented the lock to ensure that this is thread safe
     /// since actions can be dispatch in concurrent tasks

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MerinoMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MerinoMiddlewareTests.swift
@@ -27,6 +27,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
         super.tearDown()
     }
 
+    @MainActor
     func test_initializeAction_getPocketData() throws {
         let subject = createSubject(merinoManager: merinoManager)
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
@@ -49,6 +50,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(merinoManager.getMerinoItemsCalled, 1)
     }
 
+    @MainActor
     func test_enterForegroundAction_getPocketData() throws {
         let subject = createSubject(merinoManager: merinoManager)
         let action = HomepageAction(
@@ -75,6 +77,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(merinoManager.getMerinoItemsCalled, 1)
     }
 
+    @MainActor
     func test_toggleShowSectionSetting_getPocketData() throws {
         let subject = createSubject(merinoManager: merinoManager)
         let action = HomepageAction(
@@ -101,6 +104,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(merinoManager.getMerinoItemsCalled, 1)
     }
 
+    @MainActor
     func test_tapOnHomepagePocketCellAction_sendTelemetryData() throws {
         let subject = createSubject(merinoManager: merinoManager)
         let config = OpenPocketTelemetryConfig(isZeroSearch: false, position: 0)
@@ -135,6 +139,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssert(secondResultMetricType == expectedSecondMetricType, secondDebugMessage.text)
     }
 
+    @MainActor
     func test_tapOnHomepagePocketCell_doesNotSendTelemetryData() throws {
         let subject = createSubject(merinoManager: merinoManager)
         let action = MerinoAction(
@@ -147,6 +152,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockGleanWrapper.recordLabelCalled, 0)
     }
 
+    @MainActor
     func test_viewedSectionAction_sendTelemetryData() throws {
         let subject = createSubject(merinoManager: merinoManager)
         let action = MerinoAction(windowUUID: .XCTestDefaultUUID, actionType: MerinoActionType.viewedSection)
@@ -162,6 +168,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 
+    @MainActor
     func test_tappedOnOpenNewPrivateTabAction_sendTelemetryData() throws {
         let subject = createSubject(merinoManager: merinoManager)
         let action = ContextMenuAction(
@@ -180,6 +187,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 
+    @MainActor
     func test_tappedOnOpenNewPrivateTabAction_doesNotSendTelemetryData() {
         let subject = createSubject(merinoManager: merinoManager)
         let action = ContextMenuAction(
@@ -194,6 +202,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
     }
 
     // MARK: - Helpers
+    @MainActor
     private func createSubject(merinoManager: MockMerinoManager) -> MerinoMiddleware {
         return MerinoMiddleware(
             merinoManager: merinoManager,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
@@ -24,6 +24,7 @@ class WallpaperMiddlewareTests: XCTestCase, StoreTestUtility {
         super.tearDown()
     }
 
+    @MainActor
     func test_hompageAction_returnsWallpaperManagerWallpaper() throws {
         let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
@@ -38,6 +39,7 @@ class WallpaperMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionCalled.wallpaperConfiguration.cardColor, .purple)
     }
 
+    @MainActor
     func test_wallpaperAction_returnsWallpaperManagerWallpaper() throws {
         let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
         let testWallpaper = WallpaperConfiguration()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- `MerinoMiddleware` and `WallpaperMiddleware` are now main actors
- Using `dispatch` instead of `dispatchLegacy` inside those middlewares as well

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
