### PR TITLE
Add [Shake to Summarize] FXIOS-13100 Branded label to summary report

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -73,8 +73,8 @@ let package = Package(
             url: "https://github.com/swhitty/SwiftDraw",
             exact: "0.18.3"),
         .package(
-            url: "https://github.com/bmoliveira/MarkdownKit.git", 
-            exact: "1.7.3"),
+            url: "https://github.com/johnxnguyen/Down.git",
+            exact: "0.11.0"),
     ],
     targets: [
         .target(name: "Shared",
@@ -153,7 +153,7 @@ let package = Package(
             dependencies: [
                 "Common",
                 "ComponentLibrary",
-                "MarkdownKit"
+                "Down"
             ],
             swiftSettings: [.unsafeFlags(["-enable-testing"])]
         ),

--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -13,6 +13,8 @@ class CustomStyler: DownStyler {
     // NOTE: The content is produced by an LLM; generated links may be unsafe or unreachable.
     // To keep the MVP safe, link rendering is disabled.
     override func style(link str: NSMutableAttributedString, title: String?, url: String?) {}
+
+    override func style(image str: NSMutableAttributedString, title: String?, url: String?) {}
 }
 
 public class SummarizeController: UIViewController, Themeable, CAAnimationDelegate {
@@ -281,7 +283,8 @@ public class SummarizeController: UIViewController, Themeable, CAAnimationDelega
         let tabSnapshotYTransform = view.frame.height - UX.tabSnapshotFinalPositionBottomPadding - tabSnapshotOffset
 
         let brandedSummary = """
-        ###### *\(viewModel.brandLabel)* \n
+        ###### *\(viewModel.brandLabel)*
+        
         \(summary)
         """
         summaryView.attributedText = parse(markdown: brandedSummary)

--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -6,7 +6,6 @@ import Foundation
 import Common
 import UIKit
 import ComponentLibrary
-import MarkdownKit
 import WebKit
 import Down
 

--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -284,9 +284,10 @@ public class SummarizeController: UIViewController, Themeable, CAAnimationDelega
 
         let brandedSummary = """
         ###### *\(viewModel.brandLabel)*
-        
+
         \(summary)
         """
+
         summaryView.attributedText = parse(markdown: brandedSummary)
         UIView.animate(withDuration: UX.showSummaryAnimationDuration) { [self] in
             gradient.alpha = 0.0

--- a/BrowserKit/Sources/SummarizeKit/SummarizeViewModel.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeViewModel.swift
@@ -11,6 +11,7 @@ public struct SummarizeViewModel {
     let loadingA11yId: String
     let summarizeTextViewA11yLabel: String
     let summarizeTextViewA11yId: String
+    let brandLabel: String
 
     let closeButtonModel: CloseButtonViewModel
     let tabSnapshot: UIImage
@@ -24,6 +25,7 @@ public struct SummarizeViewModel {
         loadingLabel: String,
         loadingA11yLabel: String,
         loadingA11yId: String,
+        brandLabel: String,
         summarizeTextViewA11yLabel: String,
         summarizeTextViewA11yId: String,
         closeButtonModel: CloseButtonViewModel,
@@ -36,6 +38,7 @@ public struct SummarizeViewModel {
         self.loadingLabel = loadingLabel
         self.loadingA11yLabel = loadingA11yLabel
         self.loadingA11yId = loadingA11yId
+        self.brandLabel = brandLabel
         self.summarizeTextViewA11yLabel = summarizeTextViewA11yLabel
         self.summarizeTextViewA11yId = summarizeTextViewA11yId
         self.closeButtonModel = closeButtonModel

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "07e754f1a18a49a28fa0ad66be53519032b34c7e4d4236ec0ca15a4b6f7bab82",
+  "originHash" : "b8194bdb0c20dbb97b6ae621a9c12bba363d7c04b6114413417a402708bd8c1e",
   "pins" : [
     {
       "identity" : "a-star",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "c3b601df0ff22b06b6d5ff4943faf05c0bd3f9bb",
         "version" : "7.1.1"
+      }
+    },
+    {
+      "identity" : "down",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/johnxnguyen/Down.git",
+      "state" : {
+        "revision" : "f34b166be1f1db4aa8f573067e901d72f2a6be57",
+        "version" : "0.11.0"
       }
     },
     {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b8194bdb0c20dbb97b6ae621a9c12bba363d7c04b6114413417a402708bd8c1e",
+  "originHash" : "b1d3d8248618ee0b9328b70113d5ffde4b1075d6dc5d75aaa2717907e7fbbb3a",
   "pins" : [
     {
       "identity" : "a-star",
@@ -98,15 +98,6 @@
       "state" : {
         "branch" : "master",
         "revision" : "f56a6e483163a761adc8cd25c337db0ed1eac524"
-      }
-    },
-    {
-      "identity" : "markdownkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/bmoliveira/MarkdownKit.git",
-      "state" : {
-        "revision" : "39ea7a3fc7e65bcafe55152592b834859be574a5",
-        "version" : "1.7.3"
       }
     },
     {

--- a/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
@@ -90,10 +90,16 @@ class SummarizeCoordinator: BaseCoordinator, SummarizerServiceLifecycle {
             retryButtonLabel: .Summarizer.RetryButtonLabel,
             closeButtonLabel: .Summarizer.CloseButtonLabel
         )
+        let brandLabel: String = if summarizerNimbusUtils.isAppleSummarizerEnabled() {
+            .Summarizer.AppleBrandLabel
+        } else {
+            String(format: .Summarizer.HostedBrandLabel, AppName.shortName.rawValue)
+        }
         let model = SummarizeViewModel(
             loadingLabel: .Summarizer.LoadingLabel,
             loadingA11yLabel: .Summarizer.LoadingAccessibilityLabel,
             loadingA11yId: AccessibilityIdentifiers.Summarizer.loadingLabel,
+            brandLabel: brandLabel,
             summarizeTextViewA11yLabel: .Summarizer.SummaryTextAccessibilityLabel,
             summarizeTextViewA11yId: AccessibilityIdentifiers.Summarizer.summaryTextView,
             closeButtonModel: CloseButtonViewModel(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2162,7 +2162,6 @@ extension String {
             value: "Page is still loading. Wait for it to finish, then hit summarize.",
             comment: "The error message displayed when the summarizer encounters missing page content while summarizing a page (e.g the page is still loading)."
         )
-        // TODO: correct label ?
         public static let UnknownErrorMessage = MZLocalizedString(
             key: "Summarizer.Error.Unknown.Message.v142",
             tableName: "Summarizer",
@@ -2180,6 +2179,18 @@ extension String {
             tableName: "Summarizer",
             value: "Close",
             comment: "The label for the error button that allows the user to close the summary view because there is an error summarizing the page and the summary cannot be retried."
+        )
+        public static let HostedBrandLabel = MZLocalizedString(
+            key: "Summarizer.HostedBrand.Label.v142",
+            tableName: "Summarizer",
+            value: "Summarized by %@",
+            comment: "The label displayed in the summary report when the summary was generated using by a third-party service. %@ refers to the name of the service/app (e.g Firefox)."
+        )
+        public static let AppleBrandLabel = MZLocalizedString(
+            key: "Summarizer.AppleBrand.Label.v142",
+            tableName: "Summarizer",
+            value: "Summarized by Apple Intelligence",
+            comment: "The label displayed in the summary report when the summary was generated using Apple Intelligence."
         )
         public static let ToSAlertTitleLabel = MZLocalizedString(
             key: "Summarizer.ToS.Alert.Title.Label.v142",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13100)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28250)

## :bulb: Description
Added branded label to summary report and changed markdown renderer lib with a more customizable one.

## :movie_camera: Demos

https://github.com/user-attachments/assets/99e0ee00-50ad-45c0-bc71-99c1ff3c12d4


https://github.com/user-attachments/assets/58191c6b-f036-4367-8558-97f09a1d5598

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
