### PR TITLE
Add FXIOS-12927 [Experiment] advanced targeting for apple intelligence

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -214,6 +214,9 @@ public struct PrefsKeys {
     // Used to only show the Default Browser Banner, in Main Menu, until is dismissed by the user
     public static let defaultBrowserBannerShown = "defaultBrowserBannerShownKey"
 
+    // Used to determine if Apple Intelligence is available
+    public static let appleIntelligenceAvailable = "appleIntelligenceAvailableKey"
+
     public struct Usage {
         public static let profileId = "profileId"
     }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1448,6 +1448,8 @@
 		BAEB9EB22E2869C400F9F482 /* SummarizationChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEB9EB12E2869BE00F9F482 /* SummarizationChecker.swift */; };
 		BAEB9EB42E28726A00F9F482 /* SummarizationCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEB9EB32E28726100F9F482 /* SummarizationCheckerTests.swift */; };
 		BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */; };
+		BC0723522E33D7A6005BAC05 /* AppleIntelligenceUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0723512E33D7A2005BAC05 /* AppleIntelligenceUtilTests.swift */; };
+		BC8E91DC2E32953C00434FD0 /* AppleIntelligenceUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */; };
 		BCFB141D2E1FFEC00005D46B /* feltPrivacySimplifiedUIOff.json in Resources */ = {isa = PBXBuildFile; fileRef = BCFB141C2E1FFEC00005D46B /* feltPrivacySimplifiedUIOff.json */; };
 		BCFB141F2E1FFECC0005D46B /* feltPrivacySimplifiedUIOn.json in Resources */ = {isa = PBXBuildFile; fileRef = BCFB141E2E1FFECC0005D46B /* feltPrivacySimplifiedUIOn.json */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
@@ -9265,8 +9267,10 @@
 		BBE94C27A604339C9C38E02F /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/Menu.strings; sourceTree = "<group>"; };
 		BBF04862A944340C80C053E0 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerTests.swift; sourceTree = "<group>"; };
+		BC0723512E33D7A2005BAC05 /* AppleIntelligenceUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceUtilTests.swift; sourceTree = "<group>"; };
 		BC4B49618B8FC822D4D0FCC2 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BC81442AA84F635F3067A2C5 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
+		BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceUtil.swift; sourceTree = "<group>"; };
 		BCD04CE4A62EAA4DF96DE812 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/Storage.strings"; sourceTree = "<group>"; };
 		BCFB141C2E1FFEC00005D46B /* feltPrivacySimplifiedUIOff.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = feltPrivacySimplifiedUIOff.json; sourceTree = "<group>"; };
 		BCFB141E2E1FFECC0005D46B /* feltPrivacySimplifiedUIOn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = feltPrivacySimplifiedUIOn.json; sourceTree = "<group>"; };
@@ -12388,6 +12392,7 @@
 		8A171A6029F82AD90085770E /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				BC0723512E33D7A2005BAC05 /* AppleIntelligenceUtilTests.swift */,
 				5AD3B67F2CF6674B00AFA1FE /* MockUIApplication.swift */,
 				5AD3B6792CF653A200AFA1FE /* MockLocale.swift */,
 				8A13FA882AD82BC8007527AB /* AppSendTabDelegateTests.swift */,
@@ -15540,6 +15545,7 @@
 			isa = PBXGroup;
 			children = (
 				5AD3B6732CF625A300AFA1FE /* DefaultBrowserUtil.swift */,
+				BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */,
 				8A46F5AA2C9E4389005B6422 /* RemoteSettings */,
 				C84266742728462900382274 /* AccessibilityIdentifiers.swift */,
 				5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */,
@@ -17995,6 +18001,7 @@
 				21B548952B1E5F1400DC1DF8 /* InactiveTabsManager.swift in Sources */,
 				8A6E63C92D4948BE0040D355 /* JumpBackInTabConfiguration.swift in Sources */,
 				C8F457A81F1FD75A000CB895 /* BrowserViewController+WebViewDelegates.swift in Sources */,
+				BC8E91DC2E32953C00434FD0 /* AppleIntelligenceUtil.swift in Sources */,
 				964FA97728A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift in Sources */,
 				8A1E3BDF28CBA81E003388C4 /* SponsoredContentFilterUtility.swift in Sources */,
 				8A5BD95F2878B7B6000FE773 /* TopSitesWidgetManager.swift in Sources */,
@@ -18771,6 +18778,7 @@
 				8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */,
 				8ABB15C92D5A4E3900A4635C /* RemoteTabsMiddlewareTests.swift in Sources */,
 				C787D8C32C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift in Sources */,
+				BC0723522E33D7A6005BAC05 /* AppleIntelligenceUtilTests.swift in Sources */,
 				39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */,
 				630FE1352C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift in Sources */,
 				8AAEB9FE2BF50718000C02B5 /* MicrosurveyViewControllerTests.swift in Sources */,

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -36,6 +36,11 @@ final class AppLaunchUtil: Sendable {
         }
 
         DefaultBrowserUtil().processUserDefaultState(isFirstRun: introScreenManager.shouldShowIntroScreen)
+        if #available(iOS 26, *) {
+            #if canImport(FoundationModels)
+                AppleIntelligenceUtil().processAvailabilityState()
+            #endif
+        }
 
         // Need to get "settings.sendCrashReports" this way so that Sentry can be initialized before getting the Profile.
         let sendCrashReports = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.prefSendCrashReports) ?? true

--- a/firefox-ios/Client/Application/AppleIntelligenceUtil.swift
+++ b/firefox-ios/Client/Application/AppleIntelligenceUtil.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+#if canImport(FoundationModels)
+import Common
+import Foundation
+import FoundationModels
+import Shared
+
+protocol LanguageModelProtocol {
+    var isAvailable: Bool { get }
+}
+
+@available(iOS 26, *)
+extension SystemLanguageModel: LanguageModelProtocol { }
+
+/// Utility for capturing apple intelligence availability
+struct AppleIntelligenceUtil {
+    private let userDefaults: UserDefaultsInterface
+
+    init(userDefaults: UserDefaultsInterface = UserDefaults.standard) {
+        self.userDefaults = userDefaults
+    }
+
+    var isAppleIntelligenceAvailable: Bool {
+        userDefaults.bool(forKey: PrefsKeys.appleIntelligenceAvailable)
+    }
+
+    @available(iOS 26.0, *)
+    func processAvailabilityState(_ model: LanguageModelProtocol = SystemLanguageModel.default) {
+        let isAvailable = checkAppleIntelligenceAvailability(with: model)
+        userDefaults.set(isAvailable, forKey: PrefsKeys.appleIntelligenceAvailable)
+    }
+
+    @available(iOS 26, *)
+    private func checkAppleIntelligenceAvailability(with model: LanguageModelProtocol) -> Bool {
+        return model.isAvailable
+    }
+}
+#endif

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -200,6 +200,15 @@ enum Experiments {
         return prefsReader.hasEnabledTipsNotifications()
     }
 
+    private static func isAppleIntelligenceAvailable() -> Bool {
+        guard #available(iOS 26, *) else { return false }
+        #if canImport(FoundationModels)
+            return AppleIntelligenceUtil().isAppleIntelligenceAvailable
+        #else
+            return false
+        #endif
+    }
+
     private static func buildNimbus(dbPath: String,
                                     errorReporter: @escaping NimbusErrorReporter,
                                     initialExperiments: URL?,
@@ -214,7 +223,8 @@ enum Experiments {
             isFirstRun: isFirstRun,
             isDefaultBrowser: isDefaultBrowser(),
             isBottomToolbarUser: isBottomToolbarUser(),
-            hasEnabledTipsNotifications: hasEnabledTipsNotifications()
+            hasEnabledTipsNotifications: hasEnabledTipsNotifications(),
+            isAppleIntelligenceAvailable: isAppleIntelligenceAvailable()
         )
 
         return NimbusBuilder(dbPath: dbPath)

--- a/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
+++ b/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
@@ -44,6 +44,7 @@ class RecordedNimbusContext: RecordedContext {
     var isDefaultBrowser: Bool
     var isBottomToolbarUser: Bool
     var hasEnabledTipsNotifications: Bool
+    var isAppleIntelligenceAvailable: Bool
     var appVersion: String?
     var region: String?
     var language: String?
@@ -60,6 +61,7 @@ class RecordedNimbusContext: RecordedContext {
          isDefaultBrowser: Bool,
          isBottomToolbarUser: Bool,
          hasEnabledTipsNotifications: Bool,
+         isAppleIntelligenceAvailable: Bool,
          eventQueries: [String: String] = RecordedNimbusContext.EVENT_QUERIES,
          isPhone: Bool = UIDevice.current.userInterfaceIdiom == .phone,
          bundle: Bundle = Bundle.main,
@@ -73,6 +75,7 @@ class RecordedNimbusContext: RecordedContext {
         self.isDefaultBrowser = isDefaultBrowser
         self.isBottomToolbarUser = isBottomToolbarUser
         self.hasEnabledTipsNotifications = hasEnabledTipsNotifications
+        self.isAppleIntelligenceAvailable = isAppleIntelligenceAvailable
 
         let info = bundle.infoDictionary ?? [:]
         appVersion = info["CFBundleShortVersionString"] as? String
@@ -141,7 +144,8 @@ class RecordedNimbusContext: RecordedContext {
                 region: region,
                 isDefaultBrowser: isDefaultBrowser,
                 isBottomToolbarUser: isBottomToolbarUser,
-                hasEnabledTipsNotifications: hasEnabledTipsNotifications
+                hasEnabledTipsNotifications: hasEnabledTipsNotifications,
+                isAppleIntelligenceAvailable: isAppleIntelligenceAvailable
             )
         )
         GleanMetrics.Pings.shared.nimbus.submit()
@@ -184,6 +188,7 @@ class RecordedNimbusContext: RecordedContext {
             "is_default_browser": isDefaultBrowser,
             "is_bottom_toolbar_user": isBottomToolbarUser,
             "has_enabled_tips_notifications": hasEnabledTipsNotifications,
+            "is_apple_intelligence_available": isAppleIntelligenceAvailable
         ]),
             let jsonString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as? String
         else {

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -3586,6 +3586,8 @@ nimbus_system:
           type: boolean
         has_enabled_tips_notifications:
           type: boolean
+        is_apple_intelligence_available:
+          type: boolean
     description: |
       The Nimbus context object that is recorded to Glean
     bugs:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppleIntelligenceUtilTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppleIntelligenceUtilTests.swift
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+#if canImport(FoundationModels)
+import Shared
+import XCTest
+
+@testable import Client
+
+@available(iOS 26, *)
+final class AppleIntelligenceUtilTests: XCTestCase {
+    var userDefaults: MockUserDefaults!
+    override func setUp() {
+        super.setUp()
+        userDefaults = MockUserDefaults()
+    }
+
+    override func tearDown() {
+        userDefaults = nil
+        super.tearDown()
+    }
+
+    func testAppleIntelligenceAvailability_whenIsAvailable_returnsTrue() {
+        let subject = createSubject()
+        subject.processAvailabilityState(MockLanguageModel(isAvailable: true))
+
+        XCTAssertTrue(subject.isAppleIntelligenceAvailable)
+        XCTAssertTrue(userDefaults.bool(forKey: PrefsKeys.appleIntelligenceAvailable))
+        XCTAssertEqual(userDefaults.setCalledCount, 1)
+    }
+
+    func testAppleIntelligenceAvailability_whenIsNotAvailable_returnsFalse() {
+        let subject = createSubject()
+        subject.processAvailabilityState(MockLanguageModel(isAvailable: false))
+
+        XCTAssertFalse(subject.isAppleIntelligenceAvailable)
+        XCTAssertFalse(userDefaults.bool(forKey: PrefsKeys.appleIntelligenceAvailable))
+        XCTAssertEqual(userDefaults.setCalledCount, 1)
+    }
+
+    func testAppleIntelligenceAvailability_whenNotProcessed_returnsFalse() {
+        let subject = createSubject()
+
+        XCTAssertFalse(subject.isAppleIntelligenceAvailable)
+        XCTAssertFalse(userDefaults.bool(forKey: PrefsKeys.appleIntelligenceAvailable))
+        XCTAssertEqual(userDefaults.setCalledCount, 0)
+    }
+
+    private func createSubject() -> AppleIntelligenceUtil {
+        return AppleIntelligenceUtil(userDefaults: userDefaults)
+    }
+}
+
+final class MockLanguageModel: LanguageModelProtocol {
+    let isAvailable: Bool
+    init(isAvailable: Bool) {
+        self.isAvailable = isAvailable
+    }
+}
+#endif

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
@@ -23,7 +23,8 @@ class RecordedNimbusContextTests: XCTestCase {
             isFirstRun: true,
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
-            hasEnabledTipsNotifications: true
+            hasEnabledTipsNotifications: true,
+            isAppleIntelligenceAvailable: true
         )
         try validateEventQueries(recordedContext: recordedContext)
     }
@@ -33,7 +34,8 @@ class RecordedNimbusContextTests: XCTestCase {
             isFirstRun: true,
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
-            hasEnabledTipsNotifications: true
+            hasEnabledTipsNotifications: true,
+            isAppleIntelligenceAvailable: true
         )
         recordedContext.setEventQueryValues(eventQueryValues: [RecordedNimbusContext.DAYS_OPENED_IN_LAST_28: 1.5])
         let jsonString = recordedContext.toJson()
@@ -58,6 +60,10 @@ class RecordedNimbusContextTests: XCTestCase {
             json?.removeValue(forKey: "has_enabled_tips_notifications") as? Bool,
             recordedContext.hasEnabledTipsNotifications
         )
+        XCTAssertEqual(
+            json?.removeValue(forKey: "is_apple_intelligence_available") as? Bool,
+            recordedContext.isAppleIntelligenceAvailable
+        )
 
         var events = json?.removeValue(forKey: "events") as? [String: Double]
         XCTAssertNotNil(events)
@@ -72,7 +78,8 @@ class RecordedNimbusContextTests: XCTestCase {
             isFirstRun: true,
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
-            hasEnabledTipsNotifications: true
+            hasEnabledTipsNotifications: true,
+            isAppleIntelligenceAvailable: true
         )
 
         var value: GleanMetrics.NimbusSystem.RecordedNimbusContextObject?
@@ -112,7 +119,8 @@ class RecordedNimbusContextTests: XCTestCase {
             isFirstRun: true,
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
-            hasEnabledTipsNotifications: true
+            hasEnabledTipsNotifications: true,
+            isAppleIntelligenceAvailable: true
         )
         let eventQueries = recordedContext.getEventQueries()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12927)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28179)

## :bulb: Description
Add advanced targeting for apple intelligence and created a new utility `AppleIntelligenceUtil` with tests. The apple intelligence checks should be behind iOS 26 and Foundation Models check and we return false to nimbus otherwise. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
