### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Common - Protect CrashManager mutable state and make it safely `@unchecked Sendable`

### DIFF
--- a/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
+++ b/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// Contains application information necessary for BrowserKit functionalities.
-// FIXME: FXIOS-13125 We should be able to mark this Sendable without mutable state
+/// FIXME: FXIOS-13125 We should be able to mark this Sendable without mutable state
 public class BrowserKitInformation: @unchecked Sendable {
     // FIXME: FXIOS-13125 Shared state for the app should not be stored in the Common package.
     public static let shared = BrowserKitInformation()

--- a/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
+++ b/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
@@ -5,9 +5,10 @@
 import Foundation
 
 /// Contains application information necessary for BrowserKit functionalities.
-public class BrowserKitInformation {
+// FIXME: FXIOS-13125 We should be able to mark this Sendable without mutable state
+public class BrowserKitInformation: @unchecked Sendable {
     // FIXME: FXIOS-13125 Shared state for the app should not be stored in the Common package.
-    nonisolated(unsafe) public static let shared = BrowserKitInformation()
+    public static let shared = BrowserKitInformation()
 
     public var buildChannel: AppBuildChannel?
     public var nightlyAppVersion: String?

--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -6,7 +6,7 @@ import Foundation
 import Sentry
 
 // MARK: - CrashManager
-public protocol CrashManager {
+public protocol CrashManager: Sendable {
     var crashedLastLaunch: Bool { get }
     func captureError(error: Error)
     func setup(sendCrashReports: Bool)
@@ -17,7 +17,7 @@ public protocol CrashManager {
 }
 
 /**
- *Crash report for rust errors
+ * Crash report for rust errors
  *
  * We implement this on exception classes that correspond to Rust errors to
  * customize how the crash reports look.
@@ -30,7 +30,9 @@ public protocol CustomCrashReport {
     var message: String { get set }
 }
 
-public class DefaultCrashManager: CrashManager {
+/// **Note**: This class is safely `@unchecked Sendable` because we protect the only mutable state (`enabled`) with a manual
+/// synchronization method (a lock).
+public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
     enum Environment: String {
         case nightly = "Nightly"
         case production = "Production"
@@ -41,9 +43,14 @@ public class DefaultCrashManager: CrashManager {
     private let defaultDeviceAppHash = "0000000000000000000000000000000000000000"
     private let deviceAppHashLength = UInt(20)
 
+    // We are using a lock to manually protect our mutable state to make this class @unchecked Sendable
+    private let enabledLock = NSLock()
     private var enabled = false
 
     private var shouldSetup: Bool {
+        enabledLock.lock()
+        defer { enabledLock.unlock() }
+
         return !enabled
                 && !isSimulator
                 && isValidReleaseName
@@ -68,11 +75,10 @@ public class DefaultCrashManager: CrashManager {
         return "\(AppInfo.bundleIdentifier)@\(AppInfo.appVersion)"
     }
 
-    // MARK: - Init
-    private var appInfo: BrowserKitInformation
-    private var sentryWrapper: SentryWrapper
-    private var isSimulator: Bool
-    private var skipReleaseNameCheck: Bool
+    private let appInfo: BrowserKitInformation
+    private let sentryWrapper: SentryWrapper
+    private let isSimulator: Bool
+    private let skipReleaseNameCheck: Bool
 
     // Only enable app hang tracking in Beta for now
     private var shouldEnableAppHangTracking: Bool {
@@ -86,6 +92,8 @@ public class DefaultCrashManager: CrashManager {
     private var shouldEnableTraceProfiling: Bool {
         return appInfo.buildChannel == .beta
     }
+
+    // MARK: - Init
 
     public init(appInfo: BrowserKitInformation = BrowserKitInformation.shared,
                 sentryWrapper: SentryWrapper = DefaultSentry(),
@@ -103,7 +111,11 @@ public class DefaultCrashManager: CrashManager {
     }
 
     public func setup(sendCrashReports: Bool) {
-        guard shouldSetup, sendCrashReports, let dsn = sentryWrapper.dsn else { return }
+        guard shouldSetup,
+              sendCrashReports,
+              let dsn = sentryWrapper.dsn else {
+            return
+        }
 
         sentryWrapper.startWithConfigureOptions(configure: { options in
             options.dsn = dsn
@@ -135,6 +147,9 @@ public class DefaultCrashManager: CrashManager {
                 return event
             }
         })
+
+        enabledLock.lock()
+        defer { enabledLock.unlock() }
         enabled = true
 
         configureScope()
@@ -160,6 +175,8 @@ public class DefaultCrashManager: CrashManager {
                      category: LoggerCategory,
                      level: LoggerLevel,
                      extraEvents: [String: String]?) {
+        enabledLock.lock()
+        defer { enabledLock.unlock() }
         guard enabled else { return }
 
         guard shouldSendEventFor(level) else {

--- a/BrowserKit/Sources/Common/Logger/Wrapper/SentryWrapper.swift
+++ b/BrowserKit/Sources/Common/Logger/Wrapper/SentryWrapper.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Sentry
 
-public protocol SentryWrapper {
+public protocol SentryWrapper: Sendable {
     var crashedInLastRun: Bool { get }
     var dsn: String? { get }
 
@@ -16,7 +16,7 @@ public protocol SentryWrapper {
     func configureScope(scope: @escaping (Scope) -> Void)
 }
 
-public class DefaultSentry: SentryWrapper {
+public final class DefaultSentry: SentryWrapper {
     private let dsnKey = "SentryCloudDSN"
     public init() {}
 

--- a/BrowserKit/Tests/CommonTests/LoggerTests/CrashManagerTests.swift
+++ b/BrowserKit/Tests/CommonTests/LoggerTests/CrashManagerTests.swift
@@ -209,7 +209,7 @@ extension CrashManagerTests {
 }
 
 // MARK: - MockSentryWrapper
-private class MockSentryWrapper: SentryWrapper {
+private final class MockSentryWrapper: SentryWrapper, @unchecked Sendable {
     var mockCrashedInLastRun = false
     var crashedInLastRun: Bool {
         return mockCrashedInLastRun

--- a/BrowserKit/Tests/CommonTests/LoggerTests/LoggerTests.swift
+++ b/BrowserKit/Tests/CommonTests/LoggerTests/LoggerTests.swift
@@ -268,7 +268,7 @@ final class MockSwiftyBeaver: SwiftyBeaverWrapper {
 }
 
 // MARK: - CrashManager
-class MockCrashManager: CrashManager {
+final class MockCrashManager: CrashManager, @unchecked Sendable {
     var crashedLastLaunch = false
 
     var savedSendCrashReportsCalled = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
In this PR, I manually protect CrashManager mutable state (the `enabled` var) to make the type safely `@unchecked Sendable`. Other properties were made `Sendable` and changed from `var` to `let` as well so the rest of the properties are properly `Sendable`.

<img width="1437" height="285" alt="Screenshot 2025-08-12 at 1 57 07 PM" src="https://github.com/user-attachments/assets/2d64181c-aa62-4ad5-8e3d-68794b52f719" />

cc @Cramsden @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
