### PR TITLE
Refactor FXIOS-11340 - Remove 1 function_body_length violation from MenuBuilderHelper.swift and decreases the threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -107,8 +107,8 @@ closure_body_length:
   error: 34
 
 function_body_length:
-  warning: 240
-  error: 240
+  warning: 230
+  error: 230
 
 file_header:
   required_string: |

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -282,4 +282,28 @@ class MenuBuilderHelper {
             ]
         )
     }
+
+    private func makeBookmarksMenu() -> UIMenu {
+        return UIMenu(
+            title: .KeyboardShortcuts.Sections.Bookmarks,
+            identifier: MenuIdentifiers.bookmarks,
+            options: .displayInline,
+            children: [
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.ShowBookmarks,
+                    action: #selector(BrowserViewController.showBookmarksKeyCommand),
+                    input: "o",
+                    modifierFlags: [.command, .shift],
+                    discoverabilityTitle: .KeyboardShortcuts.ShowBookmarks
+                ),
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.AddBookmark,
+                    action: #selector(BrowserViewController.addBookmarkKeyCommand),
+                    input: "d",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .KeyboardShortcuts.AddBookmark
+                )
+            ]
+        )
+    }
 }

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -64,7 +64,7 @@ class MenuBuilderHelper {
         builder.insertSibling(makeHistoryMenu(), afterMenu: .view)
         builder.insertSibling(makeBookmarksMenu(), afterMenu: MenuIdentifiers.history)
         builder.insertSibling(makeToolsMenu(), afterMenu: MenuIdentifiers.bookmarks)
-        builder.insertChild(windowMenu, atStartOfMenu: .window)
+        builder.insertChild(makeWindowMenu(), atStartOfMenu: .window)
     }
 
     private func makeApplicationMenu() -> UIMenu {

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -244,7 +244,7 @@ class MenuBuilderHelper {
         }
 
         builder.insertChild(makeApplicationMenu(), atStartOfMenu: .application)
-        builder.insertChild(fileMenu, atStartOfMenu: .file)
+        builder.insertChild(makeFileMenu(), atStartOfMenu: .file)
         builder.replace(menu: .find, with: findMenu)
         builder.remove(menu: .font)
         builder.insertChild(viewMenu, atStartOfMenu: .view)

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -256,7 +256,7 @@ class MenuBuilderHelper {
             ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
         }
 
-        builder.insertChild(applicationMenu, atStartOfMenu: .application)
+        builder.insertChild(makeApplicationMenu(), atStartOfMenu: .application)
         builder.insertChild(fileMenu, atStartOfMenu: .file)
         builder.replace(menu: .find, with: findMenu)
         builder.remove(menu: .font)

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -201,7 +201,7 @@ class MenuBuilderHelper {
 
         builder.insertChild(makeApplicationMenu(), atStartOfMenu: .application)
         builder.insertChild(makeFileMenu(), atStartOfMenu: .file)
-        builder.replace(menu: .find, with: findMenu)
+        builder.replace(menu: .find, with: makeFindMenu())
         builder.remove(menu: .font)
         builder.insertChild(viewMenu, atStartOfMenu: .view)
         builder.insertSibling(historyMenu, afterMenu: .view)

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -276,4 +276,55 @@ class MenuBuilderHelper {
 
         return findMenu
     }
+
+    private func makeViewMenu() -> UIMenu {
+        var viewMenuChildren: [UIMenuElement] = [
+            UIKeyCommand(
+                title: .KeyboardShortcuts.ZoomIn,
+                action: #selector(BrowserViewController.zoomIn),
+                input: "+",
+                modifierFlags: .command,
+                discoverabilityTitle: .KeyboardShortcuts.ZoomIn
+            ),
+            UIKeyCommand(
+                title: .KeyboardShortcuts.ZoomOut,
+                action: #selector(BrowserViewController.zoomOut),
+                input: "-",
+                modifierFlags: .command,
+                discoverabilityTitle: .KeyboardShortcuts.ZoomOut
+            ),
+            UIKeyCommand(
+                title: .KeyboardShortcuts.ActualSize,
+                action: #selector(BrowserViewController.resetZoom),
+                input: "0",
+                modifierFlags: .command,
+                discoverabilityTitle: .KeyboardShortcuts.ActualSize
+            ),
+            UIKeyCommand(
+                title: .KeyboardShortcuts.ReloadPage,
+                action: #selector(BrowserViewController.reloadTabKeyCommand),
+                input: "r",
+                modifierFlags: .command,
+                discoverabilityTitle: .KeyboardShortcuts.ReloadPage
+            )
+        ]
+
+        // UIKeyCommand.f5 is only available since iOS 13.4 - Shortcut will only work from this version
+        viewMenuChildren.append(
+            UIKeyCommand(
+                title: .KeyboardShortcuts.ReloadWithoutCache,
+                action: #selector(BrowserViewController.reloadTabIgnoringCacheKeyCommand),
+                input: UIKeyCommand.f5,
+                modifierFlags: [.control],
+                discoverabilityTitle: .KeyboardShortcuts.ReloadWithoutCache
+            )
+        )
+
+        let viewMenu = UIMenu(options: .displayInline, children: viewMenuChildren)
+        viewMenu.children.forEach {
+            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
+        }
+
+        return viewMenu
+    }
 }

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -12,28 +12,6 @@ class MenuBuilderHelper {
     }
 
     func mainMenu(for builder: UIMenuBuilder) {
-        let bookmarksMenu = UIMenu(
-            title: .KeyboardShortcuts.Sections.Bookmarks,
-            identifier: MenuIdentifiers.bookmarks,
-            options: .displayInline,
-            children: [
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.ShowBookmarks,
-                    action: #selector(BrowserViewController.showBookmarksKeyCommand),
-                    input: "o",
-                    modifierFlags: [.command, .shift],
-                    discoverabilityTitle: .KeyboardShortcuts.ShowBookmarks
-                ),
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.AddBookmark,
-                    action: #selector(BrowserViewController.addBookmarkKeyCommand),
-                    input: "d",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .KeyboardShortcuts.AddBookmark
-                )
-            ]
-        )
-
         let toolsMenu = UIMenu(
             title: .KeyboardShortcuts.Sections.Tools,
             identifier: MenuIdentifiers.tools,

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -12,50 +12,6 @@ class MenuBuilderHelper {
     }
 
     func mainMenu(for builder: UIMenuBuilder) {
-        let newPrivateTab = UICommandAlternate(
-            title: .KeyboardShortcuts.NewPrivateTab,
-            action: #selector(BrowserViewController.newPrivateTabKeyCommand),
-            modifierFlags: [.shift]
-        )
-
-        let fileMenu = UIMenu(
-            options: .displayInline,
-            children: [
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.NewTab,
-                    action: #selector(BrowserViewController.newTabKeyCommand),
-                    input: "t",
-                    modifierFlags: .command,
-                    alternates: [newPrivateTab],
-                    discoverabilityTitle: .KeyboardShortcuts.NewTab
-                ),
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.NewPrivateTab,
-                    action: #selector(BrowserViewController.newPrivateTabKeyCommand),
-                    input: "p",
-                    modifierFlags: [.command, .shift],
-                    discoverabilityTitle: .KeyboardShortcuts.NewPrivateTab
-                ),
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.SelectLocationBar,
-                    action: #selector(BrowserViewController.selectLocationBarKeyCommand),
-                    input: "l",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .KeyboardShortcuts.SelectLocationBar
-                ),
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.CloseCurrentTab,
-                    action: #selector(BrowserViewController.closeTabKeyCommand),
-                    input: "w",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .KeyboardShortcuts.CloseCurrentTab
-                ),
-            ]
-        )
-        fileMenu.children.forEach {
-            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
-        }
-
         let findMenu = UIMenu(
             options: .displayInline,
             children: [

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -12,29 +12,6 @@ class MenuBuilderHelper {
     }
 
     func mainMenu(for builder: UIMenuBuilder) {
-        let findMenu = UIMenu(
-            options: .displayInline,
-            children: [
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.Find,
-                    action: #selector(BrowserViewController.findInPageKeyCommand),
-                    input: "f",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .KeyboardShortcuts.Find
-                ),
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.FindAgain,
-                    action: #selector(BrowserViewController.findInPageAgainKeyCommand),
-                    input: "g",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .KeyboardShortcuts.FindAgain
-                ),
-            ]
-        )
-        findMenu.children.forEach {
-            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
-        }
-
         var viewMenuChildren: [UIMenuElement] = [
             UIKeyCommand(
                 title: .KeyboardShortcuts.ZoomIn,

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -99,7 +99,7 @@ class MenuBuilderHelper {
         builder.remove(menu: .font)
         builder.insertChild(makeViewMenu(), atStartOfMenu: .view)
         builder.insertSibling(makeHistoryMenu(), afterMenu: .view)
-        builder.insertSibling(bookmarksMenu, afterMenu: MenuIdentifiers.history)
+        builder.insertSibling(makeBookmarksMenu(), afterMenu: MenuIdentifiers.history)
         builder.insertSibling(toolsMenu, afterMenu: MenuIdentifiers.bookmarks)
         builder.insertChild(windowMenu, atStartOfMenu: .window)
     }

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -18,19 +18,6 @@ class MenuBuilderHelper {
             modifierFlags: [.shift]
         )
 
-        let applicationMenu = UIMenu(
-            options: .displayInline,
-            children: [
-                UIKeyCommand(
-                    title: .AppSettingsTitle,
-                    action: #selector(BrowserViewController.openSettingsKeyCommand),
-                    input: ",",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .AppSettingsTitle
-                )
-            ]
-        )
-
         let fileMenu = UIMenu(
             options: .displayInline,
             children: [

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -284,4 +284,21 @@ class MenuBuilderHelper {
             ]
         )
     }
+
+    private func makeToolsMenu() -> UIMenu {
+        return UIMenu(
+            title: .KeyboardShortcuts.Sections.Tools,
+            identifier: MenuIdentifiers.tools,
+            options: .displayInline,
+            children: [
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.ShowDownloads,
+                    action: #selector(BrowserViewController.showDownloadsKeyCommand),
+                    input: "j",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .KeyboardShortcuts.ShowDownloads
+                )
+            ]
+        )
+    }
 }

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -12,42 +12,6 @@ class MenuBuilderHelper {
     }
 
     func mainMenu(for builder: UIMenuBuilder) {
-        let historyMenu = UIMenu(
-            title: .KeyboardShortcuts.Sections.History,
-            identifier: MenuIdentifiers.history,
-            options: .displayInline,
-            children: [
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.ShowHistory,
-                    action: #selector(BrowserViewController.showHistoryKeyCommand),
-                    input: "y",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .KeyboardShortcuts.ShowHistory
-                ),
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.Back,
-                    action: #selector(BrowserViewController.goBackKeyCommand),
-                    input: "[",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .KeyboardShortcuts.Back
-                ),
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.Forward,
-                    action: #selector(BrowserViewController.goForwardKeyCommand),
-                    input: "]",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .KeyboardShortcuts.Forward
-                ),
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.ClearRecentHistory,
-                    action: #selector(BrowserViewController.openClearHistoryPanelKeyCommand),
-                    input: "\u{8}",
-                    modifierFlags: [.command, .shift],
-                    discoverabilityTitle: .KeyboardShortcuts.ClearRecentHistory
-                )
-            ]
-        )
-
         let bookmarksMenu = UIMenu(
             title: .KeyboardShortcuts.Sections.Bookmarks,
             identifier: MenuIdentifiers.bookmarks,

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -12,50 +12,6 @@ class MenuBuilderHelper {
     }
 
     func mainMenu(for builder: UIMenuBuilder) {
-        let windowMenu = UIMenu(
-            title: .KeyboardShortcuts.Sections.Window,
-            options: .displayInline,
-            children: [
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.ShowNextTab,
-                    action: #selector(BrowserViewController.nextTabKeyCommand),
-                    input: "\t",
-                    modifierFlags: [.control],
-                    discoverabilityTitle: .KeyboardShortcuts.ShowNextTab
-                ),
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.ShowPreviousTab,
-                    action: #selector(BrowserViewController.previousTabKeyCommand),
-                    input: "\t",
-                    modifierFlags: [.control, .shift],
-                    discoverabilityTitle: .KeyboardShortcuts.ShowPreviousTab
-                ),
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.ShowTabTray,
-                    action: #selector(BrowserViewController.showTabTrayKeyCommand),
-                    input: "\t",
-                    modifierFlags: [.command, .alternate],
-                    discoverabilityTitle: .KeyboardShortcuts.ShowTabTray
-                ),
-                UIKeyCommand(
-                    action: #selector(BrowserViewController.selectFirstTab),
-                    input: "1",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .KeyboardShortcuts.ShowFirstTab
-                ),
-                UIKeyCommand(
-                    action: #selector(BrowserViewController.selectLastTab),
-                    input: "9",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .KeyboardShortcuts.ShowLastTab
-                ),
-            ]
-        )
-
-        windowMenu.children.forEach {
-            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
-        }
-
         builder.insertChild(makeApplicationMenu(), atStartOfMenu: .application)
         builder.insertChild(makeFileMenu(), atStartOfMenu: .file)
         builder.replace(menu: .find, with: makeFindMenu())

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -78,7 +78,7 @@ class MenuBuilderHelper {
         builder.insertChild(makeViewMenu(), atStartOfMenu: .view)
         builder.insertSibling(makeHistoryMenu(), afterMenu: .view)
         builder.insertSibling(makeBookmarksMenu(), afterMenu: MenuIdentifiers.history)
-        builder.insertSibling(toolsMenu, afterMenu: MenuIdentifiers.bookmarks)
+        builder.insertSibling(makeToolsMenu(), afterMenu: MenuIdentifiers.bookmarks)
         builder.insertChild(windowMenu, atStartOfMenu: .window)
     }
 

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -286,4 +286,52 @@ class MenuBuilderHelper {
             ]
         )
     }
+
+    private func makeWindowMenu() -> UIMenu {
+        let windowMenu = UIMenu(
+            title: .KeyboardShortcuts.Sections.Window,
+            options: .displayInline,
+            children: [
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.ShowNextTab,
+                    action: #selector(BrowserViewController.nextTabKeyCommand),
+                    input: "\t",
+                    modifierFlags: [.control],
+                    discoverabilityTitle: .KeyboardShortcuts.ShowNextTab
+                ),
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.ShowPreviousTab,
+                    action: #selector(BrowserViewController.previousTabKeyCommand),
+                    input: "\t",
+                    modifierFlags: [.control, .shift],
+                    discoverabilityTitle: .KeyboardShortcuts.ShowPreviousTab
+                ),
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.ShowTabTray,
+                    action: #selector(BrowserViewController.showTabTrayKeyCommand),
+                    input: "\t",
+                    modifierFlags: [.command, .alternate],
+                    discoverabilityTitle: .KeyboardShortcuts.ShowTabTray
+                ),
+                UIKeyCommand(
+                    action: #selector(BrowserViewController.selectFirstTab),
+                    input: "1",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .KeyboardShortcuts.ShowFirstTab
+                ),
+                UIKeyCommand(
+                    action: #selector(BrowserViewController.selectLastTab),
+                    input: "9",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .KeyboardShortcuts.ShowLastTab
+                ),
+            ]
+        )
+
+        windowMenu.children.forEach {
+            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
+        }
+
+        return windowMenu
+    }
 }

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -266,4 +266,19 @@ class MenuBuilderHelper {
         builder.insertSibling(toolsMenu, afterMenu: MenuIdentifiers.bookmarks)
         builder.insertChild(windowMenu, atStartOfMenu: .window)
     }
+
+    private func makeApplicationMenu() -> UIMenu {
+        return UIMenu(
+            options: .displayInline,
+            children: [
+                UIKeyCommand(
+                    title: .AppSettingsTitle,
+                    action: #selector(BrowserViewController.openSettingsKeyCommand),
+                    input: ",",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .AppSettingsTitle
+                )
+            ]
+        )
+    }
 }

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -180,7 +180,7 @@ class MenuBuilderHelper {
         builder.insertChild(makeFileMenu(), atStartOfMenu: .file)
         builder.replace(menu: .find, with: makeFindMenu())
         builder.remove(menu: .font)
-        builder.insertChild(viewMenu, atStartOfMenu: .view)
+        builder.insertChild(makeViewMenu(), atStartOfMenu: .view)
         builder.insertSibling(historyMenu, afterMenu: .view)
         builder.insertSibling(bookmarksMenu, afterMenu: MenuIdentifiers.history)
         builder.insertSibling(toolsMenu, afterMenu: MenuIdentifiers.bookmarks)

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -280,4 +280,42 @@ class MenuBuilderHelper {
 
         return viewMenu
     }
+
+    private func makeHistoryMenu() -> UIMenu {
+        return UIMenu(
+            title: .KeyboardShortcuts.Sections.History,
+            identifier: MenuIdentifiers.history,
+            options: .displayInline,
+            children: [
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.ShowHistory,
+                    action: #selector(BrowserViewController.showHistoryKeyCommand),
+                    input: "y",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .KeyboardShortcuts.ShowHistory
+                ),
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.Back,
+                    action: #selector(BrowserViewController.goBackKeyCommand),
+                    input: "[",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .KeyboardShortcuts.Back
+                ),
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.Forward,
+                    action: #selector(BrowserViewController.goForwardKeyCommand),
+                    input: "]",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .KeyboardShortcuts.Forward
+                ),
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.ClearRecentHistory,
+                    action: #selector(BrowserViewController.openClearHistoryPanelKeyCommand),
+                    input: "\u{8}",
+                    modifierFlags: [.command, .shift],
+                    discoverabilityTitle: .KeyboardShortcuts.ClearRecentHistory
+                )
+            ]
+        )
+    }
 }

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -268,4 +268,52 @@ class MenuBuilderHelper {
             ]
         )
     }
+
+    private func makeFileMenu() -> UIMenu {
+        let newPrivateTab = UICommandAlternate(
+            title: .KeyboardShortcuts.NewPrivateTab,
+            action: #selector(BrowserViewController.newPrivateTabKeyCommand),
+            modifierFlags: [.shift]
+        )
+
+        let fileMenu = UIMenu(
+            options: .displayInline,
+            children: [
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.NewTab,
+                    action: #selector(BrowserViewController.newTabKeyCommand),
+                    input: "t",
+                    modifierFlags: .command,
+                    alternates: [newPrivateTab],
+                    discoverabilityTitle: .KeyboardShortcuts.NewTab
+                ),
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.NewPrivateTab,
+                    action: #selector(BrowserViewController.newPrivateTabKeyCommand),
+                    input: "p",
+                    modifierFlags: [.command, .shift],
+                    discoverabilityTitle: .KeyboardShortcuts.NewPrivateTab
+                ),
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.SelectLocationBar,
+                    action: #selector(BrowserViewController.selectLocationBarKeyCommand),
+                    input: "l",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .KeyboardShortcuts.SelectLocationBar
+                ),
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.CloseCurrentTab,
+                    action: #selector(BrowserViewController.closeTabKeyCommand),
+                    input: "w",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .KeyboardShortcuts.CloseCurrentTab
+                ),
+            ]
+        )
+        fileMenu.children.forEach {
+            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
+        }
+
+        return fileMenu
+    }
 }

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -134,7 +134,7 @@ class MenuBuilderHelper {
         builder.replace(menu: .find, with: makeFindMenu())
         builder.remove(menu: .font)
         builder.insertChild(makeViewMenu(), atStartOfMenu: .view)
-        builder.insertSibling(historyMenu, afterMenu: .view)
+        builder.insertSibling(makeHistoryMenu(), afterMenu: .view)
         builder.insertSibling(bookmarksMenu, afterMenu: MenuIdentifiers.history)
         builder.insertSibling(toolsMenu, afterMenu: MenuIdentifiers.bookmarks)
         builder.insertChild(windowMenu, atStartOfMenu: .window)

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -12,53 +12,6 @@ class MenuBuilderHelper {
     }
 
     func mainMenu(for builder: UIMenuBuilder) {
-        var viewMenuChildren: [UIMenuElement] = [
-            UIKeyCommand(
-                title: .KeyboardShortcuts.ZoomIn,
-                action: #selector(BrowserViewController.zoomIn),
-                input: "+",
-                modifierFlags: .command,
-                discoverabilityTitle: .KeyboardShortcuts.ZoomIn
-            ),
-            UIKeyCommand(
-                title: .KeyboardShortcuts.ZoomOut,
-                action: #selector(BrowserViewController.zoomOut),
-                input: "-",
-                modifierFlags: .command,
-                discoverabilityTitle: .KeyboardShortcuts.ZoomOut
-            ),
-            UIKeyCommand(
-                title: .KeyboardShortcuts.ActualSize,
-                action: #selector(BrowserViewController.resetZoom),
-                input: "0",
-                modifierFlags: .command,
-                discoverabilityTitle: .KeyboardShortcuts.ActualSize
-            ),
-            UIKeyCommand(
-                title: .KeyboardShortcuts.ReloadPage,
-                action: #selector(BrowserViewController.reloadTabKeyCommand),
-                input: "r",
-                modifierFlags: .command,
-                discoverabilityTitle: .KeyboardShortcuts.ReloadPage
-            )
-        ]
-
-        // UIKeyCommand.f5 is only available since iOS 13.4 - Shortcut will only work from this version
-        viewMenuChildren.append(
-            UIKeyCommand(
-                title: .KeyboardShortcuts.ReloadWithoutCache,
-                action: #selector(BrowserViewController.reloadTabIgnoringCacheKeyCommand),
-                input: UIKeyCommand.f5,
-                modifierFlags: [.control],
-                discoverabilityTitle: .KeyboardShortcuts.ReloadWithoutCache
-            )
-        )
-
-        let viewMenu = UIMenu(options: .displayInline, children: viewMenuChildren)
-        viewMenu.children.forEach {
-            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
-        }
-
         let historyMenu = UIMenu(
             title: .KeyboardShortcuts.Sections.History,
             identifier: MenuIdentifiers.history,

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -12,21 +12,6 @@ class MenuBuilderHelper {
     }
 
     func mainMenu(for builder: UIMenuBuilder) {
-        let toolsMenu = UIMenu(
-            title: .KeyboardShortcuts.Sections.Tools,
-            identifier: MenuIdentifiers.tools,
-            options: .displayInline,
-            children: [
-                UIKeyCommand(
-                    title: .KeyboardShortcuts.ShowDownloads,
-                    action: #selector(BrowserViewController.showDownloadsKeyCommand),
-                    input: "j",
-                    modifierFlags: .command,
-                    discoverabilityTitle: .KeyboardShortcuts.ShowDownloads
-                )
-            ]
-        )
-
         let windowMenu = UIMenu(
             title: .KeyboardShortcuts.Sections.Window,
             options: .displayInline,

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -272,4 +272,31 @@ class MenuBuilderHelper {
 
         return fileMenu
     }
+
+    private func makeFindMenu() -> UIMenu {
+        let findMenu = UIMenu(
+            options: .displayInline,
+            children: [
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.Find,
+                    action: #selector(BrowserViewController.findInPageKeyCommand),
+                    input: "f",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .KeyboardShortcuts.Find
+                ),
+                UIKeyCommand(
+                    title: .KeyboardShortcuts.FindAgain,
+                    action: #selector(BrowserViewController.findInPageAgainKeyCommand),
+                    input: "g",
+                    modifierFlags: .command,
+                    discoverabilityTitle: .KeyboardShortcuts.FindAgain
+                ),
+            ]
+        )
+        findMenu.children.forEach {
+            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
+        }
+
+        return findMenu
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11340)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24679)

## :bulb: Description
In this pull request, I removed 1 `function_body_length` violation from `MenuBuilderHelper.swift` extracting some logics of the `mainMenu` function into new small functions. Also, I decreased the threshold to 230 for this rule.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
