### PR TITLE
New tab [MTE-4857]-related auto test changes

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NightModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NightModeTests.swift
@@ -25,15 +25,16 @@ class NightModeTests: BaseTestCase {
         navigator.openURL(path(forTestPage: url1))
         waitUntilPageLoad()
         // turn on the night mode
+        navigator.goto(BrowserTabMenuMore)
         navigator.performAction(Action.ToggleNightMode)
         navigator.nowAt(BrowserTab)
-        navigator.goto(BrowserTabMenu)
+        navigator.goto(BrowserTabMenuMore)
         // checking night mode on or off
         checkNightModeOn()
 
         // checking night mode on or off
         navigator.nowAt(BrowserTab)
-        navigator.goto(BrowserTabMenu)
+        navigator.goto(BrowserTabMenuMore)
         checkNightModeOff()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
@@ -208,7 +208,9 @@ class OnboardingTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306815
-    func testWhatsNewPage() {
+    func testWhatsNewPage() throws {
+        throw XCTSkip("Skipping. The option whats new page is not available on the new menu")
+        /*
         app.buttons["\(AccessibilityIdentifiers.Onboarding.closeButton)"].waitAndTap()
         // Dismiss new changes pop up if exists
         app.buttons["Close"].tapIfExists()
@@ -240,6 +242,7 @@ class OnboardingTests: BaseTestCase {
                 app.staticTexts["Get the most recent version"]
             ]
         )
+         */
     }
 
     // TOOLBAR THEME

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
@@ -198,7 +198,9 @@ class ReadingListTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306999
-    func testAddToReadingListFromBrowserTabMenu() {
+    func testAddToReadingListFromBrowserTabMenu() throws {
+        throw XCTSkip("Skipping. The option add to reading list is not available on the new menu")
+        /*
         app.launch()
         navigator.nowAt(NewTabScreen)
         // First time Reading list is empty
@@ -214,6 +216,7 @@ class ReadingListTests: FeatureFlaggedTestBase {
         navigator.nowAt(BrowserTab)
         navigator.goto(LibraryPanel_ReadingList)
         checkReadingListNumberOfItems(items: 1)
+         */
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307000

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabMenuNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabMenuNavigation.swift
@@ -15,7 +15,11 @@ func registerTabMenuNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIAppl
             app.tables.cells[AccessibilityIdentifiers.MainMenu.addToShortcuts],
             forAction: Action.PinToTopSitesPAM
         )
-        // Web Site Dark Mode (TODO)
+        // Web Site Dark Mode
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.nightMode],
+            forAction: Action.ToggleNightMode
+        )
         // Save As PDF (TODO)
         // Print (TODO)
         // Turn on night mode


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4857

## :bulb: Description
Disabled testWhatsNewPage, testAddToReadingListFromBrowserTabMenu
Changes for dark mode navigation. 
testNightModeUI will be fixed after https://github.com/mozilla-mobile/firefox-ios/issues/28394 is fixed
