### PR TITLE
Bugfix 13040 ⁃ [Terms of Use] Bottom Sheet Content is Scrollable

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
@@ -23,15 +23,13 @@ final class TermsOfUseViewController: UIViewController,
         static let grabberHeight: CGFloat = 5
         static let grabberTopPadding: CGFloat = 8
         static let iPadWidthMultiplier: CGFloat = 0.6
+        static let textViewHeightMultiplier: CGFloat = 0.4
         static let panDismissDistance: CGFloat = 100
         static let panDismissVelocity: CGFloat = 800
         static let animationDuration: TimeInterval = 0.25
         static let springDamping: CGFloat = 0.8
         static let initialSpringVelocity: CGFloat = 1
         static let backgroundAlpha: CGFloat = 0.6
-        static let baseTextViewHeight: CGFloat = 120
-        static let largeTextViewHeight: CGFloat = 180
-        static let extraLargeTextViewHeight: CGFloat = 240
 
         static let titleFont = FXFontStyles.Regular.headline.scaledFont()
         static let descriptionFont = FXFontStyles.Regular.body.scaledFont()
@@ -47,18 +45,8 @@ final class TermsOfUseViewController: UIViewController,
     private let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
 
-    private var dynamicTextViewHeight: CGFloat {
-        switch traitCollection.preferredContentSizeCategory {
-        case .accessibilityMedium, .accessibilityLarge:
-            return UX.largeTextViewHeight
-        case .accessibilityExtraLarge, .accessibilityExtraExtraLarge, .accessibilityExtraExtraExtraLarge:
-            return UX.extraLargeTextViewHeight
-        default:
-            return UX.baseTextViewHeight
-        }
-    }
-
     private var activeContainerConstraints: [NSLayoutConstraint] = []
+    private var textViewHeightConstraint: NSLayoutConstraint?
 
     private var sheetContainer: UIView = .build { view in
         view.layer.cornerRadius = UX.cornerRadius
@@ -80,6 +68,7 @@ final class TermsOfUseViewController: UIViewController,
         imageView.contentMode = .scaleAspectFit
         imageView.heightAnchor.constraint(equalToConstant: UX.logoSize).isActive = true
         imageView.widthAnchor.constraint(equalToConstant: UX.logoSize).isActive = true
+        imageView.accessibilityIdentifier = AccessibilityIdentifiers.TermsOfUse.logo
     }
 
     private lazy var titleLabel: UILabel = .build { label in
@@ -88,11 +77,12 @@ final class TermsOfUseViewController: UIViewController,
         label.textAlignment = .center
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
+        label.accessibilityIdentifier = AccessibilityIdentifiers.TermsOfUse.title
     }
 
     private lazy var descriptionTextView: UITextView = .build { [self] textView in
         textView.isEditable = false
-        textView.isScrollEnabled = true
+        textView.isScrollEnabled = false
         textView.backgroundColor = .clear
         textView.attributedText = self.makeAttributedDescription()
         textView.adjustsFontForContentSizeCategory = true
@@ -100,8 +90,8 @@ final class TermsOfUseViewController: UIViewController,
             .foregroundColor: currentTheme().colors.textAccent,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
+        textView.accessibilityIdentifier = AccessibilityIdentifiers.TermsOfUse.description
         textView.delegate = self
-        textView.heightAnchor.constraint(greaterThanOrEqualToConstant: dynamicTextViewHeight).isActive = true
     }
 
     private lazy var acceptButton: UIButton = .build { button in
@@ -109,6 +99,7 @@ final class TermsOfUseViewController: UIViewController,
         button.titleLabel?.font = UX.acceptButtonFont
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.layer.cornerRadius = UX.acceptButtonCornerRadius
+        button.accessibilityIdentifier = AccessibilityIdentifiers.TermsOfUse.acceptButton
         button.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.acceptButtonHeight).isActive = true
         button.addTarget(self, action: #selector(self.acceptTapped), for: .touchUpInside)
     }
@@ -117,6 +108,7 @@ final class TermsOfUseViewController: UIViewController,
         button.setTitle(TermsOfUseStrings.remindMeLaterButtonTitle, for: .normal)
         button.titleLabel?.font = UX.remindMeLaterFont
         button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.accessibilityIdentifier = AccessibilityIdentifiers.TermsOfUse.remindMeLaterButton
         button.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.remindMeLaterButtonHeight).isActive = true
         button.addTarget(self, action: #selector(self.remindMeLaterTapped), for: .touchUpInside)
     }
@@ -181,6 +173,7 @@ final class TermsOfUseViewController: UIViewController,
             view.layoutIfNeeded()
         }
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            configureTextViewScrolling()
             descriptionTextView.attributedText = makeAttributedDescription()
             view.setNeedsLayout()
             view.layoutIfNeeded()
@@ -199,6 +192,7 @@ final class TermsOfUseViewController: UIViewController,
         sheetContainer.addSubview(stackView)
         addStackSubviews()
         setupConstraints()
+        configureTextViewScrolling()
         setupDismissGesture()
         setupPanGesture()
     }
@@ -335,6 +329,23 @@ final class TermsOfUseViewController: UIViewController,
 
     private func currentTheme() -> Theme {
         themeManager.getCurrentTheme(for: currentWindowUUID)
+    }
+
+    private func configureTextViewScrolling() {
+        if let existingConstraint = textViewHeightConstraint {
+            existingConstraint.isActive = false
+        }
+        switch traitCollection.preferredContentSizeCategory {
+        case .accessibilityExtraLarge, .accessibilityExtraExtraLarge, .accessibilityExtraExtraExtraLarge:
+            descriptionTextView.isScrollEnabled = true
+            textViewHeightConstraint = descriptionTextView.heightAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.heightAnchor,
+                multiplier: UX.textViewHeightMultiplier)
+            textViewHeightConstraint?.isActive = true
+
+        default:
+            descriptionTextView.isScrollEnabled = false
+        }
     }
 
     // MARK: TextView Delegate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13040)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28424)

## :bulb: Description
When using dynamic text the content of bottom sheet won t be scrollable, the height will increase. Just for the case of extraextralarge dynamic font when the text won't fit on the entire screen we will use scrolling so the user will be able to read the text.

## :movie_camera: Demos

<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-05 at 11 51 42" src="https://github.com/user-attachments/assets/b3163c98-0ab1-4fea-b4dc-c9af3507c22f" />

|
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [X] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
