### PR TITLE
Fix [MTE-4877] - homeapageSettingsUi test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
@@ -97,7 +97,7 @@ class DataManagementTests: BaseTestCase {
         app.typeText("mozilla")
         mozWaitForElementToExist(app.tables["Search results"])
         let expectedSearchResults = app.tables["Search results"].cells.count
-        XCTAssertEqual(expectedSearchResults-1, 1)
+        XCTAssertEqual(expectedSearchResults, 1)
         app.buttons["Cancel"].waitAndTap()
         mozWaitForElementToExist(app.tables.otherElements["Website Data"])
         if #available(iOS 17, *) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -284,6 +284,8 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2307034
     func testRecentlySaved_tabTrayExperimentOff() {
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "tab-tray-ui-experiments")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
         app.launch()
         // Preconditons: Create 6 bookmarks & add 1 items to reading list
         bookmarkPages()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4877

## :bulb: Description
Fixes for: testRecentlySaved_tabTrayExperimentOff, testFilterWebsiteData