### PR TITLE
Add FXIOS-12992 [Shake to Summarize] Settings cell

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1465,6 +1465,7 @@
 		BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */; };
 		BC0723522E33D7A6005BAC05 /* AppleIntelligenceUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0723512E33D7A2005BAC05 /* AppleIntelligenceUtilTests.swift */; };
 		BC8E91DC2E32953C00434FD0 /* AppleIntelligenceUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */; };
+		BCBE058C2E3A8720004B6039 /* SummarizeSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBE058B2E3A871B004B6039 /* SummarizeSetting.swift */; };
 		BCFB141D2E1FFEC00005D46B /* feltPrivacySimplifiedUIOff.json in Resources */ = {isa = PBXBuildFile; fileRef = BCFB141C2E1FFEC00005D46B /* feltPrivacySimplifiedUIOff.json */; };
 		BCFB141F2E1FFECC0005D46B /* feltPrivacySimplifiedUIOn.json in Resources */ = {isa = PBXBuildFile; fileRef = BCFB141E2E1FFECC0005D46B /* feltPrivacySimplifiedUIOn.json */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
@@ -9301,6 +9302,7 @@
 		BC4B49618B8FC822D4D0FCC2 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BC81442AA84F635F3067A2C5 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
 		BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceUtil.swift; sourceTree = "<group>"; };
+		BCBE058B2E3A871B004B6039 /* SummarizeSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizeSetting.swift; sourceTree = "<group>"; };
 		BCD04CE4A62EAA4DF96DE812 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/Storage.strings"; sourceTree = "<group>"; };
 		BCFB141C2E1FFEC00005D46B /* feltPrivacySimplifiedUIOff.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = feltPrivacySimplifiedUIOff.json; sourceTree = "<group>"; };
 		BCFB141E2E1FFECC0005D46B /* feltPrivacySimplifiedUIOn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = feltPrivacySimplifiedUIOn.json; sourceTree = "<group>"; };
@@ -12773,6 +12775,7 @@
 		8A5D1CA22A30D661005AD35C /* General */ = {
 			isa = PBXGroup;
 			children = (
+				BCBE058B2E3A871B004B6039 /* SummarizeSetting.swift */,
 				8ADED55D2D667A7700345293 /* BrowsingSetting.swift */,
 				8A15AB722D5FDB24008BB03C /* AutoplaySetting.swift */,
 				8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */,
@@ -18349,6 +18352,7 @@
 				5A2918CB2B522338002B197E /* GeneralBrowserAction.swift in Sources */,
 				8A5D1CC12A30DCA4005AD35C /* SettingDisclosureUtility.swift in Sources */,
 				8ADED55C2D6679D500345293 /* BrowsingSettingsViewController.swift in Sources */,
+				BCBE058C2E3A8720004B6039 /* SummarizeSetting.swift in Sources */,
 				E1442FD5294782D9003680B0 /* UIView+SnapKit.swift in Sources */,
 				2816F0001B33E05400522243 /* UIConstants.swift in Sources */,
 				21E78A7228F9A93100F8D687 /* UIDeviceInterface.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -673,6 +673,10 @@ struct AccessibilityIdentifiers {
             static let blockImages = "NoImageModeStatus"
         }
 
+        struct Summarize {
+            static let title = "SummarizeSettings"
+        }
+
         struct Theme {
             static let title = "DisplayThemeOption"
         }

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -432,6 +432,10 @@ final class SettingsCoordinator: BaseCoordinator,
         router.push(viewController)
     }
 
+    func pressedSummarize() {
+        /// TODO: FXIOS-12645 Add Summarize Settings View Controller
+    }
+
     // MARK: AccountSettingsDelegate
 
     func pressedConnectSetting() {

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -363,6 +363,10 @@ class AppSettingsTableViewController: SettingsTableViewController,
             )
         }
 
+        if SummarizerNimbusUtils.shared.isSummarizeFeatureEnabled {
+            generalSettings.append(SummarizeSetting(settings: self, settingsDelegate: parentCoordinator))
+        }
+
         generalSettings += [
             SiriPageSetting(settings: self, settingsDelegate: parentCoordinator)
         ]

--- a/firefox-ios/Client/Frontend/Settings/Main/General/GeneralSettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/GeneralSettingsDelegate.swift
@@ -31,5 +31,8 @@ protocol GeneralSettingsDelegate: AnyObject {
     func pressedBrowsing()
 
     @MainActor
+    func pressedSummarize()
+
+    @MainActor
     func pressedAutoFillsPasswords()
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SummarizeSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SummarizeSetting.swift
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class SummarizeSetting: Setting {
+    private weak var settingsDelegate: GeneralSettingsDelegate?
+
+    override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
+        return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
+    }
+
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.Summarize.title
+    }
+
+    init(settings: SettingsTableViewController,
+         settingsDelegate: GeneralSettingsDelegate?) {
+        self.settingsDelegate = settingsDelegate
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
+        // TODO: FXIOS-12645 - Add from Strings when ready
+        let settingTitle = "Summarize Content"
+        super.init(
+            title: NSAttributedString(
+                string: settingTitle,
+                attributes: [
+                    NSAttributedString.Key.foregroundColor: theme.colors.textPrimary
+                ]
+            )
+        )
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        settingsDelegate?.pressedSummarize()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -13,6 +13,7 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
                                 AboutSettingsDelegate,
                                 SupportSettingsDelegate,
                                 BrowsingSettingsDelegate {
+
     var showDevicePassCodeCalled = 0
     var showCreditCardSettingsCalled = 0
     var didFinishShowingSettingsCalled = 0
@@ -70,7 +71,9 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
 
     func pressedBrowsing() {}
 
-    func pressedAutoFillsPasswords() {}
+    func pressedSummarize() { }
+
+    func pressedAutoFillsPasswords() { }
 
     // MARK: BrowsingSettingsDelegate
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -13,7 +13,6 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
                                 AboutSettingsDelegate,
                                 SupportSettingsDelegate,
                                 BrowsingSettingsDelegate {
-
     var showDevicePassCodeCalled = 0
     var showCreditCardSettingsCalled = 0
     var didFinishShowingSettingsCalled = 0
@@ -71,9 +70,9 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
 
     func pressedBrowsing() {}
 
-    func pressedSummarize() { }
+    func pressedSummarize() {}
 
-    func pressedAutoFillsPasswords() { }
+    func pressedAutoFillsPasswords() {}
 
     // MARK: BrowsingSettingsDelegate
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12992)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28327)

## :bulb: Description
This PR adds the "Summarize Content" setting to our Settings screen and sets up the coordinator to present the Summarize Settings screen (which will be in a separate PR). The setting cell should appear depending on the whether the summarize feature is enabled.

Note: UI tests will be created in future PR as well.

## :movie_camera: Demos
| iPhone | iPad
| --- | --- |
|<img alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-30 at 13 11 23" src="https://github.com/user-attachments/assets/622e05d7-da26-47a7-bedc-b4c2acba5e83" />| <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-07-31 at 08 21 22" src="https://github.com/user-attachments/assets/1f2c11c1-f3a8-4755-a2ee-a119c681463b" />|

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
