### PR TITLE
Build FXIOS-13136 [Local Rust Components] Update automation to target main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,6 @@
 /firefox-ios/Client/Assets/RemoteSettingsData/ @nbhasin2 @issammani @mattreaganmozilla
 /MozillaRustComponents/ @issammani
 
-
 # When someone opens a pull request that only modifies those folders / files, 
 # only @mozilla-mobile/fxios-automation and not the global
 # owners will be requested for a review.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,8 @@
 /firefox-ios/Client/Experiments/initial_experiments.json @afurlan-firefox
 /firefox-ios/Client/Assets/CC_Script @nbhasin2 @issammani
 /firefox-ios/Client/Assets/RemoteSettingsData/ @nbhasin2 @issammani @mattreaganmozilla
+/MozillaRustComponents/ @issammani
+
 
 # When someone opens a pull request that only modifies those folders / files, 
 # only @mozilla-mobile/fxios-automation and not the global

--- a/.github/workflows/update-appservices-nightly.yml
+++ b/.github/workflows/update-appservices-nightly.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: tmp/rust-components
+          ref: main
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13136)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28585)

## :bulb: Description
This PR:
- Updates the local rust components automation to target main. We have tried it on an off branch for about two weeks now and it works as expected ( [for reference](https://github.com/mozilla-mobile/firefox-ios/pulls?q=is%3Apr+%28WIP%29%28Local+AS+flow%29+is%3Aclosed) )
- Updates codeowners file since the PR confused a few people. For now, I will deal with reviewing them until we start consuming the package and then I will revert the change so that somone from `FxiOS eng ` gets auto assigned same as the current automation. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
