### PR TITLE
Bugfix FXIOS-12917 - [Toolbar UI Experiments 2] - The zoom page bar percentage is not reset when we swipe tabs from the URL bar

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1817,6 +1817,7 @@
 		DF8C6DD72A52EED1007FAAF2 /* ClientSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8C6DD62A52EED1007FAAF2 /* ClientSyncManagerTests.swift */; };
 		DFACBF7F277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF7E277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift */; };
 		DFACBF85277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF84277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift */; };
+		DFBAE93C2E38E3C000078687 /* BrowserViewController+AddressBarPanGestureHandlerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFBAE93B2E38E3C000078687 /* BrowserViewController+AddressBarPanGestureHandlerDelegate.swift */; };
 		E11C0E3D2CEF328B00D884D3 /* TermsOfServiceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11C0E3C2CEF328B00D884D3 /* TermsOfServiceManager.swift */; };
 		E127313C28B6AD99006F39D2 /* WallpaperSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E127313A28B6AD99006F39D2 /* WallpaperSettingsViewController.swift */; };
 		E127313D28B6AD99006F39D2 /* WallpaperSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E127313B28B6AD99006F39D2 /* WallpaperSettingsViewModel.swift */; };
@@ -10138,6 +10139,7 @@
 		DF8C6DD62A52EED1007FAAF2 /* ClientSyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientSyncManagerTests.swift; sourceTree = "<group>"; };
 		DFACBF7E277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyWallpaperBackgroundView.swift; sourceTree = "<group>"; };
 		DFACBF84277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesRowCountSettingsController.swift; sourceTree = "<group>"; };
+		DFBAE93B2E38E3C000078687 /* BrowserViewController+AddressBarPanGestureHandlerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+AddressBarPanGestureHandlerDelegate.swift"; sourceTree = "<group>"; };
 		DFD6456AA6B9F19B62C14026 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		DFE8447DBAB67C2A5B61E4D0 /* bo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bo; path = bo.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E00742CA84A2A2D0DD19B0AE /* ast */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ast; path = ast.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
@@ -12248,6 +12250,7 @@
 				C8F457A71F1FD75A000CB895 /* BrowserViewController+WebViewDelegates.swift */,
 				434E733625EED32E006D3BDE /* BrowserViewController+URLBarDelegate.swift */,
 				DAE6DF1A29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift */,
+				DFBAE93B2E38E3C000078687 /* BrowserViewController+AddressBarPanGestureHandlerDelegate.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -18356,6 +18359,7 @@
 				E18EA57128AD46D3003F97FC /* WallpaperCollectionType.swift in Sources */,
 				C84655E42887394B00861B4A /* WallpaperMetadata.swift in Sources */,
 				8AB8572E27D94A1A0075C173 /* UXSizeClass.swift in Sources */,
+				DFBAE93C2E38E3C000078687 /* BrowserViewController+AddressBarPanGestureHandlerDelegate.swift in Sources */,
 				965C3C8F29313A1B006499ED /* AppSessionManager.swift in Sources */,
 				ED07C0EF2CCAE856006C0627 /* SearchEngineSelectionMiddleware.swift in Sources */,
 				45D5EDA729269F7500311934 /* DataObserver.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+AddressBarPanGestureHandlerDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+AddressBarPanGestureHandlerDelegate.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 extension BrowserViewController: AddressBarPanGestureHandler.Delegate {
-    func swipeGestureDidChange() {
+    func swipeGestureDidBegin() {
         updateZoomPageBarVisibility(visible: false)
         readerModeBar?.isHidden = true
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+AddressBarPanGestureHandlerDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+AddressBarPanGestureHandlerDelegate.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+extension BrowserViewController: AddressBarPanGestureHandler.Delegate {
+    func swipeGestureDidChange() {
+        updateZoomPageBarVisibility(visible: false)
+        readerModeBar?.isHidden = true
+    }
+
+    func swipeGestureDidEnd() {
+        updateReaderModeBar()
+        readerModeBar?.isHidden = false
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1299,6 +1299,7 @@ class BrowserViewController: UIViewController,
             screenshotHelper: screenshotHelper,
             prefs: profile.prefs
         )
+        addressBarPanGestureHandler?.delegate = self
     }
 
     func addSubviews() {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -8,6 +8,18 @@ import Redux
 import Shared
 
 final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
+    /// Delegate protocol for handling address bar pan gesture events.
+    /// Allows external objects to respond to swipe gesture state changes during tab switching.
+    protocol Delegate: AnyObject {
+        /// Called when the pan gesture state changes during a swipe operation.
+        /// This method is invoked continuously while the user is actively swiping between tabs.
+        func swipeGestureDidChange()
+
+        /// Called when the pan gesture ends, either by completion, cancellation, or failure.
+        /// This method is invoked once at the end of the swipe operation, regardless of outcome.
+        func swipeGestureDidEnd()
+    }
+
     typealias SubscriberStateType = ToolbarState
     // MARK: - UX Constants
     private struct UX {
@@ -32,6 +44,7 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
     private let screenshotHelper: ScreenshotHelper?
     var homepageScreenshotToolProvider: (() -> Screenshotable?)?
     var newTabSettingsProvider: (() -> NewTabPage?)?
+    weak var delegate: AddressBarPanGestureHandler.Delegate?
     private var homepageScreenshot: UIImage?
     private var toolbarState: ToolbarState?
     private let prefs: Prefs
@@ -159,6 +172,7 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
             )
             statusBarOverlay.showOverlay(animated: !UIAccessibility.isReduceMotionEnabled)
         case .changed:
+            delegate?.swipeGestureDidChange()
             if nextTab == nil, homepageScreenshot == nil {
                 let homepageScreenshotTool = homepageScreenshotToolProvider?()
                 homepageScreenshot = homepageScreenshotTool?.screenshot(bounds: CGRect(
@@ -256,6 +270,7 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
                 statusBarOverlay.restoreOverlay(animated: !UIAccessibility.isReduceMotionEnabled,
                                                 isHomepage: contentContainer.hasHomepage)
             }
+            delegate?.swipeGestureDidEnd()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -11,8 +11,8 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
     /// Delegate protocol for handling address bar pan gesture events.
     /// Allows external objects to respond to swipe gesture state changes during tab switching.
     protocol Delegate: AnyObject {
-        /// Called when the pan gesture state changes during a swipe operation.
-        /// This method is invoked once when the user began swiping between tabs.
+        /// Called when the pan gesture begins during a swipe operation.
+        /// This method is invoked once when the user starts swiping between tabs.
         func swipeGestureDidBegin()
 
         /// Called when the pan gesture ends, either by completion, cancellation, or failure.

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -12,8 +12,8 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
     /// Allows external objects to respond to swipe gesture state changes during tab switching.
     protocol Delegate: AnyObject {
         /// Called when the pan gesture state changes during a swipe operation.
-        /// This method is invoked continuously while the user is actively swiping between tabs.
-        func swipeGestureDidChange()
+        /// This method is invoked once when the user began swiping between tabs.
+        func swipeGestureDidBegin()
 
         /// Called when the pan gesture ends, either by completion, cancellation, or failure.
         /// This method is invoked once at the end of the swipe operation, regardless of outcome.
@@ -171,8 +171,8 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
                 )
             )
             statusBarOverlay.showOverlay(animated: !UIAccessibility.isReduceMotionEnabled)
+            delegate?.swipeGestureDidBegin()
         case .changed:
-            delegate?.swipeGestureDidChange()
             if nextTab == nil, homepageScreenshot == nil {
                 let homepageScreenshotTool = homepageScreenshotToolProvider?()
                 homepageScreenshot = homepageScreenshotTool?.screenshot(bounds: CGRect(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12917)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28153)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Remove zoom and reader bar when swiping between tabs.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

https://github.com/user-attachments/assets/111cbb3e-84ee-4d0c-bbef-c0a00655b847


</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
