### PR TITLE
Add FXIOS-13370 ⁃ [iOS 26] Glass effect is not applied to input fields in Passwords, Payment Methods, and Addresses

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -70,18 +70,28 @@ struct CreditCardInputView: View {
 
     private var form: some View {
         return VStack(spacing: 0) {
-            Divider()
-                .frame(height: 0.7)
-                .foregroundColor(borderColor)
+            if #unavailable(iOS 26.0) {
+                Divider()
+                    .frame(height: 0.7)
+                    .foregroundColor(borderColor)
+            }
 
             name
                 .background(textFieldBackgroundColor)
+                .modifier(RoundedCorners(topLeadingCorner: 24,
+                                         topTrailingCorner: 24,
+                                         bottomLeadingCorner: nil,
+                                         bottomTrailingCorner: nil))
 
             number
                 .background(textFieldBackgroundColor)
 
             expiration
                 .background(textFieldBackgroundColor)
+                .modifier(RoundedCorners(topLeadingCorner: nil,
+                                         topTrailingCorner: nil,
+                                         bottomLeadingCorner: 24,
+                                         bottomTrailingCorner: 24))
 
             Spacer()
                 .frame(height: 4)
@@ -94,6 +104,7 @@ struct CreditCardInputView: View {
 
             Spacer()
         }
+        .modifier(ExtraPadding())
     }
 
     private var name: some View {
@@ -134,10 +145,12 @@ struct CreditCardInputView: View {
                                  inputViewModel: viewModel)
             .padding(.top, 11)
 
-            Divider()
-                .frame(height: 0.7)
-                .foregroundColor(borderColor)
-                .padding(.top, 1)
+            if #unavailable(iOS 26.0) {
+                Divider()
+                    .frame(height: 0.7)
+                    .foregroundColor(borderColor)
+                    .padding(.top, 1)
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
@@ -34,7 +34,13 @@ class CreditCardTableViewController: UIViewController, Themeable {
     // MARK: View
 
     private lazy var tableView: UITableView = {
-        let tableView = UITableView(frame: .zero, style: .grouped)
+        let tableView: UITableView = {
+            if #available(iOS 26.0, *) {
+                UITableView(frame: .zero, style: .insetGrouped)
+            } else {
+                UITableView(frame: .zero, style: .grouped)
+            }
+        }()
         tableView.register(HostingTableViewCell<CreditCardItemRow>.self,
                            forCellReuseIdentifier: HostingTableViewCell<CreditCardItemRow>.cellIdentifier)
         tableView.register(HostingTableViewCell<CreditCardAutofillToggle>.self,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
@@ -46,6 +46,7 @@ struct CreditCardAutofillToggle: View {
                     .foregroundColor(textColor)
                     .padding(.leading, 16)
                     .padding(.trailing, 16)
+                    .modifier(ExtraPaddingTopAndBottom(paddingSize: 4))
                     .toggleStyle(SwitchToggleStyle(tint: toggleTintColor))
             }
             Divider()

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
@@ -71,6 +71,10 @@ struct RemoveCardButton: View {
             // prevents the screen dismissal, hiding it is the simplest way to solve the issue.
             showAlert = false
         }
+        .modifier(RoundedCorners(topLeadingCorner: 24,
+                                 topTrailingCorner: 24,
+                                 bottomLeadingCorner: 24,
+                                 bottomTrailingCorner: 24))
     }
 
     func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -10,6 +10,10 @@ import Common
 import struct MozillaAppServices.LoginEntry
 
 class PasswordManagerListViewController: SensitiveViewController, Themeable {
+    private struct UX {
+        static let separatorInset: CGFloat = 20
+        static let selectAllButtonMargin: CGFloat = 16
+    }
     static let loginsSettingsSection = 0
 
     var themeManager: ThemeManager
@@ -23,7 +27,7 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
     private let loadingView: SettingsLoadingView = .build()
     private var deleteAlert: UIAlertController?
     private var selectedIndexPaths = [IndexPath]()
-    private let tableView: UITableView = .build()
+    private let tableView: UITableView
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { return windowUUID }
 
@@ -53,6 +57,12 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         self.loginDataSource = LoginDataSource(viewModel: viewModel)
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
+        if #available(iOS 26.0, *) {
+            tableView = UITableView(frame: .zero, style: .insetGrouped)
+            tableView.translatesAutoresizingMaskIntoConstraints = false
+        } else {
+            tableView = .build()
+        }
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -63,7 +73,14 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = .Settings.Passwords.Title
-        tableView.separatorInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 0)
+        let rightInset: CGFloat = {
+            if #available(iOS 26.0, *) {
+                UX.separatorInset / 1.5
+            } else {
+                0
+            }
+        }()
+        tableView.separatorInset = UIEdgeInsets(top: 0, left: UX.separatorInset, bottom: 0, right: rightInset)
         tableView.register(cellType: PasswordManagerSettingsTableViewCell.self)
         tableView.register(cellType: PasswordManagerTableViewCell.self)
         tableView.registerHeaderFooter(cellType: ThemedTableSectionHeaderFooterView.self)
@@ -110,9 +127,6 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: selectionButton.topAnchor),
 
-            selectionButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            selectionButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            selectionButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             selectionButton.topAnchor.constraint(equalTo: tableView.bottomAnchor),
             selectionButton.heightAnchor.constraint(equalToConstant: UIConstants.ToolbarHeight),
 
@@ -123,6 +137,30 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         ])
 
         selectionButton.isHidden = true
+
+        if #available(iOS 26.0, *) {
+            selectionButton.layer.cornerRadius = UIConstants.ToolbarHeight / 2
+            NSLayoutConstraint.activate([
+                selectionButton.leadingAnchor.constraint(
+                    equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+                    constant: UX.selectAllButtonMargin
+                ),
+                selectionButton.trailingAnchor.constraint(
+                    equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                    constant: -UX.selectAllButtonMargin
+                ),
+                selectionButton.bottomAnchor.constraint(
+                    equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                    constant: -UX.selectAllButtonMargin / 2
+                )
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                selectionButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                selectionButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+                selectionButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            ])
+        }
 
         listenForThemeChanges(withNotificationCenter: notificationCenter)
         applyTheme()
@@ -379,8 +417,13 @@ extension PasswordManagerListViewController: UITableViewDelegate {
         ) as? ThemedTableSectionHeaderFooterView else { return nil }
         headerView.titleLabel.text = .LoginsListTitle
         // not using a grouped table: show header borders
-        headerView.showBorder(for: .top, true)
-        headerView.showBorder(for: .bottom, true)
+        if #available(iOS 26.0, *) {
+            headerView.showBorder(for: .top, false)
+            headerView.showBorder(for: .bottom, false)
+        } else {
+            headerView.showBorder(for: .top, true)
+            headerView.showBorder(for: .bottom, true)
+        }
         headerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return headerView
     }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/StylingViewModifiers.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/StylingViewModifiers.swift
@@ -80,3 +80,49 @@ struct PaddingWithColorStyle: ViewModifier {
         }
     }
 }
+
+struct ExtraPaddingTopAndBottom: ViewModifier {
+    let paddingSize: CGFloat
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .padding(.top, paddingSize)
+                .padding(.bottom, paddingSize)
+        } else {
+            content
+        }
+    }
+}
+
+struct ExtraPadding: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .padding()
+        } else {
+            content
+        }
+    }
+}
+
+struct RoundedCorners: ViewModifier {
+    let topLeadingCorner: CGFloat?
+    let topTrailingCorner: CGFloat?
+    let bottomLeadingCorner: CGFloat?
+    let bottomTrailingCorner: CGFloat?
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .clipShape(
+                    UnevenRoundedRectangle(topLeadingRadius: topLeadingCorner ?? 0,
+                                           bottomLeadingRadius: bottomLeadingCorner ?? 0,
+                                           bottomTrailingRadius: bottomTrailingCorner ?? 0,
+                                           topTrailingRadius: topTrailingCorner ?? 0)
+                )
+        } else {
+            content
+        }
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13370)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29077)

## :bulb: Description
I've added iOS style for Passwords and Payment Methods screens and sub-screens

## :movie_camera: Demos

https://github.com/user-attachments/assets/72ea9ea5-1d5f-4e57-818b-396641eff458



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
