### PR TITLE
Bugfix FXIOS-13473 [Tracking Protection] Enhanced tracking protection sheet text not readable due to translucency

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -698,7 +698,7 @@ class TrackingProtectionViewController: UIViewController,
     func applyTheme() {
         let theme = currentTheme()
         overrideUserInterfaceStyle = theme.type.getInterfaceStyle()
-        view.backgroundColor = theme.colors.layer3.withAlphaComponent(backgroundAlpha())
+        view.backgroundColor = theme.colors.layer3.withAlphaComponent(backgroundAlpha)
         headerContainer.applyTheme(theme: theme)
         connectionDetailsHeaderView.applyTheme(theme: theme)
         trackersView.applyTheme(theme: theme)
@@ -710,7 +710,7 @@ class TrackingProtectionViewController: UIViewController,
         setNeedsStatusBarAppearanceUpdate()
     }
 
-    private func backgroundAlpha() -> CGFloat {
+    private var backgroundAlpha: CGFloat {
         guard !UIAccessibility.isReduceTransparencyEnabled else {
             return 1.0
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13473)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29281)

## :bulb: Description
Adjusts the background alpha depending on a11y setting and iOS version.

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-11 at 13 57 11" src="https://github.com/user-attachments/assets/e895cc87-7731-4769-afd4-ac28a9a68c40" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-11 at 15 59 21" src="https://github.com/user-attachments/assets/412bfbd5-272f-493b-9c1d-31a4055ba34f" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
