### PR TITLE
Bugfix MTE-4879 Update L10n tests for the current state of FF iOS

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -147,6 +147,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     @MainActor
     func testHistoryTableContextMenu() {
         navigator.openURL(loremIpsumURL)
+        waitUntilPageLoad()
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"], timeout: 5)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         waitForTabsButton()

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -121,8 +121,8 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         navigator.goto(SettingsScreen)
         mozWaitForElementToExist(app.cells["Search"])
         app.cells["Search"].swipeUp()
-        app.cells["Autofills & Passwords"].waitAndTap(timeout: 15)
-        app.cells["Passwords"].waitAndTap(timeout: 15)
+        app.cells["AutofillsPasswordsSettings"].waitAndTap(timeout: 15)
+        app.cells["Logins"].waitAndTap(timeout: 15)
 
         // Press continue button on the password onboarding if it's shown
         if app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].exists {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4879)

## :bulb: Description
The following L10n screenshot tests are failing at the moment:
*` L10nSuite1SnapshotTests.testHistoryTableContextMenu()`
* `L10nSuite2SnapshotTests.testLoginDetails()`

I used the following command to test the changes. All tests passed.
```
firefox-ios/l10n-screenshots.sh zh-TW
```

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
