### PR TITLE
Refactor FXIOS-127986 #27871 ⁃ [Swift 6 Migration] Turn on Strict Concurrency in Xcode 26 Beta 2+ and fix warnings LegacyTabScrollController

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -7,6 +7,7 @@ import SnapKit
 import Shared
 import Common
 
+@MainActor
 protocol LegacyTabScrollProvider: TabScrollHandlerProtocol {
     var headerTopConstraint: Constraint? { get set }
     var overKeyboardContainerConstraint: Constraint? { get set }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -136,11 +136,11 @@ final class TabScrollHandler: NSObject,
         // recommended work around here.
         guard Thread.isMainThread else {
             logger.log(
-                "TabScrollController was not deallocated on the main thread. KVOs were not cleaned up.",
+                "TabScrollHandler was not deallocated on the main thread. KVOs were not cleaned up.",
                 level: .fatal,
                 category: .lifecycle
             )
-            assertionFailure("TabScrollController was not deallocated on the main thread. KVOs were not cleaned up.")
+            assertionFailure("TabScrollHandler was not deallocated on the main thread. KVOs were not cleaned up.")
             return
         }
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -293,7 +293,7 @@ final class TabScrollHandler: NSObject,
         if keyPath == "contentSize" {
             ensureMainThread { [weak self] in
                 guard let self, shouldUpdateUIWhenScrolling, toolbarDisplayState.isExpanded else { return }
-                
+
                 showToolbars(animated: true)
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -6,6 +6,7 @@ import UIKit
 import Shared
 import Common
 
+@MainActor
 protocol TabScrollHandlerProtocol: AnyObject {
     var zoomPageBar: ZoomPageBar? { get set }
     var tab: Tab? { get set }
@@ -290,9 +291,11 @@ final class TabScrollHandler: NSObject,
         context: UnsafeMutableRawPointer?
     ) {
         if keyPath == "contentSize" {
-            guard shouldUpdateUIWhenScrolling, toolbarDisplayState.isExpanded else { return }
-
-            showToolbars(animated: true)
+            ensureMainThread { [weak self] in
+                guard let self, shouldUpdateUIWhenScrolling, toolbarDisplayState.isExpanded else { return }
+                
+                showToolbars(animated: true)
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -284,7 +284,7 @@ final class TabScrollHandler: NSObject,
         scrollView.removeObserver(self, forKeyPath: KVOConstants.contentSize.rawValue)
     }
 
-    override func observeValue(
+    override nonisolated func observeValue(
         forKeyPath keyPath: String?,
         of object: Any?,
         change: [NSKeyValueChangeKey: Any]?,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
@@ -9,6 +9,7 @@ import Shared
 
 @testable import Client
 
+@MainActor
 final class TabScrollHandlerTests: XCTestCase {
     var tab: Tab!
     var mockProfile: MockProfile!


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
- Fix warnings for LegacyTabScrollController and TabScrollHandler

## :movie_camera: Demos
<img width="451" height="1324" alt="Screenshot 2025-08-11 at 3 25 37 PM" src="https://github.com/user-attachments/assets/600dc691-85b2-4004-a07d-b1290bab07c2" />
<img width="445" height="474" alt="Screenshot 2025-08-11 at 3 25 55 PM" src="https://github.com/user-attachments/assets/a91df3bd-4d0e-4f55-9df8-b947cd90913c" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
