### PR TITLE
 Refactor FXIOS-13502 [Swift 6 Migration] Fix/suppress `Sendable` errors in MozillaRustComponents package

### DIFF
--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/ASOhttpClient/OhttpManager.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/ASOhttpClient/OhttpManager.swift
@@ -13,7 +13,8 @@ public class OhttpManager {
     // Global cache to caching Gateway encryption keys. Stale entries are
     // ignored and on Gateway errors the key used should be purged and retrieved
     // again next at next network attempt.
-    static var keyCache = [URL: ([UInt8], Date)]()
+    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    static nonisolated(unsafe) var keyCache = [URL: ([UInt8], Date)]()
 
     private var configUrl: URL
     private var relayUrl: URL

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAKeychain/FxAKeychain.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAKeychain/FxAKeychain.swift
@@ -19,7 +19,8 @@ open class FxAKeychain {
         return baseBundleIdentifier
     }
 
-    static var shared: FxAKeychain?
+    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    static nonisolated(unsafe) var shared: FxAKeychain?
 
     static func sharedAppContainerKeychainForFxA(keychainAccessGroup: String?) -> FxAKeychain {
         if let s = shared {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAKeychain/FxAKeychainItemAccessibility.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAKeychain/FxAKeychainItemAccessibility.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public enum FxAKeychainItemAccessibility: String {
+public enum FxAKeychainItemAccessibility: String, Sendable {
     /**
       The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by
       the user.

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
@@ -16,13 +16,15 @@ public extension Notification.Name {
 public enum MigrationResult {}
 
 // swiftlint:disable type_body_length
-open class FxAccountManager: Sendable {
+open class FxAccountManager {
     let accountStorage: KeyChainAccountStorage
     let config: FxAConfig
-    var deviceConfig: DeviceConfig
+    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    nonisolated(unsafe) var deviceConfig: DeviceConfig
     let applicationScopes: [String]
 
-    var acct: PersistedFirefoxAccount?
+    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    nonisolated(unsafe) var acct: PersistedFirefoxAccount?
     var account: PersistedFirefoxAccount? {
         get { return acct }
         set {
@@ -113,7 +115,8 @@ open class FxAccountManager: Sendable {
         completionHandler: @escaping (Result<URL, Error>) -> Void
     ) {
         FxALog.info("beginAuthentication")
-        var scopes = scopes
+        // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+        nonisolated(unsafe) var scopes = scopes
         if scopes.isEmpty {
             scopes = applicationScopes
         }

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
@@ -16,7 +16,7 @@ public extension Notification.Name {
 public enum MigrationResult {}
 
 // swiftlint:disable type_body_length
-open class FxAccountManager {
+open class FxAccountManager: Sendable {
     let accountStorage: KeyChainAccountStorage
     let config: FxAConfig
     var deviceConfig: DeviceConfig

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
@@ -65,7 +65,7 @@ open class FxAccountManager {
     /// It is required to call this method before doing anything else with the manager.
     /// Note that as a result of this initialization, notifications such as `accountAuthenticated` might be
     /// fired.
-    public func initialize(completionHandler: @escaping (Result<Void, Error>) -> Void) {
+    public func initialize(completionHandler: @Sendable @escaping (Result<Void, Error>) -> Void) {
         processEvent(event: .initialize) {
             DispatchQueue.main.async { completionHandler(Result.success(())) }
         }
@@ -183,7 +183,7 @@ open class FxAccountManager {
     /// If it succeeds, a `.accountAuthenticated` notification will get fired.
     public func finishAuthentication(
         authData: FxaAuthData,
-        completionHandler: @escaping (Result<Void, Error>) -> Void
+        completionHandler: @Sendable @escaping (Result<Void, Error>) -> Void
     ) {
         if latestOAuthStateParam == nil {
             DispatchQueue.main.async { completionHandler(.failure(FxaError.NoExistingAuthFlow(message: ""))) }
@@ -223,7 +223,7 @@ open class FxAccountManager {
     }
 
     /// The account password has been changed locally and a new session token has been sent to us through WebChannel.
-    public func handlePasswordChanged(newSessionToken: String, completionHandler: @escaping () -> Void) {
+    public func handlePasswordChanged(newSessionToken: String, completionHandler: @Sendable @escaping () -> Void) {
         processEvent(event: .changedPassword(newSessionToken: newSessionToken)) {
             DispatchQueue.main.async { completionHandler() }
         }
@@ -303,7 +303,7 @@ open class FxAccountManager {
 
     /// Log-out from the account.
     /// The `.accountLoggedOut` notification will also get fired.
-    public func logout(completionHandler: @escaping (Result<Void, Error>) -> Void) {
+    public func logout(completionHandler: @Sendable @escaping (Result<Void, Error>) -> Void) {
         processEvent(event: .logout) {
             DispatchQueue.main.async { completionHandler(.success(())) }
         }

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
@@ -146,7 +146,8 @@ open class FxAccountManager {
         scopes: [String] = [],
         completionHandler: @escaping (Result<URL, Error>) -> Void
     ) {
-        var scopes = scopes
+        // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+        nonisolated(unsafe) var scopes = scopes
         if scopes.isEmpty {
             scopes = applicationScopes
         }

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountStorage.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountStorage.swift
@@ -8,9 +8,9 @@ class KeyChainAccountStorage {
     var useRustKeychainForFxA: Bool
     var legacyKeychainWrapper: MZKeychainWrapper
     var keychainWrapper: FxAKeychain
-    static var keychainKey: String = "accountJSON"
-    static var legacyAccessibility: MZKeychainItemAccessibility = .afterFirstUnlock
-    static var accessibility: FxAKeychainItemAccessibility = .afterFirstUnlock
+    static let keychainKey: String = "accountJSON"
+    static let legacyAccessibility: MZKeychainItemAccessibility = .afterFirstUnlock
+    static let accessibility: FxAKeychainItemAccessibility = .afterFirstUnlock
 
     init(keychainAccessGroup: String?, useRustKeychainForFxA: Bool = false) {
         self.useRustKeychainForFxA = useRustKeychainForFxA

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/KeychainWrapper+.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/KeychainWrapper+.swift
@@ -21,7 +21,8 @@ extension MZKeychainWrapper {
         return baseBundleIdentifier
     }
 
-    static var shared: MZKeychainWrapper?
+    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    static nonisolated(unsafe) var shared: MZKeychainWrapper?
 
     static func sharedAppContainerKeychain(keychainAccessGroup: String?) -> MZKeychainWrapper {
         if let s = shared {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/MZKeychain/KeychainItemAccessibility.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/MZKeychain/KeychainItemAccessibility.swift
@@ -99,7 +99,8 @@ public enum MZKeychainItemAccessibility: Sendable {
     }
 }
 
-private let keychainItemAccessibilityLookup: [MZKeychainItemAccessibility: CFString] =
+// FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+private nonisolated(unsafe) let keychainItemAccessibilityLookup: [MZKeychainItemAccessibility: CFString] =
     [
         .afterFirstUnlock: kSecAttrAccessibleAfterFirstUnlock,
         .afterFirstUnlockThisDeviceOnly: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/MZKeychain/KeychainItemAccessibility.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/MZKeychain/KeychainItemAccessibility.swift
@@ -35,7 +35,7 @@ protocol MZKeychainAttrRepresentable {
 
 // MARK: - KeychainItemAccessibility
 
-public enum MZKeychainItemAccessibility {
+public enum MZKeychainItemAccessibility: Sendable {
     /**
       The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
 

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/MZKeychain/KeychainWrapper.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/MZKeychain/KeychainWrapper.swift
@@ -44,7 +44,7 @@ private let SecReturnAttributes: String = kSecReturnAttributes as String
 private let SecAttrSynchronizable: String = kSecAttrSynchronizable as String
 
 /// KeychainWrapper is a class to help make Keychain access in Swift more straightforward. It is designed to make accessing the Keychain services more like using NSUserDefaults, which is much more familiar to people.
-open class MZKeychainWrapper {
+public final class MZKeychainWrapper: Sendable {
     @available(*, deprecated, message: "KeychainWrapper.defaultKeychainWrapper is deprecated since version 2.2.1, use KeychainWrapper.standard instead")
     public static let defaultKeychainWrapper = MZKeychainWrapper.standard
 
@@ -52,10 +52,10 @@ open class MZKeychainWrapper {
     public static let standard = MZKeychainWrapper()
 
     /// ServiceName is used for the kSecAttrService property to uniquely identify this keychain accessor. If no service name is specified, KeychainWrapper will default to using the bundleIdentifier.
-    public private(set) var serviceName: String
+    public let serviceName: String
 
     /// AccessGroup is used for the kSecAttrAccessGroup property to identify which Keychain Access Group this entry belongs to. This allows you to use the KeychainWrapper with shared keychain access between different applications.
-    public private(set) var accessGroup: String?
+    public let accessGroup: String?
 
     private static let defaultServiceName = Bundle.main.bundleIdentifier ?? "SwiftKeychainWrapper"
 
@@ -80,11 +80,11 @@ open class MZKeychainWrapper {
     /// - parameter withAccessibility: Optional accessibility to use when retrieving the keychain item.
     /// - parameter isSynchronizable: A bool that describes if the item should be synchronizable, to be synched with the iCloud. If none is provided, will default to false
     /// - returns: True if a value exists for the key. False otherwise.
-    open func hasValue(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+    public func hasValue(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
         data(forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable) != nil
     }
 
-    open func accessibilityOfKey(_ key: String) -> MZKeychainItemAccessibility? {
+    public func accessibilityOfKey(_ key: String) -> MZKeychainItemAccessibility? {
         var keychainQueryDictionary = setupKeychainQueryDictionary(forKey: key)
 
         // Remove accessibility attribute
@@ -107,7 +107,7 @@ open class MZKeychainWrapper {
     }
 
     /// Get the keys of all keychain entries matching the current ServiceName and AccessGroup if one is set.
-    open func allKeys() -> Set<String> {
+    public func allKeys() -> Set<String> {
         var keychainQueryDictionary: [String: Any] = [
             SecClass: kSecClassGenericPassword,
             SecAttrService: serviceName,
@@ -143,28 +143,28 @@ open class MZKeychainWrapper {
 
     // MARK: Public Getters
 
-    open func integer(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Int? {
+    public func integer(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Int? {
         return object(forKey: key,
                       ofClass: NSNumber.self,
                       withAccessibility: accessibility,
                       isSynchronizable: isSynchronizable)?.intValue
     }
 
-    open func float(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Float? {
+    public func float(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Float? {
         return object(forKey: key,
                       ofClass: NSNumber.self,
                       withAccessibility: accessibility,
                       isSynchronizable: isSynchronizable)?.floatValue
     }
 
-    open func double(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Double? {
+    public func double(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Double? {
         return object(forKey: key,
                       ofClass: NSNumber.self,
                       withAccessibility: accessibility,
                       isSynchronizable: isSynchronizable)?.doubleValue
     }
 
-    open func bool(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool? {
+    public func bool(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool? {
         return object(forKey: key,
                       ofClass: NSNumber.self,
                       withAccessibility: accessibility,
@@ -177,7 +177,7 @@ open class MZKeychainWrapper {
     /// - parameter withAccessibility: Optional accessibility to use when retrieving the keychain item.
     /// - parameter isSynchronizable: A bool that describes if the item should be synchronizable, to be synched with the iCloud. If none is provided, will default to false
     /// - returns: The String associated with the key if it exists. If no data exists, or the data found cannot be encoded as a string, returns nil.
-    open func string(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> String? {
+    public func string(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> String? {
         guard let keychainData = data(forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable) else {
             return nil
         }
@@ -192,7 +192,7 @@ open class MZKeychainWrapper {
     /// - parameter withAccessibility: Optional accessibility to use when retrieving the keychain item.
     /// - parameter isSynchronizable: A bool that describes if the item should be synchronizable, to be synched with the iCloud. If none is provided, will default to false
     /// - returns: The decoded object associated with the key if it exists. If no data exists, or the data found cannot be decoded, returns nil.
-    open func object<DecodedObjectType>(forKey key: String,
+    public func object<DecodedObjectType>(forKey key: String,
                                         ofClass cls: DecodedObjectType.Type,
                                         withAccessibility accessibility: MZKeychainItemAccessibility? = nil,
                                         isSynchronizable: Bool = false
@@ -210,7 +210,7 @@ open class MZKeychainWrapper {
     /// - parameter withAccessibility: Optional accessibility to use when retrieving the keychain item.
     /// - parameter isSynchronizable: A bool that describes if the item should be synchronizable, to be synched with the iCloud. If none is provided, will default to false
     /// - returns: The Data object associated with the key if it exists. If no data exists, returns nil.
-    open func data(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Data? {
+    public func data(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Data? {
         var keychainQueryDictionary = setupKeychainQueryDictionary(forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable)
 
         // Limit search results to one
@@ -232,7 +232,7 @@ open class MZKeychainWrapper {
     /// - parameter withAccessibility: Optional accessibility to use when retrieving the keychain item.
     /// - parameter isSynchronizable: A bool that describes if the item should be synchronizable, to be synched with the iCloud. If none is provided, will default to false
     /// - returns: The persistent data reference object associated with the key if it exists. If no data exists, returns nil.
-    open func dataRef(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Data? {
+    public func dataRef(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Data? {
         var keychainQueryDictionary = setupKeychainQueryDictionary(forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable)
 
         // Limit search results to one
@@ -250,19 +250,19 @@ open class MZKeychainWrapper {
 
     // MARK: Public Setters
 
-    @discardableResult open func set(_ value: Int, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+    @discardableResult public func set(_ value: Int, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
         return set(NSNumber(value: value), forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable)
     }
 
-    @discardableResult open func set(_ value: Float, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+    @discardableResult public func set(_ value: Float, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
         return set(NSNumber(value: value), forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable)
     }
 
-    @discardableResult open func set(_ value: Double, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+    @discardableResult public func set(_ value: Double, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
         return set(NSNumber(value: value), forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable)
     }
 
-    @discardableResult open func set(_ value: Bool, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+    @discardableResult public func set(_ value: Bool, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
         return set(NSNumber(value: value), forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable)
     }
 
@@ -273,7 +273,7 @@ open class MZKeychainWrapper {
     /// - parameter withAccessibility: Optional accessibility to use when setting the keychain item.
     /// - parameter isSynchronizable: A bool that describes if the item should be synchronizable, to be synched with the iCloud. If none is provided, will default to false
     /// - returns: True if the save was successful, false otherwise.
-    @discardableResult open func set(_ value: String, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+    @discardableResult public func set(_ value: String, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
         guard let data = value.data(using: .utf8) else { return false }
         return set(data, forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable)
     }
@@ -285,7 +285,7 @@ open class MZKeychainWrapper {
     /// - parameter withAccessibility: Optional accessibility to use when setting the keychain item.
     /// - parameter isSynchronizable: A bool that describes if the item should be synchronizable, to be synched with the iCloud. If none is provided, will default to false
     /// - returns: True if the save was successful, false otherwise.
-    @discardableResult open func set<T>(_ value: T,
+    @discardableResult public func set<T>(_ value: T,
                                         forKey key: String,
                                         withAccessibility accessibility: MZKeychainItemAccessibility? = nil,
                                         isSynchronizable: Bool = false
@@ -304,7 +304,7 @@ open class MZKeychainWrapper {
     /// - parameter withAccessibility: Optional accessibility to use when setting the keychain item.
     /// - parameter isSynchronizable: A bool that describes if the item should be synchronizable, to be synched with the iCloud. If none is provided, will default to false
     /// - returns: True if the save was successful, false otherwise.
-    @discardableResult open func set(_ value: Data, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+    @discardableResult public func set(_ value: Data, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
         var keychainQueryDictionary: [String: Any] = setupKeychainQueryDictionary(forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable)
 
         keychainQueryDictionary[SecValueData] = value
@@ -328,7 +328,7 @@ open class MZKeychainWrapper {
     }
 
     @available(*, deprecated, message: "remove is deprecated since version 2.2.1, use removeObject instead")
-    @discardableResult open func remove(key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+    @discardableResult public func remove(key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
         return removeObject(forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable)
     }
 
@@ -338,7 +338,7 @@ open class MZKeychainWrapper {
     /// - parameter withAccessibility: Optional accessibility level to use when looking up the keychain item.
     /// - parameter isSynchronizable: A bool that describes if the item should be synchronizable, to be synched with the iCloud. If none is provided, will default to false
     /// - returns: True if successful, false otherwise.
-    @discardableResult open func removeObject(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+    @discardableResult public func removeObject(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
         let keychainQueryDictionary: [String: Any] = setupKeychainQueryDictionary(forKey: key, withAccessibility: accessibility, isSynchronizable: isSynchronizable)
 
         // Delete
@@ -347,7 +347,7 @@ open class MZKeychainWrapper {
     }
 
     /// Remove all keychain data added through KeychainWrapper. This will only delete items matching the current ServiceName and AccessGroup if one is set.
-    @discardableResult open func removeAllKeys() -> Bool {
+    @discardableResult public func removeAllKeys() -> Bool {
         // Setup dictionary to access keychain and specify we are using a generic password (rather than a certificate, internet password, etc)
         var keychainQueryDictionary: [String: Any] = [SecClass: kSecClassGenericPassword]
 
@@ -366,7 +366,7 @@ open class MZKeychainWrapper {
     ///
     /// - Warning: This may remove custom keychain entries you did not add via SwiftKeychainWrapper.
     ///
-    open class func wipeKeychain() {
+    public class func wipeKeychain() {
         deleteKeychainSecClass(kSecClassGenericPassword) // Generic password items
         deleteKeychainSecClass(kSecClassInternetPassword) // Internet password items
         deleteKeychainSecClass(kSecClassCertificate) // Certificate items

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/FeatureVariables.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/FeatureVariables.swift
@@ -415,7 +415,8 @@ class JSONVariables: VariablesWithBundle {
 
 // Another implementation of `Variables` may just return nil for everything.
 public class NilVariables: Variables {
-    public static let instance = NilVariables()
+    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    public static nonisolated(unsafe) let instance = NilVariables()
 
     public private(set) var resourceBundles: [Bundle] = [Bundle.main]
 

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/Nimbus.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/Nimbus.swift
@@ -462,7 +462,8 @@ extension Nimbus: NimbusMessagingProtocol {
 }
 
 public class NimbusDisabled: NimbusApi {
-    public static let shared = NimbusDisabled()
+    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    public static nonisolated(unsafe) let shared = NimbusDisabled()
 
     public var experimentParticipation: Bool = false
     public var rolloutParticipation: Bool = false

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusApi.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusApi.swift
@@ -271,7 +271,7 @@ public struct NimbusAppSettings {
 
 /// This error reporter is passed to `Nimbus` and any errors that are caught are reported via this type.
 ///
-public typealias NimbusErrorReporter = (Error) -> Void
+public typealias NimbusErrorReporter = @Sendable (Error) -> Void
 
 /// `ExperimentBranch` is a copy of the `Branch` without the `FeatureConfig`.
 public typealias Branch = ExperimentBranch

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusCreate.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusCreate.swift
@@ -19,7 +19,7 @@ public let defaultErrorReporter: NimbusErrorReporter = { err in
     }
 }
 
-class GleanMetricsHandler: MetricsHandler {
+final class GleanMetricsHandler: MetricsHandler {
     func recordEnrollmentStatuses(enrollmentStatusExtras: [EnrollmentStatusExtraDef]) {
         for extra in enrollmentStatusExtras {
             GleanMetrics.NimbusEvents.enrollmentStatus

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusMessagingHelpers.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusMessagingHelpers.swift
@@ -41,7 +41,7 @@ public protocol NimbusMessagingHelperProtocol: NimbusStringHelperProtocol, Nimbu
  *
  * It should also provide a similar function for String substitution, though this scheduled for EXP-2159.
  */
-public class NimbusMessagingHelper: NimbusMessagingHelperProtocol {
+public final class NimbusMessagingHelper: NimbusMessagingHelperProtocol {
     private let targetingHelper: NimbusTargetingHelperProtocol
     private let stringHelper: NimbusStringHelperProtocol
     // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
@@ -81,7 +81,7 @@ public class NimbusMessagingHelper: NimbusMessagingHelperProtocol {
 
 // MARK: Dummy implementations
 
-class AlwaysConstantTargetingHelper: NimbusTargetingHelperProtocol {
+final class AlwaysConstantTargetingHelper: NimbusTargetingHelperProtocol {
     private let constant: Bool
 
     init(constant: Bool = false) {
@@ -93,7 +93,7 @@ class AlwaysConstantTargetingHelper: NimbusTargetingHelperProtocol {
     }
 }
 
-class EchoStringHelper: NimbusStringHelperProtocol {
+final class EchoStringHelper: NimbusStringHelperProtocol {
     func getUuid(template _: String) -> String? {
         nil
     }

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusMessagingHelpers.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusMessagingHelpers.swift
@@ -44,7 +44,8 @@ public protocol NimbusMessagingHelperProtocol: NimbusStringHelperProtocol, Nimbu
 public class NimbusMessagingHelper: NimbusMessagingHelperProtocol {
     private let targetingHelper: NimbusTargetingHelperProtocol
     private let stringHelper: NimbusStringHelperProtocol
-    private var cache: [String: Bool]
+    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    private nonisolated(unsafe) var cache: [String: Bool]
 
     public init(targetingHelper: NimbusTargetingHelperProtocol,
                 stringHelper: NimbusStringHelperProtocol,

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/Utils/Logger.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/Utils/Logger.swift
@@ -5,7 +5,7 @@
 import Foundation
 import os.log
 
-class Logger {
+final class Logger: Sendable {
     private let log: OSLog
 
     /// Creates a new logger instance with the specified tag value

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/Utils/Sysctl.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/Utils/Sysctl.swift
@@ -144,7 +144,7 @@ struct Sysctl {
     }
 
     /// Always the same on Apple hardware
-    public static var manufacturer: String = "Apple"
+    public static let manufacturer: String = "Apple"
 
     /// e.g. "N71mAP"
     public static var machine: String {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Viaduct/Viaduct.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Viaduct/Viaduct.swift
@@ -15,7 +15,8 @@ import Foundation
 /// `shared` static member.
 public class Viaduct {
     /// The singleton instance of Viaduct
-    public static let shared = Viaduct()
+    /// FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
+    public nonisolated(unsafe) static let shared = Viaduct()
 
     private init() {}
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13502)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29346)

## :bulb: Description
Fix or suppress Sendable errors in MozillaRustComponents package.

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
