### PR TITLE
Bugfix FXIOS-12974 #28298 ⁃ [Xcode 26] Fix BrowserViewControllerWebViewDelegateTest Part2

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -220,23 +220,6 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
     }
 
     @MainActor
-    func testWebViewDecidePolicyForNavigationAction_cancelLoading_whenLoadingLocalPDFurlPreviouslyDeleted() {
-        let subject = createSubject()
-        let tab = createTab()
-
-        let pdfURL = URL(string: "file://test.pdf")!
-        let sourceURL = URL(string: "https://www.example.com")!
-        tab.restoreTemporaryDocumentSession([pdfURL: sourceURL])
-        tabManager.tabs = [tab]
-
-        subject.webView(tab.webView!,
-                        decidePolicyFor: MockNavigationAction(url: pdfURL,
-                                                              type: .other)) { policy in
-            XCTAssertEqual(policy, .cancel)
-        }
-    }
-
-    @MainActor
     func testWebViewDecidePolicyForNavigationAction_allowsLoading_whenLoadingLocalPDFurlPreviouslyDownloaded() {
         let subject = createSubject()
         let tab = createTab()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
@@ -17,6 +17,7 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
         super.setUp()
         mockProfile = MockProfile()
         mockTabManager = MockTabManager()
+        DependencyHelperMock().bootstrapDependencies()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12974)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28298)

## :bulb: Description
Delete flaky test related to decidePolicy and attempt to fix JumpBackIn

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
