### PR TITLE
Add FXIOS-13146 [Shake to Summarize] swipe up to cancel

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -520,7 +520,7 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
     }
 
     @objc
-    private func onTabSnapshotTap(_ gesture: UITapGestureRecognizer) {
+    private func dismissSummaryFromGesture(_ gesture: UITapGestureRecognizer) {
         triggerDismissingAnimation()
     }
 
@@ -562,8 +562,22 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
         guard flag,
               let animation = anim as? CABasicAnimation,
               animation.keyPath == UX.tabSnapshotTranslationKeyPath else { return }
-        tabSnapshotContainer.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onTabSnapshotTap)))
+        setupDismissGestures()
         summarize()
+    }
+
+    /// Sets up gestures that allow the user to dismiss the summary.
+    /// - Adds a tap gesture on the tab snapshot to close.
+    /// - Adds a swipe-up gesture on the tab snapshot to close.
+    ///
+    /// Both gestures call `dismissSummaryFromGesture`, which handles the dismissal animation.
+    private func setupDismissGestures() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissSummaryFromGesture))
+        tabSnapshotContainer.addGestureRecognizer(tap)
+
+        let swipeUp = UISwipeGestureRecognizer(target: self, action: #selector(dismissSummaryFromGesture))
+        swipeUp.direction = .up
+        tabSnapshotContainer.addGestureRecognizer(swipeUp)
     }
 
     // MARK: - Notifiable


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13146)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28600)

## :bulb: Description
Add swiping gesture to cancel the summarization. Originally, I was debating on using the existing pan gesture, but it seems more complicated than what we want and decided to add a new simple swipe gesture. It does seem that when we do show summary, the pan gesture takes priority, so I didn't see any issues. We can test it out live and do a follow up if needed.

## :movie_camera: Demos
https://github.com/user-attachments/assets/014fb70e-d631-470e-b711-c2a6d05283b6

Note: I see a weird animation on the toolbar, but I always see this in main on Fennec and not when I test the build in Beta / Nightly.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
