### PR TITLE
Disable [MTE-4852] - share menu tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -206,6 +206,7 @@
         "SettingsTests\/testImageOnOff_tabTrayExperimentOff()",
         "SettingsTests\/testImageOnOff_tabTrayExperimentOn()",
         "SettingsTests\/testSettingsOptionSubtitles()",
+        "ShareMenuTests",
         "SiteLoadTest",
         "SyncUITests\/testAccountManagementPage()",
         "TabTraySearchTabsTests\/testSearchTabs()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
@@ -7,6 +7,11 @@ import Foundation
 let pdfUrl = "https://storage.googleapis.com/mobile_test_assets/public/lorem_ipsum.pdf"
 
 class ShareMenuTests: BaseTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        throw XCTSkip("Skipping all ShareMenuTests. The option is not available on the new menu")
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2863631
     func testShareNormalWebsiteTabViaReminders() {
         // Coudn't find a way to tap on reminders on iOS 16


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4852

## :bulb: Description
The share menu button is no longer available from the new menu. Disabling tests.