### PR TITLE
Bugfix FXIOS-11849 ⁃ iOS widget to open new tab causes new tab to open every time app opens in multitask

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3175,10 +3175,14 @@ class BrowserViewController: UIViewController,
         if let url {
             switchToTabForURLOrOpen(url, isPrivate: isPrivate)
         } else {
-            openBlankNewTab(
-                focusLocationField: options?.contains(.focusLocationField) == true,
-                isPrivate: isPrivate
-            )
+            if let isHomepage = tabManager.selectedTab?.isFxHomeTab, isHomepage {
+                focusLocationTextField(forTab: tabManager.selectedTab)
+            } else {
+                openBlankNewTab(
+                    focusLocationField: options?.contains(.focusLocationField) == true,
+                    isPrivate: isPrivate
+                )
+            }
         }
     }
 
@@ -3265,7 +3269,7 @@ class BrowserViewController: UIViewController,
     }
 
     func focusLocationTextField(forTab tab: Tab?, setSearchText searchText: String? = nil) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(400)) {
             // Without a delay, the text field fails to become first responder
             // Check that the newly created tab is still selected.
             // This let's the user spam the Cmd+T button without lots of responder changes.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11849)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25821)

## :bulb: Description
Open new tab only if current tab is a website and not the homepage

## :movie_camera: Demos

https://github.com/user-attachments/assets/c475ec56-e813-47ab-ba67-d1218fec9cc7



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
