### PR TITLE
Bugfix FXIOS-13233 [Swift 6 Migration] nonisolated @obj method in ToolbarKit with MenuHelperURLBarInterface

### DIFF
--- a/BrowserKit/Sources/Common/Utilities/MenuHelper/MenuHelperURLBarInterface.swift
+++ b/BrowserKit/Sources/Common/Utilities/MenuHelper/MenuHelperURLBarInterface.swift
@@ -7,8 +7,9 @@ import Foundation
 @objc
 public protocol MenuHelperURLBarInterface {
     /// Used to add a paste and go option on the URL bar textfield
+    /// Note: objc methods should always be marked nonisolated as `@MainActor` isolation can't be guaranteed
     @objc
-    optional func menuHelperPasteAndGo()
+    nonisolated optional func menuHelperPasteAndGo()
 }
 
 /// Used to pass in the Client strings for the URL bar textfield menu options

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -600,10 +600,12 @@ final class LocationView: UIView,
         return super.canPerformAction(action, withSender: sender)
     }
 
-    func menuHelperPasteAndGo() {
-        guard let pasteboardContents = UIPasteboard.general.string else { return }
-        delegate?.locationViewDidSubmitText(pasteboardContents)
-        urlTextField.text = pasteboardContents
+    nonisolated func menuHelperPasteAndGo() {
+        ensureMainThread {
+            guard let pasteboardContents = UIPasteboard.general.string else { return }
+            self.delegate?.locationViewDidSubmitText(pasteboardContents)
+            self.urlTextField.text = pasteboardContents
+        }
     }
 
     // MARK: - LocationTextFieldDelegate

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2d9aa486f2522133c5e014f11b57e376b0275a8613f95f4ea6055d63323a02f7",
+  "originHash" : "fd9e7ee0a5a4a51afa470f26a1227faf19a6a9a8d18a6fe0350eae566b77a495",
   "pins" : [
     {
       "identity" : "a-star",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13233)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28786)

## :bulb: Description
- Last warning from `ToolbarKit` with an `@objc` protocol. Adding `nonisolated` fixed the warning
<img width="2077" height="339" alt="Screenshot 2025-09-03 at 8 32 28 PM" src="https://github.com/user-attachments/assets/00c1ff5f-c854-4a17-80b3-86473829cf66" />

- I commit the hash change from the `xcshareddata` since I keep getting it locally


cc: @Cramsden @dataports 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
