### PR TITLE
Fix FXIOS-13214 [Tab Animation] Fix increase in time to present and dismiss tab tray on iOS 26

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -147,7 +147,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         finalFrame: CGRect,
         selectedTab: Tab
     ) {
-        let start = DispatchTime.now()
         // Snapshot of the BVC view
         let bvcSnapshot = UIImageView(image: browserVC.view.snapshot)
         bvcSnapshot.layer.cornerCurve = .continuous
@@ -289,9 +288,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         animator.addCompletion { _ in
             backgroundView.removeFromSuperview()
             borderLayer.removeFromSuperlayer()
-            let end = DispatchTime.now()
-            let elapsed = Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
-            print("👽Presentation animation took \(elapsed) seconds👽")
             context.completeTransition(true)
         }
 
@@ -312,7 +308,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         finalFrame: CGRect,
         selectedTab: Tab
     ) {
-        let start = DispatchTime.now()
         guard let panel = currentExperimentPanel as? ThemedNavigationController,
               let panelViewController = panel.viewControllers.first as? TabDisplayPanelViewController
         else {
@@ -385,9 +380,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             self.view.removeFromSuperview()
             tabSnapshot.removeFromSuperview()
             toView.removeFromSuperview()
-            let end = DispatchTime.now()
-            let elapsed = Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
-            print("👽Dismissal animation took \(elapsed) seconds👽")
             context.completeTransition(true)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -203,7 +203,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
               let item = findItem(by: selectedTab.tabUUID, dataSource: dataSource)
         else { return }
 
-        cv.layoutIfNeeded()
+        cv.reloadData()
         var tabCell: ExperimentTabCell?
         var cellFrame: CGRect?
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -203,7 +203,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
               let item = findItem(by: selectedTab.tabUUID, dataSource: dataSource)
         else { return }
 
-        cv.reloadData()
+        cv.layoutIfNeeded()
         var tabCell: ExperimentTabCell?
         var cellFrame: CGRect?
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -75,7 +75,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
 
         let finalFrame = context.finalFrame(for: destinationController)
 
-        DispatchQueue.main.async { [self] in
+        ensureMainThread { [self] in
             runPresentationAnimation(
                 context: context,
                 browserVC: bvc,
@@ -129,7 +129,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         toView.frame = finalFrame
 
         // Allow the UI to render to make the snapshotting code more performant
-        DispatchQueue.main.async { [self] in
+        ensureMainThread { [self] in
             runDismissalAnimation(
                 context: context,
                 toView: toView,
@@ -147,6 +147,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         finalFrame: CGRect,
         selectedTab: Tab
     ) {
+        let start = DispatchTime.now()
         // Snapshot of the BVC view
         let bvcSnapshot = UIImageView(image: browserVC.view.snapshot)
         bvcSnapshot.layer.cornerCurve = .continuous
@@ -288,6 +289,9 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         animator.addCompletion { _ in
             backgroundView.removeFromSuperview()
             borderLayer.removeFromSuperlayer()
+            let end = DispatchTime.now()
+            let elapsed = Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
+            print("👽Presentation animation took \(elapsed) seconds👽")
             context.completeTransition(true)
         }
 
@@ -308,6 +312,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         finalFrame: CGRect,
         selectedTab: Tab
     ) {
+        let start = DispatchTime.now()
         guard let panel = currentExperimentPanel as? ThemedNavigationController,
               let panelViewController = panel.viewControllers.first as? TabDisplayPanelViewController
         else {
@@ -380,6 +385,9 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             self.view.removeFromSuperview()
             tabSnapshot.removeFromSuperview()
             toView.removeFromSuperview()
+            let end = DispatchTime.now()
+            let elapsed = Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
+            print("👽Dismissal animation took \(elapsed) seconds👽")
             context.completeTransition(true)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -170,9 +170,12 @@ class TabDisplayView: UIView,
             return
         }
 
-        tabsState = state
+        // TODO: FXIOS-13264 - Fix compositional layout using estimated heights for cells so this check isn't necessary.
+        if tabsState != state {
+            dataSource.updateSnapshot(state: tabsState)
+        }
 
-        dataSource.updateSnapshot(state: tabsState)
+        tabsState = state
 
         if let scrollState = state.scrollState {
             scrollToTab(scrollState)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -309,6 +309,8 @@ final class HomepageViewController: UIViewController,
     }
 
     func newState(state: HomepageState) {
+        guard self.homepageState != state else { return }
+
         self.homepageState = state
         wallpaperView.wallpaperState = state.wallpaperState
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -309,15 +309,17 @@ final class HomepageViewController: UIViewController,
     }
 
     func newState(state: HomepageState) {
-        guard self.homepageState != state else { return }
-
-        self.homepageState = state
         wallpaperView.wallpaperState = state.wallpaperState
 
-        dataSource?.updateSnapshot(
-            state: state,
-            jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
-        )
+        // TODO: FXIOS-13265 - Fix compositional layout using estimated heights for cells so this check isn't necessary.
+        if self.homepageState != state {
+            dataSource?.updateSnapshot(
+                state: state,
+                jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
+            )
+        }
+
+        self.homepageState = state
         // FXIOS-11523 - Trigger impression when user opens homepage view new tab + scroll to top
         if homepageState.shouldTriggerImpression {
             scrollToTop()

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
@@ -103,6 +103,8 @@ class ShortcutsLibraryViewController: UIViewController,
     }
 
     func newState(state: ShortcutsLibraryState) {
+        // TODO: FXIOS-13265 Fix compositional layout using estimated heights for cells so this check isn't necessary.
+        guard self.shortcutsLibraryState != state else { return }
         self.shortcutsLibraryState = state
 
         dataSource?.updateSnapshot(state: state)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -219,21 +219,39 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
     func test_viewDidAppear_withStoriesRedesignDisabled_triggersHomepageAction() throws {
         setIsStoriesRedesignEnabled(isEnabled: false)
         let subject = createSubject()
+        let initialState = HomepageState(windowUUID: .XCTestDefaultUUID)
         // Need to call loadViewIfNeeded and newState to populate the datasource
         // used to check whether we should send dispatch action or not
         // layoutIfNeeded() recalculates the collection view to have items
         subject.loadViewIfNeeded()
-        subject.newState(state: HomepageState(windowUUID: .XCTestDefaultUUID))
+        subject.newState(state: initialState)
+        subject.view.layoutIfNeeded()
+
+        let firstActionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.last(where: { $0 is HomepageAction }) as? HomepageAction
+        )
+        let firstActionType = try XCTUnwrap(firstActionCalled.actionType as? HomepageActionType)
+        XCTAssertEqual(firstActionType, HomepageActionType.initialize)
+
+        // Trigger a new state so that we have a snapshot update
+        let newState =  HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            GeneralBrowserAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: GeneralBrowserActionType.didSelectedTabChangeToHomepage
+            )
+        )
+        subject.newState(state: newState)
         subject.view.layoutIfNeeded()
         subject.viewDidAppear(false)
 
         XCTAssertTrue(mockThrottler.didCallThrottle)
-        let actionCalled = try XCTUnwrap(
+        let secondActionCalled = try XCTUnwrap(
             mockStore.dispatchedActions.last(where: { $0 is HomepageAction }) as? HomepageAction
         )
-        let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
-        XCTAssertEqual(actionType, HomepageActionType.sectionSeen)
-        XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+        let secondActionType = try XCTUnwrap(secondActionCalled.actionType as? HomepageActionType)
+        XCTAssertEqual(secondActionType, HomepageActionType.sectionSeen)
+        XCTAssertEqual(secondActionCalled.windowUUID, .XCTestDefaultUUID)
     }
 
     // This test differs from the one above in that is has the `stories-redesign` feature flag enabled.
@@ -268,13 +286,30 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
     func test_scrollViewDidEndDecelerating_withStoriesRedesignDisabled_triggersHomepageAction() throws {
         setIsStoriesRedesignEnabled(isEnabled: false)
         let subject = createSubject()
+        let initialState = HomepageState(windowUUID: .XCTestDefaultUUID)
         // Need to call loadViewIfNeeded and newState to populate the datasource
         // used to check whether we should send dispatch action or not
         // layoutIfNeeded() recalculates the collection view to have items
         subject.loadViewIfNeeded()
-        subject.newState(state: HomepageState(windowUUID: .XCTestDefaultUUID))
+        subject.newState(state: initialState)
         subject.view.layoutIfNeeded()
 
+        let firstActionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.last(where: { $0 is HomepageAction }) as? HomepageAction
+        )
+        let firstActionType = try XCTUnwrap(firstActionCalled.actionType as? HomepageActionType)
+        XCTAssertEqual(firstActionType, HomepageActionType.initialize)
+
+        // Trigger a new state so that we have a snapshot update
+        let newState =  HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            GeneralBrowserAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: GeneralBrowserActionType.didSelectedTabChangeToHomepage
+            )
+        )
+        subject.newState(state: newState)
+        subject.view.layoutIfNeeded()
         subject.scrollViewDidEndDecelerating(UIScrollView())
 
         XCTAssertTrue(mockThrottler.didCallThrottle)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13214)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28753)

## :bulb: Description
This task was initiated because it was noticed that there was a slowdown of the tab tray animation for dismissal and presentation on iOS 26, however while investigating I discovered a severe memory leak that was causing our favIconImageViews to be retained and spawning 1000s of instances that stayed in memory after only a few open/close cycles of tabTrayViewController.

The root cause of this is likely in the SiteImageViewCode, which has some weirdness going on with concurrency that spins off tasks to reload the FavIcons, but that will have to be addressed later since the refactor will be complex.

This PR mitigates the problem the leak causes by stopping our DiffableDatasources on Homepage, TabDisplayView and Shortcuts library reloading their data to get cellHeights/widths too often. This is caused by using .estimated in our compositional layouts for these collectionViews, which forces diffable datasources to reload even when there's no change in state. I've verified this on a test branch [here (not pretty)](https://github.com/mozilla-mobile/firefox-ios/commit/24e49772f03f5c658e1c2fcfdf2ebb043c35c1ea) and confirmed this does not force reload the data when actual cellHeights are set, and not calculated.

For now, we are not getting the benefits of diffableDatasource while we use compositionalLayout like this, there are linked tickets in the codebase to refactor them at a later date as part of this PR.
## Before/After results

### Before 
#### iPhone 16 Pro Sim iOS 26
Homepage
Presentation animation average: ≈ 0.455 seconds (≈ 455 ms)
Dismissal animation average: ≈ 0.361 seconds (≈ 361 ms)


Webpage - Facebook
Presentation animation average: ≈ 0.431 seconds (≈ 431 ms)
Dismissal animation average: ≈ 0.353 seconds (≈ 353 ms)


#### iPhone 16 Pro 18.6
Homepage
Presentation animation average: ≈ 0.416 seconds (≈ 416 ms)
Dismissal animation average: ≈ 0.307 seconds (≈ 307 ms)

Webpage - Facebook
Presentation animation average: ≈ 0.402 seconds (≈ 402 ms)
Dismissal animation average: ≈ 0.340 seconds (≈ 340 ms)



### After
#### iPhone 16 Pro Sim iOS 26
Homepage:
Presentation animation average: ≈ 0.386 seconds (≈ 386 ms)
Dismissal animation average: ≈ 0.323 seconds (≈ 323 ms)

Facebook
Presentation animation average: ≈ 0.398 seconds (≈ 398 ms)
Dismissal animation average: ≈ 0.371 seconds (≈ 371 ms)


#### iPhone 16 Pro 18.6
Homepage
Presentation animation average: ≈ 0.349 seconds (≈ 349 ms)
Dismissal animation average: ≈ 0.311 seconds (≈ 311 ms)


Webpage - Facebook
Presentation animation average: ≈ 0.358 seconds (≈ 358 ms)
Dismissal animation average: ≈ 0.347 seconds (≈ 347 ms)

## Before (Memory leak) 
5 times open and close home - main
￼
<img width="372" height="314" alt="DefaultFaviconURLCache (1)" src="https://github.com/user-attachments/assets/a1f06a6c-96cc-4689-850b-eb00fb9defc6" />
<img width="878" height="935" alt="Screenshot 2025-08-21 at 5 39 14 PM" src="https://github.com/user-attachments/assets/0f8b61b0-6fca-437c-b845-cd0df33ce084" />

￼
## After
5 times open and close home - this branch
<img width="390" height="554" alt="DefaultFaviconURLCache (1)" src="https://github.com/user-attachments/assets/c0f19a15-355a-4011-9b89-274c43d35905" />
<img width="896" height="666" alt="76 5мв" src="https://github.com/user-attachments/assets/b4c42581-24bf-417b-bdef-70aede6057f8" />

￼

The 
## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
