### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Shared - Fix (or suppress) global state warnings in AppInfo extension.

### DIFF
--- a/BrowserKit/Sources/Shared/AppInfo.swift
+++ b/BrowserKit/Sources/Shared/AppInfo.swift
@@ -17,11 +17,12 @@ extension AppInfo {
         return appVersion.components(separatedBy: ".").first!
     }
 
+    // FIXME: FXIOS-13210 nonisolated(unsafe) because some tests need to mutate this global state
     /// The port for the internal webserver, tests can change this
     /// Please be aware that we needed to migrate this webserverPort in WebEngine.WKEngineInfo
     /// due to Shared target issues in #17721. This webserverPort needs to be deleted with
     /// FXIOS-7960 once the WebEngine package is integrated in Firefox iOS
-    public static var webserverPort = 6571
+    public static nonisolated(unsafe) var webserverPort = 6571
 
     /// Return the keychain access group.
     public static func keychainAccessGroupWithPrefix(_ prefix: String) -> String {
@@ -36,7 +37,7 @@ extension AppInfo {
 
     public static let debugPrefIsChinaEdition = "debugPrefIsChinaEdition"
 
-    public static var isChinaEdition: Bool = {
+    public static let isChinaEdition: Bool = {
         if UserDefaults.standard.bool(forKey: AppInfo.debugPrefIsChinaEdition) {
             return true
         }
@@ -44,7 +45,7 @@ extension AppInfo {
     }()
 
     // The App Store page identifier for the Firefox iOS application
-    public static var appStoreId = "id989804926"
+    public static let appStoreId = "id989804926"
 
     /// Return the shared container identifier (also known as the app group) to be used with for example background
     /// http requests. It is the base bundle identifier with a "group." prefix.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix (or suppress) global state warnings in the Shared package's AppInfo extension.

<img width="1468" height="654" alt="Screenshot 2025-08-18 at 2 16 08 PM" src="https://github.com/user-attachments/assets/fe0e25da-6242-4951-914b-01e6f6b6cf60" />

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
