### PR TITLE
Refactor FXIOS-13152 Avoid adding second shortcut for iOS 16 and below

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -429,29 +429,31 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         navigator.nowAt(HomeSettings)
         navigator.goto(NewTabScreen)
         addWebsiteToShortcut(website: url_3)
-        addWebsiteToShortcut(website: path(forTestPage: url_2["url"]!))
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
+        if #available(iOS 17, *) {
+            addWebsiteToShortcut(website: path(forTestPage: url_2["url"]!))
+            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
 
-        // Verify shortcuts are displayed on the homepage
-        let itemCell = app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
-        let firstWebsite = itemCell.staticTexts["Example Domain"]
-        let secondWebsite = itemCell.staticTexts["Internet for people, not profit — Mozilla"]
-        mozWaitForElementToExist(firstWebsite)
-        mozWaitForElementToExist(secondWebsite)
+            // Verify shortcuts are displayed on the homepage
+            let itemCell = app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
+            let firstWebsite = itemCell.staticTexts["Example Domain"]
+            let secondWebsite = itemCell.staticTexts["Internet for people, not profit — Mozilla"]
+            mozWaitForElementToExist(firstWebsite)
+            mozWaitForElementToExist(secondWebsite)
 
-        // Disable shortcuts toggle
-        navigator.goto(HomeSettings)
-        navigator.performAction(Action.SelectShortcuts)
-        shortCutSwitch.waitAndTap()
+            // Disable shortcuts toggle
+            navigator.goto(HomeSettings)
+            navigator.performAction(Action.SelectShortcuts)
+            shortCutSwitch.waitAndTap()
 
-        // Verify shortcuts are not displayed on the homepage
-        navigator.nowAt(Shortcuts)
-        navigator.goto(HomeSettings)
-        navigator.nowAt(HomeSettings)
-        navigator.goto(BrowserTab)
-        mozWaitForElementToNotExist(itemCell)
-        mozWaitForElementToNotExist(firstWebsite)
-        mozWaitForElementToNotExist(secondWebsite)
+            // Verify shortcuts are not displayed on the homepage
+            navigator.nowAt(Shortcuts)
+            navigator.goto(HomeSettings)
+            navigator.nowAt(HomeSettings)
+            navigator.goto(BrowserTab)
+            mozWaitForElementToNotExist(itemCell)
+            mozWaitForElementToNotExist(firstWebsite)
+            mozWaitForElementToNotExist(secondWebsite)
+        }
     }
 
     private func addWebsiteToShortcut(website: String) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13152)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The crash may be automation only in older iOS versions. Let's disable the portion of `testShortcutsToggle()` for iOS 16 and below.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
