### PR TITLE
Add FXIOS-13289 #28919 ⁃  protocol to remove Tab dependency and inject to TabScrollHandler the information that needs from Tab

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 		219A0FD72ACC8C03009A6D1A /* InactiveTabsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A0FD62ACC8C03009A6D1A /* InactiveTabsHeaderView.swift */; };
 		219A0FD92ACC8C0F009A6D1A /* InactiveTabsFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A0FD82ACC8C0F009A6D1A /* InactiveTabsFooterView.swift */; };
 		219A0FDB2ACCCFFC009A6D1A /* InactiveTabsSectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A0FDA2ACCCFFC009A6D1A /* InactiveTabsSectionManager.swift */; };
+		219AEE4A2E5E38BD00BF5F6F /* TabProviderAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219AEE492E5E38B200BF5F6F /* TabProviderAdapter.swift */; };
 		21A1C3C72996AFF800181B7C /* OverlayModeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A1C3C62996AFF800181B7C /* OverlayModeManagerTests.swift */; };
 		21A43CDD291461C700B1206D /* ReaderModeFontTypeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A43CDC291461C700B1206D /* ReaderModeFontTypeButton.swift */; };
 		21A7C44E283539170071D996 /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C44D283539170071D996 /* IntroViewModel.swift */; };
@@ -2939,6 +2940,7 @@
 		219A0FD62ACC8C03009A6D1A /* InactiveTabsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabsHeaderView.swift; sourceTree = "<group>"; };
 		219A0FD82ACC8C0F009A6D1A /* InactiveTabsFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabsFooterView.swift; sourceTree = "<group>"; };
 		219A0FDA2ACCCFFC009A6D1A /* InactiveTabsSectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabsSectionManager.swift; sourceTree = "<group>"; };
+		219AEE492E5E38B200BF5F6F /* TabProviderAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabProviderAdapter.swift; sourceTree = "<group>"; };
 		219F41288625C09DD40F008C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		21A1C3C62996AFF800181B7C /* OverlayModeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayModeManagerTests.swift; sourceTree = "<group>"; };
 		21A43CDC291461C700B1206D /* ReaderModeFontTypeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontTypeButton.swift; sourceTree = "<group>"; };
@@ -11587,6 +11589,7 @@
 		21F422642E315DFD004FF994 /* TabScrollController */ = {
 			isa = PBXGroup;
 			children = (
+				219AEE492E5E38B200BF5F6F /* TabProviderAdapter.swift */,
 				21F422652E315E55004FF994 /* LegacyTabScrollController.swift */,
 				E698FFD91B4AADF40001F623 /* TabScrollHandler.swift */,
 			);
@@ -17834,6 +17837,7 @@
 				C8BA0E7627F20B8E00DD8214 /* HistoryDeletionUtility.swift in Sources */,
 				8A93F86D29D3A131004159D9 /* DefaultRouter.swift in Sources */,
 				B236204B2B851FE1000B1DE7 /* AddressAutoFillBottomSheetView.swift in Sources */,
+				219AEE4A2E5E38BD00BF5F6F /* TabProviderAdapter.swift in Sources */,
 				8ADAE4262A33A13B007BF926 /* OpenSupportPageSetting.swift in Sources */,
 				8A590C6128C123100032F1AA /* OpenPassBookHelper.swift in Sources */,
 				BA4BB9A42D7FF754006BD137 /* DarkModeToggleView.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -79,7 +79,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         else { return }
 
         if let selectedTab = tabManager.selectedTab,
-            selectedTab.isFxHomeTab || !selectedTab.loading,
+            selectedTab.isFxHomeTab || !selectedTab.isLoading,
             !state.microsurveyState.showPrompt {
             present(navigationContextHintVC, animated: true)
             UIAccessibility.post(notification: .layoutChanged, argument: navigationContextHintVC)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4620,7 +4620,11 @@ extension BrowserViewController: TabManagerDelegate {
         readerModeCache = selectedTab.isPrivate ? MemoryReaderModeCache.shared : DiskReaderModeCache.shared
         ReaderModeHandlers.setCache(readerModeCache)
 
-        scrollController.tab = selectedTab
+        if let scrollController = scrollController as? LegacyTabScrollProvider {
+            scrollController.tab = selectedTab
+        } else {
+            scrollController.tabProvider = TabProviderAdapter(selectedTab)
+        }
 
         var needsReload = false
         if let webView = selectedTab.webView {
@@ -4656,7 +4660,7 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
         updateFindInPageVisibility(isVisible: false, tab: previousTab)
-        setupMiddleButtonStatus(isLoading: selectedTab.loading)
+        setupMiddleButtonStatus(isLoading: selectedTab.isLoading)
 
         if isToolbarRefactorEnabled {
             dispatchBackForwardToolbarAction(canGoBack: selectedTab.canGoBack,

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -9,6 +9,7 @@ import Common
 
 @MainActor
 protocol LegacyTabScrollProvider: TabScrollHandlerProtocol {
+    var tab: Tab? { get set }
     var zoomPageBar: ZoomPageBar? { get set }
     var headerTopConstraint: Constraint? { get set }
     var overKeyboardContainerConstraint: Constraint? { get set }
@@ -69,6 +70,9 @@ final class LegacyTabScrollController: NSObject,
             }
         }
     }
+
+    // Not implemented in this class
+    weak var tabProvider: TabProviderProtocol?
 
     // Toolbar Views
     private weak var headerContainer: BaseAlphaStackView?
@@ -491,7 +495,7 @@ private extension LegacyTabScrollController {
     }
 
     func tabIsLoading() -> Bool {
-        return tab?.loading ?? true
+        return tab?.isLoading ?? true
     }
 
     /// Returns true if scroll has reach the bottom

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabProviderAdapter.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabProviderAdapter.swift
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+@MainActor
+protocol TabProviderProtocol: AnyObject {
+    var scrollView: UIScrollView? { get }
+    var shouldScrollToTop: Bool { get set }
+    var isFxHomeTab: Bool { get }
+    var isFindInPageMode: Bool { get }
+    var isLoading: Bool { get }
+    // Pull to refresh related
+    var onLoadingStateChanged: (() -> Void)? { get set }
+    func removePullToRefresh()
+    func addPullToRefresh(onReload: @escaping () -> Void)
+    func reloadPage()
+}
+
+final class TabProviderAdapter: TabProviderProtocol {
+    private unowned let tab: Tab
+
+    init(_ tab: Tab) {
+        self.tab = tab
+    }
+
+    var isFxHomeTab: Bool { tab.isFxHomeTab }
+    var isFindInPageMode: Bool { tab.isFindInPageMode }
+    var isLoading: Bool { tab.isLoading }
+
+    var shouldScrollToTop: Bool {
+        get { tab.shouldScrollToTop }
+        set { tab.shouldScrollToTop = newValue }
+    }
+
+    var scrollView: UIScrollView? { tab.webView?.scrollView }
+
+    var onLoadingStateChanged: (() -> Void)? {
+        get { tab.onWebViewLoadingStateChanged }
+        set { tab.onWebViewLoadingStateChanged = newValue }
+    }
+
+    func addPullToRefresh(onReload: @escaping () -> Void) {
+        tab.webView?.addPullRefresh(onReload: onReload)
+    }
+
+    func removePullToRefresh() {
+        tab.webView?.removePullRefresh()
+    }
+
+    func reloadPage() {
+        tab.reloadPage()
+    }
+}

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -177,7 +177,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         return url
     }
 
-    var loading: Bool {
+    var isLoading: Bool {
         return webView?.isLoading ?? false
     }
 

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -281,6 +281,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     var lastExecutedTime: Timestamp
     var firstCreatedTime: Timestamp
     private let faviconHelper: SiteImageHandler
+    // TODO: FXIOS-13297 Keep track of new DispatchQueueInterface usages
     private var removeDispatchQueue: DispatchQueueInterface
     var faviconURL: String? {
         didSet {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
@@ -249,7 +249,7 @@ final class TabScrollHandlerTests: XCTestCase {
         tab.webView?.scrollView.frame.size = CGSize(width: 200, height: 2000)
         tab.webView?.scrollView.contentSize = CGSize(width: 200, height: 2000)
         tab.webView?.scrollView.delegate = subject
-        subject.tab = tab
+        subject.tabProvider = TabProviderAdapter(tab)
     }
 
     private func createSubject() -> TabScrollHandler {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13289)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28919)

## :bulb: Description
- No visual changes were made, just removing the Tab dependency and replacing it with a protocol

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
