### PR TITLE
Refactor FXIOS [Build] Fix asserts on Fennec configuration

### DIFF
--- a/firefox-ios/Client/Configuration/Fennec.xcconfig
+++ b/firefox-ios/Client/Configuration/Fennec.xcconfig
@@ -17,3 +17,5 @@ CHANNEL = developer
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_$(CHANNEL)
 MOZ_INTERNAL_URL_SCHEME = fennec
 OTHER_LDFLAGS = -ObjC -fprofile-instr-generate -Xlinker -no_application_extension
+SWIFT_OPTIMIZATION_LEVEL = -Onone
+ENABLE_NS_ASSERTIONS = YES


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
Asserts where not behaving as expected. Turns out the `Fennec` build configuration was missing some key flags for them to work as expected. My current understanding is that `assert` was working under certain circumstances in `Client` files, but it seems not fine under some `BrowserKit` packages, like the Redux store. `assert(Thread.isMainThread)` wasn't working (at least for me!) in that case.

By default the build configuration is `Fennec` and not `Debug` on the project:
<img width="1023" height="622" alt="Screenshot 2025-07-25 at 4 20 45 PM" src="https://github.com/user-attachments/assets/3f014947-3bdf-4883-a2f5-aed8fb817bbc" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
