### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] Changes to SearchEngineSelectionMiddleware to make it main actor

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -35,6 +35,10 @@ final class SearchEngineSelectionMiddleware {
                         self?.logger.log("SearchEngineSelectionMiddleware completion is not called on the main thread",
                                          level: .fatal,
                                          category: .storage)
+                        // Fallback
+                        Task { @MainActor in
+                            self?.notifyDidLoad(windowUUID: action.windowUUID, searchEngines: searchEngines)
+                        }
                         return
                     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- `SearchEngineSelectionMiddleware` is now main actor
- Using `dispatch` instead of `dispatchLegacy` inside this middleware as well
- Unit tests passed locally, lets see on BR

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
