### PR TITLE
Build FXIOS-13479 [Local Rust Components] Fix script creating nested directory

### DIFF
--- a/scripts/update_from_application_services.py
+++ b/scripts/update_from_application_services.py
@@ -213,12 +213,12 @@ def extract_tarball(version: VersionInfo, dest: Path) -> None:
 
 def replace_all_files(tmp_dir: Path) -> None:
     replace_files(
-        tmp_dir / "swift-components/all",
-        "MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/",
+        tmp_dir / "swift-components/all/Generated",
+        "MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated",
     )
     replace_files(
-        tmp_dir / "swift-components/focus",
-        "MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/"
+        tmp_dir / "swift-components/focus/Generated",
+        "MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated"
     )
 
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13479)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
When we were syncing all the files, it was fine since we nuked all the nested directories and started from scratch. Since we only sync `Generated` now, the script needs a tiny update since now it copies stuff to `Generated/Generated` instead of just `Generated`.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
