### PR TITLE
Bugfix FXIOS-13140 [Shake to Summarize] update tests for iOS 26

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppleIntelligenceUtilTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppleIntelligenceUtilTests.swift
@@ -26,7 +26,8 @@ final class AppleIntelligenceUtilTests: XCTestCase {
 
         XCTAssertTrue(subject.isAppleIntelligenceAvailable)
         XCTAssertTrue(userDefaults.bool(forKey: PrefsKeys.appleIntelligenceAvailable))
-        XCTAssertEqual(userDefaults.setCalledCount, 1)
+        XCTAssertFalse(userDefaults.bool(forKey: PrefsKeys.cannotRunAppleIntelligence))
+        XCTAssertEqual(userDefaults.setCalledCount, 2)
     }
 
     func testAppleIntelligenceAvailability_whenIsNotAvailable_returnsFalse() {
@@ -35,7 +36,8 @@ final class AppleIntelligenceUtilTests: XCTestCase {
 
         XCTAssertFalse(subject.isAppleIntelligenceAvailable)
         XCTAssertFalse(userDefaults.bool(forKey: PrefsKeys.appleIntelligenceAvailable))
-        XCTAssertEqual(userDefaults.setCalledCount, 1)
+        XCTAssertFalse(userDefaults.bool(forKey: PrefsKeys.cannotRunAppleIntelligence))
+        XCTAssertEqual(userDefaults.setCalledCount, 2)
     }
 
     func testAppleIntelligenceAvailability_whenNotProcessed_returnsFalse() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
@@ -28,7 +28,7 @@ final class SummarizeSettingsViewControllerTests: XCTestCase {
         let subject = createSubject()
         let sections = subject.generateSettings()
         XCTAssertEqual(sections.count, 2)
-        XCTAssertEqual(sections.first?.title, nil)
+        XCTAssertNil(sections.first?.title)
         XCTAssertEqual(sections.first?.children.count, 1)
         XCTAssertEqual(sections.last?.title?.string, "Gestures")
         XCTAssertEqual(sections.last?.children.count, 1)
@@ -40,9 +40,9 @@ final class SummarizeSettingsViewControllerTests: XCTestCase {
         let subject = createSubject()
         let sections = subject.generateSettings()
         XCTAssertEqual(sections.count, 1)
-        XCTAssertEqual(sections.first?.title, nil)
+        XCTAssertNil(sections.first?.title)
         XCTAssertEqual(sections.first?.children.count, 1)
-        XCTAssertEqual(sections.last?.title?.string, nil)
+        XCTAssertNil(sections.last?.title?.string)
         XCTAssertEqual(sections.last?.children.count, 1)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
@@ -13,6 +13,7 @@ final class SummarizeSettingsViewControllerTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         self.profile = MockProfile()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
     override func tearDown() {
@@ -22,7 +23,8 @@ final class SummarizeSettingsViewControllerTests: XCTestCase {
     }
 
     @MainActor
-    func test_generateSettings_withDefault_hasExpectedSections() {
+    func test_generateSettings_withShakeFeature_hasExpectedSections() {
+        setupNimbusHostedSummarizerTesting(isEnabled: true)
         let subject = createSubject()
         let sections = subject.generateSettings()
         XCTAssertEqual(sections.count, 2)
@@ -32,10 +34,28 @@ final class SummarizeSettingsViewControllerTests: XCTestCase {
         XCTAssertEqual(sections.last?.children.count, 1)
     }
 
+    @MainActor
+    func test_generateSettings_withoutShakeFeature_hasExpectedSections() {
+        setupNimbusHostedSummarizerTesting(isEnabled: false)
+        let subject = createSubject()
+        let sections = subject.generateSettings()
+        XCTAssertEqual(sections.count, 1)
+        XCTAssertEqual(sections.first?.title, nil)
+        XCTAssertEqual(sections.first?.children.count, 1)
+        XCTAssertEqual(sections.last?.title?.string, nil)
+        XCTAssertEqual(sections.last?.children.count, 1)
+    }
+
     // MARK: - Helper
     private func createSubject() -> SummarizeSettingsViewController {
         let subject = SummarizeSettingsViewController(prefs: profile.prefs, windowUUID: .XCTestDefaultUUID)
         trackForMemoryLeaks(subject)
         return subject
+    }
+
+    private func setupNimbusHostedSummarizerTesting(isEnabled: Bool) {
+        FxNimbus.shared.features.hostedSummarizerFeature.with { _, _ in
+            return HostedSummarizerFeature(enabled: isEnabled, shakeGesture: isEnabled)
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13140)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28591)

## :bulb: Description
Fix tests that were broken in our iOS 26 unit tests workflow due to requirement changes but no update to tests.
Bitrise: https://app.bitrise.io/build/226c5475-8bb0-4e5f-9ebd-a9d3e0ed2ee8

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
