### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Shared - fix Deferred `all()` method warnings

### DIFF
--- a/BrowserKit/Sources/Shared/Deferred/Deferred.swift
+++ b/BrowserKit/Sources/Shared/Deferred/Deferred.swift
@@ -131,7 +131,6 @@ public func all<T>(_ deferreds: [Deferred<T>]) -> Deferred<[T]> {
     results.reserveCapacity(deferreds.count)
 
     DispatchQueue.global(qos: .default).async {
-        // Attempt 2
         var iterator = 0
         let group = DispatchGroup()
         let block: SendableGenericClosure = { t in

--- a/firefox-ios/Client/AccountSyncHandler.swift
+++ b/firefox-ios/Client/AccountSyncHandler.swift
@@ -114,18 +114,25 @@ class AccountSyncHandler: TabEventHandler {
         // It's fine if we wait until more busy work has finished. We tend to contend with more important
         // work like querying for top sites.
         DispatchQueue.main.asyncAfter(deadline: .now() + queueDelay) { [weak self] in
-            self?.logger.log(
-                "Storing \(storedTabs.count) total tabs for \(windowCount) windows", level: .debug, category: .sync)
-            self?.profile.storeAndSyncTabs(storedTabs).upon { result in
+            guard let self else { return }
+
+            let logger = self.logger
+            let onSyncCompleted = self.onSyncCompleted
+
+            self.logger.log(
+                "Storing \(storedTabs.count) total tabs for \(windowCount) windows", level: .debug, category: .sync
+            )
+
+            self.profile.storeAndSyncTabs(storedTabs).upon { result in
                 switch result {
                 case .success(let tabCount):
-                    self?.logger.log(
+                    logger.log(
                         "Successfully stored \(tabCount) tabs", level: .debug, category: .sync)
                 case .failure(let error):
-                    self?.logger.log(
+                    logger.log(
                         "Failed to store tabs: \(error.localizedDescription)", level: .warning, category: .sync)
                 }
-                self?.onSyncCompleted?() // callback for tests
+                onSyncCompleted?() // callback for tests
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -91,7 +91,7 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
     }
 
     // MARK: - Redux
-    func subscribeToRedux() {
+    nonisolated func subscribeToRedux() {
         let uuid = windowUUID
         store.subscribe(self, transform: {
             $0.select({ appState in

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -93,7 +93,7 @@ actor JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
     private func updateTabsData() async {
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
-                let recentTabs = await self.updateRecentTabs()
+                let recentTabs = await self.recentlyAccessedNormalTabs()
                 await self.setRecentTabs(recentTabs: recentTabs)
             }
             group.addTask {
@@ -110,7 +110,7 @@ actor JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
     }
 
     @MainActor
-    private func updateRecentTabs() async -> [Tab] {
+    private func recentlyAccessedNormalTabs() async -> [Tab] {
         // Recent tabs need to be accessed from .main otherwise value isn't proper
         return await self.tabManager.recentlyAccessedNormalTabs
     }

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -109,14 +109,10 @@ actor JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
         self.recentTabs = recentTabs
     }
 
+    @MainActor
     private func updateRecentTabs() async -> [Tab] {
         // Recent tabs need to be accessed from .main otherwise value isn't proper
-        return await withCheckedContinuation { continuation in
-            ensureMainThread {
-                let recentTabs = self.tabManager.recentlyAccessedNormalTabs
-                continuation.resume(returning: recentTabs)
-            }
-        }
+        return await self.tabManager.recentlyAccessedNormalTabs
     }
 
     // MARK: Synced tab data

--- a/firefox-ios/CredentialProvider/CredentialProviderViewController.swift
+++ b/firefox-ios/CredentialProvider/CredentialProviderViewController.swift
@@ -199,8 +199,11 @@ extension CredentialProviderViewController: CredentialWelcomeViewControllerDeleg
                 self.extensionContext.cancelRequest(withError: ASExtensionError(.failed))
                 return
             }
-            self.presenter?.profile.syncCredentialIdentities().upon { result in
-                self.extensionContext.completeExtensionConfigurationRequest()
+            self.presenter?.profile.syncCredentialIdentities().uponQueue(.main) { result in
+                // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                MainActor.assumeIsolated {
+                    self.extensionContext.completeExtensionConfigurationRequest()
+                }
             }
         }
     }

--- a/firefox-ios/Storage/SQL/SQLiteQueue.swift
+++ b/firefox-ios/Storage/SQL/SQLiteQueue.swift
@@ -27,11 +27,10 @@ open class SQLiteQueue: TabQueue {
             return deferMaybe(cursor.asArray())
         }
 
-        deferredResponse.upon { result in
-            // TODO: FXIOS-12842 It would be better if we could refactor Defer usage to rely on Swift Concurrency
-            let shareItem: [ShareItem] = result.successValue ?? []
-            DispatchQueue.main.async {
-                completion(shareItem)
+        deferredResponse.uponQueue(.main) { result in
+            // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+            MainActor.assumeIsolated {
+                completion(result.successValue ?? [])
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/DeferredTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/DeferredTests.swift
@@ -117,6 +117,7 @@ class DeferredTests: XCTestCase {
             XCTAssertEqual(results.count, 2)
 
             if let failure = results.first(where: { $0.isFailure }) {
+                XCTFail()
                 return deferMaybe(failure.failureValue!)
             }
 
@@ -147,6 +148,7 @@ class DeferredTests: XCTestCase {
                 return deferMaybe(failure.failureValue!)
             }
 
+            XCTFail()
             return succeed()
         }
 
@@ -167,6 +169,7 @@ class DeferredTests: XCTestCase {
                 XCTAssertEqual(results.count, 2)
 
                 if let failure = results.first(where: { $0.isFailure }) {
+                    XCTFail()
                     return deferMaybe(failure.failureValue!)
                 }
 
@@ -199,6 +202,7 @@ class DeferredTests: XCTestCase {
                     return deferMaybe(failure.failureValue!)
                 }
 
+                XCTFail()
                 return succeed()
             }
         }

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,8 +4,8 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THRESHOLD_UNIT_TEST=13
-THRESHOLD_XCUITEST=13
+THRESHOLD_UNIT_TEST=14
+THRESHOLD_XCUITEST=14
 
 WARNINGS=$(grep -E -v 'SourcePackages/checkouts' "$BUILD_LOG_FILE" \
   | grep -E '^[^ ]+:[0-9]+:[0-9]+: warning:' \

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,8 +4,8 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THRESHOLD_UNIT_TEST=14
-THRESHOLD_XCUITEST=14
+THRESHOLD_UNIT_TEST=13
+THRESHOLD_XCUITEST=13
 
 WARNINGS=$(grep -E -v 'SourcePackages/checkouts' "$BUILD_LOG_FILE" \
   | grep -E '^[^ ]+:[0-9]+:[0-9]+: warning:' \


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
By adding `Sendable` to the `upon` Deferred function, we suddenly exposed a bunch of warnings in the `all()` method at the bottom of the file.

This is a hacky workaround. Followup ticket here: FXIOS-13242

Added some unit tests to validate we won't accidentally hang the MT or anything.

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

---
P.S. I'm currently merging this down to my other PR since I think it depends on earlier work I did. Have to wait until https://github.com/mozilla-mobile/firefox-ios/pull/28752 is merged first.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
