### PR TITLE
Add FXIOS-12983 Toolbar entry points for shake to summarize

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -506,10 +506,12 @@ public class BrowserAddressToolbar: UIView,
     // MARK: - UIDragInteractionDelegate
     public func dragInteraction(_ interaction: UIDragInteraction,
                                 itemsForBeginning session: UIDragSession) -> [UIDragItem] {
-        let point = session.location(in: self)
-        // TODO: - refactor it
-        guard locationView.frame.contains(point) else { return [] }
-        guard let url = droppableUrl, let itemProvider = NSItemProvider(contentsOf: url) else { return [] }
+        let dragPoint = session.location(in: self)
+        guard let url = droppableUrl,
+              let itemProvider = NSItemProvider(contentsOf: url),
+              // allow drag only on the location view frame in order to don't mess with long press gesture
+              // on the address bar buttons.
+              locationView.frame.contains(dragPoint) else { return [] }
 
         toolbarDelegate?.addressToolbarDidProvideItemsForDragInteraction()
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -506,6 +506,9 @@ public class BrowserAddressToolbar: UIView,
     // MARK: - UIDragInteractionDelegate
     public func dragInteraction(_ interaction: UIDragInteraction,
                                 itemsForBeginning session: UIDragSession) -> [UIDragItem] {
+        let point = session.location(in: self)
+        // TODO: - refactor it
+        guard locationView.frame.contains(point) else { return [] }
         guard let url = droppableUrl, let itemProvider = NSItemProvider(contentsOf: url) else { return [] }
 
         toolbarDelegate?.addressToolbarDidProvideItemsForDragInteraction()

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -98,7 +98,7 @@ final class LocationView: UIView,
     }
 
     // MARK: - URL Text Field
-    private(set) lazy var urlTextField: LocationTextField = .build { [self] urlTextField in
+    private lazy var urlTextField: LocationTextField = .build { [self] urlTextField in
         urlTextField.backgroundColor = .clear
         urlTextField.font = FXFontStyles.Regular.body.scaledFont()
         urlTextField.adjustsFontForContentSizeCategory = true

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -98,7 +98,7 @@ final class LocationView: UIView,
     }
 
     // MARK: - URL Text Field
-    private lazy var urlTextField: LocationTextField = .build { [self] urlTextField in
+    private(set) lazy var urlTextField: LocationTextField = .build { [self] urlTextField in
         urlTextField.backgroundColor = .clear
         urlTextField.font = FXFontStyles.Regular.body.scaledFont()
         urlTextField.adjustsFontForContentSizeCategory = true

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -23,6 +23,7 @@ struct AccessibilityIdentifiers {
         static let readerModeButton = "TabLocationView.readerModeButton"
         static let reloadButton = "TabLocationView.reloadButton"
         static let shareButton = "TabLocationView.shareButton"
+        static let summarizeButton = "TabLocationView.summarizeButton"
         static let backButton = "TabToolbar.backButton"
         static let fireButton = "TabToolbar.fireButton"
         static let forwardButton = "TabToolbar.forwardButton"

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -54,6 +54,7 @@ enum GeneralBrowserActionType: ActionType {
     case showReloadLongPressAction
     case showMenu
     case showLocationViewLongPressActionSheet
+    case showSummarizer
     case stopLoadingWebsite
     case reloadWebsite
     case reloadWebsiteNoCache

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -34,6 +34,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         case readerModeLongPressAction
         case dataClearance
         case passwordGenerator
+        case summarizer
     }
 
     let windowUUID: WindowUUID
@@ -440,8 +441,15 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 browserViewType: state.browserViewType,
                 displayView: .passwordGenerator,
                 frame: action.frame,
-                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action)
-                )
+                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
+
+        case GeneralBrowserActionType.showSummarizer:
+            return BrowserViewControllerState(
+                searchScreenState: state.searchScreenState,
+                windowUUID: state.windowUUID,
+                browserViewType: state.browserViewType,
+                displayView: .summarizer,
+                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
         default:
             return defaultState(from: state, action: action)
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2742,6 +2742,8 @@ class BrowserViewController: UIViewController,
             presentNewTabLongPressActionSheet(from: view)
         case .dataClearance:
             didTapOnDataClearance()
+        case .summarizer:
+            navigationHandler?.showSummarizePanel()
         case .passwordGenerator:
             if let tab = tabManager.selectedTab, let frame = state.frame {
                 navigationHandler?.showPasswordGenerator(tab: tab, frame: frame)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -76,6 +76,13 @@ struct AddressBarState: StateType, Sendable, Equatable {
         a11yLabel: .TabToolbarDataClearanceAccessibilityLabel,
         a11yId: AccessibilityIdentifiers.Toolbar.fireButton)
 
+    private static let summaryAction = ToolbarActionConfiguration(
+        actionType: .summarizer,
+        iconName: StandardImageIdentifiers.Medium.sun,
+        isEnabled: true,
+        a11yLabel: .Toolbars.SummarizeButtonAccessibilityLabel,
+        a11yId: AccessibilityIdentifiers.Toolbar.summarizeButton)
+
     init(windowUUID: WindowUUID) {
         self.init(
             windowUUID: windowUUID,
@@ -953,17 +960,23 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
         switch readerModeState {
         case .active, .available:
-            let readerModeAction = ToolbarActionConfiguration(
-                actionType: .readerMode,
-                iconName: StandardImageIdentifiers.Medium.readerView,
-                isEnabled: true,
-                isSelected: readerModeState == .active,
-                hasCustomColor: true,
-                a11yLabel: .TabLocationReaderModeAccessibilityLabel,
-                a11yHint: .TabLocationReloadAccessibilityHint,
-                a11yId: AccessibilityIdentifiers.Toolbar.readerModeButton,
-                a11yCustomActionName: .TabLocationReaderModeAddToReadingListAccessibilityLabel)
-            actions.append(readerModeAction)
+            let isSummarizeFeatureEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(.summarizer,
+                                                                                              checking: .buildOnly)
+            if isSummarizeFeatureEnabled {
+                actions.append(summaryAction)
+            } else {
+                let readerModeAction = ToolbarActionConfiguration(
+                    actionType: .readerMode,
+                    iconName: StandardImageIdentifiers.Medium.readerView,
+                    isEnabled: true,
+                    isSelected: readerModeState == .active,
+                    hasCustomColor: true,
+                    a11yLabel: .TabLocationReaderModeAccessibilityLabel,
+                    a11yHint: .TabLocationReloadAccessibilityHint,
+                    a11yId: AccessibilityIdentifiers.Toolbar.readerModeButton,
+                    a11yCustomActionName: .TabLocationReaderModeAddToReadingListAccessibilityLabel)
+                actions.append(readerModeAction)
+            }
         default: break
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -960,8 +960,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
         switch readerModeState {
         case .active, .available:
-            let isSummarizeFeatureEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(.summarizer,
-                                                                                              checking: .buildOnly)
+            let isSummarizeFeatureEnabled = FxNimbus.shared.features.summarizerFeature.value().enabled
             if isSummarizeFeatureEnabled {
                 actions.append(summaryAction)
             } else {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionConfiguration.swift
@@ -20,6 +20,7 @@ struct ToolbarActionConfiguration: Equatable, FeatureFlaggable {
         case trackingProtection
         case locationView
         case readerMode
+        case summarizer
         case dataClearance
         case cancelEdit
     }
@@ -47,6 +48,7 @@ struct ToolbarActionConfiguration: Equatable, FeatureFlaggable {
                actionType == .reload ||
                actionType == .newTab ||
                actionType == .readerMode ||
+               actionType == .summarizer ||
                (actionType == .tabs && isShowingTopTabs == false)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -254,6 +254,10 @@ final class ToolbarMiddleware: FeatureFlaggable {
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.clearData)
             store.dispatchLegacy(action)
+        case .summarizer:
+            let action = GeneralBrowserAction(windowUUID: action.windowUUID,
+                                              actionType: GeneralBrowserActionType.showSummarizer)
+            store.dispatchLegacy(action)
         default:
             break
         }
@@ -296,6 +300,10 @@ final class ToolbarMiddleware: FeatureFlaggable {
         case .readerMode:
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.addToReadingListLongPressAction)
+            store.dispatchLegacy(action)
+        case .summarizer:
+            let action = GeneralBrowserAction(windowUUID: action.windowUUID,
+                                              actionType: GeneralBrowserActionType.showReaderMode)
             store.dispatchLegacy(action)
         default:
             break

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -6686,6 +6686,12 @@ extension String {
             value: "New Tab",
             comment: "Accessibility label for the new tab button that can be displayed in the navigation or address toolbar.")
 
+        public static let SummarizeButtonAccessibilityLabel = MZLocalizedString(
+            key: "Toolbar.NewTab.Button.v130",
+            tableName: "Toolbar",
+            value: "Summarize page",
+            comment: "Accessibility label for the summarize button that can be displayed in the address toolbar.")
+
         public static let TabsButtonAccessibilityLabel = MZLocalizedString(
             key: "Toolbar.Tabs.Button.A11y.Label.v135",
             tableName: "Toolbar",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -91,6 +91,16 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.navigateTo, .reload)
     }
 
+    func testShowSummarizerAction() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        let action = getAction(for: .showSummarizer)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.displayView, .summarizer)
+    }
+
     // MARK: - Navigation Browser Action
     func test_tapOnCustomizeHomepage_navigationBrowserAction_returnsExpectedState() {
         let initialState = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -352,6 +352,19 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
     }
 
+    func testNewState_whenSummarizeDisplayRequested() {
+        let subject = createSubject()
+
+        let newState = BrowserViewControllerState.reducer(
+            BrowserViewControllerState(windowUUID: .XCTestDefaultUUID),
+            GeneralBrowserAction(windowUUID: .XCTestDefaultUUID,
+                                 actionType: GeneralBrowserActionType.showSummarizer)
+        )
+        subject.newState(state: newState)
+
+        XCTAssertEqual(browserCoordinator.showSummarizePanelCalled, 1)
+    }
+
     private func createSubject() -> BrowserViewController {
         let subject = BrowserViewController(profile: profile,
                                             tabManager: tabManager,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -525,6 +525,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(savedExtras.isPrivate, false)
     }
 
+    func testDidTapButton_tapOnSummarizerButton_dispatchesShowSummarizer() throws {
+        try didTapButton(buttonType: .summarizer, expectedActionType: .showSummarizer)
+    }
+
     func testDidTapButton_longPressOnBackButton_dispatchesShowBackForwardList() throws {
         try didLongPressButton(buttonType: .back, expectedActionType: GeneralBrowserActionType.showBackForwardList)
 
@@ -624,6 +628,10 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
     func testDidTapButton_longPressOnReaderMode_dispatchesAddToReadingListLongPressAction() throws {
         try didLongPressButton(buttonType: .readerMode,
                                expectedActionType: GeneralBrowserActionType.addToReadingListLongPressAction)
+    }
+
+    func testDidTapButton_longPressOnSummarizer_dispatchesShowReaderModeAction() throws {
+        try didLongPressButton(buttonType: .summarizer, expectedActionType: .showReaderMode)
     }
 
     func testUrlDidChange_dispatchesBorderPositionChanged() throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12983)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28313)

## :bulb: Description
Add toolbar summarizer button when summarize feature is on.

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
