### PR TITLE
Refactor FXIOS-13274 [Unit Tests] credit card input tests

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardProvider.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardProvider.swift
@@ -12,6 +12,7 @@ protocol CreditCardProvider {
         completion: @escaping @Sendable (CreditCard?, Error?) -> Void
     )
     func decryptCreditCardNumber(encryptedCCNum: String?) -> String?
+    func deleteCreditCard(id: String, completion: @escaping @Sendable (Bool, Error?) -> Void)
     func listCreditCards(completion: @escaping @Sendable ([CreditCard]?, Error?) -> Void)
     func updateCreditCard(
         id: String,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -97,7 +97,7 @@ class CreditCardInputViewModel: ObservableObject {
     typealias CreditCardText = String.CreditCard.Alert
     var logger: Logger?
     let profile: Profile
-    let autofill: RustAutofill
+    let autofill: CreditCardProvider
     var creditCard: CreditCard?
     let creditCardValidator: CreditCardValidator
 
@@ -187,10 +187,11 @@ class CreditCardInputViewModel: ObservableObject {
     init(profile: Profile,
          creditCard: CreditCard? = nil,
          creditCardValidator: CreditCardValidator = CreditCardValidator(),
+         creditCardProvider: CreditCardProvider,
          logger: Logger = DefaultLogger.shared
     ) {
         self.profile = profile
-        self.autofill = profile.autofill
+        self.autofill = creditCardProvider
         self.creditCard = creditCard
         self.state = .add
         self.creditCardValidator = creditCardValidator

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
@@ -24,7 +24,7 @@ class CreditCardSettingsViewModel {
     let windowUUID: WindowUUID
     var appAuthenticator: AppAuthenticationProtocol?
 
-    lazy var cardInputViewModel = CreditCardInputViewModel(profile: profile)
+    lazy var cardInputViewModel = CreditCardInputViewModel(profile: profile, creditCardProvider: profile.autofill)
     lazy var toggleModel = ToggleModel(isEnabled: isAutofillEnabled, delegate: self)
     var tableViewModel = CreditCardTableViewModel()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockCreditCardProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockCreditCardProvider.swift
@@ -10,8 +10,9 @@ class MockCreditCardProvider: CreditCardProvider {
     var addCreditCardCalledCount = 0
     var updateCreditCardCalledCount = 0
     var listCreditCardsCalledCount = 0
+    var deleteCreditCardsCalledCount = 0
 
-    private var exampleCreditCard = CreditCard(
+    var exampleCreditCard = CreditCard(
         guid: "1",
         ccName: "Allen Burges",
         ccNumberEnc: "4111111111111111",
@@ -25,6 +26,10 @@ class MockCreditCardProvider: CreditCardProvider {
         timesUsed: 123123
     )
 
+    private(set) var lastDeletedID: String?
+    var deleteResult: (status: Bool, error: Error?) = (false, nil)
+    var updateResult: (status: Bool?, error: Error?) = (nil, nil)
+
     func addCreditCard(
         creditCard: UnencryptedCreditCardFields,
         completion: @escaping (CreditCard?, Error?) -> Void
@@ -33,6 +38,11 @@ class MockCreditCardProvider: CreditCardProvider {
         completion(exampleCreditCard, nil)
     }
     func decryptCreditCardNumber(encryptedCCNum: String?) -> String? { return "testCCNum" }
+    func deleteCreditCard(id: String, completion: @escaping @Sendable (Bool, (any Error)?) -> Void) {
+        deleteCreditCardsCalledCount += 1
+        lastDeletedID = id
+        completion(deleteResult.status, deleteResult.error)
+    }
     func listCreditCards(completion: @escaping ([CreditCard]?, Error?) -> Void) {
         listCreditCardsCalledCount += 1
         completion([exampleCreditCard], nil)
@@ -43,6 +53,6 @@ class MockCreditCardProvider: CreditCardProvider {
         completion: @escaping (Bool?, Error?) -> Void
     ) {
         updateCreditCardCalledCount += 1
-        completion(nil, nil)
+        completion(updateResult.status, updateResult.error)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputFieldTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputFieldTests.swift
@@ -18,7 +18,7 @@ class CreditCardInputFieldTests: XCTestCase {
         super.setUp()
 
         profile = MockProfile()
-        viewModel = CreditCardInputViewModel(profile: profile)
+        viewModel = CreditCardInputViewModel(profile: profile, creditCardProvider: MockCreditCardProvider())
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardSettingsViewControllerTests.swift
@@ -15,7 +15,7 @@ final class CreditCardSettingsViewControllerTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        viewModel = CreditCardInputViewModel(profile: profile)
+        viewModel = CreditCardInputViewModel(profile: profile, creditCardProvider: MockCreditCardProvider())
     }
 
     override func tearDown() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13274)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28896)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13273)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28895)

## :bulb: Description
Fix credit card tests that was commented out by this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/28831) and kept failing. Mock out the RustAutofill component so that we aren't relying on databases in the unit test and instead check that the autofill method is being called instead.

Ran 5000 times and wasn't able to get to fail. Previously, it was failing on a DB error.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
