### PR TITLE
Refactor FXIOS-12977 #28304 ⁃ [TabScrollController refactor] Create TabScrollController protocol to isolate scroll interaction

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1112,7 +1112,9 @@ extension BrowserViewController: WKNavigationDelegate {
         // TODO: content blocking hasn't really changed, can we improve code clarity here? [FXIOS-10091]
         tab.contentBlocker?.notifyContentBlockingChanged()
 
-        self.scrollController.resetZoomState()
+        if let scrollController = scrollController as? LegacyTabScrollProvider {
+            scrollController.resetZoomState()
+        }
 
         if tabManager.selectedTab === tab {
             updateUIForReaderHomeStateForTab(tab, focusUrlBar: true)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -448,12 +448,6 @@ class BrowserViewController: UIViewController,
         self.zoomManager = ZoomPageManager(windowUUID: tabManager.windowUUID)
         self.tabsPanelTelemetry = TabsPanelTelemetry(gleanWrapper: gleanWrapper, logger: logger)
         self.userInitiatedQueue = userInitiatedQueue
-        
-        if isTabScrollRefactoringEnabled {
-            scrollController = TabScrollHandler(windowUUID: windowUUID)
-        } else {
-            scrollController = LegacyTabScrollController(windowUUID: windowUUID)
-        }
 
         super.init(nibName: nil, bundle: nil)
         didInit()
@@ -1686,7 +1680,9 @@ class BrowserViewController: UIViewController,
                 // if we don't have the URL bar at the top then header height is 0
                 make.height.equalTo(0)
             } else {
-                scrollController.headerTopConstraint = make.top.equalTo(view.safeArea.top).constraint
+                if let scrollController = scrollController as? LegacyTabScrollProvider {
+                    scrollController.headerTopConstraint = make.top.equalTo(view.safeArea.top).constraint
+                }
                 make.left.right.equalTo(view)
             }
         }
@@ -1711,8 +1707,10 @@ class BrowserViewController: UIViewController,
             }
         }
 
+        let legacyScrollController = scrollController as? LegacyTabScrollProvider
         overKeyboardContainer.snp.remakeConstraints { make in
-            scrollController.overKeyboardContainerConstraint = make.bottom.equalTo(bottomContainer.snp.top).constraint
+            legacyScrollController?.overKeyboardContainerConstraint = make.bottom.equalTo(bottomContainer.snp.top).constraint
+            
             if !isBottomSearchBar, zoomPageBar != nil {
                 make.height.greaterThanOrEqualTo(0)
             } else if !isBottomSearchBar {
@@ -1722,7 +1720,7 @@ class BrowserViewController: UIViewController,
         }
 
         bottomContainer.snp.remakeConstraints { make in
-            scrollController.bottomContainerConstraint = make.bottom.equalTo(view.snp.bottom).constraint
+            legacyScrollController?.bottomContainerConstraint = make.bottom.equalTo(view.snp.bottom).constraint
             make.leading.trailing.equalTo(view)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1057,9 +1057,11 @@ class BrowserViewController: UIViewController,
         }
 
         navigationToolbarContainer.toolbarDelegate = self
-        scrollController.configureToolbarViews(overKeyboardContainer: overKeyboardContainer,
-                                               bottomContainer: bottomContainer,
-                                               headerContainer: header)
+        if let scrollController = scrollController as? LegacyTabScrollProvider {
+            scrollController.configureToolbarViews(overKeyboardContainer: overKeyboardContainer,
+                                                   bottomContainer: bottomContainer,
+                                                   headerContainer: header)
+        }
 
         // Setup UIDropInteraction to handle dragging and dropping
         // links into the view from other apps.

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -559,7 +559,7 @@ class BrowserViewController: UIViewController,
         searchBarView.updateConstraints()
         updateMicrosurveyConstraints()
         updateToolbarDisplay()
-        
+
         if let legacyController = scrollController as? LegacyTabScrollProvider {
             let action = GeneralBrowserMiddlewareAction(
                 scrollOffset: legacyController.contentOffset,
@@ -1570,7 +1570,6 @@ class BrowserViewController: UIViewController,
         }, completion: { _ in
             legacyScrollController?.traitCollectionDidChange()
             legacyScrollController?.setMinimumZoom()
-            
         })
         microsurvey?.setNeedsUpdateConstraints()
         webPagePreview.invalidateScreenshotData()
@@ -1682,6 +1681,8 @@ class BrowserViewController: UIViewController,
             } else {
                 if let scrollController = scrollController as? LegacyTabScrollProvider {
                     scrollController.headerTopConstraint = make.top.equalTo(view.safeArea.top).constraint
+                } else {
+                    make.top.equalTo(view.safeArea.top)
                 }
                 make.left.right.equalTo(view)
             }
@@ -1707,10 +1708,13 @@ class BrowserViewController: UIViewController,
             }
         }
 
-        let legacyScrollController = scrollController as? LegacyTabScrollProvider
         overKeyboardContainer.snp.remakeConstraints { make in
-            legacyScrollController?.overKeyboardContainerConstraint = make.bottom.equalTo(bottomContainer.snp.top).constraint
-            
+            if let scrollController = scrollController as? LegacyTabScrollProvider {
+                scrollController.overKeyboardContainerConstraint = make.bottom.equalTo(bottomContainer.snp.top).constraint
+            } else {
+                make.bottom.equalTo(bottomContainer.snp.top)
+            }
+
             if !isBottomSearchBar, zoomPageBar != nil {
                 make.height.greaterThanOrEqualTo(0)
             } else if !isBottomSearchBar {
@@ -1720,7 +1724,11 @@ class BrowserViewController: UIViewController,
         }
 
         bottomContainer.snp.remakeConstraints { make in
-            legacyScrollController?.bottomContainerConstraint = make.bottom.equalTo(view.snp.bottom).constraint
+            if let scrollController = scrollController as? LegacyTabScrollProvider {
+                scrollController.bottomContainerConstraint = make.bottom.equalTo(view.snp.bottom).constraint
+            } else {
+                make.bottom.equalTo(view.snp.bottom)
+            }
             make.leading.trailing.equalTo(view)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -350,7 +350,7 @@ class BrowserViewController: UIViewController,
 
     // TODO: Add proper feature flag mechanism
     var isTabScrollRefactoringEnabled: Bool {
-        return true
+        return false
     }
 
     // MARK: Computed vars

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -13,6 +13,9 @@ protocol LegacyTabScrollProvider: TabScrollHandlerProtocol {
     var overKeyboardContainerConstraint: Constraint? { get set }
     var bottomContainerConstraint: Constraint? { get set }
 
+    func configureToolbarViews(overKeyboardContainer: BaseAlphaStackView?,
+                               bottomContainer: BaseAlphaStackView?,
+                               headerContainer: BaseAlphaStackView?)
     func updateMinimumZoom()
     func setMinimumZoom()
     func resetZoomState()

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -7,7 +7,6 @@ import SnapKit
 import Shared
 import Common
 
-@MainActor
 protocol LegacyTabScrollProvider: TabScrollHandlerProtocol {
     var headerTopConstraint: Constraint? { get set }
     var overKeyboardContainerConstraint: Constraint? { get set }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -9,6 +9,10 @@ import Common
 
 @MainActor
 protocol LegacyTabScrollProvider: TabScrollHandlerProtocol {
+    var headerTopConstraint: Constraint? { get set }
+    var overKeyboardContainerConstraint: Constraint? { get set }
+    var bottomContainerConstraint: Constraint? { get set }
+
     func updateMinimumZoom()
     func setMinimumZoom()
     func resetZoomState()

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -279,7 +279,7 @@ final class LegacyTabScrollController: NSObject,
         if let containerView = scrollView?.superview {
             let translation = gesture.translation(in: containerView)
             let delta = lastPanTranslation - translation.y
-            setScrollDirection(delta)
+            scrollDirection = delta > 0 ? .down : .up
 
             guard shouldRespondToScrollGesture(gesture, delta: delta, in: containerView) else {
                 return
@@ -309,20 +309,6 @@ final class LegacyTabScrollController: NSObject,
         let isFastEnough = abs(velocity) > UX.minimumScrollVelocity
         shouldRespondToScroll = isSignificantScroll || isFastEnough
         return shouldRespondToScroll
-    }
-
-    /// Updates the current scroll direction based on the scroll delta.
-    ///
-    /// - Parameter delta: The change in vertical scroll position.
-    /// This is the inverse of the user's drag gesture. For example:
-    /// - If the user drags **up**, the content moves **down** (delta > 0), so the scroll direction is `.down`.
-    /// - If the user drags **down**, the content moves **up** (delta < 0), so the scroll direction is `.up`.
-    private func setScrollDirection(_ delta: CGFloat) {
-        if delta > 0 {
-            scrollDirection = .down
-        } else if delta < 0 {
-            scrollDirection = .up
-        }
     }
 
     func showToolbars(animated: Bool) {

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -8,10 +8,6 @@ import Shared
 import Common
 
 protocol TabScrollHandlerProtocol: AnyObject {
-    var headerTopConstraint: Constraint? { get set }
-    var overKeyboardContainerConstraint: Constraint? { get set }
-    var bottomContainerConstraint: Constraint? { get set }
-
     var zoomPageBar: ZoomPageBar? { get set }
     var tab: Tab? { get set }
     var contentOffset: CGPoint { get }
@@ -93,14 +89,14 @@ final class TabScrollHandler: NSObject,
         }
     }
 
-    // Toolbar  Constraints
-    var headerTopConstraint: Constraint?
-    var overKeyboardContainerConstraint: Constraint?
-    var bottomContainerConstraint: Constraint?
-
+    // Toolbar height and offset
     private var overKeyboardScrollHeight: CGFloat = 0
     private var bottomContainerScrollHeight: CGFloat = 0
     private var headerHeight: CGFloat = 0
+    private var headerTopOffset: CGFloat = 0
+    private var overKeyboardContainerOffset: CGFloat = 0
+    private var bottomContainerOffset: CGFloat = 0
+
     weak var zoomPageBar: ZoomPageBar?
     private var observedScrollViews = WeakList<UIScrollView>()
 
@@ -117,13 +113,6 @@ final class TabScrollHandler: NSObject,
     private var isZoomedOut = false
     private var lastZoomedScale: CGFloat = 0
     private var isUserZoom = false
-
-    // Top Toolbar offset updates related constraints
-    private var headerTopOffset: CGFloat = 0 {
-        didSet {
-            headerTopConstraint?.update(offset: headerTopOffset)
-        }
-    }
 
     /// Calculates the header offset based on device type and toolbar visibility.
     ///
@@ -144,19 +133,6 @@ final class TabScrollHandler: NSObject,
             return baseOffset
         }
         return baseOffset + UX.heightOffset
-    }
-
-    // Bottom toolbar offset updates related constraints
-    private var overKeyboardContainerOffset: CGFloat = 0 {
-        didSet {
-            overKeyboardContainerConstraint?.update(offset: overKeyboardContainerOffset)
-        }
-    }
-
-    private var bottomContainerOffset: CGFloat = 0 {
-        didSet {
-            bottomContainerConstraint?.update(offset: bottomContainerOffset)
-        }
     }
 
     /// Helper method for testing overKeyboardScrollHeight behavior.

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -236,11 +236,13 @@ final class TabScrollHandler: NSObject,
 
     func showToolbars(animated: Bool) {
         toolbarDisplayState.update(displayState: .expanded)
+        lastValidState = toolbarDisplayState
         delegate?.showToolbar()
     }
 
     func hideToolbars(animated: Bool) {
         toolbarDisplayState.update(displayState: .collapsed)
+        lastValidState = toolbarDisplayState
         delegate?.hideToolbar()
     }
 
@@ -458,7 +460,6 @@ private extension TabScrollHandler {
         } else if scrollDirection == .up && !toolbarDisplayState.isExpanded {
             showToolbars(animated: true)
         } else {
-            lastValidState = toolbarDisplayState
             toolbarDisplayState.update(displayState: .transitioning)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -454,9 +454,9 @@ private extension TabScrollHandler {
     func updateToolbarDisplayState(for delta: CGFloat) {
         guard !toolbarDisplayState.isAnimating else { return }
 
-        if scrollDirection == .down && !toolbarDisplayState.isCollapsed {
+        if scrollDirection == .down && !toolbarDisplayState.isExpanded {
             hideToolbars(animated: true)
-        } else if scrollDirection == .up && !toolbarDisplayState.isExpanded {
+        } else if scrollDirection == .up && !toolbarDisplayState.isCollapsed {
             showToolbars(animated: true)
         } else {
             lastValidState = toolbarDisplayState

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import SnapKit
 import Shared
 import Common
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -454,9 +454,9 @@ private extension TabScrollHandler {
     func updateToolbarDisplayState(for delta: CGFloat) {
         guard !toolbarDisplayState.isAnimating else { return }
 
-        if scrollDirection == .down && !toolbarDisplayState.isExpanded {
+        if scrollDirection == .down && !toolbarDisplayState.isCollapsed {
             hideToolbars(animated: true)
-        } else if scrollDirection == .up && !toolbarDisplayState.isCollapsed {
+        } else if scrollDirection == .up && !toolbarDisplayState.isExpanded {
             showToolbars(animated: true)
         } else {
             lastValidState = toolbarDisplayState

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
@@ -9,6 +9,7 @@ import Shared
 
 @testable import Client
 
+@MainActor
 final class LegacyTabScrollControllerTests: XCTestCase {
     var tab: Tab!
     var mockProfile: MockProfile!
@@ -144,7 +145,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
 
         let safeAreaInsets = UIEdgeInsets(top: 44, left: 0, bottom: 34, right: 0)
-        let result = subject.overKeyboardScrollHeight(
+        let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
             isMinimalAddressBarEnabled: false,
             isBottomSearchBar: true
@@ -158,7 +159,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         setupTabScroll(with: subject)
 
         let safeAreaInsets = UIEdgeInsets(top: 44, left: 0, bottom: 34, right: 0)
-        let result = subject.overKeyboardScrollHeight(
+        let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
             isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
@@ -175,7 +176,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         let topInset: CGFloat = 20
 
         let safeAreaInsets = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
-        let result = subject.overKeyboardScrollHeight(
+        let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
             isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
@@ -191,7 +192,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         setupToolbarViews(with: subject, overKeyboardContainer: nil)
 
         let safeAreaInsets = UIEdgeInsets(top: 44, left: 0, bottom: 0, right: 0)
-        let result = subject.overKeyboardScrollHeight(
+        let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
             isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
@@ -206,7 +207,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
 
         let containerHeight: CGFloat = 100
 
-        let result = subject.overKeyboardScrollHeight(
+        let result = subject.calculateOverKeyboardScrollHeight(
             with: nil,
             isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
@@ -220,7 +221,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         setupTabScroll(with: subject)
 
         let containerHeight: CGFloat = 100
-        let result = subject.overKeyboardScrollHeight(
+        let result = subject.calculateOverKeyboardScrollHeight(
             with: UIEdgeInsets.zero,
             isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
@@ -237,7 +238,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         let topInset: CGFloat = 20
 
         let safeAreaInsets = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
-        let result = subject.overKeyboardScrollHeight(
+        let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
             isMinimalAddressBarEnabled: true,
             isBottomSearchBar: false
@@ -258,7 +259,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         subject.zoomPageBar = zoomPageBar
 
         let safeAreaInsets = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
-        let result = subject.overKeyboardScrollHeight(
+        let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
             isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
@@ -275,7 +276,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         let containerHeight: CGFloat = 100
         let safeAreaInsets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
 
-        let result = subject.overKeyboardScrollHeight(
+        let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
             isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
@@ -290,7 +291,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
 
         let safeAreaInsets = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
 
-        let result = subject.overKeyboardScrollHeight(
+        let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
             isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
@@ -66,7 +66,7 @@ final class TabScrollHandlerTests: XCTestCase {
         let subject = createSubject()
         setupTabScroll(with: subject)
 
-        let translation = CGPoint(x: 0, y: -10)
+        let translation = CGPoint(x: 0, y: 10)
         let velocity = CGPoint(x: 10, y: 110)
         subject.handleScroll(for: translation, velocity: velocity)
         subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
@@ -34,10 +34,9 @@ final class TabScrollHandlerTests: XCTestCase {
         let subject = createSubject()
         setupTabScroll(with: subject)
 
-        let translation = CGPoint(x: 0, y: 100)
+        let translation = CGPoint(x: 0, y: -100)
         let velocity = CGPoint(x: 10, y: 10)
         subject.handleScroll(for: translation, velocity: velocity)
-        subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
         XCTAssertEqual(subject.toolbarDisplayState, .collapsed)
     }
 
@@ -45,7 +44,7 @@ final class TabScrollHandlerTests: XCTestCase {
         let subject = createSubject()
         setupTabScroll(with: subject)
 
-        let translation = CGPoint(x: 0, y: -100)
+        let translation = CGPoint(x: 0, y: 100)
         let velocity = CGPoint(x: 10, y: 10)
         subject.handleScroll(for: translation, velocity: velocity)
         subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
@@ -56,7 +55,7 @@ final class TabScrollHandlerTests: XCTestCase {
         let subject = createSubject()
         setupTabScroll(with: subject)
 
-        let translation = CGPoint(x: 0, y: 10)
+        let translation = CGPoint(x: 0, y: -10)
         let velocity = CGPoint(x: 10, y: 110)
         subject.handleScroll(for: translation, velocity: velocity)
         subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
@@ -104,7 +103,6 @@ final class TabScrollHandlerTests: XCTestCase {
         let translation = CGPoint(x: 0, y: 100)
         let velocity = CGPoint(x: 10, y: 80)
         subject.handleScroll(for: translation, velocity: velocity)
-        subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
 
         // Force call to showToolbars like clicking on top bar area
         subject.showToolbars(animated: true)
@@ -124,6 +122,7 @@ final class TabScrollHandlerTests: XCTestCase {
         let velocity = CGPoint(x: 10, y: 80)
         subject.handleScroll(for: translation, velocity: velocity)
         XCTAssertTrue(subject.scrollViewShouldScrollToTop(scrollView))
+        subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
         XCTAssertEqual(subject.toolbarDisplayState, .expanded)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
@@ -37,6 +37,7 @@ final class TabScrollHandlerTests: XCTestCase {
         let translation = CGPoint(x: 0, y: 100)
         let velocity = CGPoint(x: 10, y: 10)
         subject.handleScroll(for: translation, velocity: velocity)
+        subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
         XCTAssertEqual(subject.toolbarDisplayState, .collapsed)
     }
 
@@ -47,7 +48,7 @@ final class TabScrollHandlerTests: XCTestCase {
         let translation = CGPoint(x: 0, y: -100)
         let velocity = CGPoint(x: 10, y: 10)
         subject.handleScroll(for: translation, velocity: velocity)
-
+        subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
         XCTAssertEqual(subject.toolbarDisplayState, .expanded)
     }
 
@@ -58,6 +59,7 @@ final class TabScrollHandlerTests: XCTestCase {
         let translation = CGPoint(x: 0, y: 10)
         let velocity = CGPoint(x: 10, y: 110)
         subject.handleScroll(for: translation, velocity: velocity)
+        subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
         XCTAssertEqual(subject.toolbarDisplayState, .collapsed)
     }
 
@@ -68,7 +70,7 @@ final class TabScrollHandlerTests: XCTestCase {
         let translation = CGPoint(x: 0, y: -10)
         let velocity = CGPoint(x: 10, y: 110)
         subject.handleScroll(for: translation, velocity: velocity)
-
+        subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
         XCTAssertEqual(subject.toolbarDisplayState, .expanded)
     }
 
@@ -79,7 +81,7 @@ final class TabScrollHandlerTests: XCTestCase {
         let translation = CGPoint(x: 0, y: 10)
         let velocity = CGPoint(x: 10, y: 10)
         subject.handleScroll(for: translation, velocity: velocity)
-
+        subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
         XCTAssertEqual(subject.toolbarDisplayState, .expanded)
     }
 
@@ -90,7 +92,7 @@ final class TabScrollHandlerTests: XCTestCase {
         let translation = CGPoint(x: 0, y: -10)
         let velocity = CGPoint(x: 10, y: 10)
         subject.handleScroll(for: translation, velocity: velocity)
-
+        subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
         XCTAssertEqual(subject.toolbarDisplayState, .expanded)
     }
 
@@ -102,6 +104,7 @@ final class TabScrollHandlerTests: XCTestCase {
         let translation = CGPoint(x: 0, y: 100)
         let velocity = CGPoint(x: 10, y: 80)
         subject.handleScroll(for: translation, velocity: velocity)
+        subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
 
         // Force call to showToolbars like clicking on top bar area
         subject.showToolbars(animated: true)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12977)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
- Separate protocols to have common logic (that will be removed gradually) in `TabScrollHandlerProtocol` and variables and functions related to the legacy version in `LegacyTabScrollProvider`.
- Check for mock feature flag to create Legacy or new version
- Add handling for calls that are needed only in legacy version
- Remove all views related to toolbar (zoombar and pullToRefresh coming soon) and add calls to delegate 
- Fix test for Legacy and new version

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
