### PR TITLE
Bugfix FXIOS-12958 ⁃ [Menu Redesign] Horizontal Squares menu title, is not aligned

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquareCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuRedesign/MenuSquareCell.swift
@@ -87,15 +87,25 @@ final class MenuSquareView: UIView, ThemeApplicable {
         backgroundContentView.addSubview(contentStackView)
         contentStackView.addArrangedSubview(icon)
         contentStackView.addArrangedSubview(titleLabel)
-        backgroundContentView.addSubview(dividerView)
 
         if #available(iOS 26.0, *) {
+            backgroundContentView.addSubview(dividerView)
             NSLayoutConstraint.activate([
                 dividerView.widthAnchor.constraint(equalToConstant: UX.dividerWidth),
                 dividerView.trailingAnchor.constraint(equalTo: backgroundContentView.trailingAnchor),
                 dividerView.topAnchor.constraint(equalTo: backgroundContentView.topAnchor),
-                dividerView.bottomAnchor.constraint(equalTo: backgroundContentView.bottomAnchor)
+                dividerView.bottomAnchor.constraint(equalTo: backgroundContentView.bottomAnchor),
+
+                contentStackView.trailingAnchor.constraint(
+                    equalTo: dividerView.leadingAnchor,
+                    constant: -UX.contentViewHorizontalMargin
+                )
             ])
+        } else {
+            contentStackView.trailingAnchor.constraint(
+                equalTo: backgroundContentView.trailingAnchor,
+                constant: -UX.contentViewHorizontalMargin
+            ).isActive = true
         }
 
         NSLayoutConstraint.activate([
@@ -111,10 +121,6 @@ final class MenuSquareView: UIView, ThemeApplicable {
             contentStackView.leadingAnchor.constraint(
                 equalTo: backgroundContentView.leadingAnchor,
                 constant: UX.contentViewHorizontalMargin
-            ),
-            contentStackView.trailingAnchor.constraint(
-                equalTo: dividerView.leadingAnchor,
-                constant: -UX.contentViewHorizontalMargin
             ),
             contentStackView.bottomAnchor.constraint(
                 lessThanOrEqualTo: backgroundContentView.bottomAnchor,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12958)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28263)

## :bulb: Description
Don't add divider view for iOS versions, under iOS 26.0

## :movie_camera: Demos
<img width="1206" height="2622" alt="IMG_8545" src="https://github.com/user-attachments/assets/43e3e8e6-ab20-4b96-b759-fa29aa3eb2ad" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
