### PR TITLE
Bugfix FXIOS-13381 Add menu background blur for iOS 26 when app built with < 26

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -258,9 +258,13 @@ class MainMenuViewController: UIViewController,
     }
 
     private func setupView() {
+        #if canImport(FoundationModels)
         if #unavailable(iOS 26.0) {
             view.addBlurEffectWithClearBackgroundAndClipping(using: .regular)
         }
+        #else
+            view.addBlurEffectWithClearBackgroundAndClipping(using: .regular)
+        #endif
         view.addSubview(menuContent)
 
         NSLayoutConstraint.activate([

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -36,7 +36,11 @@ final class ToolbarHelper: ToolbarHelperInterface {
 
     var glassEffectAlpha: CGFloat {
         guard shouldBlur() else { return 1 }
+        #if canImport(FoundationModels)
         if #available(iOS 26, *) { return .zero } else { return UX.backgroundAlphaForBlur }
+        #else
+            return UX.backgroundAlphaForBlur
+        #endif
     }
 
     func shouldShowNavigationToolbar(for traitCollection: UITraitCollection) -> Bool {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13381)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29090)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
