### PR TITLE
Bugfix FXIOS-12796 #27871 ⁃ [Swift 6 Migration] Turn on Strict Concurrency in Xcode 26 Beta 2+ and fix warnings

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
@@ -5,6 +5,7 @@
 import Common
 import Foundation
 
+@MainActor
 struct SimpleToast: ThemeApplicable {
     struct UX {
         static let labelPadding: CGFloat = 16

--- a/firefox-ios/Client/Frontend/FeltPrivacy/DataClearanceAnimation.swift
+++ b/firefox-ios/Client/Frontend/FeltPrivacy/DataClearanceAnimation.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 // Animation for when the user confirms they want to delete their data through the data clearance flow in private mode
 // There are different animations depending on the orientation of the device
+@MainActor
 struct DataClearanceAnimation {
     enum AnimationType {
         case phonePortrait

--- a/firefox-ios/Client/Frontend/Home/Blurrable.swift
+++ b/firefox-ios/Client/Frontend/Home/Blurrable.swift
@@ -8,11 +8,14 @@ import Foundation
 // Convenience protocol to have a blur on a collection view cell
 // Currently used on the homepage cells
 protocol Blurrable: UICollectionViewCell {
+    @MainActor
     var shouldApplyWallpaperBlur: Bool { get }
+    @MainActor
     func adjustBlur(theme: Theme)
 }
 
 extension Blurrable {
+    @MainActor
     var shouldApplyWallpaperBlur: Bool {
         guard !UIAccessibility.isReduceTransparencyEnabled else { return false }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
- Fixes for SimpleToast, DataClearanceAnimation and Blurrable

## :movie_camera: Demos
<img width="313" height="1329" alt="Screenshot 2025-08-04 at 10 58 33 AM" src="https://github.com/user-attachments/assets/b1094322-73ab-47b1-9f30-a9ddd484b602" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
