### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] TrackingProtectionMiddleware middleware actor isolation

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionMiddleware.swift
@@ -6,6 +6,7 @@ import Foundation
 import Redux
 import Common
 
+@MainActor
 final class TrackingProtectionMiddleware {
     private let telemetryWrapper = TrackingProtectionTelemetry()
 
@@ -36,7 +37,7 @@ final class TrackingProtectionMiddleware {
             windowUUID: windowUUID,
             actionType: TrackingProtectionActionType.toggleTrackingProtectionStatus
         )
-        store.dispatchLegacy(newAction)
+        store.dispatch(newAction)
     }
 
     private func clearCookiesAndSiteData(windowUUID: WindowUUID) {
@@ -44,7 +45,7 @@ final class TrackingProtectionMiddleware {
             windowUUID: windowUUID,
             actionType: TrackingProtectionMiddlewareActionType.clearCookies
         )
-        store.dispatchLegacy(newAction)
+        store.dispatch(newAction)
         telemetryWrapper.clearCookiesAndSiteData()
     }
 
@@ -53,7 +54,7 @@ final class TrackingProtectionMiddleware {
             windowUUID: windowUUID,
             actionType: TrackingProtectionMiddlewareActionType.showAlert
         )
-        store.dispatchLegacy(newAction)
+        store.dispatch(newAction)
         telemetryWrapper.showClearCookiesAlert()
     }
 
@@ -62,7 +63,7 @@ final class TrackingProtectionMiddleware {
             windowUUID: windowUUID,
             actionType: TrackingProtectionMiddlewareActionType.dismissTrackingProtection
         )
-        store.dispatchLegacy(newAction)
+        store.dispatch(newAction)
         telemetryWrapper.dismissTrackingProtection()
     }
 
@@ -71,7 +72,7 @@ final class TrackingProtectionMiddleware {
             windowUUID: windowUUID,
             actionType: TrackingProtectionMiddlewareActionType.showTrackingProtectionDetails
         )
-        store.dispatchLegacy(newAction)
+        store.dispatch(newAction)
         telemetryWrapper.showTrackingProtectionDetails()
     }
 
@@ -80,7 +81,7 @@ final class TrackingProtectionMiddleware {
             windowUUID: windowUUID,
             actionType: TrackingProtectionMiddlewareActionType.showBlockedTrackersDetails
         )
-        store.dispatchLegacy(newAction)
+        store.dispatch(newAction)
         telemetryWrapper.showBlockedTrackersDetails()
     }
 
@@ -89,7 +90,7 @@ final class TrackingProtectionMiddleware {
             windowUUID: windowUUID,
             actionType: TrackingProtectionMiddlewareActionType.navigateToSettings
         )
-        store.dispatchLegacy(newAction)
+        store.dispatch(newAction)
         telemetryWrapper.tappedShowSettings()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
Migrate `TrackingProtectionMiddleware` middleware to use `@MainActor` isolation and the new isolated store `dispatch` method.

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
