### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] MicrosurveyMiddleware middleware actor isolation

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
@@ -6,6 +6,7 @@ import Foundation
 import Redux
 import Common
 
+@MainActor
 final class MicrosurveyMiddleware {
     private let microsurveyTelemetry = MicrosurveyTelemetry()
 
@@ -16,7 +17,7 @@ final class MicrosurveyMiddleware {
         case MicrosurveyActionType.closeSurvey:
             self.dismissSurvey(windowUUID: windowUUID, surveyId: surveyId)
         case MicrosurveyActionType.tapPrivacyNotice:
-            self.sendTelemtryForNavigatingToPrivacyNotice(surveyId: surveyId)
+            self.sendTelemetryForNavigatingToPrivacyNotice(surveyId: surveyId)
         case MicrosurveyActionType.submitSurvey:
             self.sendTelemetryAndClosePrompt(windowUUID: windowUUID, action: action, surveyId: surveyId)
         case MicrosurveyActionType.surveyDidAppear:
@@ -33,7 +34,7 @@ final class MicrosurveyMiddleware {
         closeMicrosurveyPrompt(windowUUID: windowUUID)
     }
 
-    private func sendTelemtryForNavigatingToPrivacyNotice(surveyId: String) {
+    private func sendTelemetryForNavigatingToPrivacyNotice(surveyId: String) {
         microsurveyTelemetry.privacyNoticeTapped(surveyId: surveyId)
     }
 
@@ -44,7 +45,7 @@ final class MicrosurveyMiddleware {
     }
 
     private func closeMicrosurveyPrompt(windowUUID: WindowUUID) {
-        store.dispatchLegacy(
+        store.dispatch(
             MicrosurveyPromptAction(
                 windowUUID: windowUUID,
                 actionType: MicrosurveyPromptActionType.closePrompt


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
Migrate `MicrosurveyMiddleware` middleware to use `@MainActor` isolation and the new isolated store `dispatch` method.

Also add implementation for the store mock since that was causing some tests to fail (funny others weren't for other middlewares).

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)