### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] GoogleTopSiteManager warning

### DIFF
--- a/BrowserKit/Sources/SiteImageView/Entities/SiteResource.swift
+++ b/BrowserKit/Sources/SiteImageView/Entities/SiteResource.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// The source of a favicon or hero image.
-public enum SiteResource: Codable, Hashable {
+public enum SiteResource: Codable, Hashable, Sendable {
     /// An image that may be downloaded over the network.
     /// - Parameter url: The URL of the image.
     case remoteURL(url: URL)

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
@@ -7,13 +7,13 @@ import UIKit
 import Storage
 import SiteImageView
 
-public protocol GoogleTopSiteManagerProvider {
+public protocol GoogleTopSiteManagerProvider: Sendable {
     var pinnedSiteData: Site? { get }
     func shouldAddGoogleTopSite(hasSpace: Bool) -> Bool
     func removeGoogleTopSite(site: Site)
 }
 // Manage the specific Google top site case
-class GoogleTopSiteManager: GoogleTopSiteManagerProvider {
+final class GoogleTopSiteManager: GoogleTopSiteManagerProvider {
     struct Constants {
         // US and rest of the world google urls
         static let usUrl = "https://www.google.com/webhp?client=firefox-b-1-m&channel=ts"
@@ -29,7 +29,7 @@ class GoogleTopSiteManager: GoogleTopSiteManagerProvider {
 
     // No Google Top Site, it should be removed, if it already exists for invalid region
     private let invalidRegion = ["CN", "RU", "TR", "KZ", "BY"]
-    private var prefs: Prefs
+    private let prefs: Prefs
     private var url: String? {
         // Couldn't find a valid region hence returning a nil value for url
         guard let regionCode = Locale.current.regionCode, !invalidRegion.contains(regionCode) else { return nil }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockGoogleTopSiteManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockGoogleTopSiteManager.swift
@@ -7,7 +7,7 @@ import Storage
 
 @testable import Client
 
-class MockGoogleTopSiteManager: GoogleTopSiteManagerProvider {
+final class MockGoogleTopSiteManager: GoogleTopSiteManagerProvider, @unchecked Sendable {
     private let mockSiteData: Site?
     var removeGoogleTopSiteCalledCount = 0
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Refactor `GoogleTopSiteManager.swift` to eliminate Swift 6 warnings (see error below). In this PR, I made the protocol `Sendable` and had to remove `prefs` from being mutable. Also, made `SiteResource` a `Sendable` type.

**Error Message**
<img width="1598" height="368" alt="Screenshot 2025-07-24 at 9 19 25 AM" src="https://github.com/user-attachments/assets/a538f9bd-2e87-44af-9500-db7024d5f20e" />

Also, helps make one more less warning when making `TopSitesManager` `Sendable`
<img width="1607" height="176" alt="Screenshot 2025-07-24 at 9 21 35 AM" src="https://github.com/user-attachments/assets/83530fe4-1e2f-4e3e-a4c2-be00bf60b2e3" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
