### PR TITLE
Add FXIOS-13138 #28589 ⁃ [TabScrollController refactor] Add feature flag and integrate in BVC

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -51,6 +51,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case hostedSummarizer
     case hostedSummarizerToolbarEntrypoint
     case hostedSummarizerShakeGesture
+    case tabScrollRefactorFeature
     case tabTrayUIExperiments
     case toolbarNavigationHint
     case toolbarUpdateHint
@@ -171,6 +172,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .hostedSummarizer,
                 .hostedSummarizerToolbarEntrypoint,
                 .hostedSummarizerShakeGesture,
+                .tabScrollRefactorFeature,
                 .tabTrayUIExperiments,
                 .toolbarNavigationHint,
                 .toolbarUpdateHint,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -348,9 +348,8 @@ class BrowserViewController: UIViewController,
         return summarizerNimbusUtils.isToolbarButtonEnabled
     }
 
-    // TODO: Add proper feature flag mechanism
     var isTabScrollRefactoringEnabled: Bool {
-        return false
+        return featureFlags.isFeatureEnabled(.tabScrollRefactorFeature, checking: .buildOnly)
     }
 
     // MARK: Computed vars

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -134,6 +134,9 @@ final class NimbusFeatureFlagLayer {
         case .unifiedSearch:
             return checkUnifiedSearchFeature(from: nimbus)
 
+        case .tabScrollRefactorFeature:
+            return checkTabScrollRefactorFeature(from: nimbus)
+
         case .tabTrayUIExperiments:
             return checkTabTrayUIExperiments(from: nimbus)
 
@@ -241,6 +244,10 @@ final class NimbusFeatureFlagLayer {
     private func checkHomepageFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.homepageRebuildFeature.value()
         return config.enabled
+    }
+
+    private func checkTabScrollRefactorFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.tabScrollRefactorFeature.value().enabled
     }
 
     private func checkTabTrayUIExperiments(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/nimbus-features/tabScrollRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/tabScrollRefactorFeature.yaml
@@ -1,0 +1,18 @@
+# The configuration for the tabScrollRefactorFeature feature
+features:
+  tab-scroll-refactor-feature:
+    description: >
+        The feature flag to manage the rollout of tab scroll refactor feature.
+    variables:
+      enabled:
+        description: >
+          If true, tab scroll new implementation is used to show and hide toolbar views reacting to user scroll
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+            enabled: false
+      - channel: developer
+        value:
+            enabled: false

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -42,6 +42,7 @@ include:
   - nimbus-features/splashScreenFeature.yaml
   - nimbus-features/spotlightSearchFeature.yaml
   - nimbus-features/startAtHomeFeature.yaml
+  - nimbus-features/tabScrollRefactorFeature.yaml
   - nimbus-features/tabTrayFeature.yaml
   - nimbus-features/tabTrayUIExperiments.yaml
   - nimbus-features/toolbarRefactorFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13138)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28589)

## :bulb: Description
Add feature flag for TabScrollController refactor and integrate in BrowserViewController

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
