### PR TITLE
Add [Release Automation] push phase notifications (bug 1976500)

### DIFF
--- a/taskcluster/kinds/release-notify-push/kind.yml
+++ b/taskcluster/kinds/release-notify-push/kind.yml
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - taskgraph.transforms.from_deps
+    - ffios_taskgraph.transforms.release_notifications:transforms
+    - taskgraph.transforms.task
+
+kind-dependencies:
+    - push
+
+tasks:
+  firefox-ios:
+    name: notify-release-signoff-push
+    description: Sends email to release-signoff telling a release was pushed.
+    run-on-projects: []
+    shipping-phase: push
+    worker-type: succeed
+    notifications:
+      emails:
+        by-level:
+          '3': ["release-signoff@mozilla.org"]
+          default: []
+      subject: "{product_type}-ios {release_type} {version} build{build_number} has been pushed to TestFlight!"
+      message: "{product_type}-ios {release_type} {version} build{build_number} has been pushed to TestFlight!"
+    from-deps:
+      group-by:
+        attribute: product-type
+      unique-kinds: false
+      copy-attributes: true
+      with-attributes:
+        product-type:
+          - firefox
+          - focus

--- a/taskcluster/test/params/release-push-beta.yml
+++ b/taskcluster/test/params/release-push-beta.yml
@@ -17,7 +17,7 @@ head_ref: refs/heads/main
 head_repository: https://github.com/mozilla-mobile/firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 head_tag: firefox-v137.0b1
-level: '1'
+level: '3'
 moz_build_date: '20250226191326'
 next_version: 137.0b2
 optimize_strategies: null

--- a/taskcluster/test/params/release-push-focus.yml
+++ b/taskcluster/test/params/release-push-focus.yml
@@ -17,7 +17,7 @@ head_ref: refs/heads/main
 head_repository: https://github.com/mozilla-mobile/firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 head_tag: firefox-v137.0
-level: '1'
+level: '3'
 moz_build_date: '20250226191326'
 next_version: '137.1'
 optimize_strategies: null

--- a/taskcluster/test/params/release-push.yml
+++ b/taskcluster/test/params/release-push.yml
@@ -17,7 +17,7 @@ head_ref: refs/heads/main
 head_repository: https://github.com/mozilla-mobile/firefox-ios
 head_rev: 2a56c4b0e6e7737816147da950196f99895ff3d3
 head_tag: firefox-v137.0
-level: '1'
+level: '3'
 moz_build_date: '20250226191326'
 next_version: '137.1'
 optimize_strategies: null


### PR DESCRIPTION
## :scroll: Tickets
[Bugzilla bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1976500)

## :bulb: Description
This adds email notifications to the push phase for firefox release/beta and focus.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
