### PR TITLE
Refactor FXIOS-12796 [Swift 6] Fix remaning rust autofill warnings

### DIFF
--- a/firefox-ios/Providers/RustProtocols/AutofillProvider.swift
+++ b/firefox-ios/Providers/RustProtocols/AutofillProvider.swift
@@ -16,7 +16,7 @@ protocol AddressProvider {
 }
 
 protocol SyncAutofillProvider {
-    func getStoredKey(completion: @escaping (Result<String, NSError>) -> Void)
+    func getStoredKey(completion: @Sendable @escaping (Result<String, NSError>) -> Void)
     func registerWithSyncManager()
 }
 

--- a/firefox-ios/Providers/RustProtocols/LoginProvider.swift
+++ b/firefox-ios/Providers/RustProtocols/LoginProvider.swift
@@ -14,7 +14,7 @@ protocol LoginProvider: AnyObject {
 }
 
 protocol SyncLoginProvider {
-    func getStoredKey(completion: @escaping (Result<String, NSError>) -> Void)
+    func getStoredKey(completion: @Sendable @escaping (Result<String, NSError>) -> Void)
     func registerWithSyncManager()
     func verifyLogins(completionHandler: @escaping @Sendable (Bool) -> Void)
 }

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -446,7 +446,7 @@ public class RustSyncManager: NSObject, SyncManager {
                            dispatchGroup: DispatchGroupInterface = DispatchGroup(),
                            completion: @escaping (([String], [String: String])) -> Void) {
         logins.getStoredKey { loginResult in
-            var loginKey: String?
+            let loginKey: String?
 
             switch loginResult {
             case .success(let key):
@@ -457,6 +457,7 @@ public class RustSyncManager: NSObject, SyncManager {
                     level: .warning,
                     category: .sync
                 )
+                loginKey = nil
             }
 
             self.autofill.getStoredKey { creditCardResult in

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -448,7 +448,7 @@ public class RustAutofill: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - completion: A closure called upon completion with the encryption key or an error upon failure.
-    public func getStoredKey(completion: @escaping (Result<String, NSError>) -> Void) {
+    public func getStoredKey(completion: @Sendable @escaping (Result<String, NSError>) -> Void) {
         DispatchQueue.global(qos: .background).sync {
             let (key, encryptedCanaryPhrase) = rustKeychain.getCreditCardKeyData()
 
@@ -471,7 +471,7 @@ public class RustAutofill: @unchecked Sendable {
 
     private func handleExpectedKeyAction(encryptedCanaryPhrase: String?,
                                          key: String?,
-                                         completion: @escaping (Result<String, NSError>) -> Void) {
+                                         completion: @Sendable @escaping (Result<String, NSError>) -> Void) {
         // We expected the key to be present, and it is.
         var canaryIsValid = false
         do {
@@ -498,7 +498,7 @@ public class RustAutofill: @unchecked Sendable {
         }
     }
 
-    private func handleUnexpectedKeyAction(completion: @escaping (Result<String, NSError>) -> Void) {
+    private func handleUnexpectedKeyAction(completion: @Sendable @escaping (Result<String, NSError>) -> Void) {
         // The key is present, but we didn't expect it to be there.
         // or
         // We expected the key to be present, but it's gone missing on us
@@ -509,7 +509,7 @@ public class RustAutofill: @unchecked Sendable {
     }
 
     private func handleFirstTimeCallOrClearedKeychainAction(
-        completion: @escaping (Result<String, NSError>) -> Void) {
+        completion: @Sendable @escaping (Result<String, NSError>) -> Void) {
         // We didn't expect the key to be present, which either means this is a first-time
         // call or the key data has been cleared from the keychain.
         hasCreditCards { result in
@@ -571,7 +571,7 @@ public class RustAutofill: @unchecked Sendable {
         }
     }
 
-    private func resetCreditCardsAndKey(completion: @escaping (Result<String, NSError>) -> Void) {
+    private func resetCreditCardsAndKey(completion: @Sendable @escaping (Result<String, NSError>) -> Void) {
         self.scrubCreditCardNums { result in
             switch result {
             case .success(()):
@@ -591,7 +591,7 @@ public class RustAutofill: @unchecked Sendable {
         }
     }
 
-    private func hasCreditCards(completion: @escaping (Result<Bool, Error>) -> Void) {
+    private func hasCreditCards(completion: @Sendable @escaping (Result<Bool, Error>) -> Void) {
         return listCreditCards { (creditCards, err) in
             guard err == nil else {
                 completion(.failure(err!))

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
@@ -313,7 +313,7 @@ final class MockAutofill: AddressProvider, SyncAutofillProvider {
         }
     }
 
-    func getStoredKey(completion: @escaping (Result<String, NSError>) -> Void) {
+    func getStoredKey(completion: @Sendable @escaping (Result<String, NSError>) -> Void) {
         getStoredKeyCalledCount += 1
         return completion(.success("test autofill encryption key"))
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockLoginProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockLoginProvider.swift
@@ -39,7 +39,7 @@ class MockLoginProvider: LoginProvider, SyncLoginProvider {
         completionHandler(.success(nil))
     }
 
-    func getStoredKey(completion: @escaping (Result<String, NSError>) -> Void) {
+    func getStoredKey(completion: @Sendable @escaping (Result<String, NSError>) -> Void) {
         getStoredKeyCalledCount += 1
         return completion(.success("test encryption key"))
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
There were a few remaining warnings in Rust Autofill about closures not being sendable. This PR updates them.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
