### PR TITLE
Bugfix FXIOS-13110 [Shake to Summarize] a11y labels and header

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -60,6 +60,7 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
         $0.showsLargeContentViewer = true
         $0.isUserInteractionEnabled = true
         $0.addInteraction(UILargeContentViewerInteraction())
+        $0.accessibilityTraits.insert(.header)
     }
     private let loadingLabel: UILabel = .build {
         $0.font = FXFontStyles.Regular.body.scaledFont()
@@ -229,8 +230,8 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
         loadingLabel.accessibilityIdentifier = viewModel.loadingA11yId
         loadingLabel.accessibilityLabel = viewModel.loadingA11yLabel
 
-        tabSnapshotContainer.accessibilityIdentifier = viewModel.loadingA11yId
-        tabSnapshotContainer.accessibilityLabel = viewModel.loadingA11yLabel
+        tabSnapshotContainer.accessibilityIdentifier = viewModel.tabSnapshotA11yId
+        tabSnapshotContainer.accessibilityLabel = viewModel.tabSnapshotA11yLabel
 
         closeButton.accessibilityIdentifier = viewModel.closeButtonModel.a11yIdentifier
         closeButton.accessibilityLabel = viewModel.closeButtonModel.a11yLabel


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13110)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28532)

## :bulb: Description
Bugfix a11y label to appropriate one and add header trait.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
