### PR TITLE
Refactor FXIOS-13354 [Toolbar] Enable toolbar with translucency by default on 143

### DIFF
--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -8,17 +8,17 @@ features:
         description: >
           Enables the feature
         type: Boolean
-        default: false
+        default: true
       one_tap_new_tab:
         description: >
           If true, enables the one tap new tab feature for users.
         type: Boolean
-        default: false
+        default: true
       navigation_hint:
         description: >
           If true, enables the navigation contextual hint.
         type: Boolean
-        default: false
+        default: true
       toolbar_update_hint:
         description: >
           If true, enables the toolbar update contextual hint.
@@ -38,7 +38,7 @@ features:
         description: >
           Enables translucency for toolbars.
         type: Boolean
-        default: false
+        default: true
       minimal_address_bar:
         description: >
           Enables minimal address bar mode on scroll to ensure the url is always visible.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13354)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29047)

## :bulb: Description
Turn on feature flags by default.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
