### PR TITLE
Add FXIOS-12988 #28316 ⁃ [Menu Redesign] Enable Menu Redesign on Nightly by default

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1127,7 +1127,9 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertTrue(subject.childCoordinators.first is MainMenuCoordinator)
         XCTAssertEqual(mockRouter.presentCalled, 1)
-        XCTAssertTrue(mockRouter.presentedViewController is DismissableNavigationViewController)
+        if !featureFlags.isFeatureEnabled(.menuRedesign, checking: .buildOnly) {
+            XCTAssertTrue(mockRouter.presentedViewController is DismissableNavigationViewController)
+        }
         XCTAssertTrue(mockRouter.presentedViewController?.children.first is MainMenuViewController)
     }
 
@@ -1147,19 +1149,21 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
     }
 
     func testMainMenuCoordinatorDelegate_navigatesToSettings() {
-        let subject = createSubject()
-        subject.browserHasLoaded()
+        if !featureFlags.isFeatureEnabled(.menuRedesign, checking: .buildOnly) {
+            let subject = createSubject()
+            subject.browserHasLoaded()
 
-        subject.showMainMenu()
-        guard let menuCoordinator = subject.childCoordinators[0] as? MainMenuCoordinator else {
-            XCTFail("Main menu coordinator was expected to be resolved")
-            return
+            subject.showMainMenu()
+            guard let menuCoordinator = subject.childCoordinators[0] as? MainMenuCoordinator else {
+                XCTFail("Main menu coordinator was expected to be resolved")
+                return
+            }
+
+            menuCoordinator.navigateTo(MenuNavigationDestination(.customizeHomepage), animated: false)
+
+            XCTAssertTrue(subject.childCoordinators[0] is SettingsCoordinator)
+            XCTAssertTrue(mockRouter.presentedViewController?.children.first is AppSettingsTableViewController)
         }
-
-        menuCoordinator.navigateTo(MenuNavigationDestination(.customizeHomepage), animated: false)
-
-        XCTAssertTrue(subject.childCoordinators[0] is SettingsCoordinator)
-        XCTAssertTrue(mockRouter.presentedViewController?.children.first is AppSettingsTableViewController)
     }
 
     // MARK: - Search Engine Selection

--- a/firefox-ios/nimbus-features/menuRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/menuRefactorFeature.yaml
@@ -32,15 +32,15 @@ features:
     defaults:
       - channel: beta
         value:
-          enabled: false
+          enabled: true
           menu-hint: false
-          menu-redesign: false
-          menu-default-browser-banner: false
+          menu-redesign: true
+          menu-default-browser-banner: true
           menu-redesign-hint: true
       - channel: developer
         value:
           enabled: true
           menu-hint: true
-          menu-redesign: false
-          menu-default-browser-banner: false
+          menu-redesign: true
+          menu-default-browser-banner: true
           menu-redesign-hint: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12988)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28316)

## :bulb: Description
Enabled Menu Redesign by default on dev on beta versions

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
