### PR TITLE
 Refactor FXIOS-13502 [Swift 6 Migration] Fix/suppress main actor isolation errors in MozillaRustComponents package

### DIFF
--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusCreate.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusCreate.swift
@@ -119,8 +119,20 @@ public extension Nimbus {
     static func buildExperimentContext(
         _ appSettings: NimbusAppSettings,
         bundle: Bundle = Bundle.main,
-        device: UIDevice = .current
+        device currentDevice: UIDevice? = nil
     ) -> AppContext {
+        // FIXME: FXIOS-13512 Questionable workaround to get main actor isolated UIDevice.current; rearchitect later
+        let device: UIDevice =
+            if Thread.isMainThread {
+                MainActor.assumeIsolated {
+                    return currentDevice ?? UIDevice.current
+                }
+            } else {
+                DispatchQueue.main.sync {
+                    return currentDevice ?? UIDevice.current
+                }
+            }
+
         let info = bundle.infoDictionary ?? [:]
         var inferredDateInstalledOn: Date? {
             guard


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13502)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29346)

## :bulb: Description
Fix main actor isolation warnings in MozillaRustComponents package.

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
