### PR TITLE
Refactor FXIOS-13341 [Shortcuts Library] Use pre-existing translated "Homepage" string for BVC title

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1143,7 +1143,8 @@ class BrowserViewController: UIViewController,
     }
 
     private func setupNavigationAppearance() {
-        title = .FirefoxHomepage.ScreenTitle
+        // TODO: FXIOS-13342 - replace this string with .FirefoxHomepage.ScreenTitle once it is translated (v144)
+        title = .SettingsHomePageSectionName
         navigationItem.backButtonDisplayMode = .generic
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13341)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29024)

## :bulb: Description
- Replace new "Homepage" string with a pre-existing translated version so that we can potentially release the shortcuts library feature before waiting for translations to finish for v144

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
