### PR TITLE
Refactor FXIOS-13235 [Swift 6 Migration] Enable strict concurrency inside SummarizeKit

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -176,10 +176,7 @@ let package = Package(
                 "ComponentLibrary",
                 "Down"
             ],
-            swiftSettings: [
-                .unsafeFlags(["-enable-testing"]),
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            swiftSettings: [.unsafeFlags(["-enable-testing"])]
         ),
         .testTarget(name: "SummarizeKitTests",
                     dependencies: ["SummarizeKit"]),

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -176,7 +176,10 @@ let package = Package(
                 "ComponentLibrary",
                 "Down"
             ],
-            swiftSettings: [.unsafeFlags(["-enable-testing"])]
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"]),
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
         ),
         .testTarget(name: "SummarizeKitTests",
                     dependencies: ["SummarizeKit"]),

--- a/BrowserKit/Sources/SummarizeKit/Backend/Config/DefaultSummarizerConfigSource.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/Config/DefaultSummarizerConfigSource.swift
@@ -7,8 +7,9 @@
 public struct DefaultSummarizerConfigSource: SummarizerConfigSourceProtocol {
     public init() {}
 
-    private static let appleBaseOptions: [String: AnyHashable] = [ "temperature": 0.1 ]
-    private static let liteLLMBaseOptions: [String: AnyHashable] = [
+    // FIXME: FXIOS-13417 We should strongly type options in the future so they can be any Sendable & Hashable
+    private static nonisolated(unsafe) let appleBaseOptions: [String: AnyHashable] = [ "temperature": 0.1 ]
+    private static nonisolated(unsafe) let liteLLMBaseOptions: [String: AnyHashable] = [
         "temperature": 0.1,
         "top_p": 0.01,
         "max_tokens": LiteLLMConfig.maxTokens,

--- a/BrowserKit/Sources/SummarizeKit/Backend/Config/SummarizerConfigSourceProtocol.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/Config/SummarizerConfigSourceProtocol.swift
@@ -3,6 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 /// An interface that defines the contract for loading summarizer configurations from various sources.
-public protocol SummarizerConfigSourceProtocol {
+public protocol SummarizerConfigSourceProtocol: Sendable {
     func load(_ summarizer: SummarizerModel, contentType: SummarizationContentType) -> SummarizerConfig?
 }

--- a/BrowserKit/Sources/SummarizeKit/Backend/LLM/LiteLLMClient.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/LLM/LiteLLMClient.swift
@@ -6,7 +6,7 @@ import Foundation
 
 /// A lightweight client for interacting with an OpenAI style API chat completions endpoint.
 /// TODO(FXIOS-12942): Implement proper thread-safety
-final class LiteLLMClient: LiteLLMClientProtocol, @unchecked Sendable {
+final class LiteLLMClient: LiteLLMClientProtocol, Sendable {
     private let apiKey: String
     private let baseURL: URL
 
@@ -71,7 +71,7 @@ final class LiteLLMClient: LiteLLMClientProtocol, @unchecked Sendable {
     }
 
     /// TODO(FXIOS-12994): Add tests for streaming requests.
-    /// Specifically, we need to test for the interaction with SSEDataParser and how it handles multiple reqeusts at a time.
+    /// Specifically, we need to test for the interaction with SSEDataParser and how it handles multiple requests at a time.
     private func handleStreamingRequest(request: URLRequest) -> AsyncThrowingStream<String, Error> {
         return AsyncThrowingStream { continuation in
             Task {

--- a/BrowserKit/Sources/SummarizeKit/Backend/LLM/LiteLLMClientProtocol.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/LLM/LiteLLMClientProtocol.swift
@@ -6,7 +6,7 @@ import Foundation
 
 /// Interface for a litellm client for both streamed and non-streamed responses.
 /// This used because we want to be able to replace the real `LiteLLMClient` with a mock during testing.
-protocol LiteLLMClientProtocol {
+protocol LiteLLMClientProtocol: Sendable {
     /// Sends a non-streaming chat completion request.
     func requestChatCompletion(
         messages: [LiteLLMMessage],

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizationChecker.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizationChecker.swift
@@ -5,7 +5,7 @@
 import WebKit
 import Foundation
 
-public class SummarizationChecker: SummarizationCheckerProtocol {
+public final class SummarizationChecker: SummarizationCheckerProtocol {
     public init() {}
 
     /// Calls `checkSummarization(maxWords:)` in the web page and returns a typed result.

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerCheckerProtocol.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerCheckerProtocol.swift
@@ -4,7 +4,7 @@
 
 import WebKit
 
-public protocol SummarizationCheckerProtocol {
+public protocol SummarizationCheckerProtocol: Sendable {
     /// The maximum number of words allowed before rejecting summarization.
     /// Prevents model errors caused by exceeding token or context window limits.
     /// This is enforced by the injected JS, not the model itself.

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerConfig.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerConfig.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 /// A configuration container for a summarizer.
-public struct SummarizerConfig: Equatable {
+public struct SummarizerConfig: Equatable, Sendable {
     public let instructions: String
     /// NOTE: options is intentionally untyped to allow for flexibility in the configuration.
     /// There are two main reasons for this. 

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerConfig.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerConfig.swift
@@ -5,13 +5,14 @@
 /// A configuration container for a summarizer.
 public struct SummarizerConfig: Equatable, Sendable {
     public let instructions: String
+    // FIXME: FXIOS-13417 We should strongly type options in the future so they can be any Sendable & Hashable
     /// NOTE: options is intentionally untyped to allow for flexibility in the configuration.
     /// There are two main reasons for this. 
     /// 1. The hosted model that is using an OpenAI-like API that has a lot of different parameters that can be tuned, 
     ///    and we want to allow for easy experimentation with these parameters.
     /// 2. The Apple foundation model is a new API that may introduce additional parameters or change existing ones.
     /// Options can include things like temperature, max tokens, and other model-specific settings.
-    public let options: [String: AnyHashable]
+    public nonisolated(unsafe) let options: [String: AnyHashable]
     public static let defaultConfig =
         SummarizerConfig(instructions: SummarizerModelInstructions.defaultInstructions, options: [:])
 

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerModel.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerModel.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 /// All supported LLM backends, This is used mainly as an identifier instead of using raw strings.
-public enum SummarizerModel: String {
+public enum SummarizerModel: String, Sendable {
     case appleSummarizer
     case liteLLMSummarizer
 }

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerProtocol.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerProtocol.swift
@@ -4,7 +4,7 @@
 
 /// Unified interface for all summary backends.
 /// All implementations ( local models, litellm, ... ) must conform to this.
-public protocol SummarizerProtocol {
+public protocol SummarizerProtocol: Sendable {
     var modelName: SummarizerModel { get }
     func summarize(_ contentToSummarize: String) async throws -> String
     func summarizeStreamed(_ contentToSummarize: String) -> AsyncThrowingStream<String, Error>

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerServiceLifecycle.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerServiceLifecycle.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 /// A protocol defining the lifecycle events for a text summarization service.
-public protocol SummarizerServiceLifecycle: AnyObject {
+public protocol SummarizerServiceLifecycle: AnyObject, Sendable {
     /// Called once before summarization starts.
     func summarizerServiceDidStart(_ text: String)
     /// Called on success, with the summary text.

--- a/BrowserKit/Sources/SummarizeKit/ToSBottomSheetViewController.swift
+++ b/BrowserKit/Sources/SummarizeKit/ToSBottomSheetViewController.swift
@@ -224,7 +224,10 @@ public class ToSBottomSheetViewController: UIViewController,
     // MARK: - Notifiable
     public func handleNotifications(_ notification: Notification) {
         guard notification.name == UIContentSizeCategory.didChangeNotification else { return }
-        updateDynamicFontSize()
+
+        ensureMainThread {
+            self.updateDynamicFontSize()
+        }
     }
 
     // MARK: - UITextViewDelegate

--- a/BrowserKit/Tests/SummarizeKitTests/Mocks/MockSummarizer.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/Mocks/MockSummarizer.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import SummarizeKit
 
-final class MockSummarizer: SummarizerProtocol {
+final class MockSummarizer: SummarizerProtocol, @unchecked Sendable {
     var modelName: SummarizerModel = .appleSummarizer
 
     /// If set, both `summarize` and `summarizeStreamed` will throw this error.

--- a/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 import Shared
 import WebKit
 
-class SummarizeCoordinator: BaseCoordinator, SummarizerServiceLifecycle {
+final class SummarizeCoordinator: BaseCoordinator, SummarizerServiceLifecycle {
     private let browserSnapshot: UIImage
     private let browserSnapshotTopOffset: CGFloat
     private weak var parentCoordinatorDelegate: ParentCoordinatorDelegate?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SummarizeCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SummarizeCoordinatorTests.swift
@@ -9,7 +9,7 @@ import Shared
 import ComponentLibrary
 @testable import Client
 
-class MockSummarizer: SummarizerProtocol {
+final class MockSummarizer: SummarizerProtocol, @unchecked Sendable {
     var modelName: SummarizerModel = .appleSummarizer
 
     func summarize(_ contentToSummarize: String) async throws -> String {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MockSummarizerConfigSource.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MockSummarizerConfigSource.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import SummarizeKit
 
-public final class MockSummarizerConfigSource: SummarizerConfigSourceProtocol {
+public final class MockSummarizerConfigSource: SummarizerConfigSourceProtocol, @unchecked Sendable {
     var configToReturn: SummarizerConfig
 
     init(configToReturn: SummarizerConfig) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSummarizationChecker.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSummarizationChecker.swift
@@ -5,7 +5,7 @@
 import SummarizeKit
 import WebKit
 
-class MockSummarizationChecker: SummarizationCheckerProtocol {
+final class MockSummarizationChecker: SummarizationCheckerProtocol, @unchecked Sendable {
     var checkCalledCount = 0
     static let success = SummarizationCheckResult(
         canSummarize: true,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13235)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28790)

## :bulb: Description
Enable strict concurrency inside SummarizeKit.

Didn't seem to be any warnings! Let's see what Bitrise says...

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
