### PR TITLE
Bugfix FXIOS-13316 Close tab + Force-quit leaves tab open

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -322,7 +322,8 @@ class TabManagerImplementation: NSObject,
         }
 
         if flushToDisk {
-            commitChanges()
+            preserveTabs(forced: true)
+            saveSessionData(forTab: selectedTab)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11316)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28994)


## :bulb: Description

Quick attempt to fix issue when rapidly force-quitting after closing a tab. Force commit changes immediately if the operation is a tab removal. Related: https://github.com/mozilla-mobile/firefox-ios/pull/15515

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
