### PR TITLE
Refactor FXIOS [Swift 6 Migration] Prefer using MainActor.assertIsolated

### DIFF
--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -85,7 +85,7 @@ public class Store<State: StateType & Sendable>: DefaultDispatchStore {
 
     @MainActor
     public func dispatch(_ action: Action) {
-        assert(Thread.isMainThread, "@MainActor doesn't guarantee this is running on the main thread")
+        MainActor.assertIsolated("Expected to be called only on main actor.")
         logger.log("Dispatched action: \(action.debugDescription)", level: .info, category: .redux)
         actionQueue.append(action)
         processQueuedActions()

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -985,7 +985,7 @@ class TabManagerImplementation: NSObject,
 
     @MainActor
     private func selectTabWithSession(tab: Tab, sessionData: Data?) {
-        assert(Thread.isMainThread, "Currently expected to be called only on main thread.")
+        MainActor.assertIsolated("Expected to be called only on main actor.")
         let configuration: WKWebViewConfiguration = tabConfigurationProvider.configuration(
             isPrivate: tab.isPrivate
         ).webViewConfiguration


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
It seems preferable to use `MainActor.assertIsolated` instead of `Thread.isMainThread` whenever we use modern concurrency.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
