### PR TITLE
Bugfix FXIOS [Summarizer] Add @MainActor on the check function

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerCheckerProtocol.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerCheckerProtocol.swift
@@ -9,5 +9,6 @@ public protocol SummarizationCheckerProtocol {
     /// Prevents model errors caused by exceeding token or context window limits.
     /// This is enforced by the injected JS, not the model itself.
     /// See UserScripts/MainFrame/AtDocumentStart/Summarizer.js for more context on how this is enforced.
+    @MainActor
     func check(on webView: WKWebView, maxWords: Int) async -> SummarizationCheckResult
 }


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
Testing on Xcode 26 Beta 6, I stumbled on this crash:
<img width="2551" height="794" alt="Screenshot 2025-08-20 at 12 13 35 PM" src="https://github.com/user-attachments/assets/2ab4f7e6-cfcc-4a75-8c1b-c7beda1ed476" />

Adding `@MainActor` attributes on the protocol method fixes the crash.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
