### PR TITLE
Add NO_TICKET Homepage tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -170,6 +170,19 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertFalse(actionCalled.showiPadSetup ?? true)
     }
 
+    func test_viewWillAppear_triggersHomepageAction() throws {
+        let subject = createSubject()
+
+        subject.viewWillAppear(false)
+
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.first(where: { $0 is HomepageAction }) as? HomepageAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
+        XCTAssertEqual(actionType, HomepageActionType.viewWillAppear)
+        XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+    }
+
     func test_viewDidAppear_triggersHomepageAction() throws {
         let subject = createSubject()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
@@ -45,6 +45,20 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         ])
     }
 
+    func test_viewWillAppearAction_doesNotSendTelemetryData() throws {
+        let subject = createSubject()
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.viewWillAppear
+        )
+
+        subject.homepageProvider(AppState(), action)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 0)
+        XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)
+    }
+
     func test_viewDidAppearAction_sendsTelemetryData() throws {
         let subject = createSubject()
         let action = HomepageAction(


### PR DESCRIPTION
## :bulb: Description
- Add some follow-up tests to #29034 as suggested [here](https://github.com/mozilla-mobile/firefox-ios/pull/29034#discussion_r2310347206)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
