### PR TITLE
Bugfix FXIOS-13230 [Swift 6 Migration] Enable strict concurrency in ComponentLibrary

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -13,6 +13,7 @@ public protocol BottomSheetChild: UIViewController {
     func willDismiss()
 }
 
+@MainActor
 public protocol BottomSheetDelegate: AnyObject {
     /// Returns the height of the `BottomSheetViewController` header including the close button.
     func getBottomSheetHeaderHeight() -> CGFloat


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13230)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28783)

## :bulb: Description
Update: There's only one small warning fixed in this PR, the other ones being fixed in Isabella PR

~~Two small issue~~, one in `BottomSheetViewController` where I just conformed the protocol `BottomSheetDelegate` to `@MainActor`. ~~The other is on `ContentFittingScrollView`, where `Content.Type` is not `Sendable`, I assume we can mark this as `MainActor.assumeIsolated` since this is called from a dispatchQueue.main right?~~

<img width="521" height="207" alt="Screenshot 2025-08-21 at 5 18 09 PM" src="https://github.com/user-attachments/assets/72eac9c4-cee4-444e-bf68-17906e98a2fd" />

cc: @Cramsden @dataports 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
