### PR TITLE
Refactor FXIOS-13176 [Tab tray] [iOS 26] Tab Tray Glass Updates

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -18,6 +18,7 @@ struct TabTraySelectorUX {
     static let fontScaleDelta: CGFloat = 0.055
     static let stackViewLeadingTrailingPadding: CGFloat = 8
     static let containerHorizontalSpacing: CGFloat = 16
+    static let bottomSpacingIOS26: CGFloat = 16
 }
 
 class TabTraySelectorView: UIView,
@@ -87,9 +88,15 @@ class TabTraySelectorView: UIView,
             applyButtonWidthAnchor(on: button, with: title as NSString)
         }
 
+        let bottomSpacing: CGFloat = if #available(iOS 26.0, *) {
+            -TabTraySelectorUX.bottomSpacingIOS26
+        } else {
+            0
+        }
+
         NSLayoutConstraint.activate([
             containerView.topAnchor.constraint(equalTo: topAnchor),
-            containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomSpacing),
             containerView.leadingAnchor.constraint(equalTo: leadingAnchor,
                                                    constant: TabTraySelectorUX.containerHorizontalSpacing),
             containerView.trailingAnchor.constraint(equalTo: trailingAnchor,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -47,6 +47,7 @@ final class TabTrayViewController: UIViewController,
         static let segmentedControlTopSpacing: CGFloat = 8
         static let segmentedControlHorizontalSpacing: CGFloat = 16
         static let segmentedControlMinHeight: CGFloat = 45
+        static let segmentedControlMinHeightIOS26: CGFloat = 61
     }
 
     // MARK: Theme
@@ -484,6 +485,12 @@ final class TabTrayViewController: UIViewController,
 
             containerView.addSubview(panelContainer)
 
+            let segmentControlHeight = if #available(iOS 26.0, *) {
+                UX.segmentedControlMinHeightIOS26
+            } else {
+                UX.segmentedControlMinHeight
+            }
+
             NSLayoutConstraint.activate([
                 panelContainer.topAnchor.constraint(equalTo: containerView.topAnchor),
                 panelContainer.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
@@ -505,7 +512,7 @@ final class TabTrayViewController: UIViewController,
                 experimentSegmentControl.bottomAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.bottomAnchor),
                 experimentSegmentControl.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
                 experimentSegmentControl.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-                experimentSegmentControl.heightAnchor.constraint(equalToConstant: UX.segmentedControlMinHeight)
+                experimentSegmentControl.heightAnchor.constraint(equalToConstant: segmentControlHeight)
             ])
         } else {
             view.addSubview(navigationToolbar)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13176)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28658)

## :bulb: Description
Increases the spacing under the segmented control on tab tray for iOS 26.

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-19 at 10 37 03" src="https://github.com/user-attachments/assets/f767e099-39d4-4e7d-bca5-6d0d98dc61ff" /> | <img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-19 at 10 27 12" src="https://github.com/user-attachments/assets/35300e3d-2d82-4006-9ffa-72f2419eb87d" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
