### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Shared - Suppress warning in Deferred for mutating result.

### DIFF
--- a/BrowserKit/Sources/Shared/Deferred/Deferred.swift
+++ b/BrowserKit/Sources/Shared/Deferred/Deferred.swift
@@ -77,7 +77,9 @@ open class Deferred<T>: @unchecked Sendable {
 
         // slow path - block until filled
         let group = DispatchGroup()
-        var result: T!
+        // FIXME: FXIOS-13242 We should not be mutating local context captured in closures. Here we're manually applying
+        // some synchronization using a dispatch group.
+        nonisolated(unsafe) var result: T!
         group.enter()
         self.upon { result = $0; group.leave() }
         _ = group.wait(timeout: .distantFuture)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Suppresses this warning in Shared:

<img width="1463" height="395" alt="Deferred mutation of result" src="https://github.com/user-attachments/assets/94731967-5f80-4a03-924b-f5f51e271d3d" />

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
