### PR TITLE
Add FXIOS-13096 [webcompat] Spoof Safari UAstring for a few healthcare sites

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -98,7 +98,7 @@ public enum UserAgentPlatform {
 
 struct CustomUserAgentConstant {
     private static let defaultMobileUA = UserAgentBuilder.defaultMobileUserAgent().userAgent()
-    private static let safariMobileUA = UserAgentBuilder.defaultDesktopUserAgent().clone(extensions: "Version/18.6 \(UserAgent.uaBitSafari)")
+    private static let safariMobileUA = UserAgentBuilder.defaultMobileUserAgent().clone(extensions: "Version/18.6 \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
 
     static let customMobileUAForDomain = [
         "epic.com": safariMobileUA,


### PR DESCRIPTION
## :scroll: Tickets
FXIOS-13096
#28515

## :bulb: Description

Some sites could not parse FxiOS UAstring, and end up assessing it as Safari version "unknown" (or "0"), suggesting or insisting on upgrading (mostly… to… Safari).

This adds a few exceptions that currently block or limit telehealth on bigger scale.
_(Ideally these should be solved via webcompat outreach, but some of these haven't improved much over the years… e.g. https://github.com/webcompat/web-bugs/issues/79453 …)_

Also removes an exception for Disney that no longer needs it.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
