### PR TITLE
Add FXIOS-12564 ⁃ [Menu Redesign] Add Unit Tests for new Menu Redesign classes

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuAccountCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuAccountCell.swift
@@ -6,7 +6,7 @@ import Foundation
 import Common
 import UIKit
 
-final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
+public final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private struct UX {
         static let contentMargin: CGFloat = 16
         static let horizontalMargin: CGFloat = 24
@@ -63,7 +63,7 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
         if shouldConfigureImageView {
             iconImageView.layer.cornerRadius = iconImageView.frame.size.width / 2
@@ -74,7 +74,7 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
         configureCornerRadiusForCellPosition()
     }
 
-    override func prepareForReuse() {
+    override public func prepareForReuse() {
         super.prepareForReuse()
         iconImageView.image = nil
         isFirstCell = false
@@ -145,7 +145,7 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
     }
 
     // MARK: - Theme Applicable
-    func applyTheme(theme: Theme) {
+    public func applyTheme(theme: Theme) {
         guard let model else { return }
         backgroundColor = theme.colors.layer2.withAlphaComponent(UX.backgroundAlpha)
         if let needsReAuth = model.needsReAuth, needsReAuth {

--- a/BrowserKit/Sources/MenuKit/MenuCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuCell.swift
@@ -6,7 +6,7 @@ import Foundation
 import Common
 import UIKit
 
-final class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
+public final class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private struct UX {
         static let contentMargin: CGFloat = 16
         static let horizontalMargin: CGFloat = 24
@@ -59,12 +59,12 @@ final class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
         configureCornerRadiusForCellPosition()
     }
 
-    override func prepareForReuse() {
+    override public func prepareForReuse() {
         super.prepareForReuse()
         iconImageView.image = nil
         isFirstCell = false
@@ -124,7 +124,7 @@ final class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
     }
 
     // MARK: - Theme Applicable
-    func applyTheme(theme: Theme) {
+    public func applyTheme(theme: Theme) {
         guard let model else { return }
         backgroundColor = theme.colors.layer2.withAlphaComponent(UX.backgroundAlpha)
         if model.isActive {

--- a/BrowserKit/Sources/MenuKit/MenuElement.swift
+++ b/BrowserKit/Sources/MenuKit/MenuElement.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 public struct MenuElement: Equatable {
-    let title: String
+    public let title: String
     let description: String?
     let iconName: String
     let iconImage: UIImage?

--- a/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
@@ -6,7 +6,7 @@ import Foundation
 import Common
 import UIKit
 
-final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
+public final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private struct UX {
         static let contentMargin: CGFloat = 16
         static let horizontalMargin: CGFloat = 24
@@ -63,12 +63,12 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
         infoLabelView.layer.cornerRadius = infoLabelView.frame.height / 2
     }
 
-    override func prepareForReuse() {
+    override public func prepareForReuse() {
         super.prepareForReuse()
         infoLabelView.text = nil
     }
@@ -110,7 +110,7 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
     }
 
     // MARK: - Theme Applicable
-    func applyTheme(theme: Theme) {
+    public func applyTheme(theme: Theme) {
         guard let model else { return }
         backgroundColor = theme.colors.layer2.withAlphaComponent(UX.backgroundAlpha)
         if model.isActive {

--- a/BrowserKit/Sources/MenuKit/MenuMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuMainView.swift
@@ -7,7 +7,7 @@ import UIKit
 import ComponentLibrary
 
 public final class MenuMainView: UIView,
-                                         ThemeApplicable {
+                                 ThemeApplicable {
     private struct UX {
         static let headerTopMargin: CGFloat = 24
         static let horizontalMargin: CGFloat = 16

--- a/BrowserKit/Sources/MenuKit/MenuSquaresViewContentCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSquaresViewContentCell.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Common
 
-final class MenuSquaresViewContentCell: UITableViewCell, ReusableCell, ThemeApplicable {
+public final class MenuSquaresViewContentCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private struct UX {
         static let contentViewSpacing: CGFloat = 16
         static let backgroundAlpha: CGFloat = 0.8
@@ -37,7 +37,7 @@ final class MenuSquaresViewContentCell: UITableViewCell, ReusableCell, ThemeAppl
 
     // We override this method, for handling taps on MenuSquareView views
     // This may be a temporary fix
-    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+    override public func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         if self.isHidden || self.alpha.isZero || !self.isUserInteractionEnabled {
             return nil
         }
@@ -89,7 +89,7 @@ final class MenuSquaresViewContentCell: UITableViewCell, ReusableCell, ThemeAppl
     }
 
     // MARK: - Theme Applicable
-    func applyTheme(theme: Theme) {
+    public func applyTheme(theme: Theme) {
         self.theme = theme
         backgroundColor = .clear
         if #available(iOS 26.0, *) {

--- a/BrowserKit/Sources/MenuKit/MenuTableView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuTableView.swift
@@ -6,11 +6,11 @@ import Foundation
 import UIKit
 import Common
 
-final class MenuTableView: UIView,
-                           UITableViewDelegate,
-                           UITableViewDataSource,
-                           UIScrollViewDelegate,
-                           ThemeApplicable {
+public final class MenuTableView: UIView,
+                                  UITableViewDelegate,
+                                  UITableViewDataSource,
+                                  UIScrollViewDelegate,
+                                  ThemeApplicable {
     private struct UX {
         static let topPadding: CGFloat = 24
         static let menuSiteTopPadding: CGFloat = 12
@@ -19,7 +19,7 @@ final class MenuTableView: UIView,
         static let distanceBetweenSections: CGFloat = 16
     }
 
-    private(set) var tableView: UITableView
+    public var tableView: UITableView
     private var menuData: [MenuSection]
     private var theme: Theme?
     private var isBannerVisible = false
@@ -76,11 +76,11 @@ final class MenuTableView: UIView,
     }
 
     // MARK: - UITableView Methods
-    func numberOfSections(in tableView: UITableView) -> Int {
+    public func numberOfSections(in tableView: UITableView) -> Int {
         return menuData.count
     }
 
-    func tableView(
+    public func tableView(
         _ tableView: UITableView,
         heightForHeaderInSection section: Int
     ) -> CGFloat {
@@ -92,7 +92,7 @@ final class MenuTableView: UIView,
         return section == 0 ? UX.menuSiteTopPadding : UX.distanceBetweenSections
     }
 
-    func tableView(
+    public func tableView(
         _ tableView: UITableView,
         numberOfRowsInSection section: Int
     ) -> Int {
@@ -105,7 +105,7 @@ final class MenuTableView: UIView,
         }
     }
 
-    func tableView(
+    public func tableView(
         _ tableView: UITableView,
         cellForRowAt indexPath: IndexPath
     ) -> UITableViewCell {
@@ -169,7 +169,7 @@ final class MenuTableView: UIView,
         return cell
     }
 
-    func tableView(
+    public func tableView(
         _ tableView: UITableView,
         didSelectRowAt indexPath: IndexPath
     ) {
@@ -184,7 +184,7 @@ final class MenuTableView: UIView,
         }
     }
 
-    func tableView(
+    public func tableView(
         _ tableView: UITableView,
         viewForHeaderInSection section: Int
     ) -> UIView? {
@@ -196,14 +196,14 @@ final class MenuTableView: UIView,
         return nil
     }
 
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if isHomepage, !UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory {
             scrollView.contentOffset = .zero
             scrollView.showsVerticalScrollIndicator = false
         }
     }
 
-    func reloadTableView(with data: [MenuSection], isBannerVisible: Bool) {
+    public func reloadTableView(with data: [MenuSection], isBannerVisible: Bool) {
         menuData = data
         self.isBannerVisible = isBannerVisible
         tableView.reloadData()
@@ -215,7 +215,7 @@ final class MenuTableView: UIView,
     }
 
     // MARK: - Theme Applicable
-    func applyTheme(theme: Theme) {
+    public func applyTheme(theme: Theme) {
         self.theme = theme
         backgroundColor = .clear
         tableView.backgroundColor = .clear

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		047F9B3224E1FE1F00CD7DF7 /* WidgetKitExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 047F9B2724E1FE1C00CD7DF7 /* WidgetKitExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		047F9B3E24E1FF4000CD7DF7 /* SearchQuickLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047F9B3A24E1FF4000CD7DF7 /* SearchQuickLinks.swift */; };
 		047F9B4224E1FF4000CD7DF7 /* ImageButtonWithLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047F9B3C24E1FF4000CD7DF7 /* ImageButtonWithLabel.swift */; };
+		0A0D007A2E30C2310021DD05 /* MenuTableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0D00792E30C2210021DD05 /* MenuTableViewTests.swift */; };
+		0A0DFE682E2F93510021DD05 /* MenuMainViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0DFE672E2F93380021DD05 /* MenuMainViewTests.swift */; };
 		0A3F57F92CEDD4CA0051B001 /* TermsOfServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3F57F82CEDD4CA0051B001 /* TermsOfServiceViewController.swift */; };
 		0A44ABAC2D6DC2520034FA86 /* ThemedLearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A44ABAB2D6DC2410034FA86 /* ThemedLearnMoreTableViewCell.swift */; };
 		0A49784A2C53E63200B1E82A /* TrackingProtectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4978492C53E63200B1E82A /* TrackingProtectionViewController.swift */; };
@@ -30,6 +32,7 @@
 		0A93C8AC2C870E7100BEA143 /* TrackingProtectionToggleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A93C8AB2C870E7100BEA143 /* TrackingProtectionToggleView.swift */; };
 		0ABCD45B2D355260005D704A /* TermsOfServiceTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABCD45A2D355255005D704A /* TermsOfServiceTelemetry.swift */; };
 		0ABCD45D2D356015005D704A /* TermsOfServiceTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABCD45C2D356006005D704A /* TermsOfServiceTelemetryTests.swift */; };
+		0AC0F9482E3CA17900E826D8 /* MainMenuConfigurationUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC0F9472E3CA17500E826D8 /* MainMenuConfigurationUtilityTests.swift */; };
 		0AC659272BF35854005C614A /* FxAWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC659262BF35854005C614A /* FxAWebViewModelTests.swift */; };
 		0AC659292BF493CE005C614A /* MockFxAWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */; };
 		0AD3EEAC2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD3EEAB2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift */; };
@@ -2527,6 +2530,8 @@
 		09BE46439BC761BEB09F9DD1 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		09D94B5E8CF4C06397168F78 /* my */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = my; path = "my.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		09F14D989587092C60A0078F /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Shared.strings; sourceTree = "<group>"; };
+		0A0D00792E30C2210021DD05 /* MenuTableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTableViewTests.swift; sourceTree = "<group>"; };
+		0A0DFE672E2F93380021DD05 /* MenuMainViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuMainViewTests.swift; sourceTree = "<group>"; };
 		0A3A4A9EB784F7903FB13B7A /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		0A3F57F82CEDD4CA0051B001 /* TermsOfServiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceViewController.swift; sourceTree = "<group>"; };
 		0A44ABAB2D6DC2410034FA86 /* ThemedLearnMoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedLearnMoreTableViewCell.swift; sourceTree = "<group>"; };
@@ -2546,6 +2551,7 @@
 		0A93C8AB2C870E7100BEA143 /* TrackingProtectionToggleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionToggleView.swift; sourceTree = "<group>"; };
 		0ABCD45A2D355255005D704A /* TermsOfServiceTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceTelemetry.swift; sourceTree = "<group>"; };
 		0ABCD45C2D356006005D704A /* TermsOfServiceTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceTelemetryTests.swift; sourceTree = "<group>"; };
+		0AC0F9472E3CA17500E826D8 /* MainMenuConfigurationUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuConfigurationUtilityTests.swift; sourceTree = "<group>"; };
 		0AC659262BF35854005C614A /* FxAWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAWebViewModelTests.swift; sourceTree = "<group>"; };
 		0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFxAWebViewModel.swift; sourceTree = "<group>"; };
 		0AD3EEAB2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedCenteredTableViewCell.swift; sourceTree = "<group>"; };
@@ -11866,8 +11872,6 @@
 				5FDE66022D94528A003961DC /* A11ySettingsTests.swift */,
 				E143BF642CE36FF800A1D2D9 /* A11yTabTrayTests.swift */,
 				8A94DB8E2E0F0E780005FE69 /* HomepageSearchBarTests.swift */,
-				211FD2742DF38106003F60EF /* CookiePersistenceUITests.swift */,
-				211FD2742DF38106003F60EF /* CookiePersistenceTests.swift */,
 				3B546EBF1D95ECAE00BDBE36 /* ActivityStreamTest.swift */,
 				0B3D670D1E09B90B00C1EFC7 /* AuthenticationTest.swift */,
 				0B305E1A1E3A98A900BE0767 /* BookmarksTests.swift */,
@@ -12405,6 +12409,9 @@
 		81DAB2EF2C88EFEE00F4BE98 /* MainMenu */ = {
 			isa = PBXGroup;
 			children = (
+				0AC0F9472E3CA17500E826D8 /* MainMenuConfigurationUtilityTests.swift */,
+				0A0D00792E30C2210021DD05 /* MenuTableViewTests.swift */,
+				0A0DFE672E2F93380021DD05 /* MenuMainViewTests.swift */,
 				81DAB2F22C88F14400F4BE98 /* MainMenuCoordinatorTests.swift */,
 				81DAB2F62C89004D00F4BE98 /* MainMenuMiddlewareTests.swift */,
 				81DAB2F82C8901AC00F4BE98 /* MainMenuStateTests.swift */,
@@ -18695,6 +18702,7 @@
 				213B67A827CE721E000542F5 /* StartAtHomeHelperTests.swift in Sources */,
 				033C94F72E2FBCDD00C2382F /* TermsOfUseMiddlewareTests.swift in Sources */,
 				8A13FA892AD82BC8007527AB /* AppSendTabDelegateTests.swift in Sources */,
+				0A0D007A2E30C2310021DD05 /* MenuTableViewTests.swift in Sources */,
 				8A7653C228A2E57D00924ABF /* StoryDataAdaptorTests.swift in Sources */,
 				0ABCD45D2D356015005D704A /* TermsOfServiceTelemetryTests.swift in Sources */,
 				C8CD80D42A1E268C0097C3AE /* MockGleanPlumbEvaluationUtility.swift in Sources */,
@@ -18721,6 +18729,7 @@
 				8A2F21C62DEDC17900C9F4DE /* StartAtHomeMiddlewareTests.swift in Sources */,
 				03CCC9181AF05E7300DBF30D /* RelativeDatesTests.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
+				0A0DFE682E2F93510021DD05 /* MenuMainViewTests.swift in Sources */,
 				81DAB2F12C88F02500F4BE98 /* MainMenuViewControllerTests.swift in Sources */,
 				C7F051582D9F098200EC52C0 /* ContextMenuTelemetryTests.swift in Sources */,
 				219935F12B07DFA200E5966F /* TabDisplayPanelTests.swift in Sources */,
@@ -18881,6 +18890,7 @@
 				8A6E13982A71BA4E00A88FA8 /* TabWebViewTests.swift in Sources */,
 				8AF3B15E2AF99D2F009BB262 /* DownloadsPanelTests.swift in Sources */,
 				8A32DD5028B419B300D57C60 /* HomepageMessageCardViewModelTests.swift in Sources */,
+				0AC0F9482E3CA17900E826D8 /* MainMenuConfigurationUtilityTests.swift in Sources */,
 				8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */,
 				5A3A7DD62889CF3D0065F81A /* BookmarksDataAdaptorTests.swift in Sources */,
 				8AD08D1727E91AC800B8E907 /* TabsTelemetryTests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+import Shared
+
+@testable import Client
+
+final class MainMenuConfigurationUtilityTests: XCTestCase {
+    var configUtility: MainMenuConfigurationUtility!
+    let windowUUID: WindowUUID = .XCTestDefaultUUID
+
+    override func setUp() {
+        super.setUp()
+        configUtility = MainMenuConfigurationUtility()
+    }
+
+    func testGenerateMenuElements_returnsHomepageSections_whenIsHomepageTrue() {
+        let sections = configUtility.generateMenuElements(with: getTabInfo(isHomepage: true), and: windowUUID)
+
+        XCTAssertEqual(sections.count, 2)
+        XCTAssertTrue(sections[0].isHorizontalTabsSection)
+    }
+
+    func testGenerateMenuElements_returnsAllSections_whenIsHomepageFalse() {
+        let sections = configUtility.generateMenuElements(with: getTabInfo(), and: windowUUID)
+
+        XCTAssertEqual(sections.count, 3)
+        XCTAssertFalse(sections[0].isHorizontalTabsSection)
+    }
+
+    func testGenerateMenuElements_siteSectionHasMoreOptions_whenIsExpandedFalse() {
+        let sections = configUtility.generateMenuElements(with: getTabInfo(), and: windowUUID, isExpanded: false)
+
+        let siteSection = sections.first!
+        let moreLessItem = siteSection.options.last!
+        XCTAssertEqual(moreLessItem.title, String.MainMenu.ToolsSection.MoreOptions)
+    }
+
+    func testGenerateMenuElements_siteSectionHasZoomAndPrint_whenIsExpandedTrue() {
+        let sections = configUtility.generateMenuElements(with: getTabInfo(), and: windowUUID, isExpanded: true)
+
+        let siteSection = sections.first!
+        let titles = siteSection.options.map { $0.title }
+
+        XCTAssertTrue(titles.contains(String.MainMenu.Submenus.Tools.PageZoomV2))
+        XCTAssertTrue(titles.contains(String.MainMenu.Submenus.Tools.Print))
+    }
+
+    private func getTabInfo(isHomepage: Bool = false) -> MainMenuTabInfo {
+        return MainMenuTabInfo(
+            tabID: "uuid",
+            url: nil,
+            canonicalURL: nil,
+            isHomepage: isHomepage,
+            isDefaultUserAgentDesktop: false,
+            hasChangedUserAgent: false,
+            zoomLevel: 0,
+            readerModeIsAvailable: false,
+            isBookmarked: false,
+            isInReadingList: false,
+            isPinned: false,
+            accountData: AccountData(title: "Test Title", subtitle: "Test Subtitle"),
+            accountProfileImage: UIImage()
+        )
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
@@ -24,7 +24,7 @@ final class MainMenuMiddlewareTests: XCTestCase {
         super.tearDown()
     }
 
-    func testDismissMenuAction() throws {
+    func testDismissMenuAction() {
         let mockStore = Store(
             state: AppState(),
             reducer: AppState.reducer,
@@ -33,6 +33,82 @@ final class MainMenuMiddlewareTests: XCTestCase {
 
         let action = getAction(for: .tapCloseMenu)
         mockStore.dispatchLegacy(action)
+    }
+
+    func testTapNavigateToDestination_bookmarks() {
+        let middleware = MainMenuMiddleware()
+        let mockStore = Store(
+            state: AppState(),
+            reducer: AppState.reducer,
+            middlewares: [middleware.mainMenuProvider]
+        )
+
+        let action = MainMenuAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: MainMenuActionType.tapNavigateToDestination,
+            navigationDestination: .init(.bookmarks),
+            telemetryInfo: .init(isHomepage: true)
+        )
+
+        mockStore.dispatchLegacy(action)
+    }
+
+    func testTapToggleUserAgent_switchToMobile() {
+        let middleware = MainMenuMiddleware()
+        let mockStore = Store(
+            state: AppState(),
+            reducer: AppState.reducer,
+            middlewares: [middleware.mainMenuProvider]
+        )
+
+        let action = MainMenuAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: MainMenuActionType.tapToggleUserAgent,
+            telemetryInfo: .init(isHomepage: false, isDefaultUserAgentDesktop: true, hasChangedUserAgent: false)
+        )
+
+        mockStore.dispatchLegacy(action)
+    }
+
+    func testTapToggleNightMode_turnOn() {
+        let middleware = MainMenuMiddleware()
+        let mockStore = Store(
+            state: AppState(),
+            reducer: AppState.reducer,
+            middlewares: [middleware.mainMenuProvider]
+        )
+
+        let action = MainMenuAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: MainMenuActionType.tapToggleNightMode,
+            telemetryInfo: .init(isHomepage: true, isActionOn: true)
+        )
+
+        mockStore.dispatchLegacy(action)
+    }
+
+    func testViewDidLoad_dispatchesTabInfo() {
+        let middleware = MainMenuMiddleware()
+        let store = Store(
+            state: AppState(),
+            reducer: AppState.reducer,
+            middlewares: [middleware.mainMenuProvider]
+        )
+
+        let action = getAction(for: .viewDidLoad)
+        store.dispatchLegacy(action)
+    }
+
+    func testDidInstantiateView_dispatchesBannerVisibilityUpdate() {
+        let middleware = MainMenuMiddleware()
+        let store = Store(
+            state: AppState(),
+            reducer: AppState.reducer,
+            middlewares: [middleware.mainMenuProvider]
+        )
+
+        let action = getAction(for: .didInstantiateView)
+        store.dispatchLegacy(action)
     }
 
     private func getAction(for actionType: MainMenuActionType) -> MainMenuAction {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MenuMainViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MenuMainViewTests.swift
@@ -1,0 +1,114 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MenuKit
+@testable import Client
+
+final class MenuMainViewTests: XCTestCase {
+    var menuView: MenuMainView!
+
+    override func setUp() {
+        super.setUp()
+        menuView = MenuMainView()
+        menuView.frame = CGRect(x: 0, y: 0, width: 375, height: 812)
+    }
+
+    override func tearDown() {
+        menuView = nil
+        super.tearDown()
+    }
+
+    func testShouldNotDisplayBanner_onSiteMenu() {
+        setupDetails(isBannerFlagEnabled: true, isBrowserDefault: false, bannerShown: false)
+
+        let homepageSection = MenuSection(isExpanded: false, isHomepage: false, options: [])
+        menuView.reloadDataView(with: [homepageSection])
+
+        XCTAssertFalse(menuView.subviews.contains(where: { $0 is HeaderBanner }))
+    }
+
+    func testShouldNotDisplayBanner_ifBrowserIsDefault() {
+        setupDetails(isBannerFlagEnabled: true, isBrowserDefault: true, bannerShown: false)
+
+        let homepageSection = MenuSection(isExpanded: false, isHomepage: true, options: [])
+        menuView.reloadDataView(with: [homepageSection])
+
+        XCTAssertFalse(menuView.subviews.contains(where: { $0 is HeaderBanner }))
+    }
+
+    func testShouldNotDisplayBanner_ifWasShown() {
+        setupDetails(isBannerFlagEnabled: true, isBrowserDefault: false, bannerShown: true)
+
+        let homepageSection = MenuSection(isExpanded: false, isHomepage: true, options: [])
+        menuView.reloadDataView(with: [homepageSection])
+
+        XCTAssertFalse(menuView.subviews.contains(where: { $0 is HeaderBanner }))
+    }
+
+    func testShouldDisplayBanner() {
+        setupDetails(isBannerFlagEnabled: true, isBrowserDefault: false, bannerShown: false)
+
+        let homepageSection = MenuSection(isExpanded: false, isHomepage: true, options: [])
+        menuView.reloadDataView(with: [homepageSection])
+
+        XCTAssertTrue(menuView.subviews.contains(where: { $0 is HeaderBanner }))
+    }
+
+    func testCloseBannerCallback() {
+        let homepageSection = MenuSection(isExpanded: false, isHomepage: true, options: [])
+        setupDetails(isBannerFlagEnabled: true, isBrowserDefault: false, bannerShown: false)
+        menuView.reloadDataView(with: [homepageSection])
+
+        let expectation = XCTestExpectation(description: "Close banner callback should be called")
+        menuView.closeBannerButtonCallback = {
+            expectation.fulfill()
+        }
+
+        menuView.headerBanner.closeButtonCallback?()
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testHeightCalculation_forExpandedSection() {
+        let expandedSection = MenuSection(isExpanded: true, isHomepage: false, options: [])
+        let expectation = XCTestExpectation(description: "Height should be calculated")
+
+        menuView.onCalculatedHeight = { height, isExpanded in
+            XCTAssertTrue(isExpanded)
+            XCTAssertGreaterThan(height, 0)
+            expectation.fulfill()
+        }
+
+        menuView.reloadDataView(with: [expandedSection])
+        menuView.layoutIfNeeded()
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testBannerButtonCallbackCalled() {
+        let expectation = XCTestExpectation(description: "Banner button callback")
+        setupDetails(isBannerFlagEnabled: true, isBrowserDefault: false, bannerShown: false)
+
+        menuView.bannerButtonCallback = {
+            expectation.fulfill()
+        }
+
+        menuView.reloadDataView(with: [MenuSection(isExpanded: false, isHomepage: true, options: [])])
+        menuView.headerBanner.bannerButtonCallback?()
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    private func setupDetails(isBannerFlagEnabled: Bool, isBrowserDefault: Bool, bannerShown: Bool) {
+        menuView.setupDetails(
+            title: "",
+            subtitle: "",
+            image: nil,
+            isBannerFlagEnabled: isBannerFlagEnabled,
+            isBrowserDefault: isBrowserDefault,
+            bannerShown: bannerShown
+        )
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MenuTableViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MenuTableViewTests.swift
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MenuKit
+@testable import Client
+
+final class MenuTableViewTests: XCTestCase {
+    var menuView: MenuTableView!
+
+    override func setUp() {
+        super.setUp()
+        menuView = MenuTableView()
+    }
+
+    override func tearDown() {
+        menuView = nil
+        super.tearDown()
+    }
+
+    func testTableView_isSetUpCorrectly() {
+        XCTAssertNotNil(menuView)
+        XCTAssertTrue(menuView.subviews.contains { $0 is UITableView })
+    }
+
+    func testReload_withMenuData() {
+        let option = MenuElement(
+            title: "Option 1",
+            iconName: "",
+            isEnabled: true,
+            isActive: false,
+            a11yLabel: "",
+            a11yHint: "",
+            a11yId: "",
+            action: nil,
+        )
+        let section = MenuSection(isHorizontalTabsSection: false, isExpanded: true, options: [option])
+        menuView.reloadTableView(with: [section], isBannerVisible: false)
+
+        XCTAssertEqual(menuView.tableViewContentSize > 0, true)
+        XCTAssertEqual(menuView.tableView.numberOfSections, 1)
+        XCTAssertEqual(menuView.tableView(menuView.tableView, numberOfRowsInSection: 0), 1)
+    }
+
+    func testCellForRow_shouldReturnAccountCellType() {
+        let option = MenuElement(
+            title: "Option 1",
+            iconName: "",
+            iconImage: UIImage(),
+            needsReAuth: false,
+            isEnabled: true,
+            isActive: false,
+            a11yLabel: "",
+            a11yHint: "",
+            a11yId: "",
+            action: nil,
+        )
+        let section = MenuSection(isHorizontalTabsSection: false, isExpanded: true, options: [option])
+        menuView.reloadTableView(with: [section], isBannerVisible: false)
+
+        let cell = menuView.tableView(menuView.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+        XCTAssertTrue(cell is MenuAccountCell)
+    }
+
+    func testCellForRow_shouldReturnSquaresViewContentCellType() {
+        let option = MenuElement(
+            title: "Option 1",
+            iconName: "",
+            isEnabled: true,
+            isActive: false,
+            a11yLabel: "",
+            a11yHint: "",
+            a11yId: "",
+            action: nil,
+        )
+        let section = MenuSection(isHorizontalTabsSection: true, isExpanded: true, options: [option])
+        menuView.reloadTableView(with: [section], isBannerVisible: false)
+
+        let cell = menuView.tableView(menuView.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+        XCTAssertTrue(cell is MenuSquaresViewContentCell)
+    }
+
+    func testCellForRow_shouldReturnInfoCellType() {
+        let option = MenuElement(
+            title: "Option 1",
+            iconName: "",
+            isEnabled: true,
+            isActive: false,
+            a11yLabel: "",
+            a11yHint: "",
+            a11yId: "",
+            infoTitle: "Title Test",
+            action: nil
+        )
+        let section = MenuSection(isHorizontalTabsSection: false, isExpanded: true, options: [option])
+        menuView.reloadTableView(with: [section], isBannerVisible: false)
+
+        let cell = menuView.tableView(menuView.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+        XCTAssertTrue(cell is MenuInfoCell)
+    }
+
+    func testCellForRow_shouldReturnRedesignCellType() {
+        let option = MenuElement(
+            title: "Option 1",
+            iconName: "",
+            isEnabled: true,
+            isActive: false,
+            a11yLabel: "",
+            a11yHint: "",
+            a11yId: "",
+            action: nil
+        )
+        let section = MenuSection(isHorizontalTabsSection: false, isExpanded: true, options: [option])
+        menuView.reloadTableView(with: [section], isBannerVisible: false)
+
+        let cell = menuView.tableView(menuView.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+        XCTAssertTrue(cell is MenuCell)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12564)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27366)

## :bulb: Description
Added some tests for Menu Redesign

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
