### PR TITLE
Refactor FXIOS-12962 [Merino] Use locales from Merino AS

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -794,6 +794,7 @@
 		819656192C80ECFE00E62323 /* MainMenuMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819656182C80ECFE00E62323 /* MainMenuMiddleware.swift */; };
 		81A3F6F02C2DAEE200BDD86B /* MainMenuCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A3F6EF2C2DAEE200BDD86B /* MainMenuCoordinator.swift */; };
 		81A3F6F22C2DB00900BDD86B /* MainMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A3F6F12C2DB00900BDD86B /* MainMenuViewController.swift */; };
+		81AE06F62E3AA6A3002C3E58 /* MerinoProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81AE06F52E3AA69F002C3E58 /* MerinoProviderTests.swift */; };
 		81C297F92CA3117200B8BE78 /* MenuNavigationDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81C297F82CA3117200B8BE78 /* MenuNavigationDestination.swift */; };
 		81C381502E2D22DB00096AAE /* MerinoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81C3814F2E2D22DB00096AAE /* MerinoProvider.swift */; };
 		81C3E6092C93261A00A19A5A /* MainMenuDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81C3E6082C93261A00A19A5A /* MainMenuDetailsViewController.swift */; };
@@ -8206,6 +8207,7 @@
 		81A244F4A7C6FC8976DC21F0 /* br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = br; path = br.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		81A3F6EF2C2DAEE200BDD86B /* MainMenuCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuCoordinator.swift; sourceTree = "<group>"; };
 		81A3F6F12C2DB00900BDD86B /* MainMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuViewController.swift; sourceTree = "<group>"; };
+		81AE06F52E3AA69F002C3E58 /* MerinoProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerinoProviderTests.swift; sourceTree = "<group>"; };
 		81C14765AA7C25DF1817AC04 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Today.strings; sourceTree = "<group>"; };
 		81C297F82CA3117200B8BE78 /* MenuNavigationDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuNavigationDestination.swift; sourceTree = "<group>"; };
 		81C3814F2E2D22DB00096AAE /* MerinoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerinoProvider.swift; sourceTree = "<group>"; };
@@ -15555,6 +15557,7 @@
 				0EC57CE12CA31AFC002E3F04 /* PasswordGenerator */,
 				CA24B53A24ABFE5D0093848C /* PasswordManagerDataSourceHelperTests.swift */,
 				CA24B53824ABFE250093848C /* PasswordManagerSelectionHelperTests.swift */,
+				81AE06F52E3AA69F002C3E58 /* MerinoProviderTests.swift */,
 				CA24B52024ABD7D40093848C /* PasswordManagerViewModelTests.swift */,
 				2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */,
 				8ABCFEA42B45CAC300C2988A /* PrivateBrowsingTelemetryTests.swift */,
@@ -18964,6 +18967,7 @@
 				615532D42D7AA5F30046347F /* ScreenshotHelperTests.swift in Sources */,
 				8A87B4342CC1A731003A9239 /* MerinoMiddlewareTests.swift in Sources */,
 				21B548972B1E6AC300DC1DF8 /* MockInactiveTabsManager.swift in Sources */,
+				81AE06F62E3AA6A3002C3E58 /* MerinoProviderTests.swift in Sources */,
 				21B337BB29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift in Sources */,
 				6ADB651B285C03B100947EA4 /* DownloadHelperTests.swift in Sources */,
 				8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */,

--- a/firefox-ios/Providers/Merino/MerinoProvider.swift
+++ b/firefox-ios/Providers/Merino/MerinoProvider.swift
@@ -20,19 +20,6 @@ extension MerinoStoriesProviding {
 }
 
 final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked Sendable {
-    private static let SupportedLocales = [
-        "de_DE",
-        "de_AT",
-        "de_CH",
-        "en_CA",
-        "en_US",
-        "en_GB",
-        "en_ZA",
-        "es_ES",
-        "fr_FR",
-        "it_IT",
-    ]
-
     private let prefs: Prefs
     private var logger: Logger
 
@@ -134,9 +121,8 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
         }
     }
 
-    // Returns nil if the locale is not supported
     static func islocaleSupported(_ locale: String) -> Bool {
-        return MerinoProvider.SupportedLocales.contains(locale)
+        return allCuratedRecommendationLocales().contains(locale.replacingOccurrences(of: "_", with: "-"))
     }
 
     private var shouldUseMockData: Bool {
@@ -144,22 +130,8 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
     }
 
     private func iOSToMerinoLocale(from locale: String) -> CuratedRecommendationLocale? {
-        switch locale {
-        case "en": return .en
-        case "en_CA": return .enCa
-        case "en_GB": return .enGb
-        case "en_US": return .enUs
-        case "de": return .de
-        case "de_DE": return .deDe
-        case "de_AT": return .deAt
-        case "de_CH": return .deCh
-        case "fr": return .fr
-        case "fr_FR": return .frFr
-        case "es": return .es
-        case "es_ES": return .esEs
-        case "it": return .it
-        case "it_IT": return .itIt
-        default: return nil
-        }
+        return curatedRecommendationLocaleFromString(
+            locale: locale.replacingOccurrences(of: "_", with: "-")
+        )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MozillaAppServices
+
+@testable import Client
+
+class MerinoProviderTests: XCTestCase {
+    func testIncorrectLocalesAreNotSupported() {
+        XCTAssertFalse(MerinoProvider.islocaleSupported("en_BD"))
+        XCTAssertFalse(MerinoProvider.islocaleSupported("enCA"))
+    }
+
+    func testCorrectLocalesAreSupported() {
+        XCTAssertTrue(MerinoProvider.islocaleSupported("en_US"))
+        XCTAssertTrue(MerinoProvider.islocaleSupported("en_GB"))
+        XCTAssertTrue(MerinoProvider.islocaleSupported("en_CA"))
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12962)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28172)

## :bulb: Description
Basically, instead of managing the list of supported locales manually, we're now checking against Merino, so if they update, we get it automagically!

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
