### PR TITLE
Add FXIOS [Localization] Modify codeowners to add default reviewer for strings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 /firefox-ios/Client/Experiments/initial_experiments.json @afurlan-firefox
 /firefox-ios/Client/Assets/CC_Script @nbhasin2 @issammani
 /firefox-ios/Client/Assets/RemoteSettingsData/ @nbhasin2 @issammani @mattreaganmozilla
-/firefox-ios/Shared/Strings.swift @Delphine
+/firefox-ios/Shared/Strings.swift @firefox-ios-l10n
 /MozillaRustComponents/Package.swift @issammani
 /MozillaRustComponents/Package.resolved @issammani
 /MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated @issammani

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 /firefox-ios/Client/Experiments/initial_experiments.json @afurlan-firefox
 /firefox-ios/Client/Assets/CC_Script @nbhasin2 @issammani
 /firefox-ios/Client/Assets/RemoteSettingsData/ @nbhasin2 @issammani @mattreaganmozilla
+/firefox-ios/Shared/Strings.swift @Delphine
 /MozillaRustComponents/Package.swift @issammani
 /MozillaRustComponents/Package.resolved @issammani
 /MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated @issammani


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
Delphine will review the strings changes when they are added into the project, rather than only having a look when the localization strings are exported towards l10n. This will make it easier to make modification, since we won't have to track down who added a particular string.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
