### PR TITLE
BugFix FXIOS incorrect String key

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2223,7 +2223,7 @@ extension String {
             comment: "The label for the cancel button on the ToS alert."
         )
         public static let ToSAlertLinkButtonLabel = MZLocalizedString(
-            key: "Summarizer.ToS.Alert.CancelButton.Label.v142",
+            key: "Summarizer.ToS.Alert.LinkButton.Label.v142",
             tableName: "Summarizer",
             value: "Learn more",
             comment: "The label for the learn more link button on the ToS alert."


### PR DESCRIPTION
## :scroll: Tickets
~~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~~
~~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~~

## :bulb: Description
Fix incorrect string key.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
