### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Shared - Fix a few easy Deferred & LockProtected warnings

### DIFF
--- a/BrowserKit/Sources/Shared/Deferred/Deferred.swift
+++ b/BrowserKit/Sources/Shared/Deferred/Deferred.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-public var DeferredDefaultQueue = DispatchQueue.global()
+public let DeferredDefaultQueue = DispatchQueue.global()
 
 // TODO: FXIOS-13184 Remove deferred code or validate it is sendable
 open class Deferred<T>: @unchecked Sendable {
-    typealias UponBlock = (DispatchQueue, (T) -> ())
+    typealias UponBlock = (DispatchQueue, @Sendable (T) -> ())
     private typealias Protected = (protectedValue: T?, uponBlocks: [UponBlock])
 
     private var protected: LockProtected<Protected>
@@ -57,7 +57,7 @@ open class Deferred<T>: @unchecked Sendable {
         return protected.withReadLock { $0.protectedValue }
     }
 
-    public func uponQueue(_ queue: DispatchQueue, block: @escaping (T) -> ()) {
+    public func uponQueue(_ queue: DispatchQueue, block: @Sendable @escaping (T) -> ()) {
         let maybeValue: T? = protected.withWriteLock{ data in
             if data.protectedValue == nil {
                 data.uponBlocks.append( (queue, block) )

--- a/BrowserKit/Sources/Shared/Deferred/LockProtected.swift
+++ b/BrowserKit/Sources/Shared/Deferred/LockProtected.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-public final class LockProtected<T> {
+// FIXME: FXIOS-13211 Validate this is Sendable, remove along with Deferred code, or actually make it concurrency safe.
+public final class LockProtected<T>: @unchecked Sendable {
     private var lock: ReadWriteLock
     private var item: T
 
@@ -21,13 +22,13 @@ public final class LockProtected<T> {
         self.lock = lock
     }
 
-    public func withReadLock<U>(block: (T) -> U) -> U {
+    public func withReadLock<U>(block: @Sendable (T) -> U) -> U {
         return lock.withReadLock { [unowned self] in
             return block(self.item)
         }
     }
 
-    public func withWriteLock<U>(block: (inout T) -> U) -> U {
+    public func withWriteLock<U>(block: @Sendable (inout T) -> U) -> U {
         return lock.withWriteLock { [unowned self] in
             return block(&self.item)
         }

--- a/BrowserKit/Sources/Shared/Deferred/ReadWriteLock.swift
+++ b/BrowserKit/Sources/Shared/Deferred/ReadWriteLock.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 public protocol ReadWriteLock: AnyObject {
-    func withReadLock<T>(block: () -> T) -> T
-    func withWriteLock<T>(block: () -> T) -> T
+    func withReadLock<T>(block: @Sendable () -> T) -> T
+    func withWriteLock<T>(block: @Sendable () -> T) -> T
 }
 
 public final class GCDReadWriteLock: ReadWriteLock {
@@ -26,7 +26,7 @@ public final class GCDReadWriteLock: ReadWriteLock {
         return result
     }
 
-    public func withWriteLock<T>(block: () -> T) -> T {
+    public func withWriteLock<T>(block: @Sendable () -> T) -> T {
         var result: T!
         queue.sync {
             result = block()

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -200,14 +200,19 @@ class ShareSheetCoordinator: BaseCoordinator,
             return
         }
 
-        profile.sendItem(shareItem, toDevices: devices).uponQueue(.main) { [weak self] _ in
-            guard let self = self else { return }
-            self.router.dismiss()
-            self.parentCoordinator?.didFinish(from: self)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-                self?.showToast(text: .LegacyAppMenu.AppMenuTabSentConfirmMessage)
+        profile.sendItem(shareItem, toDevices: devices)
+            .uponQueue(.main) { [weak self] _ in
+                // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    self.router.dismiss()
+                    self.parentCoordinator?.didFinish(from: self)
+
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                        self?.showToast(text: .LegacyAppMenu.AppMenuTabSentConfirmMessage)
+                    }
+                }
             }
-        }
     }
 
     // MARK: - InstructionViewDelegate

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -782,10 +782,14 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
                                      iconString: StandardImageIdentifiers.Large.bookmarkSlash) { _ in
             guard let url = self.tabUrl?.displayURL else { return }
 
-            self.profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
-                guard result.isSuccess else { return }
-                self.removeBookmarkShortcut()
-            }
+            self.profile.places.deleteBookmarksWithURL(url: url.absoluteString)
+                .uponQueue(.main) { result in
+                    // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                    MainActor.assumeIsolated {
+                        guard result.isSuccess else { return }
+                        self.removeBookmarkShortcut()
+                    }
+                }
             let bookmarksTelemetry = BookmarksTelemetry()
             bookmarksTelemetry.deleteBookmark(eventLabel: .pageActionMenu)
         }

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -419,16 +419,22 @@ class SearchViewController: SiteTableViewController,
 
         ensureMainThread {
             // Get cached tabs
-            self.profile.getCachedClientsAndTabs().uponQueue(.main) { result in
-                guard let clientAndTabs = result.successValue else { return }
-                self.viewModel.remoteClientTabs.removeAll()
-                // Update UI with cached data.
-                clientAndTabs.forEach { value in
-                    value.tabs.forEach { (tab) in
-                        self.viewModel.remoteClientTabs.append(ClientTabsSearchWrapper(client: value.client, tab: tab))
+            self.profile.getCachedClientsAndTabs()
+                .uponQueue(.main) { result in
+                    // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                    MainActor.assumeIsolated {
+                        guard let clientAndTabs = result.successValue else { return }
+                        self.viewModel.remoteClientTabs.removeAll()
+                        // Update UI with cached data.
+                        clientAndTabs.forEach { value in
+                            value.tabs.forEach { (tab) in
+                                self.viewModel.remoteClientTabs.append(
+                                    ClientTabsSearchWrapper(client: value.client, tab: tab)
+                                )
+                            }
+                        }
                     }
                 }
-            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -275,15 +275,23 @@ final class BookmarksViewController: SiteTableViewController,
     /// Performs the delete asynchronously even though we update the
     /// table view data source immediately for responsiveness.
     private func deleteBookmarkNode(_ indexPath: IndexPath, bookmarkNode: FxBookmarkNode) {
-        profile.places.deleteBookmarkNode(guid: bookmarkNode.guid).uponQueue(.main) { _ in
-            if let recentBookmarkFolderGuid = self.profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder) {
-                self.profile.places.getBookmark(guid: recentBookmarkFolderGuid).uponQueue(.main) { node in
-                    guard let nodeValue = node.successValue, nodeValue == nil else { return }
-                    self.profile.prefs.removeObjectForKey(PrefsKeys.RecentBookmarkFolder)
+        profile.places.deleteBookmarkNode(guid: bookmarkNode.guid)
+            .uponQueue(.main) { _ in
+                // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                MainActor.assumeIsolated {
+                    if let recentBookmarkFolderGuid = self.profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder) {
+                        self.profile.places.getBookmark(guid: recentBookmarkFolderGuid)
+                            .uponQueue(.main) { node in
+                                // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                                MainActor.assumeIsolated {
+                                    guard let nodeValue = node.successValue, nodeValue == nil else { return }
+                                    self.profile.prefs.removeObjectForKey(PrefsKeys.RecentBookmarkFolder)
+                                }
+                            }
+                    }
+                    self.removeBookmarkShortcut()
                 }
             }
-            self.removeBookmarkShortcut()
-        }
 
         tableView.beginUpdates()
         viewModel.bookmarkNodes.remove(at: indexPath.row)

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -786,13 +786,17 @@ extension HistoryPanel {
     }
 
     private func resyncHistory() {
-        profile.syncManager?.syncHistory().uponQueue(.main) { syncResult in
-            self.endRefreshing()
+        profile.syncManager?.syncHistory()
+            .uponQueue(.main) { syncResult in
+                // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                MainActor.assumeIsolated {
+                    self.endRefreshing()
 
-            if syncResult.isSuccess {
-                self.fetchDataAndUpdateLayout(animating: true)
+                    if syncResult.isSuccess {
+                        self.fetchDataAndUpdateLayout(animating: true)
+                    }
+                }
             }
-        }
     }
 }
 
@@ -826,13 +830,17 @@ extension HistoryPanel {
 
     /// When long pressed, a menu appears giving the choice of pinning as a Top Site.
     func pinToTopSites(_ site: Site) {
-        profile.pinnedSites.addPinnedTopSite(site).uponQueue(.main) { result in
-            if result.isSuccess {
-                SimpleToast().showAlertWithText(.LegacyAppMenu.AddPinToShortcutsConfirmMessage,
-                                                bottomContainer: self.view,
-                                                theme: self.currentTheme())
+        profile.pinnedSites.addPinnedTopSite(site)
+            .uponQueue(.main) { result in
+                // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                MainActor.assumeIsolated {
+                    if result.isSuccess {
+                        SimpleToast().showAlertWithText(.LegacyAppMenu.AddPinToShortcutsConfirmMessage,
+                                                        bottomContainer: self.view,
+                                                        theme: self.currentTheme())
+                    }
+                }
             }
-        }
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -187,10 +187,13 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             }
             .allSucceed()
             .uponQueue(.main) { result in
-                self.profile.prefs.setObject(self.toggles, forKey: Keys.keyTogglesPref.rawValue)
+                // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                MainActor.assumeIsolated {
+                    self.profile.prefs.setObject(self.toggles, forKey: Keys.keyTogglesPref.rawValue)
 
-                // Disable the Clear Private Data button after it's clicked.
-                self.clearButtonEnabled = false
+                    // Disable the Clear Private Data button after it's clicked.
+                    self.clearButtonEnabled = false
+                }
             }
     }
 

--- a/firefox-ios/Extensions/ShareTo/SendToDevice.swift
+++ b/firefox-ios/Extensions/ShareTo/SendToDevice.swift
@@ -65,11 +65,15 @@ class SendToDevice: DevicePickerViewControllerDelegate, InstructionsViewDelegate
             return finish()
         }
 
-        profile.sendItem(item, toDevices: devices).uponQueue(.main) { _ in
-            self.finish()
+        profile.sendItem(item, toDevices: devices)
+            .uponQueue(.main) { _ in
+                // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                MainActor.assumeIsolated {
+                    self.finish()
 
-            addAppExtensionTelemetryEvent(forMethod: "send-to-device")
-        }
+                    addAppExtensionTelemetryEvent(forMethod: "send-to-device")
+                }
+            }
     }
 
     func devicePickerViewControllerDidCancel(_ devicePickerViewController: DevicePickerViewController) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix a few of the easier warnings in the Deferred-related Shared package code.

This one, and some closure Sendability:
<img width="1445" height="241" alt="Screenshot 2025-08-18 at 3 17 26 PM" src="https://github.com/user-attachments/assets/c88a9b98-d842-4fc2-8ed8-3f884793fccf" />

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
