### PR TITLE
Refactor FXIOS-11340 - Remove 1 function_body_length violation from SearchSettingsTableViewController.swift and decreases the threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -107,8 +107,8 @@ closure_body_length:
   error: 34
 
 function_body_length:
-  warning: 161
-  error: 161
+  warning: 151
+  error: 151
 
 file_header:
   required_string: |

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -229,6 +229,17 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return cell
     }
 
+    private func configureCellForDefaultEngineAction(cell: ThemedSubtitleTableViewCell, engine: OpenSearchEngine) {
+        cell.editingAccessoryType = .disclosureIndicator
+        cell.accessibilityLabel = .Settings.Search.AccessibilityLabels.DefaultSearchEngine
+        cell.accessibilityValue = engine.shortName
+        cell.textLabel?.text = engine.shortName
+        cell.imageView?.image = engine.image.createScaled(IconSize)
+        cell.imageView?.layer.cornerRadius = 4
+        cell.imageView?.layer.masksToBounds = true
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+    }
+
     private func configureCellForAlternateEnginesAction(cell: ThemedSubtitleTableViewCell, indexPath: IndexPath) {
         // The default engine is not an alternate search engine.
         let index = indexPath.item + 1

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -266,6 +266,18 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return cell
     }
 
+    private func configureCellForDefaultSuggestionsAction(cell: ThemedSubtitleTableViewCell) {
+        buildSettingWith(
+            prefKey: PrefsKeys.SearchSettings.showSearchSuggestions,
+            defaultValue: model.shouldShowSearchSuggestions,
+            titleText: String.localizedStringWithFormat(
+                .Settings.Search.ShowSearchSuggestions
+            ),
+            cell: cell,
+            selector: #selector(didToggleSearchSuggestions)
+        )
+    }
+
     private func configureCellForPrivateSuggestionsAction(cell: ThemedSubtitleTableViewCell) {
         if featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) {
             buildSettingWith(

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -304,6 +304,18 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return cell
     }
 
+    private func configureCellForSyncedTabsAction(cell: ThemedSubtitleTableViewCell) {
+        buildSettingWith(
+            prefKey: PrefsKeys.SearchSettings.showFirefoxSyncedTabsSuggestions,
+            defaultValue: model.shouldShowSyncedTabsSuggestions,
+            titleText: String.localizedStringWithFormat(
+                .Settings.Search.Suggest.SearchSyncedTabs
+            ),
+            cell: cell,
+            selector: #selector(didToggleSyncedTabsSuggestions)
+        )
+    }
+
     private func configureCellForNonSponsoredAction(cell: ThemedSubtitleTableViewCell) {
         if featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) {
             buildSettingWith(

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -287,21 +287,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 }
 
             case FirefoxSuggestItem.sponsored.rawValue:
-                if featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) {
-                    buildSettingWith(
-                        prefKey: PrefsKeys.SearchSettings.showFirefoxSponsoredSuggestions,
-                        defaultValue: model.shouldShowSponsoredSuggestions,
-                        titleText: String.localizedStringWithFormat(
-                            .Settings.Search.Suggest.ShowSponsoredSuggestionsTitle
-                        ),
-                        statusText: String.localizedStringWithFormat(
-                            .Settings.Search.Suggest.ShowSponsoredSuggestionsDescription,
-                            AppName.shortName.rawValue
-                        ),
-                        cell: cell,
-                        selector: #selector(didToggleEnableSponsoredSuggestions)
-                    )
-                }
+                configureCellForSponsoredAction(cell: cell)
 
 //            case FirefoxSuggestItem.privateSuggestions.rawValue:
 //                buildSettingWith(

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -319,18 +319,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
 //                cell.isHidden = shouldHidePrivateModeFirefoxSuggestSetting
 
             case FirefoxSuggestItem.suggestionLearnMore.rawValue:
-                cell.accessibilityLabel = String.localizedStringWithFormat(
-                    .Settings.Search.AccessibilityLabels.LearnAboutSuggestions,
-                    AppName.shortName.rawValue
-                )
-                cell.textLabel?.text = String.localizedStringWithFormat(
-                    .Settings.Search.Suggest.LearnAboutSuggestions,
-                    AppName.shortName.rawValue
-                )
-                cell.imageView?.layer.cornerRadius = 4
-                cell.imageView?.layer.masksToBounds = true
-                cell.selectionStyle = .none
-                cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+                configureCellForSuggestionLearnMoreAction(cell: cell)
 
             default:
                 break

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -280,6 +280,24 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return cell
     }
 
+    private func configureCellForPrivateSuggestionsAction(cell: ThemedSubtitleTableViewCell) {
+        if featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) {
+            buildSettingWith(
+                prefKey: PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions,
+                defaultValue: model.shouldShowPrivateModeSearchSuggestions,
+                titleText: String.localizedStringWithFormat(
+                    .Settings.Search.PrivateSessionSetting
+                ),
+                statusText: String.localizedStringWithFormat(
+                    .Settings.Search.PrivateSessionDescription
+                ),
+                cell: cell,
+                selector: #selector(didToggleShowSearchSuggestionsInPrivateMode)
+            )
+            cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Search.showPrivateSuggestions
+        }
+    }
+
     private func configureCellForBrowsingHistoryAction(cell: ThemedSubtitleTableViewCell) {
         buildSettingWith(
             prefKey: PrefsKeys.SearchSettings.showFirefoxBrowsingHistorySuggestions,

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -237,15 +237,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         case .firefoxSuggestSettings:
             switch indexPath.item {
             case FirefoxSuggestItem.browsingHistory.rawValue:
-                buildSettingWith(
-                    prefKey: PrefsKeys.SearchSettings.showFirefoxBrowsingHistorySuggestions,
-                    defaultValue: model.shouldShowBrowsingHistorySuggestions,
-                    titleText: String.localizedStringWithFormat(
-                        .Settings.Search.Suggest.SearchBrowsingHistory
-                    ),
-                    cell: cell,
-                    selector: #selector(didToggleBrowsingHistorySuggestions)
-                )
+                configureCellForBrowsingHistoryAction(cell: cell)
 
             case FirefoxSuggestItem.bookmarks.rawValue:
                 configureCellForBookmarksAction(cell: cell)

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -255,7 +255,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
             cell.editingAccessoryView = toggle
             cell.textLabel?.text = engine.shortName
             cell.textLabel?.adjustsFontSizeToFitWidth = true
-            cell.textLabel?.minimumScaleFactor = 0.5
+            cell.textLabel?.minimumScaleFactor = UX.textLabelMinimumScaleFactor
             cell.textLabel?.numberOfLines = 0
             cell.imageView?.image = engine.image.createScaled(IconSize)
             cell.imageView?.layer.cornerRadius = UX.imageViewCornerRadius

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -217,7 +217,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         }
 
         // So that the separator line goes all the way to the left edge.
-        cell.separatorInset = UX.cellSeparatorInsetForCurrentOS
+        cell.separatorInset = ThemedTableViewController.UX.cellSeparatorInsetForCurrentOS
 
         return cell
     }

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -296,6 +296,18 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return cell
     }
 
+    private func configureCellForBookmarksAction(cell: ThemedSubtitleTableViewCell) {
+        buildSettingWith(
+            prefKey: PrefsKeys.SearchSettings.showFirefoxBookmarksSuggestions,
+            defaultValue: model.shouldShowBookmarksSuggestions,
+            titleText: String.localizedStringWithFormat(
+                .Settings.Search.Suggest.SearchBookmarks
+            ),
+            cell: cell,
+            selector: #selector(didToggleBookmarksSuggestions)
+        )
+    }
+
     private func configureCellForSyncedTabsAction(cell: ThemedSubtitleTableViewCell) {
         buildSettingWith(
             prefKey: PrefsKeys.SearchSettings.showFirefoxSyncedTabsSuggestions,

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -257,7 +257,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
             cell.textLabel?.text = engine.shortName
             cell.textLabel?.adjustsFontSizeToFitWidth = true
             cell.textLabel?.minimumScaleFactor = UX.textLabelMinimumScaleFactor
-            cell.textLabel?.numberOfLines = 0
+            cell.textLabel?.numberOfLines = UX.textLabelLinesLimit
             cell.imageView?.image = engine.image.createScaled(IconSize)
             cell.imageView?.layer.cornerRadius = UX.imageViewCornerRadius
             cell.imageView?.layer.masksToBounds = true

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -258,6 +258,39 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return cell
     }
 
+    private func configureCellForAlternateEnginesAction(cell: ThemedSubtitleTableViewCell, indexPath: IndexPath) {
+        // The default engine is not an alternate search engine.
+        let index = indexPath.item + 1
+        if index < model.orderedEngines.count {
+            let engine = model.orderedEngines[index]
+            cell.showsReorderControl = true
+
+            let toggle = ThemedSwitch()
+            toggle.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+            // This is an easy way to get from the toggle control to the corresponding index.
+            toggle.tag = index
+            toggle.addTarget(self, action: #selector(didToggleEngine), for: .valueChanged)
+            toggle.isOn = model.isEngineEnabled(engine)
+
+            cell.editingAccessoryView = toggle
+            cell.textLabel?.text = engine.shortName
+            cell.textLabel?.adjustsFontSizeToFitWidth = true
+            cell.textLabel?.minimumScaleFactor = 0.5
+            cell.textLabel?.numberOfLines = 0
+            cell.imageView?.image = engine.image.createScaled(IconSize)
+            cell.imageView?.layer.cornerRadius = 4
+            cell.imageView?.layer.masksToBounds = true
+            cell.selectionStyle = .none
+            cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+        } else {
+            cell.editingAccessoryType = .disclosureIndicator
+            cell.accessibilityLabel = .SettingsAddCustomEngineTitle
+            cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Search.customEngineViewButton
+            cell.textLabel?.text = .SettingsAddCustomEngine
+            cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+        }
+    }
+
     private func configureCellForDefaultSuggestionsAction(cell: ThemedSubtitleTableViewCell) {
         buildSettingWith(
             prefKey: PrefsKeys.SearchSettings.showSearchSuggestions,

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -259,15 +259,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 )
 
             case FirefoxSuggestItem.syncedTabs.rawValue:
-                buildSettingWith(
-                    prefKey: PrefsKeys.SearchSettings.showFirefoxSyncedTabsSuggestions,
-                    defaultValue: model.shouldShowSyncedTabsSuggestions,
-                    titleText: String.localizedStringWithFormat(
-                        .Settings.Search.Suggest.SearchSyncedTabs
-                    ),
-                    cell: cell,
-                    selector: #selector(didToggleSyncedTabsSuggestions)
-                )
+                configureCellForSyncedTabsAction(cell: cell)
 
             case FirefoxSuggestItem.nonSponsored.rawValue:
                 configureCellForNonSponsoredAction(cell: cell)

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -232,7 +232,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         cell.accessibilityValue = engine.shortName
         cell.textLabel?.text = engine.shortName
         cell.imageView?.image = engine.image.createScaled(IconSize)
-        cell.imageView?.layer.cornerRadius = 4
+        cell.imageView?.layer.cornerRadius = UX.imageViewCornerRadius
         cell.imageView?.layer.masksToBounds = true
         cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
     }
@@ -257,7 +257,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
             cell.textLabel?.minimumScaleFactor = 0.5
             cell.textLabel?.numberOfLines = 0
             cell.imageView?.image = engine.image.createScaled(IconSize)
-            cell.imageView?.layer.cornerRadius = 4
+            cell.imageView?.layer.cornerRadius = UX.imageViewCornerRadius
             cell.imageView?.layer.masksToBounds = true
             cell.selectionStyle = .none
             cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
@@ -381,7 +381,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
             .Settings.Search.Suggest.LearnAboutSuggestions,
             AppName.shortName.rawValue
         )
-        cell.imageView?.layer.cornerRadius = 4
+        cell.imageView?.layer.cornerRadius = UX.imageViewCornerRadius
         cell.imageView?.layer.masksToBounds = true
         cell.selectionStyle = .none
         cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -19,7 +19,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     private struct UX {
         static let imageViewCornerRadius: CGFloat = 4
         static let textLabelMinimumScaleFactor: CGFloat = 0.5
-        static let textLabelLinesLimit: Int = 0
+        static let textLabelLinesLimit = 0
     }
 
     // MARK: - Properties

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -205,15 +205,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         case .searchEnginesSuggestions:
             switch indexPath.item {
             case SearchSuggestItem.defaultSuggestions.rawValue:
-                buildSettingWith(
-                    prefKey: PrefsKeys.SearchSettings.showSearchSuggestions,
-                    defaultValue: model.shouldShowSearchSuggestions,
-                    titleText: String.localizedStringWithFormat(
-                        .Settings.Search.ShowSearchSuggestions
-                    ),
-                    cell: cell,
-                    selector: #selector(didToggleSearchSuggestions)
-                )
+                configureCellForDefaultSuggestionsAction(cell: cell)
 
             case SearchSuggestItem.privateSuggestions.rawValue:
                 configureCellForPrivateSuggestionsAction(cell: cell)

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -171,36 +171,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
             cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
 
         case .alternateEngines:
-            // The default engine is not an alternate search engine.
-            let index = indexPath.item + 1
-            if index < model.orderedEngines.count {
-                let engine = model.orderedEngines[index]
-                cell.showsReorderControl = true
-
-                let toggle = ThemedSwitch()
-                toggle.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
-                // This is an easy way to get from the toggle control to the corresponding index.
-                toggle.tag = index
-                toggle.addTarget(self, action: #selector(didToggleEngine), for: .valueChanged)
-                toggle.isOn = model.isEngineEnabled(engine)
-
-                cell.editingAccessoryView = toggle
-                cell.textLabel?.text = engine.shortName
-                cell.textLabel?.adjustsFontSizeToFitWidth = true
-                cell.textLabel?.minimumScaleFactor = 0.5
-                cell.textLabel?.numberOfLines = 0
-                cell.imageView?.image = engine.image.createScaled(IconSize)
-                cell.imageView?.layer.cornerRadius = 4
-                cell.imageView?.layer.masksToBounds = true
-                cell.selectionStyle = .none
-                cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
-            } else {
-                cell.editingAccessoryType = .disclosureIndicator
-                cell.accessibilityLabel = .SettingsAddCustomEngineTitle
-                cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Search.customEngineViewButton
-                cell.textLabel?.text = .SettingsAddCustomEngine
-                cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
-            }
+            configureCellForAlternateEnginesAction(cell: cell, indexPath: indexPath)
 
         case .searchEnginesSuggestions:
             switch indexPath.item {

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -16,6 +16,10 @@ protocol SearchEnginePickerDelegate: AnyObject {
 }
 
 final class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlaggable {
+    private struct UX {
+        static let imageViewCornerRadius: CGFloat = 4
+    }
+
     // MARK: - Properties
     private enum Section: Int, CaseIterable {
         case defaultEngine

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -270,21 +270,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 )
 
             case FirefoxSuggestItem.nonSponsored.rawValue:
-                if featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) {
-                    buildSettingWith(
-                        prefKey: PrefsKeys.SearchSettings.showFirefoxNonSponsoredSuggestions,
-                        defaultValue: model.shouldShowFirefoxSuggestions,
-                        titleText: String.localizedStringWithFormat(
-                            .Settings.Search.Suggest.ShowNonSponsoredSuggestionsTitle
-                        ),
-                        statusText: String.localizedStringWithFormat(
-                            .Settings.Search.Suggest.ShowNonSponsoredSuggestionsDescription,
-                            AppName.shortName.rawValue
-                        ),
-                        cell: cell,
-                        selector: #selector(didToggleEnableNonSponsoredSuggestions)
-                    )
-                }
+                configureCellForNonSponsoredAction(cell: cell)
 
             case FirefoxSuggestItem.sponsored.rawValue:
                 configureCellForSponsoredAction(cell: cell)

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -248,15 +248,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 )
 
             case FirefoxSuggestItem.bookmarks.rawValue:
-                buildSettingWith(
-                    prefKey: PrefsKeys.SearchSettings.showFirefoxBookmarksSuggestions,
-                    defaultValue: model.shouldShowBookmarksSuggestions,
-                    titleText: String.localizedStringWithFormat(
-                        .Settings.Search.Suggest.SearchBookmarks
-                    ),
-                    cell: cell,
-                    selector: #selector(didToggleBookmarksSuggestions)
-                )
+                configureCellForBookmarksAction(cell: cell)
 
             case FirefoxSuggestItem.syncedTabs.rawValue:
                 configureCellForSyncedTabsAction(cell: cell)

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -288,6 +288,18 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return cell
     }
 
+    private func configureCellForBrowsingHistoryAction(cell: ThemedSubtitleTableViewCell) {
+        buildSettingWith(
+            prefKey: PrefsKeys.SearchSettings.showFirefoxBrowsingHistorySuggestions,
+            defaultValue: model.shouldShowBrowsingHistorySuggestions,
+            titleText: String.localizedStringWithFormat(
+                .Settings.Search.Suggest.SearchBrowsingHistory
+            ),
+            cell: cell,
+            selector: #selector(didToggleBrowsingHistorySuggestions)
+        )
+    }
+
     private func configureCellForBookmarksAction(cell: ThemedSubtitleTableViewCell) {
         buildSettingWith(
             prefKey: PrefsKeys.SearchSettings.showFirefoxBookmarksSuggestions,

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -343,6 +343,21 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return cell
     }
 
+    private func configureCellForSuggestionLearnMoreAction(cell: ThemedSubtitleTableViewCell) {
+        cell.accessibilityLabel = String.localizedStringWithFormat(
+            .Settings.Search.AccessibilityLabels.LearnAboutSuggestions,
+            AppName.shortName.rawValue
+        )
+        cell.textLabel?.text = String.localizedStringWithFormat(
+            .Settings.Search.Suggest.LearnAboutSuggestions,
+            AppName.shortName.rawValue
+        )
+        cell.imageView?.layer.cornerRadius = 4
+        cell.imageView?.layer.masksToBounds = true
+        cell.selectionStyle = .none
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+    }
+
     override func numberOfSections(in tableView: UITableView) -> Int {
         sectionsToDisplay = [
             .defaultEngine,

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -161,14 +161,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         switch section {
         case .defaultEngine:
             guard let engine = model.defaultEngine else { break }
-            cell.editingAccessoryType = .disclosureIndicator
-            cell.accessibilityLabel = .Settings.Search.AccessibilityLabels.DefaultSearchEngine
-            cell.accessibilityValue = engine.shortName
-            cell.textLabel?.text = engine.shortName
-            cell.imageView?.image = engine.image.createScaled(IconSize)
-            cell.imageView?.layer.cornerRadius = 4
-            cell.imageView?.layer.masksToBounds = true
-            cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+            configureCellForDefaultEngineAction(cell: cell, engine: engine)
 
         case .alternateEngines:
             configureCellForAlternateEnginesAction(cell: cell, indexPath: indexPath)

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -19,6 +19,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     private struct UX {
         static let imageViewCornerRadius: CGFloat = 4
         static let textLabelMinimumScaleFactor: CGFloat = 0.5
+        static let textLabelLinesLimit: Int = 0
     }
 
     // MARK: - Properties

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -332,6 +332,24 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return cell
     }
 
+    private func configureCellForSponsoredAction(cell: ThemedSubtitleTableViewCell) {
+        if featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) {
+            buildSettingWith(
+                prefKey: PrefsKeys.SearchSettings.showFirefoxSponsoredSuggestions,
+                defaultValue: model.shouldShowSponsoredSuggestions,
+                titleText: String.localizedStringWithFormat(
+                    .Settings.Search.Suggest.ShowSponsoredSuggestionsTitle
+                ),
+                statusText: String.localizedStringWithFormat(
+                    .Settings.Search.Suggest.ShowSponsoredSuggestionsDescription,
+                    AppName.shortName.rawValue
+                ),
+                cell: cell,
+                selector: #selector(didToggleEnableSponsoredSuggestions)
+            )
+        }
+    }
+
     private func configureCellForSuggestionLearnMoreAction(cell: ThemedSubtitleTableViewCell) {
         cell.accessibilityLabel = String.localizedStringWithFormat(
             .Settings.Search.AccessibilityLabels.LearnAboutSuggestions,

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -216,21 +216,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 )
 
             case SearchSuggestItem.privateSuggestions.rawValue:
-                if featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) {
-                    buildSettingWith(
-                        prefKey: PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions,
-                        defaultValue: model.shouldShowPrivateModeSearchSuggestions,
-                        titleText: String.localizedStringWithFormat(
-                            .Settings.Search.PrivateSessionSetting
-                        ),
-                        statusText: String.localizedStringWithFormat(
-                            .Settings.Search.PrivateSessionDescription
-                        ),
-                        cell: cell,
-                        selector: #selector(didToggleShowSearchSuggestionsInPrivateMode)
-                    )
-                    cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Search.showPrivateSuggestions
-                }
+                configureCellForPrivateSuggestionsAction(cell: cell)
             default: break
             }
 

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -18,6 +18,7 @@ protocol SearchEnginePickerDelegate: AnyObject {
 final class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlaggable {
     private struct UX {
         static let imageViewCornerRadius: CGFloat = 4
+        static let textLabelMinimumScaleFactor: CGFloat = 0.5
     }
 
     // MARK: - Properties

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -318,6 +318,24 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return cell
     }
 
+    private func configureCellForNonSponsoredAction(cell: ThemedSubtitleTableViewCell) {
+        if featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) {
+            buildSettingWith(
+                prefKey: PrefsKeys.SearchSettings.showFirefoxNonSponsoredSuggestions,
+                defaultValue: model.shouldShowFirefoxSuggestions,
+                titleText: String.localizedStringWithFormat(
+                    .Settings.Search.Suggest.ShowNonSponsoredSuggestionsTitle
+                ),
+                statusText: String.localizedStringWithFormat(
+                    .Settings.Search.Suggest.ShowNonSponsoredSuggestionsDescription,
+                    AppName.shortName.rawValue
+                ),
+                cell: cell,
+                selector: #selector(didToggleEnableNonSponsoredSuggestions)
+            )
+        }
+    }
+
     private func configureCellForSponsoredAction(cell: ThemedSubtitleTableViewCell) {
         if featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) {
             buildSettingWith(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11340)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24679)

## :bulb: Description
In this pull request, I removed 1 `function_body_length` violation from `SearchSettingsTableViewController.swift` by extracting the switch case logics of the tableView `cellForRowAt ` function into new functions. Also, I decreased the threshold to 151 for this rule.

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="350" alt="before" src="https://github.com/user-attachments/assets/1a8647c5-3588-4424-a329-728dd4617bab" /> |  <img width="350" alt="after" src="https://github.com/user-attachments/assets/8bf9ca50-d46b-408d-9730-912bc458a13e" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
