### PR TITLE
Bugfix FXIOS-13118 [Shake to Summarize] remove animation when summarizer not available for shake

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1438,6 +1438,8 @@
 		BACE70062DC110CA00E6102C /* ASTranslationModelsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE70052DC110C700E6102C /* ASTranslationModelsFetcher.swift */; };
 		BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */; };
 		BC0723522E33D7A6005BAC05 /* AppleIntelligenceUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0723512E33D7A2005BAC05 /* AppleIntelligenceUtilTests.swift */; };
+		BC129A2D2E452082004A6875 /* SummarizeMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC129A2C2E45207F004A6875 /* SummarizeMiddleware.swift */; };
+		BC129A2F2E455900004A6875 /* SummarizeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC129A2E2E4558FD004A6875 /* SummarizeAction.swift */; };
 		BC8E91DC2E32953C00434FD0 /* AppleIntelligenceUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */; };
 		BCBE058C2E3A8720004B6039 /* SummarizeSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBE058B2E3A871B004B6039 /* SummarizeSetting.swift */; };
 		BCBE09BF2E3BAE2A004B6039 /* SummarizeSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBE09BE2E3BAE22004B6039 /* SummarizeSettingsViewControllerTests.swift */; };
@@ -9277,6 +9279,8 @@
 		BBF04862A944340C80C053E0 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerTests.swift; sourceTree = "<group>"; };
 		BC0723512E33D7A2005BAC05 /* AppleIntelligenceUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceUtilTests.swift; sourceTree = "<group>"; };
+		BC129A2C2E45207F004A6875 /* SummarizeMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizeMiddleware.swift; sourceTree = "<group>"; };
+		BC129A2E2E4558FD004A6875 /* SummarizeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizeAction.swift; sourceTree = "<group>"; };
 		BC4B49618B8FC822D4D0FCC2 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BC81442AA84F635F3067A2C5 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
 		BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceUtil.swift; sourceTree = "<group>"; };
@@ -10958,6 +10962,8 @@
 		0B78DC6C2E3C9CDA00804872 /* Summarizer */ = {
 			isa = PBXGroup;
 			children = (
+				BC129A2E2E4558FD004A6875 /* SummarizeAction.swift */,
+				BC129A2C2E45207F004A6875 /* SummarizeMiddleware.swift */,
 				BA7CB0F02E4174A40052124B /* SummarizerTelemetry.swift */,
 				0B78DC6D2E3C9CE800804872 /* SummarizerNimbusUtils.swift */,
 			);
@@ -18143,6 +18149,7 @@
 				E1CEC2022A28C3F100B177D5 /* LoginDetailCenteredTableViewCell.swift in Sources */,
 				C2D71B972A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift in Sources */,
 				2122EE552DDCFD8C00D42716 /* PageZoomSettingsViewModel.swift in Sources */,
+				BC129A2D2E452082004A6875 /* SummarizeMiddleware.swift in Sources */,
 				8A83B7462A264FA0002FF9AC /* SettingsCoordinator.swift in Sources */,
 				619FE8932CE6595B004F83E2 /* WallpaperMiddleware.swift in Sources */,
 				8A5435562D53CB6800501214 /* JumpBackInAction.swift in Sources */,
@@ -18301,6 +18308,7 @@
 				ED6F82C32D6E539200FC1098 /* UIColor+Color.swift in Sources */,
 				1D2F68AD2ACB266300524B92 /* RemoteTabsPanelState.swift in Sources */,
 				8A9AC465276CEC4E0047F5B0 /* LegacyJumpBackInCell.swift in Sources */,
+				BC129A2F2E455900004A6875 /* SummarizeAction.swift in Sources */,
 				8CE1E4322B8C76AE0026530B /* LoginStorage.swift in Sources */,
 				BA7CB0F12E4174AC0052124B /* SummarizerTelemetry.swift in Sources */,
 				4347B398298D6D7B0045F677 /* CreditCardTableViewModel.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1440,6 +1440,7 @@
 		BC0723522E33D7A6005BAC05 /* AppleIntelligenceUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0723512E33D7A2005BAC05 /* AppleIntelligenceUtilTests.swift */; };
 		BC129A2D2E452082004A6875 /* SummarizeMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC129A2C2E45207F004A6875 /* SummarizeMiddleware.swift */; };
 		BC129A2F2E455900004A6875 /* SummarizeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC129A2E2E4558FD004A6875 /* SummarizeAction.swift */; };
+		BC129A322E461F96004A6875 /* SummarizerMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC129A312E461F91004A6875 /* SummarizerMiddlewareTests.swift */; };
 		BC8E91DC2E32953C00434FD0 /* AppleIntelligenceUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */; };
 		BCBE058C2E3A8720004B6039 /* SummarizeSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBE058B2E3A871B004B6039 /* SummarizeSetting.swift */; };
 		BCBE09BF2E3BAE2A004B6039 /* SummarizeSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBE09BE2E3BAE22004B6039 /* SummarizeSettingsViewControllerTests.swift */; };
@@ -9281,6 +9282,7 @@
 		BC0723512E33D7A2005BAC05 /* AppleIntelligenceUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceUtilTests.swift; sourceTree = "<group>"; };
 		BC129A2C2E45207F004A6875 /* SummarizeMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizeMiddleware.swift; sourceTree = "<group>"; };
 		BC129A2E2E4558FD004A6875 /* SummarizeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizeAction.swift; sourceTree = "<group>"; };
+		BC129A312E461F91004A6875 /* SummarizerMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerMiddlewareTests.swift; sourceTree = "<group>"; };
 		BC4B49618B8FC822D4D0FCC2 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BC81442AA84F635F3067A2C5 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
 		BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceUtil.swift; sourceTree = "<group>"; };
@@ -13784,6 +13786,14 @@
 			path = AppearanceSettings;
 			sourceTree = "<group>";
 		};
+		BC129A302E461F8C004A6875 /* Summarizer */ = {
+			isa = PBXGroup;
+			children = (
+				BC129A312E461F91004A6875 /* SummarizerMiddlewareTests.swift */,
+			);
+			path = Summarizer;
+			sourceTree = "<group>";
+		};
 		C22753422A3CA25100B9C0D1 /* WebsiteDataManagement */ = {
 			isa = PBXGroup;
 			children = (
@@ -14827,6 +14837,7 @@
 		E1AEC16D286E0CF500062E29 /* Frontend */ = {
 			isa = PBXGroup;
 			children = (
+				BC129A302E461F8C004A6875 /* Summarizer */,
 				E1AEC173286E0CF500062E29 /* Browser */,
 				8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */,
 				9614BF3F28A53F2000D3F7EA /* ContextualHints */,
@@ -18887,6 +18898,7 @@
 				2173326829CCDA8E007F20C7 /* LegacyTabScrollControllerTests.swift in Sources */,
 				1D3564542D9329FA00F52F12 /* SearchPrefsMigrationTests.swift in Sources */,
 				BA1C68BA2B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift in Sources */,
+				BC129A322E461F96004A6875 /* SummarizerMiddlewareTests.swift in Sources */,
 				2109726E2DCA8831001162A2 /* ZoomTelemetryTests.swift in Sources */,
 				9614BF4228A53FDF00D3F7EA /* ContextualHintEligibilityUtilityTests.swift in Sources */,
 				615532D42D7AA5F30046347F /* ScreenshotHelperTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -70,6 +70,7 @@ enum GeneralBrowserActionType: ActionType {
     case enteredZeroSearchScreen
     case didUnhideToolbar
     case didCloseTabFromToolbar
+    case shakeMotionEnded
 }
 
 struct GeneralBrowserMiddlewareAction: Action {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
@@ -15,6 +15,7 @@ enum BrowserNavigationDestination: Equatable {
     case bookmarksPanel
     case zeroSearch
     case shortcutsLibrary
+    case summarizer
 
     // Webpage views
     case link

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -134,6 +134,8 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             return reduceStateForStartAtHomeAction(action: action, state: state)
         } else if let action = action as? ToolbarMiddlewareAction {
             return reduceStateForToolbarAction(action: action, state: state)
+        } else if let action = action as? SummarizeAction {
+            return reduceStateForSummarizeAction(action: action, state: state)
         } else {
             return BrowserViewControllerState(
                 searchScreenState: state.searchScreenState,
@@ -184,6 +186,25 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         switch action.actionType {
         case StartAtHomeMiddlewareActionType.startAtHomeCheckCompleted:
             return resolveStateForStartAtHome(action: action, state: state)
+        default:
+            return defaultState(from: state, action: action)
+        }
+    }
+
+    // MARK: - Summarize Action
+    static func reduceStateForSummarizeAction(
+        action: SummarizeAction,
+        state: BrowserViewControllerState
+    ) -> BrowserViewControllerState {
+        switch action.actionType {
+        case SummarizeMiddlewareActionType.configuredSummarizer:
+            return BrowserViewControllerState(
+                searchScreenState: state.searchScreenState,
+                windowUUID: state.windowUUID,
+                browserViewType: state.browserViewType,
+                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
+                navigationDestination: NavigationDestination(.summarizer)
+            )
         default:
             return defaultState(from: state, action: action)
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -34,6 +34,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         case readerModeLongPressAction
         case dataClearance
         case passwordGenerator
+        // TODO: FXIOS-13118 Clean up and remove as we should have one navigation entry point
         case summarizer
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -840,7 +840,12 @@ class BrowserViewController: UIViewController,
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         super.motionEnded(motion, with: event)
         guard motion == .motionShake, summarizerNimbusUtils.isShakeGestureEnabled else { return }
-        navigationHandler?.showSummarizePanel(.shakeGesture)
+        store.dispatch(
+            GeneralBrowserAction(
+                windowUUID: windowUUID,
+                actionType: GeneralBrowserActionType.shakeMotionEnded
+            )
+        )
     }
 
     // MARK: - BrowserContentHiding
@@ -2714,6 +2719,8 @@ class BrowserViewController: UIViewController,
                 toastContainer: config.toastContainer,
                 popoverArrowDirection: config.popoverArrowDirection
             )
+        case .summarizer:
+            navigationHandler?.showSummarizePanel(.shakeGesture)
         case .tabTray(let panelType):
             navigationHandler?.showTabTray(selectedPanel: panelType)
         case .zeroSearch:

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizeAction.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizeAction.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import WebKit
+
+struct SummarizeAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+
+    init(
+        windowUUID: WindowUUID,
+        actionType: any ActionType
+    ) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
+    }
+}
+
+enum SummarizeMiddlewareActionType: ActionType {
+    case configuredSummarizer
+}

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import SummarizeKit
+
+final class SummarizerMiddleware {
+    private let summarizerNimbusUtils: SummarizerNimbusUtils
+    private let summarizationChecker: SummarizationCheckerProtocol
+    private let summarizerServiceFactory: SummarizerServiceFactory
+    private let logger: Logger
+    private let windowManager: WindowManager
+
+    init(
+        logger: Logger = DefaultLogger.shared,
+        windowManager: WindowManager = AppContainer.shared.resolve(),
+        summarizerNimbusUtility: SummarizerNimbusUtils = DefaultSummarizerNimbusUtils(),
+        summarizerServiceFactory: SummarizerServiceFactory = DefaultSummarizerServiceFactory(),
+        summarizationChecker: SummarizationCheckerProtocol = SummarizationChecker()
+    ) {
+        self.logger = logger
+        self.windowManager = windowManager
+        self.summarizerNimbusUtils = summarizerNimbusUtility
+        self.summarizationChecker = summarizationChecker
+        self.summarizerServiceFactory = summarizerServiceFactory
+    }
+
+    lazy var summarizerProvider: Middleware<AppState> = { state, action in
+        switch action.actionType {
+        case GeneralBrowserActionType.shakeMotionEnded:
+            Task { @MainActor in
+                await self.dispatchSummarizeConfigurationAction(for: action)
+            }
+        default:
+            break
+        }
+    }
+
+    private var maxWords: Int {
+        summarizerServiceFactory.maxWords(
+            isAppleSummarizerEnabled: summarizerNimbusUtils.isAppleSummarizerEnabled(),
+            isHostedSummarizerEnabled: summarizerNimbusUtils.isHostedSummarizerEnabled()
+        )
+    }
+
+    private func dispatchSummarizeConfigurationAction(for action: Action) async {
+        guard let webView = windowManager.tabManager(for: action.windowUUID).selectedTab?.webView else { return }
+        let result = await summarizationChecker.check(
+            on: webView,
+            maxWords: maxWords
+        )
+        guard result.canSummarize else { return }
+        store.dispatchLegacy(
+            SummarizeAction(
+                windowUUID: action.windowUUID,
+                actionType: SummarizeMiddlewareActionType.configuredSummarizer
+            )
+        )
+    }
+}

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -80,6 +80,7 @@ let middlewares = [
     BookmarksMiddleware().bookmarksProvider,
     HomepageMiddleware(notificationCenter: NotificationCenter.default).homepageProvider,
     StartAtHomeMiddleware().startAtHomeProvider,
+    SummarizerMiddleware().summarizerProvider,
     TermsOfUseMiddleware().termsOfUseProvider
 ]
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -270,6 +270,21 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         XCTAssertFalse(newState.shouldStartAtHome)
     }
 
+    // MARK: - Summarizer
+    func test_configuredSummarizer_summarizerAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        let action = SummarizeAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: SummarizeMiddlewareActionType.configuredSummarizer
+        )
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.navigationDestination?.destination, .summarizer)
+        XCTAssertEqual(newState.navigationDestination?.url, nil)
+    }
+
     // MARK: - Zero Search State
 
     func test_tapOnHomepageSearchBar_navigationBrowserAction_returnsExpectedState() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -275,7 +275,7 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         }
         tabManager.selectedTab = MockTab(profile: profile, windowUUID: .XCTestDefaultUUID)
         subject.motionEnded(.motionShake, with: nil)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: 1)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? GeneralBrowserActionType)
@@ -288,10 +288,16 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         profile.prefs.setBool(false, forKey: PrefsKeys.Summarizer.shakeGestureEnabled)
         setupSummarizedShakeGestureForTesting(isEnabled: false)
         let subject = createSubject()
+        let expectation = XCTestExpectation(description: "General browser action is dispatched")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
         tabManager.selectedTab = MockTab(profile: profile, windowUUID: .XCTestDefaultUUID)
         subject.motionEnded(.motionShake, with: nil)
+        wait(for: [expectation], timeout: 1)
 
-        XCTAssertEqual(browserCoordinator.showSummarizePanelCalled, 0)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
     }
 
     func testMotionEnded_withGestureNotShake_doesntShowSummarizePanel() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -265,14 +265,23 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
     }
 
     // MARK: - Shake motion
-    func testMotionEnded_withShakeGestureEnabled_showsSummaryPanel() {
+    func testMotionEnded_withShakeGestureEnabled_showsSummaryPanel() throws {
         profile.prefs.setBool(true, forKey: PrefsKeys.Summarizer.shakeGestureEnabled)
         setupSummarizedShakeGestureForTesting(isEnabled: true)
         let subject = createSubject()
+        let expectation = XCTestExpectation(description: "General browser action is dispatched")
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
         tabManager.selectedTab = MockTab(profile: profile, windowUUID: .XCTestDefaultUUID)
         subject.motionEnded(.motionShake, with: nil)
+        wait(for: [expectation])
 
-        XCTAssertEqual(browserCoordinator.showSummarizePanelCalled, 1)
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? GeneralBrowserActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, GeneralBrowserActionType.shakeMotionEnded)
     }
 
     func testMotionEnded_withShakeGestureDisabled_doesNotShowSummaryPanel() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
@@ -1,0 +1,186 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
+    private var mockWindowManager: MockWindowManager!
+    private var mockTabManager: MockTabManager!
+    private var mockSummarizationChecker: MockSummarizationChecker!
+    private var mockProfile: MockProfile!
+    private var mockStore: MockStoreForMiddleware<AppState>!
+
+    override func setUp() {
+        super.setUp()
+        mockProfile = MockProfile()
+        mockTabManager = MockTabManager()
+        mockWindowManager = MockWindowManager(
+            wrappedManager: WindowManagerImplementation(),
+            tabManager: mockTabManager
+        )
+        mockSummarizationChecker = MockSummarizationChecker()
+        DependencyHelperMock().bootstrapDependencies(
+            injectedWindowManager: mockWindowManager,
+            injectedTabManager: mockTabManager
+        )
+        setupStore()
+    }
+
+    override func tearDown() {
+        mockProfile = nil
+        mockWindowManager = nil
+        mockSummarizationChecker = nil
+        DependencyHelperMock().reset()
+        resetStore()
+        super.tearDown()
+    }
+
+    func test_shakeMotionAction_withFeatureFlagEnabled_dispatchesMiddlewareAction() throws {
+        setupNimbusHostedSummarizerTesting(isEnabled: true)
+        setupWebViewForTabManager()
+        mockSummarizationChecker.overrideResponse = MockSummarizationChecker.success
+
+        let subject = createSubject()
+
+        let action = GeneralBrowserAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: GeneralBrowserActionType.shakeMotionEnded
+        )
+        let expectation = XCTestExpectation(description: "General browser action initialize dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.summarizerProvider(AppState(), action)
+
+        wait(for: [expectation], timeout: 1)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? SummarizeAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? SummarizeMiddlewareActionType)
+
+        XCTAssertEqual(actionType, SummarizeMiddlewareActionType.configuredSummarizer)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(mockSummarizationChecker.checkCalledCount, 1)
+    }
+
+    func test_shakeMotionAction_failsSummarizerCheck_doesNotDispatchMiddlewareAction() throws {
+        setupNimbusHostedSummarizerTesting(isEnabled: true)
+        setupWebViewForTabManager()
+        mockSummarizationChecker.overrideResponse = MockSummarizationChecker.failure
+
+        let subject = createSubject()
+
+        let action = GeneralBrowserAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: GeneralBrowserActionType.shakeMotionEnded
+        )
+        let expectation = XCTestExpectation(description: "General browser action initialize dispatched")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.summarizerProvider(AppState(), action)
+
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertEqual(mockSummarizationChecker.checkCalledCount, 1)
+    }
+
+    func test_shakeMotionAction_withoutWebView_doesNotDispatchMiddlewareAction() throws {
+        setupNimbusHostedSummarizerTesting(isEnabled: true)
+        let subject = createSubject()
+
+        let action = GeneralBrowserAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: GeneralBrowserActionType.shakeMotionEnded
+        )
+        let expectation = XCTestExpectation(description: "General browser action initialize dispatched")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.summarizerProvider(AppState(), action)
+
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertEqual(mockSummarizationChecker.checkCalledCount, 0)
+    }
+
+    func test_shakeMotionAction_withFeatureFlagDisabled_doesNotDispatchMiddlewareAction() throws {
+        setupNimbusHostedSummarizerTesting(isEnabled: false)
+        let subject = createSubject()
+
+        let action = GeneralBrowserAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: GeneralBrowserActionType.shakeMotionEnded
+        )
+        let expectation = XCTestExpectation(description: "General browser action initialize dispatched")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.summarizerProvider(AppState(), action)
+
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertEqual(mockSummarizationChecker.checkCalledCount, 0)
+    }
+
+    // MARK: - Helpers
+    private func createSubject() -> SummarizerMiddleware {
+        return SummarizerMiddleware(
+            logger: MockLogger(),
+            windowManager: mockWindowManager,
+            summarizationChecker: mockSummarizationChecker
+        )
+    }
+
+    private func setupWebViewForTabManager() {
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.webView = MockTabWebView(tab: tab)
+        mockTabManager.selectedTab = tab
+    }
+
+    private func setupNimbusHostedSummarizerTesting(isEnabled: Bool) {
+        FxNimbus.shared.features.hostedSummarizerFeature.with { _, _ in
+            return HostedSummarizerFeature(enabled: isEnabled)
+        }
+    }
+
+    // MARK: StoreTestUtility
+    func setupAppState() -> AppState {
+        return AppState(
+            activeScreens: ActiveScreensState(
+                screens: [
+                    .homepage(
+                        HomepageState(
+                            windowUUID: .XCTestDefaultUUID
+                        )
+                    ),
+                ]
+            )
+        )
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    // In order to avoid flaky tests, we should reset the store
+    // similar to production
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSummarizationChecker.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSummarizationChecker.swift
@@ -6,6 +6,7 @@ import SummarizeKit
 import WebKit
 
 class MockSummarizationChecker: SummarizationCheckerProtocol {
+    var checkCalledCount = 0
     static let success = SummarizationCheckResult(
         canSummarize: true,
         reason: nil,
@@ -22,6 +23,7 @@ class MockSummarizationChecker: SummarizationCheckerProtocol {
     var overrideResponse: SummarizationCheckResult?
 
     func check(on webView: WKWebView, maxWords: Int) async -> SummarizationCheckResult {
+        checkCalledCount += 1
         return overrideResponse ?? Self.success
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13118)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28542)

## :bulb: Description
Remove showing the summarize animation and view if a website does not have a summarizer that is available. This follows the same logic check that we have for the toolbar entry and the main menu option. However, instead of having 3 places where we do the check, we now added a single point where we retrieve the service and logic checks, which is through the `SummarizerMiddleware`. A follow up [ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13126) has been created to refactor the other areas.

**Implemention**
- When shake motion has ended, we dispatch an action that gets observed in the `SummarizerMiddleware` , which leverages the summarizer service dependencies. 
- When the action is observed, we do the logic check using the summarizer service and only dispatch an action if it passes the check via `canSummarize`.
- When the middleware action gets dispatched, it is observed by `BrowserViewControllerState` which then updates the state with `navigationDestination = NavigationDestination(.summarizer)`.
- This triggers the logic in `BrowserViewController` to show the summarizer check.

While it seems that there is more boilerplate code with Redux, this implementation follows our current architecture flow and can see the unidirectional flow of an action taken and the consequences that occurs. This will help simplify the flow between the 3 different entry points as well when we refactor.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
