### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] Changes to toolbar middleware

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -6,6 +6,7 @@ import Common
 import Redux
 import ToolbarKit
 
+@MainActor
 final class ToolbarMiddleware: FeatureFlaggable {
     private let manager: ToolbarManager
     private let toolbarHelper: ToolbarHelperInterface
@@ -63,7 +64,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
                 canShowDataClearanceAction: canShowDataClearanceAction(),
                 windowUUID: uuid,
                 actionType: ToolbarActionType.didLoadToolbars)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case GeneralBrowserMiddlewareActionType.websiteDidScroll:
             guard let scrollOffset = action.scrollOffset else { return }
@@ -104,7 +105,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
             guard let toolbarState = state.screenState(ToolbarState.self, for: .toolbar, window: action.windowUUID)
             else { return }
             let action = ToolbarAction(windowUUID: action.windowUUID, actionType: ToolbarActionType.clearSearch)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
             toolbarTelemetry.clearSearchButtonTapped(isPrivate: toolbarState.isPrivateMode)
 
         case ToolbarMiddlewareActionType.didStartDragInteraction:
@@ -123,7 +124,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
                 windowUUID: action.windowUUID,
                 actionType: SearchEngineSelectionMiddlewareActionType.didClearAlternativeSearchEngine
             )
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         default:
             break
@@ -146,7 +147,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
         case .readerMode:
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.addToReadingListLongPressAction)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         default: break
         }
     }
@@ -160,13 +161,13 @@ final class ToolbarMiddleware: FeatureFlaggable {
             toolbarTelemetry.homeButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.goToHomepage)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .newTab:
             toolbarTelemetry.oneTapNewTabButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.addNewTab)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .qrCode:
             toolbarTelemetry.qrCodeButtonTapped(isPrivate: toolbarState.isPrivateMode)
@@ -174,24 +175,24 @@ final class ToolbarMiddleware: FeatureFlaggable {
             if toolbarState.addressToolbar.isEditing {
                 let toolbarAction = ToolbarAction(windowUUID: action.windowUUID,
                                                   actionType: ToolbarActionType.cancelEdit)
-                store.dispatchLegacy(toolbarAction)
+                store.dispatch(toolbarAction)
             }
 
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showQRcodeReader)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .back:
             toolbarTelemetry.backButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.navigateBack)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .forward:
             toolbarTelemetry.forwardButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.navigateForward)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .tabs:
             cancelEditMode(windowUUID: action.windowUUID)
@@ -199,14 +200,14 @@ final class ToolbarMiddleware: FeatureFlaggable {
             toolbarTelemetry.tabTrayButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showTabTray)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .trackingProtection:
             toolbarTelemetry.siteInfoButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(buttonTapped: action.buttonTapped,
                                               windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showTrackingProtectionDetails)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .menu:
             cancelEditMode(windowUUID: action.windowUUID)
@@ -215,7 +216,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
             let action = GeneralBrowserAction(buttonTapped: action.buttonTapped,
                                               windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showMenu)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .cancelEdit:
             cancelEditMode(windowUUID: action.windowUUID)
@@ -224,36 +225,36 @@ final class ToolbarMiddleware: FeatureFlaggable {
             recordReaderModeTelemetry(state: state, windowUUID: action.windowUUID)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showReaderMode)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .reload:
             toolbarTelemetry.refreshButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.reloadWebsite)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .stopLoading:
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.stopLoadingWebsite)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .share:
             toolbarTelemetry.shareButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(buttonTapped: action.buttonTapped,
                                               windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showShare)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .search:
             toolbarTelemetry.searchButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = ToolbarAction(windowUUID: action.windowUUID, actionType: ToolbarActionType.didStartEditingUrl)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .dataClearance:
             toolbarTelemetry.dataClearanceButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.clearData)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         default:
             break
         }
@@ -268,35 +269,35 @@ final class ToolbarMiddleware: FeatureFlaggable {
             toolbarTelemetry.backButtonLongPressed(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showBackForwardList)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .forward:
             toolbarTelemetry.forwardButtonLongPressed(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showBackForwardList)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .tabs:
             toolbarTelemetry.tabTrayButtonLongPressed(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showTabsLongPressActions)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .locationView:
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showLocationViewLongPressActionSheet)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .reload:
             let action = GeneralBrowserAction(buttonTapped: action.buttonTapped,
                                               windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showReloadLongPressAction)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .newTab:
             toolbarTelemetry.oneTapNewTabButtonLongPressed(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showNewTabLongPressActions)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .readerMode:
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.addToReadingListLongPressAction)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         default:
             break
         }
@@ -322,7 +323,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
             windowUUID: windowUUID,
             actionType: ToolbarActionType.borderPositionChanged
         )
-        store.dispatchLegacy(toolbarAction)
+        store.dispatch(toolbarAction)
     }
 
     private func isMicrosurveyShown(action: GeneralBrowserMiddlewareAction, state: AppState) -> Bool {
@@ -350,13 +351,13 @@ final class ToolbarMiddleware: FeatureFlaggable {
             let toolbarAction = ToolbarAction(displayNavBorder: !isMicrosurveyShown,
                                               windowUUID: windowUUID,
                                               actionType: ToolbarActionType.borderPositionChanged)
-            store.dispatchLegacy(toolbarAction)
+            store.dispatch(toolbarAction)
         } else {
             let toolbarAction = ToolbarAction(addressBorderPosition: isMicrosurveyShown ? .none : .top,
                                               displayNavBorder: false,
                                               windowUUID: windowUUID,
                                               actionType: ToolbarActionType.borderPositionChanged)
-            store.dispatchLegacy(toolbarAction)
+            store.dispatch(toolbarAction)
         }
     }
 
@@ -389,7 +390,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
                                           displayNavBorder: displayNavToolbarBorder,
                                           windowUUID: action.windowUUID,
                                           actionType: ToolbarActionType.toolbarPositionChanged)
-        store.dispatchLegacy(toolbarAction)
+        store.dispatch(toolbarAction)
     }
 
     // MARK: - Helper
@@ -399,12 +400,12 @@ final class ToolbarMiddleware: FeatureFlaggable {
             url = (currentURL.isWebPage() && !currentURL.isReaderModeURL) ? url : nil
         }
         let action = ToolbarAction(url: url, windowUUID: windowUUID, actionType: ToolbarActionType.cancelEdit)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
 
         let browserAction = GeneralBrowserAction(showOverlay: false,
                                                  windowUUID: windowUUID,
                                                  actionType: GeneralBrowserActionType.leaveOverlay)
-        store.dispatchLegacy(browserAction)
+        store.dispatch(browserAction)
     }
 
     private func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition) -> AddressToolbarPosition {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- `ToolbarMiddleware` is now main actor
- Using `dispatch` instead of `dispatchLegacy` inside this middleware as well
- Unit tests passed locally, lets see on BR

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
