### PR TITLE
Bugfix FXIOS-13092 [Start At Home] no tab manager for window UUID

### DIFF
--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -133,7 +133,7 @@ final class WindowManagerImplementation: WindowManager {
     func tabManager(for windowUUID: WindowUUID) -> TabManager {
         guard let tabManager = window(for: windowUUID)?.tabManager else {
             assertionFailure("Tab Manager unavailable for requested UUID: \(windowUUID). This is a client error.")
-            logger.log("No tab manager for window UUID.", level: .fatal, category: .window)
+            logger.log("No tab manager for window UUID: \(windowUUID)", level: .fatal, category: .window)
             return windows.first!.value.tabManager!
         }
 
@@ -324,6 +324,7 @@ final class WindowManagerImplementation: WindowManager {
     private func window(for windowUUID: WindowUUID, createIfNeeded: Bool = false) -> AppWindowInfo? {
         let windowInfo = windows[windowUUID]
         if windowInfo == nil && createIfNeeded {
+            logger.log("Created new app window info for window UUID: \(windowUUID)", level: .info, category: .window)
             return AppWindowInfo(tabManager: nil)
         }
         return windowInfo

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -133,6 +133,9 @@ final class WindowManagerImplementation: WindowManager {
     func tabManager(for windowUUID: WindowUUID) -> TabManager {
         func unsafeAnyTabManager() -> TabManager {
             // This is unsafe, but is the best fallback we have to try to handle non-fatally (but may crash anyway)
+            if let tabManager = windows.first?.value.tabManager {
+                logger.log("Unsafe tab manager with windowUUID: \(tabManager.windowUUID)", level: .fatal, category: .window)
+            }
             return windows.first!.value.tabManager!
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -862,6 +862,11 @@ class BrowserViewController: UIViewController,
         AppEventQueue.started(.browserUpdatedForAppActivation(uuid))
         defer { AppEventQueue.completed(.browserUpdatedForAppActivation(uuid)) }
 
+        let allWindowUUIDs = (AppContainer.shared.resolve() as WindowManager).windows.keys.map { $0.uuidString.prefix(4) }
+        logger.log("BrowserDidBecomeActive. UUID = \(windowUUID.uuidString.prefix(4)). All windows: \(allWindowUUIDs)",
+                   level: .info,
+                   category: .lifecycle)
+
         NightModeHelper.cleanNightModeDefaults()
 
         // Update lock icon without redrawing the whole locationView

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -902,6 +902,7 @@ class BrowserViewController: UIViewController,
     // MARK: - Start At Home
     private func dispatchStartAtHomeAction() {
         let startAtHomeAction = StartAtHomeAction(
+            tabManager: tabManager,
             windowUUID: windowUUID,
             actionType: StartAtHomeActionType.didBrowserBecomeActive
         )

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -463,7 +463,7 @@ class BrowserViewController: UIViewController,
     }
 
     deinit {
-        logger.log("BVC deallocating", level: .info, category: .lifecycle)
+        logger.log("BVC deallocating (window: \(windowUUID))", level: .info, category: .lifecycle)
         unsubscribeFromRedux()
         // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
         // KVO observation removal directly requires self so we can not use the apple

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -907,7 +907,6 @@ class BrowserViewController: UIViewController,
     // MARK: - Start At Home
     private func dispatchStartAtHomeAction() {
         let startAtHomeAction = StartAtHomeAction(
-            tabManager: tabManager,
             windowUUID: windowUUID,
             actionType: StartAtHomeActionType.didBrowserBecomeActive
         )

--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeAction.swift
@@ -9,15 +9,18 @@ struct StartAtHomeAction: Action {
     let windowUUID: WindowUUID
     let actionType: ActionType
     let shouldStartAtHome: Bool?
+    let tabManager: TabManager?
 
     init(
         shouldStartAtHome: Bool? = nil,
+        tabManager: TabManager? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
         self.windowUUID = windowUUID
         self.actionType = actionType
         self.shouldStartAtHome = shouldStartAtHome
+        self.tabManager = tabManager
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeAction.swift
@@ -9,18 +9,15 @@ struct StartAtHomeAction: Action {
     let windowUUID: WindowUUID
     let actionType: ActionType
     let shouldStartAtHome: Bool?
-    let tabManager: TabManager?
 
     init(
         shouldStartAtHome: Bool? = nil,
-        tabManager: TabManager? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
         self.windowUUID = windowUUID
         self.actionType = actionType
         self.shouldStartAtHome = shouldStartAtHome
-        self.tabManager = tabManager
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
@@ -38,19 +38,7 @@ final class StartAtHomeMiddleware {
         MainActor.assumeIsolated {
             switch action.actionType {
             case StartAtHomeActionType.didBrowserBecomeActive:
-                guard let action = action as? StartAtHomeAction,
-                      let tabManager = action.tabManager else {
-                    self.logger.log(
-                        "Start at Home action does not have proper setup.",
-                        level: .warning,
-                        category: .tabs
-                    )
-                    return
-                }
-                let shouldStartAtHome = self.startAtHomeCheck(
-                    windowUUID: action.windowUUID,
-                    tabManager: tabManager
-                )
+                let shouldStartAtHome = self.startAtHomeCheck(windowUUID: action.windowUUID)
                 store.dispatchLegacy(
                     StartAtHomeAction(
                         shouldStartAtHome: shouldStartAtHome,
@@ -78,9 +66,8 @@ final class StartAtHomeMiddleware {
     ///
     /// - Returns: `true` if a homepage tab was selected and displayed, `false` otherwise.
     @MainActor
-    private func startAtHomeCheck(windowUUID: WindowUUID, tabManager: TabManager) -> Bool {
-        let fetchedTabManager = fetchTabManager(for: windowUUID)
-        logger.log("Fetching tab manager from window manager \(fetchedTabManager.windowUUID)", level: .info, category: .window)
+    private func startAtHomeCheck(windowUUID: WindowUUID) -> Bool {
+        let tabManager = fetchTabManager(for: windowUUID)
         let startAtHomeManager = StartAtHomeHelper(
             prefs: prefs,
             isRestoringTabs: !tabManager.tabRestoreHasFinished

--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
@@ -63,13 +63,12 @@ final class StartAtHomeMiddleware {
         }
     }
 
-    private func tabManager(for uuid: WindowUUID) -> TabManager {
+    private func fetchTabManager(for uuid: WindowUUID) -> TabManager {
         guard uuid != .unavailable else {
             assertionFailure()
             logger.log("Unexpected or unavailable window UUID for requested TabManager.", level: .fatal, category: .tabs)
             return windowManager.allWindowTabManagers().first!
         }
-
         return windowManager.tabManager(for: uuid)
     }
 
@@ -80,6 +79,8 @@ final class StartAtHomeMiddleware {
     /// - Returns: `true` if a homepage tab was selected and displayed, `false` otherwise.
     @MainActor
     private func startAtHomeCheck(windowUUID: WindowUUID, tabManager: TabManager) -> Bool {
+        let fetchedTabManager = fetchTabManager(for: windowUUID)
+        logger.log("Fetching tab manager from window manager \(fetchedTabManager.windowUUID)", level: .info, category: .window)
         let startAtHomeManager = StartAtHomeHelper(
             prefs: prefs,
             isRestoringTabs: !tabManager.tabRestoreHasFinished

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -171,6 +171,10 @@ class TabManagerImplementation: NSObject,
             ])
     }
 
+    deinit {
+        logger.log("TabManager deallocating (window: \(windowUUID))", level: .info, category: .lifecycle)
+    }
+
     subscript(index: Int) -> Tab? {
         if index >= tabs.count {
             return nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13092)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28502)

## :bulb: Description
Add a temporary fix for start at home and add more logging. The alternative fix is to pass `tabManager` from `BrowserViewController` through the dispatch action instead of fetching it from the window manager in the Middleware. Also added logs and kept the call to fetch through window manager, so we can debug the issue properly.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
