### PR TITLE
Add FXIOS-13110 FXIOS-13147 [Shake to Summarize] fix a11y and gestures for tab snapshot 

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/SummarizeViewModel.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeViewModel.swift
@@ -10,6 +10,8 @@ public struct SummarizeViewModel {
     let loadingLabel: String
     let loadingA11yLabel: String
     let loadingA11yId: String
+    let tabSnapshotA11yLabel: String
+    let tabSnapshotA11yId: String
     let summarizeTextViewA11yLabel: String
     let summarizeTextViewA11yId: String
     let brandLabel: String
@@ -28,6 +30,8 @@ public struct SummarizeViewModel {
         loadingLabel: String,
         loadingA11yLabel: String,
         loadingA11yId: String,
+        tabSnapshotA11yLabel: String,
+        tabSnapshotA11yId: String,
         brandLabel: String,
         summaryNote: String,
         summarizeTextViewA11yLabel: String,
@@ -43,6 +47,8 @@ public struct SummarizeViewModel {
         self.loadingLabel = loadingLabel
         self.loadingA11yLabel = loadingA11yLabel
         self.loadingA11yId = loadingA11yId
+        self.tabSnapshotA11yLabel = tabSnapshotA11yLabel
+        self.tabSnapshotA11yId = tabSnapshotA11yId
         self.brandLabel = brandLabel
         self.summaryNote = summaryNote
         self.summarizeTextViewA11yLabel = summarizeTextViewA11yLabel

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -720,6 +720,7 @@ struct AccessibilityIdentifiers {
     }
 
     struct Summarizer {
+        static let tabSnapshotView = "tabSnapshotView"
         static let closeSummaryButton = "closeSummaryButton"
         static let titleLabel = "summaryTitleLabel"
         static let loadingLabel = "summaryLoadingLabel"

--- a/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
@@ -104,6 +104,8 @@ class SummarizeCoordinator: BaseCoordinator, SummarizerServiceLifecycle {
             loadingLabel: .Summarizer.LoadingLabel,
             loadingA11yLabel: .Summarizer.LoadingAccessibilityLabel,
             loadingA11yId: AccessibilityIdentifiers.Summarizer.loadingLabel,
+            tabSnapshotA11yLabel: .Summarizer.TabSnapshotAccessibilityLabel,
+            tabSnapshotA11yId: AccessibilityIdentifiers.Summarizer.tabSnapshotView,
             brandLabel: brandLabel,
             summaryNote: .Summarizer.FootnoteLabel,
             summarizeTextViewA11yLabel: .Summarizer.SummaryTextAccessibilityLabel,

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2276,6 +2276,12 @@ extension String {
             value: "Close summary button",
             comment: "The a11y label for the close button in the summary view."
         )
+        public static let TabSnapshotAccessibilityLabel = MZLocalizedString(
+            key: "", // Summarizer.TabSnapshot.Accessibility.Label.v142
+            tableName: "Summarizer",
+            value: "Close summary",
+            comment: "The a11y label for the tab snapshot view that shows on top of the summary view and tapping on the view will close the summary view."
+        )
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13110)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28532)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13147)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28601)

## :bulb: Description
Bugfix a11y ticket to make the tab snapshot view an accessibility element.
Tap on tab view snapshot to cancel (should act similar to close button).

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
