### PR TITLE
Bugfix FXIOS-10712 Blank screen when running unit tests

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -313,13 +313,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         // Corrects an issue for development when running Fennec target in
         // the simulator after having run unit tests locally.
         #if targetEnvironment(simulator) && MOZ_CHANNEL_developer
-        let key = "_FennecLaunchedUnitTestDelegate"
-        guard let flagSet = UserDefaults.standard.value(forKey: key) as? Bool, flagSet else { return }
+
+        let tmpDirectory = FileManager.default.temporaryDirectory
+        let fileURL = tmpDirectory.appendingPathComponent("_FennecLaunchedUnitTest")
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
+        try? FileManager.default.removeItem(at: fileURL)
+
         // Private API. This code is not present in release builds.
         application.openSessions.forEach {
             application.perform(Selector(("_removeSessionFromSessionSet:")), with: $0)
         }
-        UserDefaults.standard.removeObject(forKey: key)
         #endif
     }
 }

--- a/firefox-ios/Client/Application/UnitTestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UnitTestAppDelegate.swift
@@ -24,7 +24,12 @@ final class UnitTestAppDelegate: UIResponder, UIApplicationDelegate {
         for sceneSession in application.openSessions {
             application.perform(Selector(("_removeSessionFromSessionSet:")), with: sceneSession)
         }
-        UserDefaults.standard.setValue(true, forKey: "_FennecLaunchedUnitTestDelegate")
+
+        let tmpDirectory = FileManager.default.temporaryDirectory
+        let fileURL = tmpDirectory.appendingPathComponent("_FennecLaunchedUnitTest")
+        let content = "_FennecLaunchedUnitTest".data(using: .utf8) ?? Data()
+        try? content.write(to: fileURL, options: .atomic)
+
         return true
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10712)

## :bulb: Description

@Cramsden I was only able to reproduce this once. When I saw it, what it looked like was somehow the user default flag was getting reset somehow. Unfortunately I haven't been able to hit it since then.

This PR is just a stab at fixing the issue, and it changes the code from using UserDefaults to using a placeholder file in the temp directory instead.

If possible can you try cherry-picking this fix over to whatever branch you're working on and let me know if it fixes the problem for you?

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
