### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix isolation warnings in DependencyHelper

### DIFF
--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -6,6 +6,7 @@ import Storage
 import Common
 
 class DependencyHelper {
+    @MainActor
     func bootstrapDependencies() {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
             // Fatal error here so we can gather info as this would cause a crash down the line anyway


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description

Fixes the main actor isolation warnings in DependencyHelper:

<img width="1503" height="490" alt="Screenshot 2025-07-24 at 10 57 16 AM" src="https://github.com/user-attachments/assets/bca7af60-eb4a-4e47-91a7-1e823555b459" />

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
