### PR TITLE
Refactor FXIOS-11340 - Disable the function_body_length rule for a legacy function and decreases the threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -107,8 +107,8 @@ closure_body_length:
   error: 34
 
 function_body_length:
-  warning: 363
-  error: 363
+  warning: 240
+  error: 240
 
 file_header:
   required_string: |

--- a/firefox-ios/Storage/SQL/BrowserSchema.swift
+++ b/firefox-ios/Storage/SQL/BrowserSchema.swift
@@ -964,6 +964,7 @@ open class BrowserSchema: Schema {
                self.prepopulateRootFolders(db)
     }
 
+    // swiftlint:disable:next function_body_length
     public func update(_ db: SQLiteDBConnection, from: Int) -> Bool {
         let to = self.version
         if from == to {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11340)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24679)

## :bulb: Description
This pull request disables the `function_body_length` rule for the `update` function of `BrowserSchema.swift` file, and defines the threshold to 240 for this rule. I've talked with @FilippoZazzeroni about this legacy function and why we decided to disable the linter rule for it https://github.com/mozilla-mobile/firefox-ios/issues/24679#issuecomment-3134520129.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
