### PR TITLE
Fix [MTE-4876] - share reader mode tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
@@ -4,9 +4,10 @@
 
 import Foundation
 
-class ShareLongPressTests: BaseTestCase {
+class ShareLongPressTests: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2864317
     func testShareNormalWebsiteTabReminders() {
+        app.launch()
         if #available(iOS 17, *) {
             longPressPocketAndReachShareOptions(option: "Reminders")
             // The URL of the website is added in a new reminder
@@ -21,6 +22,7 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864324
     func testShareNormalWebsiteSendLinkToDevice() {
+        app.launch()
         longPressPocketAndReachShareOptions(option: "Send Link to Device")
         // If not signed in, the browser prompts you to sign in
         waitForElementsToExist(
@@ -33,6 +35,7 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864323
     func testShareNormalWebsiteCopyUrl() {
+        app.launch()
         longPressPocketAndReachShareOptions(option: "Copy")
         app.collectionViews
             .cells.matching(identifier: AccessibilityIdentifiers.FirefoxHomepage.Pocket.itemCell)
@@ -42,6 +45,7 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864380
     func testBookmarksShareNormalWebsiteReminders() {
+        app.launch()
         if #available(iOS 17, *) {
             longPressBookmarkAndReachShareOptions(option: "Reminders")
             // The URL of the website is added in a new reminder
@@ -56,6 +60,7 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864387
     func testBookmarksShareNormalWebsiteSendLinkDevice() {
+        app.launch()
         longPressBookmarkAndReachShareOptions(option: "Send Link to Device")
         // If not signed in, the browser prompts you to sign in
         waitForElementsToExist(
@@ -68,6 +73,7 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864386
     func testBookmarksShareNormalWebsiteCopyURL() {
+        app.launch()
         longPressBookmarkAndReachShareOptions(option: "Copy")
         app.buttons["Done"].waitAndTap()
         openNewTabAndValidateURLisPaste(url: url_1)
@@ -75,6 +81,7 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864396
     func testHistoryShareNormalWebsiteReminders() {
+        app.launch()
         if #available(iOS 17, *) {
             longPressHistoryAndReachShareOptions(option: "Reminders")
             // The URL of the website is added in a new reminder
@@ -89,6 +96,7 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864403
     func testHistoryShareNormalWebsiteSendLinkDevice() {
+        app.launch()
         longPressHistoryAndReachShareOptions(option: "Send Link to Device")
         // If not signed in, the browser prompts you to sign in
         waitForElementsToExist(
@@ -101,6 +109,7 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864402
     func testHistoryShareNormalWebsiteCopyURL() {
+        app.launch()
         longPressHistoryAndReachShareOptions(option: "Copy")
         app.buttons["Done"].waitAndTap()
         openNewTabAndValidateURLisPaste(url: "https://www.mozilla.org/")
@@ -108,6 +117,9 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864412
     func testReaderModeShareNormalWebsiteReminders() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launch()
         if #available(iOS 17, *) {
             longPressReadingListAndReachShareOptions(option: "Reminders")
             // The URL of the website is added in a new reminder
@@ -122,6 +134,9 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864419
     func testReaderModeShareNormalWebsiteSendLinkDevice() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launch()
         longPressReadingListAndReachShareOptions(option: "Send Link to Device")
         // If not signed in, the browser prompts you to sign in
         waitForElementsToExist(
@@ -134,6 +149,9 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864418
     func testReaderModeShareNormalWebsiteCopy() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launch()
         longPressReadingListAndReachShareOptions(option: "Copy")
         app.buttons["Done"].waitAndTap()
         openNewTabAndValidateURLisPaste(url: "test-mozilla-book.html")
@@ -141,6 +159,7 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864476
     func testShareViaLongPressLinkReminders() {
+        app.launch()
         if #available(iOS 17, *) {
             longPressLinkAndSelectShareOption(option: "Reminders")
             // The URL of the website is added in a new reminder
@@ -155,6 +174,7 @@ class ShareLongPressTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864482
     func testShareViaLongPressLinkCopy() {
+        app.launch()
         longPressLinkAndSelectShareOption(option: "Copy")
         openNewTabAndValidateURLisPaste(url: "example")
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
@@ -7,9 +7,10 @@ import Foundation
 let sendLinkMsg1 = "You are not signed in to your account."
 let sendLinkMsg2 = "Please open Firefox, go to Settings and sign in to continue."
 
-class ShareToolbarTests: BaseTestCase {
+class ShareToolbarTests: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2864270
     func testShareNormalWebsiteTabReminders() {
+        app.launch()
         if #available(iOS 17, *) {
             tapToolbarShareButtonAndSelectOption(option: "Reminders")
             // The URL of the website is added in a new reminder
@@ -24,12 +25,14 @@ class ShareToolbarTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864279
     func testShareNormalWebsitePrint() {
+        app.launch()
         tapToolbarShareButtonAndSelectOption(option: "Print")
         validatePrintLayout()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864277
     func testShareNormalWebsiteSendLinkToDevice() {
+        app.launch()
         tapToolbarShareButtonAndSelectOption(option: "Send Link to Device")
         // If not signed in, the browser prompts you to sign in
         waitForElementsToExist(
@@ -42,18 +45,23 @@ class ShareToolbarTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864278
     func testShareNormalWebsiteMarkup() {
+        app.launch()
         tapToolbarShareButtonAndSelectOption(option: "Markup")
         validateMarkupTool()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864276
     func testShareNormalWebsiteCopyUrl() {
+        app.launch()
         tapToolbarShareButtonAndSelectOption(option: "Copy")
         openNewTabAndValidateURLisPaste(url: url_3)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864301
     func testShareWebsiteReaderModeReminders() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launch()
         if #available(iOS 17, *) {
             reachReaderModeShareMenuLayoutAndSelectOption(option: "Reminders")
             // The URL of the website is added in a new reminder
@@ -68,18 +76,27 @@ class ShareToolbarTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864310
     func testShareWebsiteReaderModePrint() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launch()
         reachReaderModeShareMenuLayoutAndSelectOption(option: "Print")
         validatePrintLayout()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864307
     func testShareWebsiteReaderModeCopy() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launch()
         reachReaderModeShareMenuLayoutAndSelectOption(option: "Copy")
         openNewTabAndValidateURLisPaste(url: "test-mozilla-book.html")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864308
     func testShareWebsiteReaderModeSendLink() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launch()
         reachReaderModeShareMenuLayoutAndSelectOption(option: "Send Link to Device")
         // If not signed in, the browser prompts you to sign in
         waitForElementsToExist(
@@ -92,24 +109,30 @@ class ShareToolbarTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864309
     func testShareWebsiteReaderModeMarkup() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launch()
         reachReaderModeShareMenuLayoutAndSelectOption(option: "Markup")
         validateMarkupTool()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864293
     func testSharePdfFilePrint() {
+        app.launch()
         tapToolbarShareButtonAndSelectOption(option: "Print", url: pdfUrl)
         validatePrintLayout()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864292
     func testSharePdfFileMarkup() {
+        app.launch()
         tapToolbarShareButtonAndSelectOption(option: "Markup", url: pdfUrl)
         validateMarkupTool()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864294
     func testSharePdfFileSaveToFile() {
+        app.launch()
         if #available(iOS 17, *) {
             tapToolbarShareButtonAndSelectOption(option: "Save to Files", url: pdfUrl)
             if !iPad() {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4876

## :bulb: Description
Summarize experiment has been enabled.
Disabled the experiment for the share tests affected.