### PR TITLE
Add FXIOS-13123 [Shortcuts Library] Show shortcuts in library

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1509,6 +1509,7 @@
 		C7F051562D9EF87D00EC52C0 /* ContextMenuTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */; };
 		C7F051582D9F098200EC52C0 /* ContextMenuTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */; };
 		C7F051692DB2F38000EC52C0 /* ContextMenuPreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051682DB2F38000EC52C0 /* ContextMenuPreviewViewController.swift */; };
+		C7FA9AE62E4B7D0D004F2CA1 /* TopSitesSectionLayoutProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FA9AE52E4B7D0D004F2CA1 /* TopSitesSectionLayoutProvider.swift */; };
 		C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80685D026A0C93900DCD895 /* UserResearch.swift */; };
 		C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */; };
 		C80C11EE28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80C11ED28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift */; };
@@ -9442,6 +9443,7 @@
 		C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetry.swift; sourceTree = "<group>"; };
 		C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetryTests.swift; sourceTree = "<group>"; };
 		C7F051682DB2F38000EC52C0 /* ContextMenuPreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPreviewViewController.swift; sourceTree = "<group>"; };
+		C7FA9AE52E4B7D0D004F2CA1 /* TopSitesSectionLayoutProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesSectionLayoutProvider.swift; sourceTree = "<group>"; };
 		C80685D026A0C93900DCD895 /* UserResearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResearch.swift; sourceTree = "<group>"; };
 		C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagManagerTests.swift; sourceTree = "<group>"; };
 		C80C11ED28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMetadataTrackerTests.swift; sourceTree = "<group>"; };
@@ -12907,6 +12909,7 @@
 		8A7D08E12CAAF79F0035999C /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
+				C7FA9B672E4B9A13004F2CA1 /* Layout */,
 				8A7C125F2E01DB0600F2D7FA /* SearchBar */,
 				8A9E04172D4D07E30022ED90 /* Bookmark */,
 				8A6E63CD2D4A7FA60040D355 /* SectionHeader */,
@@ -12919,7 +12922,6 @@
 				8A7D08E22CAAF7C30035999C /* HomepageViewController.swift */,
 				8AA0A6622CAC40AA00AC7EB3 /* HomepageDiffableDataSource.swift */,
 				8AD3AFC22D143EF000CFC887 /* HomepageDimensionImplementation.swift */,
-				8AA0A6642CAC6B7100AC7EB3 /* HomepageSectionLayoutProvider.swift */,
 				8AF347DC2CADD0E100624036 /* Redux */,
 			);
 			path = "Homepage Rebuild";
@@ -13893,6 +13895,15 @@
 				C714D7B52E4673A300FC02E6 /* ShortcutsLibraryDiffableDataSourceTests.swift */,
 			);
 			path = ShortcutsLibrary;
+			sourceTree = "<group>";
+		};
+		C7FA9B672E4B9A13004F2CA1 /* Layout */ = {
+			isa = PBXGroup;
+			children = (
+				8AA0A6642CAC6B7100AC7EB3 /* HomepageSectionLayoutProvider.swift */,
+				C7FA9AE52E4B7D0D004F2CA1 /* TopSitesSectionLayoutProvider.swift */,
+			);
+			path = Layout;
 			sourceTree = "<group>";
 		};
 		C80C11F228B3CD3E0062922A /* MockTests */ = {
@@ -18315,6 +18326,7 @@
 				AB9CBC022C53B64C00102610 /* TrackingProtectionAction.swift in Sources */,
 				0E456F152C541CB300EE93BF /* PasswordGeneratorViewController.swift in Sources */,
 				213BF7532AC21D1B00C53A64 /* TabDisplayPanelViewController.swift in Sources */,
+				C7FA9AE62E4B7D0D004F2CA1 /* TopSitesSectionLayoutProvider.swift in Sources */,
 				434E733725EED32E006D3BDE /* BrowserViewController+URLBarDelegate.swift in Sources */,
 				C88E7A5B2A0553510072E638 /* OnboardingLinkInfoModel.swift in Sources */,
 				2137785F297F3B1B00D01309 /* DownloadsPanelViewModel.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDimensionImplementation.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDimensionImplementation.swift
@@ -94,7 +94,7 @@ struct HomepageDimensionCalculator {
     /// - Parameter leadingInset: padding for top site section
     /// - Parameter cellWidth: width of individual top site tiles
     static func numberOfTopSitesPerRow(availableWidth: CGFloat, leadingInset: CGFloat) -> Int {
-        let cellWidth = HomepageSectionLayoutProvider.UX.TopSitesConstants.cellEstimatedSize.width
+        let cellWidth = TopSitesSectionLayoutProvider.UX.estimatedCellSize.width
         var availableWidth = availableWidth - leadingInset * 2
         var numberOfTiles = 0
 
@@ -102,7 +102,7 @@ struct HomepageDimensionCalculator {
             numberOfTiles += 1
             availableWidth = availableWidth - cellWidth - HomepageSectionLayoutProvider.UX.standardSpacing
         }
-        let minCardsConstant = HomepageSectionLayoutProvider.UX.TopSitesConstants.minCards
+        let minCardsConstant = TopSitesSectionLayoutProvider.UX.minCards
         let tilesPerRowCount = numberOfTiles < minCardsConstant ? minCardsConstant : numberOfTiles
 
         return tilesPerRowCount

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Layout/HomepageSectionLayoutProvider.swift
@@ -83,8 +83,6 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         }
 
         struct TopSitesConstants {
-            static let cellEstimatedSize = CGSize(width: 85, height: 94)
-            static let minCards = 4
             static let redesignedTopSitesBottomSpacingLandscape: CGFloat = 16
 
             @MainActor
@@ -300,24 +298,8 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         for traitCollection: UITraitCollection,
         numberOfTilesPerRow: Int
     ) -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0 / CGFloat(numberOfTilesPerRow)),
-            heightDimension: .estimated(UX.TopSitesConstants.cellEstimatedSize.height)
-        )
-
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-        let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1),
-            heightDimension: .estimated(UX.TopSitesConstants.cellEstimatedSize.height)
-        )
-        let group = NSCollectionLayoutGroup.horizontal(
-            layoutSize: groupSize,
-            subitem: item,
-            count: numberOfTilesPerRow
-        )
-        group.interItemSpacing = NSCollectionLayoutSpacing.fixed(UX.standardSpacing)
-        let section = NSCollectionLayoutSection(group: group)
+        let section = TopSitesSectionLayoutProvider.createTopSitesSectionLayout(for: traitCollection,
+                                                                                numberOfTilesPerRow: numberOfTilesPerRow)
 
         let headerSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
@@ -329,16 +311,12 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             alignment: .top
         )
         section.boundarySupplementaryItems = [header]
+
         let leadingInset = UX.leadingInset(traitCollection: traitCollection)
         let bottomInset = isStoriesRedesignEnabled ? UX.TopSitesConstants.getBottomInset()
                                                    : UX.spacingBetweenSections - UX.interGroupSpacing
-        section.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
-            leading: leadingInset,
-            bottom: bottomInset,
-            trailing: leadingInset
-        )
-        section.interGroupSpacing = UX.standardSpacing
+        section.contentInsets.top = 0
+        section.contentInsets.bottom = bottomInset
 
         return section
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Layout/TopSitesSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Layout/TopSitesSectionLayoutProvider.swift
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@MainActor
+struct TopSitesSectionLayoutProvider {
+    struct UX {
+        static let estimatedCellSize = CGSize(width: 85, height: 94)
+        static let minCards = 4
+    }
+
+    @MainActor
+    static func createTopSitesSectionLayout(
+        for traitCollection: UITraitCollection,
+        numberOfTilesPerRow: Int
+    ) -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0 / CGFloat(numberOfTilesPerRow)),
+            heightDimension: .estimated(UX.estimatedCellSize.height)
+        )
+
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .estimated(UX.estimatedCellSize.height)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitem: item,
+            count: numberOfTilesPerRow
+        )
+        group.interItemSpacing = NSCollectionLayoutSpacing.fixed(HomepageSectionLayoutProvider.UX.standardSpacing)
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = HomepageSectionLayoutProvider.UX.standardSpacing
+        let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: traitCollection)
+        section.contentInsets.leading = leadingInset
+        section.contentInsets.trailing = leadingInset
+
+        return section
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -35,7 +35,7 @@ struct TopSitesSectionState: StateType, Equatable {
             windowUUID: windowUUID,
             topSitesData: [],
             numberOfRows: numberOfRows,
-            numberOfTilesPerRow: HomepageSectionLayoutProvider.UX.TopSitesConstants.minCards,
+            numberOfTilesPerRow: TopSitesSectionLayoutProvider.UX.minCards,
             shouldShowSection: shouldShowSection
         )
     }

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryDiffableDataSource.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Foundation
+import Common
 
 typealias ShortcutsLibrarySection = ShortcutsLibraryDiffableDataSource.Section
 typealias ShortcutsLibraryItem = ShortcutsLibraryDiffableDataSource.Item
@@ -15,6 +15,12 @@ final class ShortcutsLibraryDiffableDataSource:
 
     enum Item: Hashable {
         case shortcut(TopSiteConfiguration)
+
+        static var cellTypes: [ReusableCell.Type] {
+            return [
+                TopSiteCell.self,
+            ]
+        }
     }
 
     func updateSnapshot(state: ShortcutsLibraryState) {

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
@@ -161,10 +161,15 @@ class ShortcutsLibraryViewController: UIViewController,
     }
 
     private func createLayout() -> UICollectionViewCompositionalLayout {
-        let layout = UICollectionViewCompositionalLayout { (sectionIndex, environment)
+        let layout = UICollectionViewCompositionalLayout { [weak self ](sectionIndex, environment)
             -> NSCollectionLayoutSection? in
-            let section = TopSitesSectionLayoutProvider.createTopSitesSectionLayout(for: environment.traitCollection,
-                                                                                    numberOfTilesPerRow: 4)
+            guard let self else { return nil }
+            let homepageState = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID)
+            let numberOfTilesPerRow = homepageState?.topSitesState.numberOfTilesPerRow ?? 4
+            let section = TopSitesSectionLayoutProvider.createTopSitesSectionLayout(
+                for: environment.traitCollection,
+                numberOfTilesPerRow: numberOfTilesPerRow
+            )
             section.contentInsets.top = UX.shortcutsSectionTopInset
             return section
         }

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
@@ -137,7 +137,7 @@ class ShortcutsLibraryViewController: UIViewController,
     }
 
     private func configureCollectionView() {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
 
         collectionView.backgroundColor = .lightGray
         collectionView.delegate = self
@@ -145,6 +145,17 @@ class ShortcutsLibraryViewController: UIViewController,
         self.collectionView = collectionView
 
         view.addSubview(collectionView)
+    }
+
+    private func createLayout() -> UICollectionViewCompositionalLayout {
+        let layout = UICollectionViewCompositionalLayout { (sectionIndex, environment)
+            -> NSCollectionLayoutSection? in
+            let section = TopSitesSectionLayoutProvider.createTopSitesSectionLayout(for: environment.traitCollection,
+                                                                                    numberOfTilesPerRow: 4)
+            section.contentInsets.top = UX.shortcutsSectionTopInset
+            return section
+        }
+        return layout
     }
 
     private func configureDataSource() {

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
@@ -8,12 +8,21 @@ import Redux
 
 class ShortcutsLibraryViewController: UIViewController,
                                       UICollectionViewDelegate,
+                                      FeatureFlaggable,
                                       StoreSubscriber,
                                       Themeable {
+    struct UX {
+        static let shortcutsSectionTopInset: CGFloat = 24
+    }
+
     // MARK: - Private variables
     private var collectionView: UICollectionView?
     private var dataSource: ShortcutsLibraryDiffableDataSource?
     private var shortcutsLibraryState: ShortcutsLibraryState
+
+    private var currentTheme: Theme {
+        themeManager.getCurrentTheme(for: windowUUID)
+    }
 
     // MARK: - Private constants
     private let logger: Logger
@@ -111,7 +120,7 @@ class ShortcutsLibraryViewController: UIViewController,
     // MARK: - Themeable
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
-        view.backgroundColor = theme.colors.layer1
+        view.backgroundColor = theme.colors.layer3
     }
 
     // MARK: - Setup + Layout
@@ -139,7 +148,11 @@ class ShortcutsLibraryViewController: UIViewController,
     private func configureCollectionView() {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
 
-        collectionView.backgroundColor = .lightGray
+        ShortcutsLibraryItem.cellTypes.forEach {
+            collectionView.register($0, forCellWithReuseIdentifier: $0.cellIdentifier)
+        }
+
+        collectionView.backgroundColor = .clear
         collectionView.delegate = self
 
         self.collectionView = collectionView
@@ -170,7 +183,32 @@ class ShortcutsLibraryViewController: UIViewController,
 
         dataSource = ShortcutsLibraryDiffableDataSource(
             collectionView: collectionView
-        ) { (collectionView, indexPath, item) -> UICollectionViewCell? in
+        ) { [weak self] (collectionView, indexPath, item) -> UICollectionViewCell? in
+            return self?.configureCell(for: item, at: indexPath)
+        }
+    }
+
+    private func configureCell(
+        for item: ShortcutsLibraryItem,
+        at indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        switch item {
+        case .shortcut(let site):
+            let isTopSitesRefreshEnabled = featureFlags.isFeatureEnabled(.hntTopSitesVisualRefresh, checking: .buildOnly)
+            let cellType: ReusableCell.Type = isTopSitesRefreshEnabled ? TopSiteCell.self : LegacyTopSiteCell.self
+
+            guard let topSiteCell = collectionView?.dequeueReusableCell(cellType: cellType, for: indexPath) else {
+                return UICollectionViewCell()
+            }
+
+            if let topSiteCell = topSiteCell as? TopSiteCell {
+                topSiteCell.configure(site, position: indexPath.row, theme: currentTheme, textColor: nil)
+                return topSiteCell
+            } else if let legacyTopSiteCell = topSiteCell as? LegacyTopSiteCell {
+                legacyTopSiteCell.configure(site, position: indexPath.row, theme: currentTheme, textColor: nil)
+                return legacyTopSiteCell
+            }
+
             return UICollectionViewCell()
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13123)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28551)

## :bulb: Description
- Populate the shortcuts library with shortcuts tiles
  - Currently displays all shortcuts (to be changed in FXIOS-13128 / #28565)
- Factors out top sites section layout creation into its own struct for reusability between homepage and shortcuts library

## :movie_camera: Demos
<img width="295" height="639" alt="Simulator Screenshot - iPhone 16 - 2025-08-12 at 12 36 06" src="https://github.com/user-attachments/assets/c61e8bd4-896f-4c67-8426-d30ba2927e3e" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
