### PR TITLE
Bugfix FXIOS-12946 - The app crashes after restart and accessing the new menu

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquareCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquareCell.swift
@@ -87,9 +87,9 @@ final class MenuSquareView: UIView, ThemeApplicable {
         backgroundContentView.addSubview(contentStackView)
         contentStackView.addArrangedSubview(icon)
         contentStackView.addArrangedSubview(titleLabel)
+        backgroundContentView.addSubview(dividerView)
 
         if #available(iOS 26.0, *) {
-            backgroundContentView.addSubview(dividerView)
             NSLayoutConstraint.activate([
                 dividerView.widthAnchor.constraint(equalToConstant: UX.dividerWidth),
                 dividerView.trailingAnchor.constraint(equalTo: backgroundContentView.trailingAnchor),

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -850,27 +850,29 @@ final class TabManagerMiddleware: FeatureFlaggable {
         }
 
         fetchProfileTabInfo(for: selectedTab.url) { profileTabInfo in
-            store.dispatch(
-                MainMenuAction(
-                    windowUUID: windowUUID,
-                    actionType: MainMenuActionType.updateCurrentTabInfo,
-                    currentTabInfo: MainMenuTabInfo(
-                        tabID: selectedTab.tabUUID,
-                        url: selectedTab.url,
-                        canonicalURL: selectedTab.canonicalURL?.displayURL,
-                        isHomepage: selectedTab.isFxHomeTab,
-                        isDefaultUserAgentDesktop: UserAgent.isDesktop(ua: UserAgent.getUserAgent()),
-                        hasChangedUserAgent: selectedTab.changedUserAgent,
-                        zoomLevel: selectedTab.pageZoom,
-                        readerModeIsAvailable: selectedTab.readerModeAvailableOrActive,
-                        isBookmarked: profileTabInfo.isBookmarked,
-                        isInReadingList: profileTabInfo.isInReadingList,
-                        isPinned: profileTabInfo.isPinned,
-                        accountData: accountData,
-                        accountProfileImage: profileImage
+            Task { @MainActor in
+                store.dispatch(
+                    MainMenuAction(
+                        windowUUID: windowUUID,
+                        actionType: MainMenuActionType.updateCurrentTabInfo,
+                        currentTabInfo: MainMenuTabInfo(
+                            tabID: selectedTab.tabUUID,
+                            url: selectedTab.url,
+                            canonicalURL: selectedTab.canonicalURL?.displayURL,
+                            isHomepage: selectedTab.isFxHomeTab,
+                            isDefaultUserAgentDesktop: UserAgent.isDesktop(ua: UserAgent.getUserAgent()),
+                            hasChangedUserAgent: selectedTab.changedUserAgent,
+                            zoomLevel: selectedTab.pageZoom,
+                            readerModeIsAvailable: selectedTab.readerModeAvailableOrActive,
+                            isBookmarked: profileTabInfo.isBookmarked,
+                            isInReadingList: profileTabInfo.isInReadingList,
+                            isPinned: profileTabInfo.isPinned,
+                            accountData: accountData,
+                            accountProfileImage: profileImage
+                        )
                     )
                 )
-            )
+            }
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12946)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28238)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Wrapped store dispatch in `Task { @MainActor }` to ensure they run on the main thread.
- Fixed menu constraint that was causing the app to crash for non ios 26 devices.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
