### PR TITLE
Refactor MTE-4885 Harden removeApp()

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -71,7 +71,11 @@ class BaseTestCase: XCTestCase {
         if icon.exists {
             icon.press(forDuration: 1.5)
             springboard.buttons["Remove App"].waitAndTap()
+            mozWaitForElementToNotExist(springboard.buttons["Remove App"])
+            mozWaitForElementToExist(springboard.alerts.firstMatch)
             springboard.alerts.buttons["Delete App"].waitAndTap()
+            mozWaitForElementToNotExist(springboard.alerts.buttons["Delete App"])
+            mozWaitForElementToExist(springboard.alerts.firstMatch)
             springboard.alerts.buttons["Delete"].waitAndTap()
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4885)


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The following tests rely on `removeApp()` in the `setUp()`:
* CookiePersistenceTests
* DisplaySettingsTests
* EngagementNotificationTests
* LoginTests

These tests may fail intermittently because the test may attempt to tap on the "Delete" and "Delete App" buttons before they are ready.

<img width="200" alt="Simulator Screenshot - iPhone 15 - 2025-08-15 at 09 54 38" src="https://github.com/user-attachments/assets/01edb891-15ed-4daf-9d41-618f2e76dd1d" />


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
