### PR TITLE
Refactor FXIOS-13120 [Terms of Use] - Trigger ToU bottom sheet after 5 days on homepage, warm or cold start

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -23,6 +23,7 @@ public struct PrefsKeys {
     public static let IntroSeen = "IntroViewControllerSeen"
     public static let TermsOfServiceAccepted = "TermsOfServiceAccepted"
     public static let TermsOfUseAccepted = "TermsOfUseAccepted"
+    public static let TermsOfUseFirstShown = "TermsOfUseFirstShown"
     public static let TermsOfUseDismissedDate = "TermsOfUseDismissedDate"
     public static let HomePageTab = "HomePageTab"
     public static let HomeButtonHomePageURL = "HomeButtonHomepageURL"

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -30,7 +30,7 @@ class BrowserCoordinator: BaseCoordinator,
                           MainMenuCoordinatorDelegate,
                           ETPCoordinatorSSLStatusDelegate,
                           SearchEngineSelectionCoordinatorDelegate,
-                          TermsOfUseTriggerDelegate,
+                          TermsOfUseDelegate,
                           FeatureFlaggable {
     private struct UX {
         static let searchEnginePopoverSize = CGSize(width: 250, height: 536)
@@ -83,7 +83,6 @@ class BrowserCoordinator: BaseCoordinator,
 
         browserViewController.browserDelegate = self
         browserViewController.navigationHandler = self
-        browserViewController.termsOfUseTriggerDelegate = self
         tabManager.addDelegate(self)
     }
 
@@ -93,8 +92,7 @@ class BrowserCoordinator: BaseCoordinator,
         if let launchType = launchType, launchType.canLaunch(fromType: .BrowserCoordinator, isIphone: isIphone) {
             startLaunch(with: launchType)
         } else {
-            // Check Terms of Use on app launch
-            showTermsOfUse(context: .appLaunch)
+            showTermsOfUse()
         }
     }
 
@@ -165,7 +163,7 @@ class BrowserCoordinator: BaseCoordinator,
             statusBarScrollDelegate: statusBarScrollDelegate,
             toastContainer: toastContainer
         )
-        homepageController.termsOfUseTriggerDelegate = self
+        homepageController.termsOfUseDelegate = self
         dispatchActionForEmbeddingHomepage(with: isZeroSearch)
         guard browserViewController.embedContent(homepageController) else {
             logger.log("Unable to embed new homepage", level: .debug, category: .coordinator)
@@ -313,7 +311,7 @@ class BrowserCoordinator: BaseCoordinator,
             legacyHomepageViewController.libraryPanelDelegate = libraryPanelDelegate
             legacyHomepageViewController.statusBarScrollDelegate = statusBarScrollDelegate
             legacyHomepageViewController.browserNavigationHandler = self
-            legacyHomepageViewController.termsOfUseTriggerDelegate = self
+            legacyHomepageViewController.termsOfUseDelegate = self
 
             return legacyHomepageViewController
         }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -116,6 +116,9 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 
     @MainActor
     func showShortcutsLibrary()
+
+    @MainActor
+    func showTermsOfUse(context: TriggerContext)
 }
 
 extension BrowserNavigationHandler {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -79,6 +79,7 @@ class BrowserViewController: UIViewController,
     weak var browserDelegate: BrowserDelegate?
     weak var navigationHandler: BrowserNavigationHandler?
     weak var fullscreenDelegate: FullscreenDelegate?
+    weak var termsOfUseTriggerDelegate: TermsOfUseTriggerDelegate?
 
     var urlBarView: (URLBarViewProtocol & TopBottomInterchangeable & Autocompletable) {
         if !isToolbarRefactorEnabled, let legacyUrlBar {
@@ -826,6 +827,9 @@ class BrowserViewController: UIViewController,
             // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)
             scrollController.showToolbars(animated: false)
         }
+
+        // Trigger Terms of Use check when app becomes active from background (warm start)
+        termsOfUseTriggerDelegate?.showTermsOfUse(context: .appBecameActive)
 
         browserDidBecomeActive()
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -826,10 +826,7 @@ class BrowserViewController: UIViewController,
             // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)
             scrollController.showToolbars(animated: false)
         }
-
-        // Trigger Terms of Use check when app becomes active from background (warm start)
         navigationHandler?.showTermsOfUse(context: .appBecameActive)
-
         browserDidBecomeActive()
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -79,7 +79,6 @@ class BrowserViewController: UIViewController,
     weak var browserDelegate: BrowserDelegate?
     weak var navigationHandler: BrowserNavigationHandler?
     weak var fullscreenDelegate: FullscreenDelegate?
-    weak var termsOfUseTriggerDelegate: TermsOfUseTriggerDelegate?
 
     var urlBarView: (URLBarViewProtocol & TopBottomInterchangeable & Autocompletable) {
         if !isToolbarRefactorEnabled, let legacyUrlBar {
@@ -829,7 +828,7 @@ class BrowserViewController: UIViewController,
         }
 
         // Trigger Terms of Use check when app becomes active from background (warm start)
-        termsOfUseTriggerDelegate?.showTermsOfUse(context: .appBecameActive)
+        navigationHandler?.showTermsOfUse(context: .appBecameActive)
 
         browserDidBecomeActive()
     }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseAction.swift
@@ -16,5 +16,5 @@ struct TermsOfUseAction: Action {
 enum TermsOfUseActionType: ActionType {
     case markAccepted
     case markDismissed
-    case markFirstShown
+    case markShown
 }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseAction.swift
@@ -16,5 +16,5 @@ struct TermsOfUseAction: Action {
 enum TermsOfUseActionType: ActionType {
     case markAccepted
     case markDismissed
-    case markShownThisLaunch
+    case markFirstShown
 }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
@@ -90,22 +90,17 @@ final class TermsOfUseCoordinator: BaseCoordinator, TermsOfUseCoordinatorDelegat
         let hasAcceptedTermsOfService = prefs.intForKey(PrefsKeys.TermsOfServiceAccepted) == 1
         guard !hasAcceptedTermsOfUse && !hasAcceptedTermsOfService else { return false }
 
-        // 3. Check if this is the first time we're showing it
+        // 3. Check if this is the first time it is shown
+        // Show on fresh install or next app open for existing users
         let hasShownFirstTime = prefs.boolForKey(PrefsKeys.TermsOfUseFirstShown) ?? false
+        guard hasShownFirstTime else { return true }
 
-        if !hasShownFirstTime {
-            // FIRST TIME: Show on fresh install or next app open for existing users
-            // (Show regardless of context - homepage or app becoming active)
-            return true
-        }
-
-        // 4. Already shown before - check if user dismissed and 120 hours passed
+        // 4. Check if user dismissed and 120 hours passed
         guard let dismissedTimestamp = prefs.timestampForKey(PrefsKeys.TermsOfUseDismissedDate) else {
             // Already shown but no dismissal record - don't show
             return false
         }
 
-        // 5. Calculate time since dismissal
         let dismissedDate = Date.fromTimestamp(dismissedTimestamp)
         let hoursSinceDismissal = Calendar.current.dateComponents(
             [.hour],
@@ -113,11 +108,7 @@ final class TermsOfUseCoordinator: BaseCoordinator, TermsOfUseCoordinatorDelegat
             to: Date()
         ).hour ?? 0
 
-        // 6. Must wait 120 hours since dismissal
-        guard hoursSinceDismissal >= hoursSinceDismissedTerms else { return false }
-
-        // 7. After 120 hours: show on any trigger context (homepage, app becomes active, or app launch)
-        // whichever comes first
-        return true
+        // 5. After 120 hours: show on any trigger context
+        return hoursSinceDismissal >= hoursSinceDismissedTerms
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
@@ -4,6 +4,17 @@
 import Common
 import Shared
 
+enum TriggerContext {
+    case appLaunch
+    case homepageOpened
+    case appBecameActive
+}
+
+@MainActor
+protocol TermsOfUseTriggerDelegate: AnyObject {
+    func showTermsOfUse(context: TriggerContext)
+}
+
 // TODO: FXIOS-12947 - Add tests for TermsOfUseCoordinator
 @MainActor
 protocol TermsOfUseCoordinatorDelegate: AnyObject {
@@ -20,7 +31,7 @@ final class TermsOfUseCoordinator: BaseCoordinator, TermsOfUseCoordinatorDelegat
 
     private var presentedVC: TermsOfUseViewController?
     private let prefs: Prefs
-    private let daysSinceDismissedTerms = 5
+    private let hoursSinceDismissedTerms = 120 // 5 days = 120 hours
 
     init(windowUUID: WindowUUID,
          router: Router,
@@ -34,8 +45,8 @@ final class TermsOfUseCoordinator: BaseCoordinator, TermsOfUseCoordinatorDelegat
         super.init(router: router)
     }
 
-    func start() {
-        guard shouldShowTermsOfUse() else {
+    func start(context: TriggerContext = .appLaunch) {
+        guard shouldShowTermsOfUse(context: context) else {
             parentCoordinator?.didFinish(from: self)
             return
         }
@@ -70,35 +81,43 @@ final class TermsOfUseCoordinator: BaseCoordinator, TermsOfUseCoordinatorDelegat
         presentedVC?.present(linkVC, animated: true)
     }
 
-    func shouldShowTermsOfUse() -> Bool {
-        let isFeatureEnabled = featureFlags.isFeatureEnabled(.touFeature, checking: .buildOnly)
-        // 1. If feature is disabled, do not show.
-        guard isFeatureEnabled else { return false }
+    func shouldShowTermsOfUse(context: TriggerContext = .appLaunch) -> Bool {
+        // 1. Feature must be enabled
+        guard featureFlags.isFeatureEnabled(.touFeature, checking: .buildOnly) else { return false }
 
-        let hasAccepted = prefs.boolForKey(PrefsKeys.TermsOfUseAccepted) ?? false
-        // 2. If user has accepted, do not show again.
-        guard !hasAccepted else { return false }
+        // 2. If user has already accepted (onboarding or bottom sheet), never show again
+        let hasAcceptedTermsOfUse = prefs.boolForKey(PrefsKeys.TermsOfUseAccepted) ?? false
+        let hasAcceptedTermsOfService = prefs.intForKey(PrefsKeys.TermsOfServiceAccepted) == 1
+        guard !hasAcceptedTermsOfUse && !hasAcceptedTermsOfService else { return false }
 
-        let didShowThisLaunch = store.state.screenState(
-            TermsOfUseState.self,
-            for: .termsOfUse,
-            window: windowUUID
-        )?.didShowThisLaunch ?? false
+        // 3. Check if this is the first time we're showing it
+        let hasShownFirstTime = prefs.boolForKey(PrefsKeys.TermsOfUseFirstShown) ?? false
 
-        // 3. If not shown this launch, show it.
-        guard didShowThisLaunch else { return true }
+        if !hasShownFirstTime {
+            // FIRST TIME: Show on fresh install or next app open for existing users
+            // (Show regardless of context - homepage or app becoming active)
+            return true
+        }
 
-        // 4. If shown this launch, show it if enough time has passed since dismissal.
-        guard let dismissedTimestamp = prefs.timestampForKey(PrefsKeys.TermsOfUseDismissedDate)
-        else { return false }
+        // 4. Already shown before - check if user dismissed and 120 hours passed
+        guard let dismissedTimestamp = prefs.timestampForKey(PrefsKeys.TermsOfUseDismissedDate) else {
+            // Already shown but no dismissal record - don't show
+            return false
+        }
 
-        let dismissedWithoutAcceptDate = Date.fromTimestamp(dismissedTimestamp)
-        let daysSinceDismissal = Calendar.current.dateComponents(
-            [.day],
-            from: dismissedWithoutAcceptDate,
+        // 5. Calculate time since dismissal
+        let dismissedDate = Date.fromTimestamp(dismissedTimestamp)
+        let hoursSinceDismissal = Calendar.current.dateComponents(
+            [.hour],
+            from: dismissedDate,
             to: Date()
-        ).day ?? 0
+        ).hour ?? 0
 
-        return daysSinceDismissal >= daysSinceDismissedTerms
+        // 6. Must wait 120 hours since dismissal
+        guard hoursSinceDismissal >= hoursSinceDismissedTerms else { return false }
+
+        // 7. After 120 hours: show on any trigger context (homepage, app becomes active, or app launch)
+        // whichever comes first
+        return true
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
@@ -11,7 +11,7 @@ enum TriggerContext {
 }
 
 @MainActor
-protocol TermsOfUseTriggerDelegate: AnyObject {
+protocol TermsOfUseDelegate: AnyObject {
     func showTermsOfUse(context: TriggerContext)
 }
 
@@ -31,7 +31,7 @@ final class TermsOfUseCoordinator: BaseCoordinator, TermsOfUseCoordinatorDelegat
 
     private var presentedVC: TermsOfUseViewController?
     private let prefs: Prefs
-    private let hoursSinceDismissedTerms = 120 // 5 days = 120 hours
+    private let hoursSinceDismissedTerms = 120 // 120 hours (5 days)
 
     init(windowUUID: WindowUUID,
          router: Router,

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
@@ -41,8 +41,8 @@ class TermsOfUseMiddleware {
             case TermsOfUseActionType.markDismissed:
                 self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseDismissedDate)
 
-            case TermsOfUseActionType.markShownThisLaunch:
-                break
+            case TermsOfUseActionType.markFirstShown:
+                self.prefs.setBool(true, forKey: PrefsKeys.TermsOfUseFirstShown)
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
@@ -41,7 +41,7 @@ class TermsOfUseMiddleware {
             case TermsOfUseActionType.markDismissed:
                 self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseDismissedDate)
 
-            case TermsOfUseActionType.markFirstShown:
+            case TermsOfUseActionType.markShown:
                 self.prefs.setBool(true, forKey: PrefsKeys.TermsOfUseFirstShown)
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
@@ -9,19 +9,13 @@ struct TermsOfUseState: ScreenState, Equatable {
     let windowUUID: WindowUUID
     var hasAccepted: Bool
     var wasDismissed: Bool
-    var lastShownDate: Date?
-    var didShowThisLaunch: Bool
 
     init(windowUUID: WindowUUID,
          hasAccepted: Bool = false,
-         wasDismissed: Bool = false,
-         lastShownDate: Date? = nil,
-         didShowThisLaunch: Bool = false) {
+         wasDismissed: Bool = false) {
         self.windowUUID = windowUUID
         self.hasAccepted = hasAccepted
         self.wasDismissed = wasDismissed
-        self.lastShownDate = lastShownDate
-        self.didShowThisLaunch = didShowThisLaunch
     }
 
     static func defaultState(from state: TermsOfUseState) -> TermsOfUseState {
@@ -37,21 +31,15 @@ struct TermsOfUseState: ScreenState, Equatable {
         case .markAccepted:
             return TermsOfUseState(windowUUID: state.windowUUID,
                                    hasAccepted: true,
-                                   wasDismissed: false,
-                                   lastShownDate: state.lastShownDate,
-                                   didShowThisLaunch: state.didShowThisLaunch)
+                                   wasDismissed: false)
         case .markDismissed:
             return TermsOfUseState(windowUUID: state.windowUUID,
                                    hasAccepted: state.hasAccepted,
-                                   wasDismissed: true,
-                                   lastShownDate: Date(),
-                                   didShowThisLaunch: state.didShowThisLaunch)
-        case .markShownThisLaunch:
+                                   wasDismissed: true)
+        case .markFirstShown:
             return TermsOfUseState(windowUUID: state.windowUUID,
                                    hasAccepted: state.hasAccepted,
-                                   wasDismissed: state.wasDismissed,
-                                   lastShownDate: state.lastShownDate,
-                                   didShowThisLaunch: true)
+                                   wasDismissed: state.wasDismissed)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
@@ -36,10 +36,10 @@ struct TermsOfUseState: ScreenState, Equatable {
             return TermsOfUseState(windowUUID: state.windowUUID,
                                    hasAccepted: state.hasAccepted,
                                    wasDismissed: true)
-        case .markFirstShown:
+        case .markShown:
             return TermsOfUseState(windowUUID: state.windowUUID,
-                                   hasAccepted: state.hasAccepted,
-                                   wasDismissed: state.wasDismissed)
+                                   hasAccepted: false,
+                                   wasDismissed: false)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
@@ -140,7 +140,7 @@ final class TermsOfUseViewController: UIViewController,
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        store.dispatchLegacy(TermsOfUseAction(windowUUID: windowUUID, actionType: .markShownThisLaunch))
+        store.dispatchLegacy(TermsOfUseAction(windowUUID: windowUUID, actionType: .markFirstShown))
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
@@ -140,7 +140,7 @@ final class TermsOfUseViewController: UIViewController,
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        store.dispatchLegacy(TermsOfUseAction(windowUUID: windowUUID, actionType: .markFirstShown))
+        store.dispatchLegacy(TermsOfUseAction(windowUUID: windowUUID, actionType: .markShown))
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -298,7 +298,7 @@ final class TermsOfUseViewController: UIViewController,
         case .ended:
             if translation.y > UX.panDismissDistance || gesture.velocity(in: view).y > UX.panDismissVelocity {
                 store.dispatchLegacy(TermsOfUseAction(windowUUID: windowUUID, actionType: .markDismissed))
-                dismiss(animated: true)
+                coordinator?.dismissTermsFlow()
             } else {
                 UIView.animate(withDuration: UX.animationDuration,
                                delay: 0,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -29,6 +29,7 @@ final class HomepageViewController: UIViewController,
 
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { return windowUUID }
+    weak var termsOfUseTriggerDelegate: TermsOfUseTriggerDelegate?
 
     // MARK: - Layout variables
     var statusBarFrame: CGRect? {
@@ -165,6 +166,9 @@ final class HomepageViewController: UIViewController,
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         trackVisibleItemImpressions()
+
+        // Check Terms of Use for homepage
+        termsOfUseTriggerDelegate?.showTermsOfUse(context: .homepageOpened)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -29,7 +29,7 @@ final class HomepageViewController: UIViewController,
 
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { return windowUUID }
-    weak var termsOfUseTriggerDelegate: TermsOfUseTriggerDelegate?
+    weak var termsOfUseDelegate: TermsOfUseDelegate?
 
     // MARK: - Layout variables
     var statusBarFrame: CGRect? {
@@ -166,9 +166,9 @@ final class HomepageViewController: UIViewController,
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         trackVisibleItemImpressions()
-
-        // Check Terms of Use for homepage
-        termsOfUseTriggerDelegate?.showTermsOfUse(context: .homepageOpened)
+        Task { @MainActor in
+            termsOfUseDelegate?.showTermsOfUse(context: .homepageOpened)
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -184,7 +184,6 @@ class LegacyHomepageViewController: UIViewController,
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
             self?.displayWallpaperSelector()
         }
-        
         Task { @MainActor in
             termsOfUseDelegate?.showTermsOfUse(context: .homepageOpened)
         }

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -50,7 +50,7 @@ class LegacyHomepageViewController: UIViewController,
 
     var windowUUID: WindowUUID { return tabManager.windowUUID }
     var currentWindowUUID: UUID? { return windowUUID }
-    weak var termsOfUseTriggerDelegate: TermsOfUseTriggerDelegate?
+    weak var termsOfUseDelegate: TermsOfUseDelegate?
 
     var contentType: ContentType = .legacyHomepage
 
@@ -183,7 +183,10 @@ class LegacyHomepageViewController: UIViewController,
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
             self?.displayWallpaperSelector()
-            self?.termsOfUseTriggerDelegate?.showTermsOfUse(context: .homepageOpened)
+        }
+        
+        Task { @MainActor in
+            termsOfUseDelegate?.showTermsOfUse(context: .homepageOpened)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -50,6 +50,7 @@ class LegacyHomepageViewController: UIViewController,
 
     var windowUUID: WindowUUID { return tabManager.windowUUID }
     var currentWindowUUID: UUID? { return windowUUID }
+    weak var termsOfUseTriggerDelegate: TermsOfUseTriggerDelegate?
 
     var contentType: ContentType = .legacyHomepage
 
@@ -182,6 +183,7 @@ class LegacyHomepageViewController: UIViewController,
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
             self?.displayWallpaperSelector()
+            self?.termsOfUseTriggerDelegate?.showTermsOfUse(context: .homepageOpened)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -184,9 +184,7 @@ class LegacyHomepageViewController: UIViewController,
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
             self?.displayWallpaperSelector()
         }
-        Task { @MainActor in
-            termsOfUseDelegate?.showTermsOfUse(context: .homepageOpened)
-        }
+        termsOfUseDelegate?.showTermsOfUse(context: .homepageOpened)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -154,7 +154,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
         showSummarizePanelCalled += 1
     }
 
-    func showTermsOfUse() {
+    func showTermsOfUse(context: TriggerContext) {
         showTermsOfUseCalled += 1
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -47,6 +47,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
     var setHomepageVisibilityCalled = 0
     var showSummarizePanelCalled = 0
     var showShortcutsLibraryCalled = 0
+    var showTermsOfUseCalled = 0
 
     func show(settings: Client.Route.SettingsSection, onDismiss: (() -> Void)?) {
         showSettingsCalled += 1
@@ -151,6 +152,10 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
 
     func showSummarizePanel(_ trigger: SummarizerTrigger) {
         showSummarizePanelCalled += 1
+    }
+
+    func showTermsOfUse() {
+        showTermsOfUseCalled += 1
     }
 
     // MARK: - BrowserDelegate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseMiddlewareTests.swift
@@ -42,8 +42,8 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
             XCTAssertTrue(Calendar.current.isDate(dismissedDate, inSameDayAs: Date()))
         }
     }
-    func testMiddleware_markFirstShown_setsFirstShownPref() {
-        let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.markFirstShown)
+    func testMiddleware_markShown_setsFirstShownPref() {
+        let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.markShown)
         middleware.termsOfUseProvider(AppState(), action)
 
         // Should set the first shown preference

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseMiddlewareTests.swift
@@ -42,11 +42,15 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
             XCTAssertTrue(Calendar.current.isDate(dismissedDate, inSameDayAs: Date()))
         }
     }
-    func testMiddleware_markShownThisLaunch_doesNotWriteToPrefs() {
-        let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.markShownThisLaunch)
+    func testMiddleware_markFirstShown_setsFirstShownPref() {
+        let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.markFirstShown)
         middleware.termsOfUseProvider(AppState(), action)
 
-        XCTAssertFalse(profile.prefs.boolForKey(PrefsKeys.TermsOfUseAccepted) == false)
+        // Should set the first shown preference
+        XCTAssertTrue(profile.prefs.boolForKey(PrefsKeys.TermsOfUseFirstShown) == true)
+        
+        // Should not affect other preferences
+        XCTAssertFalse(profile.prefs.boolForKey(PrefsKeys.TermsOfUseAccepted) == true)
         let dismissedTimestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUseDismissedDate)
         XCTAssertNil(dismissedTimestamp)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseMiddlewareTests.swift
@@ -48,9 +48,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
         // Should set the first shown preference
         XCTAssertTrue(profile.prefs.boolForKey(PrefsKeys.TermsOfUseFirstShown) == true)
-        
-        // Should not affect other preferences
-        XCTAssertFalse(profile.prefs.boolForKey(PrefsKeys.TermsOfUseAccepted) == true)
+
         let dismissedTimestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUseDismissedDate)
         XCTAssertNil(dismissedTimestamp)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13120)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28548)

## :bulb: Description
This PR adds another check for users who already accepted termsofservice so that the terms of use bottom sheet won't prompt in this case, also changes the logic of appearance to follow the next requirments:

TermsOfUse logic of appearance:
FIRST TIME (New/Existing Users):
Shows immediately on the next app interaction after:
* Fresh install (if did not accepted ToS)
* App update (for existing users who never accepted ToS)

If user accepts won’t show again , if user dismisses on any way:

 AFTER DISMISSAL (120 Hours Later):
If user dismisses the bottom sheet, it will re-appear after exactly 120 hours (5 days) on:
* Whichever comes first: App launch(cold start), Homepage opened, or App became active

Trigger Points:
* App Launch (cold start)
*  Homepage Opened (user navigates to homepage)
* App Became Active (returning from background - warm start)


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
