### PR TITLE
Refactor FXIOS-13482 [Summarizer] Abstract streaming snapshot response

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/FoundationModelsSummarizer.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/FoundationModelsSummarizer.swift
@@ -71,8 +71,7 @@ final class FoundationModelsSummarizer: SummarizerProtocol {
                /// When `next()` returns nil, the underlying stream has no more data
                /// returning nil in turn ends the AsyncThrowingStream
                guard let chunk = try await responseStream.next() else { return nil }
-               /// NOTE: Casting to ResponseStream.Snapshot here since protocol type erasure gives us Any
-               guard let snapshot = chunk as? LanguageModelSession.ResponseStream<String>.Snapshot else {
+               guard let snapshot = chunk as? LanguageModelResponseSnapshotProtocol else {
                    throw SummarizerError.invalidChunk
                }
                return snapshot.content

--- a/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelResponseStreamProtocol.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelResponseStreamProtocol.swift
@@ -9,18 +9,31 @@
 import FoundationModels
 import Foundation
 
+/// A tiny abstraction over Apple's streaming snapshot type.
+/// In production, `LanguageModelSession.ResponseStream<String>.Snapshot` conforms to this.
+/// In tests, we define a `MockLanguageModelResponseSnapshot` that also conforms to this.
+@available(iOS 26, *)
+protocol LanguageModelResponseSnapshotProtocol {
+    var content: String { get }
+}
+
 /// Defines the streaming interface for language model outputs.
 /// This used because `LanguageModelSession.ResponseStream` lacks a public initializer.
 /// The protocol exposes only the essential `AsyncSequence<String>` functionality, enabling
 /// the test versions to use `AsyncThrowingStream`.
 @available(iOS 26, *)
-protocol LanguageModelResponseStreamProtocol: AsyncSequence {}
+protocol LanguageModelResponseStreamProtocol: AsyncSequence
+    where Element: LanguageModelResponseSnapshotProtocol {}
 
 @available(iOS 26, *)
 extension LanguageModelSession.ResponseStream: LanguageModelResponseStreamProtocol
     where Content == String {}
 
+@available(iOS 26, *)
 extension AsyncThrowingStream: LanguageModelResponseStreamProtocol
-    where Element == String {}
+    where Element: LanguageModelResponseSnapshotProtocol {}
+
+@available(iOS 26, *)
+extension LanguageModelSession.ResponseStream<String>.Snapshot: LanguageModelResponseSnapshotProtocol {}
 
 #endif

--- a/BrowserKit/Tests/SummarizeKitTests/Mocks/MockLanguageModelSession.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/Mocks/MockLanguageModelSession.swift
@@ -17,6 +17,11 @@ struct MockLanguageModelResponseProtocol: LanguageModelResponseProtocol {
     var transcriptEntries: ArraySlice<Transcript.Entry>
 }
 
+@available(iOS 26, *)
+struct MockLanguageModelResponseSnapshot: LanguageModelResponseSnapshotProtocol {
+    let content: String
+}
+
 /// Mock implementation of a language model session for testing the session and responses.
 /// This allows injecting controlled outputs or errors without calling the real inference backend.
 @available(iOS 26, *)
@@ -37,11 +42,13 @@ final class MockLanguageModelSession: LanguageModelSessionProtocol {
         to prompt: Prompt,
         options: GenerationOptions
     ) -> any LanguageModelResponseStreamProtocol {
-        AsyncThrowingStream<String, Error> { continuation in
+        AsyncThrowingStream<MockLanguageModelResponseSnapshot, Error> { continuation in
             if let error = respondWithError {
                 continuation.finish(throwing: error)
             } else {
-                for chunk in respondWith { continuation.yield(chunk) }
+                for chunk in respondWith {
+                    continuation.yield(MockLanguageModelResponseSnapshot(content: chunk))
+                }
                 continuation.finish()
             }
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13482)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29303)

## :bulb: Description
This PR:
- Adds `LanguageModelResponseSnapshotProtocol` to abstract return type from stream snapshot.
- Fixes `testSummarizerRespondStreaming` failing test.

ℹ️ **Note:** Ran unit tests [here](https://app.bitrise.io/build/afc733fc-8f3a-4cb8-b8c8-766fe57ebf31)

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
