### PR TITLE
Refactor FXIOS-13527 [Nimbus] Homepage rebuild and privacy UI by default in release

### DIFF
--- a/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
+++ b/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
@@ -6,7 +6,7 @@ features:
       simplified-ui-enabled:
         description: If true, enable simplified UI part of Felt Privacy
         type: Boolean
-        default: false
+        default: true
       felt-deletion-enabled:
         description: If true, enable Felt Deletion part of Felt Privacy
         type: Boolean
@@ -21,4 +21,3 @@ features:
         value:
           simplified-ui-enabled: true
           felt-deletion-enabled: false
-

--- a/firefox-ios/nimbus-features/homepageRebuildFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRebuildFeature.yaml
@@ -8,7 +8,7 @@ features:
         description: >
           If true, enables the feature
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13527)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
