### PR TITLE
Add FXIOS-13323 - [iOS 26] - Round corners of the stepper in the Zoom Bar component

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -21,7 +21,8 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         static let buttonInsets = NSDirectionalEdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16)
         static let stepperHeight: CGFloat = 36
         static let stepperTopBottomPadding: CGFloat = 12
-        static let stepperCornerRadius: CGFloat = if #available(iOS 26.0, *) { 18 } else { 6 }
+        static let stepperCornerRegularRadius: CGFloat = 6
+        static let stepperCornerGlassRadius: CGFloat = 18
         static let stepperMinTrailing: CGFloat = 10
         static let stepperSpacing: CGFloat = 8
         static let shadowRadius: CGFloat = 4
@@ -54,7 +55,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         view.alignment = .center
         view.distribution = .fillProportionally
         view.spacing = UX.stepperSpacing
-        view.layer.cornerRadius = UX.stepperCornerRadius
+        view.layer.cornerRadius = UX.stepperCornerRegularRadius
         view.layer.shadowRadius = UX.shadowRadius
         view.layer.shadowOffset = UX.stepperShadowOffset
         view.layer.shadowOpacity = UX.shadowOpacity
@@ -65,7 +66,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
 #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
             $0.effect = UIGlassEffect()
-            $0.layer.cornerRadius = UX.stepperCornerRadius
+            $0.layer.cornerRadius = UX.stepperCornerGlassRadius
         }
 #endif
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13323)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29003)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Pre iOS26 | iOS26 |
| - | - |
| ![preiOS26](https://github.com/user-attachments/assets/af3a86ac-2c72-401d-bb77-e65438ddf1a0) | ![iOS26](https://github.com/user-attachments/assets/fa8d270d-9ad8-4687-8fcd-ac7544d7095d) |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
