### PR TITLE
Bugfix FXIOS [Summarizer] Fix Summarizer Switch case warning

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerError.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerError.swift
@@ -96,7 +96,8 @@ extension SummarizerError {
         case .unsupportedLanguageOrLocale: self = .unsupportedLanguage
         case .unsupportedGuide,
                 .decodingFailure,
-                .assetsUnavailable:
+                .assetsUnavailable,
+                .refusal:
             self = .unknown(error)
         @unknown default:
             self = .unknown(error)


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
It was missing a use case and complaining about it:
<img width="1946" height="721" alt="Screenshot 2025-08-19 at 10 17 00 AM" src="https://github.com/user-attachments/assets/128f8c2d-3fbb-47e4-a111-b6751a6d6377" />

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
