### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] FeltPrivacyMiddleware middleware actor isolation

### DIFF
--- a/firefox-ios/Client/Frontend/FeltPrivacy/FeltPrivacyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/FeltPrivacy/FeltPrivacyMiddleware.swift
@@ -6,7 +6,8 @@ import Foundation
 import Redux
 import Common
 
-class FeltPrivacyMiddleware {
+@MainActor
+final class FeltPrivacyMiddleware {
     var privacyStateManager: ThemeManager
 
     init(privacyStateManager: ThemeManager = AppContainer.shared.resolve()) {
@@ -23,7 +24,7 @@ class FeltPrivacyMiddleware {
             let updateAction = PrivateModeAction(isPrivate: privateState,
                                                  windowUUID: action.windowUUID,
                                                  actionType: PrivateModeActionType.privateModeUpdated)
-            store.dispatchLegacy(updateAction)
+            store.dispatch(updateAction)
         default:
             break
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
Migrate `FeltPrivacyMiddleware` middleware to use `@MainActor` isolation and the new isolated store `dispatch` method.

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)