### PR TITLE
Refactor FXIOS-13257 Replace usage of DynamicFontChanged to UIContentSizeCategory.didChangeNotification

### DIFF
--- a/BrowserKit/Sources/Common/Constants/NotificationConstants.swift
+++ b/BrowserKit/Sources/Common/Constants/NotificationConstants.swift
@@ -34,8 +34,6 @@ extension Notification.Name {
 
     public static let RustPlacesOpened = Notification.Name("RustPlacesOpened")
 
-    public static let DynamicFontChanged = Notification.Name("DynamicFontChanged")
-
     public static let ReachabilityStatusChanged = Notification.Name("ReachabilityStatusChanged")
 
     public static let HomePanelPrefsChanged = Notification.Name("HomePanelPrefsChanged")

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -103,7 +103,7 @@ class MainMenuViewController: UIViewController,
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
     }
 
@@ -211,7 +211,7 @@ class MainMenuViewController: UIViewController,
     // MARK: Notifications
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             adjustLayout()
         default: break
         }

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -142,16 +142,10 @@ class SearchViewController: SiteTableViewController,
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged,
+            observing: [UIContentSizeCategory.didChangeNotification,
                         .SearchSettingsChanged,
                         .SponsoredAndNonSponsoredSuggestionsChanged]
         )
-    }
-
-    func dynamicFontChanged(_ notification: Notification) {
-        guard notification.name == .DynamicFontChanged else { return }
-
-        reloadData()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -837,8 +831,8 @@ class SearchViewController: SiteTableViewController,
 
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
-            dynamicFontChanged(notification)
+        case UIContentSizeCategory.didChangeNotification:
+            reloadData()
         case .SearchSettingsChanged:
             reloadSearchEngines()
         case .SponsoredAndNonSponsoredSuggestionsChanged:

--- a/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
@@ -74,7 +74,7 @@ class LegacyLabelButtonHeaderView: UICollectionReusableView, ReusableCell {
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
     }
 
@@ -174,7 +174,7 @@ extension LegacyLabelButtonHeaderView: ThemeApplicable {
 extension LegacyLabelButtonHeaderView: Notifiable {
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             adjustLayout()
         default: break
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInCell.swift
@@ -74,7 +74,7 @@ final class JumpBackInCell: UICollectionViewCell, ReusableCell, ThemeApplicable,
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
         setupLayout()
     }
@@ -225,7 +225,7 @@ final class JumpBackInCell: UICollectionViewCell, ReusableCell, ThemeApplicable,
         let name = notification.name
         ensureMainThread { [weak self] in
             switch name {
-            case .DynamicFontChanged:
+            case UIContentSizeCategory.didChangeNotification:
                 self?.adjustLayout()
             default: break
             }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/SyncedTabCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/SyncedTabCell.swift
@@ -97,7 +97,7 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurra
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
         setupLayout()
     }
@@ -325,7 +325,7 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurra
         let name = notification.name
         ensureMainThread { [weak self] in
             switch name {
-            case .DynamicFontChanged:
+            case UIContentSizeCategory.didChangeNotification:
                 self?.adjustLayout()
             default: break
             }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
@@ -55,7 +55,7 @@ class LabelButtonHeaderView: UICollectionReusableView,
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
     }
 
@@ -158,7 +158,7 @@ class LabelButtonHeaderView: UICollectionReusableView,
     // MARK: - Notifiable
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             adjustLayout()
         default: break
         }

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/LegacyJumpBackInCell.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/LegacyJumpBackInCell.swift
@@ -86,7 +86,7 @@ class LegacyJumpBackInCell: UICollectionViewCell, ReusableCell {
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
         setupLayout()
     }
@@ -242,7 +242,7 @@ extension LegacyJumpBackInCell: Notifiable {
         let name = notification.name
         ensureMainThread { [weak self] in
             switch name {
-            case .DynamicFontChanged:
+            case UIContentSizeCategory.didChangeNotification:
                 self?.adjustLayout()
             default: break
             }

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/LegacySyncedTabCell.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/LegacySyncedTabCell.swift
@@ -119,7 +119,7 @@ class LegacySyncedTabCell: UICollectionViewCell, ReusableCell {
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
         setupLayout()
     }
@@ -346,7 +346,7 @@ extension LegacySyncedTabCell: Notifiable {
         let name = notification.name
         ensureMainThread { [weak self] in
             switch name {
-            case .DynamicFontChanged:
+            case UIContentSizeCategory.didChangeNotification:
                 self?.adjustLayout()
             default: break
             }

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -28,7 +28,7 @@ class DownloadsPanel: UIViewController,
     private let logger: Logger
     private let events: [Notification.Name] = [.FileDidDownload,
                                                .PrivateDataClearedDownloadedFiles,
-                                               .DynamicFontChanged,
+                                               UIContentSizeCategory.didChangeNotification,
                                                .DownloadPanelFileWasDeleted]
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
@@ -116,7 +116,7 @@ class DownloadsPanel: UIViewController,
             switch notification.name {
             case .FileDidDownload, .PrivateDataClearedDownloadedFiles:
                 self.reloadData()
-            case .DynamicFontChanged:
+            case UIContentSizeCategory.didChangeNotification:
                 self.reloadData()
                 if self.emptyStateOverlayView.superview != nil {
                     self.emptyStateOverlayView.removeFromSuperview()

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -337,7 +337,7 @@ class HistoryPanel: UIViewController,
                 resyncHistory()
             }
             break
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             if emptyStateOverlayView.superview != nil {
                 emptyStateOverlayView.removeFromSuperview()
             }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -78,7 +78,7 @@ class HistoryPanelViewModel: FeatureFlaggable {
 
     let historyPanelNotifications = [Notification.Name.FirefoxAccountChanged,
                                      Notification.Name.PrivateDataClearedHistory,
-                                     Notification.Name.DynamicFontChanged,
+                                     UIContentSizeCategory.didChangeNotification,
                                      Notification.Name.DatabaseWasReopened,
                                      Notification.Name.OpenClearRecentHistory,
                                      Notification.Name.OpenRecentlyClosedTabs]

--- a/firefox-ios/Client/Frontend/Library/Reader/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Reader/ReaderPanel.swift
@@ -202,7 +202,7 @@ class ReadingListPanel: UITableViewController,
 
         // FIXME: FXIOS-12995 Use Notifiable
         [ Notification.Name.FirefoxAccountChanged,
-          Notification.Name.DynamicFontChanged,
+          UIContentSizeCategory.didChangeNotification,
           Notification.Name.DatabaseWasReopened ].forEach {
             NotificationCenter.default.addObserver(
                 self,
@@ -260,7 +260,7 @@ class ReadingListPanel: UITableViewController,
     @objc
     func notificationReceived(_ notification: Notification) {
         switch notification.name {
-        case .FirefoxAccountChanged, .DynamicFontChanged:
+        case .FirefoxAccountChanged, UIContentSizeCategory.didChangeNotification:
             refreshReadingList()
         case .DatabaseWasReopened:
             if let dbName = notification.object as? String, dbName == "ReadingList.db" {

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -121,7 +121,7 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
         configure(with: state)
         setupView()
@@ -217,7 +217,7 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
     // MARK: Notifiable
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             adjustIconSize()
         default: break
         }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -138,7 +138,7 @@ final class MicrosurveyViewController: UIViewController,
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
 
         subscribeToRedux()
@@ -307,7 +307,7 @@ final class MicrosurveyViewController: UIViewController,
     // MARK: Notifiable
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             adjustIconSize()
         default: break
         }

--- a/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPreferencesViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPreferencesViewController.swift
@@ -71,7 +71,7 @@ final class PrivacyPreferencesViewController: UIViewController,
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
         setupLayout()
         setDetentSize()
@@ -259,7 +259,7 @@ final class PrivacyPreferencesViewController: UIViewController,
     // MARK: - Notifications
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             setDetentSize()
         default: break
         }

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -89,7 +89,7 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged,
+            observing: [UIContentSizeCategory.didChangeNotification,
                         UIApplication.willResignActiveNotification,
                         UIApplication.didBecomeActiveNotification]
         )
@@ -237,7 +237,7 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
 
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             applyDynamicFontChange()
         case UIApplication.willResignActiveNotification:
             store.dispatchLegacy(PasswordGeneratorAction(windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorHeaderView.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorHeaderView.swift
@@ -40,7 +40,7 @@ final class PasswordGeneratorHeaderView: UIView, ThemeApplicable, Notifiable {
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
     }
 
@@ -50,7 +50,7 @@ final class PasswordGeneratorHeaderView: UIView, ThemeApplicable, Notifiable {
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
         setupLayout()
     }
@@ -86,7 +86,7 @@ final class PasswordGeneratorHeaderView: UIView, ThemeApplicable, Notifiable {
 
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             applyDynamicFontChange()
         default: break
         }

--- a/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
@@ -51,7 +51,7 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
     }
 
@@ -63,7 +63,7 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
         setupLayout()
     }
@@ -151,7 +151,7 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
 
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             applyDynamicFontChange()
         default: break
         }

--- a/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersTableController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersTableController.swift
@@ -16,7 +16,8 @@ struct BlockedTrackerItem: Hashable {
 // MARK: BlockedTrackersTableViewController
 class BlockedTrackersTableViewController: UIViewController,
                                           Themeable,
-                                          UITableViewDelegate {
+                                          UITableViewDelegate,
+                                          Notifiable {
     private struct UX {
         static let baseCellHeight: CGFloat = 44
         static let baseDistance: CGFloat = 20
@@ -51,6 +52,12 @@ class BlockedTrackersTableViewController: UIViewController,
         self.notificationCenter = notificationCenter
         self.themeManager = themeManager
         super.init(nibName: nil, bundle: nil)
+
+        startObservingNotifications(
+            withNotificationCenter: notificationCenter,
+            forObserver: self,
+            observing: [UIContentSizeCategory.didChangeNotification]
+        )
     }
 
     required init?(coder: NSCoder) {
@@ -207,7 +214,7 @@ class BlockedTrackersTableViewController: UIViewController,
     // MARK: Notifications
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             adjustLayout()
         default: break
         }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -156,7 +156,7 @@ class TrackingProtectionViewController: UIViewController,
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
             forObserver: self,
-            observing: [.DynamicFontChanged]
+            observing: [UIContentSizeCategory.didChangeNotification]
         )
         scrollView.delegate = self
         updateViewDetails()
@@ -494,7 +494,7 @@ class TrackingProtectionViewController: UIViewController,
     // MARK: Notifications
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DynamicFontChanged:
+        case UIContentSizeCategory.didChangeNotification:
             adjustLayout()
         default: break
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13257)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28855)

## :bulb: Description
This replaces all uses of `DynamicFontChanged` with `UIContentSizeCategory.didChangeNotification` as no notifiacations with that name are send anymore. Additionally one view was never listing to the notification so it now is.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
