### PR TITLE
Bugfix FXIOS-13476 [Summarizer] Enable apple intelligence for users with lang is english

### DIFF
--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -36,6 +36,11 @@ final class AppLaunchUtil: Sendable {
         }
 
         DefaultBrowserUtil().processUserDefaultState(isFirstRun: introScreenManager.shouldShowIntroScreen)
+        if #available(iOS 26, *) {
+            #if canImport(FoundationModels)
+                AppleIntelligenceUtil().processAvailabilityState()
+            #endif
+        }
 
         // Need to get "settings.sendCrashReports" this way so that Sentry can be initialized before getting the Profile.
         let sendCrashReports = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.prefSendCrashReports) ?? true

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerNimbusUtils.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerNimbusUtils.swift
@@ -66,7 +66,8 @@ struct DefaultSummarizerNimbusUtils: FeatureFlaggable, SummarizerNimbusUtils {
     func isAppleSummarizerEnabled() -> Bool {
         #if canImport(FoundationModels)
             let isFlagEnabled = featureFlags.isFeatureEnabled(.appleSummarizer, checking: .buildOnly)
-            return AppleIntelligenceUtil().isAppleIntelligenceAvailable && isFlagEnabled
+            let isEngLang = NSLocale.current.languageCode == "en"
+            return isEngLang && AppleIntelligenceUtil().isAppleIntelligenceAvailable && isFlagEnabled
         #else
             return false
         #endif
@@ -78,7 +79,8 @@ struct DefaultSummarizerNimbusUtils: FeatureFlaggable, SummarizerNimbusUtils {
 
     private func isAppleSummarizerToolbarEndpointEnabled() -> Bool {
         let isFlagEnabled = featureFlags.isFeatureEnabled(.appleSummarizerToolbarEntrypoint, checking: .buildOnly)
-        return isAppleSummarizerEnabled() && isFlagEnabled
+        let isEngLang = NSLocale.current.languageCode == "en"
+        return isEngLang && isAppleSummarizerEnabled() && isFlagEnabled
     }
 
     private func isHostedSummarizerToolbarEndpointEnabled() -> Bool {
@@ -88,7 +90,8 @@ struct DefaultSummarizerNimbusUtils: FeatureFlaggable, SummarizerNimbusUtils {
 
     private func isAppleSummarizerShakeGestureEnabled() -> Bool {
         let isShakeEnabled = featureFlags.isFeatureEnabled(.appleSummarizerShakeGesture, checking: .buildOnly)
-        return isAppleSummarizerEnabled() && isShakeEnabled
+        let isEngLang = NSLocale.current.languageCode == "en"
+        return isEngLang && isAppleSummarizerEnabled() && isShakeEnabled
     }
 
     private func isHostedSummarizerShakeGestureEnabled() -> Bool {

--- a/firefox-ios/nimbus-features/appleSummarizerFeature.yaml
+++ b/firefox-ios/nimbus-features/appleSummarizerFeature.yaml
@@ -8,17 +8,17 @@ features:
         description: >
           Enables the apple summarizer feature.
         type: Boolean
-        default: false
+        default: true
       toolbarEntrypoint:
         description: >
           Enables the toolbar entrypoint for the summarizer feature.
         type: Boolean
-        default: false
+        default: true
       shakeGesture:
         description: >
           Enables the shake gesture for the summarizer feature.
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13476)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29289)

## :bulb: Description
This PR:
- Enables apple intelligence by default for users that support it and users that have english lang.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
