### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] Changes to TabManagerMiddleware

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -65,6 +65,7 @@ protocol TabManager: AnyObject {
 
     /// Async Remove tab option using tabUUID.
     /// - Parameter tabUUID: UUID from the tab
+    @MainActor
     func removeTab(_ tabUUID: TabUUID) async
 
     /// Async Remove all tabs indicating if is on private mode or not


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- `TabManagerMiddleware` is now main actor
- Using `dispatch` instead of `dispatchLegacy` inside this middleware as well
- Unit tests passed locally, lets see on BR

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
