### PR TITLE
Refactor MTE-4495 Use Xcode 26 in L10n screenshots

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -847,7 +847,7 @@ workflows:
       the rest of the builds
     meta:
       bitrise.io:
-        stack: osx-xcode-16.2.x
+        stack: osx-xcode-26.0.x-edge
         machine_type_id: g2.mac.large
   L10nScreenshotsTests:
     steps:
@@ -892,7 +892,7 @@ workflows:
       This Workflow is to run L10n tests for all locales
     meta:
       bitrise.io:
-        stack: osx-xcode-16.2.x
+        stack: osx-xcode-26.0.x-edge
         machine_type_id: g2.mac.large
   SPM_Deploy_Prod_Beta:
     before_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -763,46 +763,9 @@ workflows:
     - certificate-and-profile-installer@1.11.4: {}
     - script@1.2.1:
         inputs:
-        - content: >-
-            #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            # debug log
-            set -x
-
-            echo
-            'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64
-            arm64e armv7 armv7s armv6 armv8' > /tmp/tmp.xcconfig
-
-            echo 'EXCLUDED_ARCHS=$(inherited)
-            $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))'
-            >> /tmp/tmp.xcconfig
-
-            echo 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig
-
-            echo 'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
-
-            echo 'GCC_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
-
-            export XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig
-
-            envman add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig
-        title: Workaround carthage lipo
-    - script@1.2.1:
-        inputs:
         - content: |-
             ./bootstrap.sh
         title: Run bootstrap
-    - script@1.2.1:
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -e
-            set -x
-
-            rm /tmp/tmp.xcconfig
-            envman add --key XCODE_XCCONFIG_FILE --value ''
-        title: Remove carthage lip
     - script@1.2.1:
         title: NPM install and build
         inputs:

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -258,6 +258,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         }
 
         allSettingsScreens.forEach { nodeName in
+            self.navigator.goto(SettingsScreen)
             self.navigator.goto(nodeName)
             if nodeName == "DisplaySettings" {
                 scrollview.forEachScreen { i in

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -11,12 +11,16 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     func testPanelsEmptyState() {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.nowAt(NewTabScreen)
-        navigator.goto(LibraryPanel_Bookmarks)
-        snapshot("PanelsEmptyState-LibraryPanels.Bookmarks")
-        // Tap on each of the library buttons
-        for i in 1...3 {
-            app.segmentedControls["librarySegmentControl"].buttons.element(boundBy: i).tap()
-            snapshot("PanelsEmptyState-\(i)")
+        let panels = [
+            LibraryPanel_Bookmarks,
+            LibraryPanel_History,
+            LibraryPanel_Downloads,
+            // ReadingList icon is not found in debugDescription
+            // LibraryPanel_ReadingList
+        ]
+        panels.forEach { panel in
+            navigator.goto(panel)
+            snapshot("PanelsEmptyState-\(panel)")
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerLibraryPanelNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerLibraryPanelNavigation.swift
@@ -6,7 +6,7 @@ import XCTest
 import MappaMundi
 
 func registerLibraryPanelNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
-    let doneButton = app.buttons["Done"]
+    let doneButton = app.buttons[AccessibilityIdentifiers.LibraryPanels.topRightButton]
 
     map.addScreenState(LibraryPanel_ReadingList) { screenState in
         screenState.dismissOnUse = true

--- a/firefox-ios/l10n-screenshots.sh
+++ b/firefox-ios/l10n-screenshots.sh
@@ -39,7 +39,7 @@ for lang in $LOCALES; do
         --skip_open_summary \
         --xcargs "-maximum-parallel-testing-workers 2" \
         --derived_data_path l10n-screenshots-dd \
-        --ios_version "18.2" \
+        --ios_version "26.0" \
         --erase_simulator --localize_simulator \
         --devices "iPhone 16" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4495)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
When Firefox iOS uses Xcode 26 in the release, let's use Xcode 26 for the L10n screenshots. 

(Note: Do not merge before Sept 2 when the screenshots for release/v142 is taken.)

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
