### PR TITLE
Bugfix FXIOS-13270 ⁃ Incorrect behavior when opening new private tab from widget or FF context menu

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3274,8 +3274,9 @@ class BrowserViewController: UIViewController,
         if let url {
             switchToTabForURLOrOpen(url, isPrivate: isPrivate)
         } else {
-            if let isHomepage = tabManager.selectedTab?.isFxHomeTab, isHomepage {
-                focusLocationTextField(forTab: tabManager.selectedTab)
+            guard let selectedTab = tabManager.selectedTab else { return }
+            if selectedTab.isPrivate == isPrivate, selectedTab.isFxHomeTab {
+                focusLocationTextField(forTab: selectedTab)
             } else {
                 openBlankNewTab(
                     focusLocationField: options?.contains(.focusLocationField) == true,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -712,7 +712,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         let result = testCanHandleAndHandle(subject, route: .search(url: nil, isPrivate: false))
 
         XCTAssertTrue(result)
-        XCTAssertTrue(!browserViewController.openBlankNewTabCalled)
+        XCTAssertFalse(browserViewController.openBlankNewTabCalled)
         XCTAssertFalse(browserViewController.openBlankNewTabIsPrivate)
         XCTAssertEqual(browserViewController.openBlankNewTabCount, 0)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -712,9 +712,9 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         let result = testCanHandleAndHandle(subject, route: .search(url: nil, isPrivate: false))
 
         XCTAssertTrue(result)
-        XCTAssertTrue(browserViewController.openBlankNewTabCalled)
+        XCTAssertTrue(!browserViewController.openBlankNewTabCalled)
         XCTAssertFalse(browserViewController.openBlankNewTabIsPrivate)
-        XCTAssertEqual(browserViewController.openBlankNewTabCount, 1)
+        XCTAssertEqual(browserViewController.openBlankNewTabCount, 0)
     }
 
     func testHandleSearchURL_returnsTrue() {
@@ -830,9 +830,9 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
         // Then
         XCTAssertTrue(result)
-        XCTAssertEqual(browserViewController.openBlankNewTabCount, 1)
+        XCTAssertEqual(browserViewController.openBlankNewTabCount, 0)
         XCTAssertFalse(browserViewController.openBlankNewTabFocusLocationField)
-        XCTAssertEqual(browserViewController.openBlankNewTabIsPrivate, true)
+        XCTAssertEqual(browserViewController.openBlankNewTabIsPrivate, false)
     }
 
     func testHandleHomepanelNewTab_returnsTrue() {
@@ -846,7 +846,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
         // Then
         XCTAssertTrue(result)
-        XCTAssertEqual(browserViewController.openBlankNewTabCount, 1)
+        XCTAssertEqual(browserViewController.openBlankNewTabCount, 0)
         XCTAssertFalse(browserViewController.openBlankNewTabFocusLocationField)
         XCTAssertEqual(browserViewController.openBlankNewTabIsPrivate, false)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13270)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28886)

## :bulb: Description
If current mode is equal with the requested new tab mode and is homepage, we just move the focus to the keyboard
If current mode is different than the requested new tab mode, we need to open a new tab in the requested tab mode

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
