### PR TITLE
Refactor FXIOS-12912 [Swift 6 Migration] Make AddressBarState Sendable

### DIFF
--- a/BrowserKit/Sources/Common/ReaderMode/ReaderModeState.swift
+++ b/BrowserKit/Sources/Common/ReaderMode/ReaderModeState.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public enum ReaderModeState: String {
+public enum ReaderModeState: String, Sendable {
     case available = "Available"
     case unavailable = "Unavailable"
     case active = "Active"

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarPosition.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarPosition.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public enum AddressToolbarPosition {
+public enum AddressToolbarPosition: Sendable {
     case bottom
     case top
 }

--- a/BrowserKit/Sources/ToolbarKit/ToolbarManager.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarManager.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public enum AddressToolbarBorderPosition {
+public enum AddressToolbarBorderPosition: Sendable {
     case bottom
     case top
     case none

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -6,7 +6,7 @@ import Common
 import Redux
 import ToolbarKit
 
-struct AddressBarState: StateType, Equatable {
+struct AddressBarState: StateType, Sendable, Equatable {
     var windowUUID: WindowUUID
     var navigationActions: [ToolbarActionConfiguration]
     var leadingPageActions: [ToolbarActionConfiguration]

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -12,7 +12,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
     var leadingPageActions: [ToolbarActionConfiguration]
     var trailingPageActions: [ToolbarActionConfiguration]
     var browserActions: [ToolbarActionConfiguration]
-    var borderPosition: AddressToolbarBorderPosition?
+    let borderPosition: AddressToolbarBorderPosition?
     var url: URL?
     var searchTerm: String?
     var lockIconImageName: String?

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -6,7 +6,7 @@ import Common
 import Redux
 import ToolbarKit
 
-struct ToolbarState: ScreenState, Equatable {
+struct ToolbarState: ScreenState, Sendable, Equatable {
     var windowUUID: WindowUUID
     var toolbarPosition: AddressToolbarPosition
     var toolbarLayout: ToolbarLayoutStyle


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12912)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28144)

## :bulb: Description
Instead of making StateType Sendable, I'm incrementally marking the States as Sendable to reduce warnings.
This is the work for AddressBarState and ToolbarState

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
