### PR TITLE
Refactor FXIOS-11340 - Enable function_body_length and disable the rule for a legacy function

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -107,8 +107,8 @@ closure_body_length:
   error: 34
 
 function_body_length:
-  warning: 364
-  error: 364
+  warning: 363
+  error: 363
 
 file_header:
   required_string: |

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -85,6 +85,7 @@ only_rules: # Only enforce these rules, ignore all others
   - accessibility_trait_for_button
   - force_cast
   - closure_body_length
+  - function_body_length
   - implicitly_unwrapped_optional
 
 # These rules were originally opted into. Disabling for now to get

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -106,6 +106,10 @@ closure_body_length:
   warning: 34
   error: 34
 
+function_body_length:
+  warning: 364
+  error: 364
+
 file_header:
   required_string: |
                     // This Source Code Form is subject to the terms of the Mozilla Public

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -752,6 +752,7 @@ extension TelemetryWrapper {
         gleanRecordEvent(category: category, method: method, object: object, value: value, extras: extras)
     }
 
+    // swiftlint:disable:next function_body_length
     static func gleanRecordEvent(category: EventCategory, method: EventMethod, object: EventObject, value: EventValue? = nil, extras: [String: Any]? = nil) {
         switch (category, method, object, value, extras) {
         // MARK: Bookmarks


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11340)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24679)

## :bulb: Description
This pull request enables the `function_body_length`, defines a threshold to 363 to this rule (lower value to avoid any violations), and disables it for a legacy method. I've discussed with @FilippoZazzeroni about this legacy method and why can be a good idea to just suppress the warning in this case https://github.com/mozilla-mobile/firefox-ios/issues/24679#issuecomment-3130171290.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
