### PR TITLE
Refactor FXIOS-13028 [Homepage Redesign] Fix UI tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomepageSearchBarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomepageSearchBarTests.swift
@@ -9,8 +9,6 @@ final class HomepageSearchBarTests: FeatureFlaggedTestBase {
     func testDoesNotShowSearchBarTabTrayToolbarOnHomepageOff_homepageSearchBarExperimentOff() {
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "toolbar-refactor-feature")
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "tab-tray-ui-experiments")
-        addLaunchArgument(jsonFileName: "homepageSearchBarOff", featureName: "homepage-redesign-feature")
-        addLaunchArgument(jsonFileName: "storiesRedesignOff", featureName: "homepage-redesign-feature")
         app.launch()
         navigator.nowAt(NewTabScreen)
         let homepageSearchBar = app.collectionViews
@@ -406,8 +404,6 @@ final class HomepageSearchBarTests: FeatureFlaggedTestBase {
         }
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "toolbar-refactor-feature")
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "tab-tray-ui-experiments")
-        addLaunchArgument(jsonFileName: "homepageSearchBarOff", featureName: "homepage-redesign-feature")
-        addLaunchArgument(jsonFileName: "storiesRedesignOff", featureName: "homepage-redesign-feature")
         app.launch()
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.SelectToolbarBottom)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13028)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28407)

## :bulb: Description
- Fix some UI tests 

### 📝 Technical notes:
From my understanding, whenever we add a launch argument with the same `featureName`, the previous one gets overridden.  

```swift
addLaunchArgument(jsonFileName: "homepageSearchBarOff", featureName: "homepage-redesign-feature")
addLaunchArgument(jsonFileName: "storiesRedesignOff", featureName: "homepage-redesign-feature")
```

I don't believe the above code ever worked as expected since the first launch argument gets overridden by the second one immediately. It just happened to work because both features were off by default at the feature layer (which is now no longer the case)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
