### PR TITLE
Refactor FXIOS-12977 #28304 ⁃ [TabScrollController refactor] Create TabScrollController protocol to isolate scroll interaction Part1

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -283,13 +283,14 @@
 		216A0D762A40E7AB008077BA /* Redux in Frameworks */ = {isa = PBXBuildFile; productRef = 216A0D752A40E7AB008077BA /* Redux */; };
 		216A0D792A40E85A008077BA /* ThemeSettingsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216A0D782A40E85A008077BA /* ThemeSettingsState.swift */; };
 		216A0D7B2A40F08B008077BA /* ThemeSettingsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216A0D7A2A40F08B008077BA /* ThemeSettingsAction.swift */; };
-		2173326829CCDA8E007F20C7 /* TabScrollControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */; };
+		2173326829CCDA8E007F20C7 /* LegacyTabScrollControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2173326629CCD259007F20C7 /* LegacyTabScrollControllerTests.swift */; };
 		2173326A29CCF901007F20C7 /* UIPanGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */; };
 		21737FB72878A4BD000A9A92 /* HistoryPanelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21737FB528789EA9000A9A92 /* HistoryPanelViewModelTests.swift */; };
 		217641B82D651DB900597B6F /* MIMEType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217641B72D651DB900597B6F /* MIMEType.swift */; };
 		2178A6A0291454B5002EC290 /* ReaderModeThemeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A69F291454B5002EC290 /* ReaderModeThemeButton.swift */; };
 		2178A6A4291455F7002EC290 /* ReaderModeFontSizeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A6A3291455F7002EC290 /* ReaderModeFontSizeButton.swift */; };
 		217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AEF75284666D4004EED37 /* IntroViewModelTests.swift */; };
+		21872A232E3CFEA500241A8A /* TabScrollHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21872A222E3CFEA500241A8A /* TabScrollHandlerTests.swift */; };
 		2191D4472DC3BC1200E1A839 /* ZoomTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2191D4462DC3BC1200E1A839 /* ZoomTelemetry.swift */; };
 		219588942D6E519F00B8715E /* AutofillPasswordSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219588932D6E519F00B8715E /* AutofillPasswordSetting.swift */; };
 		219638EC2DBFBC56007C3893 /* ZoomLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219638EB2DBFBC56007C3893 /* ZoomLevel.swift */; };
@@ -1961,7 +1962,7 @@
 		E67422C51CFF2D39009E8373 /* youtube.ico in Resources */ = {isa = PBXBuildFile; fileRef = E67422C41CFF2D39009E8373 /* youtube.ico */; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
 		E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */; };
-		E698FFDA1B4AADF40001F623 /* TabScrollController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E698FFD91B4AADF40001F623 /* TabScrollController.swift */; };
+		E698FFDA1B4AADF40001F623 /* TabScrollHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E698FFD91B4AADF40001F623 /* TabScrollHandler.swift */; };
 		E69922171B94E3EF007C480D /* Licenses.html in Resources */ = {isa = PBXBuildFile; fileRef = E69922121B94E3EF007C480D /* Licenses.html */; };
 		E6A92ADB1C52A8DA00743291 /* LoginInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A92ADA1C52A8DA00743291 /* LoginInputTests.swift */; };
 		E6B4C3D81C68F55C001F97E8 /* JSPrompt.html in Resources */ = {isa = PBXBuildFile; fileRef = E6B4C3D71C68F55C001F97E8 /* JSPrompt.html */; };
@@ -2877,13 +2878,14 @@
 		2165B2CB28748CD7004C0786 /* LibraryPanelDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPanelDescriptor.swift; sourceTree = "<group>"; };
 		216A0D782A40E85A008077BA /* ThemeSettingsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsState.swift; sourceTree = "<group>"; };
 		216A0D7A2A40F08B008077BA /* ThemeSettingsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsAction.swift; sourceTree = "<group>"; };
-		2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollControllerTests.swift; sourceTree = "<group>"; };
+		2173326629CCD259007F20C7 /* LegacyTabScrollControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabScrollControllerTests.swift; sourceTree = "<group>"; };
 		2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPanGestureRecognizerMock.swift; sourceTree = "<group>"; };
 		21737FB528789EA9000A9A92 /* HistoryPanelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryPanelViewModelTests.swift; sourceTree = "<group>"; };
 		217641B72D651DB900597B6F /* MIMEType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIMEType.swift; sourceTree = "<group>"; };
 		2178A69F291454B5002EC290 /* ReaderModeThemeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeThemeButton.swift; sourceTree = "<group>"; };
 		2178A6A3291455F7002EC290 /* ReaderModeFontSizeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontSizeButton.swift; sourceTree = "<group>"; };
 		217AEF75284666D4004EED37 /* IntroViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModelTests.swift; sourceTree = "<group>"; };
+		21872A222E3CFEA500241A8A /* TabScrollHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollHandlerTests.swift; sourceTree = "<group>"; };
 		2191D4462DC3BC1200E1A839 /* ZoomTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomTelemetry.swift; sourceTree = "<group>"; };
 		2194437EA9B44A00EDC037FA /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/FindInPage.strings"; sourceTree = "<group>"; };
 		219588932D6E519F00B8715E /* AutofillPasswordSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillPasswordSetting.swift; sourceTree = "<group>"; };
@@ -10333,7 +10335,7 @@
 		E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
 		E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsTableViewController.swift; sourceTree = "<group>"; };
 		E6934171BA2BD0BCAF225D44 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/LoginManager.strings; sourceTree = "<group>"; };
-		E698FFD91B4AADF40001F623 /* TabScrollController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabScrollController.swift; sourceTree = "<group>"; };
+		E698FFD91B4AADF40001F623 /* TabScrollHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabScrollHandler.swift; sourceTree = "<group>"; };
 		E69922121B94E3EF007C480D /* Licenses.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = Licenses.html; sourceTree = "<group>"; };
 		E69DB07D1E97DEA9008A67E6 /* SyncTelemetryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SyncTelemetryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E69DB0861E97DEAA008A67E6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -11371,7 +11373,7 @@
 			isa = PBXGroup;
 			children = (
 				21F422652E315E55004FF994 /* LegacyTabScrollController.swift */,
-				E698FFD91B4AADF40001F623 /* TabScrollController.swift */,
+				E698FFD91B4AADF40001F623 /* TabScrollHandler.swift */,
 			);
 			path = TabScrollController;
 			sourceTree = "<group>";
@@ -11804,8 +11806,6 @@
 				5FDE66022D94528A003961DC /* A11ySettingsTests.swift */,
 				E143BF642CE36FF800A1D2D9 /* A11yTabTrayTests.swift */,
 				8A94DB8E2E0F0E780005FE69 /* HomepageSearchBarTests.swift */,
-				211FD2742DF38106003F60EF /* CookiePersistenceUITests.swift */,
-				211FD2742DF38106003F60EF /* CookiePersistenceTests.swift */,
 				3B546EBF1D95ECAE00BDBE36 /* ActivityStreamTest.swift */,
 				0B3D670D1E09B90B00C1EFC7 /* AuthenticationTest.swift */,
 				0B305E1A1E3A98A900BE0767 /* BookmarksTests.swift */,
@@ -14860,7 +14860,8 @@
 				401F68F52D94966600786D0C /* RemoteTabsPanelDelegateMock.swift */,
 				F98CB66B2A4123B5005F38E9 /* EnhancedTrackingProtection */,
 				8A1E3BE828CBC57E003388C4 /* SearchEngines */,
-				2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */,
+				2173326629CCD259007F20C7 /* LegacyTabScrollControllerTests.swift */,
+				21872A222E3CFEA500241A8A /* TabScrollHandlerTests.swift */,
 				8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */,
 				E1AEC174286E0CF500062E29 /* WebView */,
 				0BAF20E42E02A1A4000D4542 /* BrowserWebUIDelegateTests.swift */,
@@ -17954,7 +17955,7 @@
 				0B0ED7292D5B46B6001515CB /* TemporaryDocumentLoadingView.swift in Sources */,
 				D88FDAAF1F4E2BA000FD9709 /* PhotonActionSheetAnimator.swift in Sources */,
 				C83432FE26BAD30D00ABAAA6 /* EnhancedTrackingProtectionDetailsVC.swift in Sources */,
-				E698FFDA1B4AADF40001F623 /* TabScrollController.swift in Sources */,
+				E698FFDA1B4AADF40001F623 /* TabScrollHandler.swift in Sources */,
 				8AF117242DDE228700577232 /* TabTrayThemeAnimator.swift in Sources */,
 				1DD4B26E2CA4D09100B51945 /* TabErrorTelemetryHelper.swift in Sources */,
 				8A359EF32A1FD449004A5BB7 /* AdjustWrapper.swift in Sources */,
@@ -18643,6 +18644,7 @@
 				E1EAA5F32D4A705500D3039C /* ToolbarMiddlewareTests.swift in Sources */,
 				8AA8389D2CA2FEFC003FA256 /* StoreTestUtility.swift in Sources */,
 				E1390FB628B040E900C9EF3E /* WallpaperSelectorViewModelTests.swift in Sources */,
+				21872A232E3CFEA500241A8A /* TabScrollHandlerTests.swift in Sources */,
 				39AF317429DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift in Sources */,
 				E14C78962C105488002AD3C7 /* AddressToolbarContainerModelTests.swift in Sources */,
 				C2A72A6B2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift in Sources */,
@@ -18877,7 +18879,7 @@
 				8A552AC72CB43AB400564C98 /* HomepageStateTests.swift in Sources */,
 				8AABBD032A001CBC0089941E /* MockApplicationHelper.swift in Sources */,
 				8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */,
-				2173326829CCDA8E007F20C7 /* TabScrollControllerTests.swift in Sources */,
+				2173326829CCDA8E007F20C7 /* LegacyTabScrollControllerTests.swift in Sources */,
 				1D3564542D9329FA00F52F12 /* SearchPrefsMigrationTests.swift in Sources */,
 				BA1C68BA2B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift in Sources */,
 				2109726E2DCA8831001162A2 /* ZoomTelemetryTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1024,9 +1024,9 @@ class BrowserViewController: UIViewController,
         }
 
         navigationToolbarContainer.toolbarDelegate = self
-        scrollController.header = header
-        scrollController.overKeyboardContainer = overKeyboardContainer
-        scrollController.bottomContainer = bottomContainer
+        scrollController.configureToolbarViews(overKeyboardContainer: overKeyboardContainer,
+                                               bottomContainer: bottomContainer,
+                                               headerContainer: header)
 
         // Setup UIDropInteraction to handle dragging and dropping
         // links into the view from other apps.

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -10,7 +10,7 @@ import Common
 final class LegacyTabScrollController: NSObject,
                                        SearchBarLocationProvider,
                                        Themeable,
-                                       TabScrollControllerProtocol {
+                                       TabScrollHandler {
     private struct UX {
         static let abruptScrollEventOffset: CGFloat = 200
         static let toolbarBaseAnimationDuration: CGFloat = 0.2

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -10,7 +10,7 @@ import Common
 final class LegacyTabScrollController: NSObject,
                                        SearchBarLocationProvider,
                                        Themeable,
-                                       TabScrollHandler {
+                                       TabScrollHandlerProtocol {
     private struct UX {
         static let abruptScrollEventOffset: CGFloat = 200
         static let toolbarBaseAnimationDuration: CGFloat = 0.2
@@ -240,9 +240,9 @@ final class LegacyTabScrollController: NSObject,
         }
     }
 
-    func configureToolbarViews(overKeyboardContainer: BaseAlphaStackView,
-                               bottomContainer: BaseAlphaStackView,
-                               headerContainer: BaseAlphaStackView) {
+    func configureToolbarViews(overKeyboardContainer: BaseAlphaStackView?,
+                               bottomContainer: BaseAlphaStackView?,
+                               headerContainer: BaseAlphaStackView?) {
         self.overKeyboardContainer = overKeyboardContainer
         self.bottomContainer = bottomContainer
         self.header = headerContainer
@@ -523,28 +523,35 @@ private extension LegacyTabScrollController {
 
     /// Updates the state of the toolbar based on the scroll positions of various UI components.
     ///
-    /// The function evaluates the current offsets of three UI containers:
-    /// - `bottomContainerOffset` compared to `bottomContainerScrollHeight`
-    /// - `overKeyboardContainerOffset` compared to `overKeyboardScrollHeight`
-    /// - `headerTopOffset` compared to `-topScrollHeight`
-    ///
     /// Based on their states, it sets the toolbar state to one of the following:
     /// - `.collapsed`: All containers are fully collapsed (scrolled to their maximum).
     /// - `.visible`: Toolbars are currently showing (`toolbarsShowing == true`).
     /// - `.animating`: In transition or partially visible state.
     func updateToolbarState() {
-        // Checks if bottom containers are fully collapsed based on their offsets
-        let bottomContainerCollapsed = bottomContainerOffset == bottomContainerScrollHeight
-        let overKeyboardContainerCollapsed = overKeyboardContainerOffset == overKeyboardScrollHeight
-
-        // top container
-        let headerContainerIsCollapsed = headerTopOffset == -headerHeight
-
-        if headerContainerIsCollapsed && (bottomContainerCollapsed && overKeyboardContainerCollapsed) {
+        if isToolbarCollapsed() {
             setToolbarState(state: .collapsed)
         } else if toolbarsShowing {
             setToolbarState(state: .visible)
         }
+    }
+
+    /// The function evaluates the current offsets of three UI containers:
+    /// - `bottomContainerOffset` compared to `bottomContainerScrollHeight`
+    /// - `overKeyboardContainerOffset` compared to `overKeyboardScrollHeight`
+    /// - `headerTopOffset` compared to `-topScrollHeight`
+    /// - Returns: `true` if the toolbar is collapsed checks if isBottomSearchBar, `false`.
+    func isToolbarCollapsed() -> Bool {
+        guard !isBottomSearchBar else {
+            // Checks if bottom containers are fully collapsed based on their offsets
+            let bottomContainerCollapsed = bottomContainerOffset == bottomContainerScrollHeight
+            let overKeyboardContainerCollapsed = overKeyboardContainerOffset == overKeyboardScrollHeight
+            return bottomContainerCollapsed && overKeyboardContainerCollapsed
+        }
+
+        // top container
+        let headerContainerIsCollapsed = headerTopOffset == -headerHeight
+
+        return headerContainerIsCollapsed
     }
 
     func setToolbarState(state: ToolbarState) {

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -9,7 +9,8 @@ import Common
 
 final class LegacyTabScrollController: NSObject,
                                        SearchBarLocationProvider,
-                                       Themeable {
+                                       Themeable,
+                                       TabScrollControllerProtocol {
     private struct UX {
         static let abruptScrollEventOffset: CGFloat = 200
         static let toolbarBaseAnimationDuration: CGFloat = 0.2
@@ -55,12 +56,12 @@ final class LegacyTabScrollController: NSObject,
     }
 
     // Top toolbar UI and Constraints
-    weak var header: BaseAlphaStackView?
+    private weak var header: BaseAlphaStackView?
     var headerTopConstraint: Constraint?
 
     // Bottom toolbar UI and Constraints
-    weak var overKeyboardContainer: BaseAlphaStackView?
-    weak var bottomContainer: BaseAlphaStackView?
+    private weak var overKeyboardContainer: BaseAlphaStackView?
+    private weak var bottomContainer: BaseAlphaStackView?
     var overKeyboardContainerConstraint: Constraint?
     var bottomContainerConstraint: Constraint?
 
@@ -237,6 +238,14 @@ final class LegacyTabScrollController: NSObject,
         themeObserver = notificationCenter.addObserver(name: .ThemeDidChange, queue: .main) { [weak self] _ in
             self?.applyTheme()
         }
+    }
+
+    func configureToolbarViews(overKeyboardContainer: BaseAlphaStackView,
+                               bottomContainer: BaseAlphaStackView,
+                               headerContainer: BaseAlphaStackView) {
+        self.overKeyboardContainer = overKeyboardContainer
+        self.bottomContainer = bottomContainer
+        self.header = headerContainer
     }
 
     private func handleOnTabContentLoading() {

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollController.swift
@@ -13,7 +13,7 @@ protocol TabScrollControllerDelegate: AnyObject {
     func hideToolbar()
 }
 
-protocol TabScrollControllerProtocol: AnyObject {
+protocol TabScrollHandler: AnyObject {
     func configureToolbarViews(overKeyboardContainer: BaseAlphaStackView,
                                bottomContainer: BaseAlphaStackView,
                                headerContainer: BaseAlphaStackView)
@@ -21,7 +21,7 @@ protocol TabScrollControllerProtocol: AnyObject {
 
 final class TabScrollController: NSObject,
                                  SearchBarLocationProvider,
-                                 TabScrollControllerProtocol,
+                                 TabScrollHandler,
                                  UIScrollViewDelegate {
     private struct UX {
         static let abruptScrollEventOffset: CGFloat = 200
@@ -144,8 +144,7 @@ final class TabScrollController: NSObject,
     ///   - isBottomSearchBar: Whether search bar is set to the bottom.
     /// - Returns: The calculated scroll height.
     func overKeyboardScrollHeight(overKeyboardContainer: BaseAlphaStackView,
-                                  safeAreaInsets: UIEdgeInsets?,
-                                  isMinimalAddressBarEnabled: Bool) -> CGFloat {
+                                  safeAreaInsets: UIEdgeInsets?) -> CGFloat {
         let containerHeight = overKeyboardContainer.frame.height
 
         let isReaderModeActive = tab?.url?.isReaderModeURL == true
@@ -172,8 +171,7 @@ final class TabScrollController: NSObject,
         if isBottomSearchBar {
             bottomContainerScrollHeight = bottomContainer.frame.height
             overKeyboardScrollHeight = overKeyboardScrollHeight(overKeyboardContainer: overKeyboardContainer,
-                                                                safeAreaInsets: UIWindow.keyWindow?.safeAreaInsets,
-                                                                isMinimalAddressBarEnabled: isMinimalAddressBarEnabled)
+                                                                safeAreaInsets: UIWindow.keyWindow?.safeAreaInsets)
             headerHeight = 0
         } else {
             headerHeight = headerContainer.frame.height
@@ -437,7 +435,7 @@ final class TabScrollController: NSObject,
         let velocity = gesture.velocity(in: containerView)
         handleScroll(for: translation, velocity: velocity)
 
-//        guard isAnimatingToolbar else { return }
+        guard isAnimatingToolbar else { return }
 
         if contentOffsetBeforeAnimation.y - scrollView.contentOffset.y > UX.abruptScrollEventOffset {
             setOffset(y: contentOffsetBeforeAnimation.y + headerHeight, for: scrollView)
@@ -619,7 +617,6 @@ private extension TabScrollController {
             overKeyboardContainerOffset = clamp(offset: overKeyboardUpdatedOffset, min: 0, max: overKeyboardScrollHeight)
         }
 
-//        header?.updateAlphaForSubviews(scrollAlpha)
         zoomPageBar?.updateAlphaForSubviews(scrollAlpha)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollController.swift
@@ -82,7 +82,6 @@ final class TabScrollController: NSObject,
     private var lastContentOffsetY: CGFloat = 0
     private var scrollDirection: ScrollDirection = .down
     var toolbarState: ToolbarState = .visible
-    
 
     weak var delegate: TabScrollControllerDelegate?
 
@@ -101,10 +100,8 @@ final class TabScrollController: NSObject,
     private var headerTopOffset: CGFloat = 0 {
         didSet {
             headerTopConstraint?.update(offset: headerTopOffset)
-//            header?.superview?.setNeedsLayout()
         }
     }
-     //{ header?.frame.height ?? 0 }
 
     /// Calculates the header offset based on device type and toolbar visibility.
     ///
@@ -131,14 +128,12 @@ final class TabScrollController: NSObject,
     private var overKeyboardContainerOffset: CGFloat = 0 {
         didSet {
             overKeyboardContainerConstraint?.update(offset: overKeyboardContainerOffset)
-//            overKeyboardContainer?.superview?.setNeedsLayout()
         }
     }
 
     private var bottomContainerOffset: CGFloat = 0 {
         didSet {
             bottomContainerConstraint?.update(offset: bottomContainerOffset)
-//            bottomContainer?.superview?.setNeedsLayout()
         }
     }
 
@@ -148,15 +143,24 @@ final class TabScrollController: NSObject,
     ///   - isMinimalAddressBarEnabled: Whether minimal address bar feature is enabled.
     ///   - isBottomSearchBar: Whether search bar is set to the bottom.
     /// - Returns: The calculated scroll height.
-    private func overKeyboardScrollHeight(overKeyboardContainer: BaseAlphaStackView,
-                                          safeAreaInsets: UIEdgeInsets?,
-                                          isMinimalAddressBarEnabled: Bool) -> CGFloat {
+    func overKeyboardScrollHeight(overKeyboardContainer: BaseAlphaStackView,
+                                  safeAreaInsets: UIEdgeInsets?,
+                                  isMinimalAddressBarEnabled: Bool) -> CGFloat {
         let containerHeight = overKeyboardContainer.frame.height
-        // Return full height if minimal address bar is disabled or not using bottom search bar
-        // or if zoom bar is not visible.
-        guard isMinimalAddressBarEnabled && isBottomSearchBar && zoomPageBar == nil else { return containerHeight }
+
+        let isReaderModeActive = tab?.url?.isReaderModeURL == true
+
+        // Return full height if conditions aren't met for adjustment.
+        let shouldAdjustHeight = isMinimalAddressBarEnabled
+                                  && isBottomSearchBar
+                                  && zoomPageBar == nil
+                                  && !isReaderModeActive
+
+        guard shouldAdjustHeight else { return containerHeight }
+
         // Devices with home indicator (newer iPhones) vs physical home button (older iPhones).
         let hasHomeIndicator = safeAreaInsets?.bottom ?? .zero > 0
+
         let topInset = safeAreaInsets?.top ?? .zero
 
         return hasHomeIndicator ? .zero : containerHeight - topInset
@@ -177,19 +181,6 @@ final class TabScrollController: NSObject,
             overKeyboardScrollHeight = 0
         }
     }
-
-//    private var overKeyboardScrollHeight: CGFloat {
-//        return overKeyboardScrollHeight(
-//            with: UIWindow.keyWindow?.safeAreaInsets,
-//            isMinimalAddressBarEnabled: isMinimalAddressBarEnabled,
-//            isBottomSearchBar: isBottomSearchBar
-//        )
-//    }
-//
-//    private var bottomContainerScrollHeight: CGFloat {
-//        let bottomContainerHeight = bottomContainer?.frame.height ?? 0
-//        return bottomContainerHeight
-//    }
 
     private var scrollView: UIScrollView? { return tab?.webView?.scrollView }
     var contentOffset: CGPoint { return scrollView?.contentOffset ?? .zero }
@@ -701,9 +692,6 @@ private extension TabScrollController {
             }
 
             overKeyboardContainerOffset = overKeyboardOffset
-
-//            header?.updateAlphaForSubviews(alpha)
-//            header?.superview?.layoutIfNeeded()
 
             zoomPageBar?.updateAlphaForSubviews(alpha)
             zoomPageBar?.superview?.layoutIfNeeded()

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -7,7 +7,7 @@ import SnapKit
 import Shared
 import Common
 
-protocol TabScrollControllerDelegate: AnyObject {
+protocol TabScrollHandlerDelegate: AnyObject {
     func startAnimatingToolbar(state: ToolbarState)
     func showToolbar()
     func hideToolbar()

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -7,12 +7,6 @@ import SnapKit
 import Shared
 import Common
 
-protocol TabScrollHandlerDelegate: AnyObject {
-    func startAnimatingToolbar(state: ToolbarState)
-    func showToolbar()
-    func hideToolbar()
-}
-
 protocol TabScrollHandlerProtocol: AnyObject {
     func configureToolbarViews(overKeyboardContainer: BaseAlphaStackView?,
                                bottomContainer: BaseAlphaStackView?,
@@ -23,6 +17,12 @@ final class TabScrollHandler: NSObject,
                                  SearchBarLocationProvider,
                                  TabScrollHandlerProtocol,
                                  UIScrollViewDelegate {
+    protocol Delegate: AnyObject {
+        func startAnimatingToolbar(state: ToolbarState)
+        func showToolbar()
+        func hideToolbar()
+    }
+
     private struct UX {
         static let abruptScrollEventOffset: CGFloat = 200
         static let toolbarBaseAnimationDuration: CGFloat = 0.2
@@ -83,7 +83,7 @@ final class TabScrollHandler: NSObject,
     private var scrollDirection: ScrollDirection = .down
     var toolbarState: ToolbarState = .visible
 
-    weak var delegate: TabScrollControllerDelegate?
+    private weak var delegate: TabScrollHandler.Delegate?
 
     private let windowUUID: WindowUUID
     private let logger: Logger
@@ -214,7 +214,7 @@ final class TabScrollHandler: NSObject,
     init(windowUUID: WindowUUID,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          logger: Logger = DefaultLogger.shared,
-         delegate: TabScrollControllerDelegate? = nil) {
+         delegate: TabScrollHandler.Delegate? = nil) {
         self.windowUUID = windowUUID
         self.notificationCenter = notificationCenter
         self.logger = logger

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
@@ -9,7 +9,7 @@ import Shared
 
 @testable import Client
 
-final class TabScrollControllerTests: XCTestCase {
+final class LegacyTabScrollControllerTests: XCTestCase {
     var tab: Tab!
     var mockProfile: MockProfile!
     var mockGesture: UIPanGestureRecognizerMock!
@@ -17,6 +17,7 @@ final class TabScrollControllerTests: XCTestCase {
 
     var header: BaseAlphaStackView = .build()
     var overKeyboardContainer: BaseAlphaStackView = .build()
+    var bottomContainer: BaseAlphaStackView = .build()
 
     override func setUp() {
         super.setUp()
@@ -66,7 +67,6 @@ final class TabScrollControllerTests: XCTestCase {
         // Force call to showToolbars like clicking on top bar area
         subject.showToolbars(animated: true)
         XCTAssertEqual(subject.toolbarState, LegacyTabScrollController.ToolbarState.visible)
-        XCTAssertEqual(subject.header?.alpha, 1)
     }
 
     func testScrollDidEndDragging_ScrollingUp() {
@@ -79,7 +79,6 @@ final class TabScrollControllerTests: XCTestCase {
         subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
 
         XCTAssertEqual(subject.toolbarState, LegacyTabScrollController.ToolbarState.visible)
-        XCTAssertEqual(subject.header?.alpha, 1)
     }
 
     func testScrollDidEndDragging_ScrollingDown() {
@@ -143,7 +142,6 @@ final class TabScrollControllerTests: XCTestCase {
 
         let containerHeight: CGFloat = 100
         overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
-        subject.overKeyboardContainer = overKeyboardContainer
 
         let safeAreaInsets = UIEdgeInsets(top: 44, left: 0, bottom: 34, right: 0)
         let result = subject.overKeyboardScrollHeight(
@@ -158,10 +156,6 @@ final class TabScrollControllerTests: XCTestCase {
     func testOverKeyboardScrollHeight_minimalEnabledWithHomeIndicator_returnsZero() {
         let subject = createSubject()
         setupTabScroll(with: subject)
-
-        let containerHeight: CGFloat = 100
-        overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
-        subject.overKeyboardContainer = overKeyboardContainer
 
         let safeAreaInsets = UIEdgeInsets(top: 44, left: 0, bottom: 34, right: 0)
         let result = subject.overKeyboardScrollHeight(
@@ -179,8 +173,6 @@ final class TabScrollControllerTests: XCTestCase {
 
         let containerHeight: CGFloat = 100
         let topInset: CGFloat = 20
-        overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
-        subject.overKeyboardContainer = overKeyboardContainer
 
         let safeAreaInsets = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
         let result = subject.overKeyboardScrollHeight(
@@ -196,8 +188,7 @@ final class TabScrollControllerTests: XCTestCase {
     func testOverKeyboardScrollHeight_nilContainer_returnsZero() {
         let subject = createSubject()
         setupTabScroll(with: subject)
-
-        subject.overKeyboardContainer = nil
+        setupToolbarViews(with: subject, overKeyboardContainer: nil)
 
         let safeAreaInsets = UIEdgeInsets(top: 44, left: 0, bottom: 0, right: 0)
         let result = subject.overKeyboardScrollHeight(
@@ -214,8 +205,6 @@ final class TabScrollControllerTests: XCTestCase {
         setupTabScroll(with: subject)
 
         let containerHeight: CGFloat = 100
-        overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
-        subject.overKeyboardContainer = overKeyboardContainer
 
         let result = subject.overKeyboardScrollHeight(
             with: nil,
@@ -231,9 +220,6 @@ final class TabScrollControllerTests: XCTestCase {
         setupTabScroll(with: subject)
 
         let containerHeight: CGFloat = 100
-        overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
-        subject.overKeyboardContainer = overKeyboardContainer
-
         let result = subject.overKeyboardScrollHeight(
             with: UIEdgeInsets.zero,
             isMinimalAddressBarEnabled: true,
@@ -249,9 +235,6 @@ final class TabScrollControllerTests: XCTestCase {
 
         let containerHeight: CGFloat = 100
         let topInset: CGFloat = 20
-
-        overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
-        subject.overKeyboardContainer = overKeyboardContainer
 
         let safeAreaInsets = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
         let result = subject.overKeyboardScrollHeight(
@@ -271,7 +254,6 @@ final class TabScrollControllerTests: XCTestCase {
         let topInset: CGFloat = 20
 
         overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
-        subject.overKeyboardContainer = overKeyboardContainer
         let zoomPageBar = ZoomPageBar(zoomManager: ZoomPageManager(windowUUID: windowUUID))
         subject.zoomPageBar = zoomPageBar
 
@@ -292,8 +274,6 @@ final class TabScrollControllerTests: XCTestCase {
 
         let containerHeight: CGFloat = 100
         let safeAreaInsets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
-        overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
-        subject.overKeyboardContainer = overKeyboardContainer
 
         let result = subject.overKeyboardScrollHeight(
             with: safeAreaInsets,
@@ -308,10 +288,7 @@ final class TabScrollControllerTests: XCTestCase {
         let subject = createSubject()
         setupTabScroll(with: subject)
 
-        let containerHeight: CGFloat = 100
         let safeAreaInsets = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
-        overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
-        subject.overKeyboardContainer = overKeyboardContainer
 
         let result = subject.overKeyboardScrollHeight(
             with: safeAreaInsets,
@@ -329,12 +306,21 @@ final class TabScrollControllerTests: XCTestCase {
         tab.webView?.scrollView.contentSize = CGSize(width: 200, height: 2000)
         tab.webView?.scrollView.delegate = subject
         subject.tab = tab
-        subject.header = header
     }
 
     private func createSubject() -> LegacyTabScrollController {
         let subject = LegacyTabScrollController(windowUUID: .XCTestDefaultUUID)
+        setupToolbarViews(with: subject, overKeyboardContainer: overKeyboardContainer)
         trackForMemoryLeaks(subject)
         return subject
+    }
+
+    private func setupToolbarViews(with subject: LegacyTabScrollController,
+                                   overKeyboardContainer: BaseAlphaStackView?) {
+        let containerHeight: CGFloat = 100
+        overKeyboardContainer?.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
+        subject.configureToolbarViews(overKeyboardContainer: overKeyboardContainer,
+                                      bottomContainer: bottomContainer,
+                                      headerContainer: header)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
@@ -1,0 +1,151 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import WebKit
+import Common
+import Shared
+
+@testable import Client
+
+final class TabScrollHandlerTests: XCTestCase {
+    var tab: Tab!
+    var mockProfile: MockProfile!
+    let windowUUID: WindowUUID = .XCTestDefaultUUID
+
+    override func setUp() {
+        super.setUp()
+
+        DependencyHelperMock().bootstrapDependencies()
+        mockProfile = MockProfile()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
+        tab = Tab(profile: mockProfile, windowUUID: windowUUID)
+    }
+
+    override func tearDown() {
+        mockProfile?.shutdown()
+        mockProfile = nil
+        tab = nil
+        super.tearDown()
+    }
+
+    func testHandlePan_ScrollingUpWithTranslation() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        let translation = CGPoint(x: 0, y: 100)
+        let velocity = CGPoint(x: 10, y: 10)
+        subject.handleScroll(for: translation, velocity: velocity)
+        XCTAssertEqual(subject.toolbarState, TabScrollHandler.ToolbarState.collapsed)
+    }
+
+    func testHandlePan_ScrollingDownWithTranslation() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        let translation = CGPoint(x: 0, y: -100)
+        let velocity = CGPoint(x: 10, y: 10)
+        subject.handleScroll(for: translation, velocity: velocity)
+
+        XCTAssertEqual(subject.toolbarState, TabScrollHandler.ToolbarState.visible)
+    }
+
+    func testHandlePan_ScrollingUpWithVelocity() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        let translation = CGPoint(x: 0, y: 10)
+        let velocity = CGPoint(x: 10, y: 110)
+        subject.handleScroll(for: translation, velocity: velocity)
+        XCTAssertEqual(subject.toolbarState, TabScrollHandler.ToolbarState.collapsed)
+    }
+
+    func testHandlePan_ScrollingDownWithVelocity() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        let translation = CGPoint(x: 0, y: -10)
+        let velocity = CGPoint(x: 10, y: 110)
+        subject.handleScroll(for: translation, velocity: velocity)
+
+        XCTAssertEqual(subject.toolbarState, TabScrollHandler.ToolbarState.visible)
+    }
+
+    func testHandlePan_ToolbarVisible_ScrollingUp() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        let translation = CGPoint(x: 0, y: 10)
+        let velocity = CGPoint(x: 10, y: 10)
+        subject.handleScroll(for: translation, velocity: velocity)
+
+        XCTAssertEqual(subject.toolbarState, TabScrollHandler.ToolbarState.visible)
+    }
+
+    func testHandlePan_ToolbarVisible_ScrollingDown() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        let translation = CGPoint(x: 0, y: -10)
+        let velocity = CGPoint(x: 10, y: 10)
+        subject.handleScroll(for: translation, velocity: velocity)
+
+        XCTAssertEqual(subject.toolbarState, TabScrollHandler.ToolbarState.visible)
+    }
+
+    func testShowToolbar_AfterHidingWithScroll() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        // Hide toolbar
+        let translation = CGPoint(x: 0, y: 100)
+        let velocity = CGPoint(x: 10, y: 80)
+        subject.handleScroll(for: translation, velocity: velocity)
+
+        // Force call to showToolbars like clicking on top bar area
+        subject.showToolbars(animated: true)
+        XCTAssertEqual(subject.toolbarState, TabScrollHandler.ToolbarState.visible)
+    }
+
+    func testShouldScrollToTop_AfterHidingBar() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        guard let scrollView = tab.webView?.scrollView else {
+            return XCTFail("Could not find scrollview")
+        }
+
+        // Hide toolbar
+        let translation = CGPoint(x: 0, y: 100)
+        let velocity = CGPoint(x: 10, y: 80)
+        subject.handleScroll(for: translation, velocity: velocity)
+        XCTAssertTrue(subject.scrollViewShouldScrollToTop(scrollView))
+        XCTAssertEqual(subject.toolbarState, TabScrollHandler.ToolbarState.visible)
+    }
+
+    // MARK: - Setup
+    private func setupTabScroll(with subject: TabScrollHandler) {
+        tab.createWebview(configuration: .init())
+        tab.webView?.scrollView.frame.size = CGSize(width: 200, height: 2000)
+        tab.webView?.scrollView.contentSize = CGSize(width: 200, height: 2000)
+        tab.webView?.scrollView.delegate = subject
+        subject.tab = tab
+    }
+
+    private func createSubject() -> TabScrollHandler {
+        let subject = TabScrollHandler(windowUUID: .XCTestDefaultUUID)
+
+        let header: BaseAlphaStackView = .build()
+        let overKeyboardContainer: BaseAlphaStackView = .build()
+        let bottomContainer: BaseAlphaStackView = .build()
+
+        overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: 100)
+
+        subject.configureToolbarViews(overKeyboardContainer: overKeyboardContainer,
+                                      bottomContainer: bottomContainer,
+                                      headerContainer: header)
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12977)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28304)

## :bulb: Description
- Rename `TabScrollController` to `TabScrollHandler`
- Create `TabScrollHandlerDelegate` not used yet
- Create `TabScrollHandlerProtocol` and conformance for `LegacyTabScrollController` and `TabScrollHandler`
- Removed toolbar views  reference from `TabScrollHandler` and add configuration function used to setup view heights
- Add TabScrollHandler tests and update test

Part 1 to unblock @PARAIPAN9  work


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
