### PR TITLE
Refactor FXIOS-13230 [Swift 6 Migration] Enable strict concurrency in the ComponentLibrary package + InferSendableFromCaptures for KeyPaths

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -90,7 +90,8 @@ let package = Package(
             dependencies: ["Common", "SiteImageView"],
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
-                .enableExperimentalFeature("StrictConcurrency")
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableUpcomingFeature("InferSendableFromCaptures")
             ]),
         .testTarget(
             name: "ComponentLibraryTests",
@@ -100,8 +101,11 @@ let package = Package(
             dependencies: ["Fuzi", "Kingfisher", "Common", "SwiftDraw"],
             exclude: ["README.md"],
             resources: [.process("BundledTopSitesFavicons.xcassets")],
-            swiftSettings: [.unsafeFlags(["-enable-testing"]),
-                            .enableExperimentalFeature("StrictConcurrency")]),
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"]),
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableUpcomingFeature("InferSendableFromCaptures")
+            ]),
         .testTarget(
             name: "SiteImageViewTests",
             dependencies: ["SiteImageView", .product(name: "GCDWebServers", package: "GCDWebServer")],
@@ -118,7 +122,8 @@ let package = Package(
                            .product(name: "Sentry-Dynamic", package: "sentry-cocoa")],
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
-                .enableExperimentalFeature("StrictConcurrency")
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableUpcomingFeature("InferSendableFromCaptures")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13230)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28783)

## :bulb: Description

- Enable strict concurrency in the ComponentLibrary package.
- For the ComponentLibrary and its dependencies, add the other experimental flag, `.enableUpcomingFeature("InferSendableFromCaptures")`, to suppress KeyPath Sendability warnings when compiling other packages that rely on ComponentLibrary.

For the second point, I enabled an upcoming feature to suppress warnings when compiling packages that rely on ComponentLibrary.
<img height="900" alt="Screenshot 2025-09-02 at 1 19 34 PM" src="https://github.com/user-attachments/assets/845d4e26-2357-4ade-adb2-25187374f103" />

Someone wrote about [this issue on the swiftlang github](https://github.com/swiftlang/swift/issues/57560). The solution was to enable the upcoming feature from SE-0418 with `.enableUpcomingFeature("InferSendableFromCaptures")`. See [another reference](https://forums.swift.org/t/6-0-strict-concurrency-warning-when-keypath-marked-as-sendable/72566) here.

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
