### PR TITLE
Bugfix FXIOS-12945 - [Minimal Address Bar] - Address bar remains visible during scroll in reader mode

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -138,9 +138,13 @@ final class LegacyTabScrollController: NSObject,
                                   isMinimalAddressBarEnabled: Bool,
                                   isBottomSearchBar: Bool) -> CGFloat {
         guard let containerHeight = overKeyboardContainer?.frame.height else { return .zero }
-        // Return full height if minimal address bar is disabled or not using bottom search bar
-        // or if zoom bar is not visible.
-        guard isMinimalAddressBarEnabled && isBottomSearchBar && zoomPageBar == nil else { return containerHeight }
+        let isReaderModeActive = tab?.url?.isReaderModeURL == true
+        // Return full height if conditions aren't met for adjustment.
+        let shouldAdjustHeight = isMinimalAddressBarEnabled
+                                  && isBottomSearchBar
+                                  && zoomPageBar == nil
+                                  && !isReaderModeActive
+        guard shouldAdjustHeight else { return containerHeight }
         // Devices with home indicator (newer iPhones) vs physical home button (older iPhones).
         let hasHomeIndicator = safeAreaInsets?.bottom ?? .zero > 0
         let topInset = safeAreaInsets?.top ?? .zero
@@ -633,7 +637,7 @@ private extension LegacyTabScrollController {
             self.headerTopOffset = headerOffset
             self.bottomContainerOffset = bottomContainerOffset
 
-            if isMinimalAddressBarEnabled && tab?.isFindInPageMode == false {
+            if isMinimalAddressBarEnabled && tab?.isFindInPageMode == false && tab?.url?.isReaderModeURL == false {
                 store.dispatchLegacy(
                     ToolbarAction(
                         scrollAlpha: Float(alpha),
@@ -644,8 +648,6 @@ private extension LegacyTabScrollController {
             }
 
             overKeyboardContainerOffset = overKeyboardOffset
-            overKeyboardContainer?.updateAlphaForSubviews(alpha)
-            overKeyboardContainer?.superview?.layoutIfNeeded()
 
             header?.updateAlphaForSubviews(alpha)
             header?.superview?.layoutIfNeeded()

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -233,7 +233,8 @@ final class AddressToolbarContainer: UIView,
 
     // MARK: - AlphaDimmable
     func updateAlphaForSubviews(_ alpha: CGFloat) {
-        if !isMinimalAddressBarEnabled {
+        let isReaderModeActive = state?.addressToolbar.readerModeState == .active
+        if !isMinimalAddressBarEnabled || isReaderModeActive {
             // when the user scrolls the webpage the address toolbar gets hidden by changing its alpha
             regularToolbar.alpha = alpha
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
@@ -285,6 +285,43 @@ final class TabScrollControllerTests: XCTestCase {
         XCTAssertEqual(result, containerHeight)
     }
 
+    func testOverKeyboardScrollHeight_minimalEnabledIsBottomSearchBarIsReaderModeActive_returnsContainerHeight() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+        tab.url = URL(string: "http://localhost:6571/reader-mode/page?url=https://example.com")!
+
+        let containerHeight: CGFloat = 100
+        let safeAreaInsets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
+        overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
+        subject.overKeyboardContainer = overKeyboardContainer
+
+        let result = subject.overKeyboardScrollHeight(
+            with: safeAreaInsets,
+            isMinimalAddressBarEnabled: true,
+            isBottomSearchBar: true
+        )
+
+        XCTAssertEqual(result, containerHeight)
+    }
+
+    func testOverKeyboardScrollHeight_minimalEnabledIsBottomSearchBarIsNotReaderModeActive_returnsAdjustedHeight() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        let containerHeight: CGFloat = 100
+        let safeAreaInsets = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
+        overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
+        subject.overKeyboardContainer = overKeyboardContainer
+
+        let result = subject.overKeyboardScrollHeight(
+            with: safeAreaInsets,
+            isMinimalAddressBarEnabled: true,
+            isBottomSearchBar: true
+        )
+
+        XCTAssertEqual(result, .zero)
+    }
+
     // MARK: - Setup
     private func setupTabScroll(with subject: LegacyTabScrollController) {
         tab.createWebview(configuration: .init())


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12945)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28236)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Make the address bar scroll when reader mode is active.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

https://github.com/user-attachments/assets/af332132-ca45-4a6d-b51a-6b64dcf86bbe


</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
