### PR TITLE
Refactor FXIOS-13157 [Merino] Add caching to provider

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -434,6 +434,7 @@
 		39A359E41BFCCE94006B9E87 /* UserActivityHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A359E31BFCCE94006B9E87 /* UserActivityHandler.swift */; };
 		39A35AED1C0662A3006B9E87 /* SpotlightHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */; };
 		39AF317429DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AF317329DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift */; };
+		39BD570E2E53F3ED00CA1317 /* MerinoFeedFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39BD570D2E53F3E400CA1317 /* MerinoFeedFetcher.swift */; };
 		39C137972655798A003DC662 /* NimbusIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C137962655798A003DC662 /* NimbusIntegrationTests.swift */; };
 		39C261CC2018DE21009D97BD /* FxScreenGraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C261CB2018DE20009D97BD /* FxScreenGraphTests.swift */; };
 		39D056382665235700FBEE59 /* initial_experiments.json in Resources */ = {isa = PBXBuildFile; fileRef = 3964F5FB2656D2B500065278 /* initial_experiments.json */; };
@@ -3222,6 +3223,7 @@
 		39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = SpotlightHelper.js; sourceTree = "<group>"; };
 		39AD454C88A908D41BA13329 /* te */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = te; path = te.lproj/Today.strings; sourceTree = "<group>"; };
 		39AF317329DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusMessagingMessageTests.swift; sourceTree = "<group>"; };
+		39BD570D2E53F3E400CA1317 /* MerinoFeedFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerinoFeedFetcher.swift; sourceTree = "<group>"; };
 		39C137962655798A003DC662 /* NimbusIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusIntegrationTests.swift; sourceTree = "<group>"; };
 		39C261CB2018DE20009D97BD /* FxScreenGraphTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxScreenGraphTests.swift; sourceTree = "<group>"; };
 		39D0DA7429D767D1000760B8 /* NimbusMessagingTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusMessagingTriggerTests.swift; sourceTree = "<group>"; };
@@ -14440,6 +14442,7 @@
 			children = (
 				C8B0F5F0283B7CCE007AE65D /* Model */,
 				81C3814F2E2D22DB00096AAE /* MerinoProvider.swift */,
+				39BD570D2E53F3E400CA1317 /* MerinoFeedFetcher.swift */,
 				81F1010C2E2EB642008F6FDC /* MerinoTestData.swift */,
 			);
 			path = Merino;
@@ -18763,6 +18766,7 @@
 				E13C07292C217D700087E404 /* NavigationBarState.swift in Sources */,
 				59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */,
 				0A93C8AA2C87070300BEA143 /* TrackingProtectionConnectionStatusView.swift in Sources */,
+				39BD570E2E53F3ED00CA1317 /* MerinoFeedFetcher.swift in Sources */,
 				C849E46126B9C39B00260F0B /* EnhancedTrackingProtectionVC.swift in Sources */,
 				8AA0A6632CAC40AA00AC7EB3 /* HomepageDiffableDataSource.swift in Sources */,
 				E40FAB0C1A7ABB77009CB80D /* WebServer.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Stories/StoryProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Stories/StoryProvider.swift
@@ -21,9 +21,10 @@ final class StoryProvider: FeatureFlaggable, Sendable {
     func fetchStories() async -> [MerinoStory] {
         let isStoriesRedesignEnabled = featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
         let numberOfStoriesIfRedesignEnabled = 9
-        let numberOfStories = isStoriesRedesignEnabled ? numberOfStoriesIfRedesignEnabled
-                                                             : self.numberOfStories
-        let data = (try? await merinoAPI.fetchStories(items: Int32(numberOfStories))) ?? []
+        let numberOfStories = isStoriesRedesignEnabled
+            ? numberOfStoriesIfRedesignEnabled
+            : self.numberOfStories
+        let data = (try? await merinoAPI.fetchStories(Int32(numberOfStories))) ?? []
         return data.map(MerinoStory.init)
     }
 }

--- a/firefox-ios/Providers/Merino/MerinoFeedFetcher.swift
+++ b/firefox-ios/Providers/Merino/MerinoFeedFetcher.swift
@@ -6,7 +6,11 @@ import Common
 import MozillaAppServices
 
 protocol MerinoFeedFetching: Sendable {
-    func fetch(items: Int32, locale: CuratedRecommendationLocale, userAgent: String) async throws -> [RecommendationDataItem]
+    func fetch(
+        itemCount: Int32,
+        locale: CuratedRecommendationLocale,
+        userAgent: String
+    ) async -> [RecommendationDataItem]
 }
 
 struct MerinoFeedFetcher: MerinoFeedFetching {
@@ -14,10 +18,10 @@ struct MerinoFeedFetcher: MerinoFeedFetching {
     let logger: Logger
 
     func fetch(
-        items: Int32,
+        itemCount: Int32,
         locale: CuratedRecommendationLocale,
         userAgent: String
-    ) async throws -> [RecommendationDataItem] {
+    ) async -> [RecommendationDataItem] {
         do {
             let client = try CuratedRecommendationsClient(
                 config: CuratedRecommendationsConfig(
@@ -25,7 +29,7 @@ struct MerinoFeedFetcher: MerinoFeedFetching {
                     userAgentHeader: userAgent
                 )
             )
-            let request = CuratedRecommendationsRequest(locale: locale, count: items)
+            let request = CuratedRecommendationsRequest(locale: locale, count: itemCount)
             let response = try client.getCuratedRecommendations(request: request)
             return response.data
         } catch let error as CuratedRecommendationsApiError {

--- a/firefox-ios/Providers/Merino/MerinoFeedFetcher.swift
+++ b/firefox-ios/Providers/Merino/MerinoFeedFetcher.swift
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import MozillaAppServices
+
+protocol MerinoFeedFetching: Sendable {
+    func fetch(items: Int32, locale: CuratedRecommendationLocale, userAgent: String) async throws -> [RecommendationDataItem]
+}
+
+struct MerinoFeedFetcher: MerinoFeedFetching {
+    let baseURL: String
+    let logger: Logger
+
+    func fetch(
+        items: Int32,
+        locale: CuratedRecommendationLocale,
+        userAgent: String
+    ) async throws -> [RecommendationDataItem] {
+        do {
+            let client = try CuratedRecommendationsClient(
+                config: CuratedRecommendationsConfig(
+                    baseHost: baseURL,
+                    userAgentHeader: userAgent
+                )
+            )
+            let request = CuratedRecommendationsRequest(locale: locale, count: items)
+            let response = try client.getCuratedRecommendations(request: request)
+            return response.data
+        } catch let error as CuratedRecommendationsApiError {
+            switch error {
+            case .Network(let reason):
+                logger.log(
+                    "Network error when fetching Curated Recommendations: \(reason)",
+                    level: .debug,
+                    category: .merino
+                )
+            case .Other(let code?, let reason) where code == 400:
+                logger.log(
+                    "Bad Request: \(reason)",
+                    level: .debug,
+                    category: .merino
+                )
+            case .Other(let code?, let reason) where code == 422:
+                logger.log(
+                    "Validation Error: \(reason)",
+                    level: .debug,
+                    category: .merino
+                )
+            case .Other(let code?, let reason) where (500...599).contains(code):
+                logger.log(
+                    "Server Error: \(reason)",
+                    level: .debug,
+                    category: .merino
+                )
+            case .Other(nil, let reason):
+                logger.log(
+                    "Missing status code: \(reason)",
+                    level: .debug,
+                    category: .merino
+                )
+            case .Other(_, let reason):
+                logger.log(
+                    "Unexpected Error: \(reason)",
+                    level: .debug,
+                    category: .merino
+                )
+            }
+            return []
+        } catch {
+            logger.log(
+                "Unhandled error: \(error)",
+                level: .debug,
+                category: .merino
+            )
+            return []
+        }
+    }
+}

--- a/firefox-ios/Providers/Merino/MerinoProvider.swift
+++ b/firefox-ios/Providers/Merino/MerinoProvider.swift
@@ -19,7 +19,7 @@ extension MerinoStoriesProviding {
     }
 }
 
-final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked Sendable {
+class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked Sendable {
     private let thresholdInHours: Double
     private let cache: CuratedRecommendationsCacheProtocol
     private let prefs: Prefs

--- a/firefox-ios/Providers/Merino/MerinoProvider.swift
+++ b/firefox-ios/Providers/Merino/MerinoProvider.swift
@@ -37,12 +37,10 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
         self.cache = cache
         self.prefs = prefs
         self.logger = logger
-        self.fetcher =
-            fetcher
-            ?? MerinoFeedFetcher(
-                baseURL: MerinoServicesBaseURL,
-                logger: logger
-            )
+        self.fetcher = fetcher ?? MerinoFeedFetcher(
+            baseURL: MerinoServicesBaseURL,
+            logger: logger
+        )
     }
 
     func fetchStories(_ itemCount: Int32) async throws -> [RecommendationDataItem] {
@@ -51,11 +49,11 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
         }
 
         guard prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.ASPocketStories) ?? true,
-            MerinoProvider.islocaleSupported(Locale.current.identifier)
+              MerinoProvider.islocaleSupported(Locale.current.identifier)
         else { throw Error.failure }
 
         if let cachedItems = cache.loadRecommendations(),
-            cacheUpdateThresholdHasNotPassed() {
+           cacheUpdateThresholdHasNotPassed() {
             return cachedItems
         }
 
@@ -79,7 +77,8 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
 
     static func islocaleSupported(_ locale: String) -> Bool {
         return allCuratedRecommendationLocales().contains(
-            locale.replacingOccurrences(of: "_", with: "-"))
+            locale.replacingOccurrences(of: "_", with: "-")
+        )
     }
 
     private var shouldUseMockData: Bool {

--- a/firefox-ios/Providers/Merino/MerinoProvider.swift
+++ b/firefox-ios/Providers/Merino/MerinoProvider.swift
@@ -44,7 +44,7 @@ class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked Senda
     }
 
     func fetchStories(items: Int32) async throws -> [RecommendationDataItem] {
-        if shouldUseMockData {
+        if !AppConstants.isRunningTest && shouldUseMockData {
             return try await MerinoTestData().getMockDataFeed(count: items)
         }
 

--- a/firefox-ios/Providers/Merino/MerinoProvider.swift
+++ b/firefox-ios/Providers/Merino/MerinoProvider.swift
@@ -10,13 +10,7 @@ import Shared
 protocol MerinoStoriesProviding: Sendable {
     typealias StoryResult = Swift.Result<[RecommendationDataItem], Error>
 
-    func fetchStories(items: Int32) async throws -> [RecommendationDataItem]
-}
-
-extension MerinoStoriesProviding {
-    func fetchStories(items: Int32) async throws -> [RecommendationDataItem] {
-        return try await fetchStories(items: items)
-    }
+    func fetchStories(_ itemCount: Int32) async throws -> [RecommendationDataItem]
 }
 
 final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked Sendable {
@@ -49,10 +43,10 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
         )
     }
 
-    func fetchStories(items: Int32) async throws -> [RecommendationDataItem] {
-        if !AppConstants.isRunningTest && shouldUseMockData {
-            return try await MerinoTestData().getMockDataFeed(count: items)
-        }
+    func fetchStories(_ itemCount: Int32) async throws -> [RecommendationDataItem] {
+//        if !AppConstants.isRunningTest && shouldUseMockData {
+//            return try await MerinoTestData().getMockDataFeed(count: itemCount)
+//        }
 
         guard prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.ASPocketStories) ?? true,
               MerinoProvider.islocaleSupported(Locale.current.identifier)
@@ -67,8 +61,8 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
             return []
         }
 
-        let items = try await fetcher.fetch(
-            items: items,
+        let items = await fetcher.fetch(
+            itemCount: itemCount,
             locale: currentLocale,
             userAgent: UserAgent.getUserAgent()
         )

--- a/firefox-ios/Providers/Merino/MerinoProvider.swift
+++ b/firefox-ios/Providers/Merino/MerinoProvider.swift
@@ -150,7 +150,7 @@ class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked Senda
 
     private func cacheUpdateThresholdHasNotPassed() -> Bool {
         let thresholdInSeconds: TimeInterval = thresholdInHours * 60 * 60
-        guard let lastUpdate = cache.lastUpdatedDate() else { return true }
+        guard let lastUpdate = cache.lastUpdatedDate() else { return false }
         return Date() < lastUpdate.addingTimeInterval(thresholdInSeconds)
     }
 }

--- a/firefox-ios/Providers/Merino/MerinoProvider.swift
+++ b/firefox-ios/Providers/Merino/MerinoProvider.swift
@@ -37,23 +37,25 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
         self.cache = cache
         self.prefs = prefs
         self.logger = logger
-        self.fetcher = fetcher ?? MerinoFeedFetcher(
-            baseURL: MerinoServicesBaseURL,
-            logger: logger
-        )
+        self.fetcher =
+            fetcher
+            ?? MerinoFeedFetcher(
+                baseURL: MerinoServicesBaseURL,
+                logger: logger
+            )
     }
 
     func fetchStories(_ itemCount: Int32) async throws -> [RecommendationDataItem] {
-//        if !AppConstants.isRunningTest && shouldUseMockData {
-//            return try await MerinoTestData().getMockDataFeed(count: itemCount)
-//        }
+        if !AppConstants.isRunningTest && shouldUseMockData {
+            return try await MerinoTestData().getMockDataFeed(count: itemCount)
+        }
 
         guard prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.ASPocketStories) ?? true,
-              MerinoProvider.islocaleSupported(Locale.current.identifier)
+            MerinoProvider.islocaleSupported(Locale.current.identifier)
         else { throw Error.failure }
 
         if let cachedItems = cache.loadRecommendations(),
-           cacheUpdateThresholdHasNotPassed() {
+            cacheUpdateThresholdHasNotPassed() {
             return cachedItems
         }
 
@@ -76,7 +78,8 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
     }
 
     static func islocaleSupported(_ locale: String) -> Bool {
-        return allCuratedRecommendationLocales().contains(locale.replacingOccurrences(of: "_", with: "-"))
+        return allCuratedRecommendationLocales().contains(
+            locale.replacingOccurrences(of: "_", with: "-"))
     }
 
     private var shouldUseMockData: Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
@@ -2,12 +2,60 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
+import Shared
 import XCTest
 import MozillaAppServices
 
 @testable import Client
 
-class MerinoProviderTests: XCTestCase {
+private final class MockCache: CuratedRecommendationsCacheProtocol {
+    private(set) var savedItemsHistory: [[RecommendationDataItem]] = []
+    private(set) var didClear = false
+
+    private var _stored: [RecommendationDataItem]?
+    private var _lastUpdated: Date?
+
+    func loadRecommendations() -> [RecommendationDataItem]? { _stored }
+
+    func save(_ items: [RecommendationDataItem]) {
+        _stored = items
+        _lastUpdated = Date()
+        savedItemsHistory.append(items)
+    }
+
+    func clearCache() {
+        didClear = true
+        _stored = nil
+        _lastUpdated = nil
+    }
+
+    func lastUpdatedDate() -> Date? { _lastUpdated }
+
+    // Testing helpers
+    func seed(items: [RecommendationDataItem], lastUpdated: Date) {
+        _stored = items
+        _lastUpdated = lastUpdated
+    }
+    func seedEmpty(lastUpdated: Date? = nil) {
+        _stored = nil
+        _lastUpdated = lastUpdated
+    }
+}
+
+private final class TestableMerinoProvider: MerinoProvider, @unchecked Sendable {
+    var stubbedItems: [RecommendationDataItem] = []
+    var getFeedItemsCallCount = 0
+
+    override func getFeedItems(items: Int32) async throws -> [RecommendationDataItem] {
+        getFeedItemsCallCount += 1
+        return stubbedItems
+    }
+}
+
+final class MerinoProviderTests: XCTestCase {
+    private let storiesFlag = PrefsKeys.UserFeatureFlagPrefs.ASPocketStories
+
     func testIncorrectLocalesAreNotSupported() {
         XCTAssertFalse(MerinoProvider.islocaleSupported("en_BD"))
         XCTAssertFalse(MerinoProvider.islocaleSupported("enCA"))
@@ -17,5 +65,89 @@ class MerinoProviderTests: XCTestCase {
         XCTAssertTrue(MerinoProvider.islocaleSupported("en_US"))
         XCTAssertTrue(MerinoProvider.islocaleSupported("en_GB"))
         XCTAssertTrue(MerinoProvider.islocaleSupported("en_CA"))
+    }
+
+    func test_fetchStories_returnsCached_whenThresholdNotPassed() async throws {
+        let (sut, cache) = createSubject(thresholdHours: 4)
+        cache.seed(items: [makeItem("a"), makeItem("b")], lastUpdated: Date())
+        sut.stubbedItems = [makeItem("net1"), makeItem("net2")]
+
+        let result = try await sut.fetchStories(items: 10)
+
+        XCTAssertEqual(result.map(\.title), ["a", "b"])
+        XCTAssertEqual(sut.getFeedItemsCallCount, 0)
+        XCTAssertFalse(cache.didClear)
+    }
+
+    func test_fetchStories_fetchesAndSaves_whenThresholdPassed() async throws {
+        let (sut, cache) = createSubject(thresholdHours: 1/60)
+        cache.seed(items: [makeItem("old")], lastUpdated: Date().addingTimeInterval(-3600))
+        sut.stubbedItems = [makeItem("new1"), makeItem("new2")]
+
+        let result = try await sut.fetchStories(items: 10)
+
+        XCTAssertEqual(result.map(\.title), ["new1", "new2"])
+        XCTAssertTrue(cache.didClear)
+        XCTAssertEqual(cache.loadRecommendations()?.map(\.title), ["new1", "new2"])
+        XCTAssertEqual(sut.getFeedItemsCallCount, 1)
+    }
+
+    func test_fetchStories_fetchesAndSaves_whenNoCache() async throws {
+        let (sut, cache) = createSubject()
+        cache.seedEmpty()
+        sut.stubbedItems = [makeItem("net")]
+
+        let result = try await sut.fetchStories(items: 5)
+
+        XCTAssertEqual(result.map(\.title), ["net"])
+        XCTAssertTrue(cache.didClear)
+        XCTAssertEqual(cache.loadRecommendations()?.map(\.title), ["net"])
+        XCTAssertEqual(sut.getFeedItemsCallCount, 1)
+    }
+
+    func test_fetchStories_throws_whenFeatureDisabled() async {
+        let (sut, _) = createSubject(prefsEnabled: false)
+
+        do {
+                _ = try await sut.fetchStories(items: 3)
+                XCTFail("Expected MerinoProvider.Error to be thrown")
+            } catch let error as MerinoProvider.Error {
+                XCTAssertEqual(error, MerinoProvider.Error.failure)
+            } catch {
+                XCTFail("Threw unexpected error: \(error)")
+            }
+    }
+
+    private func makeItem(_ name: String) -> RecommendationDataItem {
+        return RecommendationDataItem(
+            corpusItemId: "\(name)",
+            scheduledCorpusItemId: "\(name)",
+            url: "https://\(name).com",
+            title: "\(name)",
+            excerpt: "Excerpt \(name)",
+            publisher: "Publisher \(name)",
+            isTimeSensitive: false,
+            imageUrl: "https://example\(name).com",
+            iconUrl: "https://example\(name).com",
+            tileId: 0,
+            receivedRank: 0
+        )
+    }
+
+    private func createSubject(
+        thresholdHours: Double = 4,
+        prefsEnabled: Bool = true,
+        cache: MockCache = MockCache(),
+    ) -> (TestableMerinoProvider, MockCache) {
+        let prefs = MockProfilePrefs()
+        prefs.setBool(prefsEnabled, forKey: storiesFlag)
+        let sut = TestableMerinoProvider(
+            withThresholdInHours: thresholdHours,
+            prefs: prefs,
+            cache: cache,
+        )
+
+        trackForMemoryLeaks(sut)
+        return (sut, cache)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
@@ -109,13 +109,13 @@ final class MerinoProviderTests: XCTestCase {
         let (sut, _) = createSubject(prefsEnabled: false)
 
         do {
-                _ = try await sut.fetchStories(items: 3)
-                XCTFail("Expected MerinoProvider.Error to be thrown")
-            } catch let error as MerinoProvider.Error {
-                XCTAssertEqual(error, MerinoProvider.Error.failure)
-            } catch {
-                XCTFail("Threw unexpected error: \(error)")
-            }
+            _ = try await sut.fetchStories(items: 3)
+            XCTFail("Expected MerinoProvider.Error to be thrown")
+        } catch let error as MerinoProvider.Error {
+            XCTAssertEqual(error, MerinoProvider.Error.failure)
+        } catch {
+            XCTFail("Threw unexpected error: \(error)")
+        }
     }
 
     private func makeItem(_ name: String) -> RecommendationDataItem {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
@@ -123,7 +123,7 @@ final class MerinoProviderTests: XCTestCase {
         let (sut, cache) = createSubject(prefsEnabled: true)
 
         // Cache has items but NO timestamp should be treated as STALE and must fetch
-        // new stories. We should never get in this position, but it should be checked.
+        // new stories. We should never get here, but we should still test it.
         cache.seed(items: [makeItem("staleButNoTimestamp")], lastUpdated: nil)
 
         sut.stubbedItems = [makeItem("net1"), makeItem("net2")]

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
@@ -158,7 +158,7 @@ final class MerinoProviderTests: XCTestCase {
     private func createSubject(
         thresholdHours: Double = 4,
         prefsEnabled: Bool = true,
-        cache: MockCache = MockCache(),
+        cache: MockCache = MockCache()
     ) -> (TestableMerinoProvider, MockCache) {
         let prefs = MockProfilePrefs()
         prefs.setBool(prefsEnabled, forKey: storiesFlag)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockMerinoAPI.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockMerinoAPI.swift
@@ -14,10 +14,10 @@ final class MockMerinoAPI: MerinoStoriesProviding {
 
     let result: Result<[RecommendationDataItem], Error>
 
-    func fetchStories(items: Int32) async throws -> [RecommendationDataItem] {
+    func fetchStories(_ itemCount: Int32) async throws -> [RecommendationDataItem] {
         switch result {
         case .success(let value):
-            return Array(value.prefix(Int(items)))
+            return Array(value.prefix(Int(itemCount)))
         case .failure(let error):
             throw error
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13157)

## :bulb: Description
Changes the provider logic to use the caching utility.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
