### PR TITLE
Bugfix FXIOS-13201 FXIOS-13202 [Shake to Summarize] freezing on summarize after lock

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
+++ b/BrowserKit/Sources/SummarizeKit/SummarizeController.swift
@@ -200,7 +200,6 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
     }
 
     private func summarize() {
-        loadingLabel.alpha = 1.0
         errorView.alpha = 0.0
         Task { [weak self] in
             await self?.summarizeTask()
@@ -340,6 +339,8 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
         UIView.animate(withDuration: UX.initialTransformAnimationDuration) {
             self.tabSnapshot.layer.cornerRadius = UX.tabSnapshotCornerRadius
             self.loadingLabel.alpha = 1.0
+        } completion: { [weak self] _ in
+            self?.summarize()
         }
     }
 
@@ -365,7 +366,8 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
             removeBorderOverlayView()
             backgroundGradient.removeFromSuperlayer()
             tabSnapshotContainer.transform = CGAffineTransform(translationX: 0.0, y: tabSnapshotYTransform)
-            loadingLabel.alpha = 0.0
+            loadingLabel.stopShimmering()
+            loadingLabel.removeFromSuperview()
             summaryView.alpha = 1.0
             titleLabel.alpha = 1.0
         } completion: { [weak self] _ in
@@ -560,7 +562,6 @@ public class SummarizeController: UIViewController, Themeable, Notifiable, CAAni
               let animation = anim as? CABasicAnimation,
               animation.keyPath == UX.tabSnapshotTranslationKeyPath else { return }
         setupDismissGestures()
-        summarize()
     }
 
     /// Sets up gestures that allow the user to dismiss the summary.

--- a/BrowserKit/Sources/SummarizeKit/UILabel+ShimmeringEffect.swift
+++ b/BrowserKit/Sources/SummarizeKit/UILabel+ShimmeringEffect.swift
@@ -11,6 +11,7 @@ extension UILabel {
     ///   - light: The color to apply to the label when the light is spreading on the label
     ///   - dark: The color to apply to portion of the label not affected by light.
     func startShimmering(light: UIColor, dark: UIColor) {
+        stopShimmering()
         let light = light.cgColor
         let dark = dark.cgColor
 
@@ -33,10 +34,12 @@ extension UILabel {
 
         animation.duration = 1.5
         animation.repeatCount = HUGE
+        animation.isRemovedOnCompletion = false
         gradient.add(animation, forKey: "shimmer")
     }
 
     func stopShimmering() {
+        (layer.mask as? CAGradientLayer)?.removeAnimation(forKey: "shimmer")
         layer.mask = nil
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13201)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Fix for bug where user locks the screen when animating for summarize. 

**Issue:** We were waiting to summarize the page after `animationDidStop`, but it never gets called after locking the screen, so I moved the `summarize` call to where we finish the initial transform animation. Also, the shimmering animation broke, so I made sure that it loops, but I stop the animation when we no longer need it (`showSummary`) or if we call `startShimmering` again.

I don't love this change, but seems to fix the issue for now. I would love to see this area get refactored to use our Redux pattern eventually and summarize logic lives in middleware, but this is a fix for now given what we have.

Note: I left the gestures as-is to avoid making too many changes in the area.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
