### PR TITLE
BugFix FXIOS-13333 Menu hangs while being presented

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -310,6 +310,9 @@ final class HomepageViewController: UIViewController,
     }
 
     func newState(state: HomepageState) {
+        // TODO: - FXIOS-13346 - fix collection view being reloaded all the time also when data don't change
+        // this is a quick workaround to avoid blocking the main thread by calling apply snapshot many times.
+        guard homepageState != state else { return }
         self.homepageState = state
         wallpaperView.wallpaperState = state.wallpaperState
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13333)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29016)

## :bulb: Description
BugFix Menu hang while being presented by disabling unnecessary rebuild of homepage datasource

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
