### PR TITLE
Add FXIOS-12940 [Summarizer] Check for supported languages before summarizing

### DIFF
--- a/firefox-ios/Client/Frontend/Summary/SummarizationCheckResult.swift
+++ b/firefox-ios/Client/Frontend/Summary/SummarizationCheckResult.swift
@@ -8,9 +8,10 @@ public struct SummarizationCheckResult: Decodable {
     public let canSummarize: Bool
     public let reason: SummarizationReason?
     public let wordCount: Int
+    public let textContent: String?
 
     /// Convenience initializer for constructing a failure result.
     static func failure(_ error: SummarizationCheckError) -> SummarizationCheckResult {
-        SummarizationCheckResult(canSummarize: false, reason: nil, wordCount: 0)
+        SummarizationCheckResult(canSummarize: false, reason: nil, wordCount: 0, textContent: nil)
     }
 }

--- a/firefox-ios/Client/Frontend/Summary/SummarizationChecker.swift
+++ b/firefox-ios/Client/Frontend/Summary/SummarizationChecker.swift
@@ -12,9 +12,9 @@ public class SummarizationChecker {
     ///   - maxWords: The maximum allowed words before summarization is disallowed.
     /// - Returns: A `SummarizationCheckResult`, even on error.
     public func check(on webView: WKWebView, maxWords: Int) async -> SummarizationCheckResult {
-        let jsCall = "checkSummarization(\(maxWords));"
+        let jsCall = "return await window.__firefox__.Summarizer.checkSummarization(\(maxWords))"
         do {
-            let rawResult = try await webView.evaluateJavaScript(jsCall, in: nil, contentWorld: .defaultClient)
+            let rawResult = try await webView.callAsyncJavaScript(jsCall, contentWorld: .defaultClient)
             guard let rawResult = rawResult else { return SummarizationCheckResult.failure(.invalidJSON) }
             return try parse(rawResult)
         } catch {

--- a/firefox-ios/Client/Frontend/Summary/SummarizationReason.swift
+++ b/firefox-ios/Client/Frontend/Summary/SummarizationReason.swift
@@ -4,5 +4,5 @@
 
 /// Model for all the reasons summarization might be disallowed.
 public enum SummarizationReason: String, Decodable {
-    case documentNotReady, documentNotReadable, contentTooLong
+    case documentNotReady, documentLanguageUnsupported, documentNotReadable, contentTooLong
 }

--- a/firefox-ios/Client/Frontend/Summary/SummarizationReason.swift
+++ b/firefox-ios/Client/Frontend/Summary/SummarizationReason.swift
@@ -4,5 +4,5 @@
 
 /// Model for all the reasons summarization might be disallowed.
 public enum SummarizationReason: String, Decodable {
-    case documentNotReady, documentLanguageUnsupported, documentNotReadable, contentTooLong
+    case documentLanguageUnsupported, documentNotReadable, contentTooLong
 }

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
@@ -33,20 +33,31 @@ const extractContent = () => {
 };
 
 /**
+ * Helper function to wait for document to be ready before running checks.
+ * Returns a Promise that resolves when the document is ready.
+ */
+const documentReady = () =>  new Promise(resolve => {
+  if (document.readyState !== "loading") {
+    resolve();
+  } else {
+    document.addEventListener("readystatechange", () => {
+      if (document.readyState !== "loading") {
+        resolve();
+      }
+    }, { once: true });
+  }
+});
+
+
+/**
  * Checks document summarization eligibility.
  * Returns an object with `canSummarize`, `reason`, and `wordCount`.
  * @param {number} maxWords - Maximum number of words allowed for summarization.
  * @returns {{ canSummarize: boolean, reason: string, wordCount: number }}
  */
-const checkSummarization = (maxWords = MAX_DOCUMENT_LENGTH_IN_WORDS) => {
+const checkSummarization = async (maxWords) => {
   // 0. Document should be ready before we do anything.
-  if (document.readyState === "loading") {
-    return {
-      canSummarize: false,
-      reason: "documentNotReady",
-      wordCount: 0,
-    };
-  }
+  await documentReady();
 
   // 1. Readerable check
   if (!isProbablyReaderable(document)) {

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
@@ -6,6 +6,20 @@
 "use strict";
 import { Readability } from "@mozilla/readability";
 
+const ALLOWED_LANGS = ["en"];
+
+const isPageLanguageSupported = () => {
+  // Attempt to use the <html> lang attribute. 
+  // When the lang attribute is not set we get "". In that case, default to "en".
+  const rawLang = document.documentElement.lang?.trim() || "en";
+  try {
+    const locale = new Intl.Locale(rawLang);
+    return ALLOWED_LANGS.includes(locale.language);
+  } catch {
+    return true;
+  }
+}
+
 const extractContent = () => {
   const uri = {
     spec: document.location.href,
@@ -58,6 +72,15 @@ const documentReady = () =>  new Promise(resolve => {
 const checkSummarization = async (maxWords) => {
   // 0. Document should be ready before we do anything.
   await documentReady();
+
+  // 1. Check if the page language is supported.
+  if (!isPageLanguageSupported()) {
+    return {
+      canSummarize: false,
+      reason: "documentLanguageUnsupported",
+      wordCount: 0,
+    };
+  }
 
   // 1. Readerable check
   if (!isProbablyReaderable(document)) {

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
@@ -1,10 +1,9 @@
-/* vim: set ts=2 sts=2 sw=2 et tw=80: */
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 "use strict";
-import { Readability } from "@mozilla/readability";
+import { Readability, isProbablyReaderable} from "@mozilla/readability";
 
 const ALLOWED_LANGS = ["en"];
 
@@ -86,7 +85,7 @@ const checkSummarization = async (maxWords) => {
   if (!isProbablyReaderable(document)) {
     return {
       canSummarize: false,
-      reason: "documentNotReadeable",
+      reason: "documentNotReadable",
       wordCount: 0,
     };
   }
@@ -103,7 +102,13 @@ const checkSummarization = async (maxWords) => {
     };
   }
 
-  return { canSummarize: true, reason: null, wordCount };
+  return { canSummarize: true, reason: null, wordCount, textContent: text };
 };
 
-window.checkSummarization = checkSummarization;
+
+Object.defineProperty(window.__firefox__, "Summarizer", {
+  enumerable: false,
+  configurable: false,
+  writable: false,
+  value: Object.freeze({checkSummarization})
+});

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SummarizationCheckerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SummarizationCheckerTests.swift
@@ -36,6 +36,16 @@ final class SummarizationCheckerTests: XCTestCase {
         XCTAssertEqual(result.wordCount, 0)
     }
 
+    /// JS stub for a page that is in an unsupported language.
+    func testSummarizationCheckerCanSummarizeFalseSocumentLanguageUnsupported() throws {
+        let subject = createSubject()
+        let result = try subject.parse(
+            jsStubBuilder(canSummarize: false, reason: "documentLanguageUnsupported", wordCount: 0))
+        XCTAssertFalse(result.canSummarize)
+        XCTAssertEqual(result.reason, .documentLanguageUnsupported)
+        XCTAssertEqual(result.wordCount, 0)
+    }
+
     /// JS stub for a page that is not reader‑readable.
     func testSummarizationCheckerCanSummarizeFalseNotReadable() throws {
         let subject = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SummarizationCheckerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SummarizationCheckerTests.swift
@@ -26,16 +26,6 @@ final class SummarizationCheckerTests: XCTestCase {
         XCTAssertEqual(result.wordCount, 42)
     }
 
-    /// JS stub for a page that is not reader‑readable.
-    func testSummarizationCheckerCanSummarizeFalseDocumentNotReady() throws {
-        let subject = createSubject()
-        let result = try subject.parse(
-            jsStubBuilder(canSummarize: false, reason: "documentNotReady", wordCount: 0))
-        XCTAssertFalse(result.canSummarize)
-        XCTAssertEqual(result.reason, .documentNotReady)
-        XCTAssertEqual(result.wordCount, 0)
-    }
-
     /// JS stub for a page that is in an unsupported language.
     func testSummarizationCheckerCanSummarizeFalseSocumentLanguageUnsupported() throws {
         let subject = createSubject()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12940)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28215)

## :bulb: Description
This PR:
- Adds `isPageLanguageSupported` which derives language based on `html[lang]` attribute.
- Waits for document to be ready before doing anything.
- Check language and returns appropriate error.
- Adds test case.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
