### PR TITLE
Fix FXIOS-13408 [Tab Tray Animation] [iOS 26] Fix tab tray animation dismissal showing the collectionView creating the tab during the animation

### DIFF
--- a/firefox-ios/Client/Extensions/UIViewController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIViewController+Extension.swift
@@ -48,6 +48,29 @@ extension UIViewController {
         return false
     }
 
+    /// Can be used to take a screenshot of a ViewController's view
+    func takeScreenshot() -> UIImageView? {
+        guard
+            isViewLoaded,
+            let view = self.view
+        else { return nil }
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = UIScreen.main.scale
+        format.opaque = view.isOpaque
+
+        let renderer = UIGraphicsImageRenderer(size: view.bounds.size, format: format)
+        let image = renderer.image { _ in
+            view.drawHierarchy(in: view.bounds, afterScreenUpdates: false)
+        }
+
+        let imageView = UIImageView(image: image)
+        imageView.frame = view.bounds
+        imageView.isUserInteractionEnabled = false
+        imageView.contentMode = .scaleToFill  // same size as source view
+        return imageView
+    }
+
     /// This presents a View Controller with a bar button item that can be used to dismiss the VC
     /// - Parameters:
     ///     - navItemLocation: Define whether dismiss bar button item should be on the right

--- a/firefox-ios/Client/Extensions/UIViewController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIViewController+Extension.swift
@@ -48,29 +48,6 @@ extension UIViewController {
         return false
     }
 
-    /// Can be used to take a screenshot of a ViewController's view
-    func takeScreenshot() -> UIImageView? {
-        guard
-            isViewLoaded,
-            let view = self.view
-        else { return nil }
-
-        let format = UIGraphicsImageRendererFormat()
-        format.scale = UIScreen.main.scale
-        format.opaque = view.isOpaque
-
-        let renderer = UIGraphicsImageRenderer(size: view.bounds.size, format: format)
-        let image = renderer.image { _ in
-            view.drawHierarchy(in: view.bounds, afterScreenUpdates: false)
-        }
-
-        let imageView = UIImageView(image: image)
-        imageView.frame = view.bounds
-        imageView.isUserInteractionEnabled = false
-        imageView.contentMode = .scaleToFill  // same size as source view
-        return imageView
-    }
-
     /// This presents a View Controller with a bar button item that can be used to dismiss the VC
     /// - Parameters:
     ///     - navItemLocation: Define whether dismiss bar button item should be on the right

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -427,7 +427,7 @@ final class TabManagerMiddleware: FeatureFlaggable {
         let tab = tabManager.addTab(urlRequest, isPrivate: isPrivate)
         tabManager.selectTab(tab)
 
-        let model = getTabsDisplayModel(for: isPrivate, uuid: uuid)
+   //     let model = getTabsDisplayModel(for: isPrivate, uuid: uuid)
 //        let refreshAction = TabPanelMiddlewareAction(tabDisplayModel: model,
 //                                                     windowUUID: uuid,
 //                                                     actionType: TabPanelMiddlewareActionType.refreshTabs)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -428,7 +428,9 @@ final class TabManagerMiddleware: FeatureFlaggable {
         tabManager.selectTab(tab)
 
         // We do not dispatch a refresh action here because when this method is called
-        // we are always navigating away from the view.
+        // we are always navigating away from the view, and we call ScreenshotHelper.takeScreenshot
+        // which refreshes the tabs when it has a screenshot. If we change this behaviour in the future
+        // it may require us to add a refresh action here.
 
         let dismissAction = TabTrayAction(windowUUID: uuid,
                                           actionType: TabTrayActionType.dismissTabTray)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -427,6 +427,9 @@ final class TabManagerMiddleware: FeatureFlaggable {
         let tab = tabManager.addTab(urlRequest, isPrivate: isPrivate)
         tabManager.selectTab(tab)
 
+        // We do not dispatch a refresh action here because when this method is called
+        // we are always navigating away from the view.
+
         let dismissAction = TabTrayAction(windowUUID: uuid,
                                           actionType: TabTrayActionType.dismissTabTray)
         store.dispatchLegacy(dismissAction)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -428,10 +428,10 @@ final class TabManagerMiddleware: FeatureFlaggable {
         tabManager.selectTab(tab)
 
         let model = getTabsDisplayModel(for: isPrivate, uuid: uuid)
-        let refreshAction = TabPanelMiddlewareAction(tabDisplayModel: model,
-                                                     windowUUID: uuid,
-                                                     actionType: TabPanelMiddlewareActionType.refreshTabs)
-        store.dispatchLegacy(refreshAction)
+//        let refreshAction = TabPanelMiddlewareAction(tabDisplayModel: model,
+//                                                     windowUUID: uuid,
+//                                                     actionType: TabPanelMiddlewareActionType.refreshTabs)
+//        store.dispatchLegacy(refreshAction)
 
         let dismissAction = TabTrayAction(windowUUID: uuid,
                                           actionType: TabTrayActionType.dismissTabTray)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -427,11 +427,6 @@ final class TabManagerMiddleware: FeatureFlaggable {
         let tab = tabManager.addTab(urlRequest, isPrivate: isPrivate)
         tabManager.selectTab(tab)
 
-        // We do not dispatch a refresh action here because when this method is called
-        // we are always navigating away from the view, and we call ScreenshotHelper.takeScreenshot
-        // which refreshes the tabs when it has a screenshot. If we change this behaviour in the future
-        // it may require us to add a refresh action here.
-
         let dismissAction = TabTrayAction(windowUUID: uuid,
                                           actionType: TabTrayActionType.dismissTabTray)
         store.dispatchLegacy(dismissAction)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -427,12 +427,6 @@ final class TabManagerMiddleware: FeatureFlaggable {
         let tab = tabManager.addTab(urlRequest, isPrivate: isPrivate)
         tabManager.selectTab(tab)
 
-   //     let model = getTabsDisplayModel(for: isPrivate, uuid: uuid)
-//        let refreshAction = TabPanelMiddlewareAction(tabDisplayModel: model,
-//                                                     windowUUID: uuid,
-//                                                     actionType: TabPanelMiddlewareActionType.refreshTabs)
-//        store.dispatchLegacy(refreshAction)
-
         let dismissAction = TabTrayAction(windowUUID: uuid,
                                           actionType: TabTrayActionType.dismissTabTray)
         store.dispatchLegacy(dismissAction)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -435,28 +435,3 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         }
     }
 }
-
-extension UIViewController {
-    @MainActor
-    func takeScreenshot() -> UIImageView? {
-        guard
-            isViewLoaded,
-            let view = self.view
-        else { return nil }
-
-        let format = UIGraphicsImageRendererFormat()
-        format.scale = UIScreen.main.scale
-        format.opaque = view.isOpaque
-
-        let renderer = UIGraphicsImageRenderer(size: view.bounds.size, format: format)
-        let image = renderer.image { _ in
-            view.drawHierarchy(in: view.bounds, afterScreenUpdates: false)
-        }
-
-        let imageView = UIImageView(image: image)
-        imageView.frame = view.bounds
-        imageView.isUserInteractionEnabled = false
-        imageView.contentMode = .scaleToFill  // same size as source view
-        return imageView
-    }
-}

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -377,7 +377,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
                 tabSnapshot.layer.cornerRadius = UX.zeroCornerRadius
             } completion: { _ in
                 contentContainer.isHidden = false
-                //tabCell?.isHidden = false
+                // tabCell?.isHidden = false
                 self.view.removeFromSuperview()
                 tabSnapshot.removeFromSuperview()
                 tabTraySnapshot.removeFromSuperview()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -416,12 +416,11 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         toView: UIView,
         context: UIViewControllerContextTransitioning
     ) {
-        // Take a screenshot of the tab tray before the view is refreshed so that we don't
-        // see the tab appearing in the collection view before we are done animating
-        guard let tabTraySnapshot = panelViewController.takeScreenshot() else {
-            context.completeTransition(true)
-            return
-        }
+        let snapshot = panelViewController.view.snapshot
+        let tabTraySnapshot = UIImageView(image: snapshot)
+        tabTraySnapshot.frame = view.bounds
+        tabTraySnapshot.isUserInteractionEnabled = false
+        tabTraySnapshot.contentMode = .scaleToFill
 
         contentContainer.isHidden = true
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -416,6 +416,8 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         toView: UIView,
         context: UIViewControllerContextTransitioning
     ) {
+        // Take a screenshot of the tab tray before the view is refreshed so that we don't
+        // see the tab appearing in the collection view before we are done animating
         guard let tabTraySnapshot = panelViewController.takeScreenshot() else {
             context.completeTransition(true)
             return

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -422,13 +422,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         tabTraySnapshot.contentMode = .scaleToFill
 
         contentContainer.alpha = UX.clearAlpha
-
-        tabTraySnapshot.layer.cornerCurve = .continuous
-        tabTraySnapshot.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
-        tabTraySnapshot.clipsToBounds = true
-
-        toView.layer.cornerCurve = .continuous
-        toView.clipsToBounds = true
         toView.alpha = UX.clearAlpha
 
         context.containerView.addSubview(tabTraySnapshot)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -419,7 +419,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         let snapshot = panelViewController.view.snapshot
         let tabTraySnapshot = UIImageView(image: snapshot)
         tabTraySnapshot.frame = view.bounds
-        tabTraySnapshot.isUserInteractionEnabled = false
         tabTraySnapshot.contentMode = .scaleToFill
 
         contentContainer.isHidden = true

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -315,112 +315,139 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             return
         }
 
+        let contentContainer = browserVC.contentContainer
+
         if selectedTab.screenshot == nil {
-            guard let tabTraySnapshot = panelViewController.takeScreenshot()
-            else {
-                context.completeTransition(true)
-                return
-            }
-
-            let contentContainer = browserVC.contentContainer
-            contentContainer.isHidden = true
-
-            tabTraySnapshot.layer.cornerCurve = .continuous
-            tabTraySnapshot.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
-            tabTraySnapshot.clipsToBounds = true
-            tabTraySnapshot.alpha = UX.opaqueAlpha
-
-            toView.layer.cornerCurve = .continuous
-            toView.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
-            toView.clipsToBounds = true
-            toView.alpha = UX.clearAlpha
-
-            context.containerView.addSubview(tabTraySnapshot)
-            context.containerView.addSubview(toView)
-
-            UIView.animate(
-                withDuration: UX.dismissDuration,
-                delay: 0.0,
-                options: .curveEaseOut) {
-                tabTraySnapshot.transform = .init(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
-
-                toView.alpha = UX.opaqueAlpha
-                toView.layer.cornerRadius = UX.zeroCornerRadius
-            } completion: { _ in
-                contentContainer.isHidden = false
-                self.view.removeFromSuperview()
-                tabTraySnapshot.removeFromSuperview()
-                toView.removeFromSuperview()
-                context.completeTransition(true)
-            }
+            dismissWithoutTabScreenshot(panelViewController: panelViewController,
+                                        contentContainer: contentContainer,
+                                        toView: toView,
+                                        context: context)
         } else {
-            let cv = panelViewController.tabDisplayView.collectionView
-            guard let dataSource = cv.dataSource as? TabDisplayDiffableDataSource,
-                  let item = findItem(by: selectedTab.tabUUID, dataSource: dataSource)
-            else {
-                // We don't have a collection view when the view is empty (ex: in private tabs)
-                context.completeTransition(true)
-                return
-            }
+            dismissWithTabScreenshot(panelViewController: panelViewController,
+                                     contentContainer: contentContainer,
+                                     toView: toView,
+                                     context: context,
+                                     selectedTab: selectedTab,
+                                     browserVC: browserVC)
+        }
+    }
 
-            let contentContainer = browserVC.contentContainer
-            let tabSnapshot = UIImageView(image: selectedTab.screenshot)
-            // crop the tab screenshot to the contentContainer frame so the animation
-            // and the initial transform doesn't stutter
-            if let image = tabSnapshot.image, let croppedImage = image.cgImage?.cropping(
-                to: CGRect(
-                    x: contentContainer.frame.origin.x * image.scale,
-                    y: contentContainer.frame.origin.y * image.scale,
-                    width: contentContainer.frame.width * image.scale,
-                    height: contentContainer.frame.height * image.scale
-                )
-            ) {
-                tabSnapshot.image = UIImage(cgImage: croppedImage)
-            }
+    private func dismissWithTabScreenshot(
+        panelViewController: TabDisplayPanelViewController,
+        contentContainer: UIView,
+        toView: UIView,
+        context: UIViewControllerContextTransitioning,
+        selectedTab: Tab,
+        browserVC: BrowserViewController
+    ) {
+        let cv = panelViewController.tabDisplayView.collectionView
+        guard let dataSource = cv.dataSource as? TabDisplayDiffableDataSource,
+              let item = findItem(by: selectedTab.tabUUID, dataSource: dataSource)
+        else {
+            // We don't have a collection view when the view is empty (ex: in private tabs)
+            context.completeTransition(true)
+            return
+        }
 
-            tabSnapshot.clipsToBounds = true
-            tabSnapshot.contentMode = .scaleAspectFill
-            tabSnapshot.layer.cornerCurve = .continuous
-            tabSnapshot.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
+        let tabSnapshot = UIImageView(image: selectedTab.screenshot)
+        // crop the tab screenshot to the contentContainer frame so the animation
+        // and the initial transform doesn't stutter
+        if let image = tabSnapshot.image, let croppedImage = image.cgImage?.cropping(
+            to: CGRect(
+                x: contentContainer.frame.origin.x * image.scale,
+                y: contentContainer.frame.origin.y * image.scale,
+                width: contentContainer.frame.width * image.scale,
+                height: contentContainer.frame.height * image.scale
+            )
+        ) {
+            tabSnapshot.image = UIImage(cgImage: croppedImage)
+        }
 
-            contentContainer.isHidden = true
+        tabSnapshot.clipsToBounds = true
+        tabSnapshot.contentMode = .scaleAspectFill
+        tabSnapshot.layer.cornerCurve = .continuous
+        tabSnapshot.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
 
-            toView.layer.cornerCurve = .continuous
-            toView.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
-            toView.clipsToBounds = true
-            toView.alpha = UX.clearAlpha
+        contentContainer.isHidden = true
 
-            context.containerView.addSubview(toView)
-            context.containerView.addSubview(tabSnapshot)
+        toView.layer.cornerCurve = .continuous
+        toView.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
+        toView.clipsToBounds = true
+        toView.alpha = UX.clearAlpha
 
-            var tabCell: ExperimentTabCell?
-            if let indexPath = dataSource.indexPath(for: item),
-               let cell = cv.cellForItem(at: indexPath) as? ExperimentTabCell {
-                tabCell = cell
-                tabSnapshot.frame = cv.convert(cell.frame, to: browserVC.view)
+        context.containerView.addSubview(toView)
+        context.containerView.addSubview(tabSnapshot)
 
-                cell.isHidden = true
-            }
+        var tabCell: ExperimentTabCell?
+        if let indexPath = dataSource.indexPath(for: item),
+           let cell = cv.cellForItem(at: indexPath) as? ExperimentTabCell {
+            tabCell = cell
+            tabSnapshot.frame = cv.convert(cell.frame, to: browserVC.view)
 
-            UIView.animate(
-                withDuration: UX.dismissDuration,
-                delay: 0.0,
-                options: .curveEaseOut) {
-                cv.transform = .init(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
-                cv.alpha = UX.opaqueAlpha
+            cell.isHidden = true
+        }
 
-                tabSnapshot.frame = contentContainer.frame
-                toView.alpha = UX.opaqueAlpha
-                toView.layer.cornerRadius = UX.zeroCornerRadius
-                tabSnapshot.layer.cornerRadius = UX.zeroCornerRadius
-            } completion: { _ in
-                contentContainer.isHidden = false
-                tabCell?.isHidden = false
-                self.view.removeFromSuperview()
-                tabSnapshot.removeFromSuperview()
-                toView.removeFromSuperview()
-                context.completeTransition(true)
-            }
+        UIView.animate(
+            withDuration: UX.dismissDuration,
+            delay: 0.0,
+            options: .curveEaseOut) {
+            cv.transform = .init(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
+            cv.alpha = UX.opaqueAlpha
+
+            tabSnapshot.frame = contentContainer.frame
+            toView.alpha = UX.opaqueAlpha
+            toView.layer.cornerRadius = UX.zeroCornerRadius
+            tabSnapshot.layer.cornerRadius = UX.zeroCornerRadius
+        } completion: { _ in
+            contentContainer.isHidden = false
+            tabCell?.isHidden = false
+            self.view.removeFromSuperview()
+            tabSnapshot.removeFromSuperview()
+            toView.removeFromSuperview()
+            context.completeTransition(true)
+        }
+    }
+
+    private func dismissWithoutTabScreenshot(
+        panelViewController: UIViewController,
+        contentContainer: UIView,
+        toView: UIView,
+        context: UIViewControllerContextTransitioning
+    ) {
+        guard let tabTraySnapshot = panelViewController.takeScreenshot() else {
+            context.completeTransition(true)
+            return
+        }
+
+        contentContainer.isHidden = true
+
+        tabTraySnapshot.layer.cornerCurve = .continuous
+        tabTraySnapshot.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
+        tabTraySnapshot.clipsToBounds = true
+        tabTraySnapshot.alpha = UX.opaqueAlpha
+
+        toView.layer.cornerCurve = .continuous
+        toView.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
+        toView.clipsToBounds = true
+        toView.alpha = UX.clearAlpha
+
+        context.containerView.addSubview(tabTraySnapshot)
+        context.containerView.addSubview(toView)
+
+        UIView.animate(
+            withDuration: UX.dismissDuration,
+            delay: 0.0,
+            options: .curveEaseOut
+        ) {
+            tabTraySnapshot.transform = .init(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
+            toView.alpha = UX.opaqueAlpha
+            toView.layer.cornerRadius = UX.zeroCornerRadius
+        } completion: { _ in
+            contentContainer.isHidden = false
+            self.view.removeFromSuperview()
+            tabTraySnapshot.removeFromSuperview()
+            toView.removeFromSuperview()
+            context.completeTransition(true)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -316,7 +316,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         }
 
         if selectedTab.screenshot == nil {
-            let cv = panelViewController.tabDisplayView.collectionView
             let contentContainer = browserVC.contentContainer
             let tabTraySnapshot = panelViewController.takeScreenshot(afterScreenUpdates: false)!
             let tabSnapshot = UIImageView(image: selectedTab.screenshot)
@@ -354,15 +353,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             context.containerView.addSubview(toView)
             context.containerView.addSubview(tabSnapshot)
 
-//            var tabCell: ExperimentTabCell?
-//            if let indexPath = dataSource.indexPath(for: item),
-//               let cell = cv.cellForItem(at: indexPath) as? ExperimentTabCell {
-//                tabCell = cell
-//                tabSnapshot.frame = cv.convert(cell.frame, to: browserVC.view)
-//
-//                cell.isHidden = true
-//            }
-
             UIView.animate(
                 withDuration: UX.dismissDuration,
                 delay: 0.0,
@@ -370,14 +360,12 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
                 tabTraySnapshot.transform = .init(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
                 tabSnapshot.alpha = UX.opaqueAlpha
 
-             //   tabTraySnapshot.alpha = UX.opaqueAlpha
                 tabSnapshot.frame = contentContainer.frame
                 toView.alpha = UX.opaqueAlpha
                 toView.layer.cornerRadius = UX.zeroCornerRadius
                 tabSnapshot.layer.cornerRadius = UX.zeroCornerRadius
             } completion: { _ in
                 contentContainer.isHidden = false
-                // tabCell?.isHidden = false
                 self.view.removeFromSuperview()
                 tabSnapshot.removeFromSuperview()
                 tabTraySnapshot.removeFromSuperview()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -23,7 +23,7 @@ extension TabTrayViewController: UIViewControllerTransitioningDelegate {
         static let dimmedWhiteValue = 0.0
 
         static let presentDuration: TimeInterval = 0.275
-        static let dismissDuration: TimeInterval = 3
+        static let dismissDuration: TimeInterval = 0.275
 
         static let cvScalingFactor = 1.2
         static let initialOpacity = 0.0

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -316,9 +316,13 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         }
 
         if selectedTab.screenshot == nil {
-            let contentContainer = browserVC.contentContainer
-            let tabTraySnapshot = panelViewController.takeScreenshot(afterScreenUpdates: false)!
+            guard let tabTraySnapshot = panelViewController.takeScreenshot()
+            else {
+                context.completeTransition(true)
+                return
+            }
 
+            let contentContainer = browserVC.contentContainer
             contentContainer.isHidden = true
 
             tabTraySnapshot.layer.cornerCurve = .continuous
@@ -434,9 +438,11 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
 
 extension UIViewController {
     @MainActor
-    func takeScreenshot(afterScreenUpdates: Bool = true) -> UIImageView? {
-        guard isViewLoaded else { return nil }
-        let view = self.view!
+    func takeScreenshot() -> UIImageView? {
+        guard
+            isViewLoaded,
+            let view = self.view
+        else { return nil }
 
         let format = UIGraphicsImageRendererFormat()
         format.scale = UIScreen.main.scale
@@ -444,7 +450,7 @@ extension UIViewController {
 
         let renderer = UIGraphicsImageRenderer(size: view.bounds.size, format: format)
         let image = renderer.image { _ in
-            view.drawHierarchy(in: view.bounds, afterScreenUpdates: afterScreenUpdates)
+            view.drawHierarchy(in: view.bounds, afterScreenUpdates: false)
         }
 
         let imageView = UIImageView(image: image)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -428,7 +428,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         tabTraySnapshot.clipsToBounds = true
 
         toView.layer.cornerCurve = .continuous
-        toView.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
         toView.clipsToBounds = true
         toView.alpha = UX.clearAlpha
 
@@ -443,7 +442,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             tabTraySnapshot.transform = .init(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
             toView.alpha = UX.opaqueAlpha
             contentContainer.alpha = UX.opaqueAlpha
-            toView.layer.cornerRadius = UX.zeroCornerRadius
         } completion: { _ in
             self.view.removeFromSuperview()
             tabTraySnapshot.removeFromSuperview()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -317,6 +317,8 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
 
         let contentContainer = browserVC.contentContainer
 
+        // if the selectedTab screenshot is nil we assume we have tapped the new tab button
+        // from the tab tray, learn more in private, or opened a tab from the sync'd tabs
         if selectedTab.screenshot == nil {
             dismissWithoutTabScreenshot(panelViewController: panelViewController,
                                         contentContainer: contentContainer,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -439,7 +439,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             delay: 0.0,
             options: .curveEaseOut
         ) {
-            tabTraySnapshot.transform = .init(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
+            tabTraySnapshot.transform = CGAffineTransform(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
             toView.alpha = UX.opaqueAlpha
             contentContainer.alpha = UX.opaqueAlpha
         } completion: { _ in

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -318,24 +318,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         if selectedTab.screenshot == nil {
             let contentContainer = browserVC.contentContainer
             let tabTraySnapshot = panelViewController.takeScreenshot(afterScreenUpdates: false)!
-            let tabSnapshot = UIImageView(image: selectedTab.screenshot)
-            // crop the tab screenshot to the contentContainer frame so the animation
-            // and the initial transform doesn't stutter
-            if let image = tabSnapshot.image, let croppedImage = image.cgImage?.cropping(
-                to: CGRect(
-                    x: contentContainer.frame.origin.x * image.scale,
-                    y: contentContainer.frame.origin.y * image.scale,
-                    width: contentContainer.frame.width * image.scale,
-                    height: contentContainer.frame.height * image.scale
-                )
-            ) {
-                tabSnapshot.image = UIImage(cgImage: croppedImage)
-            }
-
-            tabSnapshot.clipsToBounds = true
-            tabSnapshot.contentMode = .scaleAspectFill
-            tabSnapshot.layer.cornerCurve = .continuous
-            tabSnapshot.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
 
             contentContainer.isHidden = true
 
@@ -351,23 +333,18 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
 
             context.containerView.addSubview(tabTraySnapshot)
             context.containerView.addSubview(toView)
-            context.containerView.addSubview(tabSnapshot)
 
             UIView.animate(
                 withDuration: UX.dismissDuration,
                 delay: 0.0,
                 options: .curveEaseOut) {
                 tabTraySnapshot.transform = .init(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
-                tabSnapshot.alpha = UX.opaqueAlpha
 
-                tabSnapshot.frame = contentContainer.frame
                 toView.alpha = UX.opaqueAlpha
                 toView.layer.cornerRadius = UX.zeroCornerRadius
-                tabSnapshot.layer.cornerRadius = UX.zeroCornerRadius
             } completion: { _ in
                 contentContainer.isHidden = false
                 self.view.removeFromSuperview()
-                tabSnapshot.removeFromSuperview()
                 tabTraySnapshot.removeFromSuperview()
                 toView.removeFromSuperview()
                 context.completeTransition(true)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -428,7 +428,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         tabTraySnapshot.layer.cornerCurve = .continuous
         tabTraySnapshot.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
         tabTraySnapshot.clipsToBounds = true
-        tabTraySnapshot.alpha = UX.opaqueAlpha
 
         toView.layer.cornerCurve = .continuous
         toView.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -421,7 +421,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         tabTraySnapshot.frame = view.bounds
         tabTraySnapshot.contentMode = .scaleToFill
 
-        contentContainer.isHidden = true
+        contentContainer.alpha = UX.clearAlpha
 
         tabTraySnapshot.layer.cornerCurve = .continuous
         tabTraySnapshot.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
@@ -442,9 +442,9 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         ) {
             tabTraySnapshot.transform = .init(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
             toView.alpha = UX.opaqueAlpha
+            contentContainer.alpha = UX.opaqueAlpha
             toView.layer.cornerRadius = UX.zeroCornerRadius
         } completion: { _ in
-            contentContainer.isHidden = false
             self.view.removeFromSuperview()
             tabTraySnapshot.removeFromSuperview()
             toView.removeFromSuperview()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13408)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29149)

## :bulb: Description
This change stops the refreshing of the tabPanelState when we add a new tab. The refresh is performed already when we take a tab screenshot for the new tab so this improves performance a bit and also allows us to take a screenshot of the tabPanelView to overlay during the animation so we don't see the tab being updated when takeScreenshot is fired for the tab via redux action after the dismissal is initiated. 

I've added a comment to the `addNewTab` middleware noting why there is no refresh action there anymore in case we have a use case in the future where it's required again, but since we call the refresh action in one other place already this should be okay.

## Before
https://github.com/user-attachments/assets/c14e36d6-aef5-42b5-b5b6-4841d84f862a

## After
https://github.com/user-attachments/assets/3010057f-f3a8-4e3b-8aab-4604d568a6b8

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
