### PR TITLE
Bugfix FXIOS-12949 #28248 ⁃ [Swift 6 Migration] - Fix Swift 6 warning for ScreenshotHelper and UIView+Screenshot extension

### DIFF
--- a/firefox-ios/Client/Extensions/UIView+Screenshot.swift
+++ b/firefox-ios/Client/Extensions/UIView+Screenshot.swift
@@ -5,8 +5,10 @@
 import UIKit
 
 protocol Screenshotable {
+    @MainActor
     func screenshot(quality: CGFloat) -> UIImage?
 
+    @MainActor
     func screenshot(bounds: CGRect) -> UIImage?
 }
 

--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -10,9 +10,10 @@ import Common
  * Handles screenshots for a given tab, including pages with non-webview content.
  */
 class ScreenshotHelper {
-    fileprivate weak var controller: BrowserViewController?
+    private weak var controller: BrowserViewController?
     private let logger: Logger
 
+    @MainActor
     private var isIpad: Bool {
         // An additional check for horizontalSizeClass is needed since for iPad in multi windows state
         // the smallest window possible has horizontalSizeClass equal to compact, thus behave like an iPhone.
@@ -37,6 +38,7 @@ class ScreenshotHelper {
     /// The tool used to take a screenshot for a Tab depends on the contentType.
     /// For the homepage, the controller is used to generate the screenshot.
     /// For WebView content, the screenshot is captured directly from the view using takeSnapshot.
+    @MainActor
     func takeScreenshot(_ tab: Tab,
                         windowUUID: WindowUUID,
                         screenshotBounds: CGRect,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12949)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28248)

## :bulb: Description
- Add mainActor to screenshot-related code
- Tested manually and I didn't see anything off and screenshots were shown as expected 


<img width="550" height="901" alt="Screenshot 2025-07-25 at 12 32 59 PM" src="https://github.com/user-attachments/assets/4b8bd063-b886-48e3-aef1-a974af1d8711" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
