### PR TITLE
Bugfix FXIOS-13143 [Shake to Summarize] remove italics

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -311,7 +311,7 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
         let tabSnapshotYTransform = view.frame.height - UX.tabSnapshotFinalPositionBottomPadding - tabSnapshotOffset
 
         let brandedSummary = """
-        ###### *\(viewModel.brandLabel)*
+        ###### \(viewModel.brandLabel)
 
         \(summary)
         """


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13143)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28597)

## :bulb: Description
Remove italics from summarize by text in Summarizer view.

<img width="590" height="1278" alt="Screenshot 2025-08-11 at 11 09 36 AM" src="https://github.com/user-attachments/assets/1d9c1abc-f0f0-4cb7-bd91-2b115b079b17" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
