### PR TITLE
Bugfix FXIOS-13214 Circular memory reference in TopSiteCell with FaviconImageView

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteCell.swift
@@ -35,8 +35,8 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
     }
 
     private lazy var imageView: FaviconImageView = {
-        let imageView = FaviconImageView {
-            self.configureFaviconWithTransparency()
+        let imageView = FaviconImageView { [weak self] in
+            self?.configureFaviconWithTransparency()
         }
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Found a circular memory reference to `FaviconImageView` inside `TopSiteCell`, which caused the massive memory leak @dataports identified when opening and closing the tab tray multiple times (see [related PR here](https://github.com/mozilla-mobile/firefox-ios/pull/28881)).

<img width="1351" height="681" alt="Screenshot 2025-08-27 at 11 18 32 AM" src="https://github.com/user-attachments/assets/e17515ce-af29-4356-abfe-eb8513b277d9" />
<img width="2031" height="1096" alt="Screenshot 2025-08-27 at 11 18 22 AM" src="https://github.com/user-attachments/assets/0f3fef48-b77b-4f8b-82f6-f90107ad87b2" />

Now we get a much more reasonable number of favicons after opening and closing the tab tray multiple times:

<img width="347" height="430" alt="Screenshot 2025-08-27 at 11 27 55 AM" src="https://github.com/user-attachments/assets/267ceaef-087f-4d39-be13-19b21d110f4a" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
