### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] ThemeManagerMiddleware middleware actor isolation

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3897,7 +3897,7 @@ class BrowserViewController: UIViewController,
     }
 }
 
-extension BrowserViewController: @preconcurrency LegacyClipboardBarDisplayHandlerDelegate {
+extension BrowserViewController: LegacyClipboardBarDisplayHandlerDelegate {
     func shouldDisplay(clipBoardURL url: URL) {
         let viewModel = ButtonToastViewModel(
             labelText: .GoToCopiedLink,

--- a/firefox-ios/Client/Frontend/Browser/LegacyClipboardBarDisplayHandlerDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/LegacyClipboardBarDisplayHandlerDelegate.swift
@@ -8,6 +8,7 @@ import Common
 
 // TODO: FXIOS-12907 This legacy ClipboardBar code can be removed once iOS 15 is dropped
 protocol LegacyClipboardBarDisplayHandlerDelegate: AnyObject {
+    @MainActor
     func shouldDisplay(clipBoardURL url: URL)
 }
 

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -5,6 +5,7 @@
 import Common
 import Redux
 
+@MainActor
 protocol ThemeManagerProvider {
     func getCurrentThemeManagerState(windowUUID: WindowUUID) -> ThemeSettingsState
     func updateManualTheme(with action: ThemeSettingsViewAction)
@@ -15,7 +16,8 @@ protocol ThemeManagerProvider {
     func updatePrivateMode(with action: PrivateModeAction)
 }
 
-class ThemeManagerMiddleware: ThemeManagerProvider {
+@MainActor
+final class ThemeManagerMiddleware: ThemeManagerProvider {
     var themeManager: ThemeManager
 
     init(themeManager: ThemeManager = AppContainer.shared.resolve()) {
@@ -142,6 +144,6 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
             windowUUID: oldAction.windowUUID,
             actionType: newActionType)
 
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
@@ -8,6 +8,7 @@ import XCTest
 
 @testable import Client
 
+@MainActor
 class ThemeSettingsControllerTests: XCTestCase, StoreTestUtility {
     let windowUUID: WindowUUID = .XCTestDefaultUUID
     var mockStore: MockStoreForMiddleware<AppState>!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
@@ -7,6 +7,7 @@ import Redux
 @testable import Client
 import XCTest
 
+@MainActor
 protocol StoreTestUtility {
     func setupAppState() -> AppState
     func setupStore()

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,8 +4,8 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THRESHOLD_UNIT_TEST=13
-THRESHOLD_XCUITEST=13
+THRESHOLD_UNIT_TEST=14
+THRESHOLD_XCUITEST=14
 
 WARNINGS=$(grep -E -v 'SourcePackages/checkouts' "$BUILD_LOG_FILE" \
   | grep -E '^[^ ]+:[0-9]+:[0-9]+: warning:' \


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
Migrate `ThemeManagerMiddleware` middleware to use `@MainActor` isolation and the new isolated store `dispatch` method.

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
