### PR TITLE
Refactor FXIOS-11340 - Disable the function_body_length rule for a legacy function and decreases the threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -107,8 +107,8 @@ closure_body_length:
   error: 34
 
 function_body_length:
-  warning: 188
-  error: 188
+  warning: 161
+  error: 161
 
 file_header:
   required_string: |

--- a/firefox-ios/Storage/SQL/BrowserSchema.swift
+++ b/firefox-ios/Storage/SQL/BrowserSchema.swift
@@ -741,6 +741,7 @@ open class BrowserSchema: Schema {
         )
         """
 
+    // swiftlint:disable:next function_body_length
     public func create(_ db: SQLiteDBConnection) -> Bool {
         let favicons = """
             CREATE TABLE IF NOT EXISTS favicons (

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerSettingsNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerSettingsNavigation.swift
@@ -5,6 +5,7 @@
 import XCTest
 import MappaMundi
 
+// swiftlint:disable:next function_body_length
 func registerSettingsNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
     let table = app.tables.element(boundBy: 0)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11340)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24679)

## :bulb: Description
This pull request disables the `function_body_length` rule for the `create` function of `BrowserSchema.swift` file, and for the `registerSettingsNavigation`. Also, it defines the threshold to 161 for this rule. I've talked with @FilippoZazzeroni about these legacy functions and why we decided to disable the linter rule for them https://github.com/mozilla-mobile/firefox-ios/issues/24679#issuecomment-3269493951.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
