### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix misc. under specified protocols warnings round 1

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/ReadabilityResult.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/ReadabilityResult.swift
@@ -6,7 +6,7 @@ import Common
 import Foundation
 
 /// This struct captures the response from the Readability.js code.
-public struct ReadabilityResult {
+public struct ReadabilityResult: Sendable {
     /// The `dir` global attribute is an enumerated attribute that indicates the directionality of the element's text
     enum Direction: String {
         /// Direction for languages that are written from the left to the right

--- a/firefox-ios/Client/Coordinators/Scene/ScreenshotService.swift
+++ b/firefox-ios/Client/Coordinators/Scene/ScreenshotService.swift
@@ -10,6 +10,7 @@ struct ScreenshotData {
 }
 
 /// A protocol to get PDF data for the fullscreen screenshot feature
+@MainActor
 protocol ScreenshotableView: UIViewController {
     func getScreenshotData(completionHandler: @escaping (ScreenshotData?) -> Void)
 }

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -10,6 +10,7 @@ import ComponentLibrary
 // MARK: - ZoomPageBarDelegate Protocol
 
 protocol ZoomPageBarDelegate: AnyObject {
+    @MainActor
     func zoomPageDidPressClose()
 }
 

--- a/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
+++ b/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
@@ -5,6 +5,7 @@
 import Common
 import Foundation
 
+@MainActor
 protocol AlphaDimmable {
     func updateAlphaForSubviews(_ alpha: CGFloat)
 }

--- a/firefox-ios/Client/Frontend/Components/ContentContainer.swift
+++ b/firefox-ios/Client/Frontend/Components/ContentContainer.swift
@@ -12,6 +12,7 @@ enum ContentType {
     case webview
 }
 
+@MainActor
 protocol ContentContainable: UIViewController {
     var contentType: ContentType { get }
 }

--- a/firefox-ios/Client/Frontend/Library/LibraryPanelContextMenu.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryPanelContextMenu.swift
@@ -5,6 +5,7 @@
 import Common
 import Storage
 
+@MainActor
 protocol LibraryPanelContextMenu {
     var windowUUID: WindowUUID { get }
     func getSiteDetails(for indexPath: IndexPath) -> Site?

--- a/firefox-ios/Client/Frontend/Library/Reader/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Reader/ReaderPanel.swift
@@ -166,6 +166,7 @@ class ReadingListTableViewCell: UITableViewCell, ThemeApplicable {
 
 class ReadingListPanel: UITableViewController,
                         LibraryPanel,
+                        LibraryPanelContextMenu,
                         Themeable {
     weak var libraryPanelDelegate: LibraryPanelDelegate?
     weak var navigationHandler: ReadingListNavigationHandler?
@@ -467,9 +468,9 @@ class ReadingListPanel: UITableViewController,
         tableView.backgroundColor = currentTheme().colors.layer1
         refreshReadingList()
     }
-}
 
-extension ReadingListPanel: LibraryPanelContextMenu {
+    // MARK: - LibraryPanelContextMenu
+
     func presentContextMenu(
         for site: Site,
         with indexPath: IndexPath,

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -46,9 +46,11 @@ protocol SettingsFlowDelegate: AnyObject,
 // MARK: - App Settings Screen Protocol
 
 protocol AppSettingsScreen: UIViewController {
+    @MainActor
     var settingsDelegate: SettingsDelegate? { get set }
+    @MainActor
     var parentCoordinator: SettingsFlowDelegate? { get set }
-
+    @MainActor
     func handle(route: Route.SettingsSection)
 }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/DebugSettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/DebugSettingsDelegate.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 /// Child settings pages debug actions
+@MainActor
 protocol DebugSettingsDelegate: AnyObject, SharedSettingsDelegate {
     func pressedVersion()
     func pressedShowTour()

--- a/firefox-ios/Client/Frontend/Settings/Main/SharedSettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/SharedSettingsDelegate.swift
@@ -7,6 +7,8 @@ import Shared
 
 /// The actions used by multiple child settings
 protocol SharedSettingsDelegate: AnyObject {
+    @MainActor
     func askedToReload()
+    @MainActor
     func askedToShow(alert: AlertController)
 }

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -8,6 +8,7 @@ import ComponentLibrary
 import Common
 
 protocol SearchEnginePickerDelegate: AnyObject {
+    @MainActor
     func searchEnginePicker(
         _ searchEnginePicker: SearchEnginePicker?,
         didSelectSearchEngine engine: OpenSearchEngine?

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -7,19 +7,28 @@ import UIKit
 import Shared
 
 protocol TabLocationViewDelegate: AnyObject {
+    @MainActor
     func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView)
+    @MainActor
     func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView)
+    @MainActor
     func tabLocationViewDidTapReaderMode(_ tabLocationView: TabLocationView)
+    @MainActor
     func tabLocationViewDidTapReload(_ tabLocationView: TabLocationView)
+    @MainActor
     func tabLocationViewDidTapShield(_ tabLocationView: TabLocationView)
+    @MainActor
     func tabLocationViewDidBeginDragInteraction(_ tabLocationView: TabLocationView)
+    @MainActor
     func tabLocationViewPresentCFR(at sourceView: UIView)
 
     /// - returns: whether the long-press was handled by the delegate; i.e. return `false` when the conditions
     /// for even starting handling long-press were not satisfied
-    @discardableResult
+    @MainActor @discardableResult
     func tabLocationViewDidLongPressReaderMode(_ tabLocationView: TabLocationView) -> Bool
+    @MainActor
     func tabLocationViewDidLongPressReload(_ tabLocationView: TabLocationView)
+    @MainActor
     func tabLocationViewLocationAccessibilityActions(
         _ tabLocationView: TabLocationView
     ) -> [UIAccessibilityCustomAction]?

--- a/firefox-ios/Client/Protocols/TopBottomInterchangeable.swift
+++ b/firefox-ios/Client/Protocols/TopBottomInterchangeable.swift
@@ -6,6 +6,7 @@ import Foundation
 
 /// A protocol to add and remove a view easily from a parent
 /// Used to changed search bar and reader mode bar from header to footer and vice versa
+@MainActor
 protocol TopBottomInterchangeable: UIView {
     var parent: UIStackView? { get set }
     func removeFromParent()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fixes several misc. "Conformance of..." under-specified protocol warnings in Client.

<img width="1419" height="406" alt="Screenshot 2025-09-11 at 1 33 23 PM" src="https://github.com/user-attachments/assets/bcce9037-3793-4d45-8889-156c7927919a" />

- Fix under-specified protocol in LibraryPanelContextMenu.
- Fix under-specified protocol in SearchEnginePickerDelegate.
- Fix under-specified protocol in AppSettingsScreen, DebugSettingsDelegate, SharedSettingsDelegate.
- Fix under-specified protocol in ZoomPageBarDelegate, AlphaDimmable, ContentContainable, ScreenshotableView.
- Fix under-specified protocol in TabLocationView, TopBottomInterchangeable.

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
