### PR TITLE
Add FXIOS-12678 Investigate how to disable scroll options inside Homepage Menu

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuTableView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuTableView.swift
@@ -9,6 +9,7 @@ import Common
 final class MenuTableView: UIView,
                            UITableViewDelegate,
                            UITableViewDataSource,
+                           UIScrollViewDelegate,
                            ThemeApplicable {
     private struct UX {
         static let topPadding: CGFloat = 24
@@ -22,6 +23,7 @@ final class MenuTableView: UIView,
     private var menuData: [MenuSection]
     private var theme: Theme?
     private var isBannerVisible = false
+    private var isHomepage = false
 
     public var tableViewContentSize: CGFloat {
         tableView.contentSize.height
@@ -33,6 +35,7 @@ final class MenuTableView: UIView,
         tableView.sectionFooterHeight = 0
         menuData = []
         super.init(frame: .zero)
+        tableView.delegate = self
         setupView()
     }
 
@@ -82,6 +85,7 @@ final class MenuTableView: UIView,
         heightForHeaderInSection section: Int
     ) -> CGFloat {
         if let menuSection = menuData.first(where: { $0.isHomepage }), menuSection.isHomepage {
+            self.isHomepage = true
             let topPadding = isBannerVisible ? UX.topPaddingWithBanner : UX.topPadding
             return section == 0 ? topPadding : UX.distanceBetweenSections
         }
@@ -190,6 +194,13 @@ final class MenuTableView: UIView,
             return headerView
         }
         return nil
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if isHomepage, !UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory {
+            scrollView.contentOffset = .zero
+            scrollView.showsVerticalScrollIndicator = false
+        }
     }
 
     func reloadTableView(with data: [MenuSection], isBannerVisible: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12678)

## :bulb: Description
Don't use scroll for homepage menu

## :movie_camera: Demos

https://github.com/user-attachments/assets/aa7c7700-4dec-47f9-9646-e9aa168ec654



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
