### PR TITLE
Refactor FXIOS-13231 [Swift 6 Migration] TabDataStore with strict concurrency

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -119,7 +119,8 @@ let package = Package(
         .target(
             name: "TabDataStore",
             dependencies: ["Common"],
-            swiftSettings: [.unsafeFlags(["-enable-testing"])]),
+            swiftSettings: [.unsafeFlags(["-enable-testing"]),
+                            .enableExperimentalFeature("StrictConcurrency")]),
         .testTarget(
             name: "TabDataStoreTests",
             dependencies: ["TabDataStore"]),

--- a/BrowserKit/Sources/TabDataStore/TabData.swift
+++ b/BrowserKit/Sources/TabDataStore/TabData.swift
@@ -7,7 +7,7 @@ import Foundation
 /// A dictionary with as Key the local file directory for a temporary document and its online source URL as value
 public typealias TemporaryDocumentSession = [URL: URL]
 
-public struct TabData: Codable {
+public struct TabData: Codable, Sendable {
     public let id: UUID
     public let title: String?
     public let siteUrl: String

--- a/BrowserKit/Sources/TabDataStore/TabFileManager.swift
+++ b/BrowserKit/Sources/TabDataStore/TabFileManager.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Common
 
-public protocol TabFileManager {
+public protocol TabFileManager: Sendable {
     /// Determines the directory where tab session data should be stored
     /// - Returns: the URL that should be used for storing tab session data, can be nil
     func tabSessionDataDirectory() -> URL?

--- a/BrowserKit/Sources/TabDataStore/WindowData.swift
+++ b/BrowserKit/Sources/TabDataStore/WindowData.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct WindowData: Codable {
+public struct WindowData: Codable, Sendable {
     public let id: UUID
     public let activeTabId: UUID
     public let tabData: [TabData]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13231)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28784)

## :bulb: Description
I expected worse! Made `WindowData` of `Sendable` type, and it's related `TabData` as well, both are struct. `TabFileManager` is a struct, so it could be `Sendable` to fix the related warnings too.

<img width="624" height="427" alt="Screenshot 2025-08-21 at 5 32 19 PM" src="https://github.com/user-attachments/assets/879ed8f6-f1b9-4880-8e58-d087bb8c8d21" />

cc: @ih-codes @dataports 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
