### PR TITLE
Refactor FXIOS-0000 Minor fix: tab array access & dispatch 

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -230,12 +230,12 @@ class TabManagerImplementation: NSObject,
     }
 
     func removeTabWithCompletion(_ tabUUID: TabUUID, completion: (() -> Void)?) {
-        guard let index = tabs.firstIndex(where: { $0.tabUUID == tabUUID }) else { return }
-        let tab = tabs[index]
-
-        DispatchQueue.main.async { [weak self] in
-            self?.removeTab(tab, flushToDisk: true)
-            self?.updateSelectedTabAfterRemovalOf(tab, deletedIndex: index)
+        ensureMainThread { [weak self] in
+            guard let self else { return }
+            guard let index = tabs.firstIndex(where: { $0.tabUUID == tabUUID }) else { return }
+            let tab = tabs[index]
+            removeTab(tab, flushToDisk: true)
+            updateSelectedTabAfterRemovalOf(tab, deletedIndex: index)
             completion?()
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
n/a

## :bulb: Description

- Avoid possibility of tabs access off of MT
- Avoid unnecessary async dispatch
 
In practice I don't believe this is causing any issues and all the callsites I could see at a glance look to be called on the MT anyway, but the way it is written does not make sense and so changing this at least for clarity. Wasn't sure if this should actually just be `@MainActor` but this looks like it is going away soon anyway?:

`// TODO: FXIOS-11272 Remove this function in favor of the async remove tab.`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
