### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Shared - Fix warning in Deferred _fill and make the related types Sendable

### DIFF
--- a/BrowserKit/Sources/Shared/Deferred/Deferred.swift
+++ b/BrowserKit/Sources/Shared/Deferred/Deferred.swift
@@ -10,8 +10,9 @@ import Foundation
 
 public let DeferredDefaultQueue = DispatchQueue.global()
 
-// TODO: FXIOS-13184 Remove deferred code or validate it is sendable
-open class Deferred<T>: @unchecked Sendable {
+// TODO: FXIOS-13184 Remove deferred code or validate it is sendable.
+// Also validate the T type is Sendable (actually protected) in all methods.
+open class Deferred<T: Sendable>: @unchecked Sendable {
     typealias UponBlock = (DispatchQueue, @Sendable (T) -> ())
     private typealias Protected = (protectedValue: T?, uponBlocks: [UponBlock])
 

--- a/BrowserKit/Sources/Shared/Deferred/Result.swift
+++ b/BrowserKit/Sources/Shared/Deferred/Result.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum Maybe<T> {
+public enum Maybe<T: Sendable>: Sendable {
     case failure(MaybeErrorType)
     case success(T)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix warning in Deferred _fill and make the related types Sendable.

<img width="1472" height="398" alt="Screenshot 2025-08-20 at 3 27 58 PM" src="https://github.com/user-attachments/assets/1f6fc4f3-3f0d-46be-8e17-99bf00c27230" />

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
