### PR TITLE
Add FXIOS-13082 [Discover More] Update stories section header

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -197,6 +197,7 @@ struct AccessibilityIdentifiers {
             static let bookmarks = "bookmarksSectionMoreButton"
             static let jumpBackIn = "jumpBackInSectionMoreButton"
             static let customizeHomePage = "FxHomeCustomizeHomeSettingButton"
+            static let stories = "storiesSectionMoreButton"
         }
 
         struct SectionTitles {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoState.swift
@@ -13,7 +13,6 @@ struct MerinoState: StateType, Equatable {
     let merinoData: [MerinoStoryConfiguration]
     let shouldShowSection: Bool
 
-    // TODO: FXIOS-12980: Replace "Stories" title with "Top Stories" string once it is translated in v143
     let sectionHeaderState = SectionHeaderConfiguration(
         title: .FirefoxHomepage.Pocket.SectionTitle,
         a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.merino

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoState.swift
@@ -12,11 +12,7 @@ struct MerinoState: StateType, Equatable {
     var windowUUID: WindowUUID
     let merinoData: [MerinoStoryConfiguration]
     let shouldShowSection: Bool
-
-    let sectionHeaderState = SectionHeaderConfiguration(
-        title: .FirefoxHomepage.Pocket.SectionTitle,
-        a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.merino
-    )
+    let sectionHeaderState = initializeSectionHeaderState()
 
     let footerURL = SupportUtils.URLForPocketLearnMore
 
@@ -91,6 +87,20 @@ struct MerinoState: StateType, Equatable {
             windowUUID: state.windowUUID,
             merinoData: state.merinoData,
             shouldShowSection: state.shouldShowSection
+        )
+    }
+
+    private static func initializeSectionHeaderState() -> SectionHeaderConfiguration {
+        let isDiscoverMoreEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(.homepageDiscoverMoreButton,
+                                                                                      checking: .buildOnly)
+        let title: String = isDiscoverMoreEnabled ? .FirefoxHomepage.Pocket.AllStoriesButtonTitle
+                                                  : .FirefoxHomepage.Pocket.SectionTitle
+        return SectionHeaderConfiguration(
+            title: title,
+            a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.merino,
+            isButtonHidden: !isDiscoverMoreEnabled,
+            buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.stories,
+            buttonTitle: String.FirefoxHomepage.Pocket.AllStoriesButtonTitle
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoState.swift
@@ -93,7 +93,7 @@ struct MerinoState: StateType, Equatable {
     private static func initializeSectionHeaderState() -> SectionHeaderConfiguration {
         let isDiscoverMoreEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(.homepageDiscoverMoreButton,
                                                                                       checking: .buildOnly)
-        let title: String = isDiscoverMoreEnabled ? .FirefoxHomepage.Pocket.AllStoriesButtonTitle
+        let title: String = isDiscoverMoreEnabled ? .FirefoxHomepage.Pocket.PopularTodaySectionTitle
                                                   : .FirefoxHomepage.Pocket.SectionTitle
         return SectionHeaderConfiguration(
             title: title,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
@@ -104,7 +104,7 @@ class LabelButtonHeaderView: UICollectionReusableView,
         moreButton.isHidden = state.isButtonHidden
         if !state.isButtonHidden {
             let moreButtonViewModel = ActionButtonViewModel(
-                title: .BookmarksSavedShowAllText,
+                title: state.buttonTitle ?? .BookmarksSavedShowAllText,
                 a11yIdentifier: state.buttonA11yIdentifier,
                 touchUpAction: moreButtonAction
             )

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1035,11 +1035,6 @@ extension String {
                 tableName: "FirefoxHomepage",
                 value: "Stories",
                 comment: "This is the title of the Stories section on Firefox Homepage.")
-            public static let TopStoriesSectionTitle = MZLocalizedString(
-                key: "FirefoxHome.Stories.TopStoriesSectionTitle.v143",
-                tableName: "FirefoxHomepage",
-                value: "Top Stories",
-                comment: "This is the title of the Top Stories section on Firefox Homepage.")
             public static let PopularTodaySectionTitle = MZLocalizedString(
                 key: "FirefoxHome.Stories.PopularTodaySectionTitle.v144",
                 tableName: "FirefoxHomepage",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MerinoStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MerinoStateTests.swift
@@ -12,6 +12,7 @@ final class MerinoStateTests: XCTestCase {
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
     }
 
     override func tearDown() {
@@ -88,6 +89,20 @@ final class MerinoStateTests: XCTestCase {
         XCTAssertFalse(newState.shouldShowSection)
     }
 
+    func test_initialState_withShowDiscoverMoreButtonEnabled_showsHeaderButton() {
+        setupNimbusShowDiscoverMoreButtonTesting(isEnabled: true)
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.sectionHeaderState.isButtonHidden, false)
+    }
+
+    func test_initialState_withShowDiscoverMoreButtonDisabled_hidesHeaderButton() {
+        setupNimbusShowDiscoverMoreButtonTesting(isEnabled: false)
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.sectionHeaderState.isButtonHidden, true)
+    }
+
     // MARK: - Private
     private func createSubject() -> MerinoState {
         return MerinoState(windowUUID: .XCTestDefaultUUID)
@@ -95,5 +110,13 @@ final class MerinoStateTests: XCTestCase {
 
     private func pocketReducer() -> Reducer<MerinoState> {
         return MerinoState.reducer
+    }
+
+    private func setupNimbusShowDiscoverMoreButtonTesting(isEnabled: Bool) {
+        let discoverMoreConfiguration = DiscoverMoreConfiguration(discoverMoreV1Experience: false,
+                                                                  showDiscoverMoreButton: isEnabled)
+        FxNimbus.shared.features.homepageRedesignFeature.with { _, _ in
+            return HomepageRedesignFeature(discoverMoreFeatureConfiguration: discoverMoreConfiguration)
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13082)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28490)

## :bulb: Description
- Update the section header title to "Popular today"
- Show the "All stories" section header button

Note: Changes are behind the `show-discover-more-button` variable in the `homepage-redesign-feature` flag

## :movie_camera: Demos
| Before | After |
| - | - |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-04 at 14 38 23" src="https://github.com/user-attachments/assets/67b255d2-dbd2-4bae-9f98-557ddb6e078e" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-04 at 14 36 19" src="https://github.com/user-attachments/assets/14b675bb-6cb8-481e-a14e-904ee8d372e8" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
