### PR TITLE
 Refactor FXIOS-12765 [Swift 6 Migration] Shared - Fix KeyboardHelper warnings

### DIFF
--- a/BrowserKit/Sources/Shared/KeyboardHelper.swift
+++ b/BrowserKit/Sources/Shared/KeyboardHelper.swift
@@ -7,11 +7,8 @@ import Common
 
 /**
  * The keyboard state at the time of notification.
- *
- * FIXME: FXIOS-13260 KeyboardHelper in Shared package should probably not be @unchecked Sendable without review and/or
- * manual thread synchronization
  */
-public struct KeyboardState: @unchecked Sendable {
+public struct KeyboardState: Sendable {
     public let animationDuration: Double
     public let animationCurve: UIView.AnimationCurve
     private let keyboardEndFrame: CGRect?


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
- Rewrite KeyboardHelper and KeyboardState to conform to `Notifiable` because I saw all those `@MainActor` `@objc` methods and knew that was a recipe for crashes.
- Addressed Sendability errors with Notification and notification.userInfo dictionary after the above change
- Fixed the actual strict concurrency warning from the shared mutable state by isolating it all to the main thread

<img width="1439" height="507" alt="Screenshot 2025-08-21 at 3 33 23 PM" src="https://github.com/user-attachments/assets/bb0e45a3-92ed-42b7-aa5b-8c082cdc8c4c" />

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
