### PR TITLE
Update [No ticket] Set Default language to en-US for tests only

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -18,7 +18,7 @@
         "argument" : "FIREFOX_TEST"
       }
     ],
-    "language" : "en",
+    "language" : "en-US",
     "region" : "US",
     "targetForVariableExpansion" : {
       "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -10,6 +10,8 @@
   ],
   "defaultOptions" : {
     "codeCoverage" : false,
+    "language" : "en-US",
+    "region" : "US",
     "testRepetitionMode" : "retryOnFailure"
   },
   "testTargets" : [


### PR DESCRIPTION
## :scroll: Tickets
N/A

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
For smoke tests and full functional tests, let's set the default language to en-US and locale to US. The locale affects the address tests when I test locally.

With this setting, I do not have to reset the locale of my simulators before running the tests. When I launch Fennec manually not within a test, the locale of the simulator is applied (English Canada in my case).

This change should not change the behaviour of the app outside of the XCUITest context.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
