### PR TITLE
Add [FXIOS-12969] Add ModelInfo with temporary dummy service to unblock UI

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/Backend/ModelInfo.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/ModelInfo.swift
@@ -43,7 +43,6 @@ struct ModelInfo {
     ///   - useAppleModel: Feature flag to determine if the apple model should be used.
     ///   - useHostedModel: Feature flag to determine if the hosted model should be used.
     /// - Returns: A ModelInfo for the first enabled flag, or nil if none.
-    /// 
     static func getEnabledModel(useAppleModel: Bool, useHostedModel: Bool) -> ModelInfo? {
         switch (useAppleModel, useHostedModel) {
         case (true, _):

--- a/BrowserKit/Sources/SummarizeKit/Backend/ModelInfo.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/ModelInfo.swift
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import WebKit
+
+/// A dummy SummarizerService stub to unblock UI development.
+/// TODO(FXIOS-12964): Final SummarizerService class will be merged in this ticket and this will be removed.
+/// This is mainly done to ublock the UI work.
+/// A dummy SummarizerService stub to unblock UI development.
+final class SummarizerService {
+    /// Returns a dummy summary string.
+    func summarize(from webView: WKWebView) async throws -> String {
+        return "This is a dummy summary."
+    }
+
+    /// Streams a dummy summary in chunks.
+    func summarizeStreamed(from webView: WKWebView) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield("This is ")
+            continuation.yield("a dummy ")
+            continuation.yield("streamed summary.")
+            continuation.finish()
+        }
+    }
+}
+
+/// Enum for available models. This is mainly added so that the UI layer knows which model it's using
+/// and if need be present different UI depeding on the model ( e.g. ToS modals, ... )
+enum AvailableModels {
+    case appleModel, hostedModel
+}
+
+/// Main entry point for the UI layer. This is where all the integration should ideally happen.
+/// TODO(FXIOS-12964): Once the final SummarizerService is merged. This will also be responsible for creating the summarizers
+struct ModelInfo {
+    let model: AvailableModels
+    let service: SummarizerService
+
+    /// Returns a configured ModelInfo based on feature flags.
+    /// - Parameters:
+    ///   - useAppleModel: Feature flag to determine if the apple model should be used.
+    ///   - useHostedModel: Feature flag to determine if the hosted model should be used.
+    /// - Returns: A ModelInfo for the first enabled flag, or nil if none.
+    /// 
+    static func getEnabledModel(useAppleModel: Bool, useHostedModel: Bool) -> ModelInfo? {
+        switch (useAppleModel, useHostedModel) {
+        case (true, _):
+            return ModelInfo(model: .appleModel, service: SummarizerService())
+        case (_, true):
+            return ModelInfo(model: .hostedModel, service: SummarizerService())
+        default:
+            return nil
+        }
+    }
+
+    /// Private initializer to enforce factory use
+    private init(model: AvailableModels, service: SummarizerService) {
+        self.model = model
+        self.service = service
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12969)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28294)
## :bulb: Description
This PR:
- Adds `ModelInfo.getEnabledModel(...)` which the entry point for the UI.
- Adds a dummy `SummarizerService` for now to unblock the UI work. 

⚠️ No tests are added here, I have a bunch of them in [FXIOS-12964](https://mozilla-hub.atlassian.net/browse/FXIOS-12964) along with the final service. This is mainly to unblock the UI work. The inteface will be the same as in `SummarizerService` will expose a `summarize` method.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)


[FXIOS-12964]: https://mozilla-hub.atlassian.net/browse/FXIOS-12964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ