### PR TITLE
Bugfix MTE-4879 Accomodate homepage redesign in L10n screenshot tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -177,6 +177,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         // Disable due to issue #7521
         // navigator.goto(BookmarksPanelContextMenu)
         navigator.nowAt(NewTabScreen)
+        navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Bookmarks)
         snapshot("BookmarksTableContextMenu-01")
     }
@@ -295,19 +296,26 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
         // load some web pages in some new tabs
         navigator.goto(NewTabScreen)
-        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
+        if app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].exists {
+            app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
+        }
         navigator.openURL("https://www.mozilla.org")
         waitUntilPageLoad()
         waitForTabsButton()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.backButton])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton])
         navigator.createNewTab()
-        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
+        if app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].exists {
+            app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
+        }
         navigator.openURL("https://mozilla.org/firefox/desktop")
         waitUntilPageLoad()
         waitForTabsButton()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.backButton])
         navigator.createNewTab()
-        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
+        if app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].exists {
+            app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
+        }
         navigator.openURL("https://mozilla.org/firefox/new")
         waitUntilPageLoad()
         navigator.goto(TabTray)

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -70,7 +70,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
         app.buttons["\(rootA11yId)PrimaryButton"].tap()
         currentScreen += 1
-        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
+        mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell])
         mozWaitForElementToExist(app.collectionViews["FxCollectionView"])
         snapshot("Homescreen-first-visit")
     }
@@ -106,6 +106,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func testWebViewAuthenticationDialog() {
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
         navigator.openURL("https://jigsaw.w3.org/HTTP/Basic/", waitForLoading: false)
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         navigator.nowAt(BasicAuthDialog)
@@ -114,6 +115,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func test3ReloadButtonContextMenu() {
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
         navigator.openURL(loremIpsumURL)
         waitUntilPageLoad()
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
@@ -146,10 +148,12 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func testHistoryTableContextMenu() {
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
         navigator.openURL(loremIpsumURL)
         waitUntilPageLoad()
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"], timeout: 5)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.backButton])
         waitForTabsButton()
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.nowAt(NewTabScreen)
@@ -163,6 +167,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     @MainActor
     func testBookmarksTableContextMenu() {
         sleep(3)
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
         navigator.openURL(loremIpsumURL)
         // There is no other way the test work with the new Copied.. snackbar ahow on iOS14
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
@@ -290,18 +295,27 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
         // load some web pages in some new tabs
         navigator.goto(NewTabScreen)
-        navigator.openNewURL(urlString: "https://www.mozilla.org")
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
+        navigator.openURL("https://www.mozilla.org")
         waitUntilPageLoad()
-        navigator.openNewURL(urlString: "https://mozilla.org/firefox/desktop")
+        waitForTabsButton()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.backButton])
+        navigator.createNewTab()
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
+        navigator.openURL("https://mozilla.org/firefox/desktop")
         waitUntilPageLoad()
-        navigator.openNewURL(urlString: "https://mozilla.org/firefox/new")
+        waitForTabsButton()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.backButton])
+        navigator.createNewTab()
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
+        navigator.openURL("https://mozilla.org/firefox/new")
         waitUntilPageLoad()
         navigator.goto(TabTray)
         snapshot("02TabTray")
 
         // perform a search but don't complete (we're testing autocomplete here)
         navigator.createNewTab()
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
         app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].typeText("firef")
         sleep(2)
         snapshot("01SearchResults")

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -23,6 +23,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     // From here on it is fine to load pages
     @MainActor
     func testLongPressOnTextOptions() {
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
         navigator.openURL(loremIpsumURL)
         waitUntilPageLoad()
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
@@ -39,6 +40,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func testURLBar() {
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
         navigator.goto(URLBarOpen)
         snapshot("URLBar-01")
 
@@ -65,6 +67,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func testMenuOnWebPage() {
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
         navigator.openURL(loremIpsumURL)
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         navigator.goto(BrowserTabMenu)
@@ -79,6 +82,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func testPageMenuOnWebPage() {
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
         navigator.openURL(loremIpsumURL)
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
@@ -88,6 +92,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func testFxASignInPage() {
+        app.cells[AccessibilityIdentifiers.FirefoxHomepage.SearchBar.itemCell].waitAndTap()
         navigator.openURL(loremIpsumURL)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.nowAt(NewTabScreen)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
When I tried to run the L10n screenshot tests on taskclusters yesterday, over half of the tests failed due to the homepage design being enabled:
https://app.bitrise.io/build/f2b7c82a-00e2-4ede-8130-b734e0ba4f5e

Trying to run this branch on L10nBuild. Not all tests passed, but more tests passed than before:
https://app.bitrise.io/build/dc17cb9a-9afd-47bd-a22a-424581c0e75d



## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
