### PR TITLE
Add FXIOS-12979 [Homepage Redesign - Stories] Add "Top Stories" strings for translations

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoState.swift
@@ -13,6 +13,7 @@ struct MerinoState: StateType, Equatable {
     let merinoData: [MerinoStoryConfiguration]
     let shouldShowSection: Bool
 
+    // TODO: FXIOS-12980: Replace "Stories" title with "Top Stories" string once it is translated in v143
     let sectionHeaderState = SectionHeaderConfiguration(
         title: .FirefoxHomepage.Pocket.SectionTitle,
         a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.merino

--- a/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
@@ -14,6 +14,7 @@ enum HomepageSectionType: Int, CaseIterable {
     case merino
     case customizeHome
 
+    // TODO: FXIOS-12980: Replace "Stories" title with "Top Stories" string once it is translated in v143
     var title: String? {
         switch self {
         case .merino: return .FirefoxHomepage.Pocket.SectionTitle

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -162,6 +162,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             sectionItems.append(bookmarksSetting)
         }
 
+        // TODO: FXIOS-12980: Replace "Stories" title with "Top Stories" string once it is translated in v143
         if isPocketSectionEnabled, let profile {
             let pocketSetting = BoolSetting(
                 prefs: profile.prefs,

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1021,6 +1021,11 @@ extension String {
                 tableName: "FirefoxHomepage",
                 value: "Stories",
                 comment: "This is the title of the Stories section on Firefox Homepage.")
+            public static let TopStoriesSectionTitle = MZLocalizedString(
+                key: "FirefoxHome.Stories.TopStoriesSectionTitle.v140",
+                tableName: "FirefoxHomepage",
+                value: "Top Stories",
+                comment: "This is the title of the Top Stories section on Firefox Homepage.")
             public static let NumberOfMinutes = MZLocalizedString(
                 key: "FirefoxHome.Stories.Minutes.v140",
                 tableName: nil,
@@ -2202,6 +2207,11 @@ extension String {
                     tableName: "CustomizeFirefoxHome",
                     value: "Stories",
                     comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to turn the Stories recommendations section on the Firefox homepage on or off")
+                public static let TopStories = MZLocalizedString(
+                    key: "Settings.Home.Option.TopStories.v140",
+                    tableName: "CustomizeFirefoxHome",
+                    value: "Top Stories",
+                    comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to turn the Top Stories recommendations section on the Firefox homepage on or off")
                 public static let Title = MZLocalizedString(
                     key: "Settings.Home.Option.Title.v101",
                     tableName: nil,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12979)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28310)

## :bulb: Description
- Add "Top Stories" strings for the top stories homepage section header and setting for translations
- Add `TODO` comments to remind us to replace occurrences of the "Stories" string with "Top Stories" once we have translations

- Created [FXIOS-12980: Replace "Stories" string with "Top Stories"](https://mozilla-hub.atlassian.net/browse/FXIOS-12980) to track string replacement followup for v143 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
