### PR TITLE
Disable default flag for ToU feature

### DIFF
--- a/firefox-ios/nimbus-features/touFeature.yaml
+++ b/firefox-ios/nimbus-features/touFeature.yaml
@@ -8,7 +8,7 @@ features:
         description: >
           Enables the feature
         type: Boolean
-        default: true
+        default: false
     defaults:
       - channel: beta
         value:


### PR DESCRIPTION
## :scroll: Tickets
~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~
~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~

## :bulb: Description

This PR sets Terms of Use Feature Flag on false also for default (it was already set false on channel beta and developer)
[User impact if declined]: Without this change the Terms of Use Feature would promp to the user

[Is this code covered by automated tests?] Unknown

[Has the fix been verified in Nightly?] No

[Needs manual test from QA?] Yes

[If yes, steps to reproduce] The issue is that since the channels with the flag set to false were beta and developer, the ToU bottom sheet appeared on the release channel, when the user opened the app.

[Risk to taking this patch] Low

[Why is the change not risky? ] It makes sure the ToU Feature is disabled on all configs so it won t impact since we make sure the ToU feature won't appear

[String changes made/needed] none

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
