### PR TITLE
Bugfix FXIOS-28817 [Settings: Appearance] Fix zoom page list's height

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
@@ -20,19 +20,60 @@ struct ZoomLevelCellView: View {
     }
 
     var body: some View {
-        HStack {
-            Text(domainZoomLevel.host)
-                .font(.body)
-                .foregroundColor(textColor)
+        if #available(iOS 16, *) {
+            ViewThatFits(in: .horizontal) {
+                HStack {
+                    domainZoomLevelText
 
-            Spacer()
+                    Spacer()
 
-            Text(ZoomLevel(from: domainZoomLevel.zoomLevel).displayName)
-                .font(.body)
-                .foregroundColor(textColor)
+                    textView(for: ZoomLevel(from: domainZoomLevel.zoomLevel))
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(UX.textPadding)
+
+                VStack {
+                    HStack {
+                        Text(domainZoomLevel.host)
+                            .alignmentGuide(.leading) { $0[.leading] + UX.textPadding }
+
+                        Spacer()
+                    }
+
+                    HStack {
+                        Spacer()
+
+                        Text(ZoomLevel(from: domainZoomLevel.zoomLevel).displayName)
+                            .alignmentGuide(.trailing) { $0[.trailing] + UX.textPadding }
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding(UX.textPadding)
+            }
+            .font(.body)
+            .foregroundColor(textColor)
+        } else {
+            HStack {
+                Text(domainZoomLevel.host)
+
+                Spacer()
+
+                textView(for: ZoomLevel(from: domainZoomLevel.zoomLevel))
+            }
+            .font(.body)
+            .foregroundColor(textColor)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(UX.textPadding)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(UX.textPadding)
-        .listRowBackground(Color.clear)
+    }
+
+    private var domainZoomLevelText: some View {
+        Text(domainZoomLevel.host)
+    }
+
+    private func textView(
+        for zoomLevel: ZoomLevel
+    ) -> some View {
+        Text(zoomLevel.displayName)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-28817)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28817)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

I add a state property to the `ZoomSiteListView` type to compute the height and computed the height of the list using an overlay on the `ZoomLevelCellView` inside `zoomSitesListView`.  There is one quirk of this solution (the initial height of `listHeight` is `1`).  I think this issue stems from the fact that we are using a `List` inside a `ScrollView`.  I considered a few alternatives but they all had similar a hacky feeling.  I think the correct approach here is to rewrite the `PageZoomSettingsView` and its dependencies using `Section`s inside of `List` instead.  However, I wanted to some opinions first as this code change would be much larger.

cc @FilippoZazzeroni

I also removed the bottom section divider.

## :movie_camera: Demos

There are some differences in the below screenshots and movies because I was using bold text and smaller than default font sizes.

| Before | After |
| - | - |
| <img alt="Before iPhone" src="https://github.com/user-attachments/assets/52d829e8-8c2f-4d83-a7b5-a9267137bdc0" /> | <img alt="After iPhone" src="https://github.com/user-attachments/assets/bd9a3065-3174-468c-bfac-b7fdd0da70db" /> |
| <video src="https://github.com/user-attachments/assets/bbef0580-eb08-45a7-a4be-a3809fa92808" /> | <video src="https://github.com/user-attachments/assets/e1c4de8b-ccad-4e73-88c5-fa3f058156d9"/> |
| <img src="https://github.com/user-attachments/assets/ce0f14cd-23ed-4ecb-98ab-0e3c8f9450be" /> | <img src="https://github.com/user-attachments/assets/03e34b73-b377-4ea2-b831-d8ad6d140313" /> |
| <video src="https://github.com/user-attachments/assets/3aaf143f-ccc2-4cd0-8fb8-d6a079455710"/> | <video src="https://github.com/user-attachments/assets/44d8f67e-d252-4f47-b62d-b53024654127"/> |
| <img alt="Simulator Screenshot - iPad (A16) - 2025-09-08 at 14 44 56" src="https://github.com/user-attachments/assets/bfd881cc-ace3-4564-b68e-5a53b6c6b18f" /> |  <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-09-08 at 14 16 35" src="https://github.com/user-attachments/assets/74ef1df6-d7e9-46b8-8498-c5c28dbd9245" /> |
| <video src="https://github.com/user-attachments/assets/06dfa39a-aba0-4565-a382-fce656f88788"/> | <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-09-08 at 14 16 50" src="https://github.com/user-attachments/assets/fe220c20-c90d-43af-a6b2-54235a057eae" /> |
| <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-09-08 at 14 42 13" src="https://github.com/user-attachments/assets/b8ce4d7f-3315-4a14-9ded-1147bb12c50e" /> | <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-09-08 at 14 13 32" src="https://github.com/user-attachments/assets/fc96681b-4dde-4944-bfe6-4b1ce4e1dfd6" /> |
| <video src="https://github.com/user-attachments/assets/f2835f56-585e-4a61-a38a-3df545e7f672"/> | <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-09-08 at 14 12 46" src="https://github.com/user-attachments/assets/2b4c407e-98f2-4e99-8dd1-a367b5baf446" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
