### PR TITLE
Refactor FXIOS-13502 [Swift 6 Migration] Fix/suppress shared global mutable state errors in MozillaRustComponents package.

### DIFF
--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/ASOhttpClient/OhttpManager.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/ASOhttpClient/OhttpManager.swift
@@ -13,7 +13,8 @@ public class OhttpManager {
     // Global cache to caching Gateway encryption keys. Stale entries are
     // ignored and on Gateway errors the key used should be purged and retrieved
     // again next at next network attempt.
-    static var keyCache = [URL: ([UInt8], Date)]()
+    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    static nonisolated(unsafe) var keyCache = [URL: ([UInt8], Date)]()
 
     private var configUrl: URL
     private var relayUrl: URL

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAKeychain/FxAKeychain.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAKeychain/FxAKeychain.swift
@@ -19,7 +19,8 @@ open class FxAKeychain {
         return baseBundleIdentifier
     }
 
-    static var shared: FxAKeychain?
+    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    static nonisolated(unsafe) var shared: FxAKeychain?
 
     static func sharedAppContainerKeychainForFxA(keychainAccessGroup: String?) -> FxAKeychain {
         if let s = shared {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAKeychain/FxAKeychainItemAccessibility.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAKeychain/FxAKeychainItemAccessibility.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public enum FxAKeychainItemAccessibility: String {
+public enum FxAKeychainItemAccessibility: String, Sendable {
     /**
       The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by
       the user.

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
@@ -16,7 +16,7 @@ public extension Notification.Name {
 public enum MigrationResult {}
 
 // swiftlint:disable type_body_length
-open class FxAccountManager {
+open class FxAccountManager: Sendable {
     let accountStorage: KeyChainAccountStorage
     let config: FxAConfig
     var deviceConfig: DeviceConfig

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountStorage.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountStorage.swift
@@ -8,9 +8,9 @@ class KeyChainAccountStorage {
     var useRustKeychainForFxA: Bool
     var legacyKeychainWrapper: MZKeychainWrapper
     var keychainWrapper: FxAKeychain
-    static var keychainKey: String = "accountJSON"
-    static var legacyAccessibility: MZKeychainItemAccessibility = .afterFirstUnlock
-    static var accessibility: FxAKeychainItemAccessibility = .afterFirstUnlock
+    static let keychainKey: String = "accountJSON"
+    static let legacyAccessibility: MZKeychainItemAccessibility = .afterFirstUnlock
+    static let accessibility: FxAKeychainItemAccessibility = .afterFirstUnlock
 
     init(keychainAccessGroup: String?, useRustKeychainForFxA: Bool = false) {
         self.useRustKeychainForFxA = useRustKeychainForFxA

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/KeychainWrapper+.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/KeychainWrapper+.swift
@@ -21,7 +21,8 @@ extension MZKeychainWrapper {
         return baseBundleIdentifier
     }
 
-    static var shared: MZKeychainWrapper?
+    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    static nonisolated(unsafe) var shared: MZKeychainWrapper?
 
     static func sharedAppContainerKeychain(keychainAccessGroup: String?) -> MZKeychainWrapper {
         if let s = shared {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/MZKeychain/KeychainItemAccessibility.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/MZKeychain/KeychainItemAccessibility.swift
@@ -35,7 +35,7 @@ protocol MZKeychainAttrRepresentable {
 
 // MARK: - KeychainItemAccessibility
 
-public enum MZKeychainItemAccessibility {
+public enum MZKeychainItemAccessibility: Sendable {
     /**
       The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
 

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/Utils/Sysctl.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/Utils/Sysctl.swift
@@ -144,7 +144,7 @@ struct Sysctl {
     }
 
     /// Always the same on Apple hardware
-    public static var manufacturer: String = "Apple"
+    public static let manufacturer: String = "Apple"
 
     /// e.g. "N71mAP"
     public static var machine: String {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Fix or suppress shared global mutable state errors in MozillaRustComponents package.

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
