### PR TITLE
Refactor [Summarizer] Only use `invalidResponse` for http error responses.

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/FoundationModelsSummarizer.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/FoundationModelsSummarizer.swift
@@ -69,7 +69,7 @@ final class FoundationModelsSummarizer: SummarizerProtocol {
                /// When `next()` returns nil, the underlying stream has no more data
                /// returning nil in turn ends the AsyncThrowingStream
                guard let chunk = try await responseStream.next() else { return nil }
-               guard let stringChunk = chunk as? String else { throw SummarizerError.invalidResponse }
+               guard let stringChunk = chunk as? String else { throw SummarizerError.invalidChunk }
                return stringChunk
            } catch {
                throw self.mapError(error)

--- a/BrowserKit/Sources/SummarizeKit/Backend/LLM/LiteLLMSummarizer.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/LLM/LiteLLMSummarizer.swift
@@ -70,7 +70,7 @@ final class LiteLLMSummarizer: SummarizerProtocol {
         case LiteLLMClientError.invalidResponse(let statusCode) where statusCode == 429:
             return .rateLimited
         case LiteLLMClientError.invalidResponse(let statusCode):
-            return .unknown(LiteLLMClientError.invalidResponse(statusCode: statusCode))
+            return .invalidResponse(statusCode: statusCode)
         case is CancellationError: return .cancelled
         case let e as LiteLLMClientError: return .unknown(e)
         default: return .unknown(error)

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerError.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerError.swift
@@ -12,7 +12,9 @@ enum SummarizerError: Error, LocalizedError, Sendable {
     case busy
     case safetyBlocked
     case unsupportedLanguage
-    case invalidResponse
+    case invalidResponse(statusCode: Int)
+    case unableToExtractContent
+    case invalidChunk
     case cancelled
     case noContent
     case unknown(Error)
@@ -30,6 +32,8 @@ enum SummarizerError: Error, LocalizedError, Sendable {
         case .cancelled: return ""
         case .invalidResponse: return ""
         case .noContent: return ""
+        case .invalidChunk: return ""
+        case .unableToExtractContent: return ""
         case .unknown: return ""
         }
     }
@@ -40,7 +44,7 @@ enum SummarizerError: Error, LocalizedError, Sendable {
         case .contentTooLong: self = .tooLong
         case .documentLanguageUnsupported: self = .unsupportedLanguage
         case .documentNotReadable: self = .cancelled
-        case nil: self = .invalidResponse
+        case nil: self = .unableToExtractContent
         }
     }
 }

--- a/BrowserKit/Sources/SummarizeKit/SummarizationError+LocalizedErrorsViewModel.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizationError+LocalizedErrorsViewModel.swift
@@ -7,7 +7,10 @@ import Foundation
 extension SummarizerError {
     var shouldRetrySummarizing: Bool {
         return switch self {
-        case .busy, .noContent, .invalidResponse:
+        case .busy,
+             .noContent,
+             .invalidResponse,
+             .invalidChunk:
             true
         default:
             false
@@ -20,11 +23,14 @@ extension SummarizerError {
             localizedErrors.rateLimitedMessage
         case .safetyBlocked:
             localizedErrors.unsafeContentMessage
-        case .unsupportedLanguage, .invalidResponse, .tooLong:
+        case .unsupportedLanguage,
+             .invalidResponse,
+             .tooLong,
+             .unableToExtractContent:
             localizedErrors.summarizationNotAvailableMessage
         case .noContent, .busy:
             localizedErrors.pageStillLoadingMessage
-        case .unknown, .cancelled:
+        case .unknown, .cancelled, .invalidChunk:
             localizedErrors.genericErrorMessage
         }
     }

--- a/BrowserKit/Tests/SummarizeKitTests/FoundationModelsSummarizerTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/FoundationModelsSummarizerTests.swift
@@ -125,6 +125,9 @@ extension SummarizerError: @retroactive Equatable {
              (.safetyBlocked, .safetyBlocked),
              (.unsupportedLanguage, .unsupportedLanguage),
              (.invalidResponse, .invalidResponse),
+             (.unableToExtractContent, .unableToExtractContent),
+             (.invalidChunk, .invalidChunk),
+             (.noContent, .noContent),
              (.cancelled, .cancelled):
             return true
 

--- a/BrowserKit/Tests/SummarizeKitTests/LiteLLMSummarizerTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/LiteLLMSummarizerTests.swift
@@ -20,6 +20,14 @@ final class LiteLLMSummarizerTests: XCTestCase {
         }
     }
 
+    func testSummarizeNonStreamingMapsInvalidResponse() async throws {
+        let rateLimitError = LiteLLMClientError.invalidResponse(statusCode: 502)
+        let subject = createSubject(respondWithError: rateLimitError)
+        await assertSummarizeThrows(.invalidResponse(statusCode: 502)) {
+            _ = try await subject.summarize("t")
+        }
+    }
+
     func testSummarizeNonStreamingMapsUnknownError() async throws {
         let randomError = NSError(domain: "Random error", code: 1)
         let subject = createSubject(respondWithError: randomError)
@@ -45,6 +53,15 @@ final class LiteLLMSummarizerTests: XCTestCase {
         let subject = createSubject(respondWithError: rateLimitError)
         let stream = subject.summarizeStreamed("t")
         await assertSummarizeThrows(.rateLimited) {
+            for try await _ in stream { }
+        }
+    }
+
+    func testSummarizeStreamedMapsInvalidResponse() async throws {
+        let rateLimitError = LiteLLMClientError.invalidResponse(statusCode: 567)
+        let subject = createSubject(respondWithError: rateLimitError)
+        let stream = subject.summarizeStreamed("t")
+        await assertSummarizeThrows(.invalidResponse(statusCode: 567)) {
             for try await _ in stream { }
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13056)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR:
- Adds specific error cases for extraction and model inference errors.
- Uses `invalidResponse` only for http response errors.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
