### PR TITLE
Add FXIOS-13144 [Shake to Summarize] summary footnote

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -314,6 +314,8 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
         ###### \(viewModel.brandLabel)
 
         \(summary)
+
+        ##### \(viewModel.summaryNote)
         """
         titleLabel.text = webView.title
         titleLabel.largeContentTitle = webView.title
@@ -379,40 +381,53 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
     }
 
     private func parse(markdown: String) -> NSAttributedString? {
+        let parser = Down(markdownString: markdown)
+
+        // Apply custom paragraph styling with centering to header level 5 (######)
+        let centeredParagraphStyle = NSMutableParagraphStyle()
+        centeredParagraphStyle.alignment = .center
+        centeredParagraphStyle.paragraphSpacingBefore = 16
+
+        var configuration = configuration
+        var paragraphStyles = StaticParagraphStyleCollection()
+        paragraphStyles.heading5 = centeredParagraphStyle
+        configuration.paragraphStyles = paragraphStyles
+
+        return try? parser.toAttributedString(
+            styler: CustomStyler(configuration: configuration)
+        )
+    }
+
+    private var configuration: DownStylerConfiguration {
         let theme = themeManager.getCurrentTheme(for: currentWindowUUID)
         let textColor = theme.colors.textPrimary
-        let parser = Down(markdownString: markdown)
-        return try? parser.toAttributedString(
-            styler: CustomStyler(
-                configuration: DownStylerConfiguration(
-                    fonts: StaticFontCollection(
-                        heading1: FXFontStyles.Regular.title1.scaledFont(),
-                        heading2: FXFontStyles.Regular.title2.scaledFont(),
-                        heading3: FXFontStyles.Regular.title3.scaledFont(),
-                        heading4: FXFontStyles.Regular.headline.scaledFont(),
-                        heading5: FXFontStyles.Regular.caption1.scaledFont(),
-                        heading6: FXFontStyles.Regular.caption2.scaledFont(),
-                        body: FXFontStyles.Regular.body.scaledFont(),
-                        code: FXFontStyles.Regular.body.monospacedFont(),
-                        listItemPrefix: FXFontStyles.Regular.body.scaledFont()
-                    ),
-                    colors: StaticColorCollection(
-                        heading1: textColor,
-                        heading2: textColor,
-                        heading3: textColor,
-                        heading4: textColor,
-                        heading5: textColor,
-                        heading6: textColor,
-                        body: textColor,
-                        code: textColor,
-                        link: textColor,
-                        quote: textColor,
-                        quoteStripe: textColor,
-                        thematicBreak: textColor,
-                        listItemPrefix: textColor,
-                        codeBlockBackground: .clear
-                    )
-                )
+        return DownStylerConfiguration(
+            fonts: StaticFontCollection(
+                heading1: FXFontStyles.Regular.title1.scaledFont(),
+                heading2: FXFontStyles.Regular.title2.scaledFont(),
+                heading3: FXFontStyles.Regular.title3.scaledFont(),
+                heading4: FXFontStyles.Regular.headline.scaledFont(),
+                heading5: FXFontStyles.Regular.footnote.scaledFont(),
+                heading6: FXFontStyles.Regular.caption2.scaledFont(),
+                body: FXFontStyles.Regular.body.scaledFont(),
+                code: FXFontStyles.Regular.body.monospacedFont(),
+                listItemPrefix: FXFontStyles.Regular.body.scaledFont()
+            ),
+            colors: StaticColorCollection(
+                heading1: textColor,
+                heading2: textColor,
+                heading3: textColor,
+                heading4: textColor,
+                heading5: theme.colors.textSecondary,
+                heading6: textColor,
+                body: textColor,
+                code: textColor,
+                link: textColor,
+                quote: textColor,
+                quoteStripe: textColor,
+                thematicBreak: textColor,
+                listItemPrefix: textColor,
+                codeBlockBackground: .clear
             )
         )
     }

--- a/BrowserKit/Sources/SummarizeKit/SummarizeViewModel.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeViewModel.swift
@@ -13,6 +13,7 @@ public struct SummarizeViewModel {
     let summarizeTextViewA11yLabel: String
     let summarizeTextViewA11yId: String
     let brandLabel: String
+    let summaryNote: String
 
     let closeButtonModel: CloseButtonViewModel
     let tabSnapshot: UIImage
@@ -28,6 +29,7 @@ public struct SummarizeViewModel {
         loadingA11yLabel: String,
         loadingA11yId: String,
         brandLabel: String,
+        summaryNote: String,
         summarizeTextViewA11yLabel: String,
         summarizeTextViewA11yId: String,
         closeButtonModel: CloseButtonViewModel,
@@ -42,6 +44,7 @@ public struct SummarizeViewModel {
         self.loadingA11yLabel = loadingA11yLabel
         self.loadingA11yId = loadingA11yId
         self.brandLabel = brandLabel
+        self.summaryNote = summaryNote
         self.summarizeTextViewA11yLabel = summarizeTextViewA11yLabel
         self.summarizeTextViewA11yId = summarizeTextViewA11yId
         self.closeButtonModel = closeButtonModel

--- a/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
@@ -101,6 +101,7 @@ class SummarizeCoordinator: BaseCoordinator, SummarizerServiceLifecycle {
             loadingA11yLabel: .Summarizer.LoadingAccessibilityLabel,
             loadingA11yId: AccessibilityIdentifiers.Summarizer.loadingLabel,
             brandLabel: brandLabel,
+            summaryNote: .Summarizer.FootnoteLabel,
             summarizeTextViewA11yLabel: .Summarizer.SummaryTextAccessibilityLabel,
             summarizeTextViewA11yId: AccessibilityIdentifiers.Summarizer.summaryTextView,
             closeButtonModel: CloseButtonViewModel(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2197,6 +2197,12 @@ extension String {
             value: "Summarized by Apple Intelligence",
             comment: "The label displayed in the summary report when the summary was generated using Apple Intelligence."
         )
+        public static let FootnoteLabel = MZLocalizedString(
+            key: "Summarizer.Footnote.Label.v142",
+            tableName: "Summarizer",
+            value: "Note: Summarization can make errors.",
+            comment: "The description is displayed at the end of the summary report as a footnote to the users in that the report can contain errors."
+        )
         public static let ToSAlertTitleLabel = MZLocalizedString(
             key: "Summarizer.ToS.Alert.Title.Label.v142",
             tableName: "Summarizer",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13144)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28598)

## :bulb: Description
Add summary note to bottom of the report. Needed to change the paragraph styles so we can center the text. I used heading 5 since we aren't using it for anything and the text should be bigger than the heading 6 style that we are using for the brand label.

Also, added strings.
## :movie_camera: Demos
| Figma | Device |
| - | - |
| <img width="244" height="505" alt="Screenshot 2025-08-12 at 12 13 27 PM" src="https://github.com/user-attachments/assets/b7bd32b5-d1ed-4d46-9eb6-9f5fb4c35e83" /> | <img width="244" height="505" alt="image" src="https://github.com/user-attachments/assets/7b9e8812-111f-483d-9876-77dd3212dc1e" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
