### PR TITLE
Bugfix FXIOS-13225 [New first run onboarding] “Say goodbye to creepy ads” card shows incorrect image

### DIFF
--- a/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
@@ -226,7 +226,7 @@ features:
               order: 10
               title: Onboarding/Onboarding.Modern.Welcome.Title.v140
               body: Onboarding/Onboarding.Modern.Welcome.Description.v140
-              image: welcome-globe
+              image: trackers
               buttons:
                 primary:
                   title: Onboarding/Onboarding.Modern.Welcome.ActionTreatementA.v140


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13225)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28778)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Configure experiment with the correct image token.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<img height=400 src="https://github.com/user-attachments/assets/f4175a1c-ace0-4896-9225-8ed53700e186">

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
