### PR TITLE
Refactor FXIOS-13028 [Homepage Redesign] Enable search and stories flags in beta

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1492,6 +1492,7 @@
 		C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F3B2991CFCF93A00966259 /* ButtonToast.swift */; };
 		C706CBEF2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C706CBEE2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift */; };
 		C710FDB72DCBDBEF0046475F /* TopSiteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C710FDB62DCBDBEF0046475F /* TopSiteCell.swift */; };
+		C714D8362E468D8200FC02E6 /* homepageRedesignOff.json in Resources */ = {isa = PBXBuildFile; fileRef = C714D8352E468D6900FC02E6 /* homepageRedesignOff.json */; };
 		C743CB1D2DF201D50069CB23 /* StoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C743CB1C2DF201D50069CB23 /* StoryCell.swift */; };
 		C787D8C32C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */; };
 		C796E22A2E3D48D3005D6A1D /* ShortcutsLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C796E2292E3D48D3005D6A1D /* ShortcutsLibraryViewController.swift */; };
@@ -9399,6 +9400,7 @@
 		C6C94C1CB6286845DEAF8EDD /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C706CBEE2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardSettingsViewControllerTests.swift; sourceTree = "<group>"; };
 		C710FDB62DCBDBEF0046475F /* TopSiteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSiteCell.swift; sourceTree = "<group>"; };
+		C714D8352E468D6900FC02E6 /* homepageRedesignOff.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = homepageRedesignOff.json; sourceTree = "<group>"; };
 		C7354071A05454E7FF3C70D8 /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		C743CB1C2DF201D50069CB23 /* StoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryCell.swift; sourceTree = "<group>"; };
 		C7664A29B78A808DC314353C /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Search.strings; sourceTree = "<group>"; };
@@ -14893,6 +14895,7 @@
 				BCFB141E2E1FFECC0005D46B /* feltPrivacySimplifiedUIOn.json */,
 				B184D4B72E1D4E1500549CAC /* storiesRedesignOn.json */,
 				B184D4B52E1D4C2B00549CAC /* storiesRedesignOff.json */,
+				C714D8352E468D6900FC02E6 /* homepageRedesignOff.json */,
 				8A94DB942E0F16E60005FE69 /* homepageSearchBarOff.json */,
 				8A94DB952E0F16E70005FE69 /* homepageSearchBarOn.json */,
 				8A3709E22DC1290E004B9350 /* defaultEnabledOn.json */,
@@ -16783,6 +16786,7 @@
 				8A1F6C2F2BC5A62400DA6F86 /* PrivacyInfo.xcprivacy in Resources */,
 				8A1A93592B757C7C0069C190 /* landscape.json in Resources */,
 				E4CD9F5B1A71506C00318571 /* Reader.css in Resources */,
+				C714D8362E468D8200FC02E6 /* homepageRedesignOff.json in Resources */,
 				5FACA10C2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan in Resources */,
 				D0FCF8061FE4772D004A7995 /* AllFramesAtDocumentEnd.js in Resources */,
 				BCFB141D2E1FFEC00005D46B /* feltPrivacySimplifiedUIOff.json in Resources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -962,6 +962,7 @@ final class HomepageViewController: UIViewController,
                 )
                 return
             }
+            collectionView.layoutIfNeeded()
             for indexPath in collectionView.indexPathsForVisibleItems {
                 guard let section = dataSource?.sectionIdentifier(for: indexPath.section),
                       let item = dataSource?.itemIdentifier(for: indexPath) else { continue }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -179,7 +179,6 @@ final class HomepageViewController: UIViewController,
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        collectionView?.collectionViewLayout.invalidateLayout()
         let numberOfTilesPerRow = numberOfTilesPerRow(for: availableWidth)
         guard homepageState.topSitesState.numberOfTilesPerRow != numberOfTilesPerRow else { return }
 
@@ -962,7 +961,6 @@ final class HomepageViewController: UIViewController,
                 )
                 return
             }
-            collectionView.layoutIfNeeded()
             for indexPath in collectionView.indexPathsForVisibleItems {
                 guard let section = dataSource?.sectionIdentifier(for: indexPath.section),
                       let item = dataSource?.itemIdentifier(for: indexPath) else { continue }

--- a/firefox-ios/Client/Nimbus/TestData/homepageRedesignOff.json
+++ b/firefox-ios/Client/Nimbus/TestData/homepageRedesignOff.json
@@ -1,0 +1,4 @@
+{
+    "search-bar": false,
+    "stories-redesign": false
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -99,6 +99,10 @@ class BaseTestCase: XCTestCase {
         } else {
             app.launchArguments = [LaunchArguments.PerformanceTest] + launchArguments
         }
+
+        // FXIOS-13129: Remove these arguments once we migrate existing tests to support homepage redesign
+        app.launchArguments.append("\(LaunchArguments.LoadExperiment)\("homepageRedesignOff")")
+        app.launchArguments.append("\(LaunchArguments.ExperimentFeatureName)\("homepage-redesign-feature")")
     }
 
     override func setUp() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FeatureFlaggedTestBase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FeatureFlaggedTestBase.swift
@@ -12,9 +12,6 @@ class FeatureFlaggedTestBase: BaseTestCase {
     override func setUpApp() {
         // Important: `app.launch()` must be called explicitly in each test case.
         setUpLaunchArguments()
-
-        // FXIOS-13129: Remove these arguments once we migrate existing tests to support homepage redesign
-        addLaunchArgument(jsonFileName: "homepageRedesignOff", featureName: "homepage-redesign-feature")
     }
 
     /// Adds experiment data and feature flag information to the app's launch arguments.

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FeatureFlaggedTestBase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FeatureFlaggedTestBase.swift
@@ -12,6 +12,9 @@ class FeatureFlaggedTestBase: BaseTestCase {
     override func setUpApp() {
         // Important: `app.launch()` must be called explicitly in each test case.
         setUpLaunchArguments()
+
+        // FXIOS-13129: Remove these arguments once we migrate existing tests to support homepage redesign
+        addLaunchArgument(jsonFileName: "homepageRedesignOff", featureName: "homepage-redesign-feature")
     }
 
     /// Adds experiment data and feature flag information to the app's launch arguments.

--- a/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
@@ -29,13 +29,13 @@ features:
       - channel: beta
         value:
           enabled: false
-          search-bar: false
+          search-bar: true
           shortcuts-library: false
-          stories-redesign: false
+          stories-redesign: true
     
       - channel: developer
         value:
           enabled: false
-          search-bar: false
+          search-bar: true
           shortcuts-library: false
-          stories-redesign: false
+          stories-redesign: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13028)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28407)

## :bulb: Description
- Enable the `search-bar` and `stories-redesign` feature flags under the `homepage-redesign-feature` by default in dev and beta
- Add/fix a couple of unit tests
- Disable `stories-redesign` and `search-bar` flags from all UI tests (see FXIOS-13129 for more info)
  - Any UI test enabling/disabling anything from the `homepage-redesign-feature` will override the above (eg if we specifically enable `search-bar` without specifically disabling `stories-redesign`, both will be enabled because the original launch arg gets overridden)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
