### PR TITLE
Fix MTE-4901 Remove unused tests from the test plans

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
@@ -497,7 +497,14 @@
         "ZoomingTests\/testSwitchingZoomedTabs()",
         "ZoomingTests\/testSwitchingZoomedTabsLandscape()",
         "ZoomingTests\/testZoomForceCloseFirefox()",
-        "ZoomingTests\/testZoomingActions()"
+        "ZoomingTests\/testZoomingActions()",
+        "ZoomingTestsTAE",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabsLandscape_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabs_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
+        "ZoomingTestsTAE\/testZoomingActions()",
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -165,7 +165,14 @@
         "TopTabsTestIpad",
         "TrackingProtectionTests",
         "URLValidationTests",
-        "WhatsNewTest"
+        "WhatsNewTest",
+        "ZoomingTestsTAE",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabsLandscape_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabs_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
+        "ZoomingTestsTAE\/testZoomingActions()",
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -243,7 +243,14 @@
         "TrackingProtectionTests\/testTrackingProtection()",
         "URLValidationTests",
         "ZoomingTests\/testZommingActions()",
-        "ZoomingTests\/testZoomingActions()"
+        "ZoomingTests\/testZoomingActions()",
+        "ZoomingTestsTAE",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabsLandscape_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabs_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
+        "ZoomingTestsTAE\/testZoomingActions()",
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -148,7 +148,14 @@
         "URLValidationTests",
         "UrlBarTests",
         "WhatsNewTest",
-        "ZoomingTests"
+        "ZoomingTests",
+        "ZoomingTestsTAE",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabsLandscape_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabs_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
+        "ZoomingTestsTAE\/testZoomingActions()",
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -494,7 +494,14 @@
         "ZoomingTests\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
         "ZoomingTests\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTests\/testZoomingActionsLandscape()",
-        "ZoomingTests\/testZoomingActionsLandscape_tabTrayExperimentOff()"
+        "ZoomingTests\/testZoomingActionsLandscape_tabTrayExperimentOff()",
+        "ZoomingTestsTAE",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabsLandscape_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabs_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
+        "ZoomingTestsTAE\/testZoomingActions()",
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
@@ -172,7 +172,14 @@
         "URLValidationTests",
         "UrlBarTests",
         "WhatsNewTest",
-        "ZoomingTests"
+        "ZoomingTests",
+        "ZoomingTestsTAE",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabsLandscape_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testSwitchingZoomedTabs_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
+        "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
+        "ZoomingTestsTAE\/testZoomingActions()",
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4901)

## :bulb: Description
This PR removes the ZoomingTestTAE from the test plans because they are not part of the test folder anymore.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
