### PR TITLE
Build FXIOS-13496 [Nimbus] Add timestamp to first run experiments automation to break cache

### DIFF
--- a/.github/workflows/firefox-ios-update-nimbus-experiments.yml
+++ b/.github/workflows/firefox-ios-update-nimbus-experiments.yml
@@ -20,13 +20,17 @@ jobs:
           path: firefox-ios
           ref: main
           fetch-depth: 0
+      # Get the timestamp and use it when fetching experiments to break cache
+      - name: Get current Unix timestamp
+        id: get-timestamp
+        run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
       - name: "Update Experiments JSON"
         id: update-experiments-json
         uses: mozilla-mobile/update-experiments@v3
         with:
           repo-path: firefox-ios
           output-path: firefox-ios/Client/Experiments/initial_experiments.json
-          experimenter-url: https://experimenter.services.mozilla.com/api/v6/experiments-first-run/?ts=12312312
+          experimenter-url: https://experimenter.services.mozilla.com/api/v6/experiments-first-run/?ts=${{ steps.get-timestamp.outputs.timestamp }}
           app-name: firefox_ios
           branch: automation/update-nimbus-experiments
       - name: "Debug - workaround issue: 23215"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13496)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR:
- Appends timestamp to experiments url so that we don't have to wait for an hour for the endpoint to be updated.

ℹ️ **NOTE:** `12312312` was added last Friday as a quick work around but it only worked for Friday. The timestamp today is bigger.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
