### PR TITLE
Add FXIOS-12992 [Shake to Summarize] strings for summarize content settings

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/General/SummarizeSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SummarizeSetting.swift
@@ -20,11 +20,9 @@ class SummarizeSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?) {
         self.settingsDelegate = settingsDelegate
         let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
-        // TODO: FXIOS-12992 - Add Strings when ready
-        let settingTitle = "Summarize Content"
         super.init(
             title: NSAttributedString(
-                string: settingTitle,
+                string: .Settings.Summarize.Title,
                 attributes: [
                     NSAttributedString.Key.foregroundColor: theme.colors.textPrimary
                 ]

--- a/firefox-ios/Client/Frontend/Settings/Summarize/SummarizeSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Summarize/SummarizeSettingsViewController.swift
@@ -10,8 +10,7 @@ final class SummarizeSettingsViewController: SettingsTableViewController, Featur
     init(prefs: Prefs, windowUUID: WindowUUID) {
         self.prefs = prefs
         super.init(style: .grouped, windowUUID: windowUUID)
-        // TODO: FXIOS-12992 - Add Strings when ready
-        self.title = "Summarize Content"
+        self.title = .Settings.Summarize.Title
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -29,20 +28,18 @@ final class SummarizeSettingsViewController: SettingsTableViewController, Featur
         // Shows and hides the gesture section
         // based on the summarize feature being enabled
         // and shake gesture feature flag is true
-        guard summarizeContentEnabled && shakeFeatureFlag else { return [summarizeContentSection] }
+        guard summarizeContentEnabled && shakeFeatureFlag else { return [summarizeSection] }
 
-        return [summarizeContentSection, gesturesSection]
+        return [summarizeSection, gesturesSection]
     }
 
-    private var summarizeContentSection: SettingSection {
-        // TODO: FXIOS-12992 - Add Strings when ready
-        let titleText = "Enable Summarize Content"
+    private var summarizeSection: SettingSection {
         let summarizeContentSetting = BoolSetting(
             prefs: prefs,
             theme: theme,
             prefKey: PrefsKeys.Summarizer.summarizeContentFeature,
             defaultValue: true,
-            titleText: titleText
+            titleText: .Settings.Summarize.SummarizePagesTitle
         ) { [weak self] isOn in
             guard let self else { return }
             // Reload sections to hide and show gesture section
@@ -54,18 +51,20 @@ final class SummarizeSettingsViewController: SettingsTableViewController, Featur
     }
 
     private var gesturesSection: SettingSection {
-        // TODO: FXIOS-12992 - Add Strings when ready
-        let titleText = "Enable Shake Gesture"
-        let sectionTitle = "Gestures"
         let shakeGestureSetting = BoolSetting(
             prefs: prefs,
             theme: theme,
             prefKey: PrefsKeys.Summarizer.shakeGestureEnabled,
             defaultValue: true,
-            titleText: titleText
+            titleText: .Settings.Summarize.GesturesSection.ShakeGestureTitle
         )
         return SettingSection(
-            title: NSAttributedString(string: sectionTitle),
+            title: NSAttributedString(
+                string: .Settings.Summarize.GesturesSection.Title
+            ),
+            footerTitle: NSAttributedString(
+                string: .Settings.Summarize.GesturesSection.FooterTitle
+            ),
             children: [shakeGestureSetting]
         )
     }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2486,27 +2486,46 @@ extension String {
             public static let Title = MZLocalizedString(
                 key: "Settings.Summarize.Title.v142",
                 tableName: "Settings",
-                value: "Summarize Content",
+                value: "Page Summaries",
                 comment: "In the settings menu, in the General section, this is the title for the Summarize settings section."
             )
+
             public static let SummarizeContentTitle = MZLocalizedString(
                 key: "Settings.Summarize.SummarizeContentTitle.v142",
                 tableName: "Settings",
-                value: "Enable Summarize Content",
-                comment: "This is the title for the setting that toggles the Summarize Content feature under the Summarize settings section."
+                value: "Summarize Pages",
+                comment: "This is the title for the setting that toggles the Summarize feature under the Summarize settings section."
             )
-            public static let ShakeGestureTitle = MZLocalizedString(
-                key: "Settings.Summarize.ShakeGestureTitle.v142",
-                tableName: "Settings",
-                value: "Enable Shake Gesture",
-                comment: "This is the title for the setting that toggles the Shake Gesture feature under the Summarize settings section."
-            )
-            public static let GesturesSectionTitle = MZLocalizedString(
+
+            public static let FooterTitle = MZLocalizedString(
                 key: "Settings.Summarize.GesturesSectionTitle.v142",
                 tableName: "Settings",
-                value: "Gestures",
-                comment: "This is the section title for the gestures features under the Summarize settings section."
+                value: "Request to summarize pages from the app menu and address bar.",
+                comment: "This is the footer text for the general summarize toggle setting under the Summarize settings section."
             )
+
+            public struct GesturesSection {
+                public static let GesturesSectionTitle = MZLocalizedString(
+                    key: "Settings.Summarize.GesturesSection.Title.v142",
+                    tableName: "Settings",
+                    value: "Gestures",
+                    comment: "This is the section title for the gestures features under the Summarize settings section."
+                )
+
+                public static let ShakeGestureTitle = MZLocalizedString(
+                    key: "Settings.Summarize.GesturesSection.ShakeGestureTitle.v142",
+                    tableName: "Settings",
+                    value: "Shake to Summarize",
+                    comment: "This is the title for the setting that toggles the Shake Gesture feature under the Summarize settings section."
+                )
+
+                public static let FooterTitle = MZLocalizedString(
+                    key: "Settings.Summarize.GesturesSectionTitle.v142",
+                    tableName: "Settings",
+                    value: "Shake your device from side to side to summarize a page.",
+                    comment: "This is the footer text for the gestures features under the Summarize settings section."
+                )
+            }
         }
 
         public struct Appearance {

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2482,6 +2482,33 @@ extension String {
             )
         }
 
+        public struct Summarize {
+            public static let Title = MZLocalizedString(
+                key: "Settings.Summarize.Title.v142",
+                tableName: "Settings",
+                value: "Summarize Content",
+                comment: "In the settings menu, in the General section, this is the title for the Summarize settings section."
+            )
+            public static let SummarizeContentTitle = MZLocalizedString(
+                key: "Settings.Summarize.SummarizeContentTitle.v142",
+                tableName: "Settings",
+                value: "Enable Summarize Content",
+                comment: "This is the title for the setting that toggles the Summarize Content feature under the Summarize settings section."
+            )
+            public static let ShakeGestureTitle = MZLocalizedString(
+                key: "Settings.Summarize.ShakeGestureTitle.v142",
+                tableName: "Settings",
+                value: "Enable Shake Gesture",
+                comment: "This is the title for the setting that toggles the Shake Gesture feature under the Summarize settings section."
+            )
+            public static let GesturesSectionTitle = MZLocalizedString(
+                key: "Settings.Summarize.GesturesSectionTitle.v142",
+                tableName: "Settings",
+                value: "Gestures",
+                comment: "This is the section title for the gestures features under the Summarize settings section."
+            )
+        }
+
         public struct Appearance {
             public struct PageZoom {
                 public static let SectionHeader = MZLocalizedString(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2490,22 +2490,15 @@ extension String {
                 comment: "In the settings menu, in the General section, this is the title for the Summarize settings section."
             )
 
-            public static let SummarizeContentTitle = MZLocalizedString(
-                key: "Settings.Summarize.SummarizeContentTitle.v142",
+            public static let SummarizePagesTitle = MZLocalizedString(
+                key: "Settings.Summarize.SummarizePagesTitle.v142",
                 tableName: "Settings",
                 value: "Summarize Pages",
                 comment: "This is the title for the setting that toggles the Summarize feature under the Summarize settings section."
             )
 
-            public static let FooterTitle = MZLocalizedString(
-                key: "Settings.Summarize.GesturesSectionTitle.v142",
-                tableName: "Settings",
-                value: "Request to summarize pages from the app menu and address bar.",
-                comment: "This is the footer text for the general summarize toggle setting under the Summarize settings section."
-            )
-
             public struct GesturesSection {
-                public static let GesturesSectionTitle = MZLocalizedString(
+                public static let Title = MZLocalizedString(
                     key: "Settings.Summarize.GesturesSection.Title.v142",
                     tableName: "Settings",
                     value: "Gestures",
@@ -2520,7 +2513,7 @@ extension String {
                 )
 
                 public static let FooterTitle = MZLocalizedString(
-                    key: "Settings.Summarize.GesturesSectionTitle.v142",
+                    key: "Settings.Summarize.GesturesSection.FooterTitle.v142",
                     tableName: "Settings",
                     value: "Shake your device from side to side to summarize a page.",
                     comment: "This is the footer text for the gestures features under the Summarize settings section."


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12992)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28327)

## :bulb: Description
Add strings for Shake to Summarize experiment.
Update existing hard coded strings to pull from our translated strings files.

Also added a footer to the gesture section.

## :movie_camera: Demos
| Settings | Summarize Settings |
| - | - | 
| <img width="1206" height="2622" alt="simulator_screenshot_AAA2D4BE-2EE3-4733-A161-307167218A5B" src="https://github.com/user-attachments/assets/3eaa8bdc-9ed8-4d25-9802-045df515c74c" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-04 at 09 34 49" src="https://github.com/user-attachments/assets/b5675065-6ab4-4bbb-9ec2-5e021aba60bd" /> |

Reference: 
https://www.figma.com/design/U6RLYEt44nGdFUluQ01LZW/Shake-to-Summarize?node-id=13143-14139&m=dev

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
