### PR TITLE
Add FXIOS-13019 [Shortcuts Library] Display "Show All" shortcuts button

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -192,6 +192,7 @@ struct AccessibilityIdentifiers {
         }
 
         struct MoreButtons {
+            static let shortcuts = "shortcutsSectionMoreButton"
             static let bookmarks = "bookmarksSectionMoreButton"
             static let jumpBackIn = "jumpBackInSectionMoreButton"
             static let customizeHomePage = "FxHomeCustomizeHomeSettingButton"

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -19,7 +19,10 @@ struct TopSitesSectionState: StateType, Equatable {
 
     let sectionHeaderState = SectionHeaderConfiguration(
         title: .FirefoxHomepage.Shortcuts.SectionTitle,
-        a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.topSites
+        a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.topSites,
+        isButtonHidden: !LegacyFeatureFlagsManager.shared.isFeatureEnabled(.homepageShortcutsLibrary, checking: .buildOnly),
+        buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.shortcuts,
+        buttonTitle: .BookmarksSavedShowAllText
     )
 
     init(profile: Profile = AppContainer.shared.resolve(), windowUUID: WindowUUID) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
@@ -12,6 +12,7 @@ final class TopsSitesSectionStateTests: XCTestCase {
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
     }
 
     override func tearDown() {
@@ -24,6 +25,20 @@ final class TopsSitesSectionStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
         XCTAssertEqual(initialState.topSitesData, [])
+    }
+
+    func test_initialState_withShortcutsLibraryEnabled_showsHeaderButton() {
+        setupNimbusShortcutsLibraryTesting(isEnabled: true)
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.sectionHeaderState.isButtonHidden, false)
+    }
+
+    func test_initialState_withShortcutsLibraryDisabled_hidesHeaderButton() {
+        setupNimbusShortcutsLibraryTesting(isEnabled: false)
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.sectionHeaderState.isButtonHidden, true)
     }
 
     func test_retrievedUpdatedStoriesAction_returnsExpectedState() throws {
@@ -179,5 +194,11 @@ final class TopsSitesSectionStateTests: XCTestCase {
             sites.append(TopSiteConfiguration(site: site))
         }
         return sites
+    }
+
+    private func setupNimbusShortcutsLibraryTesting(isEnabled: Bool) {
+        FxNimbus.shared.features.homepageRedesignFeature.with { _, _ in
+            return HomepageRedesignFeature(shortcutsLibrary: isEnabled)
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13019)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28383)

## :bulb: Description
- Display the "Show All" header button for the shortcuts section when the `shortcuts-library` flag is enabled

## :movie_camera: Demos
| Before | After |
| - | - |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-01 at 10 04 39" src="https://github.com/user-attachments/assets/cebc0e6c-76d6-466a-9bf9-654c5794ebe7" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-01 at 10 02 26" src="https://github.com/user-attachments/assets/88f3800a-c6ec-4635-94aa-fde990559437" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
