### PR TITLE
Refactor FXIOS-12912 [Swift 6 Migration] Conform Redux RemoteTabsPanelState to Sendable

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -46,7 +46,7 @@ enum RemoteTabsPanelEmptyStateReason {
 }
 
 /// State for RemoteTabsPanel. WIP.
-struct RemoteTabsPanelState: ScreenState, Equatable {
+struct RemoteTabsPanelState: ScreenState, Equatable, Sendable {
     let refreshState: RemoteTabsPanelRefreshState
     let allowsRefresh: Bool
     let clientAndTabs: [ClientAndTabs]

--- a/firefox-ios/Storage/Clients.swift
+++ b/firefox-ios/Storage/Clients.swift
@@ -4,7 +4,7 @@
 
 import Shared
 
-public struct RemoteClient: Equatable {
+public struct RemoteClient: Equatable, Sendable {
     public let guid: GUID?
     public let modified: Timestamp
 

--- a/firefox-ios/Storage/RemoteTabs.swift
+++ b/firefox-ios/Storage/RemoteTabs.swift
@@ -7,9 +7,9 @@ import Shared
 
 import struct MozillaAppServices.RemoteTabRecord
 
-public struct ClientAndTabs: Equatable, CustomStringConvertible {
+public struct ClientAndTabs: Equatable, CustomStringConvertible, Sendable {
     public let client: RemoteClient
-    public var tabs: [RemoteTab]
+    public let tabs: [RemoteTab]
 
     public var description: String {
         return "<Client guid: \(client.guid ?? "nil"), \(tabs.count) tabs.>"
@@ -26,7 +26,7 @@ public func == (lhs: ClientAndTabs, rhs: ClientAndTabs) -> Bool {
            (lhs.tabs == rhs.tabs)
 }
 
-public struct RemoteTab: Equatable {
+public struct RemoteTab: Equatable, Sendable {
     public let clientGUID: String?
     public let URL: Foundation.URL
     public let title: String

--- a/firefox-ios/Storage/Rust/RustRemoteTabs.swift
+++ b/firefox-ios/Storage/Rust/RustRemoteTabs.swift
@@ -163,9 +163,9 @@ public class RustRemoteTabs {
                 }
                 .map { client -> ClientAndTabs in
                     // Sort tabs in descending order by lastUsed
-                    var clientCopy = client
-                    clientCopy.tabs.sort { $0.lastUsed > $1.lastUsed }
-                    return clientCopy
+                    var sortedTabs = client.tabs
+                    sortedTabs.sort { $0.lastUsed > $1.lastUsed }
+                    return ClientAndTabs(client: client.client, tabs: sortedTabs)
                 }
                 .sorted { lhs, rhs in
                     // Get the most recent tab timestamp for each client (or 0 if no tabs)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12912)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28144)

## :bulb: Description
Conform Redux `RemoteTabsPanelState` to `Sendable`.

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)