### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Common - Adding FIXMEs to suppress warnings that need larger refactors to fix

### DIFF
--- a/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
+++ b/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
@@ -4,11 +4,10 @@
 
 import Foundation
 
-// Contains application information necessary for BrowserKit functionalities.
-// BrowserKit should stay agnostic of the application it's used in, and so the
-// client should pass down this information on setup of the application.
+/// Contains application information necessary for BrowserKit functionalities.
 public class BrowserKitInformation {
-    public static let shared = BrowserKitInformation()
+    // FIXME: FXIOS-13125 Shared state for the app should not be stored in the Common package.
+    nonisolated(unsafe) public static let shared = BrowserKitInformation()
 
     public var buildChannel: AppBuildChannel?
     public var nightlyAppVersion: String?

--- a/BrowserKit/Sources/Common/DependencyInjection/AppContainer.swift
+++ b/BrowserKit/Sources/Common/DependencyInjection/AppContainer.swift
@@ -9,7 +9,8 @@ import Dip
 /// This is our concrete dependency container. It holds all dependencies / services the app would need through
 /// a session.
 public class AppContainer: ServiceProvider {
-    public static let shared: ServiceProvider = AppContainer()
+    /// FIXME: FXIOS-13125 Shared state for the app should not be stored in the Common package.
+    nonisolated(unsafe) public static let shared: ServiceProvider = AppContainer()
 
     /// The item holding registered services.
     private var container = DependencyContainer()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
See more context in https://github.com/mozilla-mobile/firefox-ios/pull/28546#issuecomment-3168865412.

We are suppressing these warnings in order to avoid a larger refactor of app info and other shared global mutable state in the Common package which should really live in the Client.

See the followup ticket: FXIOS-13125

### Images
<img width="1465" height="181" alt="Screenshot 2025-08-08 at 2 29 24 PM" src="https://github.com/user-attachments/assets/463b1c3b-584a-493c-a259-1e5e54ad8765" />
<img height="400" alt="Screenshot 2025-08-07 at 1 18 26 PM" src="https://github.com/user-attachments/assets/00d70de7-34cf-4f58-b23e-1b6d88a31a10" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
