### PR TITLE
Bugfix FXIOS-13205 [New first run onboarding] The onboarding flow is not continued after setting FF as a default browser

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
@@ -77,9 +77,7 @@ final class OnboardingService: FeatureFlaggable {
             completion(.success(.advance(numberOfPages: 3)))
 
         case .syncSignIn:
-            handleSyncSignIn(from: cardName, with: activityEventHelper) {
-                completion(.success(.advance(numberOfPages: 1)))
-            }
+            handleSyncSignIn(from: cardName, with: activityEventHelper) {}
 
         case .setDefaultBrowser:
             handleSetDefaultBrowser(with: activityEventHelper)
@@ -189,9 +187,7 @@ final class OnboardingService: FeatureFlaggable {
     }
 
     private func handleOpenInstructionsPopup(from popupViewModel: OnboardingDefaultBrowserModelProtocol) {
-        presentDefaultBrowserPopup(from: popupViewModel) { [weak self] in
-            self?.navigationDelegate?.finishOnboardingFlow()
-        }
+        presentDefaultBrowserPopup(from: popupViewModel) {}
     }
 
     private func handleReadPrivacyPolicy(from url: URL, completion: @escaping () -> Void) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28735)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The dismissal message for onboarding is no longer sent because the completion is removed.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
