### PR TITLE
Bugfix - Redux States should always return a new default state and never the same `state`

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -55,7 +55,9 @@ struct TabPeekState: ScreenState, Equatable {
 
         switch action.actionType {
         case TabPeekActionType.loadTabPeek:
-            guard let tabPeekModel = action.tabPeekModel else { return state }
+            guard let tabPeekModel = action.tabPeekModel else {
+                return defaultState(from: state)
+            }
             return TabPeekState(windowUUID: state.windowUUID,
                                 showAddToBookmarks: tabPeekModel.canTabBeSaved,
                                 showSendToDevice: tabPeekModel.isSyncEnabled && tabPeekModel.canTabBeSaved,

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
@@ -25,7 +25,7 @@ struct TermsOfUseState: ScreenState, Equatable {
     static let reducer: Reducer<TermsOfUseState> = { state, action in
         guard let action = action as? TermsOfUseAction,
               let type = action.actionType as? TermsOfUseActionType,
-              action.windowUUID == state.windowUUID else { return state }
+              action.windowUUID == state.windowUUID else { return defaultState(from: state) }
 
         switch type {
         case .markAccepted:

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -89,7 +89,9 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
     }
 
     static let reducer: Reducer<TrackingProtectionState> = { state, action in
-        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else {
+            return defaultState(from: state)
+        }
 
         switch action.actionType {
         case TrackingProtectionMiddlewareActionType.clearCookies:


### PR DESCRIPTION
## :scroll: Tickets
N/A

## :bulb: Description
Fix for returning a new initial state in our redux states, as we never want to return the same state again (can cause issues with diffing).

Just noticed a few of these crept back into the code in different areas while we were debugging something else.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
