### PR TITLE
Fix [MTE-4848] - testLongPressOnPDFLink test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -142,6 +142,7 @@ class BrowsingPDFTests: BaseTestCase {
 
     private func longPressOnPdfLink() {
         let link = app.webViews.links.element(boundBy: 0)
+        mozWaitForElementToExist(link)
         let startCoordinate = link.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
         let endCoordinate = link.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
         startCoordinate.press(forDuration: 3, thenDragTo: endCoordinate)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4848

## :bulb: Description
Small fix for testLongPressOnPDFLink test. Sometimes the page has a delay loading.
Added wait for the link needed to be pressed
