### PR TITLE
Fix FXIOS-13214 [Tab Tray Animation] Fix increase in time to present and dismiss tab tray on iOS 26 - Round 2

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -147,7 +147,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         finalFrame: CGRect,
         selectedTab: Tab
     ) {
-        let start = DispatchTime.now()
         // Snapshot of the BVC view
         let bvcSnapshot = UIImageView(image: browserVC.view.snapshot)
         bvcSnapshot.layer.cornerCurve = .continuous
@@ -289,9 +288,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         animator.addCompletion { _ in
             backgroundView.removeFromSuperview()
             borderLayer.removeFromSuperlayer()
-            let end = DispatchTime.now()
-            let elapsed = Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
-            print("👽Presentation animation took \(elapsed) seconds👽")
             context.completeTransition(true)
         }
 
@@ -312,7 +308,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         finalFrame: CGRect,
         selectedTab: Tab
     ) {
-        let start = DispatchTime.now()
         guard let panel = currentExperimentPanel as? ThemedNavigationController,
               let panelViewController = panel.viewControllers.first as? TabDisplayPanelViewController
         else {
@@ -385,9 +380,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             self.view.removeFromSuperview()
             tabSnapshot.removeFromSuperview()
             toView.removeFromSuperview()
-            let end = DispatchTime.now()
-            let elapsed = Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
-            print("👽Dismissal animation took \(elapsed) seconds👽")
             context.completeTransition(true)
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13214)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28753)

## :bulb: Description
Increase speed for tab tray animation and remove extra reloadData call.

## Background
Previously this PR was submitted to address the slowdown of the tab tray animation, but it was ultimately not put into release because the fix was a patch to account for a memory leak and various other issues.

This week the team and I spent some time investigating the issues with diffable datasource and patched some things which has resulted in a reduction of some of the performance issues. This PR is small, but it should further improve the tab tray timing of the animation.

## Data - At the time the bug was logged
### Before 
#### iPhone 16 Pro Sim iOS 26
Homepage
Presentation animation average: ≈ 0.455 seconds (≈ 455 ms)
Dismissal animation average: ≈ 0.361 seconds (≈ 361 ms)

Webpage - Facebook
Presentation animation average: ≈ 0.431 seconds (≈ 431 ms)
Dismissal animation average: ≈ 0.353 seconds (≈ 353 ms)

### After
#### iPhone 16 Pro Sim iOS 26
Homepage 
Presentation animation average: ≈ 0.337 seconds (≈ 337 ms)
Dismissal animation average: ≈ 0.321 seconds (≈ 321 ms)

Facebook
Presentation animation average: ≈ 0.347 seconds (≈ 347 ms)
Dismissal animation average: ≈ 0.350 seconds (≈ 350 ms)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
