### PR TITLE
Improve [MTE-4878] - testCheckDisplaySettingsDefault test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DisplaySettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DisplaySettingsTests.swift
@@ -5,6 +5,18 @@
 import XCTest
 
 class DisplaySettingTests: BaseTestCase {
+    override func setUp() {
+        // Fresh install the app
+        // removeApp() does not work on iOS 15 and 16 intermittently
+        if name.contains("testCheckDisplaySettingsDefault") {
+            if #available(iOS 17, *) {
+                removeApp()
+            }
+        }
+        // The app is correctly installed
+        super.setUp()
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2337485
     func testCheckDisplaySettingsDefault() {
         navigator.nowAt(NewTabScreen)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4878

## :bulb: Description
Improved testCheckDisplaySettingsDefault test by making a fresh install before running.
The automation default theme value might change during paralel job run.
This way we make sure the default value is always set.