### PR TITLE
Update NO_TICKET [Rust Local Components] change code ownership of non-generated files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,10 @@
 /firefox-ios/Client/Experiments/initial_experiments.json @afurlan-firefox
 /firefox-ios/Client/Assets/CC_Script @nbhasin2 @issammani
 /firefox-ios/Client/Assets/RemoteSettingsData/ @nbhasin2 @issammani @mattreaganmozilla
-/MozillaRustComponents/ @issammani
+/MozillaRustComponents/Package.swift @issammani
+/MozillaRustComponents/Package.resolved @issammani
+/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated @issammani
+/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated @issammani
 
 # When someone opens a pull request that only modifies those folders / files, 
 # only @mozilla-mobile/fxios-automation and not the global


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
In https://github.com/mozilla-mobile/firefox-ios/pull/28584 I updated the codeowners for the whole `MozillaRustComponents` since it was synced via automation and we didn't own the swift files yet. Now `MozillaRustComponents` is the source of the truth and only the `Package.*` and files under `Generated/` are updated and shouldn't be changed manually.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
