### PR TITLE
Refactor FXIOS [Documentation] Adjust documentation for Strings key

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -20,7 +20,8 @@ public struct Strings {
 /// - Parameters:
 ///   - key: The key should be unique and composed of a relevant name, ended with the version the string was included in.
 ///   Example: `"FirefoxHomepage.Pocket.Sponsored.v103"` is a string that lives under the homepage for the sponsored content in the pocket
-///   section, added in v103. The name is clear and explicit.
+///   section, added in the v103 release train. The name is clear and explicit.
+///   The version needs to be the current release train in Nightly: https://whattrainisitnow.com/
 ///   - tableName: The tablename defines the name of the table containing the localized string.
 ///   This specifically need to be defined for any strings that is part of the messaging framework, but since any string can be part of messaging in the
 ///   future all strings should have a tablename. This can be nil for existing strings, `new string shouldn't have a nil tableName`.


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
I adjusted the documentation under the [wiki](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings), and I think we should adjust the documentation under the `Strings` file too

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
