### PR TITLE
Bugfix FXIOS-13301 [Keyboard] Search engines icons not visible due to overlap with keyword

### DIFF
--- a/BrowserKit/Sources/Shared/KeyboardHelper.swift
+++ b/BrowserKit/Sources/Shared/KeyboardHelper.swift
@@ -130,6 +130,7 @@ open class KeyboardHelper: NSObject, Notifiable {
         ensureMainThread {
             switch notificationName {
             case UIResponder.keyboardWillShowNotification:
+                self.currentState = keyboardState
                 self.keyboardWillShow(keyboardState: keyboardState)
             case UIResponder.keyboardDidShowNotification:
                 self.keyboardDidShow(keyboardState: keyboardState)
@@ -140,6 +141,7 @@ open class KeyboardHelper: NSObject, Notifiable {
             case UIResponder.keyboardDidChangeFrameNotification:
                 self.keyboardDidChange(keyboardState: keyboardState)
             case UIResponder.keyboardWillChangeFrameNotification:
+                self.currentState = keyboardState
                 self.keyboardWillChange(keyboardState: keyboardState)
             default: break
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28959)

## :bulb: Description
Updates current state of keyboard so we have the keyboard frame to calculate the correct position of the search engine icons.
Thanks @ih-codes for looking into it and pointing me in the right direction 🙏 

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-10 at 11 50 33" src="https://github.com/user-attachments/assets/d5276d1a-0d68-4002-8ce7-93ac8e640424" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-10 at 11 49 20" src="https://github.com/user-attachments/assets/ef3db03e-f14c-4e25-a907-bd1d510fe005" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
