### PR TITLE
Add FXIOS [WebEngine] Add documentation for WKInternalSchemeHandler

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalSchemeHandler.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalSchemeHandler.swift
@@ -20,6 +20,11 @@ public protocol SchemeHandler: WKURLSchemeHandler {
 }
 
 /// Will load resources with URL schemes that WebKit doesn’t handle like homepage and error page.
+/// Note: This class has some assumptions and cannot be used in production as of July 2025:
+///  - Error pages are only handled with native error pages (HTML error pages won't be served)
+///  - NativeErrorPageViewController is shown in the Client through a redux action, fired when an error page
+///  needs to be shown this mechanism still needs to be investigated and integrated so error pages can load
+///  (natively) under browser kit.
 public class WKInternalSchemeHandler: NSObject, SchemeHandler {
     public let scheme = "internal"
 


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
That class needs to stay public since it's used under `SampleBrowser`. This whole `SchemeHandler` protocol was added due to the `WKEngineConfigurationProvider` changes, since that class is now used under production code to create a `WKWebViewConfiguration` (this was a way to start using `WebEngine` code under production with a smaller scope rather than the whole project, which uses `Session` instead of the concrete `WKWebView` type).

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
