### PR TITLE
Remove FXIOS-13288 #28920 ⁃ [TabScrollController] Investigate if shouldScrollToTop and setOffset logic are still needed and remove if not

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabProviderAdapter.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabProviderAdapter.swift
@@ -7,7 +7,6 @@ import UIKit
 @MainActor
 protocol TabProviderProtocol: AnyObject {
     var scrollView: UIScrollView? { get }
-    var shouldScrollToTop: Bool { get set }
     var isFxHomeTab: Bool { get }
     var isFindInPageMode: Bool { get }
     var isLoading: Bool { get }
@@ -28,12 +27,6 @@ final class TabProviderAdapter: TabProviderProtocol {
     var isFxHomeTab: Bool { tab.isFxHomeTab }
     var isFindInPageMode: Bool { tab.isFindInPageMode }
     var isLoading: Bool { tab.isLoading }
-
-    var shouldScrollToTop: Bool {
-        get { tab.shouldScrollToTop }
-        set { tab.shouldScrollToTop = newValue }
-    }
-
     var scrollView: UIScrollView? { tab.webView?.scrollView }
 
     var onLoadingStateChanged: (() -> Void)? {

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -135,13 +135,13 @@ final class TabScrollHandler: NSObject,
         configureRefreshControl()
     }
 
-    // TODO: Update to private in the future for now we need to keep support for Legacy protocol
+    // TODO: FXIOS-13340 Update to private in the future for now we need to keep support for Legacy protocol
     func showToolbars(animated: Bool) {
         toolbarDisplayState.update(displayState: .expanded)
         delegate?.showToolbar()
     }
 
-    // TODO: Update to private in the future for now we need to keep support for Legacy protocol
+    // TODO: FXIOS-13340 Update to private in the future for now we need to keep support for Legacy protocol
     func hideToolbars(animated: Bool) {
         toolbarDisplayState.update(displayState: .collapsed)
         delegate?.hideToolbar()
@@ -149,33 +149,11 @@ final class TabScrollHandler: NSObject,
 
     // MARK: - ScrollView observation
 
-    // Not needed anymore
+    // TODO: FXIOS-13340 Remove
     func beginObserving(scrollView: UIScrollView) {}
 
-    // Not needed anymore
+    // TODO: FXIOS-13340 Remove 
     func stopObserving(scrollView: UIScrollView) {}
-
-    // MARK: - Zoom
-
-    func updateMinimumZoom() {
-        guard let scrollView = scrollView else { return }
-
-        isZoomedOut = roundNum(scrollView.zoomScale) == roundNum(scrollView.minimumZoomScale)
-        lastZoomedScale = isZoomedOut ? 0 : scrollView.zoomScale
-    }
-
-    func setMinimumZoom() {
-        guard let scrollView = scrollView else { return }
-
-        if isZoomedOut && roundNum(scrollView.zoomScale) != roundNum(scrollView.minimumZoomScale) {
-            scrollView.zoomScale = scrollView.minimumZoomScale
-        }
-    }
-
-    func resetZoomState() {
-        isZoomedOut = false
-        lastZoomedScale = 0
-    }
 
     // MARK: - Pull to refresh
 
@@ -195,8 +173,6 @@ final class TabScrollHandler: NSObject,
         // voice over and webview's scroll content size is not enough to scroll
         guard !tabIsLoading(),
               shouldUpdateUIWhenScrolling else { return }
-
-        tabProvider?.shouldScrollToTop = false
 
         let delta = -translation.y
         scrollDirection = delta > 0 ? .down : .up
@@ -244,11 +220,6 @@ final class TabScrollHandler: NSObject,
     // checking if an abrupt scroll event was triggered and adjusting the offset to the one
     // before the WKWebView's contentOffset is reset as a result of the contentView's frame becoming smaller
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        // for PDFs, we should set the initial offset to 0 (ZERO)
-        if let tabProvider, tabProvider.shouldScrollToTop {
-            setOffset(y: 0, for: scrollView)
-        }
-
         // this action controls the address toolbar's border position, and to prevent spamming redux with actions for every
         // change in content offset, we keep track of lastContentOffsetY to know if the border needs to be updated
         sendActionToShowToolbarBorder(contentOffset: scrollView.contentOffset)
@@ -269,8 +240,6 @@ final class TabScrollHandler: NSObject,
               !scrollReachBottom(),
               !tabProvider.isFindInPageMode
               else { return }
-
-        tabProvider.shouldScrollToTop = false
 
         guard let containerView = scrollView.superview else { return }
 
@@ -406,13 +375,6 @@ final class TabScrollHandler: NSObject,
         } else {
             hideToolbars(animated: true)
         }
-    }
-
-    private func setOffset(y: CGFloat, for scrollView: UIScrollView) {
-        scrollView.contentOffset = CGPoint(
-            x: contentOffsetBeforeAnimation.x,
-            y: y
-        )
     }
 
     /// Sends a scroll action to update the new toolbar border visibility based on scroll position changes.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabProviderProtocol.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabProviderProtocol.swift
@@ -11,7 +11,6 @@ final class MockTabProviderProtocol: TabProviderProtocol {
     var isFxHomeTab = false
     var isFindInPageMode = false
     var isLoading = false
-    var shouldScrollToTop = false
 
     var onLoadingStateChanged: (() -> Void)?
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13288)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28920)

## :bulb: Description
- No visual change
- Remove logic that manually forced to scroll to top for PDF, tested and I couldn't reproduce [FXIOS-8941](https://mozilla-hub.atlassian.net/browse/FXIOS-8941)
- Removed unused functions related to zoom bar that was removed previously

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)


[FXIOS-8941]: https://mozilla-hub.atlassian.net/browse/FXIOS-8941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ