### PR TITLE
Add FXIOS-13055 [Shake to Summarize] Footer title for summarize setting

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Summarize/SummarizeSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Summarize/SummarizeSettingsViewController.swift
@@ -47,7 +47,13 @@ final class SummarizeSettingsViewController: SettingsTableViewController, Featur
             self.settings = self.generateSettings()
             self.tableView.reloadData()
         }
-        return SettingSection(title: nil, children: [summarizeContentSetting])
+        return SettingSection(
+            title: nil,
+            footerTitle: NSAttributedString(
+                string: .Settings.Summarize.FooterTitle
+            ),
+            children: [summarizeContentSetting]
+        )
     }
 
     private var gesturesSection: SettingSection {

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2497,6 +2497,13 @@ extension String {
                 comment: "This is the title for the setting that toggles the Summarize feature under the Summarize settings section."
             )
 
+            public static let FooterTitle = MZLocalizedString(
+                key: "Settings.Summarize.FooterTitle.v142",
+                tableName: "Settings",
+                value: "Provides access to summarize pages.",
+                comment: "This is the footer text for the setting that toggles the Summarize feature under the Summarize settings section."
+            )
+
             public struct GesturesSection {
                 public static let Title = MZLocalizedString(
                     key: "Settings.Summarize.GesturesSection.Title.v142",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13055)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Add final footer title to the summarize feature settings. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| iPhone | iPad |
| - | - |
| <img width="1206" height="2622" alt="simulator_screenshot_FD5DE0EA-DACF-442B-931D-F8EDB0557B0D" src="https://github.com/user-attachments/assets/e846e743-cdd5-4944-86f3-98e31c4ea353" /> | <img width="1640" height="2360" alt="simulator_screenshot_546BA7CE-F3C9-4E7F-B3C1-6C9977F62319" src="https://github.com/user-attachments/assets/2b5fcf31-6c75-4e08-ba0a-6d6806868e42" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)