### PR TITLE
Bugfix FXIOS-12481 - [Tab tray UI experiment] - Last opened tab is briefly displayed after tapping on close all tabs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -11,7 +11,7 @@ import SiteImageView
 
 import enum MozillaAppServices.BookmarkRoots
 
-class TabManagerMiddleware: FeatureFlaggable {
+final class TabManagerMiddleware: FeatureFlaggable {
     private let profile: Profile
     private let logger: Logger
     private let windowManager: WindowManager
@@ -563,11 +563,7 @@ class TabManagerMiddleware: FeatureFlaggable {
             await tabManager.removeAllTabs(isPrivateMode: tabsState.isPrivateMode)
 
             await MainActor.run {
-                let model = getTabsDisplayModel(for: tabsState.isPrivateMode, uuid: uuid)
-                let action = TabPanelMiddlewareAction(tabDisplayModel: model,
-                                                      windowUUID: uuid,
-                                                      actionType: TabPanelMiddlewareActionType.refreshTabs)
-                store.dispatchLegacy(action)
+                triggerRefresh(uuid: uuid, isPrivate: tabsState.isPrivateMode)
 
                 if tabsState.isPrivateMode && !isTabTrayUIExperimentsEnabled {
                     let action = TabPanelMiddlewareAction(toastType: .closedAllTabs(count: privateCount),
@@ -583,13 +579,13 @@ class TabManagerMiddleware: FeatureFlaggable {
                     }
                     addNewTabIfPrivate(uuid: uuid)
                 }
-            }
-        }
 
-        if !tabsState.isPrivateMode {
-            let dismissAction = TabTrayAction(windowUUID: uuid,
-                                              actionType: TabTrayActionType.dismissTabTray)
-            store.dispatchLegacy(dismissAction)
+                if !tabsState.isPrivateMode {
+                    let dismissAction = TabTrayAction(windowUUID: uuid,
+                                                      actionType: TabTrayActionType.dismissTabTray)
+                    store.dispatchLegacy(dismissAction)
+                }
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -9,7 +9,7 @@ import Shared
 import SiteImageView
 
 /// Tab cell used in the tab tray under the .tabTrayUIExperiments Nimbus experiment
-class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
+final class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     struct UX {
         static let selectedBorderWidth: CGFloat = 3.0
         static let unselectedBorderWidth: CGFloat = 1

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -11,7 +11,7 @@ protocol TabTrayThemeable {
     func applyTheme(_ theme: Theme)
 }
 
-class TabDisplayPanelViewController: UIViewController,
+final class TabDisplayPanelViewController: UIViewController,
                                      Themeable,
                                      EmptyPrivateTabsViewDelegate,
                                      StoreSubscriber,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -22,7 +22,7 @@ protocol TabTrayViewControllerDelegate: AnyObject {
     func didFinish()
 }
 
-class TabTrayViewController: UIViewController,
+final class TabTrayViewController: UIViewController,
                              TabTrayController,
                              UIToolbarDelegate,
                              UIPageViewControllerDataSource,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12481)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27208)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Moved `TabTrayActionType.dismissTabTray` to run explicitly on Main Thread and more importantly in sync with the code from `closeAllTabs` method to make sure the animation runs as expected.
- Simplified tab refresh by calling `triggerRefresh` directly instead of dispatching `refreshTabs` action (same logic, less overhead).
- While investigating the bug, I identified several classes that could be marked as `final` to enable static dispatch optimization.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

### Before

https://github.com/user-attachments/assets/a304ef6b-7762-4ba6-aa13-d66296afecac

### After

https://github.com/user-attachments/assets/fa70c459-8703-49c4-8a4a-0bd94faebd35


</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
