### PR TITLE
Refactor FXIOS-12796 [Swift 6] Resolve remaining deinit warnings

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -94,7 +94,7 @@ class BrowserViewController: UIViewController,
     var themeManager: ThemeManager
     var notificationCenter: NotificationProtocol
     var themeListenerCancellable: Any?
-    var logger: Logger
+    nonisolated let logger: Logger
     var zoomManager: ZoomPageManager
     let documentLogger: DocumentLogger
     var downloadHelper: DownloadHelper?
@@ -448,6 +448,7 @@ class BrowserViewController: UIViewController,
 
     deinit {
         logger.log("BVC deallocating", level: .info, category: .lifecycle)
+        unsubscribeFromRedux()
         // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
         // KVO observation removal directly requires self so we can not use the apple
         // recommended work around here.
@@ -464,7 +465,6 @@ class BrowserViewController: UIViewController,
         MainActor.assumeIsolated {
             observedWebViews.forEach({ stopObserving(webView: $0) })
         }
-        unsubscribeFromRedux()
     }
 
     override var prefersStatusBarHidden: Bool {

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -217,7 +217,22 @@ final class TabScrollHandler: NSObject,
 
     deinit {
         logger.log("TabScrollController deallocating", level: .info, category: .lifecycle)
-        observedScrollViews.forEach({ stopObserving(scrollView: $0) })
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        // KVO observation removal directly requires self so we can not use the apple
+        // recommended work around here.
+        guard Thread.isMainThread else {
+            logger.log(
+                "TabScrollController was not deallocated on the main thread. KVOs were not cleaned up.",
+                level: .fatal,
+                category: .lifecycle
+            )
+            assertionFailure("TabScrollController was not deallocated on the main thread. KVOs were not cleaned up.")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            observedScrollViews.forEach({ stopObserving(scrollView: $0) })
+        }
     }
 
     init(windowUUID: WindowUUID,

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -157,7 +157,21 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
     }
 
     deinit {
-        tabManager.removeDelegate(self.topTabDisplayManager, completion: nil)
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits.
+        // Also we will remove Tab Manager Delegates as part of FXIOS-13097
+        guard Thread.isMainThread else {
+            assertionFailure(
+            """
+            TopTabsViewController was not deallocated on the main thread.
+            Tab manager delegate was not removed.
+            """
+            )
+            return
+        }
+
+        MainActor.assumeIsolated {
+            tabManager.removeDelegate(topTabDisplayManager, completion: nil)
+        }
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -150,8 +150,8 @@ class DevicePickerViewController: UITableViewController {
         }
 
         MainActor.assumeIsolated {
-            if let obj = notification {
-                NotificationCenter.default.removeObserver(obj)
+            if let notification = notification {
+                NotificationCenter.default.removeObserver(notification)
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -143,8 +143,16 @@ class DevicePickerViewController: UITableViewController {
     }
 
     deinit {
-        if let obj = notification {
-            NotificationCenter.default.removeObserver(obj)
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("DevicePickerViewController was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            if let obj = notification {
+                NotificationCenter.default.removeObserver(obj)
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -323,7 +323,7 @@ final class HomepageViewController: UIViewController,
         }
     }
 
-    func unsubscribeFromRedux() {
+    nonisolated func unsubscribeFromRedux() {
         let action = ScreenAction(
             windowUUID: windowUUID,
             actionType: ScreenActionType.closeScreen,

--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -50,8 +50,16 @@ class ManageFxAccountSetting: Setting {
     }
 
     deinit {
-        if let notification = notification {
-            NotificationCenter.default.removeObserver(notification)
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("ManageFxAccountSetting was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            if let notification = notification {
+                NotificationCenter.default.removeObserver(notification)
+            }
         }
     }
 }
@@ -160,8 +168,16 @@ class DeviceNameSetting: StringSetting {
     }
 
     deinit {
-        if let notification = notification {
-            NotificationCenter.default.removeObserver(notification)
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("DeviceNameSetting was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            if let notification = notification {
+                NotificationCenter.default.removeObserver(notification)
+            }
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Resolve the remaining deinit warnings Mostly by leveraging `MainActor.assumeIsloated`. This is a work around until we can get isolated inits as part of Swift 6.2. In theory with [ARC](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/AutomaticReferenceCounting.html) it will be called from the thread in which the last reference is found, but it is by no means guaranteed. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
