### PR TITLE
Bugfix FXIOS-11563 #25170 ⁃ History fetched from AS contains duplicates and we only check for duplicates in 200-item increments

### DIFF
--- a/BrowserKit/Sources/Common/Constants/NotificationConstants.swift
+++ b/BrowserKit/Sources/Common/Constants/NotificationConstants.swift
@@ -17,9 +17,6 @@ extension Notification.Name {
     public static let PrivateDataClearedHistory = Notification.Name("PrivateDataClearedHistory")
     public static let PrivateDataClearedDownloadedFiles = Notification.Name("PrivateDataClearedDownloadedFiles")
 
-    // Fired when the user finishes navigating to a page and the location has changed
-    public static let OnLocationChange = Notification.Name("OnLocationChange")
-
     // MARK: Notification UserInfo Keys
 
     // Fired when the login synchronizer has finished applying remote changes

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 		2128E27B292E624400FB91BE /* SendToDeviceActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2128E27A292E624400FB91BE /* SendToDeviceActivity.swift */; };
 		2128E27C2930216F00FB91BE /* SendToDeviceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AFBAF8292EA0330065E35E /* SendToDeviceHelper.swift */; };
 		2128E27E2934F78600FB91BE /* CustomAppActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2128E27D2934F78600FB91BE /* CustomAppActivity.swift */; };
+		21292E6B2E7896910001AC06 /* RecordVisitObservationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21292E6A2E7896910001AC06 /* RecordVisitObservationManagerTests.swift */; };
 		212985E42A6F078800546684 /* ScreenState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212985E32A6F078800546684 /* ScreenState.swift */; };
 		212985E72A72B39D00546684 /* ThemeSettingsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212985E52A72B22800546684 /* ThemeSettingsControllerTests.swift */; };
 		21371FA228A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21371FA128A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift */; };
@@ -2905,6 +2906,7 @@
 		2122EE562DDD75D600D42716 /* GenericButtonCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericButtonCellView.swift; sourceTree = "<group>"; };
 		2128E27A292E624400FB91BE /* SendToDeviceActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendToDeviceActivity.swift; sourceTree = "<group>"; };
 		2128E27D2934F78600FB91BE /* CustomAppActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAppActivity.swift; sourceTree = "<group>"; };
+		21292E6A2E7896910001AC06 /* RecordVisitObservationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordVisitObservationManagerTests.swift; sourceTree = "<group>"; };
 		212985E32A6F078800546684 /* ScreenState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenState.swift; sourceTree = "<group>"; };
 		212985E52A72B22800546684 /* ThemeSettingsControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsControllerTests.swift; sourceTree = "<group>"; };
 		21371FA128A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTelemetryUtilityTests.swift; sourceTree = "<group>"; };
@@ -15235,6 +15237,7 @@
 				C714D6382E46575D00FC02E6 /* ShortcutsLibrary */,
 				4331D3EE2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift */,
 				8AD54D3128FD9E2C0070D4B3 /* Theme */,
+				21292E6A2E7896910001AC06 /* RecordVisitObservationManagerTests.swift */,
 			);
 			path = Frontend;
 			sourceTree = "<group>";
@@ -19148,6 +19151,7 @@
 				C2D80BEB2AAF395200CDF7A9 /* CredentialAutofillCoordinatorTests.swift in Sources */,
 				F98CB66E2A4123F1005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift in Sources */,
 				DF8C6DD72A52EED1007FAAF2 /* ClientSyncManagerTests.swift in Sources */,
+				21292E6B2E7896910001AC06 /* RecordVisitObservationManagerTests.swift in Sources */,
 				C2D1A1112A67E73D00205DCC /* BookmarksCoordinatorTests.swift in Sources */,
 				C2200A6A2B7D148C00DC062A /* ContentBlockerTests.swift in Sources */,
 				C869916328918C36007ACC5C /* WallpaperNetworkingModuleTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 		21FA8FB02AE856590013B815 /* RemoteTabsCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FA8FAF2AE856590013B815 /* RemoteTabsCoordinatorTests.swift */; };
 		21FA8FB22AE856EB0013B815 /* MockTabTrayCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FA8FB12AE856EB0013B815 /* MockTabTrayCoordinatorDelegate.swift */; };
 		21FB43CB2E7AF25D00A8818D /* MockHistoryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FB43CA2E7AF25D00A8818D /* MockHistoryHandler.swift */; };
+		21FB441A2E7B3AE500A8818D /* MockRecordVisitObservationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FB44192E7B3AE500A8818D /* MockRecordVisitObservationManager.swift */; };
 		2386E4E624F8358E0072EF17 /* HomepageMessageCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2386E4E524F8358E0072EF17 /* HomepageMessageCard.swift */; };
 		23BEA767251A99ED00A014BF /* NewYorkMedium-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 23BEA766251A99E300A014BF /* NewYorkMedium-Bold.otf */; };
 		23BEA768251A99ED00A014BF /* NewYorkMedium-BoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 23BEA765251A99E200A014BF /* NewYorkMedium-BoldItalic.otf */; };
@@ -3012,6 +3013,7 @@
 		21FA8FAF2AE856590013B815 /* RemoteTabsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsCoordinatorTests.swift; sourceTree = "<group>"; };
 		21FA8FB12AE856EB0013B815 /* MockTabTrayCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabTrayCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		21FB43CA2E7AF25D00A8818D /* MockHistoryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHistoryHandler.swift; sourceTree = "<group>"; };
+		21FB44192E7B3AE500A8818D /* MockRecordVisitObservationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRecordVisitObservationManager.swift; sourceTree = "<group>"; };
 		220A4CC8B2685EEA3146A967 /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		222F456780B38CE88601C7E1 /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/Shared.strings; sourceTree = "<group>"; };
 		226347ACAF708B19B6BC2694 /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/Search.strings; sourceTree = "<group>"; };
@@ -14500,6 +14502,7 @@
 		C889D7D22858C85200121E1D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				21FB44192E7B3AE500A8818D /* MockRecordVisitObservationManager.swift */,
 				21FB43CA2E7AF25D00A8818D /* MockHistoryHandler.swift */,
 				219AEECD2E5E523600BF5F6F /* MockTabProviderProtocol.swift */,
 				216424D32E56174400A3AF40 /* MockTabScrollHandlerDelegate.swift */,
@@ -19344,6 +19347,7 @@
 				21B548992B1E7FDF00DC1DF8 /* InactiveTabsManagerTests.swift in Sources */,
 				8AF6D4DF2A856A9000B0474B /* MockContileNetworking.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
+				21FB441A2E7B3AE500A8818D /* MockRecordVisitObservationManager.swift in Sources */,
 				C89C91AD2A1FE9E900BE57B1 /* OnboardingTelemetryDelegationTests.swift in Sources */,
 				8A36BE2C29EDE16C00AC1C5C /* ContentContainerTests.swift in Sources */,
 				401F68A52D84726700786D0C /* RemoteTabsPanelTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -351,6 +351,7 @@
 		21FA8FAE2AE856460013B815 /* TabsCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FA8FAD2AE856460013B815 /* TabsCoordinatorTests.swift */; };
 		21FA8FB02AE856590013B815 /* RemoteTabsCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FA8FAF2AE856590013B815 /* RemoteTabsCoordinatorTests.swift */; };
 		21FA8FB22AE856EB0013B815 /* MockTabTrayCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FA8FB12AE856EB0013B815 /* MockTabTrayCoordinatorDelegate.swift */; };
+		21FB43CB2E7AF25D00A8818D /* MockHistoryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FB43CA2E7AF25D00A8818D /* MockHistoryHandler.swift */; };
 		2386E4E624F8358E0072EF17 /* HomepageMessageCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2386E4E524F8358E0072EF17 /* HomepageMessageCard.swift */; };
 		23BEA767251A99ED00A014BF /* NewYorkMedium-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 23BEA766251A99E300A014BF /* NewYorkMedium-Bold.otf */; };
 		23BEA768251A99ED00A014BF /* NewYorkMedium-BoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 23BEA765251A99E200A014BF /* NewYorkMedium-BoldItalic.otf */; };
@@ -3010,6 +3011,7 @@
 		21FA8FAD2AE856460013B815 /* TabsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsCoordinatorTests.swift; sourceTree = "<group>"; };
 		21FA8FAF2AE856590013B815 /* RemoteTabsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsCoordinatorTests.swift; sourceTree = "<group>"; };
 		21FA8FB12AE856EB0013B815 /* MockTabTrayCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabTrayCoordinatorDelegate.swift; sourceTree = "<group>"; };
+		21FB43CA2E7AF25D00A8818D /* MockHistoryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHistoryHandler.swift; sourceTree = "<group>"; };
 		220A4CC8B2685EEA3146A967 /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		222F456780B38CE88601C7E1 /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/Shared.strings; sourceTree = "<group>"; };
 		226347ACAF708B19B6BC2694 /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/Search.strings; sourceTree = "<group>"; };
@@ -14498,6 +14500,7 @@
 		C889D7D22858C85200121E1D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				21FB43CA2E7AF25D00A8818D /* MockHistoryHandler.swift */,
 				219AEECD2E5E523600BF5F6F /* MockTabProviderProtocol.swift */,
 				216424D32E56174400A3AF40 /* MockTabScrollHandlerDelegate.swift */,
 				0B5CAF0C2E40DA89008B5D5A /* MockSummarizationChecker.swift */,
@@ -19206,6 +19209,7 @@
 				C2506C952A6A8D2600F2B76E /* HistoryCoordinatorTests.swift in Sources */,
 				0B7B05432D64C08F007FD7AC /* MockURLProtocol.swift in Sources */,
 				8ADAFAC628AEBF6300FFEBE3 /* HomeLogoHeaderViewModelTests.swift in Sources */,
+				21FB43CB2E7AF25D00A8818D /* MockHistoryHandler.swift in Sources */,
 				E1EAA5EF2D49182700D3039C /* NavigationBarStateTests.swift in Sources */,
 				613489A52D9443610009AF01 /* ToastTelemetryTests.swift in Sources */,
 				8A75F1B828B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -267,6 +267,7 @@
 		214099652DD295F5004881E1 /* ZoomLevelPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214099642DD295F5004881E1 /* ZoomLevelPickerView.swift */; };
 		214099672DD392D1004881E1 /* ZoomSiteListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214099662DD392D1004881E1 /* ZoomSiteListView.swift */; };
 		214099692DD3B8AD004881E1 /* ZoomLevelCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214099682DD3B8AD004881E1 /* ZoomLevelCellView.swift */; };
+		2140E4632E71FC250054173A /* RecordVisitObservationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2140E4622E71FC240054173A /* RecordVisitObservationManager.swift */; };
 		21420EF72ABA338D00B28550 /* TabTrayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21420EF62ABA338D00B28550 /* TabTrayCoordinator.swift */; };
 		21420EF92ABC75A400B28550 /* TabTrayCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21420EF82ABC75A400B28550 /* TabTrayCoordinatorTests.swift */; };
 		2142B12C2D9F1284003AA82F /* ZoomPageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2142B12A2D9F1284003AA82F /* ZoomPageManager.swift */; };
@@ -2922,6 +2923,7 @@
 		214099642DD295F5004881E1 /* ZoomLevelPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomLevelPickerView.swift; sourceTree = "<group>"; };
 		214099662DD392D1004881E1 /* ZoomSiteListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomSiteListView.swift; sourceTree = "<group>"; };
 		214099682DD3B8AD004881E1 /* ZoomLevelCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomLevelCellView.swift; sourceTree = "<group>"; };
+		2140E4622E71FC240054173A /* RecordVisitObservationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordVisitObservationManager.swift; sourceTree = "<group>"; };
 		21420EF62ABA338D00B28550 /* TabTrayCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayCoordinator.swift; sourceTree = "<group>"; };
 		21420EF82ABC75A400B28550 /* TabTrayCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayCoordinatorTests.swift; sourceTree = "<group>"; };
 		2142B1292D9F1284003AA82F /* ZoomPageBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomPageBar.swift; sourceTree = "<group>"; };
@@ -14973,6 +14975,7 @@
 		D3A994941A368691008AD1AC /* Browser */ = {
 			isa = PBXGroup;
 			children = (
+				2140E4622E71FC240054173A /* RecordVisitObservationManager.swift */,
 				034784BA2E2690F600D04A84 /* TermsOfUse */,
 				81A3F6EE2C2DAED500BDD86B /* MainMenu */,
 				1D7B78952ADF324E0011E9F2 /* Event Queue */,
@@ -18188,6 +18191,7 @@
 				0AFF7F6C2C7C7BBA00265214 /* CertificatesCell.swift in Sources */,
 				8AAEBA062BF51141000C02B5 /* MicrosurveyMiddleware.swift in Sources */,
 				431C0CA925C890E500395CE4 /* DefaultBrowserOnboardingViewModel.swift in Sources */,
+				2140E4632E71FC250054173A /* RecordVisitObservationManager.swift in Sources */,
 				8A454D432CB9B8F5009436D9 /* TopSitesManager.swift in Sources */,
 				7482205C1DBAB56300EEEA72 /* MailProviders.swift in Sources */,
 				8A93F87029D3A597004159D9 /* SceneCoordinator.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3406,11 +3406,11 @@ class BrowserViewController: UIViewController,
     }
 
     func focusLocationTextField(forTab tab: Tab?, setSearchText searchText: String? = nil) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(400)) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(400)) { [weak self] in
             // Without a delay, the text field fails to become first responder
             // Check that the newly created tab is still selected.
             // This let's the user spam the Cmd+T button without lots of responder changes.
-            guard tab == self.tabManager.selectedTab else { return }
+            guard let self, tab == self.tabManager.selectedTab else { return }
 
             if self.isToolbarRefactorEnabled {
                 let action = ToolbarAction(searchTerm: searchText,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2933,6 +2933,7 @@ class BrowserViewController: UIViewController,
         case .newTab:
             willNavigateAway(from: tabManager.selectedTab)
             topTabsDidPressNewTab(tabManager.selectedTab?.isPrivate ?? false)
+            recordVisitManager.resetRecording()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -469,7 +469,7 @@ class BrowserViewController: UIViewController,
         self.zoomManager = ZoomPageManager(windowUUID: tabManager.windowUUID)
         self.tabsPanelTelemetry = TabsPanelTelemetry(gleanWrapper: gleanWrapper, logger: logger)
         self.userInitiatedQueue = userInitiatedQueue
-        self.recordVisitManager = RecordVisitObservationManager(profile: profile)
+        self.recordVisitManager = RecordVisitObservationManager(historyHandler: profile.places)
 
         super.init(nibName: nil, bundle: nil)
         didInit()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2572,11 +2572,13 @@ class BrowserViewController: UIViewController,
             // to navigateInTab(tab:) except when ReaderModeState is active
             // so that evaluateJavascriptInDefaultContentWorld() is called.
             guard let title = tab.title else { break }
-            if !title.isEmpty && title != tab.lastTitle {
-                tab.lastTitle = title
-                navigateInTab(tab: tab, webViewStatus: .title)
-            } else {
-                navigateIfReaderModeActive(currentTab: tab)
+            if !title.isEmpty {
+                if title != tab.lastTitle {
+                    tab.lastTitle = title
+                    navigateInTab(tab: tab, webViewStatus: .title)
+                } else {
+                    navigateIfReaderModeActive(currentTab: tab)
+                }
             }
             TelemetryWrapper.recordEvent(category: .action, method: .navigate, object: .tab)
         case .canGoBack:
@@ -3476,7 +3478,7 @@ class BrowserViewController: UIViewController,
         return navigationController?.topViewController?.presentedViewController as? JSPromptAlertController != nil
     }
 
-    fileprivate func postLocationChangeNotificationForTab(_ tab: Tab, navigation: WKNavigation?) {
+    fileprivate func recordVisitForLocationChange(_ tab: Tab, navigation: WKNavigation?) {
         let visitType = getVisitTypeForTab(tab, navigation: navigation) ?? .link
         let url = tab.url?.displayURL?.description ?? ""
         let visitObservation = VisitObservation(url: url, title: tab.title, visitType: visitType)
@@ -3505,7 +3507,7 @@ class BrowserViewController: UIViewController,
 
         if let url = webView.url {
             if (!InternalURL.isValid(url: url) || url.isReaderModeURL) && !url.isFileURL {
-                postLocationChangeNotificationForTab(tab, navigation: navigation)
+                recordVisitForLocationChange(tab, navigation: navigation)
                 tab.readabilityResult = nil
                 webView.evaluateJavascriptInDefaultContentWorld(
                     "\(ReaderModeInfo.namespace.rawValue).checkReadability()"

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -398,7 +398,6 @@ class BrowserViewController: UIViewController,
     private var keyboardState: KeyboardState?
 
     // Tracking navigation items to record history types.
-    // TODO: YRD Confirm if can be deleted
     var ignoredNavigation = Set<WKNavigation>()
     var typedNavigation = [WKNavigation: VisitType]()
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -470,7 +470,6 @@ class BrowserViewController: UIViewController,
         self.zoomManager = ZoomPageManager(windowUUID: tabManager.windowUUID)
         self.tabsPanelTelemetry = TabsPanelTelemetry(gleanWrapper: gleanWrapper, logger: logger)
         self.userInitiatedQueue = userInitiatedQueue
-        // Pass nil to have the option to use default value and no affect BVC initializers
         self.recordVisitManager = recordVisitManager ?? RecordVisitObservationManager(historyHandler: profile.places)
 
         super.init(nibName: nil, bundle: nil)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -126,7 +126,7 @@ class BrowserViewController: UIViewController,
     var downloadToast: DownloadToast? // A toast that is showing the combined download progress
     var downloadProgressManager: DownloadProgressManager?
     let tabsPanelTelemetry: TabsPanelTelemetry
-    let recordVisitManager: RecordVisitObservationManager
+    let recordVisitManager: RecordVisitObserving
 
     private var _downloadLiveActivityWrapper: Any?
 
@@ -448,7 +448,8 @@ class BrowserViewController: UIViewController,
         documentLogger: DocumentLogger = AppContainer.shared.resolve(),
         appAuthenticator: AppAuthenticationProtocol = AppAuthenticator(),
         searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
-        userInitiatedQueue: DispatchQueueInterface = DispatchQueue.global(qos: .userInitiated)
+        userInitiatedQueue: DispatchQueueInterface = DispatchQueue.global(qos: .userInitiated),
+        recordVisitManager: RecordVisitObserving? = nil
     ) {
         self.summarizerNimbusUtils = summarizerNimbusUtils
         self.profile = profile
@@ -469,7 +470,8 @@ class BrowserViewController: UIViewController,
         self.zoomManager = ZoomPageManager(windowUUID: tabManager.windowUUID)
         self.tabsPanelTelemetry = TabsPanelTelemetry(gleanWrapper: gleanWrapper, logger: logger)
         self.userInitiatedQueue = userInitiatedQueue
-        self.recordVisitManager = RecordVisitObservationManager(historyHandler: profile.places)
+        // Pass nil to have the option to use default value and no affect BVC initializers
+        self.recordVisitManager = recordVisitManager ?? RecordVisitObservationManager(historyHandler: profile.places)
 
         super.init(nibName: nil, bundle: nil)
         didInit()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3506,10 +3506,7 @@ class BrowserViewController: UIViewController,
 
         if let url = webView.url {
             if (!InternalURL.isValid(url: url) || url.isReaderModeURL) && !url.isFileURL {
-                // Post location changed that records visit only when called from webview's didFinishNavigation
-                if webViewStatus == .finishedNavigation {
-                    postLocationChangeNotificationForTab(tab, navigation: navigation)
-                }
+                postLocationChangeNotificationForTab(tab, navigation: navigation)
                 tab.readabilityResult = nil
                 webView.evaluateJavascriptInDefaultContentWorld(
                     "\(ReaderModeInfo.namespace.rawValue).checkReadability()"

--- a/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
@@ -8,7 +8,7 @@ import Shared
 import Storage
 import WebKit
 
-// Handles recording visit to website that will be used to list History
+// Handles recording visits to websites, which will be displayed in the History Panel.
 class RecordVisitObservationManager {
     private var historyHandler: HistoryHandler
     nonisolated let logger: Logger
@@ -40,17 +40,17 @@ class RecordVisitObservationManager {
         }
     }
 
-    // Based in user action like create new tab we reset the last visit observation
+    // Based on user actions like creating a new tab, we reset the last visit observation.
     func resetRecording() {
         lastObservationRecorded = nil
     }
 
-    // Should record if is not Private tab, URL should not be ignored
-    // or title is not empty
+    // Record visits for websites that are not in a private tab, have non-empty titles,
+    // and are not URLs that we ignore (localhost and about schemes).
     private func shouldRecordObservation(visitObservation: VisitObservation, isPrivateTab: Bool) -> Bool {
         guard let title = visitObservation.title, !title.isEmpty,
-              let url = URL(string: visitObservation.url), !isIgnoredURL(url),
-              !isPrivateTab else {
+              !isPrivateTab,
+              isValidURLToRecord(url: visitObservation.url) else {
             logger.log("Ignoring location change",
                        level: .debug,
                        category: .lifecycle)
@@ -58,5 +58,11 @@ class RecordVisitObservationManager {
         }
 
         return true
+    }
+
+    private func isValidURLToRecord(url: Url) -> Bool {
+        guard let url = URL(string: url) else { return false }
+
+        return !isIgnoredURL(url) && (!InternalURL.isValid(url: url) || url.isReaderModeURL) && !url.isFileURL
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
@@ -9,7 +9,12 @@ import Storage
 import WebKit
 
 // Handles recording visits to websites, which will be displayed in the History Panel.
-class RecordVisitObservationManager {
+protocol RecordVisitObserving: AnyObject {
+    func recordVisit(visitObservation: VisitObservation, isPrivateTab: Bool)
+    func resetRecording()
+}
+
+class RecordVisitObservationManager: RecordVisitObserving {
     private var historyHandler: HistoryHandler
     let logger: Logger
     var lastObservationRecorded: VisitObservation?

--- a/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
@@ -10,10 +10,8 @@ import WebKit
 
 // Handles recording visit to website that will be used to list History
 class RecordVisitObservationManager {
-    // some kind of mech to avoid recording same observation twice based in user actions like new tab
     private var historyHandler: HistoryHandler
     nonisolated let logger: Logger
-
     var lastObservationRecorded: VisitObservation?
 
     init (profile: Profile,
@@ -47,9 +45,8 @@ class RecordVisitObservationManager {
         lastObservationRecorded = nil
     }
 
-    // Should record if is not Private tab
-    // if URL should not be ignored
-    // or title is empty
+    // Should record if is not Private tab, URL should not be ignored
+    // or title is not empty
     private func shouldRecordObservation(visitObservation: VisitObservation, isPrivateTab: Bool) -> Bool {
         guard let title = visitObservation.title, !title.isEmpty,
               let url = URL(string: visitObservation.url), !isIgnoredURL(url),

--- a/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import MozillaAppServices
+import Shared
+import Storage
+import WebKit
+
+// Handles recording visit to website that will be used to list History
+struct RecordVisitObservationManager {
+    // some kind of mech to avoid recording same observation twice based in user actions like new tab
+    private var historyHandler: HistoryHandler
+    nonisolated let logger: Logger
+
+    init (profile: Profile,
+          logger: Logger = DefaultLogger.shared) {
+        self.historyHandler = profile.places
+        self.logger = logger
+    }
+
+    func recordVisit(visitObservation: VisitObservation, isPrivateTab: Bool) {
+        guard shouldRecordObservation(visitObservation: visitObservation, isPrivateTab: isPrivateTab) else { return }
+
+        let result = historyHandler.applyObservation(visitObservation: visitObservation)
+        result.upon { result in
+            guard result.isSuccess else {
+                self.logger.log(
+                    result.failureValue?.localizedDescription ?? "Unknown error adding history visit",
+                    level: .warning,
+                    category: .sync
+                )
+                return
+            }
+        }
+    }
+
+    // Should record if is not Private tab
+    // if URL should not be ignored
+    // or title is empty
+    private func shouldRecordObservation(visitObservation: VisitObservation, isPrivateTab: Bool) -> Bool {
+        guard let title = visitObservation.title, !title.isEmpty,
+              let url = URL(string: visitObservation.url), !isIgnoredURL(url),
+              !isPrivateTab else {
+            logger.log("Ignoring location change",
+                       level: .debug,
+                       category: .lifecycle)
+            return false
+        }
+
+        return true
+    }
+    
+    /*
+     @objc
+     func onLocationChange(notification: NSNotification) {
+         let v = notification.userInfo!["visitType"] as? Int
+         let visitType = VisitType.fromRawValue(rawValue: v)
+         if let url = notification.userInfo!["url"] as? URL, !isIgnoredURL(url),
+            let title = notification.userInfo!["title"] as? NSString {
+             // Only record local visits if the change notification originated from a non-private tab
+             if !(notification.userInfo!["isPrivate"] as? Bool ?? false) {
+                 let visitObservation = VisitObservation(
+                     url: url.description,
+                     title: title as String,
+                     visitType: visitType
+                 )
+                 let result = self.places.applyObservation(visitObservation: visitObservation)
+                 result.upon { result in
+                     guard result.isSuccess else {
+                         self.logger.log(
+                             result.failureValue?.localizedDescription ?? "Unknown error adding history visit",
+                             level: .warning,
+                             category: .sync
+                         )
+                         return
+                     }
+                 }
+             }
+         } else {
+             logger.log("Ignoring location change",
+                        level: .debug,
+                        category: .lifecycle)
+         }
+     }
+     */
+}

--- a/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
@@ -24,17 +24,16 @@ class RecordVisitObservationManager {
         guard shouldRecordObservation(visitObservation: visitObservation, isPrivateTab: isPrivateTab) else { return }
 
         // Check this observation hasn't been recorded already
-        if lastObservationRecorded?.url != visitObservation.url {
-            historyHandler.applyObservation(visitObservation: visitObservation) { [weak self] result in
-                switch result {
-                case .success:
-                    print("--- YRD: Recorded visit: \(visitObservation.url)")
-                    self?.lastObservationRecorded = visitObservation
-                case .failure(let error):
-                    self?.logger.log(error.localizedDescription,
-                                     level: .warning,
-                                     category: .sync)
-                }
+        guard lastObservationRecorded?.url != visitObservation.url else { return }
+
+        historyHandler.applyObservation(visitObservation: visitObservation) { [weak self] result in
+            switch result {
+            case .success:
+                self?.lastObservationRecorded = visitObservation
+            case .failure(let error):
+                self?.logger.log(error.localizedDescription,
+                                 level: .warning,
+                                 category: .sync)
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
@@ -11,11 +11,11 @@ import WebKit
 // Handles recording visits to websites, which will be displayed in the History Panel.
 class RecordVisitObservationManager {
     private var historyHandler: HistoryHandler
-    nonisolated let logger: Logger
+    let logger: Logger
     var lastObservationRecorded: VisitObservation?
 
-    init (historyHandler: HistoryHandler,
-          logger: Logger = DefaultLogger.shared) {
+    init(historyHandler: HistoryHandler,
+         logger: Logger = DefaultLogger.shared) {
         self.historyHandler = historyHandler
         self.logger = logger
     }

--- a/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
@@ -14,9 +14,9 @@ class RecordVisitObservationManager {
     nonisolated let logger: Logger
     var lastObservationRecorded: VisitObservation?
 
-    init (profile: Profile,
+    init (historyHandler: HistoryHandler,
           logger: Logger = DefaultLogger.shared) {
-        self.historyHandler = profile.places
+        self.historyHandler = historyHandler
         self.logger = logger
     }
 
@@ -35,6 +35,7 @@ class RecordVisitObservationManager {
                     )
                     return
                 }
+                print("--- YRD: Recorded visit: \(visitObservation.url)")
                 self?.lastObservationRecorded = visitObservation
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/RecordVisitObservationManager.swift
@@ -25,18 +25,16 @@ class RecordVisitObservationManager {
 
         // Check this observation hasn't been recorded already
         if lastObservationRecorded?.url != visitObservation.url {
-            let result = historyHandler.applyObservation(visitObservation: visitObservation)
-            result.upon { [weak self] result in
-                guard result.isSuccess else {
-                    self?.logger.log(
-                        result.failureValue?.localizedDescription ?? "Unknown error adding history visit",
-                        level: .warning,
-                        category: .sync
-                    )
-                    return
+            historyHandler.applyObservation(visitObservation: visitObservation) { [weak self] result in
+                switch result {
+                case .success:
+                    print("--- YRD: Recorded visit: \(visitObservation.url)")
+                    self?.lastObservationRecorded = visitObservation
+                case .failure(let error):
+                    self?.logger.log(error.localizedDescription,
+                                     level: .warning,
+                                     category: .sync)
                 }
-                print("--- YRD: Recorded visit: \(visitObservation.url)")
-                self?.lastObservationRecorded = visitObservation
             }
         }
     }

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -379,13 +379,12 @@ open class BrowserProfile: Profile,
         let title = notification.userInfo!["title"] as? NSString {
             // Only record local visits if the change notification originated from a non-private tab
             if !(notification.userInfo!["isPrivate"] as? Bool ?? false) {
-                let result = self.places.applyObservation(
-                    visitObservation: VisitObservation(
-                        url: url.description,
-                        title: title as String,
-                        visitType: visitType
-                    )
+                let visitObservation = VisitObservation(
+                    url: url.description,
+                    title: title as String,
+                    visitType: visitType
                 )
+                let result = self.places.applyObservation(visitObservation: visitObservation)
                 result.upon { result in
                     guard result.isSuccess else {
                         self.logger.log(

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -311,15 +311,6 @@ open class BrowserProfile: Profile,
         // because opening them can trigger events to which the SyncManager listens.
         self.syncManager = RustSyncManager(profile: self)
 
-        let notificationCenter = NotificationCenter.default
-
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(onLocationChange),
-            name: .OnLocationChange,
-            object: nil
-        )
-
         // Remove the default homepage. This does not change the user's preference,
         // just the behaviour when there is no homepage.
         prefs.removeObjectForKey(PrefsKeys.KeyDefaultHomePageURL)
@@ -369,38 +360,6 @@ open class BrowserProfile: Profile,
         _ = places.forceClose()
         _ = tabs.forceClose()
         _ = autofill.forceClose()
-    }
-
-    @objc
-    func onLocationChange(notification: NSNotification) {
-        let v = notification.userInfo!["visitType"] as? Int
-        let visitType = VisitType.fromRawValue(rawValue: v)
-        if let url = notification.userInfo!["url"] as? URL, !isIgnoredURL(url),
-        let title = notification.userInfo!["title"] as? NSString {
-            // Only record local visits if the change notification originated from a non-private tab
-            if !(notification.userInfo!["isPrivate"] as? Bool ?? false) {
-                let visitObservation = VisitObservation(
-                    url: url.description,
-                    title: title as String,
-                    visitType: visitType
-                )
-                let result = self.places.applyObservation(visitObservation: visitObservation)
-                result.upon { result in
-                    guard result.isSuccess else {
-                        self.logger.log(
-                            result.failureValue?.localizedDescription ?? "Unknown error adding history visit",
-                            level: .warning,
-                            category: .sync
-                        )
-                        return
-                    }
-                }
-            }
-        } else {
-            logger.log("Ignoring location change",
-                       level: .debug,
-                       category: .lifecycle)
-        }
     }
 
     deinit {

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -58,9 +58,9 @@ public protocol BookmarksHandler {
 }
 
 public protocol HistoryHandler {
-//    Deferred<Maybe<Void>>
     func applyObservation(visitObservation: VisitObservation) -> Success
-    func applyObservation(visitObservation: VisitObservation, completion: @escaping (Result<Void, any Error>) -> Void)
+    func applyObservation(visitObservation: VisitObservation,
+                          completion: @escaping (Result<Void, any Error>) -> Void)
 }
 
 // TODO: FXIOS-13208 Make RustPlaces actually Sendable

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -60,7 +60,7 @@ public protocol BookmarksHandler {
 public protocol HistoryHandler {
 //    Deferred<Maybe<Void>>
     func applyObservation(visitObservation: VisitObservation) -> Success
-    func applyObservation(visitObservation: VisitObservation, completion: (Result<Void, any Error>) -> Void)
+    func applyObservation(visitObservation: VisitObservation, completion: @escaping (Result<Void, any Error>) -> Void)
 }
 
 // TODO: FXIOS-13208 Make RustPlaces actually Sendable
@@ -654,7 +654,10 @@ extension RustPlaces {
         }
     }
 
-    public func applyObservation(visitObservation: VisitObservation, completion: (Result<Void, any Error>) -> Void) {
+    public func applyObservation(
+        visitObservation: VisitObservation,
+        completion: @escaping (Result<Void, any Error>) -> Void
+    ) {
         withWriter { connection in
             return try connection.applyObservation(visitObservation: visitObservation)
         } completion: { result in

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -58,7 +58,6 @@ public protocol BookmarksHandler {
 }
 
 public protocol HistoryHandler {
-    func applyObservation(visitObservation: VisitObservation) -> Success
     func applyObservation(visitObservation: VisitObservation,
                           completion: @escaping (Result<Void, any Error>) -> Void)
 }

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -58,7 +58,9 @@ public protocol BookmarksHandler {
 }
 
 public protocol HistoryHandler {
+//    Deferred<Maybe<Void>>
     func applyObservation(visitObservation: VisitObservation) -> Success
+    func applyObservation(visitObservation: VisitObservation, completion: (Result<Void, any Error>) -> Void)
 }
 
 // TODO: FXIOS-13208 Make RustPlaces actually Sendable
@@ -649,6 +651,15 @@ extension RustPlaces {
         }.map { result in
             self.notificationCenter.post(name: .TopSitesUpdated, withObject: nil)
             return result
+        }
+    }
+
+    public func applyObservation(visitObservation: VisitObservation, completion: (Result<Void, any Error>) -> Void) {
+        withWriter { connection in
+            return try connection.applyObservation(visitObservation: visitObservation)
+        } completion: { result in
+            self.notificationCenter.post(name: .TopSitesUpdated, withObject: nil)
+            completion(result)
         }
     }
 

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -57,8 +57,12 @@ public protocol BookmarksHandler {
     func isBookmarked(url: String, completion: @escaping @Sendable (Result<Bool, Error>) -> Void)
 }
 
+public protocol HistoryHandler {
+    func applyObservation(visitObservation: VisitObservation) -> Success
+}
+
 // TODO: FXIOS-13208 Make RustPlaces actually Sendable
-public class RustPlaces: @unchecked Sendable, BookmarksHandler {
+public class RustPlaces: @unchecked Sendable, BookmarksHandler, HistoryHandler {
     let databasePath: String
 
     let writerQueue: DispatchQueue

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/RecordVisitObservationManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/RecordVisitObservationManagerTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import MozillaAppServices
+import Common
 import XCTest
 
 @testable import Client
@@ -124,6 +125,18 @@ final class RecordVisitObservationManagerTests: XCTestCase {
         // because it is an ignored URL scheme (unless it's for `test-fixture`)
         let subject = createSubject()
         let observation = createObservation(url: "http://localhost:8080/", title: "Localhost")
+
+        subject.recordVisit(visitObservation: observation, isPrivateTab: false)
+
+        XCTAssertTrue(historyHandler.applied.isEmpty)
+        XCTAssertNil(subject.lastObservationRecorded)
+    }
+
+    func testRecordVisitReaderModeURLDoesNotRecord() {
+        // reader-mode should be ignored by isValidURLToRecord
+        let subject = createSubject()
+        let url = "http://localhost:\(AppInfo.webserverPort)/reader-mode/page"
+        let observation = createObservation(url: url, title: "Reader Mode")
 
         subject.recordVisit(visitObservation: observation, isPrivateTab: false)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/RecordVisitObservationManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/RecordVisitObservationManagerTests.swift
@@ -1,0 +1,176 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MozillaAppServices
+import Shared
+import Storage
+import XCTest
+
+@testable import Client
+
+final class MockHistoryHandler: HistoryHandler {
+    var applied: [VisitObservation] = []
+    var appplyObservationCallCount = 0
+    var nextResult: Result<Void, Error> = .success(())
+
+    var onApply: ((Success) -> Void)?
+
+    // Success = Deferred<Maybe<Void>>
+    func applyObservation(visitObservation: VisitObservation) -> Success {
+        applied.append(visitObservation)
+        let result = Success()
+
+        DispatchQueue.main.async {
+            result.fill(.success(()))
+            self.onApply?(result)
+        }
+        return result
+    }
+
+    /*
+     func getBookmarksTree(rootGUID: Shared.GUID, recursive: Bool) -> Deferred<Maybe<BookmarkNodeData?>> {
+         let deferred = Deferred<Maybe<BookmarkNodeData?>>()
+         deferred.fill(Maybe(success: bookmarkFolderData))
+         return deferred
+     }
+
+     func getBookmarksTree(
+         rootGUID: GUID,
+         recursive: Bool,
+         completion: @escaping (Result<BookmarkNodeData?, any Error>) -> Void
+     ) {
+         completion(.success(bookmarkFolderData))
+     }
+     */
+}
+
+final class RecordVisitObservationManagerTests: XCTestCase {
+    private var historyHandler: MockHistoryHandler!
+    private var logger: MockLogger!
+    private var profile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+        historyHandler = MockHistoryHandler()
+        logger = MockLogger()
+        profile = MockProfile()
+    }
+
+    override func tearDown() {
+        profile = nil
+        logger = nil
+        historyHandler = nil
+        super.tearDown()
+    }
+
+    func testRecordVisitRecordsAndUpdatesLastObservation() {
+        let subject = createSubject()
+        let observation = createObservation()
+
+        let exp = expectation(description: "applyObservation finished")
+        historyHandler.onApply = { deferred in
+            deferred.upon { _ in
+                DispatchQueue.main.async {
+                    exp.fulfill()
+                }
+            }
+        }
+
+        subject.recordVisit(visitObservation: observation, isPrivateTab: false)
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(historyHandler.applied.count, 1)
+        XCTAssertEqual(historyHandler.applied.first?.url, observation.url)
+        print("--- YRD checking observation")
+        XCTAssertEqual(subject.lastObservationRecorded?.url, observation.url)
+    }
+
+    func testRecordVisitDedupesSameURLNotRecordedTwice() {
+        let subject = createSubject()
+        let observation1 = createObservation(url: "https://example.com/a", title: "A")
+        let observation2 = createObservation(url: "https://example.com/a", title: "A again")
+
+        subject.recordVisit(visitObservation: observation1, isPrivateTab: false)
+        subject.recordVisit(visitObservation: observation2, isPrivateTab: false)
+
+        print("--- YRD checking observation")
+        XCTAssertEqual(historyHandler.applied.count, 1)
+        XCTAssertEqual(subject.lastObservationRecorded?.url, observation1.url)
+    }
+
+    func testRecordVisitPrivateTabDoesNotRecord() {
+        let subject = createSubject()
+        let observation = createObservation()
+
+        subject.recordVisit(visitObservation: observation, isPrivateTab: true)
+
+        XCTAssertTrue(historyHandler.applied.isEmpty)
+        XCTAssertNil(subject.lastObservationRecorded)
+    }
+
+    func testRecordVisitEmptyTitleDoesNotRecord() {
+        let subject = createSubject()
+        let observation = createObservation(title: "")
+
+        subject.recordVisit(visitObservation: observation, isPrivateTab: false)
+
+        XCTAssertTrue(historyHandler.applied.isEmpty)
+        XCTAssertNil(subject.lastObservationRecorded)
+    }
+
+    func test_recordVisit_aboutURL_doesNotRecord() {
+        // about: scheme should be ignored by isValidURLToRecord path
+        let subject = createSubject()
+        let observation = createObservation(url: "about:preferences", title: "About Prefs")
+
+        subject.recordVisit(visitObservation: observation, isPrivateTab: false)
+
+        XCTAssertTrue(historyHandler.applied.isEmpty)
+        XCTAssertNil(subject.lastObservationRecorded)
+    }
+
+    func testRecordVisitLocalhostURLDoesNotRecord() {
+        // localhost should be ignored
+        let subject = createSubject()
+        let observation = createObservation(url: "http://localhost:8080/", title: "Localhost")
+
+        subject.recordVisit(visitObservation: observation, isPrivateTab: false)
+
+        XCTAssertTrue(historyHandler.applied.isEmpty)
+        XCTAssertNil(subject.lastObservationRecorded)
+    }
+
+    func testRecordVisitFileURLDoesNotRecord() {
+        let subject = createSubject()
+        let observation = createObservation(url: "file:///Users/me/index.html", title: "File")
+
+        subject.recordVisit(visitObservation: observation, isPrivateTab: false)
+
+        XCTAssertTrue(historyHandler.applied.isEmpty)
+        XCTAssertNil(subject.lastObservationRecorded)
+    }
+
+    func testResetRecordingSetsLastObservationToNil() {
+        let subject = createSubject()
+        subject.lastObservationRecorded = createObservation()
+        subject.resetRecording()
+
+        XCTAssertNil(subject.lastObservationRecorded)
+    }
+
+    // MARK: - Private helpers
+
+    private func createSubject() -> RecordVisitObservationManager {
+        let manager = RecordVisitObservationManager(historyHandler: historyHandler, logger: logger)
+
+        trackForMemoryLeaks(manager)
+        return manager
+    }
+
+    private func createObservation(url: String = "https://example.com/",
+                                   title: String? = "Example",
+                                   visitType: VisitType = .link) -> VisitObservation {
+        return VisitObservation(url: url, title: title, visitType: visitType)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/RecordVisitObservationManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/RecordVisitObservationManagerTests.swift
@@ -83,6 +83,7 @@ final class RecordVisitObservationManagerTests: XCTestCase {
 
     func testRecordVisitAboutURLDoesNotRecord() {
         // about: scheme should be ignored by isValidURLToRecord path
+        // because it is an ignored URL scheme
         let subject = createSubject()
         let observation = createObservation(url: "about:preferences", title: "About Prefs")
 
@@ -93,7 +94,8 @@ final class RecordVisitObservationManagerTests: XCTestCase {
     }
 
     func testRecordVisitLocalhostURLDoesNotRecord() {
-        // localhost should be ignored
+        // localhost should be ignored by isValidURLToRecord path
+        // because it is an ignored URL scheme (unless it's for `test-fixture`)
         let subject = createSubject()
         let observation = createObservation(url: "http://localhost:8080/", title: "Localhost")
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/RecordVisitObservationManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/RecordVisitObservationManagerTests.swift
@@ -14,18 +14,17 @@ final class MockHistoryHandler: HistoryHandler {
     var appplyObservationCallCount = 0
     var nextResult: Result<Void, Error> = .success(())
 
-    var onApply: ((Success) -> Void)?
+    var onApply: (() -> Void)?
 
     // Success = Deferred<Maybe<Void>>
     func applyObservation(visitObservation: VisitObservation) -> Success {
-        applied.append(visitObservation)
-        let result = Success()
+        XCTFail("Should not be implemented, use completion instead of defer")
+        fatalError()
+    }
 
-        DispatchQueue.main.async {
-            result.fill(.success(()))
-            self.onApply?(result)
-        }
-        return result
+    func applyObservation(visitObservation: VisitObservation, completion: (Result<Void, any Error>) -> Void) {
+        completion(nextResult)
+        onApply?()
     }
 
     /*
@@ -69,12 +68,8 @@ final class RecordVisitObservationManagerTests: XCTestCase {
         let observation = createObservation()
 
         let exp = expectation(description: "applyObservation finished")
-        historyHandler.onApply = { deferred in
-            deferred.upon { _ in
-                DispatchQueue.main.async {
-                    exp.fulfill()
-                }
-            }
+        historyHandler.onApply = {
+           exp.fulfill()
         }
 
         subject.recordVisit(visitObservation: observation, isPrivateTab: false)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/RecordVisitObservationManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/RecordVisitObservationManagerTests.swift
@@ -3,30 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import MozillaAppServices
-import Shared
-import Storage
 import XCTest
 
 @testable import Client
-
-final class MockHistoryHandler: HistoryHandler {
-    var applied: [VisitObservation] = []
-    var appplyObservationCallCount = 0
-    var nextResult: Result<Void, Error> = .success(())
-    var onApply: (() -> Void)?
-
-    func applyObservation(visitObservation: VisitObservation) -> Success {
-        XCTFail("Should not be implemented, use completion instead of defer")
-        fatalError()
-    }
-
-    func applyObservation(visitObservation: VisitObservation, completion: (Result<Void, any Error>) -> Void) {
-        appplyObservationCallCount += 1
-        applied.append(visitObservation)
-        completion(nextResult)
-        onApply?()
-    }
-}
 
 final class RecordVisitObservationManagerTests: XCTestCase {
     private var historyHandler: MockHistoryHandler!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockHistoryHandler.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockHistoryHandler.swift
@@ -15,11 +15,6 @@ final class MockHistoryHandler: HistoryHandler {
     var nextResult: Result<Void, Error> = .success(())
     var onApply: (() -> Void)?
 
-    func applyObservation(visitObservation: VisitObservation) -> Success {
-        XCTFail("Should not be implemented, use completion instead of defer")
-        fatalError()
-    }
-
     func applyObservation(visitObservation: VisitObservation, completion: (Result<Void, any Error>) -> Void) {
         appplyObservationCallCount += 1
         applied.append(visitObservation)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockHistoryHandler.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockHistoryHandler.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MozillaAppServices
+import Shared
+import Storage
+import XCTest
+
+@testable import Client
+
+final class MockHistoryHandler: HistoryHandler {
+    var applied: [VisitObservation] = []
+    var appplyObservationCallCount = 0
+    var nextResult: Result<Void, Error> = .success(())
+    var onApply: (() -> Void)?
+
+    func applyObservation(visitObservation: VisitObservation) -> Success {
+        XCTFail("Should not be implemented, use completion instead of defer")
+        fatalError()
+    }
+
+    func applyObservation(visitObservation: VisitObservation, completion: (Result<Void, any Error>) -> Void) {
+        appplyObservationCallCount += 1
+        applied.append(visitObservation)
+        completion(nextResult)
+        onApply?()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRecordVisitObservationManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRecordVisitObservationManager.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MozillaAppServices
+import XCTest
+
+@testable import Client
+
+class MockRecordVisitObservationManager: RecordVisitObserving {
+    private(set) var recordVisitCalled = 0
+    private(set) var resetVisitCalled = 0
+    var lastVisitObservation: VisitObservation?
+
+    func recordVisit(visitObservation: VisitObservation, isPrivateTab: Bool) {
+        recordVisitCalled += 1
+        lastVisitObservation = visitObservation
+    }
+
+    func resetRecording() {
+        resetVisitCalled += 1
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11563)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25170)

## :bulb: Description
- The bug is that we are recording the visit twice from two different code paths, from observing tab title changes and from `webView(_ webView: WKWebView, didFinish navigation: WKNavigation?)`. There are other calls to `navigateInTab` but the two mentioned above are triggered every time. The call ub title observation was added because there are cases where the title is not available when `webView(_ webView: WKWebView, didFinish navigation: WKNavigation?)` is called. Therefore, we ignore the visit at this point and record it once the title is ready. These logic causes (for most cases) that the visit is recorded twice. After attempting to hack our recording just once using `webViewStatus` enum different side effects were detected so the solutions will be:
- Create a RecordVisitObservationManager.
- Remove `onLocationChange` notification and handler and move logic to record the visit to the manager
- Logic to avoid recording multiple times the same entry.
- Reset logic based in user actions like create new tab 

Creating as draft while I manually test other scenarios 
- We still have some duplicates related to google search but it will require investigation and how we want to handle those cases
- Other issue we found debugging is that visit type is always return as link even when should be typed

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-11 at 11 03 19" src="https://github.com/user-attachments/assets/4a336ab1-5860-404c-b2ad-f7047fa2ca5e" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
