### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix strict concurrency errors in QuickActions

### DIFF
--- a/firefox-ios/Client/Application/QuickActions.swift
+++ b/firefox-ios/Client/Application/QuickActions.swift
@@ -26,13 +26,15 @@ struct QuickActionInfos {
 }
 
 // MARK: - QuickActions
-protocol QuickActions {
+protocol QuickActions: Sendable {
+    @MainActor
     func addDynamicApplicationShortcutItemOfType(
         _ type: ShortcutType,
         withUserData userData: [String: String],
         toApplication application: UIApplication
     )
 
+    @MainActor
     func removeDynamicApplicationShortcutItemOfType(
         _ type: ShortcutType,
         fromApplication application: UIApplication
@@ -40,6 +42,7 @@ protocol QuickActions {
 }
 
 extension QuickActions {
+    @MainActor
     func addDynamicApplicationShortcutItemOfType(
         _ type: ShortcutType,
         withUserData userData: [String: String] = [String: String](),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CanRemoveQuickActionBookmarkTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CanRemoveQuickActionBookmarkTests.swift
@@ -76,7 +76,7 @@ private class MockCanRemoveQuickActionBookmark: CanRemoveQuickActionBookmark {
 }
 
 // MARK: - MockQuickActions
-class MockQuickActions: QuickActions {
+class MockQuickActions: QuickActions, @unchecked Sendable {
     var addFromShareItemCalled = 0
     func addDynamicApplicationShortcutItemOfType(_ type: ShortcutType,
                                                  fromShareItem shareItem: ShareItem,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fixes strict concurrency errors in QuickActions.

I'm waiting on some changes in #29257 because @Cramsden isolated some TabManagerMiddleware methods to the main actor which I need for this to compile.

<img width="412" height="400" alt="Screenshot 2025-09-11 at 11 25 32 AM" src="https://github.com/user-attachments/assets/6eb1064c-ebcf-4fe2-92de-736170da65ec" />

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
