### PR TITLE
Add FXIOS-13142 [Shake to Summarize] new border animation + UI updates

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/DarkTheme.swift
@@ -56,11 +56,9 @@ private struct DarkColourPalette: ThemeColourPalette {
     ])
     var layerSurfaceLow = FXColors.DarkGrey60
     var layerSurfaceMedium = FXColors.DarkGrey80
-    var layerSummary: UIColor = FXColors.Pink50
-    var layerSummaryGradient = Gradient(colors: [
-        FXColors.Orange50,
-        FXColors.Pink50,
-        FXColors.Blue10
+    var layerSummary = Gradient(colors: [
+        FXColors.Red70,
+        FXColors.Orange50
     ])
 
     // MARK: - Ratings
@@ -131,4 +129,5 @@ private struct DarkColourPalette: ThemeColourPalette {
     var shadowSubtle: UIColor = FXColors.DarkGrey80.withAlphaComponent(0.10)
     var shadowDefault: UIColor = FXColors.DarkGrey80.withAlphaComponent(0.12)
     var shadowStrong: UIColor = FXColors.DarkGrey80.withAlphaComponent(0.16)
+    var shadowBorder: UIColor = FXColors.DarkGrey50.withAlphaComponent(0.50)
 }

--- a/BrowserKit/Sources/Common/Theming/LightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/LightTheme.swift
@@ -45,11 +45,9 @@ private struct LightColourPalette: ThemeColourPalette {
     ])
     var layerSurfaceLow = FXColors.LightGrey20
     var layerSurfaceMedium = FXColors.White
-    var layerSummary: UIColor = FXColors.Pink50
-    var layerSummaryGradient = Gradient(colors: [
-        FXColors.Orange50,
-        FXColors.Pink50,
-        FXColors.Blue10
+    var layerSummary = Gradient(colors: [
+        FXColors.Red70,
+        FXColors.Orange50
     ])
 
     // MARK: - Ratings
@@ -120,4 +118,5 @@ private struct LightColourPalette: ThemeColourPalette {
     var shadowSubtle: UIColor = FXColors.DarkGrey40.withAlphaComponent(0.10)
     var shadowDefault: UIColor = FXColors.DarkGrey40.withAlphaComponent(0.12)
     var shadowStrong: UIColor = FXColors.DarkGrey40.withAlphaComponent(0.16)
+    var shadowBorder: UIColor = FXColors.DarkGrey50.withAlphaComponent(0.50)
 }

--- a/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
@@ -47,11 +47,9 @@ private struct PrivateModeColorPalette: ThemeColourPalette {
     ])
     var layerSurfaceLow = UIColor(rgb: 0x342B4A)
     var layerSurfaceMedium = UIColor(rgb: 0x24183A)
-    var layerSummary: UIColor = FXColors.Pink50
-    var layerSummaryGradient = Gradient(colors: [
-        FXColors.Orange50,
-        FXColors.Pink50,
-        FXColors.Blue10
+    var layerSummary = Gradient(colors: [
+        FXColors.Red70,
+        FXColors.Orange50
     ])
 
     // MARK: - Ratings
@@ -122,4 +120,5 @@ private struct PrivateModeColorPalette: ThemeColourPalette {
     var shadowSubtle: UIColor = FXColors.DarkGrey80.withAlphaComponent(0.10)
     var shadowDefault: UIColor = FXColors.DarkGrey80.withAlphaComponent(0.12)
     var shadowStrong: UIColor = FXColors.DarkGrey80.withAlphaComponent(0.16)
+    var shadowBorder: UIColor = FXColors.DarkGrey50.withAlphaComponent(0.50)
 }

--- a/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
@@ -34,8 +34,7 @@ public protocol ThemeColourPalette {
     var layerSurfaceLow: UIColor { get }
     var layerSurfaceMedium: UIColor { get }
     // TODO: - FXIOS-12896 - colors name might need to be adjusted as per design review
-    var layerSummary: UIColor { get }
-    var layerSummaryGradient: Gradient { get }
+    var layerSummary: Gradient { get }
 
     // MARK: - Ratings
     var layerRatingA: UIColor { get }
@@ -105,4 +104,5 @@ public protocol ThemeColourPalette {
     var shadowSubtle: UIColor { get }
     var shadowDefault: UIColor { get }
     var shadowStrong: UIColor { get }
+    var shadowBorder: UIColor { get }
 }

--- a/BrowserKit/Sources/SummarizeKit/AnimatedGradientOutlineView.swift
+++ b/BrowserKit/Sources/SummarizeKit/AnimatedGradientOutlineView.swift
@@ -12,7 +12,7 @@ class AnimatedGradientOutlineView: UIView,
         static let positionChangeAnimationDuration: CFTimeInterval = 1.25
         static let startPointFinalAnimationValue = CGPoint(x: 1.0, y: 0.3)
         static let endPointFinalAnimationValue = CGPoint(x: 0.0, y: 0.8)
-        static let colorsLocation = [NSNumber(0.0), NSNumber(0.8), NSNumber(1.0)]
+        static let colorsLocation = [NSNumber(0.0), NSNumber(1.0)]
         static let colorsKeyPath = "colors"
         static let initialAnimationDuration = 1.0
         static let startPointKeyPath = "startPoint"
@@ -87,7 +87,6 @@ class AnimatedGradientOutlineView: UIView,
     }
 
     func animatePositionChange(animationCurve: CAMediaTimingFunction) {
-        fadeLayer.animateFadeDown()
         let startPointAnimation = CABasicAnimation(keyPath: UX.startPointKeyPath)
         startPointAnimation.fromValue = CGPoint.topCenter
         startPointAnimation.toValue = UX.startPointFinalAnimationValue
@@ -108,6 +107,6 @@ class AnimatedGradientOutlineView: UIView,
     }
 
     func applyTheme(theme: any Theme) {
-        gradientLayer.colors = theme.colors.layerSummaryGradient.cgColors
+        gradientLayer.colors = [theme.colors.shadowBorder.cgColor, theme.colors.shadowBorder.cgColor]
     }
 }

--- a/BrowserKit/Sources/SummarizeKit/RectangularFadeMaskLayer.swift
+++ b/BrowserKit/Sources/SummarizeKit/RectangularFadeMaskLayer.swift
@@ -11,7 +11,8 @@ extension CGPoint {
     static let bottomCenter = CGPoint(x: 0.5, y: 1.0)
 }
 
-/// This adds the layer on
+/// A CALayer subclass that creates a rectangular fading mask
+/// using two CAGradientLayers (horizontal and vertical).
 final class RectangularFadeMaskLayer: CALayer {
     private struct UX {
         static let defaultEdgeFade: CGFloat = 50.0

--- a/BrowserKit/Sources/SummarizeKit/RectangularFadeMaskLayer.swift
+++ b/BrowserKit/Sources/SummarizeKit/RectangularFadeMaskLayer.swift
@@ -11,9 +11,10 @@ extension CGPoint {
     static let bottomCenter = CGPoint(x: 0.5, y: 1.0)
 }
 
-class RectangularFadeMaskLayer: CALayer {
+/// This adds the layer on
+final class RectangularFadeMaskLayer: CALayer {
     private struct UX {
-        static let defaultEdgeFade: CGFloat = 130.0
+        static let defaultEdgeFade: CGFloat = 50.0
         static let fadeDownAnimationDuration: CFTimeInterval = 0.5
         static let filterMode = "multiplyBlendMode"
         static let colorsKeyPath = "colors"
@@ -72,21 +73,5 @@ class RectangularFadeMaskLayer: CALayer {
             1.0
         ]
         maskLayer.frame = bounds
-    }
-
-    /// Animates the fade layer down by moving the clear area from the center to the bottom of the layer's bound.
-    func animateFadeDown() {
-        let animation = CABasicAnimation(keyPath: UX.colorsKeyPath)
-        animation.fromValue = vertical.colors
-        animation.toValue = [
-            UIColor.white.cgColor,
-            UIColor.white.cgColor,
-            UIColor.clear.cgColor,
-            UIColor.white.cgColor,
-        ]
-        animation.duration = UX.fadeDownAnimationDuration
-        animation.fillMode = .forwards
-        animation.isRemovedOnCompletion = false
-        vertical.add(animation, forKey: UX.fadeDownAnimationKey)
     }
 }

--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -157,7 +157,6 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
 
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        let theme = themeManager.getCurrentTheme(for: currentWindowUUID)
         let impact = UIImpactFeedbackGenerator(style: .medium)
         impact.prepare()
         impact.impactOccurred()

--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -153,17 +153,21 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
         )
     }
 
+    private lazy var backgroundGradient = CAGradientLayer()
+
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         let theme = themeManager.getCurrentTheme(for: currentWindowUUID)
         let impact = UIImpactFeedbackGenerator(style: .medium)
         impact.prepare()
         impact.impactOccurred()
+
         gradient.startAnimating { [weak self] in
-            self?.closeButton.alpha = 1.0
-            self?.view.backgroundColor = theme.colors.layerSummary
-            self?.viewModel.onShouldShowTabSnapshot()
-            self?.embedSnapshot()
+            guard let self else { return }
+            self.closeButton.alpha = 1.0
+            self.view.layer.insertSublayer(backgroundGradient, at: 0)
+            self.viewModel.onShouldShowTabSnapshot()
+            self.embedSnapshot()
         }
     }
 
@@ -218,7 +222,15 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
         summaryView.accessibilityLabel = viewModel.summarizeTextViewA11yLabel
     }
 
+    private func setupBackgroundGradient() {
+        backgroundGradient.frame = view.bounds
+        backgroundGradient.locations = [0.0, 1.0]
+        backgroundGradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+        backgroundGradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+    }
+
     private func setupLayout() {
+        setupBackgroundGradient()
         view.addSubviews(tabSnapshotContainer, gradient, titleLabel, closeButton, summaryView, loadingLabel, errorView)
         tabSnapshotContainer.addSubview(tabSnapshot)
         tabSnapshot.pinToSuperview()
@@ -279,7 +291,7 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
         tabSnapshotTopConstraint?.constant = viewModel.tabSnapshotTopOffset
 
         let frameHeight = view.frame.height
-        loadingLabel.startShimmering(light: .white, dark: .white.withAlphaComponent(0.1))
+        loadingLabel.startShimmering(light: .white, dark: .white.withAlphaComponent(0.5))
 
         let transformAnimation = CABasicAnimation(keyPath: UX.tabSnapshotTranslationKeyPath)
         transformAnimation.fromValue = 0
@@ -322,6 +334,7 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
         summaryView.attributedText = parse(markdown: brandedSummary)
         UIView.animate(withDuration: UX.showSummaryAnimationDuration) { [self] in
             gradient.alpha = 0.0
+            backgroundGradient.removeFromSuperlayer()
             tabSnapshotContainer.transform = CGAffineTransform(translationX: 0.0, y: tabSnapshotYTransform)
             loadingLabel.alpha = 0.0
             summaryView.alpha = 1.0
@@ -419,7 +432,7 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
                 heading3: textColor,
                 heading4: textColor,
                 heading5: theme.colors.textSecondary,
-                heading6: textColor,
+                heading6: theme.colors.textSecondary,
                 body: textColor,
                 code: textColor,
                 link: textColor,
@@ -503,6 +516,7 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
             closeButton.configuration?.baseBackgroundColor = theme.colors.actionTabActive
         }
         closeButton.configuration?.baseForegroundColor = theme.colors.textPrimary
+        backgroundGradient.colors = theme.colors.layerSummary.cgColors
         gradient.applyTheme(theme: theme)
         errorView.applyTheme(theme: theme)
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
@@ -94,8 +94,7 @@ struct TabTrayPanelSwipePalette: ThemeColourPalette {
     var layerGradientURL: Gradient { base.layerGradientURL }
     var layerSurfaceLow: UIColor { base.layerSurfaceLow }
     var layerSurfaceMedium: UIColor { base.layerSurfaceMedium }
-    var layerSummary: UIColor { base.layerSummary }
-    var layerSummaryGradient: Gradient { base.layerSummaryGradient }
+    var layerSummary: Gradient { base.layerSummary }
 
     var layerRatingA: UIColor { base.layerRatingA }
     var layerRatingASubdued: UIColor { base.layerRatingASubdued }
@@ -150,6 +149,7 @@ struct TabTrayPanelSwipePalette: ThemeColourPalette {
 
     var shadowSubtle: UIColor { base.shadowSubtle }
     var shadowStrong: UIColor { base.shadowStrong }
+    var shadowBorder: UIColor { base.shadowBorder }
 
     init(base: ThemeColourPalette, overrides: PartialOverrides) {
         self.base = base


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13142)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28596)

## :bulb: Description
Update Shake 2 Summarize animation to use a dark grey border animation instead of the colorful one because it look like the Siri animations. See video capture below.

- We updated the background color of `layerSummary` to be a gradient (red / orange) instead of a solid pink color. Therefore, added `backgroundGradient` instead of simply changing the background color.
- We also added a new `shadowBorder` color for the new animation. Needed to update `AnimatedGradientOutlineView.swift`, but would like to revisit this to see what we can clean up here.

Other small UI changes:
- Increase opacity for the loading label for when its dark
- Change the brand label in the summary report to match color of the footnote

Note: we need to update design tokens in Figma so we are consistent with design system + code. Added a separate ticket [here](https://mozilla-hub.atlassian.net/browse/FXIOS-13166). 

## :movie_camera: Demos
See previous animation in this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/27947).

https://github.com/user-attachments/assets/d8c7ecf0-3000-4c92-91fb-1718f2d3cad9

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
