### PR TITLE
Add FXIOS-13319 ⁃ [iOS 26] - Tracking protection bottom sheet doesn't have rounded corners, nor the submenus and glass effect is not applied

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionStatusView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionStatusView.swift
@@ -41,7 +41,11 @@ class TrackingProtectionStatusView: UIView {
 
     // MARK: View Setup
     private func setupView() {
-        layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
+        if #available(iOS 26.0, *) {
+            layer.cornerRadius = TPMenuUX.UX.newStyleCornerRadius
+        } else {
+            layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
+        }
         layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         layer.masksToBounds = true
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionStatusView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionStatusView.swift
@@ -41,11 +41,7 @@ class TrackingProtectionStatusView: UIView {
 
     // MARK: View Setup
     private func setupView() {
-        if #available(iOS 26.0, *) {
-            layer.cornerRadius = TPMenuUX.UX.newStyleCornerRadius
-        } else {
-            layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
-        }
+        layer.cornerRadius = TPMenuUX.UX.newStyleCornerRadius
         layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         layer.masksToBounds = true
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionVerifiedByView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionVerifiedByView.swift
@@ -29,11 +29,7 @@ class TrackingProtectionVerifiedByView: UIView {
 
     // MARK: View Setup
     private func setupView() {
-        if #available(iOS 26.0, *) {
-            layer.cornerRadius = TPMenuUX.UX.newStyleCornerRadius
-        } else {
-            layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
-        }
+        layer.cornerRadius = TPMenuUX.UX.newStyleCornerRadius
         layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
         layer.masksToBounds = true
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionVerifiedByView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionVerifiedByView.swift
@@ -29,7 +29,11 @@ class TrackingProtectionVerifiedByView: UIView {
 
     // MARK: View Setup
     private func setupView() {
-        layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
+        if #available(iOS 26.0, *) {
+            layer.cornerRadius = TPMenuUX.UX.newStyleCornerRadius
+        } else {
+            layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
+        }
         layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
         layer.masksToBounds = true
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionButton.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionButton.swift
@@ -14,6 +14,7 @@ public struct TrackingProtectionButtonModel {
 class TrackingProtectionButton: ResizableButton, ThemeApplicable {
     private struct UX {
         static let buttonCornerRadius: CGFloat = 12
+        static let newStyleButtonCornerRadius: CGFloat = 24
         static let buttonVerticalInset: CGFloat = 12
         static let buttonHorizontalInset: CGFloat = 16
         static let buttonFontSize: CGFloat = 16
@@ -83,7 +84,11 @@ class TrackingProtectionButton: ResizableButton, ThemeApplicable {
 //        By explicitly setting it to nil, we're ensuring a static background color
 //        that is defined in updatedConfiguration.background.backgroundColor
         updatedConfiguration.background.backgroundColorTransformer = nil
-        updatedConfiguration.background.cornerRadius = UX.buttonCornerRadius
+        if #available(iOS 26.0, *) {
+            updatedConfiguration.background.cornerRadius = UX.newStyleButtonCornerRadius
+        } else {
+            updatedConfiguration.background.cornerRadius = UX.buttonCornerRadius
+        }
 
         updatedConfiguration.cornerStyle = .fixed
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -22,7 +22,11 @@ struct TPMenuUX {
         static let clearDataButtonBorderWidth: CGFloat = 0
         static let settingsLinkButtonBottomSpacing: CGFloat = 16
         static let modalMenuCornerRadius: CGFloat = 12
-        static let newStyleCornerRadius: CGFloat = 24
+        static let newStyleCornerRadius: CGFloat = if #available(iOS 26.0, *) {
+            24
+        } else {
+            viewCornerRadius
+        }
         static let backgroundAlpha: CGFloat = 0.80
         struct Line {
             static let height: CGFloat = 0.5

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -19,10 +19,11 @@ struct TPMenuUX {
         static let connectionDetailsHeaderMargins: CGFloat = 8
         static let faviconCornerRadius: CGFloat = 16
         static let clearDataButtonTopDistance: CGFloat = 32
-        static let clearDataButtonCornerRadius: CGFloat = 12
         static let clearDataButtonBorderWidth: CGFloat = 0
         static let settingsLinkButtonBottomSpacing: CGFloat = 16
         static let modalMenuCornerRadius: CGFloat = 12
+        static let newStyleCornerRadius: CGFloat = 24
+        static let backgroundAlpha: CGFloat = 0.80
         struct Line {
             static let height: CGFloat = 0.5
         }
@@ -88,7 +89,6 @@ class TrackingProtectionViewController: UIViewController,
     private lazy var clearCookiesButton: TrackingProtectionButton = .build { button in
         button.titleLabel?.textAlignment = .left
         button.titleLabel?.numberOfLines = 0
-        button.layer.cornerRadius = TPMenuUX.UX.clearDataButtonCornerRadius
         button.layer.borderWidth = TPMenuUX.UX.clearDataButtonBorderWidth
         button.addTarget(self, action: #selector(self.didTapClearCookiesAndSiteData), for: .touchUpInside)
     }
@@ -330,6 +330,9 @@ class TrackingProtectionViewController: UIViewController,
                 equalTo: baseView.topAnchor,
                 constant: TPMenuUX.UX.connectionDetailsHeaderMargins),
         ]
+        if #available(iOS 26.0, *) {
+            connectionDetailsHeaderView.layer.cornerRadius = TPMenuUX.UX.newStyleCornerRadius
+        }
         constraints.append(contentsOf: connectionHeaderConstraints)
     }
 
@@ -391,6 +394,9 @@ class TrackingProtectionViewController: UIViewController,
             // site is safelisted if site ETP is disabled
             self?.model.toggleSiteSafelistStatus()
             self?.updateProtectionViewStatus()
+        }
+        if #available(iOS 26.0, *) {
+            toggleView.layer.cornerRadius = TPMenuUX.UX.newStyleCornerRadius
         }
     }
 
@@ -683,7 +689,7 @@ extension TrackingProtectionViewController {
     func applyTheme() {
         let theme = currentTheme()
         overrideUserInterfaceStyle = theme.type.getInterfaceStyle()
-        view.backgroundColor = theme.colors.layer3
+        view.backgroundColor = theme.colors.layer3.withAlphaComponent(TPMenuUX.UX.backgroundAlpha)
         headerContainer.applyTheme(theme: theme)
         connectionDetailsHeaderView.applyTheme(theme: theme)
         trackersView.applyTheme(theme: theme)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13319)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28997)

## :bulb: Description
Added iOS 26 style for Tracking Protection panel

## :movie_camera: Demos
<img width="603" height="1311" alt="IMG_0867" src="https://github.com/user-attachments/assets/56884172-1d4e-43a8-aba3-079ada10e2bf" />
<img width="603" height="1311" alt="IMG_0866" src="https://github.com/user-attachments/assets/617564c6-00f5-4b86-b3b7-c6c8b33471b7" />
<img width="603" height="1311" alt="IMG_0865" src="https://github.com/user-attachments/assets/48750b3f-e9cc-4823-bb14-9c83e88ba8c2" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
