### PR TITLE
Add FXIOS-13163 [Shortcuts Library] Webpage navigation for shortcuts when tapped

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -272,6 +272,11 @@ class BrowserCoordinator: BaseCoordinator,
             logger.log("Webview controller was created and embedded \(isEmbedded)", level: .info, category: .coordinator)
         }
 
+        // Shortcuts library is pushed on top of BVC, so we need to pop that view controller once the web view is showing
+        if router.navigationController.topViewController is ShortcutsLibraryViewController {
+            router.popViewController(animated: false)
+        }
+
         screenshotService.screenshotableView = webviewController
     }
 

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryDiffableDataSource.swift
@@ -9,6 +9,7 @@ typealias ShortcutsLibraryItem = ShortcutsLibraryDiffableDataSource.Item
 
 final class ShortcutsLibraryDiffableDataSource:
     UICollectionViewDiffableDataSource<ShortcutsLibrarySection, ShortcutsLibraryItem> {
+    // MARK: - Enums
     enum Section: Hashable {
         case shortcuts
     }
@@ -23,6 +24,7 @@ final class ShortcutsLibraryDiffableDataSource:
         }
     }
 
+    // MARK: - Private constants
     private let maxShortcutsToShow = 16
 
     func updateSnapshot(state: ShortcutsLibraryState) {

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
@@ -217,4 +217,32 @@ class ShortcutsLibraryViewController: UIViewController,
             return UICollectionViewCell()
         }
     }
+
+    // MARK: - UICollectionViewDelegate
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let item = dataSource?.itemIdentifier(for: indexPath) else {
+            self.logger.log(
+                "Item selected at \(indexPath) but does not navigate anywhere",
+                level: .debug,
+                category: .homepage
+            )
+            return
+        }
+
+        guard case let .shortcut(config) = item else { return }
+        let destination = NavigationDestination(
+            .link,
+            url: config.site.url.asURL,
+            isGoogleTopSite: config.isGoogleURL,
+            visitType: .link
+        )
+
+        store.dispatchLegacy(
+            NavigationBrowserAction(
+                navigationDestination: destination,
+                windowUUID: self.windowUUID,
+                actionType: NavigationBrowserActionType.tapOnCell
+            )
+        )
+    }
 }

--- a/firefox-ios/Client/Protocols/NavigationController.swift
+++ b/firefox-ios/Client/Protocols/NavigationController.swift
@@ -11,6 +11,7 @@ protocol NavigationController {
     var transitionCoordinator: UIViewControllerTransitionCoordinator? { get }
     var fromViewController: UIViewController? { get }
     var presentedViewController: UIViewController? { get }
+    var topViewController: UIViewController? { get }
 
     func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?)
     func dismiss(animated flag: Bool, completion: (() -> Void)?)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -292,6 +292,17 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertNotNil(screenshotService.screenshotableView)
     }
 
+    func testShowWebview_popsShortcutLibrary() {
+        let webview = WKWebView()
+        let subject = createSubject()
+        subject.browserViewController = browserViewController
+        subject.showShortcutsLibrary()
+
+        subject.show(webView: webview)
+
+        XCTAssertEqual(mockRouter.popViewControllerCalled, 1)
+    }
+
     // MARK: - BrowserNavigationHandler
 
     func testShowSettings() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNavigationController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNavigationController.swift
@@ -12,6 +12,7 @@ class MockNavigationController: NavigationController {
     var delegate: UINavigationControllerDelegate?
     var isNavigationBarHidden = false
     var fromViewController: UIViewController?
+    var topViewController: UIViewController?
 
     var presentCalled = 0
     var dismissCalled = 0
@@ -30,6 +31,7 @@ class MockNavigationController: NavigationController {
     func pushViewController(_ viewController: UIViewController, animated: Bool) {
         pushCalled += 1
         presentedViewController = viewController
+        topViewController = viewController
     }
 
     func popViewController(animated: Bool) -> UIViewController? {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
@@ -23,6 +23,7 @@ class MockRouter: NSObject, Router {
     var setRootViewControllerCalled = 0
     var savedCompletion: (() -> Void)?
     var isNavigationBarHidden = false
+    var topViewController: UIViewController?
 
     init(navigationController: NavigationController) {
         self.navigationController = navigationController
@@ -51,6 +52,7 @@ class MockRouter: NSObject, Router {
     func push(_ viewController: UIViewController, animated: Bool, completion: (() -> Void)?) {
         savedCompletion = completion
         pushedViewController = viewController
+        navigationController.pushViewController(viewController, animated: false)
         pushCalled += 1
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13163)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28632)

## :bulb: Description
- Displays webview and pops shortcut library off the navigation stack when a shortcut on the shortcuts library screen is tapped

## :movie_camera: Demos
<details>
<summary>Demo</summary>

https://github.com/user-attachments/assets/88c92dcc-8087-4e47-a2e7-a960fd09e095

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
