### PR TITLE
Bugfix FXIOS-13023 ⁃ The website dark mode option from the menu is not working

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -27,6 +27,8 @@ final class ThemeManagerMiddleware: ThemeManagerProvider {
             self.resolveThemeSettingsViewActionType(action: action)
         } else if let action = action as? PrivateModeAction {
             self.resolvePrivateModeAction(action: action)
+        } else if let action = action as? MainMenuAction {
+            self.resolveMainMenuAction(action: action)
         }
     }
 
@@ -35,6 +37,15 @@ final class ThemeManagerMiddleware: ThemeManagerProvider {
         case PrivateModeActionType.privateModeUpdated:
             updatePrivateMode(with: action)
 
+        default:
+            break
+        }
+    }
+
+    private func resolveMainMenuAction(action: MainMenuAction) {
+        switch action.actionType {
+        case MainMenuActionType.tapToggleNightMode:
+            updateNightMode()
         default:
             break
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13023)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28394)

## :bulb: Description
Handle Website dark mode action

## :movie_camera: Demos

https://github.com/user-attachments/assets/71366c9a-7735-4ff7-911a-1d5d75736278



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
