### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Shared - Deferred Sendable round 2

### DIFF
--- a/BrowserKit/Sources/Shared/Deferred/Deferred.swift
+++ b/BrowserKit/Sources/Shared/Deferred/Deferred.swift
@@ -87,7 +87,7 @@ open class Deferred<T: Sendable>: @unchecked Sendable {
         return result
     }
 
-    public func bindQueue<U>(_ queue: DispatchQueue, f: @escaping (T) -> Deferred<U>) -> Deferred<U> {
+    public func bindQueue<U>(_ queue: DispatchQueue, f: @escaping @Sendable (T) -> Deferred<U>) -> Deferred<U> {
         let d = Deferred<U>()
         self.uponQueue(queue) {
             f($0).uponQueue(queue) {
@@ -97,7 +97,7 @@ open class Deferred<T: Sendable>: @unchecked Sendable {
         return d
     }
 
-    public func mapQueue<U>(_ queue: DispatchQueue, f: @escaping (T) -> U) -> Deferred<U> {
+    public func mapQueue<U>(_ queue: DispatchQueue, f: @escaping @Sendable (T) -> U) -> Deferred<U> {
         return bindQueue(queue) { t in Deferred<U>(value: f(t)) }
     }
 
@@ -105,11 +105,11 @@ open class Deferred<T: Sendable>: @unchecked Sendable {
         uponQueue(defaultQueue, block: block)
     }
 
-    public func bind<U>(_ f: @escaping (T) -> Deferred<U>) -> Deferred<U> {
+    public func bind<U>(_ f: @escaping @Sendable (T) -> Deferred<U>) -> Deferred<U> {
         return bindQueue(defaultQueue, f: f)
     }
 
-    public func map<U>(_ f: @escaping (T) -> U) -> Deferred<U> {
+    public func map<U>(_ f: @escaping @Sendable (T) -> U) -> Deferred<U> {
         return mapQueue(defaultQueue, f: f)
     }
 

--- a/BrowserKit/Sources/Shared/DeferredUtils.swift
+++ b/BrowserKit/Sources/Shared/DeferredUtils.swift
@@ -21,12 +21,12 @@ infix operator >>== : MonadicBindPrecedence
 infix operator >>> : MonadicDoPrecedence
 
 @discardableResult
-public func >>== <T, U>(x: Deferred<Maybe<T>>, f: @escaping (T) -> Deferred<Maybe<U>>) -> Deferred<Maybe<U>> {
+public func >>== <T, U>(x: Deferred<Maybe<T>>, f: @escaping @Sendable (T) -> Deferred<Maybe<U>>) -> Deferred<Maybe<U>> {
     return chainDeferred(x, f: f)
 }
 
 // A termination case.
-public func >>== <T>(x: Deferred<Maybe<T>>, f: @escaping (T) -> Void) {
+public func >>== <T>(x: Deferred<Maybe<T>>, f: @escaping @Sendable (T) -> Void) {
     return x.upon { result in
         if let v = result.successValue {
             f(v)
@@ -36,7 +36,7 @@ public func >>== <T>(x: Deferred<Maybe<T>>, f: @escaping (T) -> Void) {
 
 // Monadic `do` for Deferred.
 @discardableResult
-public func >>> <T, U>(x: Deferred<Maybe<T>>, f: @escaping () -> Deferred<Maybe<U>>) -> Deferred<Maybe<U>> {
+public func >>> <T, U>(x: Deferred<Maybe<T>>, f: @escaping @Sendable () -> Deferred<Maybe<U>>) -> Deferred<Maybe<U>> {
     return x.bind { res in
         if res.isSuccess {
             return f()
@@ -46,7 +46,7 @@ public func >>> <T, U>(x: Deferred<Maybe<T>>, f: @escaping () -> Deferred<Maybe<
 }
 
 // Another termination case.
-public func >>> <T>(x: Deferred<Maybe<T>>, f: @escaping () -> Void) {
+public func >>> <T>(x: Deferred<Maybe<T>>, f: @escaping @Sendable () -> Void) {
     return x.upon { res in
         if res.isSuccess {
             f()
@@ -90,7 +90,10 @@ extension Array where Element: Success {
     }
 }
 
-public func chainDeferred<T, U>(_ a: Deferred<Maybe<T>>, f: @escaping (T) -> Deferred<Maybe<U>>) -> Deferred<Maybe<U>> {
+public func chainDeferred<T, U>(
+    _ a: Deferred<Maybe<T>>,
+    f: @escaping @Sendable (T) -> Deferred<Maybe<U>>
+) -> Deferred<Maybe<U>> {
     return a.bind { res in
         if let v = res.successValue {
             return f(v)

--- a/firefox-ios/Client/Frontend/Settings/Clearables.swift
+++ b/firefox-ios/Client/Frontend/Settings/Clearables.swift
@@ -42,9 +42,13 @@ class HistoryClearable: Clearable {
         Tab.ChangeUserAgent.clear()
 
         // Clear everything in places
-        return profile.places.deleteEverythingHistory().bindQueue(.main) { success in
-            return self.clearAfterHistory(success: success)
-        }
+        return profile.places.deleteEverythingHistory()
+            .bindQueue(.main) { success in
+                // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                MainActor.assumeIsolated {
+                    return self.clearAfterHistory(success: success)
+                }
+            }
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/DeferredTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/DeferredTests.swift
@@ -44,11 +44,11 @@ class DeferredTests: XCTestCase {
         let e1 = self.expectation(description: "First.")
         let e2 = self.expectation(description: "Second.")
 
-        let f1: () -> Deferred<Maybe<Int>> = {
+        let f1: @Sendable () -> Deferred<Maybe<Int>> = {
             return deferMaybe(5)
         }
 
-        let f2: (_ x: Int) -> Deferred<Maybe<String>> = {
+        let f2: @Sendable (_ x: Int) -> Deferred<Maybe<String>> = {
             if $0 == 5 {
                 e1.fulfill()
             }

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSQLitePinnedSites.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSQLitePinnedSites.swift
@@ -44,19 +44,19 @@ class TestSQLitePinnedSites: XCTestCase {
         let site2 = Site.createBasicSite(url: "http://s\(2)ite\(2).com/foo", title: "A \(2)")
 
         let expectation = self.expectation(description: "First.")
-        func done() -> Success {
+        let done: @Sendable () -> Success = {
             expectation.fulfill()
             return succeed()
         }
 
-        func addPinnedSites() -> Success {
+        let addPinnedSites: @Sendable () -> Success = {
             return pinnedSites.addPinnedTopSite(site1) >>== {
                 sleep(1) // Sleep to prevent intermittent issue with sorting on the timestamp
                 return pinnedSites.addPinnedTopSite(site2)
             }
         }
 
-        func checkPinnedSites() -> Success {
+        let checkPinnedSites: @Sendable () -> Success = {
             return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
                 XCTAssertEqual(pinnedSites.count, 2)
                 XCTAssertEqual(pinnedSites[0]?.url, site2.url)
@@ -65,7 +65,7 @@ class TestSQLitePinnedSites: XCTestCase {
             }
         }
 
-        func removePinnedSites() -> Success {
+        let removePinnedSites: @Sendable () -> Success = {
             return pinnedSites.removeFromPinnedTopSites(site2) >>== {
                 return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
                     XCTAssertEqual(pinnedSites.count, 1, "There should only be one pinned site")
@@ -75,7 +75,7 @@ class TestSQLitePinnedSites: XCTestCase {
             }
         }
 
-        func dupePinnedSite() -> Success {
+        let dupePinnedSite: @Sendable () -> Success = {
             return pinnedSites.addPinnedTopSite(site1) >>== {
                 return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
                     XCTAssertEqual(pinnedSites.count, 1, "There should not be a dupe")
@@ -110,19 +110,19 @@ class TestSQLitePinnedSites: XCTestCase {
         let site2 = Site.createBasicSite(url: "http://site.com/foo2", title: "A duplicate domain \(2)")
 
         let expectation = self.expectation(description: "First.")
-        func done() -> Success {
+        let done: @Sendable () -> Success = {
             expectation.fulfill()
             return succeed()
         }
 
-        func addPinnedSites() -> Success {
+        let addPinnedSites: @Sendable () -> Success = {
             return pinnedSites.addPinnedTopSite(site1) >>== {
                 sleep(1) // Sleep to prevent intermittent issue with sorting on the timestamp
                 return pinnedSites.addPinnedTopSite(site2)
             }
         }
 
-        func checkPinnedSites() -> Success {
+        let checkPinnedSites: @Sendable () -> Success = {
             return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
                 XCTAssertEqual(pinnedSites.count, 2)
                 XCTAssertEqual(pinnedSites[0]?.url, site2.url)
@@ -131,7 +131,7 @@ class TestSQLitePinnedSites: XCTestCase {
             }
         }
 
-        func removePinnedSites() -> Success {
+        let removePinnedSites: @Sendable () -> Success = {
             return pinnedSites.removeFromPinnedTopSites(site2) >>== {
                 return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
                     XCTAssertEqual(pinnedSites.count, 0, "Duplicate pinned domains are removed with a fuzzy search")
@@ -170,16 +170,16 @@ class TestSQLitePinnedSites: XCTestCase {
         )
 
         let expectation = self.expectation(description: "Add site")
-        func done() -> Success {
+        let done: @Sendable () -> Success = {
             expectation.fulfill()
             return succeed()
         }
 
-        func addPinnedSite() -> Success {
+        let addPinnedSite: @Sendable () -> Success = {
             return pinnedSites.addPinnedTopSite(site)
         }
 
-        func checkPinnedSite() -> Success {
+        let checkPinnedSite: @Sendable () -> Success = {
             return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
                 XCTAssertEqual(pinnedSites.count, 1)
                 XCTAssertEqual(pinnedSites[0]?.id, siteId)
@@ -189,7 +189,7 @@ class TestSQLitePinnedSites: XCTestCase {
             }
         }
 
-        func removePinnedSite() -> Success {
+        let removePinnedSite: @Sendable () -> Success = {
             return pinnedSites.removeFromPinnedTopSites(site) >>== {
                 return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
                     XCTAssertEqual(pinnedSites.count, 0, "There should be no pinned sites")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fixes multiple Sendable closure warnings.

Just when I thought I was done all the warnings in Shared... you fix one Sendable closure and tons more warnings pop up!!

Depends on https://github.com/mozilla-mobile/firefox-ios/pull/28853.

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
