### PR TITLE
Bugfix FXIOS-12978 #28306 ⁃ [TabScrollController refactor] Do we need ThemeManager in TabScrollController

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollController.swift
@@ -212,13 +212,6 @@ final class TabScrollController: NSObject,
         }
     }
 
-    @objc
-    private func applicationWillTerminate(_ notification: Notification) {
-        // Ensures that we immediately de-register KVO observations for content size changes in
-        // webviews if the app is about to terminate.
-        observedScrollViews.forEach({ stopObserving(scrollView: $0) })
-    }
-
     func handlePan(_ gesture: UIPanGestureRecognizer) {
         guard !tabIsLoading() else { return }
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollController.swift
@@ -197,11 +197,19 @@ final class TabScrollController: NSObject,
         self.notificationCenter = notificationCenter
         self.logger = logger
         super.init()
+        setupNotifications()
     }
 
     func traitCollectionDidChange() {
         removePullRefreshControl()
         configureRefreshControl()
+    }
+
+    private func setupNotifications() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(applicationWillTerminate(_:)),
+                                               name: UIApplication.willTerminateNotification,
+                                               object: nil)
     }
 
     private func handleOnTabContentLoading() {
@@ -210,6 +218,13 @@ final class TabScrollController: NSObject,
         } else {
             configureRefreshControl()
         }
+    }
+
+    @objc
+    private func applicationWillTerminate(_ notification: Notification) {
+        // Ensures that we immediately de-register KVO observations for content size changes in
+        // webviews if the app is about to terminate.
+        observedScrollViews.forEach({ stopObserving(scrollView: $0) })
     }
 
     func handlePan(_ gesture: UIPanGestureRecognizer) {

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollController.swift
@@ -9,7 +9,6 @@ import Common
 
 final class TabScrollController: NSObject,
                                  SearchBarLocationProvider,
-                                 Themeable,
                                  UIScrollViewDelegate {
     private struct UX {
         static let abruptScrollEventOffset: CGFloat = 200
@@ -168,8 +167,6 @@ final class TabScrollController: NSObject,
     private var isAnimatingToolbar = false
     private var shouldRespondToScroll = false
 
-    var themeManager: any ThemeManager
-    var themeObserver: (any NSObjectProtocol)?
     var notificationCenter: any NotificationProtocol
     var currentWindowUUID: WindowUUID? {
         return windowUUID
@@ -191,37 +188,20 @@ final class TabScrollController: NSObject,
     deinit {
         logger.log("TabScrollController deallocating", level: .info, category: .lifecycle)
         observedScrollViews.forEach({ stopObserving(scrollView: $0) })
-        guard let themeObserver else { return }
-        notificationCenter.removeObserver(themeObserver)
     }
 
     init(windowUUID: WindowUUID,
-         themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          logger: Logger = DefaultLogger.shared) {
-        self.themeManager = themeManager
         self.windowUUID = windowUUID
         self.notificationCenter = notificationCenter
         self.logger = logger
         super.init()
-        setupNotifications()
     }
 
     func traitCollectionDidChange() {
         removePullRefreshControl()
         configureRefreshControl()
-    }
-
-    private func setupNotifications() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(applicationWillTerminate(_:)),
-                                               name: UIApplication.willTerminateNotification,
-                                               object: nil)
-        // need to add this manually otherwise listenForThemeChanges(view) will retain the view in memory
-        // causing memory leaks
-        themeObserver = notificationCenter.addObserver(name: .ThemeDidChange, queue: .main) { [weak self] _ in
-            self?.applyTheme()
-        }
     }
 
     private func handleOnTabContentLoading() {
@@ -390,13 +370,6 @@ final class TabScrollController: NSObject,
         tab?.webView?.addPullRefresh { [weak self] in
             self?.reload()
         }
-        applyTheme()
-    }
-
-    // MARK: - Themeable
-
-    func applyTheme() {
-        tab?.webView?.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
     }
 
     // MARK: - UIScrollViewDelegate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12978)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28306)

## :bulb: Description
- Remove theming from TabScrollController
- Tested manually and I couldn't find any bug related to theming with toolbars, reader mode and ZoomBar


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
