### PR TITLE
Bugfix FXIOS-12998 [Summarizer] Make view read-only and fix typo in plist var

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -129,6 +129,7 @@ public class SummarizeController: UIViewController, Themeable {
             bottom: UX.tabSnapshotFinalPositionBottomPadding,
             right: 0.0
         )
+        $0.isEditable = false
     }
 
     public init(

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -6,7 +6,7 @@
 	<string>$(LITE_LLM_API_KEY)</string>
 	<key>LiteLLMAPIEndpoint</key>
 	<string>$(LITE_LLM_API_ENDPOINT)</string>
-	<key> LiteLLMAPIModel</key>
+	<key>LiteLLMAPIModel</key>
 	<string>$(LITE_LLM_API_MODEL)</string>
 	<key>SKAdNetworkItems</key>
 	<array>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12998)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28347)

## :bulb: Description
This PR:
- Makes summarizer view read only.
- Fixes typo in plist var key that had a leading space.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/fbac9c04-cc54-463a-9797-6b2a224f5b80" /> | <video src="https://github.com/user-attachments/assets/f4c7ec69-6852-4429-8a72-e7031a1edd61"/> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
