### PR TITLE
Add FXIOS-13027 [Experiment] advanced targeting for users who cannot use apple intelligence

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -220,8 +220,11 @@ public struct PrefsKeys {
     // Used to only show the Default Browser Banner, in Main Menu, until is dismissed by the user
     public static let defaultBrowserBannerShown = "defaultBrowserBannerShownKey"
 
+    // MARK: - Apple Intelligence
     // Used to determine if Apple Intelligence is available
     public static let appleIntelligenceAvailable = "appleIntelligenceAvailableKey"
+    // Used to determine if cannot run the Apple Intelligence model
+    public static let cannotRunAppleIntelligence = "cannotRunAppleIntelligenceKey"
 
     public struct Usage {
         public static let profileId = "profileId"

--- a/firefox-ios/Client/Application/AppleIntelligenceUtil.swift
+++ b/firefox-ios/Client/Application/AppleIntelligenceUtil.swift
@@ -27,15 +27,32 @@ struct AppleIntelligenceUtil {
         userDefaults.bool(forKey: PrefsKeys.appleIntelligenceAvailable)
     }
 
+    var cannotUseAppleIntelligence: Bool {
+        userDefaults.bool(forKey: PrefsKeys.cannotRunAppleIntelligence)
+    }
+
     @available(iOS 26.0, *)
     func processAvailabilityState(_ model: LanguageModelProtocol = SystemLanguageModel.default) {
         let isAvailable = checkAppleIntelligenceAvailability(with: model)
+        let cannotUseAppleIntelligence = checkCannotUseAppleIntelligenceModel()
         userDefaults.set(isAvailable, forKey: PrefsKeys.appleIntelligenceAvailable)
+        userDefaults.set(cannotUseAppleIntelligence, forKey: PrefsKeys.cannotRunAppleIntelligence)
     }
 
     @available(iOS 26, *)
     private func checkAppleIntelligenceAvailability(with model: LanguageModelProtocol) -> Bool {
         return model.isAvailable
+    }
+
+    @available(iOS 26.0, *)
+    private func checkCannotUseAppleIntelligenceModel() -> Bool {
+        let model = SystemLanguageModel.default
+        switch model.availability {
+        case .available, .unavailable(.appleIntelligenceNotEnabled), .unavailable(.modelNotReady):
+            return false
+        case .unavailable(.deviceNotEligible), .unavailable:
+            return true
+        }
     }
 }
 #endif

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -209,6 +209,15 @@ enum Experiments {
         #endif
     }
 
+    private static func cannotUseAppleIntelligence() -> Bool {
+        guard #available(iOS 26, *) else { return true }
+        #if canImport(FoundationModels)
+            return AppleIntelligenceUtil().cannotUseAppleIntelligence
+        #else
+            return true
+        #endif
+    }
+
     private static func buildNimbus(dbPath: String,
                                     errorReporter: @escaping NimbusErrorReporter,
                                     initialExperiments: URL?,
@@ -224,7 +233,8 @@ enum Experiments {
             isDefaultBrowser: isDefaultBrowser(),
             isBottomToolbarUser: isBottomToolbarUser(),
             hasEnabledTipsNotifications: hasEnabledTipsNotifications(),
-            isAppleIntelligenceAvailable: isAppleIntelligenceAvailable()
+            isAppleIntelligenceAvailable: isAppleIntelligenceAvailable(),
+            cannotUseAppleIntelligence: cannotUseAppleIntelligence()
         )
 
         return NimbusBuilder(dbPath: dbPath)

--- a/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
+++ b/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
@@ -45,6 +45,7 @@ class RecordedNimbusContext: RecordedContext {
     var isBottomToolbarUser: Bool
     var hasEnabledTipsNotifications: Bool
     var isAppleIntelligenceAvailable: Bool
+    var cannotUseAppleIntelligence: Bool
     var appVersion: String?
     var region: String?
     var language: String?
@@ -62,6 +63,7 @@ class RecordedNimbusContext: RecordedContext {
          isBottomToolbarUser: Bool,
          hasEnabledTipsNotifications: Bool,
          isAppleIntelligenceAvailable: Bool,
+         cannotUseAppleIntelligence: Bool,
          eventQueries: [String: String] = RecordedNimbusContext.EVENT_QUERIES,
          isPhone: Bool = UIDevice.current.userInterfaceIdiom == .phone,
          bundle: Bundle = Bundle.main,
@@ -76,6 +78,7 @@ class RecordedNimbusContext: RecordedContext {
         self.isBottomToolbarUser = isBottomToolbarUser
         self.hasEnabledTipsNotifications = hasEnabledTipsNotifications
         self.isAppleIntelligenceAvailable = isAppleIntelligenceAvailable
+        self.cannotUseAppleIntelligence = cannotUseAppleIntelligence
 
         let info = bundle.infoDictionary ?? [:]
         appVersion = info["CFBundleShortVersionString"] as? String
@@ -145,7 +148,8 @@ class RecordedNimbusContext: RecordedContext {
                 isDefaultBrowser: isDefaultBrowser,
                 isBottomToolbarUser: isBottomToolbarUser,
                 hasEnabledTipsNotifications: hasEnabledTipsNotifications,
-                isAppleIntelligenceAvailable: isAppleIntelligenceAvailable
+                isAppleIntelligenceAvailable: isAppleIntelligenceAvailable,
+                cannotUseAppleIntelligence: cannotUseAppleIntelligence
             )
         )
         GleanMetrics.Pings.shared.nimbus.submit()
@@ -188,7 +192,8 @@ class RecordedNimbusContext: RecordedContext {
             "is_default_browser": isDefaultBrowser,
             "is_bottom_toolbar_user": isBottomToolbarUser,
             "has_enabled_tips_notifications": hasEnabledTipsNotifications,
-            "is_apple_intelligence_available": isAppleIntelligenceAvailable
+            "is_apple_intelligence_available": isAppleIntelligenceAvailable,
+            "cannot_use_apple_intelligence": cannotUseAppleIntelligence
         ]),
             let jsonString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as? String
         else {

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -3588,6 +3588,8 @@ nimbus_system:
           type: boolean
         is_apple_intelligence_available:
           type: boolean
+        cannot_use_apple_intelligence:
+          type: boolean
     description: |
       The Nimbus context object that is recorded to Glean
     bugs:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
@@ -24,7 +24,8 @@ class RecordedNimbusContextTests: XCTestCase {
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
             hasEnabledTipsNotifications: true,
-            isAppleIntelligenceAvailable: true
+            isAppleIntelligenceAvailable: true,
+            cannotUseAppleIntelligence: true
         )
         try validateEventQueries(recordedContext: recordedContext)
     }
@@ -35,7 +36,8 @@ class RecordedNimbusContextTests: XCTestCase {
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
             hasEnabledTipsNotifications: true,
-            isAppleIntelligenceAvailable: true
+            isAppleIntelligenceAvailable: true,
+            cannotUseAppleIntelligence: true
         )
         recordedContext.setEventQueryValues(eventQueryValues: [RecordedNimbusContext.DAYS_OPENED_IN_LAST_28: 1.5])
         let jsonString = recordedContext.toJson()
@@ -64,6 +66,10 @@ class RecordedNimbusContextTests: XCTestCase {
             json?.removeValue(forKey: "is_apple_intelligence_available") as? Bool,
             recordedContext.isAppleIntelligenceAvailable
         )
+        XCTAssertEqual(
+            json?.removeValue(forKey: "cannot_use_apple_intelligence") as? Bool,
+            recordedContext.cannotUseAppleIntelligence
+        )
 
         var events = json?.removeValue(forKey: "events") as? [String: Double]
         XCTAssertNotNil(events)
@@ -79,7 +85,8 @@ class RecordedNimbusContextTests: XCTestCase {
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
             hasEnabledTipsNotifications: true,
-            isAppleIntelligenceAvailable: true
+            isAppleIntelligenceAvailable: true,
+            cannotUseAppleIntelligence: true
         )
 
         var value: GleanMetrics.NimbusSystem.RecordedNimbusContextObject?
@@ -120,7 +127,8 @@ class RecordedNimbusContextTests: XCTestCase {
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
             hasEnabledTipsNotifications: true,
-            isAppleIntelligenceAvailable: true
+            isAppleIntelligenceAvailable: true,
+            cannotUseAppleIntelligence: true
         )
         let eventQueries = recordedContext.getEventQueries()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13027)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28406)

## :bulb: Description
Add advanced targeting for users who cannot use apple intelligence. Uses similar logic to other advanced targeting [here](https://github.com/mozilla-mobile/firefox-ios/compare/cc/FXIOS-13027_add-advance-targeting-for-non-apple-intelligence-users?expand=1) except we want this targeting to enroll users who are either:
- Not on iOS 26
- On iOS 26, but device is not eligible
- On iOS 26, but model is unavailable for some other [reason](https://developer.apple.com/documentation/foundationmodels/generating-content-and-performing-tasks-with-foundation-models#Check-for-availability)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
