### PR TITLE
Bugfix [FXIOS-13090] Disable streaming for FoundationModels summarizer until we get a stable API

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelResponseStreamProtocol.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelResponseStreamProtocol.swift
@@ -16,9 +16,12 @@ import Foundation
 @available(iOS 26, *)
 protocol LanguageModelResponseStreamProtocol: AsyncSequence where Element == String {}
 
-@available(iOS 26, *)
-extension LanguageModelSession.ResponseStream: LanguageModelResponseStreamProtocol
-    where Content == String {}
+// TODO(FXIOS-FXIOS-13088): The API changed between beta 4 and 5, so this now breaks when building.
+// To avoid any future issues, this is commented out until we get the stable API.
+// This is unused in the current implementation. We only use non-streaming responses.
+// @available(iOS 26, *)
+// extension LanguageModelSession.ResponseStream: LanguageModelResponseStreamProtocol
+//     where Content == String {}
 
 extension AsyncThrowingStream: LanguageModelResponseStreamProtocol
     where Element == String {}

--- a/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelSessionAdapter.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelSessionAdapter.swift
@@ -36,7 +36,17 @@ final class LanguageModelSessionAdapter: LanguageModelSessionProtocol {
         to prompt: Prompt,
         options: GenerationOptions
     ) -> any LanguageModelResponseStreamProtocol {
-        realSession.streamResponse(to: prompt, options: options)
+        // TODO(FXIOS-13088): The API changed between beta 4 and 5, so this now breaks when building.
+        // To avoid any future issues, this is commented out until we get the stable API.
+        // This is unused in the current implementation. We only use non-streaming responses.
+        // realSession.streamResponse(to: prompt, options: options)
+        assertionFailure(
+        """
+        streaming is disabled until we get a stable API for
+        `LanguageModelSession.ResponseStream`.
+        """
+        )
+        return AsyncThrowingStream<String, Error> { $0.finish() }
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13090)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR:
- Comments out comformance to protocol.
- Add assertion to streaming method.
- Throw error if streaming is used.  

⚠️ This is done because the type definitions between beta 4 and 5 changed. We don't use streaming right now so I am disabling it so we can build on both 4 and 5 ( and hopefully the newer versions if nothing changes )
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
