### PR TITLE
Add FXIOS-13525 - [Minimal Address Bar] - Animate minimal address bar to full size on tap

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -862,7 +862,7 @@ class BrowserViewController: UIViewController,
 
         if let tab = tabManager.selectedTab, !tab.isFindInPageMode {
             // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)
-            scrollController.showToolbars(animated: false)
+            if !isMinimalAddressBarEnabled { scrollController.showToolbars(animated: false) }
         }
         navigationHandler?.showTermsOfUse(context: .appBecameActive)
         browserDidBecomeActive()

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -266,9 +266,19 @@ final class LegacyTabScrollController: NSObject,
     func configureToolbarViews(overKeyboardContainer: BaseAlphaStackView?,
                                bottomContainer: BaseAlphaStackView?,
                                headerContainer: BaseAlphaStackView?) {
+        let tapHandler = createToolbarTapHandler()
+        overKeyboardContainer?.onTap = tapHandler
+        headerContainer?.onTap = tapHandler
         self.overKeyboardContainer = overKeyboardContainer
         self.bottomContainer = bottomContainer
         self.headerContainer = headerContainer
+    }
+
+    private func createToolbarTapHandler() -> (() -> Void) {
+        return { [unowned self] in
+            guard isMinimalAddressBarEnabled && toolbarState == .collapsed else { return }
+            showToolbars(animated: true)
+        }
     }
 
     @MainActor

--- a/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
+++ b/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
@@ -14,6 +14,7 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
     var isClearBackground = false
     var isSpacerClearBackground = false
     lazy var toolbarHelper: ToolbarHelperInterface = ToolbarHelper()
+    var onTap: (() -> Void)?
 
     private var isToolbarRefactorEnabled: Bool {
         return FxNimbus.shared.features.toolbarRefactorFeature.value().enabled
@@ -27,6 +28,7 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
         super.init(frame: frame)
 
         setupStyle()
+        setupTapGesture()
     }
 
     required init(coder: NSCoder) {
@@ -44,6 +46,16 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
         axis = .vertical
         distribution = .fill
         alignment = .fill
+    }
+
+    private func setupTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        addGestureRecognizer(tapGesture)
+    }
+
+    @objc
+    private func handleTap() {
+        onTap?()
     }
 
     // MARK: - Spacer view

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
@@ -300,6 +300,26 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         XCTAssertEqual(result, .zero)
     }
 
+    func testToolbarTapHandler_WhenMinimalAddressBarEnabledAndCollapsed_ShowsToolbar() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        subject.toolbarState = .collapsed
+        overKeyboardContainer.onTap?()
+
+        XCTAssertEqual(subject.toolbarState, .visible)
+    }
+
+    func testToolbarTapHandler_WhenToolbarVisible_DoesNothing() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        subject.toolbarState = .visible
+        overKeyboardContainer.onTap?()
+
+        XCTAssertEqual(subject.toolbarState, .visible)
+    }
+
     // MARK: - Setup
     private func setupTabScroll(with subject: LegacyTabScrollController) {
         tab.createWebview(configuration: .init())


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13525)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Animate minimal address bar to full size on tap.
- If the address bar is minimized avoid resizing to the full size to avoid UI glitch.
- Write unit tests.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

https://github.com/user-attachments/assets/1b3cdd94-44ac-450e-8cce-813faf6b34b3


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
