### PR TITLE
Refactor FXIOS-13532 [Swift 6 Migration] NotificationManager strict concurrency warnings

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1234,6 +1234,7 @@
 		8AD40FD127BADCBA00672675 /* ToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FD027BADCBA00672675 /* ToolbarButton.swift */; };
 		8AD40FD327BB068F00672675 /* MainMenuActionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FD227BB068F00672675 /* MainMenuActionHelper.swift */; };
 		8AD40FD527BB1C1000672675 /* LockButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FD427BB1C1000672675 /* LockButton.swift */; };
+		8ADA19A22E7DB86400E95E5E /* NotificationManagerTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADA19A12E7DB86400E95E5E /* NotificationManagerTelemetryTests.swift */; };
 		8ADAA6D42CD175FB00E3D3E8 /* StickersCatalog.xcstickers in Resources */ = {isa = PBXBuildFile; fileRef = 8ADAA6D32CD175FB00E3D3E8 /* StickersCatalog.xcstickers */; };
 		8ADAE41E2A33A0E2007BF926 /* ShowIntroductionSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADAE41D2A33A0E2007BF926 /* ShowIntroductionSetting.swift */; };
 		8ADAE4202A33A0FD007BF926 /* SendFeedbackSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADAE41F2A33A0FD007BF926 /* SendFeedbackSetting.swift */; };
@@ -8942,6 +8943,7 @@
 		8AD40FD227BB068F00672675 /* MainMenuActionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuActionHelper.swift; sourceTree = "<group>"; };
 		8AD40FD427BB1C1000672675 /* LockButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockButton.swift; sourceTree = "<group>"; };
 		8AD440CBBF202B15E74E186D /* ur */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ur; path = ur.lproj/Search.strings; sourceTree = "<group>"; };
+		8ADA19A12E7DB86400E95E5E /* NotificationManagerTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerTelemetryTests.swift; sourceTree = "<group>"; };
 		8ADAA6D32CD175FB00E3D3E8 /* StickersCatalog.xcstickers */ = {isa = PBXFileReference; lastKnownFileType = folder.stickers; path = StickersCatalog.xcstickers; sourceTree = "<group>"; };
 		8ADAE41D2A33A0E2007BF926 /* ShowIntroductionSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowIntroductionSetting.swift; sourceTree = "<group>"; };
 		8ADAE41F2A33A0FD007BF926 /* SendFeedbackSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendFeedbackSetting.swift; sourceTree = "<group>"; };
@@ -13520,6 +13522,7 @@
 		8AC225632B6D3F9600CDA7FD /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				8ADA19A12E7DB86400E95E5E /* NotificationManagerTelemetryTests.swift */,
 				C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */,
 				8A87E98B2E70792F006F0239 /* FxSuggestTelemetryTests.swift */,
 				C7F0514F2D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift */,
@@ -19216,6 +19219,7 @@
 				212985E72A72B39D00546684 /* ThemeSettingsControllerTests.swift in Sources */,
 				8A9E46BD2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift in Sources */,
 				216424D42E56175100A3AF40 /* MockTabScrollHandlerDelegate.swift in Sources */,
+				8ADA19A22E7DB86400E95E5E /* NotificationManagerTelemetryTests.swift in Sources */,
 				8A1A66072CDD168A00DD883C /* MockTopSiteHistoryManager.swift in Sources */,
 				8A5189C92C1B614E00CDB668 /* SearchViewModelTests.swift in Sources */,
 				E1463D0629830E4F0074E16E /* MockUserNotificationCenter.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -873,6 +873,7 @@
 		8A1A93592B757C7C0069C190 /* landscape.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A1A93532B757C7B0069C190 /* landscape.json */; };
 		8A1A935A2B757C7C0069C190 /* portrait.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A1A93542B757C7B0069C190 /* portrait.json */; };
 		8A1A935B2B757C7C0069C190 /* wave.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A1A93552B757C7B0069C190 /* wave.json */; };
+		8A1AB6BB2E7B8D5C00167FF5 /* NotificationManagerTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1AB6BA2E7B8D5C00167FF5 /* NotificationManagerTelemetry.swift */; };
 		8A1C0B8F2E723EDF0030DCC8 /* AppLaunchUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1C0B8E2E723EDC0030DCC8 /* AppLaunchUtilTests.swift */; };
 		8A1CBB952BE017D3008BE4D4 /* MicrosurveyPromptAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1CBB942BE017D3008BE4D4 /* MicrosurveyPromptAction.swift */; };
 		8A1CBB972BE0182C008BE4D4 /* MicrosurveyPromptMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1CBB962BE0182C008BE4D4 /* MicrosurveyPromptMiddleware.swift */; };
@@ -8597,6 +8598,7 @@
 		8A1A93532B757C7B0069C190 /* landscape.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = landscape.json; sourceTree = "<group>"; };
 		8A1A93542B757C7B0069C190 /* portrait.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = portrait.json; sourceTree = "<group>"; };
 		8A1A93552B757C7B0069C190 /* wave.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = wave.json; sourceTree = "<group>"; };
+		8A1AB6BA2E7B8D5C00167FF5 /* NotificationManagerTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerTelemetry.swift; sourceTree = "<group>"; };
 		8A1C0B8E2E723EDC0030DCC8 /* AppLaunchUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchUtilTests.swift; sourceTree = "<group>"; };
 		8A1CBB942BE017D3008BE4D4 /* MicrosurveyPromptAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyPromptAction.swift; sourceTree = "<group>"; };
 		8A1CBB962BE0182C008BE4D4 /* MicrosurveyPromptMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyPromptMiddleware.swift; sourceTree = "<group>"; };
@@ -15580,6 +15582,7 @@
 		E69DB0B91E97E301008A67E6 /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				8A1AB6BA2E7B8D5C00167FF5 /* NotificationManagerTelemetry.swift */,
 				8A732A812DE8AFCA0099F575 /* FxSuggestTelemetry.swift */,
 				8A0DF2C12D6D1C670066EC00 /* AutoplaySettingTelemetry.swift */,
 				43175DB726B87D2C00C41C31 /* AdsTelemetryHelper.swift */,
@@ -18465,6 +18468,7 @@
 				63F7A9AA2C7529ED005846F5 /* NativeErrorPageModel.swift in Sources */,
 				8A6E63CF2D4A7FB70040D355 /* SectionHeaderConfiguration.swift in Sources */,
 				63F7A9AC2C752BB0005846F5 /* NativeErrorPageViewController.swift in Sources */,
+				8A1AB6BB2E7B8D5C00167FF5 /* NotificationManagerTelemetry.swift in Sources */,
 				0E65573E2D81CD1A00D7F017 /* DownloadQueue.swift in Sources */,
 				C88E7A572A0553360072E638 /* OnboardingButtonInfoModel.swift in Sources */,
 				AB9A0C012C6CBC9100BFA22A /* TrackingProtectionDetailsViewController.swift in Sources */,

--- a/firefox-ios/Client/Application/BackgroundNotificationSurfaceUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundNotificationSurfaceUtility.swift
@@ -49,7 +49,7 @@ class BackgroundNotificationSurfaceUtility: BackgroundUtilityProtocol {
         let hasPermission = await notificationManager.hasPermission()
 
         if hasPermission, surfaceManager.shouldShowSurface {
-            surfaceManager.showNotificationSurface()
+            await surfaceManager.showNotificationSurface()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1049,6 +1049,8 @@ class BrowserViewController: UIViewController,
         subscribeToRedux()
         enqueueTabRestoration()
 
+        // FXIOS-13551 - testWillNavigateAway calls into viewDidLoad during unit tests, creates a leak
+        guard !AppConstants.isRunningUnitTest else { return }
         Task(priority: .background) { [weak self] in
             // App startup telemetry accesses RustLogins to queryLogins, shouldn't be on the app startup critical path
             await self?.trackStartupTelemetry()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1051,7 +1051,7 @@ class BrowserViewController: UIViewController,
 
         Task(priority: .background) { [weak self] in
             // App startup telemetry accesses RustLogins to queryLogins, shouldn't be on the app startup critical path
-            self?.trackStartupTelemetry()
+            await self?.trackStartupTelemetry()
         }
     }
 
@@ -5123,11 +5123,11 @@ extension BrowserViewController: DevicePickerViewControllerDelegate, Instruction
 }
 
 extension BrowserViewController {
-    func trackStartupTelemetry() {
+    func trackStartupTelemetry() async {
         let toolbarLocation: SearchBarPosition = self.isBottomSearchBar ? .bottom : .top
         SearchBarSettingsViewModel.recordLocationTelemetry(for: toolbarLocation)
         trackAccessibility()
-        trackNotificationPermission()
+        await trackNotificationPermission()
         appStartupTelemetry.sendStartupTelemetry()
         creditCardInitialSetupTelemetry()
     }
@@ -5178,7 +5178,7 @@ extension BrowserViewController {
         }
     }
 
-    func trackNotificationPermission() {
-        NotificationManager().getNotificationSettings(sendTelemetry: true) { _ in }
+    func trackNotificationPermission() async {
+        _ = await NotificationManager().getNotificationSettings(sendTelemetry: true)
     }
 }

--- a/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
@@ -50,18 +50,17 @@ class NotificationSurfaceManager: NotificationSurfaceDelegate {
     // MARK: - Functionality
     /// Checks whether a message exists, and is not expired, and schedules
     /// a notification to be presented.
-    func showNotificationSurface() {
+    func showNotificationSurface() async {
         guard let message = message, !message.isExpired else { return }
 
         let notificationId = Constant.notificationBaseId + ".\(message.id)"
 
         // Check if message is already getting displayed
-        notificationManager.findDeliveredNotificationForId(id: notificationId) { [weak self] notification in
-            // Don't schedule the notification again if it was already delivered
-            guard notification == nil else { return }
+        let notification = await notificationManager.findDeliveredNotificationForId(id: notificationId)
+        // Don't schedule the notification again if it was already delivered
+        guard notification == nil else { return }
 
-            self?.scheduleNotification(message: message, notificationId: notificationId)
-        }
+        scheduleNotification(message: message, notificationId: notificationId)
     }
 
     // MARK: NotificationSurfaceDelegate

--- a/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
@@ -34,9 +34,9 @@ final class DefaultAppStartupTelemetry: AppStartupTelemetry {
     // MARK: Credit Cards
     func queryCreditCards() {
         _ = profile.autofill.reopenIfClosed()
-        profile.autofill.listCreditCards(completion: { cards, error in
+        profile.autofill.listCreditCards(completion: { [weak self] cards, error in
             guard let cards = cards, error == nil else { return }
-            self.sendCreditCardsSavedAllTelemetry(numberOfSavedCreditCards: cards.count)
+            self?.sendCreditCardsSavedAllTelemetry(numberOfSavedCreditCards: cards.count)
         })
     }
 
@@ -51,8 +51,8 @@ final class DefaultAppStartupTelemetry: AppStartupTelemetry {
         let dataSource = LoginDataSource(viewModel: loginsViewModel)
         loginsViewModel.loadLogins(loginDataSource: dataSource)
 
-        loginsViewModel.queryLogins("") { logins in
-            self.sendLoginsSavedAllTelemetry(numberOfSavedLogins: logins.count)
+        loginsViewModel.queryLogins("") { [weak self] logins in
+            self?.sendLoginsSavedAllTelemetry(numberOfSavedLogins: logins.count)
         }
     }
 
@@ -67,16 +67,16 @@ final class DefaultAppStartupTelemetry: AppStartupTelemetry {
     func queryBookmarks() {
         profile.places
             .getBookmarksTree(rootGUID: BookmarkRoots.MobileFolderGUID, recursive: false)
-            .uponQueue(.main) { result in
+            .uponQueue(.main) { [weak self] result in
                 guard let mobileFolder = result.successValue as? BookmarkFolderData else {
                     return
                 }
 
                 if let mobileBookmarks = mobileFolder.fxChildren, !mobileBookmarks.isEmpty {
-                    self.sendDoesHaveMobileBookmarksTelemetry()
-                    self.sendMobileBookmarksCountTelemetry(bookmarksCount: Int64(mobileBookmarks.count))
+                    self?.sendDoesHaveMobileBookmarksTelemetry()
+                    self?.sendMobileBookmarksCountTelemetry(bookmarksCount: Int64(mobileBookmarks.count))
                 } else {
-                    self.sendDoesntHaveMobileBookmarksTelemetry()
+                    self?.sendDoesntHaveMobileBookmarksTelemetry()
                 }
             }
     }

--- a/firefox-ios/Client/Telemetry/NotificationManagerTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/NotificationManagerTelemetry.swift
@@ -12,9 +12,7 @@ struct NotificationManagerTelemetry {
         self.gleanWrapper = gleanWrapper
     }
 
-    func sendNotificationPermission(settings: NotificationSettingsSnapshot) {
-        guard !AppConstants.isRunningUnitTest else { return }
-
+    func sendNotificationPermission(settings: NotificationSettings) {
         var authorizationStatus = ""
         switch settings.authorizationStatus {
         case .authorized: authorizationStatus = "authorized"
@@ -47,3 +45,10 @@ struct NotificationManagerTelemetry {
                                  extras: permissionExtra)
     }
 }
+
+protocol NotificationSettings {
+    var authorizationStatus: UNAuthorizationStatus { get }
+    var alertSetting: UNNotificationSetting { get }
+}
+
+extension UNNotificationSettings: NotificationSettings {}

--- a/firefox-ios/Client/Telemetry/NotificationManagerTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/NotificationManagerTelemetry.swift
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Glean
+
+struct NotificationManagerTelemetry {
+    static func sendTelemetry(settings: NotificationSettingsSnapshot) {
+        guard !AppConstants.isRunningUnitTest else { return }
+
+        var authorizationStatus = ""
+        switch settings.authorizationStatus {
+        case .authorized: authorizationStatus = "authorized"
+        case .denied: authorizationStatus = "denied"
+        case .ephemeral: authorizationStatus = "ephemeral"
+        case .provisional: authorizationStatus = "provisional"
+        case .notDetermined: authorizationStatus = "notDetermined"
+        @unknown default: authorizationStatus = "notDetermined"
+        }
+
+        var alertSetting = ""
+        switch settings.alertSetting {
+        case .enabled: alertSetting = "enabled"
+        case .disabled: alertSetting = "disabled"
+        case .notSupported: alertSetting = "notSupported"
+        @unknown default: alertSetting = "notSupported"
+        }
+
+        let extras = [TelemetryWrapper.EventExtraKey.notificationPermissionStatus.rawValue: authorizationStatus,
+                      TelemetryWrapper.EventExtraKey.notificationPermissionAlertSetting.rawValue: alertSetting]
+
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .view,
+                                     object: .notificationPermission,
+                                     extras: extras)
+    }
+}

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -458,7 +458,6 @@ extension TelemetryWrapper {
         case creditCardSavedAll = "creditCard-saved-all"
         case creditCardDeleted = "creditCard-deleted"
         case creditCardModified = "creditCard-modified"
-        case notificationPermission = "notificationPermission"
         case defaultBrowser = "defaultBrowser"
         case choiceScreenAcquisition = "choiceScreenAcquisition"
         case engagementNotification = "engagementNotification"
@@ -707,11 +706,6 @@ extension TelemetryWrapper {
         case flowType = "flow-type"
         case buttonAction = "button-action"
         case multipleChoiceButtonAction = "mutiple-choice-button-action"
-
-        // Notification permission
-        case notificationPermissionIsGranted = "is-granted"
-        case notificationPermissionStatus = "status"
-        case notificationPermissionAlertSetting = "alert-setting"
 
         // Credit card
         case isCreditCardAutofillToggleEnabled = "is-credit-card-autofill-toggle-enabled"
@@ -1135,20 +1129,6 @@ extension TelemetryWrapper {
             GleanMetrics.DefaultBrowserCard.goToSettingsPressed.add()
         case (.action, .open, .asDefaultBrowser, _, _):
             GleanMetrics.App.openedAsDefaultBrowser.add()
-        case(.action, .view, .notificationPermission, _, let extras):
-            if let status = extras?[EventExtraKey.notificationPermissionStatus.rawValue] as? String,
-               let alertSetting = extras?[EventExtraKey.notificationPermissionAlertSetting.rawValue] as? String {
-                let permissionExtra = GleanMetrics.App.NotificationPermissionExtra(alertSetting: alertSetting,
-                                                                                   status: status)
-                GleanMetrics.App.notificationPermission.record(permissionExtra)
-            } else {
-                recordUninstrumentedMetrics(
-                    category: category,
-                    method: method,
-                    object: object,
-                    value: value,
-                    extras: extras)
-            }
         case (.action, .open, .defaultBrowser, _, let extras):
             if let isDefaultBrowser = extras?[EventExtraKey.isDefaultBrowser.rawValue] as? Bool {
                 GleanMetrics.App.defaultBrowser.set(isDefaultBrowser)
@@ -1280,18 +1260,6 @@ extension TelemetryWrapper {
             GleanMetrics.Onboarding.wallpaperSelectorView.record()
         case (.action, .close, .onboardingWallpaperSelector, _, _):
             GleanMetrics.Onboarding.wallpaperSelectorClose.record()
-        case(.prompt, .tap, .notificationPermission, _, let extras):
-            if let isPermissionGranted = extras?[EventExtraKey.notificationPermissionIsGranted.rawValue] as? Bool {
-                let permissionExtra = GleanMetrics.Onboarding.NotificationPermissionPromptExtra(granted: isPermissionGranted)
-                GleanMetrics.Onboarding.notificationPermissionPrompt.record(permissionExtra)
-            } else {
-                recordUninstrumentedMetrics(
-                    category: category,
-                    method: method,
-                    object: object,
-                    value: value,
-                    extras: extras)
-            }
 
         // MARK: Widget
         case (.action, .open, .mediumTabsOpenUrl, _, _):

--- a/firefox-ios/Client/UserNotificationCenterProtocol.swift
+++ b/firefox-ios/Client/UserNotificationCenterProtocol.swift
@@ -8,14 +8,14 @@ import UserNotifications
 /// Protocol for `UNUserNotificationCenter` methods so we can mock `UNUserNotificationCenter` for unit testing. We do this
 /// because the `init` method is marked unavailable for subclasses of the `UNUserNotificationCenter` (can't override it).
 protocol UserNotificationCenterProtocol {
-    func getNotificationSettings(completionHandler: @escaping @Sendable (UNNotificationSettings) -> Void)
+    func notificationSettings() async -> UNNotificationSettings
     func requestAuthorization(options: UNAuthorizationOptions,
                               completionHandler: @escaping @Sendable (Bool, Error?) -> Void)
     func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: (@Sendable (Error?) -> Void)?)
     func getPendingNotificationRequests(completionHandler: @escaping @Sendable ([UNNotificationRequest]) -> Void)
     func removePendingNotificationRequests(withIdentifiers identifiers: [String])
     func removeAllPendingNotificationRequests()
-    func getDeliveredNotifications(completionHandler: @escaping @Sendable ([UNNotification]) -> Void)
+    func deliveredNotifications() async -> [UNNotification]
     func removeDeliveredNotifications(withIdentifiers identifiers: [String])
     func removeAllDeliveredNotifications()
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/NotificationManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/NotificationManagerTests.swift
@@ -12,7 +12,8 @@ class NotificationManagerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         center = MockUserNotificationCenter()
-        notificationManager = NotificationManager(center: center)
+        let telemetry = NotificationManagerTelemetry(gleanWrapper: MockGleanWrapper())
+        notificationManager = NotificationManager(center: center, telemetry: telemetry)
     }
 
     override func tearDown() {
@@ -28,13 +29,9 @@ class NotificationManagerTests: XCTestCase {
         }
     }
 
-    func testGetNotificationSettings() {
-        let expectation = self.expectation(description: "notification manager")
-        notificationManager.getNotificationSettings { settings in
-            XCTAssertTrue(self.center.getSettingsWasCalled)
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 5)
+    func testGetNotificationSettings() async {
+        _ = await notificationManager.getNotificationSettings()
+        XCTAssertTrue(self.center.getSettingsWasCalled)
     }
 
     func testScheduleDate() {
@@ -53,16 +50,14 @@ class NotificationManagerTests: XCTestCase {
         XCTAssertTrue(center.addWasCalled)
     }
 
-    func testFindDeliveredNotifications() {
-        notificationManager.findDeliveredNotifications { notifications in
-            XCTAssertTrue(self.center.getDeliveredWasCalled)
-        }
+    func testFindDeliveredNotifications() async {
+        _ = await notificationManager.findDeliveredNotifications()
+        XCTAssertTrue(self.center.getDeliveredWasCalled)
     }
 
-    func testFindDeliveredNotificationForId() {
-        notificationManager.findDeliveredNotificationForId(id: "id1") { notifications in
-            XCTAssertTrue(self.center.getDeliveredWasCalled)
-        }
+    func testFindDeliveredNotificationForId() async {
+        _ = await notificationManager.findDeliveredNotificationForId(id: "id1")
+        XCTAssertTrue(self.center.getDeliveredWasCalled)
     }
 
     func testRemoveAllPendingNotifications() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNotificationManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNotificationManager.swift
@@ -23,11 +23,7 @@ class MockNotificationManager: NotificationManagerProtocol {
         return wasAuthorizationSuccessful
     }
 
-    func getNotificationSettings(sendTelemetry: Bool,
-                                 completion: @escaping @Sendable (NotificationSettingsSnapshot) -> Void) {
-    }
-
-    func getNotificationSettings(sendTelemetry: Bool) async -> NotificationSettingsSnapshot {
+    func getNotificationSettings(sendTelemetry: Bool) async -> UNNotificationSettings {
         return await NotificationManager().getNotificationSettings()
     }
 
@@ -65,11 +61,12 @@ class MockNotificationManager: NotificationManagerProtocol {
         scheduleWithIntervalWasCalled = true
     }
 
-    func findDeliveredNotifications(completion: @escaping @Sendable ([NotificationSnapshot]) -> Void) {
+    func findDeliveredNotifications() async -> [UNNotification] {
+        return []
     }
 
-    func findDeliveredNotificationForId(id: String, completion: @escaping @Sendable (NotificationSnapshot?) -> Void) {
-        completion(nil)
+    func findDeliveredNotificationForId(id: String) async -> UNNotification? {
+        return nil
     }
 
     var removeAllPendingNotificationsWasCalled = false

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNotificationManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNotificationManager.swift
@@ -11,27 +11,28 @@ class MockNotificationManager: NotificationManagerProtocol {
     var shouldGrantPermission = true
     var errorToReturn: Error?
 
-    func requestAuthorization(completion: @escaping (Bool, Error?) -> Void) {
+    func requestAuthorization(completion: @escaping @Sendable (Bool, Error?) -> Void) {
         requestAuthorizationCalled = true
         completion(shouldGrantPermission, errorToReturn)
     }
 
-    func requestAuthorization(completion: @escaping (Result<Bool, Error>) -> Void) {
+    func requestAuthorization(completion: @escaping @Sendable (Result<Bool, Error>) -> Void) {
     }
 
     func requestAuthorization() async throws -> Bool {
         return wasAuthorizationSuccessful
     }
 
-    func getNotificationSettings(sendTelemetry: Bool, completion: @escaping (UNNotificationSettings) -> Void) {
+    func getNotificationSettings(sendTelemetry: Bool,
+                                 completion: @escaping @Sendable (NotificationSettingsSnapshot) -> Void) {
     }
 
-    func getNotificationSettings(sendTelemetry: Bool) async -> UNNotificationSettings {
+    func getNotificationSettings(sendTelemetry: Bool) async -> NotificationSettingsSnapshot {
         return await NotificationManager().getNotificationSettings()
     }
 
     var hasPermission = true
-    func hasPermission(completion: @escaping (Bool) -> Void) {
+    func hasPermission(completion: @escaping @Sendable (Bool) -> Void) {
         completion(hasPermission)
     }
 
@@ -64,10 +65,10 @@ class MockNotificationManager: NotificationManagerProtocol {
         scheduleWithIntervalWasCalled = true
     }
 
-    func findDeliveredNotifications(completion: @escaping ([UNNotification]) -> Void) {
+    func findDeliveredNotifications(completion: @escaping @Sendable ([NotificationSnapshot]) -> Void) {
     }
 
-    func findDeliveredNotificationForId(id: String, completion: @escaping (UNNotification?) -> Void) {
+    func findDeliveredNotificationForId(id: String, completion: @escaping @Sendable (NotificationSnapshot?) -> Void) {
         completion(nil)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUserNotificationCenter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUserNotificationCenter.swift
@@ -6,7 +6,7 @@ import Foundation
 import UserNotifications
 @testable import Client
 
-class MockUserNotificationCenter: UserNotificationCenterProtocol {    
+class MockUserNotificationCenter: UserNotificationCenterProtocol {
     var pendingRequests = [UNNotificationRequest]()
 
     var getSettingsWasCalled = false

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUserNotificationCenter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUserNotificationCenter.swift
@@ -6,15 +6,15 @@ import Foundation
 import UserNotifications
 @testable import Client
 
-class MockUserNotificationCenter: UserNotificationCenterProtocol {
+class MockUserNotificationCenter: UserNotificationCenterProtocol {    
     var pendingRequests = [UNNotificationRequest]()
 
     var getSettingsWasCalled = false
-    func getNotificationSettings(completionHandler: @escaping (UNNotificationSettings) -> Void) {
+    func notificationSettings() async -> UNNotificationSettings {
         getSettingsWasCalled = true
 
         // calling UNUserNotificationCenter as UNNotificationSettings can't be created otherwise
-        UNUserNotificationCenter.current().getNotificationSettings(completionHandler: completionHandler)
+        return await UNUserNotificationCenter.current().notificationSettings()
     }
 
     var requestAuthorizationWasCalled = false
@@ -50,9 +50,9 @@ class MockUserNotificationCenter: UserNotificationCenterProtocol {
     }
 
     var getDeliveredWasCalled = false
-    func getDeliveredNotifications(completionHandler: @escaping ([UNNotification]) -> Void) {
+    func deliveredNotifications() async -> [UNNotification] {
         getDeliveredWasCalled = true
-        completionHandler([UNNotification]())
+        return []
     }
 
     var removeDeliveredWithIdsWasCalled = false

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
@@ -36,25 +36,25 @@ class NotificationSurfaceManagerTests: XCTestCase {
         XCTAssertTrue(subject.shouldShowSurface)
     }
 
-    func testShowSurface_noMessage() {
+    func testShowSurface_noMessage() async {
         let subject = createSubject()
 
         XCTAssertFalse(subject.shouldShowSurface)
 
-        subject.showNotificationSurface()
+        await subject.showNotificationSurface()
 
         XCTAssertFalse(notificationManager.scheduleWithIntervalWasCalled)
         XCTAssertEqual(notificationManager.scheduledNotifications, 0)
     }
 
-    func testShowSurface_validMessage() {
+    func testShowSurface_validMessage() async {
         let subject = createSubject()
         let message = createMessage()
         messageManager.message = message
 
         XCTAssertTrue(subject.shouldShowSurface)
 
-        subject.showNotificationSurface()
+        await subject.showNotificationSurface()
 
         XCTAssertTrue(notificationManager.scheduleWithIntervalWasCalled)
         XCTAssertEqual(notificationManager.scheduledNotifications, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ScreenshotHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ScreenshotHelperTests.swift
@@ -98,7 +98,9 @@ final class ScreenshotHelperTests: XCTestCase, StoreTestUtility {
     }
 
     private func createSubject() -> ScreenshotHelper {
-        return ScreenshotHelper(controller: mockVC)
+        let subject = DefaultScreenshotHelper(controller: mockVC)
+        trackForMemoryLeaks(subject)
+        return subject
     }
 
     func setupAppState() -> AppState {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ScreenshotHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ScreenshotHelperTests.swift
@@ -98,7 +98,7 @@ final class ScreenshotHelperTests: XCTestCase, StoreTestUtility {
     }
 
     private func createSubject() -> ScreenshotHelper {
-        let subject = DefaultScreenshotHelper(controller: mockVC)
+        let subject = ScreenshotHelper(controller: mockVC)
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/NotificationManagerTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/NotificationManagerTelemetryTests.swift
@@ -28,8 +28,7 @@ final class NotificationManagerTelemetryTests: XCTestCase {
 
     func test_appNotificationPermission_GleanIsCalled() {
         let subject = createSubject()
-        let settings = NotificationSettingsSnapshot(authorizationStatus: .authorized,
-                                                    alertSetting: .enabled)
+        let settings = MockUNNotificationSettings(authorizationStatus: .authorized, alertSetting: .enabled)
 
         subject.sendNotificationPermission(settings: settings)
 
@@ -38,5 +37,15 @@ final class NotificationManagerTelemetryTests: XCTestCase {
 
     func createSubject() -> NotificationManagerTelemetry {
         return NotificationManagerTelemetry()
+    }
+}
+
+class MockUNNotificationSettings: NotificationSettings {
+    var authorizationStatus: UNAuthorizationStatus
+    var alertSetting: UNNotificationSetting
+
+    init(authorizationStatus: UNAuthorizationStatus, alertSetting: UNNotificationSetting) {
+        self.authorizationStatus = authorizationStatus
+        self.alertSetting = alertSetting
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/NotificationManagerTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/NotificationManagerTelemetryTests.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+import XCTest
+
+@testable import Client
+
+final class NotificationManagerTelemetryTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // Due to changes allow certain custom pings to implement their own opt-out
+        // independent of Glean, custom pings may need to be registered manually in
+        // tests in order to put them in a state in which they can collect data.
+        Glean.shared.registerPings(GleanMetrics.Pings.shared)
+        Glean.shared.resetGlean(clearStores: true)
+    }
+
+    func test_onboardingNotificationPermission_GleanIsCalled() {
+        let isGranted = true
+        let subject = createSubject()
+
+        subject.sendNotificationPermissionPrompt(isPermissionGranted: isGranted)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.notificationPermissionPrompt)
+    }
+
+    func test_appNotificationPermission_GleanIsCalled() {
+        let subject = createSubject()
+        let settings = NotificationSettingsSnapshot(authorizationStatus: .authorized,
+                                                    alertSetting: .enabled)
+
+        subject.sendNotificationPermission(settings: settings)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.App.notificationPermission)
+    }
+
+    func createSubject() -> NotificationManagerTelemetry {
+        return NotificationManagerTelemetry()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -226,17 +226,6 @@ class TelemetryWrapperTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.wallpaperSelected)
     }
 
-    func test_onboardingNotificationPermission_GleanIsCalled() {
-        let isGrantedKey = TelemetryWrapper.EventExtraKey.notificationPermissionIsGranted.rawValue
-        let extras = [isGrantedKey: true]
-        TelemetryWrapper.recordEvent(category: .prompt,
-                                     method: .tap,
-                                     object: .notificationPermission,
-                                     extras: extras)
-
-        testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.notificationPermissionPrompt)
-    }
-
     func test_onboardingEngagementNotificationTapped_GleanIsCalled() {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,
@@ -892,19 +881,6 @@ class TelemetryWrapperTests: XCTestCase {
         testQuantityMetricSuccess(metric: GleanMetrics.CreditCard.savedAll,
                                   expectedValue: expectedCreditCardsCount,
                                   failureMessage: "Should have \(expectedCreditCardsCount) credit cards")
-    }
-    // MARK: - App
-
-    func test_appNotificationPermission_GleanIsCalled() {
-        let statusKey = TelemetryWrapper.EventExtraKey.notificationPermissionStatus.rawValue
-        let alertSettingKey = TelemetryWrapper.EventExtraKey.notificationPermissionAlertSetting.rawValue
-        let extras = [statusKey: "authorized", alertSettingKey: "enabled"]
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .view,
-                                     object: .notificationPermission,
-                                     extras: extras)
-
-        testEventMetricRecordingSuccess(metric: GleanMetrics.App.notificationPermission)
     }
 
     // MARK: - Nimbus Calls


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13532)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29411)

## :bulb: Description
- Adding `@Sendable` conformance on completion handlers when they actually can be `Sendable`.
- `UNNotification` and `UNNotificationSettings` are not `Sendable` so I am opting to take snapshots (`NotificationSettingsSnapshot` and `NotificationSnapshot`) of the returned objects, so we can pass them across boundaries. Let me know if you see a better solution!
- `self.sendTelemetry(settings: settings)` was capturing `self` in that closure, so I opted to move the telemetry into it's own struct. 

cc: @Cramsden @dataports @ih-codes 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
