### PR TITLE
Bugfix FXIOS-13374 - [Tab Tray] - Firefox for iOS crashes after closing a tab on the tab tray under certain steps

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -11,7 +11,7 @@ protocol TabDisplayViewDragAndDropInteraction: AnyObject {
     func dragAndDropEnded()
 }
 
-class TabDisplayView: UIView,
+final class TabDisplayView: UIView,
                       ThemeApplicable,
                       UICollectionViewDelegate,
                       UICollectionViewDelegateFlowLayout,
@@ -235,16 +235,15 @@ class TabDisplayView: UIView,
             return headerView
 
         case TabTitleSupplementaryView.cellIdentifier:
-            let titleView = collectionView.dequeueReusableSupplementaryView(
+            guard let titleView = collectionView.dequeueReusableSupplementaryView(
                 ofKind: TabTitleSupplementaryView.cellIdentifier,
                 withReuseIdentifier: TabTitleSupplementaryView.cellIdentifier,
                 for: indexPath
-            ) as? TabTitleSupplementaryView
+            ) as? TabTitleSupplementaryView else { return nil }
 
-            guard let tab = tabsState.tabs[safe: indexPath.row] else {
-                return nil
+            if let tab = tabsState.tabs[safe: indexPath.row] {
+                titleView.configure(with: tab, theme: theme)
             }
-            titleView?.configure(with: tab, theme: theme)
             return titleView
 
         case UICollectionView.elementKindSectionFooter:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13374)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29082)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- The app was crashing with `NSInternalInconsistencyException` when `TabTitleSupplementaryView` was successfully created but then returned `nil` due to missing tab data. This violated `UICollectionViewDiffableDataSource`'s requirement that `supplementaryViewProvider` must always return a valid view.
- Returning `nil` is acceptable when cell creation fails, but we must avoid the pattern of successfully creating our designated cell only to return `nil` based on subsequent conditions.
- [Link to Apple documentation regarding return of `supplementaryViewProvider`](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource-9tqpa/supplementaryviewprovider-swift.typealias#return-value).
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
