### PR TITLE
Add FXIOS-13214 [SiteImageView improvement] Fixing some leaks under FaviconURLCache

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURL.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURL.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-struct FaviconURL: Codable {
+struct FaviconURL: Codable, Sendable {
     let cacheKey: String
     let faviconURL: String
     var createdAt: Date

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
@@ -20,15 +20,10 @@ actor DefaultFaviconURLCache: FaviconURLCache {
     private let fileManager: URLCacheFileManager
     private var urlCache = [String: FaviconURL]()
     private var preserveTask: Task<Void, Never>?
-    private let preserveDebounceTime: UInt64
+    private let preserveDebounceTime: UInt64 = 10_000_000_000 // 10 seconds
 
-    /// - Parameters:
-    ///   - fileManager: The cache file manager
-    ///   - preserveDebounceTime: The preserve debounce time to throttle how often the cache is written to persistent storage, 10 seconds by default
-    init(fileManager: URLCacheFileManager = DefaultURLCacheFileManager(),
-         preserveDebounceTime: UInt64 = 10_000_000_000) {
+    init(fileManager: URLCacheFileManager = DefaultURLCacheFileManager()) {
         self.fileManager = fileManager
-        self.preserveDebounceTime = preserveDebounceTime
 
         Task {
             await retrieveCache()

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
@@ -63,9 +63,7 @@ actor DefaultFaviconURLCache: FaviconURLCache {
             try? await Task.sleep(nanoseconds: self?.preserveDebounceTime ?? 0)
             guard !Task.isCancelled,
                   let data = await self?.archiveCacheData()
-            else {
-                return
-            }
+            else { return }
             await self?.fileManager.saveURLCache(data: data)
         }
     }

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLCacheTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLCacheTests.swift
@@ -86,7 +86,7 @@ class FaviconURLCacheTests: XCTestCase {
     func createSubject(fileManager: URLCacheFileManager,
                        file: StaticString = #filePath,
                        line: UInt = #line) -> DefaultFaviconURLCache {
-        let subject = DefaultFaviconURLCache(fileManager: fileManager, preserveDebounceTime: 0)
+        let subject = DefaultFaviconURLCache(fileManager: fileManager)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
     }

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLCacheTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLCacheTests.swift
@@ -6,31 +6,33 @@ import XCTest
 @testable import SiteImageView
 
 class FaviconURLCacheTests: XCTestCase {
-    var subject: DefaultFaviconURLCache!
     var mockFileManager: MockURLCacheFileManager!
 
     override func setUp() {
         super.setUp()
         mockFileManager = MockURLCacheFileManager()
-        subject = DefaultFaviconURLCache(fileManager: mockFileManager)
     }
 
     override func tearDown() {
         super.tearDown()
         mockFileManager = nil
-        subject = nil
     }
 
     func testGetURLFromCacheWithEmptyCache() async {
+        let subject = createSubject(fileManager: mockFileManager)
         let cacheKey = "firefox.com"
         let result = try? await subject.getURLFromCache(cacheKey: cacheKey)
         XCTAssertNil(result)
     }
 
-    func testGetURLFromCacheWithValuePresent() async {
+    func testGetURLFromCacheWithValuePresent() async throws {
+        let subject = createSubject(fileManager: MockURLCacheFileManager())
         let cacheKey = "firefox.com"
         await subject.cacheURL(cacheKey: cacheKey, faviconURL: URL(string: "www.firefox.com")!)
         let result = try? await subject.getURLFromCache(cacheKey: cacheKey)
+
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
         XCTAssertEqual(result?.absoluteString, "www.firefox.com")
     }
 
@@ -40,7 +42,7 @@ class FaviconURLCacheTests: XCTestCase {
         let testFavicons = [FaviconURL(cacheKey: cacheKey, faviconURL: "www.google.com", createdAt: Date())]
         await fileManager.saveURLCache(data: getTestData(items: testFavicons))
 
-        subject = DefaultFaviconURLCache(fileManager: fileManager)
+        let subject = createSubject(fileManager: fileManager)
 
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
@@ -58,12 +60,14 @@ class FaviconURLCacheTests: XCTestCase {
                             FaviconURL(cacheKey: "firefox", faviconURL: "www.firefox.com", createdAt: expiredDate)]
         await fileManager.saveURLCache(data: getTestData(items: testFavicons))
 
-        subject = DefaultFaviconURLCache(fileManager: fileManager)
+        let subject = createSubject(fileManager: fileManager)
 
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
         let result1 = try? await subject.getURLFromCache(cacheKey: "amazon")
         XCTAssertEqual(result1?.absoluteString, "www.amazon.com")
+
+        try await Task.sleep(nanoseconds: 1_000_000_000)
 
         let result2 = try? await subject.getURLFromCache(cacheKey: "firefox")
         XCTAssertNil(result2)
@@ -77,6 +81,14 @@ class FaviconURLCacheTests: XCTestCase {
             XCTFail("Something went wrong generating mock favicon data, file: \(file), line: \(line)")
         }
         return archiver.encodedData
+    }
+
+    func createSubject(fileManager: URLCacheFileManager,
+                       file: StaticString = #filePath,
+                       line: UInt = #line) -> DefaultFaviconURLCache {
+        let subject = DefaultFaviconURLCache(fileManager: fileManager, preserveDebounceTime: 0)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
     }
 }
 

--- a/BrowserKit/Tests/SiteImageViewTests/Resources/XCTestCaseExtension.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/Resources/XCTestCaseExtension.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+public extension XCTestCase {
+    func trackForMemoryLeaks(_ object: AnyObject?, file: StaticString = #filePath, line: UInt = #line) {
+        addTeardownBlock { [weak object] in
+            XCTAssertNil(object, "Memory leak detected in \(file):\(line)")
+        }
+    }
+}

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageHandlerTests.swift
@@ -26,8 +26,7 @@ final class SiteImageHandlerTests: XCTestCase {
         let faviconURLString = "https://www.mozilla.org/media/img/favicons/mozilla/apple-touch-icon.8cbe9c835c00.png"
         urlHandler.faviconURL = URL(string: faviconURLString)!
         let siteURL = URL(string: "https://www.mozilla.com")!
-        let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
-                                              imageHandler: imageHandler)
+        let subject = createSubject(urlHandler: urlHandler, imageHandler: imageHandler)
         let model = SiteImageModel(id: UUID(),
                                    imageType: .favicon,
                                    siteURL: siteURL,
@@ -41,8 +40,7 @@ final class SiteImageHandlerTests: XCTestCase {
         let faviconURLString = "https://www.mozilla.org/media/img/favicons/mozilla/apple-touch-icon.8cbe9c835c00.png"
         let faviconURL = URL(string: faviconURLString)!
         let siteURL = URL(string: "https://www.mozilla.com")!
-        let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
-                                              imageHandler: imageHandler)
+        let subject = createSubject(urlHandler: urlHandler, imageHandler: imageHandler)
         let model = SiteImageModel(id: UUID(),
                                    imageType: .favicon,
                                    siteURL: siteURL,
@@ -54,8 +52,7 @@ final class SiteImageHandlerTests: XCTestCase {
 
     func testGetImage_favicon_noURL_stillCallsImageHandler_fetchFavicon() async {
         let siteURL = URL(string: "https://www.mozilla.com")!
-        let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
-                                              imageHandler: imageHandler)
+        let subject = createSubject(urlHandler: urlHandler, imageHandler: imageHandler)
         let model = SiteImageModel(id: UUID(),
                                    imageType: .favicon,
                                    siteURL: siteURL,
@@ -70,8 +67,7 @@ final class SiteImageHandlerTests: XCTestCase {
         let faviconURLString = "https://www.mozilla.org/media/img/favicons/mozilla/apple-touch-icon.8cbe9c835c00.png"
         let faviconURL = URL(string: faviconURLString)!
         let siteURL = URL(string: "https://www.mozilla.com")!
-        let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
-                                              imageHandler: imageHandler)
+        let subject = createSubject(urlHandler: urlHandler, imageHandler: imageHandler)
         let model = SiteImageModel(id: UUID(),
                                    imageType: .favicon,
                                    siteURL: siteURL,
@@ -84,8 +80,7 @@ final class SiteImageHandlerTests: XCTestCase {
     func testGetImage_heroImage_hasHeroImage_fetchesHeroImage() async {
         let siteURL = URL(string: "https://www.mozilla.com")!
         imageHandler.heroImage = UIImage()
-        let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
-                                              imageHandler: imageHandler)
+        let subject = createSubject(urlHandler: urlHandler, imageHandler: imageHandler)
         let model = SiteImageModel(id: UUID(),
                                    imageType: .heroImage,
                                    siteURL: siteURL)
@@ -100,8 +95,7 @@ final class SiteImageHandlerTests: XCTestCase {
         let faviconURLString = "https://www.mozilla.org/media/img/favicons/mozilla/apple-touch-icon.8cbe9c835c00.png"
         urlHandler.faviconURL = URL(string: faviconURLString)!
 
-        let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
-                                              imageHandler: imageHandler)
+        let subject = createSubject(urlHandler: urlHandler, imageHandler: imageHandler)
         let siteURL = URL(string: "https://www.mozilla.com")!
         let model = SiteImageModel(id: UUID(),
                                    imageType: .heroImage,
@@ -115,8 +109,7 @@ final class SiteImageHandlerTests: XCTestCase {
 
     // Test cache
     func testCacheFavicon() {
-        let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
-                                              imageHandler: imageHandler)
+        let subject = createSubject(urlHandler: urlHandler, imageHandler: imageHandler)
         let siteURL = URL(string: "https://firefox.com")!
         let faviconURL = URL(string: "https://firefox.com/favicon.ico")!
         subject.cacheFaviconURL(siteURL: siteURL,
@@ -127,8 +120,7 @@ final class SiteImageHandlerTests: XCTestCase {
     }
 
     func testClearCache() {
-        let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
-                                              imageHandler: imageHandler)
+        let subject = createSubject(urlHandler: urlHandler, imageHandler: imageHandler)
         subject.clearAllCaches()
 
         XCTAssertEqual(urlHandler.clearCacheCalled, 1)
@@ -151,12 +143,9 @@ final class SiteImageHandlerTests: XCTestCase {
         urlHandler1.faviconURL = URL(string: "https://firefox.com/favicon.ico")!
 
         let siteURL = URL(string: "https://www.example.hello.com")!
-        let subject1 = DefaultSiteImageHandler(urlHandler: urlHandler1,
-                                               imageHandler: imageHandler)
-        let subject2 = DefaultSiteImageHandler(urlHandler: urlHandler2,
-                                               imageHandler: imageHandler)
-        let subject3 = DefaultSiteImageHandler(urlHandler: urlHandler3,
-                                               imageHandler: imageHandler)
+        let subject1 = createSubject(urlHandler: urlHandler1, imageHandler: imageHandler)
+        let subject2 = createSubject(urlHandler: urlHandler2, imageHandler: imageHandler)
+        let subject3 = createSubject(urlHandler: urlHandler3, imageHandler: imageHandler)
         let model = SiteImageModel(id: UUID(),
                                    imageType: .favicon,
                                    siteURL: siteURL)
@@ -192,6 +181,16 @@ final class SiteImageHandlerTests: XCTestCase {
         ]
         XCTAssertEqual(urlHandlerCalls.reduce(0, +), 1, "Only one of the urlHandlers should ever be called")
         XCTAssertEqual(imageHandler.fetchFaviconCalledCount, 1, "image handler should only be called once")
+    }
+
+    func createSubject(urlHandler: FaviconURLHandler,
+                       imageHandler: ImageHandler,
+                       file: StaticString = #filePath,
+                       line: UInt = #line) -> DefaultSiteImageHandler {
+        let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
+                                              imageHandler: imageHandler)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
     }
 }
 
@@ -254,5 +253,13 @@ private final class MockImageHandler: ImageHandler, @unchecked Sendable {
 
     func clearCache() {
         clearCacheCalledCount += 1
+    }
+}
+
+public extension XCTestCase {
+    func trackForMemoryLeaks(_ object: AnyObject?, file: StaticString = #filePath, line: UInt = #line) {
+        addTeardownBlock { [weak object] in
+            XCTAssertNil(object, "Memory leak detected in \(file):\(line)")
+        }
     }
 }

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageHandlerTests.swift
@@ -255,11 +255,3 @@ private final class MockImageHandler: ImageHandler, @unchecked Sendable {
         clearCacheCalledCount += 1
     }
 }
-
-public extension XCTestCase {
-    func trackForMemoryLeaks(_ object: AnyObject?, file: StaticString = #filePath, line: UInt = #line) {
-        addTeardownBlock { [weak object] in
-            XCTAssertNil(object, "Memory leak detected in \(file):\(line)")
-        }
-    }
-}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13214)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Introduced some leaks testing in `SiteImageView` package under some of the classes there. Didn't find any leak issue under `SiteImageHandlerTests`.

Under the `FaviconURLCache`:
- We had some strong retain cycle detected in the unit tests by adding `trackForMemoryLeaks`. Using `weak self` for now to fix this.
- I needed to add some `Task.sleep` under the tests cases since `getURLFromCache` spins a `Task` of its own, and we're basically not waiting for it to complete, which creates a retain cycle (since the Task is still present at the time the tests finishes and tries to deinit everything). 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
