### PR TITLE
Refactor FXIOS-12954 [Homepage Redesign] Put homepage background color change behind toolbar flag

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -335,7 +335,8 @@ final class HomepageViewController: UIViewController,
     // MARK: - Theming
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
-        view.backgroundColor = theme.colors.layer3
+        let isToolbarRefactorEnabled = featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
+        view.backgroundColor = isToolbarRefactorEnabled ? theme.colors.layer3 : theme.colors.layer1
     }
 
     // MARK: - Layout

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -336,7 +336,7 @@ final class HomepageViewController: UIViewController,
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         let isToolbarRefactorEnabled = featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
-        view.backgroundColor = isToolbarRefactorEnabled ? theme.colors.layer3 : theme.colors.layer1
+        view.backgroundColor = isToolbarRefactorEnabled ? theme.colors.layerSurfaceLow : theme.colors.layer1
     }
 
     // MARK: - Layout


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12954)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28255)

## :bulb: Description
- Put homepage background color change behind toolbar feature flag as to match the homepage background color with the toolbar color
- Update background color to match toolbar in dark theme as well

| Before | After |
| - | - |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-01 at 10 21 33" src="https://github.com/user-attachments/assets/33aa1ea1-932f-439e-aea1-beb889e0c40f" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-01 at 10 22 34" src="https://github.com/user-attachments/assets/c6701e52-d2cf-42a3-a54a-576d398410bb" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
