### PR TITLE
Bugfix FXIOS-13094 [Summarizer] Add tweaked model params in the request

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/Backend/LLM/LiteLLMClient.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/LLM/LiteLLMClient.swift
@@ -113,7 +113,15 @@ final class LiteLLMClient: LiteLLMClientProtocol, @unchecked Sendable {
         var payload: [String: Any] = [
             "model": options.model,
             "messages": messages.map { ["role": $0.role.rawValue, "content": $0.content] },
-            "max_tokens": options.maxTokens
+            "max_tokens": options.maxTokens,
+            // NOTE(FXIOS-13068): We usually shouldn't be tweaking these parameters,
+            // but we have encountered weird issues where mistral would return text with repeated words.
+            // This is being investigated in FXIOS-13068. For now, we are setting
+            //  `top_p`, `temperature`, and `frequency_penalty` explicitely as part of the request.
+            "top_p": 0.01,
+            "temperature": 0.1,
+            "frequency_penalty": 1.2,
+            "allowed_openai_params": ["frequency_penalty"]
         ]
 
         if options.stream {

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/Summarizer.js
@@ -42,7 +42,11 @@ const extractContent = () => {
   const doc = new DOMParser().parseFromString(clean, "text/html");
   const readability = new Readability(uri, doc);
   const readabilityResult = readability.parse();
-  return readabilityResult.textContent ?? readabilityResult.content;
+  const rawContent = readabilityResult.textContent ?? readabilityResult.content;
+  return rawContent
+    .trim()
+    // Replace duplicate whitespace with either a single newline or space
+    .replace(/(\s*\n\s*)|\s{2,}/g, (_, newline) => (newline ? "\n" : " "));
 };
 
 /**


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13094)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28506)

## :bulb: Description
This PR:
- Add explicit `top_p`, `temperature` and `frequency_penalty` params.
- Skips unnecessary new lines and spaces in returned text from JS.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
