### PR TITLE
Refactor FXIOS-12990 [Summarizer] Update nimbus configurations

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -46,8 +46,10 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case startAtHome
     case appleSummarizer
     case appleSummarizerToolbarEntrypoint
+    case appleSummarizerShakeGesture
     case hostedSummarizer
     case hostedSummarizerToolbarEntrypoint
+    case hostedSummarizerShakeGesture
     case tabTrayUIExperiments
     case toolbarNavigationHint
     case toolbarUpdateHint
@@ -160,8 +162,10 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .splashScreen,
                 .appleSummarizer,
                 .appleSummarizerToolbarEntrypoint,
+                .appleSummarizerShakeGesture,
                 .hostedSummarizer,
                 .hostedSummarizerToolbarEntrypoint,
+                .hostedSummarizerShakeGesture,
                 .tabTrayUIExperiments,
                 .toolbarNavigationHint,
                 .toolbarUpdateHint,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -332,16 +332,8 @@ class BrowserViewController: UIViewController,
         return featureFlags.isFeatureEnabled(.homepageSearchBar, checking: .buildOnly)
     }
 
-    var isAppleSummarizerFeatureEnabled: Bool {
-        SummarizerNimbusUtils.shared.isAppleSummarizerEnabled()
-    }
-
-    var isHostedSummarizerFeatureEnabled: Bool {
-        SummarizerNimbusUtils.shared.isHostedSummarizerEnabled()
-    }
-
     var isSummarizeFeatureEnabled: Bool {
-        isAppleSummarizerFeatureEnabled || isHostedSummarizerFeatureEnabled
+        return SummarizerNimbusUtils.shared.isSummarizeFeatureEnabled
     }
 
     // MARK: Computed vars

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -61,16 +61,8 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         featureFlags.isFeatureEnabled(.appearanceMenu, checking: .buildOnly)
     }
 
-    var isAppleSummarizerFeatureEnabled: Bool {
-        SummarizerNimbusUtils.shared.isAppleSummarizerEnabled()
-    }
-
-    var isHostedSummarizerFeatureEnabled: Bool {
-        SummarizerNimbusUtils.shared.isHostedSummarizerEnabled()
-    }
-
     private var isSummarizerOn: Bool {
-        isAppleSummarizerFeatureEnabled || isHostedSummarizerFeatureEnabled
+        return SummarizerNimbusUtils.shared.isSummarizeFeatureEnabled
     }
 
     private var isMenuRedesignOn: Bool {

--- a/firefox-ios/Client/Frontend/Summary/SummarizerNimbusUtils.swift
+++ b/firefox-ios/Client/Frontend/Summary/SummarizerNimbusUtils.swift
@@ -8,7 +8,11 @@ import Foundation
 struct SummarizerNimbusUtils: FeatureFlaggable {
     static let shared = SummarizerNimbusUtils()
 
-    func isAppleSummarizerEnabled() -> Bool {
+    var isSummarizeFeatureEnabled: Bool {
+        return isAppleSummarizerEnabled() || isHostedSummarizerEnabled()
+    }
+
+    private func isAppleSummarizerEnabled() -> Bool {
         #if canImport(FoundationModels)
             let isFlagEnabled = featureFlags.isFeatureEnabled(.appleSummarizer, checking: .buildOnly)
             return AppleIntelligenceUtil().isAppleIntelligenceAvailable && isFlagEnabled
@@ -17,7 +21,7 @@ struct SummarizerNimbusUtils: FeatureFlaggable {
         #endif
     }
 
-    func isHostedSummarizerEnabled() -> Bool {
+    private func isHostedSummarizerEnabled() -> Bool {
         return featureFlags.isFeatureEnabled(.hostedSummarizer, checking: .buildOnly)
     }
 

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -113,11 +113,17 @@ final class NimbusFeatureFlagLayer {
         case .appleSummarizerToolbarEntrypoint:
            return checkAppleSummarizerToolbarEntrypoint(from: nimbus)
 
+        case .appleSummarizerShakeGesture:
+           return checkAppleSummarizerShakeGesture(from: nimbus)
+
         case .hostedSummarizer:
             return checkHostedSummarizerFeature(from: nimbus)
 
         case .hostedSummarizerToolbarEntrypoint:
            return checkHostedSummarizerToolbarEntrypoint(from: nimbus)
+
+        case .hostedSummarizerShakeGesture:
+           return checkHostedSummarizerShakeGesture(from: nimbus)
 
         case .toolbarRefactor:
             return checkToolbarRefactorFeature(from: nimbus)
@@ -423,6 +429,7 @@ final class NimbusFeatureFlagLayer {
         return config.enabled
     }
 
+    // MARK: - Summarizer Feature
     private func checkAppleSummarizerFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.appleSummarizerFeature.value()
         return config.enabled
@@ -433,6 +440,10 @@ final class NimbusFeatureFlagLayer {
         return config.toolbarEntrypoint
     }
 
+    private func checkAppleSummarizerShakeGesture(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.appleSummarizerFeature.value().shakeGesture
+    }
+
     private func checkHostedSummarizerFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.hostedSummarizerFeature.value()
         return config.enabled
@@ -441,6 +452,10 @@ final class NimbusFeatureFlagLayer {
     private func checkHostedSummarizerToolbarEntrypoint(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.hostedSummarizerFeature.value()
         return config.toolbarEntrypoint
+    }
+
+    private func checkHostedSummarizerShakeGesture(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.hostedSummarizerFeature.value().shakeGesture
     }
 
     private func checkUpdatedPasswordManagerFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/nimbus-features/appleSummarizerFeature.yaml
+++ b/firefox-ios/nimbus-features/appleSummarizerFeature.yaml
@@ -14,12 +14,19 @@ features:
           Enables the toolbar entrypoint for the summarizer feature.
         type: Boolean
         default: false
+      shakeGesture:
+        description: >
+          Enables the shake gesture for the summarizer feature.
+        type: Boolean
+        default: false
     defaults:
       - channel: beta
         value:
           enabled: true
           toolbarEntrypoint: true
+          shakeGesture: true
       - channel: developer
         value:
           enabled: true
           toolbarEntrypoint: true
+          shakeGesture: true

--- a/firefox-ios/nimbus-features/hostedSummarizerFeature.yaml
+++ b/firefox-ios/nimbus-features/hostedSummarizerFeature.yaml
@@ -14,12 +14,19 @@ features:
           Enables the toolbar entrypoint for the summarizer feature.
         type: Boolean
         default: false
+      shakeGesture:
+        description: >
+          Enables the shake gesture for the summarizer feature.
+        type: Boolean
+        default: false
     defaults:
       - channel: beta
         value:
           enabled: true
           toolbarEntrypoint: true
+          shakeGesture: true
       - channel: developer
         value:
           enabled: true
           toolbarEntrypoint: true
+          shakeGesture: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12990)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28322)

## :bulb: Description
- Update `isSummarizeFeatureEnabled` to be included in `SummarizerNimbusUtils` to avoid duplication of code and for simple access whether the summarize feature is on in general
- Add sub-flag for Shake Gesture, related to this [ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12993) 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
