### PR TITLE
Bugfix FXIOS-13343 - Bugfix for scrolling on some websites causing the webpage to freeze/hang

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -124,7 +124,9 @@ struct BrowserViewControllerState: ScreenState, Equatable {
 
     static let reducer: Reducer<Self> = { state, action in
         // Only process actions for the current window
-        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else {
+            return defaultState(from: state)
+        }
 
         if let action = action as? MicrosurveyPromptAction {
             return reduceStateForMicrosurveyAction(action: action, state: state)
@@ -256,7 +258,9 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                                                    state: BrowserViewControllerState) -> BrowserViewControllerState {
         switch action.actionType {
         case GeneralBrowserActionType.showToast:
-            guard let toastType = action.toastType else { return state }
+            guard let toastType = action.toastType else {
+                return defaultState(from: state)
+            }
             return BrowserViewControllerState(
                 searchScreenState: state.searchScreenState,
                 toast: toastType,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -311,12 +311,17 @@ final class HomepageViewController: UIViewController,
 
     func newState(state: HomepageState) {
         self.homepageState = state
+
         wallpaperView.wallpaperState = state.wallpaperState
 
-        dataSource?.updateSnapshot(
-            state: state,
-            jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
-        )
+        // FIXME: FXIOS-13343 We need to make sure redux isn't sending so many new states that aren't actually changing
+        if self.homepageState != state {
+            dataSource?.updateSnapshot(
+                state: state,
+                jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
+            )
+        }
+
         // FXIOS-11523 - Trigger impression when user opens homepage view new tab + scroll to top
         if homepageState.shouldTriggerImpression {
             scrollToTop()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Add workaround for aggressive reloading of the diffable data source in response to too many `TrackingProtectionAction` redux actions firing.

Let's keep FXIOS-13343 open as this is just a bandaid fix for release.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
