### PR TITLE
Bugfix NO_TICKET [L10n] Spell out `ToS` in comments instead of using acronym

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2201,25 +2201,25 @@ extension String {
             key: "Summarizer.ToS.Alert.Title.Label.v142",
             tableName: "Summarizer",
             value: "Allow Page Summaries?",
-            comment: "The title for the ToS alert that asks the user if they want to allow page summaries."
+            comment: "The title for the Terms of Service alert that asks the user if they want to allow page summaries."
         )
         public static let ToSAlertMessageFirefoxLabel = MZLocalizedString(
             key: "Summarizer.ToS.Alert.FirefoxMessage.Label.v142",
             tableName: "Summarizer",
             value: "%@ uses AI securely hosted on Mozilla servers to summarize pages.",
-            comment: "The message for the ToS alert that asks the user if they want to allow page summaries with Firefox AI. %@ is the app name (e.g Firefox)."
+            comment: "The message for the Terms of Service alert that asks the user if they want to allow page summaries with Firefox AI. %@ is the app name (e.g Firefox)."
         )
         public static let ToSAlertMessageAppleLabel = MZLocalizedString(
             key: "Summarizer.ToS.Alert.AppleMessage.Label.v142",
             tableName: "Summarizer",
             value: "%@ uses Apple Intelligence to summarize pages.",
-            comment: "The message for the ToS alert that asks the user if they want to allow page summaries with Apple Intelligence. %@ is the app name (e.g Firefox)."
+            comment: "The message for the Terms of Service alert that asks the user if they want to allow page summaries with Apple Intelligence. %@ is the app name (e.g Firefox)."
         )
         public static let ToSAlertAllowButtonLabel = MZLocalizedString(
             key: "Summarizer.ToS.Alert.AllowButton.Label.v142",
             tableName: "Summarizer",
             value: "Allow",
-            comment: "The label for the allow button on the ToS alert."
+            comment: "The label for the allow button on the Terms of Service alert."
         )
         public static let ToSAlertCancelButtonLabel = MZLocalizedString(
             key: "Summarizer.ToS.Alert.CancelButton.Label.v142",
@@ -2238,19 +2238,19 @@ extension String {
             key: "", // Summarizer.ToS.Alert.CloseButton.Accessibility.Label.v142
             tableName: "Summarizer",
             value: "Close Terms of Service Alert button",
-            comment: "The a11y label for the close button on the ToS alert."
+            comment: "The a11y label for the close button on the Terms of Service alert."
         )
         public static let ToSAlertCancelButtonAccessibilityLabel = MZLocalizedString(
             key: "", // Summarizer.ToS.Alert.CancelButton.Accessibility.Label.v142
             tableName: "Summarizer",
             value: "Deny Term of Service button",
-            comment: "The a11y label for the cancel button on the ToS alert."
+            comment: "The a11y label for the cancel button on the Terms of Service alert."
         )
         public static let ToSAlertAllowButtonAccessibilityLabel = MZLocalizedString(
             key: "", // Summarizer.ToS.Alert.AllowButton.Accessibility.Label.v142
             tableName: "Summarizer",
             value: "Agree to Term of Service button",
-            comment: "The a11y label for the allow button on the ToS alert."
+            comment: "The a11y label for the allow button on the Terms of Service alert."
         )
         public static let LoadingAccessibilityLabel = MZLocalizedString(
             key: "", // Summarizer.Loading.Accessibility.Label.v142


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
