### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Synchronize `StoreSubscriber`'s `newState` method to the main actor

### DIFF
--- a/BrowserKit/Sources/Redux/StoreSubscriber.swift
+++ b/BrowserKit/Sources/Redux/StoreSubscriber.swift
@@ -17,10 +17,12 @@ public protocol StoreSubscriber: AnyStoreSubscriber {
 
     /// Updates the subscriber with a new State for its screen state type.
     /// - Parameter state: the changed screen state.
+    @MainActor
     func newState(state: SubscriberStateType)
 }
 
 extension StoreSubscriber {
+    @MainActor
     public func newState(state: Any) {
         if let typedState = state as? SubscriberStateType {
             newState(state: typedState)

--- a/BrowserKit/Tests/ReduxTests/StoreTests.swift
+++ b/BrowserKit/Tests/ReduxTests/StoreTests.swift
@@ -75,6 +75,7 @@ final class StoreTests: XCTestCase {
         XCTAssertEqual(MockState.actionsReduced[0] as? FakeReduxActionType, FakeReduxActionType.counterIncreased)
     }
 
+    @MainActor
     func testDispatchMultipleActions_mixThread() async {
         let expectation = expectation(description: "Wait for actions to run")
 
@@ -95,12 +96,12 @@ final class StoreTests: XCTestCase {
         let action2 = FakeReduxAction(
             windowUUID: UUID(),
             actionType: FakeReduxActionType.counterDecreased)
-        store.dispatchLegacy(action2)
+        store.dispatch(action2)
 
         let action3 = FakeReduxAction(
             windowUUID: UUID(),
             actionType: FakeReduxActionType.increaseCounter)
-        store.dispatchLegacy(action3)
+        store.dispatch(action3)
 
         await fulfillment(of: [expectation])
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelTests.swift
@@ -8,6 +8,7 @@ import XCTest
 
 @testable import Client
 
+@MainActor
 final class RemoteTabPanelTests: XCTestCase {
     override func setUp() {
         super.setUp()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
@@ -6,6 +6,8 @@ import Common
 import XCTest
 
 @testable import Client
+
+@MainActor
 final class TabDisplayPanelTests: XCTestCase {
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Synchronize `StoreSubscriber`'s `newState` method to the main actor. This clears up a number of under-specified protocol conformance errors for main actor synchronized conforming types.

Warning count: 2,400 -> 2,384

I saw `testDispatchMultipleActions_mixThread` fail locally on a full suite run, but not again when I ran the test repeatedly. I figured that this was an indication the test should be upgraded to use the new main actor synchronized `dispatch` and the test itself could be synchronized, since we expect our store/middlewares to eventually also all be synchronized. So we'll see what Bitrise says...

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
