### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix warnings in the ThemeManager/DefaultThemeManager related to main actor isolation for Apple UIKit types.

### DIFF
--- a/BrowserKit/Sources/Common/ReaderMode/ReaderModeFontSize.swift
+++ b/BrowserKit/Sources/Common/ReaderMode/ReaderModeFontSize.swift
@@ -5,7 +5,7 @@
 import Foundation
 import UIKit
 
-public enum ReaderModeFontSize: Int {
+public enum ReaderModeFontSize: Int, Sendable {
     case size1 = 1
     case size2 = 2
     case size3 = 3

--- a/BrowserKit/Sources/Common/ReaderMode/ReaderModeStyle.swift
+++ b/BrowserKit/Sources/Common/ReaderMode/ReaderModeStyle.swift
@@ -5,7 +5,8 @@
 import Foundation
 import UIKit
 
-public struct ReaderModeStyle {
+@MainActor
+final public class ReaderModeStyle {
     let windowUUID: WindowUUID?
     public var theme: ReaderModeTheme
     public var fontType: ReaderModeFontType
@@ -37,6 +38,7 @@ public struct ReaderModeStyle {
     }
 
     /// Initialize the style from a dictionary, taken from the profile. Returns nil if the object cannot be decoded.
+    @MainActor
     public init?(windowUUID: WindowUUID?, dict: [String: Any]) {
         let themeRawValue = dict["theme"] as? String
         let fontTypeRawValue = dict["fontType"] as? String
@@ -58,7 +60,7 @@ public struct ReaderModeStyle {
         self.fontSize = fontSize!
     }
 
-    public mutating func ensurePreferredColorThemeIfNeeded() {
+    public func ensurePreferredColorThemeIfNeeded() {
         self.theme = ReaderModeTheme.preferredTheme(for: self.theme, window: windowUUID)
     }
 

--- a/BrowserKit/Sources/Common/ReaderMode/ReaderModeTheme.swift
+++ b/BrowserKit/Sources/Common/ReaderMode/ReaderModeTheme.swift
@@ -4,11 +4,12 @@
 
 import Foundation
 
-public enum ReaderModeTheme: String {
+public enum ReaderModeTheme: String, Sendable {
     case light
     case dark
     case sepia
 
+    @MainActor
     public static func preferredTheme(for theme: ReaderModeTheme? = nil, window: WindowUUID?) -> ReaderModeTheme {
         let themeManager: ThemeManager = AppContainer.shared.resolve()
 

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -4,8 +4,10 @@
 
 import UIKit
 
+@MainActor
 public protocol ThemeManager {
     // Current theme
+    @MainActor
     func getCurrentTheme(for window: WindowUUID?) -> Theme
 
     /// Resolves the appropriate theme based on window context and privacy override logic.
@@ -27,14 +29,21 @@ public protocol ThemeManager {
     var systemThemeIsOn: Bool { get }
     var automaticBrightnessIsOn: Bool { get }
     var automaticBrightnessValue: Float { get }
+
+    @MainActor
     func setSystemTheme(isOn: Bool)
+    @MainActor
     func setManualTheme(to newTheme: ThemeType)
     func getUserManualTheme() -> ThemeType
+    @MainActor
     func setAutomaticBrightness(isOn: Bool)
+    @MainActor
     func setAutomaticBrightnessValue(_ value: Float)
 
     // Window management and window-specific theming
+    @MainActor
     func applyThemeUpdatesToWindows()
+    @MainActor
     func setPrivateTheme(isOn: Bool, for window: WindowUUID)
     func getPrivateThemeIsOn(for window: WindowUUID) -> Bool
     func setWindow(_ window: UIWindow, for uuid: WindowUUID)

--- a/BrowserKit/Sources/WebEngine/Engine.swift
+++ b/BrowserKit/Sources/WebEngine/Engine.swift
@@ -18,6 +18,7 @@ public protocol Engine {
     func createSession(dependencies: EngineSessionDependencies) throws -> EngineSession
 
     /// Warm the `Engine` whenever we move the application to foreground
+    @MainActor
     func warmEngine()
 
     /// Idle the `Engine` whenever we move the application to background

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/ReaderModeContentScript.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/ReaderModeContentScript.swift
@@ -82,6 +82,7 @@ class ReaderModeContentScript: WKContentScript, ReaderModeStyleSetter {
     }
 
     // This sets the style onto the reader mode through JavaScript injection
+    @MainActor
     lazy var style = ReaderModeStyle.defaultStyle() {
         didSet {
             if state == ReaderModeState.active, let session {

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/ReaderModeUtils.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/ReaderModeUtils.swift
@@ -6,6 +6,7 @@ import Common
 import Foundation
 
 public struct ReaderModeUtils {
+    @MainActor
     public static func generateReaderContent(
         _ readabilityResult: ReadabilityResult,
         initialStyle: ReaderModeStyle

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
@@ -59,6 +59,7 @@ public class WKEngine: Engine {
         return session
     }
 
+    @MainActor
     public func warmEngine() {
         shutdownWebServerTimer?.cancel()
         shutdownWebServerTimer = nil

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -368,6 +368,7 @@ class WKEngineSession: NSObject,
         )
     }
 
+    @MainActor
     func setReaderMode(style: ReaderModeStyle, namespace: ReaderModeInfo) {
         webView.evaluateJavascriptInDefaultContentWorld(
             "\(namespace.rawValue).setStyle(\(style.encode()))"

--- a/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKWebServerUtil.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKWebServerUtil.swift
@@ -5,6 +5,7 @@
 import Common
 
 protocol WKWebServerUtil {
+    @MainActor
     func setUpWebServer(readerModeConfiguration: ReaderModeConfiguration)
     func stopWebServer()
 }
@@ -29,6 +30,7 @@ class DefaultWKWebServerUtil: WKWebServerUtil {
         return DefaultWKWebServerUtil(webServer: webServer)
     }
 
+    @MainActor
     func setUpWebServer(readerModeConfiguration: ReaderModeConfiguration) {
         guard !webServer.isRunning else { return }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -8,6 +8,7 @@ import Storage
 import struct MozillaAppServices.UpdatableAddressFields
 import struct MozillaAppServices.Address
 
+@MainActor
 final class AddressListViewModel: ObservableObject, FeatureFlaggable {
     enum Destination: Swift.Identifiable, Equatable {
         case add(Address)

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -233,6 +233,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
         return section
     }
 
+    @MainActor
     private func getFirstMiscSection(_ navigationController: UINavigationController?) -> [PhotonRowActions] {
         var section = [PhotonRowActions]()
 
@@ -491,6 +492,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
         return openSettings
     }
 
+    @MainActor
     private func getNightModeTitle(_ isNightModeOn: Bool) -> String {
         if themeManager.isNewAppearanceMenuOn {
             return isNightModeOn
@@ -503,6 +505,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
         }
     }
 
+    @MainActor
     private func getNightModeAction() -> [PhotonRowActions] {
         var items: [PhotonRowActions] = []
 

--- a/firefox-ios/Client/Frontend/FeltPrivacy/FeltPrivacyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/FeltPrivacy/FeltPrivacyMiddleware.swift
@@ -6,6 +6,7 @@ import Foundation
 import Redux
 import Common
 
+@MainActor
 final class FeltPrivacyMiddleware {
     var privacyStateManager: ThemeManager
 

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryActionables.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryActionables.swift
@@ -33,6 +33,7 @@ struct HistoryActionablesModel: Hashable {
         self.imageName = imageName
     }
 
+    @MainActor
     mutating func configureImage(for window: WindowUUID) {
         if let imageName = imageName {
             let themeManager: ThemeManager = AppContainer.shared.resolve()

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
@@ -9,6 +9,7 @@ import Shared
 import ComponentLibrary
 import OnboardingKit
 
+@MainActor
 final class OnboardingService: FeatureFlaggable {
     // MARK: - Properties
     private weak var delegate: OnboardingServiceDelegate?
@@ -54,7 +55,6 @@ final class OnboardingService: FeatureFlaggable {
         self.searchBarLocationSaver = searchBarLocationSaver
     }
 
-    @MainActor
     func handleAction(
         _ action: OnboardingActions,
         from cardName: String,
@@ -169,7 +169,6 @@ final class OnboardingService: FeatureFlaggable {
         askForNotificationPermission(from: cardName)
     }
 
-    @MainActor
     private func handleSyncSignIn(
         from cardName: String,
         with activityEventHelper: ActivityEventHelper,
@@ -182,7 +181,6 @@ final class OnboardingService: FeatureFlaggable {
         presentSignToSync(with: fxaParams, profile: profile, completion: completion)
     }
 
-    @MainActor
     private func handleSetDefaultBrowser(with activityEventHelper: ActivityEventHelper) {
         activityEventHelper.chosenOptions.insert(.setAsDefaultBrowser)
         activityEventHelper.updateOnboardingUserActivationEvent()
@@ -190,24 +188,20 @@ final class OnboardingService: FeatureFlaggable {
         defaultApplicationHelper.openSettings()
     }
 
-    @MainActor
     private func handleOpenInstructionsPopup(from popupViewModel: OnboardingDefaultBrowserModelProtocol) {
         presentDefaultBrowserPopup(from: popupViewModel) { [weak self] in
             self?.navigationDelegate?.finishOnboardingFlow()
         }
     }
 
-    @MainActor
     private func handleReadPrivacyPolicy(from url: URL, completion: @escaping () -> Void) {
         presentPrivacyPolicy(from: url, completion: completion)
     }
 
-    @MainActor
     private func handleOpenIosFxSettings(from cardName: String) {
         defaultApplicationHelper.openSettings()
     }
 
-    @MainActor
     private func handleEndOnboarding(with activityEventHelper: ActivityEventHelper) {
         introScreenManager?.didSeeIntroScreen()
         searchBarLocationSaver.saveUserSearchBarLocation(
@@ -240,7 +234,6 @@ final class OnboardingService: FeatureFlaggable {
         hasRegisteredForDefaultBrowserNotification = true
     }
 
-    @MainActor
     private func presentSignToSync(with params: FxALaunchParams, profile: Profile, completion: @escaping () -> Void) {
         guard let delegate = delegate else { return }
 
@@ -254,7 +247,6 @@ final class OnboardingService: FeatureFlaggable {
         delegate.present(signInVC, animated: true, completion: nil)
     }
 
-    @MainActor
     private func presentDefaultBrowserPopup(
         from popupViewModel: OnboardingDefaultBrowserModelProtocol,
         completion: @escaping @MainActor () -> Void
@@ -268,7 +260,6 @@ final class OnboardingService: FeatureFlaggable {
         delegate?.present(popupVC, animated: false, completion: nil)
     }
 
-    @MainActor
     private func presentPrivacyPolicy(from url: URL, completion: @escaping () -> Void) {
         guard let delegate = delegate else { return }
         let privacyVC = createPrivacyPolicyViewController(
@@ -351,10 +342,10 @@ final class OnboardingService: FeatureFlaggable {
         return controller
     }
 
-    @MainActor
     @objc
-    private func dismissSelector() {
-        assert(Thread.isMainThread, "Sometimes we have issues with @objc obeying @MainActor -- debug if this assert fails")
-        delegate?.dismiss(animated: true, completion: nil)
+    nonisolated private func dismissSelector() {
+        ensureMainThread {
+            self.delegate?.dismiss(animated: true, completion: nil)
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -97,6 +97,7 @@ class ReaderMode: TabContentScript {
         }
     }
 
+    @MainActor
     lazy var style = ReaderModeStyle.defaultStyle(for: tab?.windowUUID) {
         didSet {
             if state == ReaderModeState.active {

--- a/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewController.swift
+++ b/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewController.swift
@@ -162,9 +162,11 @@ class ReaderModeStyleViewController: UIViewController, Themeable, Notifiable {
     }
 
     @objc
-    func changeFontType(_ button: ReaderModeFontTypeButton) {
-        viewModel.fontTypeDidChange(button.fontType)
-        updateFontTypeButtons()
+    nonisolated func changeFontType(_ button: ReaderModeFontTypeButton) {
+        ensureMainThread {
+            self.viewModel.fontTypeDidChange(button.fontType)
+            self.updateFontTypeButtons()
+        }
     }
 
     private func updateFontTypeButtons() {
@@ -184,9 +186,11 @@ class ReaderModeStyleViewController: UIViewController, Themeable, Notifiable {
     }
 
     @objc
-    func changeFontSize(_ button: ReaderModeFontSizeButton) {
-        viewModel.fontSizeDidChangeSizeAction(button.fontSizeAction)
-        updateFontSizeButtons()
+    nonisolated func changeFontSize(_ button: ReaderModeFontSizeButton) {
+        ensureMainThread {
+            self.viewModel.fontSizeDidChangeSizeAction(button.fontSizeAction)
+            self.updateFontSizeButtons()
+        }
     }
 
     private func updateFontSizeButtons() {
@@ -205,14 +209,18 @@ class ReaderModeStyleViewController: UIViewController, Themeable, Notifiable {
     }
 
     @objc
-    func changeTheme(_ button: ReaderModeThemeButton) {
-        guard let readerModeTheme = button.readerModeTheme else { return }
-        viewModel.readerModeDidChangeTheme(readerModeTheme)
+    nonisolated func changeTheme(_ button: ReaderModeThemeButton) {
+        ensureMainThread {
+            guard let readerModeTheme = button.readerModeTheme else { return }
+            self.viewModel.readerModeDidChangeTheme(readerModeTheme)
+        }
     }
 
     @objc
-    func changeBrightness(_ slider: UISlider) {
-        viewModel.sliderDidChange(value: CGFloat(slider.value))
+    nonisolated func changeBrightness(_ slider: UISlider) {
+        ensureMainThread {
+            self.viewModel.sliderDidChange(value: CGFloat(slider.value))
+        }
     }
 
     // MARK: - Private

--- a/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewModel.swift
+++ b/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewModel.swift
@@ -8,13 +8,14 @@ import Common
 // MARK: - ReaderModeStyleViewModelDelegate
 
 protocol ReaderModeStyleViewModelDelegate: AnyObject {
+    @MainActor
     func readerModeStyleViewModel(_ readerModeStyleViewModel: ReaderModeStyleViewModel,
                                   didConfigureStyle style: ReaderModeStyle,
                                   isUsingUserDefinedColor: Bool)
 }
 
 // MARK: - ReaderModeStyleViewModel
-
+@MainActor
 class ReaderModeStyleViewModel {
     public init(windowUUID: WindowUUID,
                 isBottomPresented: Bool,

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -6,15 +6,29 @@ import Common
 import Redux
 
 protocol ThemeManagerProvider {
+    @MainActor
     func getCurrentThemeManagerState(windowUUID: WindowUUID) -> ThemeSettingsState
+
+    @MainActor
     func updateManualTheme(with action: ThemeSettingsViewAction)
+
+    @MainActor
     func updateSystemTheme(with action: ThemeSettingsViewAction)
+
+    @MainActor
     func updateAutomaticBrightness(with action: ThemeSettingsViewAction)
+
+    @MainActor
     func updateAutomaticBrightnessValue(with action: ThemeSettingsViewAction)
+
+    @MainActor
     func updateThemeFromSystemBrightnessChange(with action: ThemeSettingsViewAction)
+
+    @MainActor
     func updatePrivateMode(with action: PrivateModeAction)
 }
 
+@MainActor
 final class ThemeManagerMiddleware: ThemeManagerProvider {
     var themeManager: ThemeManager
 

--- a/firefox-ios/Extensions/ShareTo/SendToDevice.swift
+++ b/firefox-ios/Extensions/ShareTo/SendToDevice.swift
@@ -8,6 +8,7 @@ import SwiftUI
 import UIKit
 import Common
 
+@MainActor
 class SendToDevice: DevicePickerViewControllerDelegate, InstructionsViewDelegate {
     var sharedItem: ShareItem?
     weak var delegate: ShareControllerDelegate?
@@ -30,7 +31,6 @@ class SendToDevice: DevicePickerViewControllerDelegate, InstructionsViewDelegate
         return themeManager.windowNonspecificTheme()
     }
 
-    @MainActor
     func initialViewController() -> UIViewController {
         let theme = currentTheme()
         guard let shareItem = sharedItem else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Draft.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
