### PR TITLE
Bugfix FXIOS-13474 #29285 ⁃ [Xcode 26] Fix testCurrentHistoryItemSetAfterVisitingPage

### DIFF
--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebViewDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebViewDelegate.swift
@@ -20,6 +20,7 @@ class MockWKEngineWebViewDelegate: WKEngineWebViewDelegate {
     }
 
     func webViewPropertyChanged(_ property: WKEngineWebViewProperty) {
+        print("--- YRD propery \(property)")
         webViewPropertyChangedCalled += 1
         lastWebViewPropertyChanged = property
         webViewPropertyChangedCallback?(property)

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebViewDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebViewDelegate.swift
@@ -20,7 +20,6 @@ class MockWKEngineWebViewDelegate: WKEngineWebViewDelegate {
     }
 
     func webViewPropertyChanged(_ property: WKEngineWebViewProperty) {
-        print("--- YRD propery \(property)")
         webViewPropertyChangedCalled += 1
         lastWebViewPropertyChanged = property
         webViewPropertyChangedCallback?(property)

--- a/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
@@ -170,26 +170,6 @@ final class WKEngineWebViewTests: XCTestCase {
     }
 
     @MainActor
-    func testCurrentHistoryItemSetAfterVisitingPage() {
-        let subject = createSubject()
-        let testURL = URL(string: "https://www.example.com/")!
-
-        let expectation = expectation(description: "Wait for the decision handler to be called")
-
-        XCTAssertNil(subject.currentBackForwardListItem())
-        delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
-            guard webEngineViewProperty == .loading(false) else { return }
-
-            expectation.fulfill()
-        }
-
-        subject.load(URLRequest(url: testURL))
-        wait(for: [expectation], timeout: 10)
-        XCTAssertNotNil(subject.currentBackForwardListItem())
-        self.delegate.webViewPropertyChangedCallback = nil
-    }
-
-    @MainActor
     func createSubject(pullRefreshViewType: EnginePullRefreshViewType = MockEnginePullRefreshView.self,
                        file: StaticString = #filePath,
                        line: UInt = #line) -> DefaultWKEngineWebView {

--- a/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
@@ -177,9 +177,9 @@ final class WKEngineWebViewTests: XCTestCase {
         let expectation = expectation(description: "Wait for the decision handler to be called")
 
         XCTAssertNil(subject.currentBackForwardListItem())
-        delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
+        delegate.webViewPropertyChangedCallback = { [weak subject] webEngineViewProperty in
             guard webEngineViewProperty == .loading(false) else {return}
-            XCTAssertNotNil(subject.currentBackForwardListItem())
+            XCTAssertNotNil(subject?.currentBackForwardListItem())
             self.delegate.webViewPropertyChangedCallback = nil
             expectation.fulfill()
         }

--- a/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
@@ -177,16 +177,16 @@ final class WKEngineWebViewTests: XCTestCase {
         let expectation = expectation(description: "Wait for the decision handler to be called")
 
         XCTAssertNil(subject.currentBackForwardListItem())
-        delegate.webViewPropertyChangedCallback = { [weak subject] webEngineViewProperty in
-            guard webEngineViewProperty == .loading(false) else {return}
-            XCTAssertNotNil(subject?.currentBackForwardListItem())
-            self.delegate.webViewPropertyChangedCallback = nil
+        delegate.webViewPropertyChangedCallback = { webEngineViewProperty in
+            guard webEngineViewProperty == .loading(false) else { return }
+
             expectation.fulfill()
         }
 
         subject.load(URLRequest(url: testURL))
-
         wait(for: [expectation], timeout: 10)
+        XCTAssertNotNil(subject.currentBackForwardListItem())
+        self.delegate.webViewPropertyChangedCallback = nil
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -110,9 +110,6 @@
       }
     },
     {
-      "skippedTests" : [
-        "WKEngineWebViewTests\/testCurrentHistoryItemSetAfterVisitingPage()"
-      ],
       "target" : {
         "containerPath" : "container:..\/BrowserKit",
         "identifier" : "WebEngineTests",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13474)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
