### PR TITLE
Remove Identifiable from Site and remove ID. Allow Hashable/Equatable…

### DIFF
--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -728,13 +728,11 @@ extension RustPlaces {
                 if let actualTitle = info.title, !actualTitle.isEmpty {
                     title = actualTitle
                 } else {
-                    // In case there is no title, we use the url
-                    // as the title
+                    // In case there is no title, we use the url as the title
                     title = info.url
                 }
-                // Note: FXIOS-10740 Necessary to have unique Site ID iOS 18 HistoryPanel crash with diffable data sources
-                let hashValue = "\(info.url)_\(info.timestamp)".hashValue
-                var site = Site.createBasicSite(id: hashValue, url: info.url, title: title)
+
+                var site = Site.createBasicSite(url: info.url, title: title)
                 site.latestVisit = Visit(date: UInt64(info.timestamp) * 1000, type: info.visitType)
                 return site
             }

--- a/firefox-ios/Storage/SQL/SQLiteHistoryFactories.swift
+++ b/firefox-ios/Storage/SQL/SQLiteHistoryFactories.swift
@@ -9,15 +9,12 @@ import Foundation
  */
 extension BrowserDBSQLite {
     class func basicHistoryColumnFactory(_ row: SDRow) -> Site {
-        let id = row["historyID"] as? Int
         guard let url = row["url"] as? String, let title = row["title"] as? String else {
             assertionFailure("None of these properties should be nil")
             return Site.createBasicSite(url: "", title: "")
         }
 
-        // FXIOS-10996 improved our `Site` type to have strict unique IDs. But this `historyID` field was previously
-        // optional, so we need to migrate users over in v136. Otherwise users will lose all their pinned top sites.
-        var site = Site.createBasicSite(id: id, url: url, title: title, isBookmarked: nil)
+        var site = Site.createBasicSite(url: url, title: title, isBookmarked: nil)
 
         // Extract a boolean from the row if it's present.
         if let isBookmarked = row["is_bookmarked"] as? Int {

--- a/firefox-ios/Storage/SQL/SQLitePinnedSites.swift
+++ b/firefox-ios/Storage/SQL/SQLitePinnedSites.swift
@@ -103,10 +103,10 @@ extension BrowserDBSQLite: PinnedSites {
             return deferMaybe(DatabaseError(description: "Invalid site \(site.url)"))
         }
 
-        let args: Args = [site.url, now, site.title, site.id, host]
+        let args: Args = [site.url, now, site.title, host]
         let arglist = BrowserDB.varlist(args.count)
 
-        return self.database.run([("INSERT OR REPLACE INTO pinned_top_sites (url, pinDate, title, historyID, domain) VALUES \(arglist)", args)])
+        return self.database.run([("INSERT OR REPLACE INTO pinned_top_sites (url, pinDate, title, domain) VALUES \(arglist)", args)])
         >>== {
             self.notificationCenter.post(name: .TopSitesUpdated, object: self)
             return succeed()

--- a/firefox-ios/Storage/Sites/Site.swift
+++ b/firefox-ios/Storage/Sites/Site.swift
@@ -7,13 +7,11 @@ import SiteImageView
 
 // TODO: FXIOS-12712 Make Site actually sendable
 public struct Site: @unchecked Sendable,
-                    Identifiable,
                     Hashable,
                     Equatable,
                     Codable,
                     CustomStringConvertible,
                     CustomDebugStringConvertible {
-    public let id: Int
     public let url: String
     public let title: String
     public let type: SiteType
@@ -57,20 +55,19 @@ public struct Site: @unchecked Sendable,
     // MARK: - Factory Methods
 
     public static func createBasicSite(
-        id: Int? = nil,
         url: String,
         title: String,
         isBookmarked: Bool? = false,
         faviconResource: SiteResource? = nil
     ) -> Site {
-        var site = Site(id: id ?? UUID().hashValue, url: url, title: title, type: .basic)
+        var site = Site(url: url, title: title, type: .basic)
         site.isBookmarked = isBookmarked
         site.faviconResource = faviconResource
         return site
     }
 
     public static func createSponsoredSite(url: String, title: String, siteInfo: SponsoredSiteInfo) -> Site {
-        return Site(id: UUID().hashValue, url: url, title: title, type: .sponsoredSite(siteInfo))
+        return Site(url: url, title: title, type: .sponsoredSite(siteInfo))
     }
 
     public static func createSuggestedSite(
@@ -82,7 +79,6 @@ public struct Site: @unchecked Sendable,
     ) -> Site {
         let siteInfo = SuggestedSiteInfo(trackingId: trackingId)
         return Site(
-            id: id ?? UUID().hashValue,
             url: url,
             title: title,
             type: .suggestedSite(siteInfo),
@@ -91,7 +87,6 @@ public struct Site: @unchecked Sendable,
     }
 
     public static func createPinnedSite(
-        id: Int? = nil,
         url: String,
         title: String,
         isGooglePinnedTile: Bool,
@@ -99,7 +94,6 @@ public struct Site: @unchecked Sendable,
     ) -> Site {
         let siteInfo = PinnedSiteInfo(isGooglePinnedTile: isGooglePinnedTile)
         return Site(
-            id: id ?? UUID().hashValue,
             url: url,
             title: title,
             type: .pinnedSite(siteInfo),
@@ -112,7 +106,6 @@ public struct Site: @unchecked Sendable,
         let siteInfo = PinnedSiteInfo(isGooglePinnedTile: isGooglePinnedTile)
 
         return Site(
-            id: site.id,
             url: site.url,
             title: site.title,
             type: .pinnedSite(siteInfo),
@@ -126,7 +119,6 @@ public struct Site: @unchecked Sendable,
     /// Note: This *copies* the pre-existing Site's ID.
     public static func copiedFrom(site: Site, withLocalizedURLString urlString: String) -> Site {
         return Site(
-            id: site.id,
             url: urlString,
             title: site.title,
             type: site.type,
@@ -139,8 +131,7 @@ public struct Site: @unchecked Sendable,
 
     // MARK: - Initializers
 
-    private init(id: Int, url: String, title: String, type: SiteType, faviconResource: SiteResource? = nil) {
-        self.id = id
+    private init(url: String, title: String, type: SiteType, faviconResource: SiteResource? = nil) {
         self.url = url
         self.title = title
         self.type = type
@@ -148,7 +139,6 @@ public struct Site: @unchecked Sendable,
     }
 
     private init(
-        id: Int,
         url: String,
         title: String,
         type: SiteType,
@@ -157,7 +147,6 @@ public struct Site: @unchecked Sendable,
         latestVisit: Visit? = nil,
         isBookmarked: Bool? = nil
     ) {
-        self.id = id
         self.url = url
         self.title = title
         self.type = type
@@ -196,7 +185,6 @@ public struct Site: @unchecked Sendable,
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(id, forKey: .id)
         try container.encode(url, forKey: .url)
         try container.encode(title, forKey: .title)
         try container.encode(type, forKey: .type)
@@ -209,10 +197,6 @@ public struct Site: @unchecked Sendable,
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
 
-        // FXIOS-10996 improved our `Site` type to have strict unique IDs. But this field was previously optional, so we need
-        // to migrate users over in v136. Otherwise users will lose all their pinned top sites.
-        let id = try? values.decode(Int.self, forKey: .id)
-
         let url = try values.decode(String.self, forKey: .url)
         let title = try values.decode(String.self, forKey: .title)
 
@@ -222,6 +206,6 @@ public struct Site: @unchecked Sendable,
         // Optional properties
         let faviconResource = try? values.decode(SiteResource.self, forKey: .faviconResource)
 
-        self.init(id: id ?? UUID().hashValue, url: url, title: title, type: type, faviconResource: faviconResource)
+        self.init(url: url, title: title, type: type, faviconResource: faviconResource)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13365)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29069)

## :bulb: Description

- Removes `Identifiable` from `Site` and removes the ID property. 
- Allows `Hashable`/`Equatable` conformance to strictly rely a `Site`'s properties to determine if two `Site`s are the same or unique.

Hopefully this should provide some optimization to how the homepage diffable data source is rendering... the underlying `TopSiteConfiguration` contained a `Site` but if every `Site` is generally initialized with unique IDs, the diffable data source would assume they're all different and we'd lose all performance optimizations. 🤔 

This didn't seem to "fix" the scroll issues recorded in FXIOS-13343 when I removed the bandaid fix from HomepageViewController's newState... but I strongly suspect we might have more than one problem here. And bad `Hashable` implementation could totally cause unintended reloads. [Further reading here](https://developer.apple.com/documentation/UIKit/updating-collection-views-using-diffable-data-sources#Populate-snapshots-with-lightweight-data-structures).

## Testing Notes

Since I changed how Sites are recorded and loaded from the SQLite DB, it would be good to test running on main, pinning some tabs, logging into a sync account with history, etc. and then running my branch. There's also a widget that populates with the pinned top sites (“Website Shortcuts”) to check.

We also want to make sure the history panel doesn't crash for duplicates (since this change touches on the incident fix from Jan 2025 in this ticket FXIOS-10996).

The related ticket for this has detailed testing instructions here: https://mozilla-hub.atlassian.net/browse/FXIOS-13365?focusedCommentId=1128877

---
CC @mattreaganmozilla I don't suppose you can see any reason we would've needed the IDs for Sites because of the history databases?

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
