### PR TITLE
Fix [MTE-4896] - navigation tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -145,7 +145,7 @@ class NavigationTest: FeatureFlaggedTestBase {
         navigator.goto(TabTray)
         navigator.performAction(Action.ToggleSyncMode)
 
-        app.tables.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaSettingsButton].waitAndTap()
+        app.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaSettingsButton].waitAndTap()
         waitForElementsToExist(
             [
                 app.navigationBars["Sync and Save Data"],
@@ -164,7 +164,7 @@ class NavigationTest: FeatureFlaggedTestBase {
         navigator.goto(TabTray)
         navigator.performAction(Action.ToggleExperimentSyncMode)
 
-        app.tables.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaSettingsButton].waitAndTap()
+        app.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaSettingsButton].waitAndTap()
         waitForElementsToExist(
             [
                 app.navigationBars["Sync and Save Data"],


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4896

## :bulb: Description
Fixes for:
testTapSignInShowsFxAFromRemoteTabPanel_tabTrayExperimentOn
testTapSignInShowsFxAFromRemoteTabPanel_tabTrayExperimentOff