### PR TITLE
Refactor FXIOS-13166 [Acorn] summarize color tokens to proper naming

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/DarkTheme.swift
@@ -56,7 +56,7 @@ private struct DarkColourPalette: ThemeColourPalette {
     ])
     var layerSurfaceLow = FXColors.DarkGrey60
     var layerSurfaceMedium = FXColors.DarkGrey80
-    var layerSummary = Gradient(colors: [
+    var layerGradientSummary = Gradient(colors: [
         FXColors.Red70,
         FXColors.Orange50
     ])

--- a/BrowserKit/Sources/Common/Theming/LightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/LightTheme.swift
@@ -45,7 +45,7 @@ private struct LightColourPalette: ThemeColourPalette {
     ])
     var layerSurfaceLow = FXColors.LightGrey20
     var layerSurfaceMedium = FXColors.White
-    var layerSummary = Gradient(colors: [
+    var layerGradientSummary = Gradient(colors: [
         FXColors.Red70,
         FXColors.Orange50
     ])

--- a/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
@@ -47,7 +47,7 @@ private struct PrivateModeColorPalette: ThemeColourPalette {
     ])
     var layerSurfaceLow = UIColor(rgb: 0x342B4A)
     var layerSurfaceMedium = UIColor(rgb: 0x24183A)
-    var layerSummary = Gradient(colors: [
+    var layerGradientSummary = Gradient(colors: [
         FXColors.Red70,
         FXColors.Orange50
     ])

--- a/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
@@ -33,8 +33,7 @@ public protocol ThemeColourPalette {
     var layerGradientURL: Gradient { get }
     var layerSurfaceLow: UIColor { get }
     var layerSurfaceMedium: UIColor { get }
-    // TODO: - FXIOS-12896 - colors name might need to be adjusted as per design review
-    var layerSummary: Gradient { get }
+    var layerGradientSummary: Gradient { get }
 
     // MARK: - Ratings
     var layerRatingA: UIColor { get }
@@ -104,12 +103,11 @@ public protocol ThemeColourPalette {
     var shadowSubtle: UIColor { get }
     var shadowDefault: UIColor { get }
     var shadowStrong: UIColor { get }
+    var shadowBorder: UIColor { get }
 
     // MARK: - Gradient
     var gradientOnboardingStop1: UIColor { get }
     var gradientOnboardingStop2: UIColor { get }
     var gradientOnboardingStop3: UIColor { get }
     var gradientOnboardingStop4: UIColor { get }
-
-    var shadowBorder: UIColor { get }
 }

--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -586,7 +586,7 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
             closeButton.configuration?.baseBackgroundColor = theme.colors.actionTabActive
         }
         closeButton.configuration?.baseForegroundColor = theme.colors.textPrimary
-        backgroundGradient.colors = theme.colors.layerSummary.cgColors
+        backgroundGradient.colors = theme.colors.layerGradientSummary.cgColors
         gradient.applyTheme(theme: theme)
         errorView.applyTheme(theme: theme)
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
@@ -94,7 +94,7 @@ struct TabTrayPanelSwipePalette: ThemeColourPalette {
     var layerGradientURL: Gradient { base.layerGradientURL }
     var layerSurfaceLow: UIColor { base.layerSurfaceLow }
     var layerSurfaceMedium: UIColor { base.layerSurfaceMedium }
-    var layerSummary: Gradient { base.layerSummary }
+    var layerGradientSummary: Gradient { base.layerGradientSummary }
 
     var layerRatingA: UIColor { base.layerRatingA }
     var layerRatingASubdued: UIColor { base.layerRatingASubdued }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13166)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
To move fast, we added some new tokens for the shake to summarize project: `shadowBorder` and `layerSummary`  in this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/28639/files).

Looped in acorn team after already merging the tokens. Now, the [Figma](https://www.figma.com/design/pEyGeE4KV5ytYHeXMfLcEr/Mobile-Styles?node-id=5446-15666&m=dev) is updated, so this PR is to update tokens for consistency. Seems like we only need to change `layerGradientSummary` and we're up to date!

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
