### PR TITLE
Add FXIOS-13173 [Liquid Glass] Settings updates

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1445,6 +1445,7 @@
 		BC129A2F2E455900004A6875 /* SummarizeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC129A2E2E4558FD004A6875 /* SummarizeAction.swift */; };
 		BC129A322E461F96004A6875 /* SummarizerMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC129A312E461F91004A6875 /* SummarizerMiddlewareTests.swift */; };
 		BC8E91DC2E32953C00434FD0 /* AppleIntelligenceUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */; };
+		BCB769192E4F80650046AA37 /* StylingViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB769182E4F805C0046AA37 /* StylingViewModifiers.swift */; };
 		BCBE058C2E3A8720004B6039 /* SummarizeSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBE058B2E3A871B004B6039 /* SummarizeSetting.swift */; };
 		BCBE09BF2E3BAE2A004B6039 /* SummarizeSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBE09BE2E3BAE22004B6039 /* SummarizeSettingsViewControllerTests.swift */; };
 		BCFB141D2E1FFEC00005D46B /* feltPrivacySimplifiedUIOff.json in Resources */ = {isa = PBXBuildFile; fileRef = BCFB141C2E1FFEC00005D46B /* feltPrivacySimplifiedUIOff.json */; };
@@ -9318,6 +9319,7 @@
 		BC4B49618B8FC822D4D0FCC2 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BC81442AA84F635F3067A2C5 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
 		BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceUtil.swift; sourceTree = "<group>"; };
+		BCB769182E4F805C0046AA37 /* StylingViewModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylingViewModifiers.swift; sourceTree = "<group>"; };
 		BCBE058B2E3A871B004B6039 /* SummarizeSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizeSetting.swift; sourceTree = "<group>"; };
 		BCBE09BE2E3BAE22004B6039 /* SummarizeSettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizeSettingsViewControllerTests.swift; sourceTree = "<group>"; };
 		BCD04CE4A62EAA4DF96DE812 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/Storage.strings"; sourceTree = "<group>"; };
@@ -13825,6 +13827,7 @@
 		BA4BB9962D7F371F006BD137 /* AppearanceSettings */ = {
 			isa = PBXGroup;
 			children = (
+				BCB769182E4F805C0046AA37 /* StylingViewModifiers.swift */,
 				214099602DCBF4DB004881E1 /* Zoom */,
 				BA4BB9992D7F3743006BD137 /* AppearanceSettingsView.swift */,
 				BA1237C22DAE6D5100BB6333 /* AddressBarSettingsView.swift */,
@@ -17973,6 +17976,7 @@
 				D0E89A2920910917001CE5C7 /* DownloadsPanel.swift in Sources */,
 				D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */,
 				8AC0B1C02D1D935C004237FD /* ContextMenuConfiguration.swift in Sources */,
+				BCB769192E4F80650046AA37 /* StylingViewModifiers.swift in Sources */,
 				BD011FB82D89B0D400FE1A32 /* AddressBarPanGestureHandler.swift in Sources */,
 				E19B38B328A42D5E00D8C541 /* WallpaperCollectionViewCell.swift in Sources */,
 				C7FA9E1E2E4BD4D1004F2CA1 /* AddShortcutsSetting.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconSelectionView.swift
@@ -47,7 +47,7 @@ struct AppIconSelectionView: View, ThemeApplicable {
                     )
                 }.listRowBackground(themeColors.layer2.color)
             }
-            .listStyle(.plain)
+            .modifier(ListStyle())
             .alert(isPresented: $isShowingErrorAlert) {
                 Alert(
                     title: Text(String.Settings.AppIconSelection.Errors.SelectErrorMessage),
@@ -66,6 +66,7 @@ struct AppIconSelectionView: View, ThemeApplicable {
             }
         }
         .background(themeColors.layer1.color)
+        .modifier(ScrollContentBackgroundModifier())
     }
 
     func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSettingsView.swift
@@ -28,6 +28,7 @@ struct AddressBarSettingsView: View {
 
     private struct UX {
         static let spacing: CGFloat = 24
+        static let cornerRadius: CGFloat = 24
     }
 
     var body: some View {
@@ -39,11 +40,11 @@ struct AddressBarSettingsView: View {
                     theme: currentTheme,
                     selectedAddressBarPosition: addressBarPosition,
                     onSelected: viewModel.saveSearchBarPosition)
+                .modifier(SectionStyle(theme: currentTheme, cornerRadius: UX.cornerRadius))
             }
             Spacer()
         }
-        .padding(.top, UX.spacing)
-        .frame(maxWidth: .infinity)
+        .modifier(PaddingStyle(theme: currentTheme, spacing: UX.spacing))
         .background(viewBackground)
         .onAppear {
             currentTheme = themeManager.getCurrentTheme(for: windowUUID)

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionView.swift
@@ -52,12 +52,12 @@ struct GenericSectionView<Content: View>: View {
                                      sectionTitleColor: sectionTitleColor)
             .padding([.leading, .trailing], UX.sectionPadding)
 
-            Divider().frame(height: UX.dividerHeight)
+            dividerView()
 
             content()
                 .padding([.top, .bottom], UX.contentPadding)
 
-            Divider().frame(height: UX.dividerHeight)
+            dividerView()
 
             // Optional description at the bottom
             if let description = description {
@@ -80,6 +80,13 @@ struct GenericSectionView<Content: View>: View {
                 .font(.caption)
                 .foregroundColor(descriptionTextColor)
                 .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private func dividerView() -> some View {
+        if #unavailable(iOS 26.0) {
+            Divider().frame(height: UX.dividerHeight)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/StylingViewModifiers.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/StylingViewModifiers.swift
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+import Common
+
+struct SectionStyle: ViewModifier {
+    let theme: Theme?
+    let cornerRadius: CGFloat
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .fill(Color(theme?.colors.layer2 ?? UIColor.clear))
+                )
+        } else {
+            content
+        }
+    }
+}
+
+struct PaddingStyle: ViewModifier {
+    let theme: Theme?
+    let spacing: CGFloat
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .padding(.top, spacing)
+                .padding(.horizontal, spacing / 2)
+        } else {
+            content
+                .padding(.top, spacing)
+                .frame(maxWidth: .infinity)
+        }
+    }
+}
+
+struct ListStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.listStyle(.insetGrouped)
+        } else {
+            content.listStyle(.plain)
+        }
+    }
+}
+
+struct ScrollContentBackgroundModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content.scrollContentBackground(.hidden)
+        } else {
+            content
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -337,7 +337,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         }
 
         // So that the separator line goes all the way to the left edge.
-        cell.separatorInset = .zero
+        cell.separatorInset = UX.cellSeparatorInsetForCurrentOS
 
         return cell
     }

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -29,6 +29,17 @@ extension UILabel {
 // A base setting class that shows a title. You probably want to subclass this, not use it directly.
 @MainActor
 class Setting: NSObject {
+    struct UX {
+        static let horizontalMargin: CGFloat = 15
+        static var cellLayoutMarginsForCurrentOS: UIEdgeInsets {
+            guard #available(iOS 26.0, *) else { return .zero }
+            return UIEdgeInsets(top: 0, left: horizontalMargin, bottom: 0, right: 0)
+        }
+        static var cellSeparatorInsetForCurrentOS: UIEdgeInsets {
+            guard #available(iOS 26.0, *) else { return .zero }
+            return UIEdgeInsets(top: 0, left: horizontalMargin, bottom: 0, right: horizontalMargin)
+        }
+    }
     private var _title: NSAttributedString?
     private var _footerTitle: NSAttributedString?
     private var _cellHeight: CGFloat?
@@ -103,15 +114,14 @@ class Setting: NSObject {
         cell.imageView?.image = _image
         cell.accessibilityTraits = UIAccessibilityTraits.button
         cell.indentationWidth = 0
-        cell.layoutMargins = .zero
+        cell.layoutMargins = UX.cellLayoutMarginsForCurrentOS
+        cell.separatorInset = UX.cellSeparatorInsetForCurrentOS
         cell.isUserInteractionEnabled = enabled
 
         backgroundView.backgroundColor = theme.colors.layer5Hover
         backgroundView.bounds = cell.bounds
         cell.selectedBackgroundView = backgroundView
 
-        // So that the separator line goes all the way to the left edge.
-        cell.separatorInset = .zero
         if let cell = cell as? ThemedTableViewCell {
             cell.applyTheme(theme: theme)
         }

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -17,7 +17,17 @@ class WebsiteDataManagementViewController: UIViewController,
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
     private static let showMoreCellReuseIdentifier = "showMoreCell"
-
+    private struct UX {
+        static let sectionTopMargin: CGFloat = 10
+        static var tableViewStyleForCurrentOS: UITableView.Style {
+            guard #available(iOS 26.0, *) else { return .grouped }
+            return .insetGrouped
+        }
+        static var sectionTopMarginForCurrentOS: CGFloat {
+            guard #available(iOS 26.0, *) else { return 0 }
+            return UX.sectionTopMargin
+        }
+    }
     private enum Section: Int {
         case sites = 0
         case showMore = 1
@@ -66,7 +76,10 @@ class WebsiteDataManagementViewController: UIViewController,
     private func setupView() {
         title = .SettingsWebsiteDataTitle
 
-        let tableView = UITableView()
+        let tableView = UITableView(
+            frame: .zero,
+            style: UX.tableViewStyleForCurrentOS
+        )
         tableView.dataSource = self
         tableView.delegate = self
         tableView.separatorColor = currentTheme().colors.borderPrimary
@@ -317,11 +330,11 @@ class WebsiteDataManagementViewController: UIViewController,
         let section = Section(rawValue: section)!
         switch section {
         case .clearButton:
-            return 10 // Controls the space between the site list and the button
+            return UX.sectionTopMargin // Controls the space between the site list and the button
         case .sites:
             return UITableView.automaticDimension
         case .showMore:
-            return 0
+            return UX.sectionTopMarginForCurrentOS
         }
     }
 

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedLearnMoreTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedLearnMoreTableViewCell.swift
@@ -12,6 +12,10 @@ class ThemedLearnMoreTableViewCell: ThemedTableViewCell {
         static let verticalMargin: CGFloat = 10
         static let labelsSpacing: CGFloat = 3
         static let learnMoreInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+        static var cellSeparatorInsetForCurrentOS: UIEdgeInsets {
+            guard #available(iOS 26.0, *) else { return .zero }
+            return UIEdgeInsets(top: 0, left: horizontalMargin, bottom: 0, right: horizontalMargin)
+        }
     }
 
     private lazy var labelsStackView: UIStackView = .build { stackView in
@@ -64,7 +68,7 @@ class ThemedLearnMoreTableViewCell: ThemedTableViewCell {
     }
 
     private func setupLayout() {
-        separatorInset = .zero
+        separatorInset = UX.cellSeparatorInsetForCurrentOS
         selectionStyle = .none
         contentView.addSubview(labelsStackView)
         contentView.addSubview(learnMoreButton)

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewController.swift
@@ -12,6 +12,18 @@ class ThemedTableViewController: UITableViewController, Themeable, InjectedTheme
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { return windowUUID }
 
+    struct UX {
+        static let horizontalMargin: CGFloat = 15
+        static func tableViewStyleForCurrentOS(with style: UITableView.Style) -> UITableView.Style {
+            guard #available(iOS 26.0, *) else { return style }
+            return .insetGrouped
+        }
+        static var cellSeparatorInsetForCurrentOS: UIEdgeInsets {
+            guard #available(iOS 26.0, *) else { return .zero }
+            return UIEdgeInsets(top: 0, left: horizontalMargin, bottom: 0, right: horizontalMargin)
+        }
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -23,7 +35,7 @@ class ThemedTableViewController: UITableViewController, Themeable, InjectedTheme
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
-        super.init(style: style)
+        super.init(style: UX.tableViewStyleForCurrentOS(with: style))
     }
 
     override func tableView(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13173)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Refactored this [PR ](https://github.com/mozilla-mobile/firefox-ios/pull/28692/files). Added a new file, `StylingViewModifiers`, that holds all the modifiers that changes UI depending on whether we are on iOS 26 or iOS 18. Also, added appropriate variables in `UX` for individual cells.

This PR is only a refactor and there are other sub views that do not follow the iOS 26 new designs (i.e. page zoom) and does not include transparent background. That will be a follow up PR to this one.

## :movie_camera: Demos
**iOS 16**

https://github.com/user-attachments/assets/59e9e818-5c70-4c3f-bc13-39d0faed01c0

**iOS 26**

https://github.com/user-attachments/assets/3b705374-7296-4ba3-80ab-6fea5d653dc8

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
