### PR TITLE
Add FXIOS-13508 [Trending Searches] parsing trending url for OpenSearchEngine

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineUtilities.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineUtilities.swift
@@ -13,12 +13,14 @@ struct ASSearchEngineUtilities {
         let telemetrySuffix = engine.telemetrySuffix
         let searchTemplate = convertASSearchURLToOpenSearchURL(engine.urls.search, for: engine) ?? ""
         let suggestTemplate = convertASSearchURLToOpenSearchURL(engine.urls.suggestions, for: engine) ?? ""
+        let trendingTemplate = convertASSearchURLToOpenSearchURL(engine.urls.trending, for: engine) ?? ""
         let converted = OpenSearchEngine(engineID: engineID,
                                          shortName: name,
                                          telemetrySuffix: telemetrySuffix,
                                          image: image,
                                          searchTemplate: searchTemplate,
                                          suggestTemplate: suggestTemplate,
+                                         trendingTemplate: trendingTemplate,
                                          isCustomEngine: false)
         return converted
     }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -35,6 +35,7 @@ final class OpenSearchEngine: NSObject, NSSecureCoding, Sendable {
     }
 
     private let suggestTemplate: String?
+    private let trendingTemplate: String?
     private let searchTermComponent = "{searchTerms}"
     private let searchQueryComponentKey: String?
     private let googleEngineID = {
@@ -74,11 +75,13 @@ final class OpenSearchEngine: NSObject, NSSecureCoding, Sendable {
          image: UIImage,
          searchTemplate: String,
          suggestTemplate: String?,
+         trendingTemplate: String? = nil,
          isCustomEngine: Bool) {
         self.shortName = shortName
         self.image = image
         self.searchTemplate = searchTemplate
         self.suggestTemplate = suggestTemplate
+        self.trendingTemplate = trendingTemplate
         self.telemetrySuffix = telemetrySuffix
         self.isCustomEngine = isCustomEngine
         self.engineID = engineID
@@ -111,6 +114,7 @@ final class OpenSearchEngine: NSObject, NSSecureCoding, Sendable {
         Self.generateCustomEngineID()
         self.telemetrySuffix = aDecoder.decodeObject(forKey: CodingKeys.telemetrySuffix.rawValue) as? String
         self.suggestTemplate = nil
+        self.trendingTemplate = nil
 
         self.searchQueryComponentKey = OpenSearchEngine.getQueryArgFromTemplate(
             searchTemplate: self.searchTemplate,
@@ -146,6 +150,12 @@ final class OpenSearchEngine: NSObject, NSSecureCoding, Sendable {
             return getURLFromTemplate(suggestTemplate, query: query)
         }
         return nil
+    }
+
+    /// Returns the trending search URL for the specific search engine.
+    func trendingURLForEngine() -> URL? {
+        guard let trendingTemplate else { return nil }
+        return URL(string: trendingTemplate)
     }
 
     /// Returns the query that was used to construct a given search URL

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchParser.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchParser.swift
@@ -15,6 +15,7 @@ class OpenSearchParser {
     private let userInterfaceIdiom: UIUserInterfaceIdiom
     private let typeSearch = "text/html"
     private let typeSuggest = "application/x-suggestions+json"
+    private let typeTrending = "application/x-trending+json"
 
     init(pluginMode: Bool, userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         self.pluginMode = pluginMode
@@ -48,13 +49,15 @@ class OpenSearchParser {
 
         var searchTemplate: String?
         var suggestTemplate: String?
+        var trendingTemplate: String?
+
         for urlIndexer in urlIndexers {
             let type = urlIndexer.attributes["type"]
             if type == nil {
                 return nil
             }
 
-            if type != typeSearch && type != typeSuggest {
+            if type != typeSearch && type != typeSuggest && type != typeTrending {
                 // Not a supported search type.
                 continue
             }
@@ -95,6 +98,8 @@ class OpenSearchParser {
 
             if type == typeSearch {
                 searchTemplate = template
+            } else if type == typeTrending {
+                trendingTemplate = template
             } else {
                 suggestTemplate = template
             }
@@ -143,6 +148,7 @@ class OpenSearchParser {
             image: uiImage,
             searchTemplate: searchTemplate,
             suggestTemplate: suggestTemplate,
+            trendingTemplate: trendingTemplate,
             isCustomEngine: false
         )
     }

--- a/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -119,6 +119,7 @@ class CustomSearchViewController: SettingsTableViewController {
                                       image: image,
                                       searchTemplate: template,
                                       suggestTemplate: nil,
+                                      trendingTemplate: nil,
                                       isCustomEngine: true)
 
         // Make sure a valid scheme is used

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/OpenSearchEngineTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/OpenSearchEngineTests.swift
@@ -89,6 +89,41 @@ class OpenSearchEngineTests: XCTestCase {
         )
     }
 
+    func test_trendingURLForEngine_returnsExpectedURL() throws {
+        let searchEngine = OpenSearchEngine(
+            engineID: "Bing_Test",
+            shortName: "Bing",
+            telemetrySuffix: nil,
+            image: UIImage(),
+            searchTemplate: "some link",
+            suggestTemplate: nil,
+            trendingTemplate: "www.mozilla.org",
+            isCustomEngine: true
+        )
+
+        let url = searchEngine.trendingURLForEngine()
+
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, "www.mozilla.org")
+    }
+
+    func test_trendingURLForEngine_withNoTrendingTemplate_returnsNil() throws {
+        let searchEngine = OpenSearchEngine(
+            engineID: "Bing_Test",
+            shortName: "Bing",
+            telemetrySuffix: nil,
+            image: UIImage(),
+            searchTemplate: "some link",
+            suggestTemplate: nil,
+            trendingTemplate: nil,
+            isCustomEngine: true
+        )
+
+        let url = searchEngine.trendingURLForEngine()
+
+        XCTAssertNil(url)
+    }
+
     /// For generating test `OpenSearchEngine` data.
     public enum TestSearchEngine {
         case youtube, wikipedia
@@ -139,6 +174,7 @@ class OpenSearchEngineTests: XCTestCase {
             image: testImage,
             searchTemplate: "some link",
             suggestTemplate: nil,
+            trendingTemplate: nil,
             isCustomEngine: true
         )
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/OpenSearchEngineTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/OpenSearchEngineTests.swift
@@ -97,14 +97,14 @@ class OpenSearchEngineTests: XCTestCase {
             image: UIImage(),
             searchTemplate: "some link",
             suggestTemplate: nil,
-            trendingTemplate: "www.mozilla.org",
+            trendingTemplate: "www.example.com",
             isCustomEngine: true
         )
 
         let url = searchEngine.trendingURLForEngine()
 
         XCTAssertNotNil(url)
-        XCTAssertEqual(url?.absoluteString, "www.mozilla.org")
+        XCTAssertEqual(url?.absoluteString, "www.example.com")
     }
 
     func test_trendingURLForEngine_withNoTrendingTemplate_returnsNil() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/ASSearchEngineUtilitiesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/ASSearchEngineUtilitiesTests.swift
@@ -122,12 +122,20 @@ class ASSearchEngineUtilitiesTests: XCTestCase {
             trending: SearchEngineUrl(
                 base: "https://www.google.com/complete/search",
                 method: "GET",
-                params: [SearchUrlParam(
-                    name: "client",
-                    value: "firefox",
-                    enterpriseValue: nil,
-                    experimentConfig: nil
-                )],
+                params: [
+                    SearchUrlParam(
+                        name: "client",
+                        value: "firefox",
+                        enterpriseValue: nil,
+                        experimentConfig: nil
+                    ),
+                    SearchUrlParam(
+                        name: "channel",
+                        value: "ftr",
+                        enterpriseValue: nil,
+                        experimentConfig: nil
+                    )
+                ],
                 searchTermParamName: "q",
                 displayName: nil
             ),
@@ -151,6 +159,14 @@ class ASSearchEngineUtilitiesTests: XCTestCase {
         let result = ASSearchEngineUtilities.convertASSearchURLToOpenSearchURL(engine.urls.suggestions,
                                                                                for: engine)
         let expected = "https://www.google.com/complete/search?client=firefox&q={searchTerms}"
+        XCTAssertEqual(result, expected)
+    }
+
+    func testConvertGoogleEngineTrendingURL() {
+        let engine = google_US_testEngine
+        let result = ASSearchEngineUtilities.convertASSearchURLToOpenSearchURL(engine.urls.trending,
+                                                                               for: engine)
+        let expected = "https://www.google.com/complete/search?client=firefox&channel=ftr&q={searchTerms}"
         XCTAssertEqual(result, expected)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13508)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29361)

## :bulb: Description

- Add fetching trending url to `OpenSearchEngine` so that we can get the proper trending searches from the url per engine (only Bing / Google for now).
- We modify `OpenSearchParser` so we can fetch from xml files (soon to be deprecated - see more details in https://github.com/mozilla-mobile/firefox-ios/pull/29343). 
- We modify `ASSearchEngineUtilities` so we can fetch from configs via remote settings.

## Screenshots
From AS:
<img width="1017" height="353" alt="image" src="https://github.com/user-attachments/assets/7ddb174a-d095-49c4-8d6b-2d9ad8c344c1" />

From XML:
<img width="1015" height="308" alt="image" src="https://github.com/user-attachments/assets/3bd6291b-a838-45d7-aff0-2b078339a21c" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
