### PR TITLE
Bugfix FXIOS-12779 [webcompat] Use Safari mobile UA product version instead of desktop

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -7,7 +7,7 @@ import WebKit
 import UIKit
 
 open class UserAgent {
-    public static let uaBitSafari = "Safari/605.1.15"
+    public static let uaBitSafari = "Safari/604.1"
     public static let uaBitMobile = "Mobile/15E148"
     public static let uaBitFx = "FxiOS/\(AppInfo.appVersion)"
     public static let product = "Mozilla/5.0"
@@ -175,6 +175,6 @@ public struct UserAgentBuilder {
             systemInfo: "(Macintosh; Intel Mac OS X 10_15_7)",
             platform: UserAgent.platform,
             platformDetails: UserAgent.platformDetails,
-            extensions: "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
+            extensions: "Version/17.7 Safari/605.1.15")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
@@ -50,7 +50,7 @@ final class UserAgentBuilderTests: XCTestCase {
     func testDefaultDesktopUserAgent() {
         let builder = UserAgentBuilder.defaultDesktopUserAgent()
         let systemInfo = "(Macintosh; Intel Mac OS X 10_15_7)"
-        let extensions = "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)"
+        let extensions = "Version/17.7 Safari/605.1.15"
         let testAgent = "\(UserAgent.product) \(systemInfo) \(UserAgent.platform) \(UserAgent.platformDetails) \(extensions)"
         XCTAssertEqual(builder.userAgent(), testAgent)
     }


### PR DESCRIPTION
## :scroll: Tickets
FXIOS-12779
#27829

## :bulb: Description

To avoid fingerprinting on this quirk and to prevent any webcompat woes from broken sniffing libraries, this uses the correct `Safari/*` version for mobile mode.

Additionally hard-codes fixed values for these bits in UA builder desktop defaults to match the real hard-coded WebKit UAstring as used for the versions served/spoofed. (Currently `defaultDesktopUserAgent` is only used with custom `extensions` set, so this has no impact on existing behavior.)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
