### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Add `UIDeviceDetails` helper and fix warnings in Shared package

### DIFF
--- a/BrowserKit/Sources/Shared/DeviceInfo.swift
+++ b/BrowserKit/Sources/Shared/DeviceInfo.swift
@@ -56,7 +56,7 @@ extension DeviceInfo {
     }
 
     public class func deviceModel() -> String {
-        return UIDevice.current.model
+        return UIDeviceDetails.model
     }
 
     public class func isBlurSupported() -> Bool {

--- a/BrowserKit/Sources/Shared/KeyboardHelper.swift
+++ b/BrowserKit/Sources/Shared/KeyboardHelper.swift
@@ -33,6 +33,7 @@ public struct KeyboardState {
     /// accurate than simply using the height of UIKeyboardFrameBeginUserInfoKey since for example
     /// on iPad the overlap may be partial or if an external keyboard is attached, the intersection
     /// height will be zero. (Even if the height of the *invisible* keyboard will look normal!)
+    @MainActor
     public func intersectionHeightForView(_ view: UIView) -> CGFloat {
         if let keyboardFrameValue = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
             let keyboardFrame = keyboardFrameValue.cgRectValue

--- a/BrowserKit/Sources/Shared/SupportUtils.swift
+++ b/BrowserKit/Sources/Shared/SupportUtils.swift
@@ -76,7 +76,7 @@ public struct SupportUtils {
         // that this about Firefox on iOS. It makes it easier for webcompat people doing triage and diagnostics.
         // It adds a device-type label to help discriminating in between tablet and mobile devices.
         let deviceType: String
-        if UIDevice.current.userInterfaceIdiom == .pad {
+        if UIDeviceDetails.userInterfaceIdiom == .pad {
             deviceType = "device-tablet"
         } else {
             deviceType = "device-mobile"

--- a/BrowserKit/Sources/Shared/UIDeviceDetails.swift
+++ b/BrowserKit/Sources/Shared/UIDeviceDetails.swift
@@ -5,8 +5,8 @@
 import UIKit
 
 /// Contains static, unchanging information about the current `UIDevice`, like the model and system version.
-/// This makes it easier for code that runs on a background thread without an asynchronous context to use these values
-/// (e.g. to log additional information during background operations like networking).
+/// This makes it easier for code that runs on a background thread (without an asynchronous context) to use these values
+/// (e.g. to log additional information during background networking).
 ///
 /// **Never put values in here that might change during runtime.**
 struct UIDeviceDetails {
@@ -30,15 +30,13 @@ struct UIDeviceDetails {
 
     // MARK: Helper method
 
-    /// This nonisolated function will execute the `work` closure on the main thread return a value outside an asynchronous
-    /// or main actor context. If not called on the main thread, it will use `DispatchQueue.main.sync` to synchronously wait
-    /// for the `main` thread to be available, get the value on the main thread, and then return the value to the current
-    /// context without any suspension.
+    /// This nonisolated function will execute the `work` closure on the main thread to return a value outside an
+    /// asynchronous or main actor context. If called off the main thread, this method will use `DispatchQueue.main.sync`
+    /// to synchronously return a value without a suspension point.
     ///
-    /// This method should only be used to get unchanging (but main actor isolated) values like `UIDevice.current.model` on
-    /// first launch of the app. This is a workaround for code that Apple will probably mark `nonisolated` in the future.
+    /// This is a workaround to access unchanging values that Apple will probably mark `nonisolated` in the future.
     ///
-    /// Do not use this method to get the value of main actor isolated state which can change during runtime, such as the
+    /// **Do not** use this method to get the value of main actor-isolated state which can change during runtime, such as the
     /// device orientation or current system theme.
     /// - Parameter work: Work to execute to return a value for variables normally isolated to the main thread.
     /// - Returns: The value from `work`.

--- a/BrowserKit/Sources/Shared/UIDeviceDetails.swift
+++ b/BrowserKit/Sources/Shared/UIDeviceDetails.swift
@@ -14,12 +14,12 @@ struct UIDeviceDetails {
     static let model = {
         getMainThreadDataSynchronously { UIDevice.current.model }
     }()
-    
+
     /// The style of interface to use on the current device.
     static let userInterfaceIdiom = {
         getMainThreadDataSynchronously { UIDevice.current.userInterfaceIdiom }
     }()
-    
+
     /// The current version of the operating system.
     static let systemVersion = {
         getMainThreadDataSynchronously { UIDevice.current.systemVersion }
@@ -29,7 +29,7 @@ struct UIDeviceDetails {
     private init() {}
 
     // MARK: Helper method
-    
+
     /// This nonisolated function will execute the `work` closure on the main thread return a value outside an asynchronous
     /// or main actor context. If not called on the main thread, it will use `DispatchQueue.main.sync` to synchronously wait
     /// for the `main` thread to be available, get the value on the main thread, and then return the value to the current

--- a/BrowserKit/Sources/Shared/UIDeviceDetails.swift
+++ b/BrowserKit/Sources/Shared/UIDeviceDetails.swift
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+/// Contains static, unchanging information about the current `UIDevice`, like the model and system version.
+/// This makes it easier for code that runs on a background thread without an asynchronous context to use these values
+/// (e.g. to log additional information during background operations like networking).
+///
+/// **Never put values in here that might change during runtime.**
+struct UIDeviceDetails {
+    /// The model of the device.
+    static let model = {
+        getMainThreadDataSynchronously { UIDevice.current.model }
+    }()
+    
+    /// The style of interface to use on the current device.
+    static let userInterfaceIdiom = {
+        getMainThreadDataSynchronously { UIDevice.current.userInterfaceIdiom }
+    }()
+    
+    /// The current version of the operating system.
+    static let systemVersion = {
+        getMainThreadDataSynchronously { UIDevice.current.systemVersion }
+    }()
+
+    /// Never instantiate this type.
+    private init() {}
+
+    // MARK: Helper method
+    
+    /// This nonisolated function will execute the `work` closure on the main thread return a value outside an asynchronous
+    /// or main actor context. If not called on the main thread, it will use `DispatchQueue.main.sync` to synchronously wait
+    /// for the `main` thread to be available, get the value on the main thread, and then return the value to the current
+    /// context without any suspension.
+    ///
+    /// This method should only be used to get unchanging (but main actor isolated) values like `UIDevice.current.model` on
+    /// first launch of the app. This is a workaround for code that Apple will probably mark `nonisolated` in the future.
+    ///
+    /// Do not use this method to get the value of main actor isolated state which can change during runtime, such as the
+    /// device orientation or current system theme.
+    /// - Parameter work: Work to execute to return a value for variables normally isolated to the main thread.
+    /// - Returns: The value from `work`.
+    private static func getMainThreadDataSynchronously<T: Sendable>(
+        work: @MainActor @Sendable () -> (T)
+    ) -> T {
+        if Thread.isMainThread {
+            MainActor.assumeIsolated {
+                work()
+            }
+        } else {
+            DispatchQueue.main.sync {
+                work()
+            }
+        }
+    }
+}

--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -14,7 +14,8 @@ open class UserAgent {
     public static let platform = "AppleWebKit/605.1.15"
     public static let platformDetails = "(KHTML, like Gecko)"
 
-    private static var defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
+    // FIXME: FXIOS-13197 UserDefaults is not thread safe
+    nonisolated(unsafe) private static let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
 
     private static func clientUserAgent(prefix: String) -> String {
         let versionStr: String
@@ -23,7 +24,7 @@ open class UserAgent {
         } else {
             versionStr = "dev"
         }
-        return "\(prefix)/\(versionStr) (\(DeviceInfo.deviceModel()); iPhone OS \(UIDevice.current.systemVersion)) (\(AppInfo.displayName))"
+        return "\(prefix)/\(versionStr) (\(DeviceInfo.deviceModel()); iPhone OS \(UIDeviceDetails.systemVersion)) (\(AppInfo.displayName))"
     }
 
     public static var syncUserAgent: String {
@@ -83,7 +84,7 @@ open class UserAgent {
     public static func getUserAgent(domain: String = "") -> String {
         // As of iOS 13 using a hidden webview method does not return the correct UA on
         // iPad (it returns mobile UA). We should consider that method no longer reliable.
-        if UIDevice.current.userInterfaceIdiom == .pad {
+        if UIDeviceDetails.userInterfaceIdiom == .pad {
             return getUserAgent(domain: domain, platform: .Desktop)
         } else {
             return getUserAgent(domain: domain, platform: .Mobile)
@@ -165,7 +166,7 @@ public struct UserAgentBuilder {
     public static func defaultMobileUserAgent() -> UserAgentBuilder {
         return UserAgentBuilder(
             product: UserAgent.product,
-            systemInfo: "(\(UIDevice.current.model); CPU iPhone OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)",
+            systemInfo: "(\(UIDeviceDetails.model); CPU iPhone OS \(UIDeviceDetails.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)",
             platform: UserAgent.platform,
             platformDetails: UserAgent.platformDetails,
             extensions: "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
This is a proposed fix for main actor-isolation warnings related to using `UIDevice` in nonisolated contexts within the `Shared` package. There are other areas of the codebase which can benefit from this as well.

I would like to move the `UIDeviceDetails` into its own separate package eventually.

---

As discussed in a few conversations over slack, this is a proposed workaround to address the issue of `UIDevice.current` being main actor isolated, which in turn leads to static, unchanging info like `model`, `systemVersion`, etc. being isolated to the main thread. I suspect this is something Apple might change ([apparently there's a bug ticket filed for this](https://github.com/swiftlang/swift/issues/76478)?).

It's not really reasonable to expect background networking to switch to an asynchronous context to await getting this very basic info off the main thread (or otherwise using a GCD solution to synchronously get the info).

I tested this in the Client and saw the data set in these variables:
```
UIDevice.current.userInterfaceIdiom: UIUserInterfaceIdiom(rawValue: 0)
UIDevice.current.model: iPhone
UIDevice.current.systemVersion: 26.0
```

⚠️ However, this seems to cause crashes running the test suite. Will have to investigate more.

✅ Let's discuss this at our next Monday at our concurrency meeting.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
