### PR TITLE
Add FXIOS-13437 ⁃ [Menu Redesign] Add Share option to the Menu and change the alignment for the Site protections button

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
@@ -139,17 +139,14 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
             siteProtectionsIcon.widthAnchor.constraint(equalToConstant: UX.siteProtectionsIcon),
             siteProtectionsMoreSettingsIcon.widthAnchor.constraint(equalToConstant: UX.siteProtectionsMoreSettingsIcon),
 
-            siteProtectionsContent.topAnchor.constraint(equalTo: contentLabels.bottomAnchor,
+            siteProtectionsContent.topAnchor.constraint(equalTo: favicon.bottomAnchor,
                                                         constant: UX.siteProtectionsContentTopMargin),
             siteProtectionsContent.trailingAnchor.constraint(lessThanOrEqualTo: closeButton.leadingAnchor),
             siteProtectionsContent.bottomAnchor.constraint(equalTo: self.bottomAnchor),
 
             closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
             closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
-            siteProtectionsContent.leadingAnchor.constraint(
-                equalTo: favicon.trailingAnchor,
-                constant: UX.horizontalContentMargin - UX.siteProtectionsContentHorizontalPadding - UX.protectionIconMargin
-            )
+            siteProtectionsContent.leadingAnchor.constraint(equalTo: favicon.leadingAnchor)
         ])
 
         closeButton.layer.cornerRadius = 0.5 * UX.closeButtonSize

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -23,6 +23,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         static let saveAsPDFV2 = StandardImageIdentifiers.Large.saveFile
         static let summarizer = StandardImageIdentifiers.Large.summarizer
         static let avatarCircle = StandardImageIdentifiers.Large.avatarCircle
+        static let share = StandardImageIdentifiers.Large.share
     }
 
     private var shouldShowReportSiteIssue: Bool {
@@ -285,6 +286,29 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
                                 actionType: MainMenuActionType.tapNavigateToDestination,
                                 navigationDestination: MenuNavigationDestination(
                                     .printSheetV2,
+                                    url: tabInfo.canonicalURL
+                                ),
+                                telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)
+                            )
+                        )
+                    }
+                ),
+                MenuElement(
+                    title: .MainMenu.Submenus.Tools.Share,
+                    iconName: Icons.share,
+                    isEnabled: true,
+                    isActive: false,
+                    a11yLabel: .MainMenu.Submenus.Tools.AccessibilityLabels.Share,
+                    a11yHint: "",
+                    a11yId: AccessibilityIdentifiers.MainMenu.share,
+                    isOptional: true,
+                    action: {
+                        store.dispatchLegacy(
+                            MainMenuAction(
+                                windowUUID: uuid,
+                                actionType: MainMenuActionType.tapNavigateToDestination,
+                                navigationDestination: MenuNavigationDestination(
+                                    .shareSheet,
                                     url: tabInfo.canonicalURL
                                 ),
                                 telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -137,6 +137,9 @@ class MainMenuCoordinator: BaseCoordinator, FeatureFlaggable {
         case .printSheetV2:
             navigationHandler?.showPrintSheet()
 
+        case .shareSheet:
+            navigationHandler?.showShareSheetForCurrentlySelectedTab()
+
         case .saveAsPDFV2:
             navigationHandler?.presentSavePDFController()
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -16,6 +16,7 @@ final class MainMenuMiddleware: FeatureFlaggable {
         static let passwords = "passwords"
         static let settings = "settings"
         static let print = "print"
+        static let share = "share"
         static let saveAsPDF = "save_as_PDF"
         static let switchToDesktopSite = "switch_to_desktop_site"
         static let switchToMobileSite = "switch_to_mobile_site"
@@ -221,6 +222,9 @@ final class MainMenuMiddleware: FeatureFlaggable {
 
         case .printSheetV2:
             telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.print)
+
+        case .shareSheet:
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.share)
 
         case .saveAsPDFV2:
             telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.saveAsPDF)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MenuNavigationDestination.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MenuNavigationDestination.swift
@@ -17,6 +17,7 @@ enum MainMenuNavigationDestination: Equatable {
     case siteProtections
     case syncSignIn
     case printSheetV2
+    case shareSheet
     case saveAsPDFV2
     case webpageSummary(config: SummarizerConfig?)
     case zoom
@@ -39,6 +40,7 @@ enum MainMenuNavigationDestination: Equatable {
             .siteProtections,
             .syncSignIn,
             .printSheetV2,
+            .shareSheet,
             .saveAsPDFV2,
             .webpageSummary(config: SummarizerConfig(instructions: "", options: [:])),
             .zoom

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4936,6 +4936,11 @@ extension String {
                     tableName: "MainMenu",
                     value: "Print",
                     comment: "On the main menu, the title for the action that will take the user to the Print module in the application.")
+                public static let Share = MZLocalizedString(
+                    key: "MainMenu.Submenus.Tools.Share.Title.v144",
+                    tableName: "MainMenu",
+                    value: "Share",
+                    comment: "On the main menu, the title for the action that will take the user to the Share module in the application.")
 
                 public struct AccessibilityLabels {
                     public static let NightModeOn = MZLocalizedString(
@@ -4953,6 +4958,11 @@ extension String {
                         tableName: "MainMenu",
                         value: "Print",
                         comment: "On the main menu, the accessibility label for the action that will take the user to the Print module in the application.")
+                    public static let Share = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.Share.Title.v144",
+                        tableName: "MainMenu",
+                        value: "Share",
+                        comment: "On the main menu, the accessibility label for the action (Share with others) that will take the user/open (to) the Share submenu.")
                 }
             }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
@@ -173,6 +173,27 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(savedExtras.option, "print")
     }
 
+    func test_tapNavigateToDestination_shareSheetAction_sendTelemetryData() throws {
+        let action = getNavigationDestinationAction(for: .shareSheet)
+        let subject = createSubject()
+
+        subject.mainMenuProvider(AppState(), action)
+
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
+        )
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.AppMenu.MainMenuOptionSelectedExtra
+        )
+        let expectedMetricType = type(of: GleanMetrics.AppMenu.mainMenuOptionSelected)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(savedExtras.option, "share")
+    }
+
     func test_tapNavigateToDestination_saveAsPDFV2Action_sendTelemetryData() throws {
         let action = getNavigationDestinationAction(for: .saveAsPDFV2)
         let subject = createSubject()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13437)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29205)

## :bulb: Description
Added share option to the menu and moved site protections button position

## :movie_camera: Demos

https://github.com/user-attachments/assets/931f8540-1f9c-4509-97f0-ae1f17008076



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
