### PR TITLE
Bugfix FXIOS-13066 ⁃ [Menu Redesign] Menu CFR overlap Iphone island

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -23,6 +23,7 @@ class MainMenuViewController: UIViewController,
         static let hintViewMargin: CGFloat = 20
         static let backgroundAlpha: CGFloat = 0.85
         static let menuHeightTolerance: CGFloat = 30
+        static let topMarginCFR: CGFloat = 100
     }
     typealias SubscriberStateType = MainMenuState
 
@@ -304,7 +305,9 @@ class MainMenuViewController: UIViewController,
                   let window = windowScene.windows.first {
             window.addSubview(hintView)
 
-            if UIScreen.main.bounds.height < UX.hintViewHeight + menuContent.frame.height {
+            let contentHeight =  UX.hintViewHeight + menuContent.frame.height + UX.hintViewMargin
+            let safeHeight = UIScreen.main.bounds.height - UX.topMarginCFR
+            if safeHeight < contentHeight {
                 hintView.topAnchor.constraint(equalTo: menuContent.topAnchor,
                                               constant: UX.hintViewMargin).isActive = true
             } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13066)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28461)

## :bulb: Description
Changed CFR position if it not fit in screen

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
