### PR TITLE
Refactor EXP-5870 [Nimbus] Use rolloutParticipation and experimentParticipation

### DIFF
--- a/MozillaRustComponents/Tests/MozillaRustComponentsTests/NimbusTests.swift
+++ b/MozillaRustComponents/Tests/MozillaRustComponentsTests/NimbusTests.swift
@@ -475,7 +475,7 @@ class NimbusTests: XCTestCase {
 
         // Opt out of all experiments, which should generate a "disqualification" event for the enrolled
         // experiment
-        try nimbus.setGlobalUserParticipationOnThisThread(false)
+        try nimbus.setExperimentParticipationOnThisThread(false)
 
         // Use the Glean test API to check that the valid event is present
         XCTAssertNotNil(GleanMetrics.NimbusEvents.disqualification.testGetValue(), "Event must have a value")

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -59,7 +59,7 @@ enum Experiments {
 
     static func setStudiesSetting(_ setting: Bool) {
         studiesSetting = setting
-        updateGlobalUserParticipation()
+        updateUserParticipation()
     }
 
     static func setTelemetrySetting(_ setting: Bool) {
@@ -67,17 +67,19 @@ enum Experiments {
         if !setting {
             shared.resetTelemetryIdentifiers()
         }
-        updateGlobalUserParticipation()
+        updateUserParticipation()
     }
 
-    private static func updateGlobalUserParticipation() {
-        // we only want to reset the globalUserParticipation flag if both settings have been
+    private static func updateUserParticipation() {
+        // we only want to reset the participation flags if both settings have been
         // initialized.
         if let studiesSetting = studiesSetting, let telemetrySetting = telemetrySetting {
-            // we only enable experiments if users are opting in BOTH
+            // we only enable experiments and rollouts if users are opting in BOTH
             // telemetry and studies. If either is opted-out, we make
-            // sure users are not enrolled in any experiments
-            shared.globalUserParticipation = studiesSetting && telemetrySetting
+            // sure users are not enrolled in any experiments or rollouts
+            let participationEnabled = studiesSetting && telemetrySetting
+            shared.experimentParticipation = participationEnabled
+            shared.rolloutParticipation = participationEnabled
         }
     }
 

--- a/focus-ios/Blockzilla/Settings/Controller/SettingsViewController.swift
+++ b/focus-ios/Blockzilla/Settings/Controller/SettingsViewController.swift
@@ -483,7 +483,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return UITableView.automaticDimension
     }
-    
+
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return UITableView.automaticDimension
     }
@@ -620,7 +620,8 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             sender.isOn = false
             sender.isEnabled = false
             sender.alpha = 0.5
-            NimbusWrapper.shared.nimbus.globalUserParticipation = false
+            NimbusWrapper.shared.nimbus.experimentParticipation = false
+            NimbusWrapper.shared.nimbus.rolloutParticipation = false
             updateSetting(false, forToggle: .studies)
         }
 
@@ -657,7 +658,8 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         } else if toggle.setting == .studies {
             // Ensure 'studies' is disabled if 'sendAnonymousUsageData' is turned off, even when 'studies' is being enabled.
             if sendAnonymousUsageDataToggle?.isOn == true {
-                NimbusWrapper.shared.nimbus.globalUserParticipation = sender.isOn
+                NimbusWrapper.shared.nimbus.experimentParticipation = sender.isOn
+                NimbusWrapper.shared.nimbus.rolloutParticipation = sender.isOn
             } else {
                 disableAndTurnOffStudiesToggle(sender)
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-5870)

## :bulb: Description
Update the Nimbus SDK to use the latest functions from `application-services`. The variable `globalUserParticipation` is deprecated, and split into two now:
- `experimentParticipation`
- `rolloutParticipation` 


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
