### PR TITLE
Add FXIOS-13001 [Shortcuts Library] Shortcuts library feature flag

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -25,6 +25,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case homepageRebuild
     case homepageRedesign
     case homepageSearchBar
+    case homepageShortcutsLibrary
     case homepageStoriesRedesign
     case inactiveTabs
     case loginsVerificationEnabled
@@ -75,6 +76,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .homepageRebuild,
                 .homepageStoriesRedesign,
                 .homepageSearchBar,
+                .homepageShortcutsLibrary,
                 .feltPrivacyFeltDeletion,
                 .feltPrivacySimplifiedUI,
                 .menuRefactor,
@@ -141,6 +143,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .homepageRebuild,
                 .homepageRedesign,
                 .homepageSearchBar,
+                .homepageShortcutsLibrary,
                 .homepageStoriesRedesign,
                 .loginsVerificationEnabled,
                 .menuDefaultBrowserBanner,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -146,6 +146,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .homepageShortcutsLibrary,
+                titleText: format(string: "Shortcuts Library"),
+                statusText: format(string: "Toggle to enable the homepage shortcuts library")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .homepageStoriesRedesign,
                 titleText: format(string: "Stories Redesign"),
                 statusText: format(string: "Toggle to enable homepage stories section redesign")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -50,6 +50,9 @@ final class NimbusFeatureFlagLayer {
         case .homepageSearchBar:
             return checkHomepageSearchBarFeature(from: nimbus)
 
+        case .homepageShortcutsLibrary:
+            return checkHomepageShortcutsLibraryFeature(from: nimbus)
+
         case .homepageStoriesRedesign:
             return checkHomepageStoriesRedesignFeature(from: nimbus)
 
@@ -206,6 +209,10 @@ final class NimbusFeatureFlagLayer {
 
     private func checkHomepageSearchBarFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.homepageRedesignFeature.value().searchBar
+    }
+
+    private func checkHomepageShortcutsLibraryFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.homepageRedesignFeature.value().shortcutsLibrary
     }
 
     private func checkHomepageStoriesRedesignFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
@@ -14,6 +14,11 @@ features:
           If true, enables the search bar feature on homepage for users.
         type: Boolean
         default: false
+      shortcuts-library:
+        description: >
+          If true, enables the shortcuts library feature, accessible from the homepage
+        type: Boolean
+        default: false
       stories-redesign:
         description: >
           If true, enables the stories section redesign on homepage, which also includes the removal of other sections (i.e. jump back in, bookmarks)
@@ -25,10 +30,12 @@ features:
         value:
           enabled: false
           search-bar: false
+          show-all-shortcuts: false
           stories-redesign: false
     
       - channel: developer
         value:
           enabled: false
           search-bar: false
+          shortcuts-library: false
           stories-redesign: false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13001)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28351)

## :bulb: Description
- Add `shortcuts-library` feature flag to the `homepage-redesign-feature`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
