### PR TITLE
Bugfix FXIOS-12796 #27871 ⁃ [Swift 6 Migration] Turn on Strict Concurrency in Xcode 26 Beta 2+ and fix warnings BrowserPrompts

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -57,6 +57,7 @@ class JSPromptAlertController: UIAlertController {
 }
 
 protocol JSAlertInfo {
+    @MainActor
     func alertController() -> JSPromptAlertController
     func cancel()
     func handleAlertDismissal(_ result: Any?)
@@ -199,6 +200,7 @@ extension TextInputAlert: JavaScriptAlertProtocol {
 /// Show a title for a JavaScript Panel (alert) based on the WKFrameInfo. On iOS9 we will use the new securityOrigin
 /// and on iOS 8 we will fall back to the request URL. If the request URL is nil, which happens for JavaScript pages,
 /// we fall back to "JavaScript" as a title.
+@MainActor
 private func titleForJavaScriptPanelInitiatedByFrame(_ frame: WKFrameInfo) -> String {
     var title = "\(frame.securityOrigin.`protocol`)://\(frame.securityOrigin.host)"
     if frame.securityOrigin.port != 0 {

--- a/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
@@ -38,6 +38,7 @@ final class OpenPassBookHelper: @unchecked Sendable {
         self.logger = logger
     }
 
+    @MainActor
     static func shouldOpenWithPassBook(mimeType: String, forceDownload: Bool = false) -> Bool {
         return mimeType == MIMEType.Passbook && PKAddPassesViewController.canAddPasses() && !forceDownload
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
- Add @MainActor for BrowserPrompts present alert 
- Add @mainActor to `shouldOpenWithPassBook` check
- Manually tested and prompts continue to show when tab is selected, and if tab is not selected the prompt is queued and  shown when the tab is selected again. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<img width="485" height="1345" alt="Screenshot 2025-08-06 at 2 34 11 PM" src="https://github.com/user-attachments/assets/633f4a69-43b4-49c1-97f8-8b07e2ce3008" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
