### PR TITLE
Bugfix FXIOS-13369 [iOS 26] Glass effect is not applied to save username pop up

### DIFF
--- a/firefox-ios/Client/Frontend/Components/SaveLoginAlert.swift
+++ b/firefox-ios/Client/Frontend/Components/SaveLoginAlert.swift
@@ -63,7 +63,7 @@ class SaveLoginAlert: UIView, ThemeApplicable {
         if #available(iOS 26.0, *) {
             button.configuration = .glass()
         }
-        #else
+        #endif
         button.addTarget(self, action: #selector(self.notNowButtonPressed), for: .touchUpInside)
     }
 
@@ -72,7 +72,7 @@ class SaveLoginAlert: UIView, ThemeApplicable {
         if #available(iOS 26.0, *) {
             button.configuration = .glass()
         }
-        #else
+        #endif
         button.addTarget(self, action: #selector(self.saveButtonPressed), for: .touchUpInside)
     }
 

--- a/firefox-ios/Client/Frontend/Components/SaveLoginAlert.swift
+++ b/firefox-ios/Client/Frontend/Components/SaveLoginAlert.swift
@@ -59,16 +59,20 @@ class SaveLoginAlert: UIView, ThemeApplicable {
     }
 
     private lazy var notNowButton: SecondaryRoundedButton = .build { button in
+        #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
             button.configuration = .glass()
         }
+        #else
         button.addTarget(self, action: #selector(self.notNowButtonPressed), for: .touchUpInside)
     }
 
     private lazy var saveButton: PrimaryRoundedButton = .build { button in
+        #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
             button.configuration = .glass()
         }
+        #else
         button.addTarget(self, action: #selector(self.saveButtonPressed), for: .touchUpInside)
     }
 
@@ -190,10 +194,19 @@ class SaveLoginAlert: UIView, ThemeApplicable {
         guard glassEffectView == nil else { return }
 
         let effectView = UIVisualEffectView()
-        let glassEffect = UIGlassEffect()
-        glassEffect.isInteractive = true
 
-        effectView.effect = glassEffect
+        #if canImport(FoundationModels)
+        if #available(iOS 26, *) {
+            let glassEffect = UIGlassEffect()
+            glassEffect.isInteractive = true
+            effectView.effect = glassEffect
+        } else {
+            effectView.effect = UIBlurEffect(style: .systemUltraThinMaterial)
+        }
+        #else
+        effectView.effect = UIBlurEffect(style: .systemUltraThinMaterial)
+        #endif
+
         effectView.layer.cornerRadius = UX.cornerRadius
         effectView.clipsToBounds = true
         effectView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13369)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29076)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add glass effect to save username popup.

<img height="440" alt="IMG_0970" src="https://github.com/user-attachments/assets/48388bf0-8474-484f-abbe-8435a1a1fa8c" />


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
