### PR TITLE
Refactor FXIOS-13463 [Swift 6 Migration] Content scripts inside WebEngine

### DIFF
--- a/BrowserKit/Sources/WebEngine/EngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSession.swift
@@ -62,6 +62,7 @@ public protocol EngineSession: NSObject {
     func restore(state: Data)
 
     /// Close the session. This may free underlying objects. Call this when you are finished using this session.
+    @MainActor
     func close()
 
     /// Switch to standard tracking protection mode.

--- a/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKAboutHomeHandler.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKAboutHomeHandler.swift
@@ -4,7 +4,7 @@
 
 import WebKit
 
-class WKAboutHomeHandler: WKInternalSchemeResponse {
+struct WKAboutHomeHandler: WKInternalSchemeResponse {
     static let path = "about/home"
 
     // Return a blank page, the webview delegate will look at the current URL and load the home panel based on that

--- a/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalSchemeHandler.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalSchemeHandler.swift
@@ -11,6 +11,7 @@ enum WKInternalPageSchemeHandlerError: Error {
     case notAuthorized
 }
 
+@MainActor
 protocol WKInternalSchemeResponse {
     func response(forRequest: URLRequest) -> (URLResponse, Data)?
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/AdsTelemetryContentScript.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/AdsTelemetryContentScript.swift
@@ -58,7 +58,7 @@ protocol AdsTelemetryScriptDelegate: AnyObject {
 }
 
 /// Script utility to handle tracking of ads on pages, based on provided search engine regexes. (See `searchProviderModels`)
-class AdsTelemetryContentScript: WKContentScript {
+final class AdsTelemetryContentScript: WKContentScript {
     private var logger: Logger
     private weak var delegate: ContentScriptDelegate?
     private let searchProviderModels: [EngineSearchProviderModel]

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/FocusContentScript.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/FocusContentScript.swift
@@ -4,7 +4,7 @@
 
 import Common
 
-class FocusContentScript: WKContentScript {
+final class FocusContentScript: WKContentScript {
     private let logger: Logger
     private weak var delegate: ContentScriptDelegate?
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/ReaderModeContentScript.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/ReaderModeContentScript.swift
@@ -9,12 +9,13 @@ public enum ReaderModeInfo: String {
     case namespace = "window.__firefox__.reader"
 }
 
+@MainActor
 public protocol ReaderModeStyleSetter {
     var style: ReaderModeStyle { get set }
 }
 
 // TODO: FXIOS-11373 - finish handling reader mode in WebEngine - this class is to be tested
-class ReaderModeContentScript: WKContentScript, ReaderModeStyleSetter {
+final class ReaderModeContentScript: WKContentScript, ReaderModeStyleSetter {
     weak var delegate: WKReaderModeDelegate?
 
     private var logger: Logger

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/WKReadabilityOperation.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/ReaderMode/WKReadabilityOperation.swift
@@ -17,10 +17,10 @@ protocol ReaderModeNavigationDelegate: AnyObject {
 }
 
 // TODO: FXIOS-11373 - finish handling reader mode in WebEngine - this class is to be tested
-class WKReadabilityOperation: Operation,
-                              @unchecked Sendable,
-                              ReaderModeNavigationDelegate,
-                              WKReaderModeDelegate {
+final class WKReadabilityOperation: Operation,
+                                    @unchecked Sendable,
+                                    ReaderModeNavigationDelegate,
+                                    WKReaderModeDelegate {
     var url: URL
     var semaphore: DispatchSemaphore
     var result: ReadabilityOperationResult?

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKContentScript.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKContentScript.swift
@@ -7,6 +7,7 @@ import WebKit
 
 /// Protocol each script injected into a WKEngineSession needs to follow.
 /// Scripts are injected through the `WKContentScriptManager`
+@MainActor
 protocol WKContentScript {
     static func name() -> String
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKContentScriptManager.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKContentScriptManager.swift
@@ -6,6 +6,7 @@ import Foundation
 import WebKit
 
 /// Manager used to add and remove scripts inside a WKEngineSession
+@MainActor
 protocol WKContentScriptManager: WKScriptMessageHandler {
     var scripts: [String: WKContentScript] { get }
 
@@ -24,7 +25,7 @@ protocol WKContentScriptManager: WKScriptMessageHandler {
     func uninstall(session: WKEngineSession)
 }
 
-class DefaultContentScriptManager: NSObject, WKContentScriptManager {
+final class DefaultContentScriptManager: NSObject, WKContentScriptManager {
     private(set) var scripts = [String: WKContentScript]()
 
     func addContentScript(_ script: WKContentScript,

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKUserScriptManager.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKUserScriptManager.swift
@@ -11,7 +11,7 @@ protocol WKUserScriptManager {
     func injectUserScriptsIntoWebView(_ webView: WKEngineWebView)
 }
 
-class DefaultUserScriptManager: WKUserScriptManager {
+final class DefaultUserScriptManager: WKUserScriptManager {
     // Scripts can use this to verify the application (not JS on the web) is calling into them
     private let appIdToken = UUID().uuidString
     private let scriptProvider: UserScriptProvider

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -344,6 +344,7 @@ class WKEngineSession: NSObject,
 
     // MARK: - Content scripts
 
+    @MainActor
     private func addContentScripts(readerModeDelegate: WKReaderModeDelegate?) {
         scriptResponder.session = self
         let searchProviders = delegate?.adsSearchProviderModels() ?? []

--- a/BrowserKit/Tests/WebEngineTests/Scripts/AdsTelemetryContentScriptTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/Scripts/AdsTelemetryContentScriptTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 @testable import WebEngine
 
+@MainActor
 final class AdsTelemetryContentScriptTests: XCTestCase {
     private var contentScriptDelegate: MockContentScriptDelegate!
 
@@ -18,7 +19,6 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
         super.tearDown()
     }
 
-    @MainActor
     func testDidReceiveMessageGivenEmptyMessageThenNoDelegateCalled() {
         let subject = createSubject()
 
@@ -28,7 +28,6 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
         XCTAssertNil(contentScriptDelegate.lastContentScriptEvent)
     }
 
-    @MainActor
     func testDidReceiveMessageWithNoAdURLMatchThenNoDelegateCalled() {
         let subject = createSubject()
 
@@ -42,7 +41,6 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
         XCTAssertNil(contentScriptDelegate.lastContentScriptEvent)
     }
 
-    @MainActor
     func testDidReceiveMessageWithBasicURLMatchButNoAdURLsThenNoDelegateCalled() {
         let subject = createSubject()
 
@@ -56,7 +54,6 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
         XCTAssertNil(contentScriptDelegate.lastContentScriptEvent)
     }
 
-    @MainActor
     func testDidReceiveMessageWithBasicURLMatchAndMatchingAdURLsThenTrackOnPageCalled() throws {
         let subject = createSubject()
 
@@ -72,7 +69,6 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
                                                      urls: ["https://www.mocksearch.com/pagead/aclk"]))
     }
 
-    @MainActor
     func testDidReceiveMessageWithBasicURLMatchAndMatchingAdURLsThenTrackOnPageCalledAndURLsSent() throws {
         let subject = createSubject()
 
@@ -94,7 +90,6 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
         XCTAssertEqual(provider, "mocksearch")
     }
 
-    @MainActor
     private func createSubject() -> AdsTelemetryContentScript {
         let subject = AdsTelemetryContentScript(
             delegate: contentScriptDelegate,

--- a/BrowserKit/Tests/WebEngineTests/Scripts/AdsTelemetryContentScriptTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/Scripts/AdsTelemetryContentScriptTests.swift
@@ -18,6 +18,7 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testDidReceiveMessageGivenEmptyMessageThenNoDelegateCalled() {
         let subject = createSubject()
 
@@ -27,6 +28,7 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
         XCTAssertNil(contentScriptDelegate.lastContentScriptEvent)
     }
 
+    @MainActor
     func testDidReceiveMessageWithNoAdURLMatchThenNoDelegateCalled() {
         let subject = createSubject()
 
@@ -40,6 +42,7 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
         XCTAssertNil(contentScriptDelegate.lastContentScriptEvent)
     }
 
+    @MainActor
     func testDidReceiveMessageWithBasicURLMatchButNoAdURLsThenNoDelegateCalled() {
         let subject = createSubject()
 
@@ -53,6 +56,7 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
         XCTAssertNil(contentScriptDelegate.lastContentScriptEvent)
     }
 
+    @MainActor
     func testDidReceiveMessageWithBasicURLMatchAndMatchingAdURLsThenTrackOnPageCalled() throws {
         let subject = createSubject()
 
@@ -68,6 +72,7 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
                                                      urls: ["https://www.mocksearch.com/pagead/aclk"]))
     }
 
+    @MainActor
     func testDidReceiveMessageWithBasicURLMatchAndMatchingAdURLsThenTrackOnPageCalledAndURLsSent() throws {
         let subject = createSubject()
 
@@ -89,6 +94,7 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
         XCTAssertEqual(provider, "mocksearch")
     }
 
+    @MainActor
     private func createSubject() -> AdsTelemetryContentScript {
         let subject = AdsTelemetryContentScript(
             delegate: contentScriptDelegate,

--- a/BrowserKit/Tests/WebEngineTests/Scripts/FocusContentScriptTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/Scripts/FocusContentScriptTests.swift
@@ -18,6 +18,7 @@ final class FocusContentScriptTests: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testUserContentControllerGivenEmptyDataDoesNotCallContentScriptDelegate() {
         let subject = createSubject()
 
@@ -27,6 +28,7 @@ final class FocusContentScriptTests: XCTestCase {
         XCTAssertNil(contentScriptDelegate.lastContentScriptEvent)
     }
 
+    @MainActor
     func testUserContentControllerGivenFocusEventCallsContentScriptDelegate() throws {
         let subject = createSubject()
 
@@ -40,6 +42,7 @@ final class FocusContentScriptTests: XCTestCase {
         XCTAssertEqual(event, .fieldFocusChanged(true))
     }
 
+    @MainActor
     func testUserContentControllerGivenBlurEventCallsContentScriptDelegate() throws {
         let subject = createSubject()
 
@@ -53,6 +56,7 @@ final class FocusContentScriptTests: XCTestCase {
         XCTAssertEqual(event, .fieldFocusChanged(false))
     }
 
+    @MainActor
     private func createSubject() -> FocusContentScript {
         let subject = FocusContentScript(delegate: contentScriptDelegate)
         trackForMemoryLeaks(subject)

--- a/BrowserKit/Tests/WebEngineTests/Scripts/FocusContentScriptTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/Scripts/FocusContentScriptTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 @testable import WebEngine
 
+@MainActor
 final class FocusContentScriptTests: XCTestCase {
     private var contentScriptDelegate: MockContentScriptDelegate!
 
@@ -18,7 +19,6 @@ final class FocusContentScriptTests: XCTestCase {
         super.tearDown()
     }
 
-    @MainActor
     func testUserContentControllerGivenEmptyDataDoesNotCallContentScriptDelegate() {
         let subject = createSubject()
 
@@ -28,7 +28,6 @@ final class FocusContentScriptTests: XCTestCase {
         XCTAssertNil(contentScriptDelegate.lastContentScriptEvent)
     }
 
-    @MainActor
     func testUserContentControllerGivenFocusEventCallsContentScriptDelegate() throws {
         let subject = createSubject()
 
@@ -42,7 +41,6 @@ final class FocusContentScriptTests: XCTestCase {
         XCTAssertEqual(event, .fieldFocusChanged(true))
     }
 
-    @MainActor
     func testUserContentControllerGivenBlurEventCallsContentScriptDelegate() throws {
         let subject = createSubject()
 
@@ -56,7 +54,6 @@ final class FocusContentScriptTests: XCTestCase {
         XCTAssertEqual(event, .fieldFocusChanged(false))
     }
 
-    @MainActor
     private func createSubject() -> FocusContentScript {
         let subject = FocusContentScript(delegate: contentScriptDelegate)
         trackForMemoryLeaks(subject)

--- a/BrowserKit/Tests/WebEngineTests/Scripts/WKContentScriptManagerTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/Scripts/WKContentScriptManagerTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 @testable import WebEngine
 
+@MainActor
 @available(iOS 16.0, *)
 final class WKContentScriptManagerTests: XCTestCase {
     private var script: MockWKContentScript!
@@ -19,7 +20,6 @@ final class WKContentScriptManagerTests: XCTestCase {
         script = nil
     }
 
-    @MainActor
     func testAddContentGivenAddedTwiceThenOnlyAddOnce() async {
         let subject = createSubject()
         let session = await MockWKEngineSession()
@@ -38,9 +38,9 @@ final class WKContentScriptManagerTests: XCTestCase {
         let subject = createSubject()
         let session = await MockWKEngineSession()
 
-        await subject.addContentScript(script,
-                                       name: MockWKContentScript.name(),
-                                       forSession: session)
+        subject.addContentScript(script,
+                                 name: MockWKContentScript.name(),
+                                 forSession: session)
 
         XCTAssertEqual(script.scriptMessageHandlerNamesCalled, 1)
         guard let config = session.webView.engineConfiguration as? MockWKEngineConfiguration else {
@@ -70,9 +70,9 @@ final class WKContentScriptManagerTests: XCTestCase {
         let subject = createSubject()
         let session = await MockWKEngineSession()
 
-        await subject.addContentScriptToPage(script,
-                                             name: MockWKContentScript.name(),
-                                             forSession: session)
+        subject.addContentScriptToPage(script,
+                                       name: MockWKContentScript.name(),
+                                       forSession: session)
 
         XCTAssertEqual(script.scriptMessageHandlerNamesCalled, 1)
         guard let config = session.webView.engineConfiguration as? MockWKEngineConfiguration else {
@@ -86,11 +86,11 @@ final class WKContentScriptManagerTests: XCTestCase {
     func testUninstallGivenAScriptThenCallsDeinitAndMessageHandlerNames() async {
         let subject = createSubject()
         let session = await MockWKEngineSession()
-        await subject.addContentScript(script,
-                                       name: MockWKContentScript.name(),
-                                       forSession: session)
+        subject.addContentScript(script,
+                                 name: MockWKContentScript.name(),
+                                 forSession: session)
 
-        await subject.uninstall(session: session)
+        subject.uninstall(session: session)
 
         XCTAssertEqual(script.scriptMessageHandlerNamesCalled, 2)
         XCTAssertEqual(script.prepareForDeinitCalled, 1)

--- a/BrowserKit/Tests/WebEngineTests/Scripts/WKContentScriptManagerTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/Scripts/WKContentScriptManagerTests.swift
@@ -51,7 +51,6 @@ final class WKContentScriptManagerTests: XCTestCase {
         XCTAssertEqual(config.scriptNameAdded, "MockWKContentScriptHandler")
     }
 
-    @MainActor
     func testAddContentToPageGivenAddedTwiceThenOnlyAddOnce() async {
         let subject = createSubject()
         let session = await MockWKEngineSession()

--- a/BrowserKit/Tests/WebEngineTests/WKInternalSchemeHandlerTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKInternalSchemeHandlerTests.swift
@@ -55,6 +55,7 @@ final class WKInternalSchemeHandlerTests: XCTestCase {
         XCTAssertEqual(error, WKInternalPageSchemeHandlerError.noResponder)
     }
 
+    @MainActor
     func testSchemeStartIsCalledWithPrivilegedURLWithCorrectResponder() throws {
         setupFakeInternalHandlers()
         let subject = createSubject()
@@ -80,6 +81,7 @@ final class WKInternalSchemeHandlerTests: XCTestCase {
         return subject
     }
 
+    @MainActor
     func setupFakeInternalHandlers() {
         let responders: [(String, WKInternalSchemeResponse)] = [(MockSchemeHandler.path, MockSchemeHandler())]
         responders.forEach { (path, responder) in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13463)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29256)

## :bulb: Description
- `WKContentScript` and `WKContentScriptManager` needs to be `@MainActor` since that manager is a [`WKScriptMessageHandler`](https://developer.apple.com/documentation/webkit/wkscriptmessagehandler) which is a `@MainActor` protocol to receive JavaScript messages.
- I set some classes to be `final` at the same time
- FYI there's around 80 other warnings to fix under the `WebEngine` package

cc: @ih-codes, @dataports, @Cramsden 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
