### PR TITLE
Add FXIOS-13029 Add pref and metric recording value of ToU accepted version and date for new users

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -22,6 +22,8 @@ public struct PrefsKeys {
     public static let HasPocketInstalled = "HasPocketInstalled"
     public static let IntroSeen = "IntroViewControllerSeen"
     public static let TermsOfServiceAccepted = "TermsOfServiceAccepted"
+    public static let TermsOfServiceAcceptedVersion = "TermsOfServiceAcceptedVersion"
+    public static let TermsOfServiceAcceptedDate = "TermsOfServiceAcceptedDate"
     // TermsOfUseAccepted should use same string key as before to maintain compatibility
     public static let TermsOfUseAccepted = "termsOfUseAccepted"
     public static let TermsOfUseAcceptedVersion = "TermsOfUseAcceptedVersion"

--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -150,8 +150,9 @@ final class LaunchCoordinator: BaseCoordinator,
             },
             onComplete: { [weak self] in
                 guard let self = self else { return }
-                manager.setAccepted()
-                TermsOfServiceTelemetry().termsOfServiceAcceptButtonTapped()
+                let acceptedDate = Date()
+                manager.setAccepted(acceptedDate: acceptedDate)
+                TermsOfServiceTelemetry().termsOfServiceAcceptButtonTapped(acceptedDate: acceptedDate)
 
                 let sendTechnicalData = profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
                 let sendStudies = profile.prefs.boolForKey(AppConstants.prefStudiesToggle) ?? true
@@ -210,8 +211,9 @@ final class LaunchCoordinator: BaseCoordinator,
         let viewController = TermsOfServiceViewController(profile: profile, windowUUID: windowUUID)
         viewController.didFinishFlow = { [weak self] in
             guard let self = self else { return }
-            manager.setAccepted()
-            TermsOfServiceTelemetry().termsOfServiceAcceptButtonTapped()
+            let acceptedDate = Date()
+            manager.setAccepted(acceptedDate: acceptedDate)
+            TermsOfServiceTelemetry().termsOfServiceAcceptButtonTapped(acceptedDate: acceptedDate)
 
             let sendTechnicalData = profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
             let sendStudies = profile.prefs.boolForKey(AppConstants.prefStudiesToggle) ?? true

--- a/firefox-ios/Client/Frontend/Onboarding/Models/TermsOfServiceTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/TermsOfServiceTelemetry.swift
@@ -32,7 +32,16 @@ struct TermsOfServiceTelemetry {
         GleanMetrics.Onboarding.termsOfServiceManageLinkClicked.record()
     }
 
-    func termsOfServiceAcceptButtonTapped() {
+    func termsOfServiceAcceptButtonTapped(acceptedDate: Date) {
         GleanMetrics.Onboarding.termsOfServiceAccepted.record()
+
+        // Record the ToU version and date metrics with onboarding surface
+        let acceptedExtra = GleanMetrics.Termsofuse.AcceptedExtra(
+            surface: TermsOfUseTelemetry.Surface.onboarding.rawValue,
+            touVersion: String(TermsOfUseTelemetry().termsOfUseVersion)
+        )
+        GleanMetrics.Termsofuse.accepted.record(acceptedExtra)
+        GleanMetrics.Termsofuse.version.set(TermsOfUseTelemetry().termsOfUseVersion)
+        GleanMetrics.Termsofuse.date.set(acceptedDate)
     }
 }

--- a/firefox-ios/Client/Frontend/Onboarding/Models/TermsOfServiceTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/TermsOfServiceTelemetry.swift
@@ -34,7 +34,6 @@ struct TermsOfServiceTelemetry {
 
     func termsOfServiceAcceptButtonTapped(acceptedDate: Date) {
         GleanMetrics.Onboarding.termsOfServiceAccepted.record()
-
         // Record the ToU version and date metrics with onboarding surface
         let acceptedExtra = GleanMetrics.Termsofuse.AcceptedExtra(
             surface: TermsOfUseTelemetry.Surface.onboarding.rawValue,

--- a/firefox-ios/Client/TermsOfServiceManager.swift
+++ b/firefox-ios/Client/TermsOfServiceManager.swift
@@ -40,8 +40,10 @@ struct TermsOfServiceManager: FeatureFlaggable, Sendable {
         return prefs.intForKey(PrefsKeys.TermsOfServiceAccepted) == nil
     }
 
-    func setAccepted() {
+    func setAccepted(acceptedDate: Date) {
         prefs.setInt(1, forKey: PrefsKeys.TermsOfServiceAccepted)
+        prefs.setString(String(TermsOfUseTelemetry().termsOfUseVersion), forKey: PrefsKeys.TermsOfServiceAcceptedVersion)
+        prefs.setTimestamp(acceptedDate.toTimestamp(), forKey: PrefsKeys.TermsOfServiceAcceptedDate)
     }
 
     func shouldSendTechnicalData(telemetryValue: Bool, studiesValue: Bool) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/TermsOfServiceTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/TermsOfServiceTelemetryTests.swift
@@ -57,7 +57,21 @@ final class TermsOfServiceTelemetryTests: XCTestCase {
     }
 
     func testRecordTermsOfServiceAcceptButtonTappedThenGleanIsCalled() throws {
-        subject?.termsOfServiceAcceptButtonTapped()
+        let acceptedDate = Date()
+        subject?.termsOfServiceAcceptButtonTapped(acceptedDate: acceptedDate)
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.termsOfServiceAccepted)
+
+        // Test that ToU accepted event is recorded with onboarding surface
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Termsofuse.accepted)
+        let acceptedEventValue = try XCTUnwrap(GleanMetrics.Termsofuse.accepted.testGetValue())
+        XCTAssertEqual(acceptedEventValue[0].extra?["surface"], "onboarding")
+        let expectedVersionString = String(TermsOfUseTelemetry().termsOfUseVersion)
+        XCTAssertEqual(acceptedEventValue[0].extra?["tou_version"], expectedVersionString)
+
+        // Test that ToU version and date metrics are also recorded for consistency
+        let versionValue = try XCTUnwrap(GleanMetrics.Termsofuse.version.testGetValue())
+        XCTAssertEqual(versionValue, TermsOfUseTelemetry().termsOfUseVersion)
+        let dateValue = try XCTUnwrap(GleanMetrics.Termsofuse.date.testGetValue())
+        XCTAssertTrue(Calendar.current.isDate(dateValue, inSameDayAs: acceptedDate))
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13029)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28410)

## :bulb: Description
This PR will add version and date records as prefs and metrics for acceptance of Terms Of Service from onboarding.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
