### PR TITLE
Refactor FXIOS-13075 [Terms Of Use] Update triggering logic for Terms Of Use

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -146,7 +146,6 @@ class BrowserCoordinator: BaseCoordinator,
         guard browserViewController.embedContent(legacyHomepageViewController) else { return }
         self.legacyHomepageViewController = legacyHomepageViewController
         legacyHomepageViewController.scrollToTop()
-        showTermsOfUse()
         // We currently don't support full page screenshot of the homepage
         screenshotService.screenshotableView = nil
     }
@@ -170,7 +169,6 @@ class BrowserCoordinator: BaseCoordinator,
         }
         self.homepageViewController = homepageController
         homepageController.scrollToTop()
-        showTermsOfUse()
     }
 
     func homepageScreenshotTool() -> (any Screenshotable)? {

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
@@ -12,7 +12,7 @@ class TermsOfUseMiddleware {
     struct DefaultKeys {
         static let acceptedKey = "termsOfUseAccepted"
         static let dismissedKey = "termsOfUseDismissed"
-        static let lastShownKey = "termsOfUseLastShownDate"
+        static let dismissedWithoutAcceptDate = "termsOfUseDismissedWithoutAcceptDate"
     }
     private let userDefaults: UserDefaultsInterface
     private let logger: Logger
@@ -47,7 +47,7 @@ class TermsOfUseMiddleware {
 
             case TermsOfUseActionType.markDismissed:
                 self.userDefaults.set(true, forKey: DefaultKeys.dismissedKey)
-                self.userDefaults.set(Date(), forKey: DefaultKeys.lastShownKey)
+                self.userDefaults.set(Date(), forKey: DefaultKeys.dismissedWithoutAcceptDate)
 
             case TermsOfUseActionType.markShownThisLaunch:
                 break

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
@@ -285,6 +285,7 @@ final class TermsOfUseViewController: UIViewController,
         // Only dismiss the view if the tap occurred outside the visible sheetContainer.
         // This prevents dismissing the Terms of Use sheet when interacting with its content.
         if !sheetContainer.frame.contains(sender.location(in: view)) {
+            store.dispatchLegacy(TermsOfUseAction(windowUUID: windowUUID, actionType: .markDismissed))
             coordinator?.dismissTermsFlow()
         }
     }
@@ -296,6 +297,7 @@ final class TermsOfUseViewController: UIViewController,
             sheetContainer.transform = CGAffineTransform(translationX: 0, y: translation.y)
         case .ended:
             if translation.y > UX.panDismissDistance || gesture.velocity(in: view).y > UX.panDismissVelocity {
+                store.dispatchLegacy(TermsOfUseAction(windowUUID: windowUUID, actionType: .markDismissed))
                 dismiss(animated: true)
             } else {
                 UIView.animate(withDuration: UX.animationDuration,


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13075)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28476)

## :bulb: Description
This PR refactors appearance logic to be implemented as last product requirements. It should appear on app launch if the terms are not accepted and after 5 days since last dismissed without accept. So added recording events for all the 3 possible cases of dismiss without accept (pressing Remind me later, tapping outside or swiping the grabber down) and updated the days passed counter to 5 (from 3 days as it was before). Also removed `showTermsOfUse()` calls from the homepage methods for eliminating the duplicate/inappropriate triggers. The Terms of Use should now only appear during actual app launch scenarios - as is already implemented in `func start` from BrowserCoordinator.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
