### PR TITLE
Bugfix FXIOS-13396 Fix blank screen after closing old tabs

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -349,7 +349,13 @@ class TabManagerImplementation: NSObject,
         }
 
         guard !tabsToRemove.isEmpty else { return }
-        removeTabs(tabsToRemove)
+
+        Task { @MainActor in
+            for tab in tabsToRemove {
+                await self.removeTab(tab.tabUUID)
+            }
+            commitChanges()
+        }
     }
 
     // MARK: - Add Tab


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13396)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29119)

## :bulb: Description

Initial attempt at a fix for FXIOS-13396. Summary:
- We have multiple removeTab functions, many of them working slightly differently (for example, some flush to disk, and others don't)
- The removeTabs() func that was being used when clearing old tabs works differently than Close All Tabs; the latter does not appear to suffer from the same issue
- The fix here is to update the code for removing old tabs to use the same codepath as Remove All Tabs for consistency
- Sidenote: I believe that calling `await removeTab` in a `for` loop like this is fundamentally unsafe, but that is a separate architectural problem and I raised a discussion about it [here](https://mozilla.slack.com/archives/C09235AH0P4/p1756938427437859). Since we're already doing that for Remove All Tabs I think it's fine for now to address this bug by at least making it consistent with the current Remove All Tabs code.

I will take a closer look at this tomorrow also, but would love some extra eyes from anyone who has more context on this tab removal code. (cc @FilippoZazzeroni @Cramsden) 👀 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
