### PR TITLE
Bugfix FXIOS-13135 - [Tab Tray] - The thumbnails are not displayed in tab tray after FF was in the background for a longer period of time

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -9,7 +9,7 @@ import Common
 /**
  * Handles screenshots for a given tab, including pages with non-webview content.
  */
-final class ScreenshotHelper {
+class ScreenshotHelper {
     private weak var controller: BrowserViewController?
     private let logger: Logger
 

--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -9,7 +9,7 @@ import Common
 /**
  * Handles screenshots for a given tab, including pages with non-webview content.
  */
-class ScreenshotHelper {
+final class ScreenshotHelper {
     private weak var controller: BrowserViewController?
     private let logger: Logger
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -93,9 +93,6 @@ final class TabManagerMiddleware: FeatureFlaggable {
     }
 
     private func resolveScreenshotActions(action: ScreenshotAction, state: AppState) {
-        guard let tabsState = state.screenState(TabsPanelState.self,
-                                                for: .tabsPanel,
-                                                window: action.windowUUID) else { return }
         // TODO: FXIOS-12101 this should be removed once we figure out screenshots
         guard windowManager.windows[action.windowUUID]?.tabManager != nil else {
             logger.log("Tab manager does not exist for this window, bailing from taking a screenshot.", level: .fatal, category: .tabs, extra: ["windowUUID": "\(action.windowUUID)"])
@@ -104,6 +101,10 @@ final class TabManagerMiddleware: FeatureFlaggable {
 
         let manager = tabManager(for: action.windowUUID)
         manager.tabDidSetScreenshot(action.tab)
+
+        guard let tabsState = state.screenState(TabsPanelState.self,
+                                                for: .tabsPanel,
+                                                window: action.windowUUID) else { return }
         triggerRefresh(uuid: action.windowUUID, isPrivate: tabsState.isPrivateMode)
     }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -753,8 +753,13 @@ class TabManagerImplementation: NSObject,
 
     private func restoreScreenshot(tab: Tab) {
         Task {
-            let screenshot = try? await imageStore?.getImageForKey(tab.tabUUID)
-            tab.setScreenshot(screenshot)
+            do {
+                let screenshot = try await imageStore?.getImageForKey(tab.tabUUID)
+                tab.setScreenshot(screenshot)
+            } catch {
+                logger.log("Failed to restore screenshot: \(error)", level: .warning, category: .tabs)
+                tab.setScreenshot(nil)
+            }
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13135)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28582)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

- Previously, `resolveScreenshotActions` returned early when `TabsPanelState` was `nil` (i.e., the tab tray wasn’t shown). That prevented persisting screenshots to disk unless the tab tray was open. Tabs can have screenshots outside the tab tray, so we now persist unconditionally and only trigger a UI refresh when `TabsPanelState` is available.
- Added logs for better error messages.

Before: saving gated by `TabsPanelState` → screenshots often not written.
After: always persist via `tabDidSetScreenshot`; refresh UI only if Tabs panel is visible.
Impact: prevents lost screenshots when users never open the tab tray.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
