### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix warning in the CreditCards VCs and view model

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 /// Protocol followed by child of the bottom sheet, which holds the content shown in the bottom sheet.
 public protocol BottomSheetChild: UIViewController {
     /// Tells the child that the bottom sheet will get dismissed
+    @MainActor
     func willDismiss()
 }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
@@ -6,7 +6,9 @@ import Common
 import ComponentLibrary
 import UIKit
 
-class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell, ThemeApplicable {
+class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView,
+                                       ReusableCell,
+                                       ThemeApplicable {
     private struct UX {
         static let manageCardsButtonLeadingSpace: CGFloat = 0
         static let manageCardsButtonTopSpace: CGFloat = 24

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
@@ -8,7 +8,9 @@ import Common
 import Shared
 
 // MARK: Header View
-class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView, ReusableCell, ThemeApplicable {
+class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView,
+                                       ReusableCell,
+                                       ThemeApplicable {
     // MARK: UX
     struct UX {
         static let headerElementsSpacing: CGFloat = 7.0

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -14,6 +14,7 @@ class CreditCardBottomSheetViewController: UIViewController,
                                            BottomSheetChild,
                                            Themeable {
     // MARK: UX
+    @MainActor
     struct UX {
         static let containerPadding: CGFloat = 18.0
         static let tableMargin: CGFloat = 0

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
@@ -101,33 +101,33 @@ class CreditCardBottomSheetViewModel {
 
     // MARK: Main Button Action
     public func didTapMainButton(queue: DispatchQueueInterface = DispatchQueue.main,
-                                 completion: @escaping (Error?) -> Void) {
+                                 completion: @escaping @Sendable (Error?) -> Void) {
         let decryptedCard = getPlainCreditCardValues(bottomSheetState: state)
         switch state {
         case .save:
-            saveCreditCard(with: decryptedCard) { _, error in
+            saveCreditCard(with: decryptedCard) { [logger] _, error in
                 queue.async {
                     guard let error = error else {
                         completion(nil)
                         return
                     }
-                    self.logger.log("Unable to save credit card with error: \(error)",
-                                    level: .fatal,
-                                    category: .autofill)
+                    logger.log("Unable to save credit card with error: \(error)",
+                               level: .fatal,
+                               category: .autofill)
                     completion(error)
                 }
             }
         case .update:
             updateCreditCard(for: creditCard?.guid,
-                             with: decryptedCard) { _, error in
+                             with: decryptedCard) { [logger] _, error in
                 queue.async {
                     guard let error = error else {
                         completion(nil)
                         return
                     }
-                    self.logger.log("Unable to save credit card with error: \(error)",
-                                    level: .fatal,
-                                    category: .autofill)
+                    logger.log("Unable to save credit card with error: \(error)",
+                               level: .fatal,
+                               category: .autofill)
                     completion(error)
                 }
             }
@@ -304,11 +304,10 @@ class CreditCardBottomSheetViewModel {
         })
     }
 
-    func updateCreditCardList(queue: DispatchQueueInterface = DispatchQueue.main,
-                              completionHandler: @escaping ([CreditCard]?) -> Void) {
+    func updateCreditCardList(completionHandler: @escaping @Sendable ([CreditCard]?) -> Void) {
         if state == .selectSavedCard {
             listStoredCreditCards { [weak self] cards in
-                queue.async {
+                Task { @MainActor in
                     self?.creditCards = cards
                     completionHandler(cards)
                 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
@@ -375,7 +375,7 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         subject.decryptedCreditCard = nil
         subject.state = .selectSavedCard
 
-        subject.updateCreditCardList(queue: dispatchQueue) { cards in
+        subject.updateCreditCardList { cards in
             XCTAssertEqual(subject.creditCards, cards)
             XCTAssertEqual(cards?.count, 1)
             XCTAssertEqual(cards?.first?.guid, "1")
@@ -394,7 +394,7 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         subject.creditCard = nil
         subject.decryptedCreditCard = nil
 
-        subject.updateCreditCardList(queue: dispatchQueue) { cards in
+        subject.updateCreditCardList { cards in
             expectation.fulfill()
         }
         waitForExpectations(timeout: 1.0)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix the under-specified protocol warnings and Sendability related to credit card screens.

We did this one during our morning walkthrough meeting, so I skipped the context screenshot. 🤡 

cc @Cramsden @lmarceau @cyndichin @dataports @yoanarios 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
