### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] Adjust microsurvey and message card middlewares

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardMiddleware.swift
@@ -12,6 +12,7 @@ struct MessageCardConfiguration: Hashable {
     let buttonLabel: String?
 }
 
+@MainActor
 final class MessageCardMiddleware {
     private var message: GleanPlumbMessage?
     private let messagingManager: GleanPlumbMessageManagerProtocol
@@ -20,7 +21,6 @@ final class MessageCardMiddleware {
         self.messagingManager = messagingManager
     }
 
-    // TODO: FXIOS-12831 We need this middleware isolated to the main actor (due to `onMessagePressed` call)
     lazy var messageCardProvider: Middleware<AppState> = { state, action in
         let windowUUID = action.windowUUID
 
@@ -60,6 +60,6 @@ final class MessageCardMiddleware {
             windowUUID: windowUUID,
             actionType: MessageCardMiddlewareActionType.initialize
         )
-        store.dispatchLegacy(newAction)
+        store.dispatch(newAction)
     }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
@@ -6,6 +6,7 @@ import Foundation
 import Redux
 import Common
 
+@MainActor
 final class MicrosurveyPromptMiddleware {
     private let microsurveyManager: MicrosurveyManager
 
@@ -13,7 +14,6 @@ final class MicrosurveyPromptMiddleware {
         self.microsurveyManager = microsurveyManager
     }
 
-    // TODO: FXIOS-12831 We need this middleware isolated to the main actor (due to `onMessagePressed` call)
     lazy var microsurveyProvider: Middleware<AppState> = { state, action in
         let windowUUID = action.windowUUID
 
@@ -43,7 +43,7 @@ final class MicrosurveyPromptMiddleware {
             windowUUID: windowUUID,
             actionType: MicrosurveyPromptMiddlewareActionType.initialize
         )
-        store.dispatchLegacy(newAction)
+        store.dispatch(newAction)
         microsurveyManager.handleMessageDisplayed()
     }
 
@@ -51,7 +51,6 @@ final class MicrosurveyPromptMiddleware {
         microsurveyManager.handleMessageDismiss()
     }
 
-    @MainActor
     private func openSurvey() {
         microsurveyManager.handleMessagePressed()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardMiddlewareTests.swift
@@ -22,6 +22,7 @@ final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
         super.tearDown()
     }
 
+    @MainActor
     func test_initializeAction_getMessageCardData() throws {
         let messagingManager = MockGleanPlumbMessageManagerProtocol()
         let message = createMessage()
@@ -50,6 +51,7 @@ final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(messagingManager.onMessageDisplayedCalled, 1)
     }
 
+    @MainActor
     func test_initializeAction_withInvalidSurface_doesNotGetMessageCardData() throws {
         let messagingManager = MockGleanPlumbMessageManagerProtocol()
         let message = createMessage(with: MockMessageData(surface: .microsurvey))
@@ -72,6 +74,7 @@ final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(messagingManager.onMessageDisplayedCalled, 0)
     }
 
+    @MainActor
     func test_tappedOnActionButton_performsActionAndDismissesMessageCard() throws {
         let messagingManager = MockGleanPlumbMessageManagerProtocol()
         let message = createMessage(with: MockMessageData(surface: .newTabCard))
@@ -92,6 +95,7 @@ final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(messagingManager.onMessagePressedCalled, 1)
     }
 
+    @MainActor
     func test_tappedOnCloseButton_dismissesMessageCard() throws {
         let messagingManager = MockGleanPlumbMessageManagerProtocol()
         let message = createMessage(with: MockMessageData(surface: .newTabCard))
@@ -113,6 +117,7 @@ final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
     }
 
     // MARK: - Helpers
+    @MainActor
     private func createSubject(messagingManager: GleanPlumbMessageManagerProtocol) -> MessageCardMiddleware {
         return MessageCardMiddleware(messagingManager: messagingManager)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyPromptMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyPromptMiddlewareTests.swift
@@ -37,6 +37,7 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testShowPromptAction_withInvalidModel() {
         let subject = createSubject(microsurveyManager: MockMicrosurveySurfaceManager(with: nil))
 
@@ -51,6 +52,7 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
         XCTAssertEqual(mockMicrosurveyManager.handleMessageDisplayedCount, 0)
     }
 
+    @MainActor
     func testShowPromptAction_withValidModel() throws {
         let subject = createSubject(microsurveyManager: mockMicrosurveyManager)
         let action = MicrosurveyPromptMiddlewareAction(
@@ -68,6 +70,7 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
         XCTAssertEqual(mockMicrosurveyManager.handleMessageDisplayedCount, 1)
     }
 
+    @MainActor
     func testClosePromptAction() {
         let subject = createSubject(microsurveyManager: mockMicrosurveyManager)
         let action = MicrosurveyPromptMiddlewareAction(
@@ -81,6 +84,7 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
         XCTAssertEqual(mockMicrosurveyManager.handleMessageDismissCount, 1)
     }
 
+    @MainActor
     func testContinueToSurveyAction() {
         let subject = createSubject(microsurveyManager: mockMicrosurveyManager)
         let action = MicrosurveyPromptMiddlewareAction(
@@ -95,6 +99,7 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
     }
 
     // MARK: - Helpers
+    @MainActor
     private func createSubject(microsurveyManager: MockMicrosurveySurfaceManager) -> MicrosurveyPromptMiddleware {
         return MicrosurveyPromptMiddleware(microsurveyManager: microsurveyManager)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- `MicrosurveyPromptMiddleware` and `MessageCardMiddleware` are now main actors
- Using `dispatch` instead of `dispatchLegacy` inside those middlewares as well

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
