### PR TITLE
[WIP] Add FXIOS-13276 #28898 [OHttpManager] Mock up of what this could look like

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1074,6 +1074,7 @@
 		8A8D277B2CBFFD710076AD3A /* BrowserNavigationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8D277A2CBFFD710076AD3A /* BrowserNavigationType.swift */; };
 		8A8D277D2CC000BE0076AD3A /* NavigationBrowserAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8D277C2CC000BE0076AD3A /* NavigationBrowserAction.swift */; };
 		8A8DDEBF276259A900E7B97A /* RatingPromptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8DDEBE276259A900E7B97A /* RatingPromptManager.swift */; };
+		8A8F54202E5CB95B00C0207F /* OhttpGleanUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8F541F2E5CB8AF00C0207F /* OhttpGleanUploader.swift */; };
 		8A927D4B2E2ED5D600E676CC /* LegacyClipboardBarDisplayHandlerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A927D4A2E2ED5D600E676CC /* LegacyClipboardBarDisplayHandlerDelegate.swift */; };
 		8A93080927BFE88F0052167D /* PhotonActionSheetContainerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93080827BFE88F0052167D /* PhotonActionSheetContainerCell.swift */; };
 		8A93080B27C01AD60052167D /* SingleActionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93080A27C01AD60052167D /* SingleActionViewModel.swift */; };
@@ -8748,6 +8749,7 @@
 		8A8D277A2CBFFD710076AD3A /* BrowserNavigationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserNavigationType.swift; sourceTree = "<group>"; };
 		8A8D277C2CC000BE0076AD3A /* NavigationBrowserAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBrowserAction.swift; sourceTree = "<group>"; };
 		8A8DDEBE276259A900E7B97A /* RatingPromptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManager.swift; sourceTree = "<group>"; };
+		8A8F541F2E5CB8AF00C0207F /* OhttpGleanUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhttpGleanUploader.swift; sourceTree = "<group>"; };
 		8A927D4A2E2ED5D600E676CC /* LegacyClipboardBarDisplayHandlerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyClipboardBarDisplayHandlerDelegate.swift; sourceTree = "<group>"; };
 		8A93080827BFE88F0052167D /* PhotonActionSheetContainerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetContainerCell.swift; sourceTree = "<group>"; };
 		8A93080A27C01AD60052167D /* SingleActionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleActionViewModel.swift; sourceTree = "<group>"; };
@@ -15389,6 +15391,7 @@
 		E65075551E37F714006961AC /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				8A8F541F2E5CB8AF00C0207F /* OhttpGleanUploader.swift */,
 				8A1165842E5CB0150068A067 /* OhttpManager.swift */,
 				818BCC732E463BA5008309B1 /* CuratedRecommendationCacheUtility.swift */,
 				1DDDCEB82E048967000D34AE /* PopupThrottler.swift */,
@@ -18459,6 +18462,7 @@
 				21F422662E315E5C004FF994 /* LegacyTabScrollController.swift in Sources */,
 				E18BAAFD28E4A44500098AE2 /* TopTabFader.swift in Sources */,
 				EDD21F2E2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift in Sources */,
+				8A8F54202E5CB95B00C0207F /* OhttpGleanUploader.swift in Sources */,
 				C8656D79270F866700E199EA /* CustomizeHomepageSectionCell.swift in Sources */,
 				C84655FB28879FC600861B4A /* WallpaperStorageUtility.swift in Sources */,
 				8A13FA8B2AD82E6D007527AB /* ApplicationStateProvider.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -848,6 +848,7 @@
 		8A0D32842A61E1CC007D976D /* StatusBarOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */; };
 		8A0DF2C22D6D1C670066EC00 /* AutoplaySettingTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0DF2C12D6D1C670066EC00 /* AutoplaySettingTelemetry.swift */; };
 		8A106D632D416F82009AD7E4 /* MessageCardMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A106D622D416F82009AD7E4 /* MessageCardMiddlewareTests.swift */; };
+		8A1165852E5CB0150068A067 /* OhttpManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1165842E5CB0150068A067 /* OhttpManager.swift */; };
 		8A11C80F2731916E00AC7318 /* defaultOnlyTestList.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */; };
 		8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */; };
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
@@ -8520,6 +8521,7 @@
 		8A0E5F3D2BFBA49400DE052B /* MicrosurveyCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A0F46E89E106C66C6C29F07 /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		8A106D622D416F82009AD7E4 /* MessageCardMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardMiddlewareTests.swift; sourceTree = "<group>"; };
+		8A1165842E5CB0150068A067 /* OhttpManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhttpManager.swift; sourceTree = "<group>"; };
 		8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = defaultOnlyTestList.json; sourceTree = "<group>"; };
 		8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleTests.swift; sourceTree = "<group>"; };
 		8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
@@ -15387,6 +15389,7 @@
 		E65075551E37F714006961AC /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				8A1165842E5CB0150068A067 /* OhttpManager.swift */,
 				818BCC732E463BA5008309B1 /* CuratedRecommendationCacheUtility.swift */,
 				1DDDCEB82E048967000D34AE /* PopupThrottler.swift */,
 				0EBD66912DBFE40100A78532 /* ConcurrencyThrottler.swift */,
@@ -18248,6 +18251,7 @@
 				8A5D1CB02A30D740005AD35C /* SearchBarSetting.swift in Sources */,
 				EB9854FF2422686F0040F24B /* AppDelegate+PushNotifications.swift in Sources */,
 				DFACBF85277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift in Sources */,
+				8A1165852E5CB0150068A067 /* OhttpManager.swift in Sources */,
 				612194E62CE50A93001664BB /* WallpaperAction.swift in Sources */,
 				9614BF4428AD1C6700D3F7EA /* AccountSyncHandler.swift in Sources */,
 				8C2447EA2DFADF6300BD2C91 /* OnboardingServiceDelegate.swift in Sources */,

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -38,6 +38,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case modernOnboardingUI
     case nativeErrorPage
     case noInternetConnectionErrorPage
+    case ohttpManagerGleanUploader
     case pdfRefactor
     case ratingPromptFeature
     case reportSiteIssue
@@ -89,6 +90,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .loginsVerificationEnabled,
                 .nativeErrorPage,
                 .noInternetConnectionErrorPage,
+                .ohttpManagerGleanUploader,
                 .searchEngineConsolidation,
                 .tabTrayUIExperiments,
                 .toolbarRefactor,
@@ -160,6 +162,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .modernOnboardingUI,
                 .nativeErrorPage,
                 .noInternetConnectionErrorPage,
+                .ohttpManagerGleanUploader,
                 .pdfRefactor,
                 .ratingPromptFeature,
                 .reportSiteIssue,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -153,6 +153,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .ohttpManagerGleanUploader,
+                titleText: format(string: "Ohttp Glean uploader"),
+                statusText: format(string: "Toggle to enable the Ohttp Glean uploader capability")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .pdfRefactor,
                 titleText: format(string: "PDF Refactor"),
                 statusText: format(string: "Toggle to enable PDF Refactor feature")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -89,6 +89,9 @@ final class NimbusFeatureFlagLayer {
         case .noInternetConnectionErrorPage:
             return checkNICErrorPageFeature(from: nimbus)
 
+        case .ohttpManagerGleanUploader:
+            return checkOhttpManagerGleanUploader(from: nimbus)
+
         case .pdfRefactor:
             return checkPdfRefactorFeature(from: nimbus)
 
@@ -439,6 +442,10 @@ final class NimbusFeatureFlagLayer {
 
     private func checkNICErrorPageFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.nativeErrorPageFeature.value().noInternetConnectionError
+    }
+
+    private func checkOhttpManagerGleanUploader(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.ohttpGleanUploaderCapabilityFeature.value().enabled
     }
 
     private func checkRevertUnsafeContinuationsRefactor(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -149,10 +149,21 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         glean.registerPings(GleanMetrics.Pings.shared)
 
         // Initialize Glean telemetry
-        let gleanConfig = Configuration(
-            channel: AppConstants.buildChannel.rawValue,
-            logLevel: .off
-        )
+        let gleanConfig: Configuration
+        if featureFlags.isFeatureEnabled(.noInternetConnectionErrorPage, checking: .buildOnly) {
+            let environment = OhttpEnvironment.getEnvironment()
+            gleanConfig = Configuration(
+                channel: AppConstants.buildChannel.rawValue,
+                logLevel: .off // ,
+                // Laurie - TODO: needs the real Glean types
+//                httpClient: OhttpGleanUploader(environment: environment)
+            )
+        } else {
+            gleanConfig = Configuration(
+                channel: AppConstants.buildChannel.rawValue,
+                logLevel: .off
+            )
+        }
         glean.initialize(uploadEnabled: sendUsageData,
                          configuration: gleanConfig,
                          buildInfo: GleanMetrics.GleanBuild.info)

--- a/firefox-ios/Client/Utils/OhttpGleanUploader.swift
+++ b/firefox-ios/Client/Utils/OhttpGleanUploader.swift
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Glean
+
+/// An enumeration representing different environments for the OHTTP client.
+public enum OhttpEnvironment {
+    case staging
+    case prod
+
+    // TODO: Laurie - config URL to pass into the OHTTPManager?
+    /// Returns the configuration URL based on the selected environment.
+    var config: URL? {
+        switch self {
+        case .staging:
+            return URL(string: "https://stage.ohttp-gateway.nonprod.webservices.mozgcp.net/ohttp-configs")
+        case .prod:
+            return URL(string: "https://prod.ohttp-gateway.prod.webservices.mozgcp.net/ohttp-configs")
+        }
+    }
+
+    // TODO: Laurie - relay URL to pass into the OHTTPManager?
+    /// Returns the relay URL based on the selected environment.
+    var relay: URL? {
+        switch self {
+        case .staging:
+            return URL(string: "https://mozilla-ohttp-dev.fastly-edge.com/")
+        case .prod:
+            return URL(string: "https://mozilla-ohttp-dev.fastly-edge.com/")
+        }
+    }
+
+    static func getEnvironment() -> OhttpEnvironment {
+        // TODO: Laurie - Double-check this is accurate
+        let shouldUseRelease = AppConstants.buildChannel == .release || AppConstants.buildChannel == .beta
+        return shouldUseRelease ? OhttpEnvironment.prod: OhttpEnvironment.staging
+    }
+}
+
+public struct OhttpGleanUploader: PingUploader {
+    private let environment: OhttpEnvironment
+    private let capabilities = ["ohttp"]
+    private let connectionTimeout = TimeInterval(10)
+
+    public init(environment: OhttpEnvironment) {
+        self.environment = environment
+    }
+
+    public func upload(request: CapablePingUploadRequest, callback: @escaping (UploadResult) -> Void) {
+        guard let config = environment.config,
+              let relay = environment.relay
+        else {
+            // TODO: Laurie - What Int8 should be passed here for the unrecoverableFailure?
+            callback(UploadResult.unrecoverableFailure(unused: 0))
+            return
+        }
+
+        let manager = StubOhttpManager(configUrl: config, relayUrl: relay)
+        guard let capableRequest = request.capable(capabilities),
+              let url = URL(string: capableRequest.url) else { return }
+
+        var body = Data(capacity: capableRequest.data.count)
+        body.append(contentsOf: capableRequest.data)
+
+        // TODO: Laurie - Cache policy? timeoutInterval? etc. Double check request info
+        var oHttpRequest = URLRequest(url: url,
+                                      cachePolicy: .reloadIgnoringLocalAndRemoteCacheData)
+        for (field, value) in capableRequest.headers {
+            oHttpRequest.addValue(value, forHTTPHeaderField: field)
+        }
+        oHttpRequest.timeoutInterval = connectionTimeout
+        oHttpRequest.httpBody = body
+        oHttpRequest.httpMethod = "POST"
+        oHttpRequest.httpShouldHandleCookies = false
+
+        Task {
+            do {
+                let response = try await manager.data(for: oHttpRequest)
+                let httpResponse = response.1
+                let statusCode = Int32(httpResponse.statusCode)
+                // HTTP status codes are handled on the Rust side
+                callback(.httpStatus(code: statusCode))
+            } catch {
+                // Upload failed on the client-side. We should try again.
+                callback(.recoverableFailure(unused: 0))
+            }
+        }
+    }
+}
+

--- a/firefox-ios/Client/Utils/OhttpGleanUploader.swift
+++ b/firefox-ios/Client/Utils/OhttpGleanUploader.swift
@@ -90,4 +90,3 @@ public struct OhttpGleanUploader: PingUploader {
         }
     }
 }
-

--- a/firefox-ios/Client/Utils/OhttpManager.swift
+++ b/firefox-ios/Client/Utils/OhttpManager.swift
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+protocol OhttpManager {
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse)
+}
+
+enum OhttpError: Error {
+    case KeyFetchFailed
+    case RelayFailed
+    case FaultyResponse
+    case FaultyRequestURL
+}
+
+/// This class will be provided by Application-Services, we're stubbing it at the moment since it's not available yet
+/// See https://mozilla-hub.atlassian.net/browse/FXIOS-13275 for more information
+actor StubOhttpManager: OhttpManager {
+    // The OhttpManager communicates with the relay and key server using
+    // URLSession.shared.data unless an alternative networking method is
+    // provided with this signature.
+    typealias NetworkFunction = (_: URLRequest) async throws -> (Data, URLResponse)
+
+    // Global cache to caching Gateway encryption keys. Stale entries are
+    // ignored and on Gateway errors the key used should be purged and retrieved
+    // again next at next network attempt.
+    static var keyCache = [URL: ([UInt8], Date)]()
+
+    private var configUrl: URL
+    private var relayUrl: URL
+    private var network: NetworkFunction
+
+    init(configUrl: URL,
+         relayUrl: URL,
+         network: @escaping NetworkFunction = URLSession.shared.data) {
+        self.configUrl = configUrl
+        self.relayUrl = relayUrl
+        self.network = network
+    }
+
+    private func fetchKey(url: URL) async throws -> [UInt8] {
+        let request = URLRequest(url: url)
+        if let (data, response) = try? await network(request),
+           let httpResponse = response as? HTTPURLResponse,
+           httpResponse.statusCode == 200 {
+            return [UInt8](data)
+        }
+
+        throw OhttpError.KeyFetchFailed
+    }
+
+    private func keyForGateway(gatewayConfigUrl: URL, ttl: TimeInterval) async throws -> [UInt8] {
+        if let (data, timestamp) = Self.keyCache[gatewayConfigUrl] {
+            if Date() < timestamp + ttl {
+                // Cache Hit!
+                return data
+            }
+
+            Self.keyCache.removeValue(forKey: gatewayConfigUrl)
+        }
+
+        let data = try await fetchKey(url: gatewayConfigUrl)
+        Self.keyCache[gatewayConfigUrl] = (data, Date())
+
+        return data
+    }
+
+    private func invalidateKey() {
+        Self.keyCache.removeValue(forKey: configUrl)
+    }
+
+    // Returning empty data for now since this is a stub
+    public func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let config = try await keyForGateway(gatewayConfigUrl: configUrl,
+                                             ttl: TimeInterval(3600))
+
+        var request = URLRequest(url: relayUrl)
+        request.httpMethod = "POST"
+        request.setValue("message/ohttp-req", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data()
+
+        guard let responseURL = request.url else {
+            throw OhttpError.FaultyRequestURL
+        }
+
+        guard let response = HTTPURLResponse(url: responseURL,
+                                             statusCode: 200,
+                                             httpVersion: "HTTP/1.1",
+                                             headerFields: nil) else {
+            throw OhttpError.FaultyResponse
+        }
+
+        return (Data(), response)
+    }
+}

--- a/firefox-ios/nimbus-features/ohttpGleanUploaderCapabilityFeature.yaml
+++ b/firefox-ios/nimbus-features/ohttpGleanUploaderCapabilityFeature.yaml
@@ -1,0 +1,19 @@
+# The configuration for the ohttpGleanUploaderCapabilityFeature feature
+features:
+  ohttp-glean-uploader-capability-feature:
+    description: >
+      Feature flag used to enabled the OHTTP Glean uploader capability.
+    variables:
+      enabled:
+        description: >
+          If true, enables the OHTTP Glean uploader capability feature.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: false
+

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -33,6 +33,7 @@ include:
   - nimbus-features/nativeErrorPageFeature.yaml
   - nimbus-features/newAddressBarMenu.yaml
   - nimbus-features/newAppearanceMenu.yaml
+  - nimbus-features/ohttpGleanUploaderCapabilityFeature.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml
   - nimbus-features/pdfRefactorFeature.yaml
   - nimbus-features/ratingPromptFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13276)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28898)

## :bulb: Description
⚠️ Not to be merged, this is only for discussion purpose for now as this will need a bunch of changes. 

This PR currently:
- Adds a feature flag to protect the changes under `TelemetryWrapper`, which is used in production.
- Adds a `OhttpEnvironment` to define the config and relay URL
- Adds a `OhttpGleanUploader` to bridge the A-S `OHttpManager` to the Glean `PingUploader`

Still missing:
- Unit tests
- Glean package update, I'm using copied protocols for now so the whole thing can build
- A-S update so we get our hands on the real `OhttpManager`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
