### PR TITLE
Bugfix FXIOS-13259 [Unit Tests] fix updateCreditCardList test

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
@@ -305,12 +305,14 @@ class CreditCardBottomSheetViewModel {
     }
 
     func updateCreditCardList(completionHandler: @escaping @Sendable ([CreditCard]?) -> Void) {
-        if state == .selectSavedCard {
-            listStoredCreditCards { [weak self] cards in
-                Task { @MainActor in
-                    self?.creditCards = cards
-                    completionHandler(cards)
-                }
+        guard state == .selectSavedCard else {
+            completionHandler(nil)
+            return
+        }
+        listStoredCreditCards { [weak self] cards in
+            Task { @MainActor in
+                self?.creditCards = cards
+                completionHandler(cards)
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
@@ -390,14 +390,14 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         let subject = createSubject()
 
         let expectation = expectation(description: "wait for credit card to be added")
-        expectation.isInverted = true
         subject.creditCard = nil
         subject.decryptedCreditCard = nil
 
         subject.updateCreditCardList { cards in
+            XCTAssertNil(cards)
             expectation.fulfill()
         }
-        waitForExpectations(timeout: 1.0)
+        wait(for: [expectation], timeout: 1.0)
     }
 
     // MARK: Helper methods


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13259)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28866)

## :bulb: Description
Improve unit tests that were flaky for `test_updateCreditCardList_withoutSelectedSavedCardState_doesNotCallListCreditCards`. 
Also, we aren't really doing anything with the completion in production, but we can refactor that when needed. 

The test was also running long and taking up the wait time of `1.0` because we never return the completion. We should return nil and this will decrease the time for test as well as make it more stable.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
