### PR TITLE
Refactor FXIOS-13313 Clean up favicon url cache file location migration

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/URLCacheFileManager.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/URLCacheFileManager.swift
@@ -19,17 +19,9 @@ actor DefaultURLCacheFileManager: URLCacheFileManager {
     }
 
     func getURLCache() async -> Data? {
-        // Migrate file to new location
-        // TODO: FXIOS-6086 Cleanup once v113 has been well adopted
         let directory = getCacheDirectory()
-        if fileManager.fileExists(atPath: directory.path) {
-            return try? Data(contentsOf: directory)
-        } else {
-            let oldDirectory = getOldCacheDirectory()
-            let data = try? Data(contentsOf: oldDirectory)
-            try? fileManager.removeItem(atPath: oldDirectory.path)
-            return data
-        }
+        guard fileManager.fileExists(atPath: directory.path) else { return nil }
+        return try? Data(contentsOf: directory)
     }
 
     func saveURLCache(data: Data) {
@@ -44,11 +36,6 @@ actor DefaultURLCacheFileManager: URLCacheFileManager {
 
     private func getCacheDirectory() -> URL {
         let paths = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)
-        return paths[0].appendingPathComponent(fileName)
-    }
-
-    private func getOldCacheDirectory() -> URL {
-        let paths = fileManager.urls(for: .documentDirectory, in: .userDomainMask)
         return paths[0].appendingPathComponent(fileName)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13313)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28986)

## :bulb: Description
Removed `oldDirectory`.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
