### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Enable strict concurrency in Common

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -108,7 +108,11 @@ let package = Package(
             dependencies: ["Dip",
                            "SwiftyBeaver",
                            .product(name: "Sentry-Dynamic", package: "sentry-cocoa")],
-            swiftSettings: [.unsafeFlags(["-enable-testing"])]),
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"]),
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
+        ),
         .testTarget(
             name: "CommonTests",
             dependencies: ["Common"]),

--- a/BrowserKit/Sources/Common/Extensions/URLExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/URLExtension.swift
@@ -348,6 +348,6 @@ private func loadEntries() -> TLDEntryMap? {
     return entries
 }
 
-private var etldEntries: TLDEntryMap? = {
+private let etldEntries: TLDEntryMap? = {
     return loadEntries()
 }()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix the last warning and enable strict concurrency permanently in Common! 🎉 

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
