### PR TITLE
Bugfix FXIOS-13353 ⁃ Reduce all the dispatch in MainMenuViewController's viewDidLoad method to one call

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
@@ -59,7 +59,7 @@ enum MainMenuActionType: ActionType {
     case updateCurrentTabInfo
     case updateProfileImage
     case tapMoreOptions
-    case didInstantiateView
+    case viewDidLoad
     case menuDismissed
     case tapAddToBookmarks
     case tapEditBookmark

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
@@ -60,7 +60,6 @@ enum MainMenuActionType: ActionType {
     case updateProfileImage
     case tapMoreOptions
     case didInstantiateView
-    case viewDidLoad
     case menuDismissed
     case tapAddToBookmarks
     case tapEditBookmark

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -74,11 +74,8 @@ final class MainMenuMiddleware: FeatureFlaggable {
         case MainMenuActionType.didInstantiateView:
             handleDidInstantiateViewAction(action: action)
 
-        case MainMenuActionType.viewDidLoad:
-            handleViewDidLoadAction(action: action)
-
         case MainMenuActionType.updateMenuAppearance:
-            handleUpdateMenuAppearance(action: action)
+            dispatchUpdateMenuAppearance(action: action)
 
         case MainMenuActionType.menuDismissed:
             telemetry.menuDismissed(isHomepage: isHomepage)
@@ -128,6 +125,8 @@ final class MainMenuMiddleware: FeatureFlaggable {
     @MainActor
     private func handleDidInstantiateViewAction(action: MainMenuAction) {
         dispatchUpdateBannerVisibility(action: action)
+        dispatchUpdateMenuAppearance(action: action)
+        handleViewDidLoadAction(action: action)
     }
 
     @MainActor
@@ -141,7 +140,7 @@ final class MainMenuMiddleware: FeatureFlaggable {
         )
     }
 
-    private func handleUpdateMenuAppearance(action: MainMenuAction) {
+    private func dispatchUpdateMenuAppearance(action: MainMenuAction) {
         store.dispatchLegacy(
             MainMenuAction(
                 windowUUID: action.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -71,7 +71,7 @@ final class MainMenuMiddleware: FeatureFlaggable {
         case MainMenuActionType.tapCloseMenu:
             telemetry.closeButtonTapped(isHomepage: isHomepage)
 
-        case MainMenuActionType.didInstantiateView:
+        case MainMenuActionType.viewDidLoad:
             handleDidInstantiateViewAction(action: action)
 
         case MainMenuActionType.updateMenuAppearance:

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -167,7 +167,7 @@ struct MainMenuState: ScreenState, Equatable, Sendable {
         }
 
         switch action.actionType {
-        case MainMenuActionType.didInstantiateView:
+        case MainMenuActionType.viewDidLoad:
             return handleViewDidLoadAction(state: state)
         case MainMenuMiddlewareActionType.updateAccountHeader:
             return handleUpdateAccountHeaderAction(state: state, action: action)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -167,7 +167,7 @@ struct MainMenuState: ScreenState, Equatable, Sendable {
         }
 
         switch action.actionType {
-        case MainMenuActionType.viewDidLoad:
+        case MainMenuActionType.didInstantiateView:
             return handleViewDidLoadAction(state: state)
         case MainMenuMiddlewareActionType.updateAccountHeader:
             return handleUpdateAccountHeaderAction(state: state, action: action)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -130,7 +130,7 @@ class MainMenuViewController: UIViewController,
         store.dispatchLegacy(
             MainMenuAction(
                 windowUUID: windowUUID,
-                actionType: MainMenuActionType.didInstantiateView
+                actionType: MainMenuActionType.viewDidLoad
             )
         )
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -119,22 +119,6 @@ class MainMenuViewController: UIViewController,
 
         subscribeToRedux()
 
-        // TODO: FXIOS-13353 We are dispatching multiple actions when we should be dispatching only one.
-        // Actions should not need to know about the consequences.
-        store.dispatchLegacy(
-            MainMenuAction(
-                windowUUID: windowUUID,
-                actionType: MainMenuActionType.didInstantiateView
-            )
-        )
-
-        store.dispatchLegacy(
-            MainMenuAction(
-                windowUUID: self.windowUUID,
-                actionType: MainMenuActionType.updateMenuAppearance
-            )
-        )
-
         setupView()
         setupMenuOrientation()
 
@@ -145,8 +129,8 @@ class MainMenuViewController: UIViewController,
 
         store.dispatchLegacy(
             MainMenuAction(
-                windowUUID: self.windowUUID,
-                actionType: MainMenuActionType.viewDidLoad
+                windowUUID: windowUUID,
+                actionType: MainMenuActionType.didInstantiateView
             )
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
@@ -400,7 +400,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = createSubject()
         let action = MainMenuAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: MainMenuActionType.viewDidLoad
+            actionType: MainMenuActionType.didInstantiateView
         )
 
         let dispatchExpectation = XCTestExpectation(description: "Request tab info middleware action dispatched")
@@ -427,7 +427,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = createSubject()
         let action = MainMenuAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: MainMenuActionType.viewDidLoad
+            actionType: MainMenuActionType.didInstantiateView
         )
 
         let dispatchExpectation = XCTestExpectation(description: "Request tab info header middleware action dispatched")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
@@ -373,7 +373,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = createSubject()
         let action = MainMenuAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: MainMenuActionType.didInstantiateView
+            actionType: MainMenuActionType.viewDidLoad
         )
 
         let dispatchExpectation = XCTestExpectation(description: "Update banner visibility middleware action dispatched")
@@ -400,7 +400,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = createSubject()
         let action = MainMenuAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: MainMenuActionType.didInstantiateView
+            actionType: MainMenuActionType.viewDidLoad
         )
 
         let dispatchExpectation = XCTestExpectation(description: "Request tab info middleware action dispatched")
@@ -427,7 +427,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = createSubject()
         let action = MainMenuAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: MainMenuActionType.didInstantiateView
+            actionType: MainMenuActionType.viewDidLoad
         )
 
         let dispatchExpectation = XCTestExpectation(description: "Request tab info header middleware action dispatched")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13353)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29045)

## :bulb: Description
Dispatch only one call in viewDidLoad instead of three

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
