### PR TITLE
Bugfix FXIOS-12796 #27871 ⁃ [Swift 6 Migration] Turn on Strict Concurrency in Xcode 26 Beta 2 and fix warnings for BadgeWithBackdrop

### DIFF
--- a/firefox-ios/Client/Frontend/Theme/PrivateModeUI.swift
+++ b/firefox-ios/Client/Frontend/Theme/PrivateModeUI.swift
@@ -5,5 +5,6 @@
 import Common
 
 protocol PrivateModeUI {
+    @MainActor
     func applyUIMode(isPrivate: Bool, theme: Theme)
 }

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -6,6 +6,7 @@ import UIKit
 import Shared
 import Common
 
+@MainActor
 protocol TabToolbarProtocol: AnyObject {
     var tabToolbarDelegate: TabToolbarDelegate? { get set }
 

--- a/firefox-ios/Client/Frontend/Widgets/BadgeWithBackdrop.swift
+++ b/firefox-ios/Client/Frontend/Widgets/BadgeWithBackdrop.swift
@@ -6,6 +6,7 @@ import Common
 import UIKit
 
 // Puts a backdrop (i.e. dark highlight) circle on the badged button.
+@MainActor
 class BadgeWithBackdrop: ThemeApplicable {
     struct UX {
         static let backdropAlpha: CGFloat = 0.05
@@ -16,7 +17,7 @@ class BadgeWithBackdrop: ThemeApplicable {
 
     // MARK: - Variables
     var backdrop: UIView
-    var badge: ToolbarBadge
+    let badge: ToolbarBadge
     private let backdropCircleSize: CGFloat
     private let isPrivateBadge: Bool
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
- Add @MainActor to BadgeWithBackdrop and TabToolbarProtocol and PrivateModeUI protocol

## :movie_camera: Demos
<img width="327" height="1324" alt="Screenshot 2025-08-04 at 2 05 44 PM" src="https://github.com/user-attachments/assets/316ffa78-a6c2-4952-83d7-111816457f72" />


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
