### PR TITLE
Refactor FXIOS-12912 [Swift 6 Migration] Conform Redux MainMenuState to Sendable

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuSection.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSection.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct MenuSection: Equatable {
+public struct MenuSection: Equatable, Sendable {
     public let isHorizontalTabsSection: Bool
     public let groupA11yLabel: String?
     public let isExpanded: Bool?

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
@@ -6,14 +6,14 @@ import Common
 import MenuKit
 import Redux
 
-struct MainMenuDetailsState: ScreenState, Equatable {
-    var windowUUID: WindowUUID
-    var menuElements: [MenuSection]
-    var shouldDismiss: Bool
-    var shouldGoBackToMainMenu: Bool
-    var navigationDestination: MenuNavigationDestination?
-    var submenuType: MainMenuDetailsViewType?
-    var isHomepage: Bool?
+struct MainMenuDetailsState: ScreenState, Equatable, Sendable {
+    let windowUUID: WindowUUID
+    let menuElements: [MenuSection]
+    let shouldDismiss: Bool
+    let shouldGoBackToMainMenu: Bool
+    let navigationDestination: MenuNavigationDestination?
+    let submenuType: MainMenuDetailsViewType?
+    let isHomepage: Bool?
 
     var title: String {
         typealias Titles = String.MainMenu.ToolsSection

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -71,23 +71,23 @@ struct MainMenuTabInfo: Equatable {
     let accountProfileImage: UIImage?
 }
 
-struct MainMenuState: ScreenState, Equatable {
-    var windowUUID: WindowUUID
-    var menuElements: [MenuSection]
+struct MainMenuState: ScreenState, Equatable, Sendable {
+    let windowUUID: WindowUUID
+    let menuElements: [MenuSection]
 
-    var shouldDismiss: Bool
+    let shouldDismiss: Bool
 
-    var accountData: AccountData?
-    var accountIcon: UIImage?
-    var isBrowserDefault: Bool
-    var isPhoneLandscape: Bool
-    var moreCellTapped: Bool
+    let accountData: AccountData?
+    let accountIcon: UIImage?
+    let isBrowserDefault: Bool
+    let isPhoneLandscape: Bool
+    let moreCellTapped: Bool
 
-    var siteProtectionsData: SiteProtectionsData?
+    let siteProtectionsData: SiteProtectionsData?
 
-    var navigationDestination: MenuNavigationDestination?
-    var currentTabInfo: MainMenuTabInfo?
-    var currentSubmenuView: MainMenuDetailsViewType?
+    let navigationDestination: MenuNavigationDestination?
+    let currentTabInfo: MainMenuTabInfo?
+    let currentSubmenuView: MainMenuDetailsViewType?
 
     private let menuConfigurator = MainMenuConfigurationUtility()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12912)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28144)

## :bulb: Description
Conform Redux `MainMenuState` to `Sendable`.

Pretty sure this will require a warning fix from https://github.com/mozilla-mobile/firefox-ios/pull/28227.

cc @Cramsden @lmarceau 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
