### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Make the Reducer closure explicitly Sendable

### DIFF
--- a/BrowserKit/Sources/Redux/Reducer.swift
+++ b/BrowserKit/Sources/Redux/Reducer.swift
@@ -6,4 +6,4 @@ import Foundation
 
 /// Provide pure functions, that based on the current `Action` and the current app `State`,
 /// create a new app state. `Reducers` are the only place in which the application state should be modified.
-public typealias Reducer<State> = (State, Action) -> State
+public typealias Reducer<State> = @Sendable (State, Action) -> State


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
I noticed that as we made Redux State types `Sendable`, I was seeing this warning:

<img width="1480" height="202" alt="Screenshot 2025-07-24 at 2 22 37 PM" src="https://github.com/user-attachments/assets/0de0f98a-83e9-449f-8653-72097b0a642e" />

So we need to mark the public type as explicitly `Sendable`.

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
