### PR TITLE
Bugfix FXIOS crash on BookmarkMiddleware

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksMiddleware.swift
@@ -37,11 +37,12 @@ final class BookmarksMiddleware {
                     )
                 )
             }
-            self?.dispatchBookmarksAction(windowUUID: windowUUID, updatedBookmarks: bookmarks)
+            Task { @MainActor in
+                self?.dispatchBookmarksAction(windowUUID: windowUUID, updatedBookmarks: bookmarks)
+            }
         }
     }
 
-    @MainActor
     private func dispatchBookmarksAction(windowUUID: WindowUUID, updatedBookmarks: [BookmarkConfiguration]) {
         let newAction = BookmarksAction(
             bookmarks: updatedBookmarks,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksMiddleware.swift
@@ -41,6 +41,7 @@ final class BookmarksMiddleware {
         }
     }
 
+    @MainActor
     private func dispatchBookmarksAction(windowUUID: WindowUUID, updatedBookmarks: [BookmarkConfiguration]) {
         let newAction = BookmarksAction(
             bookmarks: updatedBookmarks,


### PR DESCRIPTION
## :scroll: Tickets
~~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~~
~~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~~

## :bulb: Description
Bugfix crash on BookmarkMiddleware caused by `store.dispatch` being called not from a `MainActor` isolated context.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
