### PR TITLE
Bugfix FXIOS-13344 [Shortcuts Library] Prevent duplicate `shortcuts_library.viewed` telemetry

### DIFF
--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
@@ -15,8 +15,10 @@ class ShortcutsLibraryViewController: UIViewController,
         static let shortcutsSectionTopInset: CGFloat = 24
     }
 
-    // Used to only record closed telemetry on back button press and swipe gestures
+    // Used to only record "closed" telemetry on back button press and swipe gestures
     var recordTelemetryOnDisappear = true
+    // Used to only record "viewed" telemetry once per initialization
+    var viewedTelemetryRecorded = false
 
     // MARK: - Private variables
     private var collectionView: UICollectionView?
@@ -94,11 +96,14 @@ class ShortcutsLibraryViewController: UIViewController,
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        store.dispatch(
-            ShortcutsLibraryAction(
-                windowUUID: windowUUID,
-                actionType: ShortcutsLibraryActionType.viewDidAppear)
-        )
+        if !viewedTelemetryRecorded {
+            viewedTelemetryRecorded = true
+            store.dispatch(
+                ShortcutsLibraryAction(
+                    windowUUID: windowUUID,
+                    actionType: ShortcutsLibraryActionType.viewDidAppear)
+            )
+        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13344)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29031)

## :bulb: Description
- Prevent `homepage.shortcuts_library.viewed` telemetry from recording when initiating then cancelling a swipe-to-go-back gesture

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
