### PR TITLE
Refactor [Merino] Update StoryProvider with homepage and DM methods

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoManager.swift
@@ -16,7 +16,7 @@ final class MerinoManager: MerinoManagerProvider {
     }
 
     func getMerinoItems() async -> [MerinoStoryConfiguration] {
-        let stories = await storyProvider.fetchStories()
+        let stories = await storyProvider.fetchHomepageStories()
         return stories.compactMap { MerinoStoryConfiguration(story: $0) }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Stories/StoryDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/Stories/StoryDataAdaptor.swift
@@ -47,7 +47,7 @@ final class StoryDataAdaptorImplementation: StoryDataAdaptor, FeatureFlaggable, 
     }
 
     private func updateMerinoSites() async {
-        let stories = await storyProvider.fetchStories()
+        let stories = await storyProvider.fetchHomepageStories()
         merinoStories = stories
         delegate?.didLoadNewData()
     }

--- a/firefox-ios/Client/Frontend/Home/Stories/StoryProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Stories/StoryProvider.swift
@@ -7,15 +7,15 @@ import MozillaAppServices
 import Shared
 
 final class StoryProvider: FeatureFlaggable, Sendable {
-    private let numberOfStories: Int
+    private struct Constants {
+        static let defaultNumberOfHomepageStories = 12
+        static let defaultNumberOfDiscoverMoreStories = 25
+    }
+
     private let merinoAPI: MerinoStoriesProviding
 
-    init(
-        merinoAPI: MerinoStoriesProviding,
-        numberOfStories: Int = 12
-    ) {
+    init(merinoAPI: MerinoStoriesProviding) {
         self.merinoAPI = merinoAPI
-        self.numberOfStories = numberOfStories
     }
 
     func fetchHomepageStories() async -> [MerinoStory] {
@@ -23,12 +23,12 @@ final class StoryProvider: FeatureFlaggable, Sendable {
         let numberOfStoriesIfRedesignEnabled = 9
         let numberOfStories = isStoriesRedesignEnabled
             ? numberOfStoriesIfRedesignEnabled
-            : self.numberOfStories
+            : Constants.defaultNumberOfHomepageStories
         return await fetchStories(numberOfStories)
     }
 
     func fetchDiscoverMoreStories() async -> [MerinoStory] {
-        return await fetchStories(25)
+        return await fetchStories(Constants.defaultNumberOfDiscoverMoreStories)
     }
 
     private func fetchStories(_ numberOfRequestedStories: Int) async -> [MerinoStory] {

--- a/firefox-ios/Client/Frontend/Home/Stories/StoryProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Stories/StoryProvider.swift
@@ -18,13 +18,21 @@ final class StoryProvider: FeatureFlaggable, Sendable {
         self.numberOfStories = numberOfStories
     }
 
-    func fetchStories() async -> [MerinoStory] {
+    func fetchHomepageStories() async -> [MerinoStory] {
         let isStoriesRedesignEnabled = featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
         let numberOfStoriesIfRedesignEnabled = 9
         let numberOfStories = isStoriesRedesignEnabled
             ? numberOfStoriesIfRedesignEnabled
             : self.numberOfStories
-        let data = (try? await merinoAPI.fetchStories(numberOfStories)) ?? []
+        return await fetchStories(numberOfStories)
+    }
+
+    func fetchDiscoverMoreStories() async -> [MerinoStory] {
+        return await fetchStories(25)
+    }
+
+    private func fetchStories(_ numberOfRequestedStories: Int) async -> [MerinoStory] {
+        let data = (try? await merinoAPI.fetchStories(numberOfRequestedStories)) ?? []
         return data.map(MerinoStory.init)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Stories/StoryDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Stories/StoryDataAdaptorTests.swift
@@ -35,9 +35,9 @@ class StoryDataAdaptorTests: XCTestCase {
 
     func testGetPocketData() async throws {
         let stories: [RecommendationDataItem] = [
-            .make(title: "feed1"),
-            .make(title: "feed2"),
-            .make(title: "feed3"),
+            .makeItem("feed1"),
+            .makeItem("feed2"),
+            .makeItem("feed3"),
         ]
         mockMerinoAPI = MockMerinoAPI(result: .success(stories))
         let subject = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Stories/StoryProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Stories/StoryProviderTests.swift
@@ -15,43 +15,29 @@ class StoryProviderTests: XCTestCase, FeatureFlaggable {
         subject = nil
     }
 
-    func tesFetchingStories_ReturnsList() async {
-        let stories: [RecommendationDataItem] = [
-            .make(title: "feed1"),
-            .make(title: "feed2"),
-            .make(title: "feed3"),
-        ]
+    func testFetchingStories_forHomepage_returnsList() async {
+        let stories: [RecommendationDataItem] = (0...30).map { .makeItem("feed\($0)") }
+        let expectedResult = Array(stories.prefix(12)).map(MerinoStory.init)
 
-        subject = StoryProvider(
-            merinoAPI: MockMerinoAPI(result: .success(stories))
-        )
+        subject = StoryProvider(merinoAPI: MockMerinoAPI(result: .success(stories)))
+        let fetched = await subject.fetchHomepageStories()
 
-        let fetched = await subject.fetchStories()
-        XCTAssertEqual(fetched, stories.map(MerinoStory.init))
+        XCTAssertEqual(fetched, expectedResult)
+    }
+
+    func testFetchingStories_forDiscoverMore_returnsList() async {
+        let stories: [RecommendationDataItem] = (0...30).map { .makeItem("feed\($0)") }
+        let expectedResult = Array(stories.prefix(25)).map(MerinoStory.init)
+
+        subject = StoryProvider(merinoAPI: MockMerinoAPI(result: .success(stories)))
+        let fetched = await subject.fetchDiscoverMoreStories()
+
+        XCTAssertEqual(fetched, expectedResult)
     }
 }
 
 extension StoryProviderTests {
     enum TestError: Error {
         case `default`
-    }
-}
-
-extension RecommendationDataItem {
-    static func make(title: String) -> RecommendationDataItem {
-        RecommendationDataItem(
-            corpusItemId: "",
-            scheduledCorpusItemId: "",
-            url: "www.google.com",
-            title: title,
-            excerpt: "",
-            topic: "",
-            publisher: "",
-            isTimeSensitive: false,
-            imageUrl: "www.google.com",
-            iconUrl: "",
-            tileId: 0,
-            receivedRank: 0
-        )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Stories/StoryProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Stories/StoryProviderTests.swift
@@ -17,7 +17,8 @@ class StoryProviderTests: XCTestCase, FeatureFlaggable {
 
     func testFetchingStories_forHomepage_returnsList() async {
         let stories: [RecommendationDataItem] = (0...30).map { .makeItem("feed\($0)") }
-        let expectedResult = Array(stories.prefix(12)).map(MerinoStory.init)
+        let expectedNumberOfStories = featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly) ? 9 : 12
+        let expectedResult = Array(stories.prefix(expectedNumberOfStories)).map(MerinoStory.init)
 
         subject = StoryProvider(merinoAPI: MockMerinoAPI(result: .success(stories)))
         let fetched = await subject.fetchHomepageStories()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -269,7 +269,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
     private func createStories(count: Int = 20) -> [MerinoStoryConfiguration] {
         var feedStories = [RecommendationDataItem]()
         (0..<count).forEach {
-            let story: RecommendationDataItem = .make(title: "feed \($0)")
+            let story: RecommendationDataItem = .makeItem("feed \($0)")
             feedStories.append(story)
         }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/MerinoManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/MerinoManagerTests.swift
@@ -44,9 +44,9 @@ final class MerinoManagerTests: XCTestCase {
 
     private func getMockStoriesData() -> [RecommendationDataItem] {
         return [
-            .make(title: "feed1"),
-            .make(title: "feed2"),
-            .make(title: "feed3"),
+            .makeItem("feed1"),
+            .makeItem("feed2"),
+            .makeItem("feed3"),
         ]
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockPocketManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockPocketManager.swift
@@ -13,9 +13,9 @@ final class MockMerinoManager: MerinoManagerProvider, @unchecked Sendable {
     func getMerinoItems() async -> [MerinoStoryConfiguration] {
         getMerinoItemsCalled += 1
         let stories: [RecommendationDataItem] = [
-            .make(title: "feed1"),
-            .make(title: "feed2"),
-            .make(title: "feed3"),
+            .makeItem("feed1"),
+            .makeItem("feed2"),
+            .makeItem("feed3"),
         ]
 
         return stories.compactMap { MerinoStoryConfiguration(story: MerinoStory(from: $0)) }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MerinoStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MerinoStateTests.swift
@@ -31,9 +31,9 @@ final class MerinoStateTests: XCTestCase {
         let reducer = pocketReducer()
 
         let feedStories: [RecommendationDataItem] = [
-            .make(title: "feed1"),
-            .make(title: "feed2"),
-            .make(title: "feed3"),
+            .makeItem("feed1"),
+            .makeItem("feed2"),
+            .makeItem("feed3"),
         ]
 
         let stories = feedStories.compactMap {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MerinoProviderTests.swift
@@ -98,8 +98,8 @@ final class MerinoProviderTests: XCTestCase {
 
     func test_fetchStories_returnsCached_whenThresholdNotPassed() async throws {
         let control = createSubject(thresholdHours: 4)
-        control.cache.seed(items: [makeItem("a"), makeItem("b")], lastUpdated: Date())
-        control.fetcher.stubbedItems = [makeItem("net1"), makeItem("net2")]
+        control.cache.seed(items: [.makeItem("a"), .makeItem("b")], lastUpdated: Date())
+        control.fetcher.stubbedItems = [.makeItem("net1"), .makeItem("net2")]
 
         let result = try await control.subject.fetchStories(10)
 
@@ -110,8 +110,8 @@ final class MerinoProviderTests: XCTestCase {
 
     func test_fetchStories_fetchesAndSaves_whenThresholdPassed() async throws {
         let control = createSubject(thresholdHours: 1/60)
-        control.cache.seed(items: [makeItem("old")], lastUpdated: Date().addingTimeInterval(-3600))
-        control.fetcher.stubbedItems = [makeItem("new1"), makeItem("new2")]
+        control.cache.seed(items: [.makeItem("old")], lastUpdated: Date().addingTimeInterval(-3600))
+        control.fetcher.stubbedItems = [.makeItem("new1"), .makeItem("new2")]
 
         let result = try await control.subject.fetchStories(10)
 
@@ -124,7 +124,7 @@ final class MerinoProviderTests: XCTestCase {
     func test_fetchStories_fetchesAndSaves_whenNoCache() async throws {
         let control = createSubject()
         control.cache.seedEmpty()
-        control.fetcher.stubbedItems = [makeItem("net")]
+        control.fetcher.stubbedItems = [.makeItem("net")]
 
         let result = try await control.subject.fetchStories(5)
 
@@ -152,9 +152,9 @@ final class MerinoProviderTests: XCTestCase {
 
         // Cache has _ itemCount but NO timestamp should be treated as STALE and must fetch
         // new stories. We should never get here, but we should still test it.
-        control.cache.seed(items: [makeItem("staleButNoTimestamp")], lastUpdated: nil)
+        control.cache.seed(items: [.makeItem("staleButNoTimestamp")], lastUpdated: nil)
 
-        control.fetcher.stubbedItems = [makeItem("net1"), makeItem("net2")]
+        control.fetcher.stubbedItems = [.makeItem("net1"), .makeItem("net2")]
 
         let result = try await control.subject.fetchStories(3)
 
@@ -165,22 +165,6 @@ final class MerinoProviderTests: XCTestCase {
         XCTAssertTrue(control.cache.didClear)
         XCTAssertEqual(control.cache.loadRecommendations()?.count, 2)
         XCTAssertEqual(control.cache.loadRecommendations()?.map(\.title), ["net1", "net2"])
-    }
-
-    private func makeItem(_ name: String) -> RecommendationDataItem {
-        return RecommendationDataItem(
-            corpusItemId: "\(name)",
-            scheduledCorpusItemId: "\(name)",
-            url: "https://\(name).com",
-            title: "\(name)",
-            excerpt: "Excerpt \(name)",
-            publisher: "Publisher \(name)",
-            isTimeSensitive: false,
-            imageUrl: "https://example\(name).com",
-            iconUrl: "https://example\(name).com",
-            tileId: 0,
-            receivedRank: 0
-        )
     }
 
     private func createSubject(
@@ -200,5 +184,23 @@ final class MerinoProviderTests: XCTestCase {
 
         trackForMemoryLeaks(subject)
         return TestableSubject(subject: subject, cache: cache, fetcher: fetcher)
+    }
+}
+
+extension RecommendationDataItem {
+    static func makeItem(_ name: String) -> RecommendationDataItem {
+        return RecommendationDataItem(
+            corpusItemId: "\(name)",
+            scheduledCorpusItemId: "\(name)",
+            url: "https://\(name).com",
+            title: "\(name)",
+            excerpt: "Excerpt \(name)",
+            publisher: "Publisher \(name)",
+            isTimeSensitive: false,
+            imageUrl: "https://example\(name).com",
+            iconUrl: "https://example\(name).com",
+            tileId: 0,
+            receivedRank: 0
+        )
     }
 }


### PR DESCRIPTION
## :bulb: Description
As per a conversation with PM, I've updated the story provider to fetch for homepage and DM.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
