### PR TITLE
Refactor FXIOS-13234 [Swift 6 Migration] Enable strict concurrency inside MenuKit.

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -162,7 +162,10 @@ let package = Package(
         .target(
             name: "MenuKit",
             dependencies: ["Common", "ComponentLibrary"],
-            swiftSettings: [.unsafeFlags(["-enable-testing"])]),
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"]),
+                .enableExperimentalFeature("StrictConcurrency")
+            ]),
         .testTarget(
             name: "MenuKitTests",
             dependencies: ["MenuKit"]),

--- a/BrowserKit/Sources/MenuKit/MenuTableViewHelper.swift
+++ b/BrowserKit/Sources/MenuKit/MenuTableViewHelper.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Common
 
+@MainActor
 final class MenuTableViewHelper: NSObject {
     private weak var tableView: UITableView?
     private var menuData: [MenuSection] = []

--- a/BrowserKit/Tests/MenuKitTests/MenuTableViewHelperTests.swift
+++ b/BrowserKit/Tests/MenuKitTests/MenuTableViewHelperTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 @testable import MenuKit
 
+@MainActor
 final class MenuTableViewHelperTests: XCTestCase {
     var tableView: UITableView!
     var helper: MenuTableViewHelper!
@@ -39,7 +40,6 @@ final class MenuTableViewHelperTests: XCTestCase {
         XCTAssertEqual(tableView.numberOfSections, 1)
     }
 
-    @MainActor
     func testCellForRow_shouldReturnAccountCellType() {
         let option = MenuElement(
             title: "Option 1",
@@ -63,7 +63,6 @@ final class MenuTableViewHelperTests: XCTestCase {
         XCTAssertTrue(cell is MenuAccountCell)
     }
 
-    @MainActor
     func testCellForRow_shouldReturnSquaresViewContentCellType() {
         let option = MenuElement(
             title: "Option 1",
@@ -86,7 +85,6 @@ final class MenuTableViewHelperTests: XCTestCase {
         XCTAssertTrue(cell is MenuSquaresViewContentCell)
     }
 
-    @MainActor
     func testCellForRow_shouldReturnInfoCellType() {
         let option = MenuElement(
             title: "Option 1",
@@ -109,7 +107,6 @@ final class MenuTableViewHelperTests: XCTestCase {
         XCTAssertTrue(cell is MenuInfoCell)
     }
 
-    @MainActor
     func testCellForRow_shouldReturnRedesignCellType() {
         let option = MenuElement(
             title: "Option 1",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13234)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28787)

## :bulb: Description
Didn't seem to be any warnings! Let's see what Bitrise says...

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

Update: Bitrise showed me which errors to clear up in Client. Here's an example of one:
<img width="1559" height="624" alt="Screenshot 2025-09-03 at 3 24 45 PM" src="https://github.com/user-attachments/assets/ed7085ae-d707-41c4-8199-aa06af92b03e" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
