### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] PasswordGeneratorMiddleware middleware actor isolation

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
@@ -8,6 +8,7 @@ import Shared
 import Common
 import WebKit
 
+@MainActor
 final class PasswordGeneratorMiddleware {
     private let logger: Logger
     private let generatedPasswordStorage: GeneratedPasswordStorageProtocol
@@ -65,7 +66,7 @@ final class PasswordGeneratorMiddleware {
                 actionType: PasswordGeneratorActionType.updateGeneratedPassword,
                 password: password
             )
-            store.dispatchLegacy(newAction)
+            store.dispatch(newAction)
         } else {
             generateNewPassword(frame: frame, completion: { generatedPassword in
                 self.generatedPasswordStorage.setPasswordForOrigin(origin: origin, password: generatedPassword)
@@ -74,7 +75,7 @@ final class PasswordGeneratorMiddleware {
                     actionType: PasswordGeneratorActionType.updateGeneratedPassword,
                     password: generatedPassword
                 )
-                store.dispatchLegacy(newAction)
+                store.dispatch(newAction)
             })
         }
     }
@@ -128,7 +129,7 @@ final class PasswordGeneratorMiddleware {
                 actionType: PasswordGeneratorActionType.updateGeneratedPassword,
                 password: generatedPassword
             )
-            store.dispatchLegacy(newAction)
+            store.dispatch(newAction)
         })
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
Migrate `PasswordGeneratorMiddleware` middleware to use `@MainActor` isolation and the new isolated store `dispatch` method.

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)