### PR TITLE
Refactor FXIOS-13014 [Remove Monadic Deferred Operators] Replace >>> operator with bind

### DIFF
--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -515,10 +515,10 @@ open class BrowserProfile: Profile,
             return deferMaybe([])
         }
         return syncManager.syncTabs().bind { result in
-                    if result.isSuccess {
-                        return self.retrieveTabData()
-                    }
-                    return deferMaybe(result.failureValue!)
+            if result.isSuccess {
+                return self.retrieveTabData()
+            }
+            return deferMaybe(result.failureValue!)
         }
     }
 

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -514,7 +514,12 @@ open class BrowserProfile: Profile,
         guard let syncManager else {
             return deferMaybe([])
         }
-        return syncManager.syncTabs() >>> { self.retrieveTabData() }
+        return syncManager.syncTabs().bind { result in
+                    if result.isSuccess {
+                        return self.retrieveTabData()
+                    }
+                    return deferMaybe(result.failureValue!)
+                }
     }
 
     public func getClientsAndTabs(completion: @escaping ([ClientAndTabs]?) -> Void) {

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -519,7 +519,7 @@ open class BrowserProfile: Profile,
                         return self.retrieveTabData()
                     }
                     return deferMaybe(result.failureValue!)
-                }
+        }
     }
 
     public func getClientsAndTabs(completion: @escaping ([ClientAndTabs]?) -> Void) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13014)  
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28370)

## :bulb: Description
This PR replaces the deprecated `>>>` Deferred operator with `.bind` in `Profile.swift` under `getClientsAndTabs()`.  

- On success: the function now continues to `retrieveTabData()`.  
- On failure: the same error is propagated through `deferMaybe(.failure(error))`.  
- Behavior is unchanged; only implementation was updated to remove the `>>>` operator.  

## :movie_camera: Demos
_Not applicable — no UI changes._  
This change affects only background sync logic.  

| Before | After |
| - | - |
| `return syncManager.syncTabs() >>> { self.retrieveTabData() }` | `return syncManager.syncTabs().bind { result in … }` |

<details>
<summary>Demo</summary>
No visual demo — tested by running unit tests (`⌘U`) and verifying sync flow.
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work  
- [x] I updated the PR name to follow the [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)  
- [x] I ensured unit tests pass for my changes  
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)  
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review  
- [ ] If needed, I updated documentation and added comments to complex code  
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)  