### PR TITLE
Refactor FXIOS-12716 [webcompat] Use latest UAstring versions for desktop mode

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -49,7 +49,7 @@ open class UserAgent {
 
     public static func desktopUserAgent() -> String {
         // swiftlint:disable line_length
-        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.7 Safari/605.1.15"
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Safari/605.1.15"
         // swiftlint:enable line_length
     }
 
@@ -178,6 +178,6 @@ public struct UserAgentBuilder {
             systemInfo: "(Macintosh; Intel Mac OS X 10_15_7)",
             platform: UserAgent.platform,
             platformDetails: UserAgent.platformDetails,
-            extensions: "Version/17.7 Safari/605.1.15")
+            extensions: "Version/18.6 Safari/605.1.15")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
@@ -50,7 +50,7 @@ final class UserAgentBuilderTests: XCTestCase {
     func testDefaultDesktopUserAgent() {
         let builder = UserAgentBuilder.defaultDesktopUserAgent()
         let systemInfo = "(Macintosh; Intel Mac OS X 10_15_7)"
-        let extensions = "Version/17.7 Safari/605.1.15"
+        let extensions = "Version/18.6 Safari/605.1.15"
         let testAgent = "\(UserAgent.product) \(systemInfo) \(UserAgent.platform) \(UserAgent.platformDetails) \(extensions)"
         XCTAssertEqual(builder.userAgent(), testAgent)
     }

--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -161,9 +161,9 @@ class LegacyWebViewController: UIViewController, LegacyWebController {
         // Focus on iPad, which means there could be some edge cases right now.
 
         if UIDevice.current.userInterfaceIdiom == .pad {
-            configuration.applicationNameForUserAgent = "Version/17.7 Safari/605.1.15"
+            configuration.applicationNameForUserAgent = "Version/18.6 Safari/605.1.15"
         } else {
-            configuration.applicationNameForUserAgent = "FxiOS/\(AppInfo.majorVersion) Mobile/15E148 Version/17.7"
+            configuration.applicationNameForUserAgent = "FxiOS/\(AppInfo.majorVersion) Mobile/15E148 Version/18.6"
         }
 
         if #available(iOS 15.0, *) {


### PR DESCRIPTION
## :scroll: Tickets
FXIOS-12716
#27698

## :bulb: Description

While some platforms drop support for iOS 16 and lower soon (and would be happy with Mobile Safari 17.x), they may not always support any desktop browser older than the current (or one older, in a few weeks) no matter what OS — and since these are used in spoofing desktop, not mobile values, we actually have to track desktop support cycles, not mobile, so pushing this a bit further — now that it seems safe that 18.6 would be the ultimate version on that major, to keep around for a while in the constants.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)