### PR TITLE
 Add FXIOS-13525 #29388 - [Minimal Address Bar] - Animate minimal address bar to full size on tap for TabScrollHandler

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1103,6 +1103,9 @@ class BrowserViewController: UIViewController,
                                                    bottomContainer: bottomContainer,
                                                    headerContainer: header)
         }
+        let tapHandler = scrollController.createToolbarTapHandler()
+        overKeyboardContainer.onTap = tapHandler
+        header.onTap = tapHandler
 
         // Setup UIDropInteraction to handle dragging and dropping
         // links into the view from other apps.

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -266,15 +266,12 @@ final class LegacyTabScrollController: NSObject,
     func configureToolbarViews(overKeyboardContainer: BaseAlphaStackView?,
                                bottomContainer: BaseAlphaStackView?,
                                headerContainer: BaseAlphaStackView?) {
-        let tapHandler = createToolbarTapHandler()
-        overKeyboardContainer?.onTap = tapHandler
-        headerContainer?.onTap = tapHandler
         self.overKeyboardContainer = overKeyboardContainer
         self.bottomContainer = bottomContainer
         self.headerContainer = headerContainer
     }
 
-    private func createToolbarTapHandler() -> (() -> Void) {
+    func createToolbarTapHandler() -> (() -> Void) {
         return { [unowned self] in
             guard isMinimalAddressBarEnabled && toolbarState == .collapsed else { return }
             showToolbars(animated: true)

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -17,6 +17,7 @@ protocol TabScrollHandlerProtocol: AnyObject {
     func beginObserving(scrollView: UIScrollView)
     func stopObserving(scrollView: UIScrollView)
     func traitCollectionDidChange()
+    func createToolbarTapHandler() -> (() -> Void)
 }
 
 final class TabScrollHandler: NSObject,
@@ -290,11 +291,14 @@ final class TabScrollHandler: NSObject,
         isStatusBarScrollToTop = false
     }
 
-    // MARK: - Private
+    func createToolbarTapHandler() -> (() -> Void) {
+        return { [unowned self] in
+            guard isMinimalAddressBarEnabled && toolbarDisplayState.isCollapsed  else { return }
+            showToolbars(animated: true)
+        }
+    }
 
-    func configureToolbarViews(overKeyboardContainer: BaseAlphaStackView?,
-                               bottomContainer: BaseAlphaStackView?,
-                               headerContainer: BaseAlphaStackView? ) {}
+    // MARK: - Private
 
     private func handleOnTabContentLoading() {
         if tabIsLoading() || (tabProvider?.isFxHomeTab ?? false) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
@@ -304,6 +304,10 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         let subject = createSubject()
         setupTabScroll(with: subject)
 
+        // Manually setup onTap handler
+        let handler = subject.createToolbarTapHandler()
+        overKeyboardContainer.onTap = handler
+
         subject.toolbarState = .collapsed
         overKeyboardContainer.onTap?()
 
@@ -313,6 +317,10 @@ final class LegacyTabScrollControllerTests: XCTestCase {
     func testToolbarTapHandler_WhenToolbarVisible_DoesNothing() {
         let subject = createSubject()
         setupTabScroll(with: subject)
+
+        // Manually setup onTap handler
+        let handler = subject.createToolbarTapHandler()
+        overKeyboardContainer.onTap = handler
 
         subject.toolbarState = .visible
         overKeyboardContainer.onTap?()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
@@ -17,6 +17,10 @@ final class TabScrollHandlerTests: XCTestCase {
     var delegate: MockTabScrollHandlerDelegate!
     var tabProvider: MockTabProviderProtocol!
 
+    var header: BaseAlphaStackView = .build()
+    var overKeyboardContainer: BaseAlphaStackView = .build()
+    var bottomContainer: BaseAlphaStackView = .build()
+
     override func setUp() {
         super.setUp()
 
@@ -367,6 +371,34 @@ final class TabScrollHandlerTests: XCTestCase {
         XCTAssertEqual(delegate.hideCount, 2, "After jump completes, hides work again")
     }
 
+    // MARK: - OnTap
+
+    func testToolbarTapHandler_WhenMinimalAddressBarEnabledAndCollapsed_ShowsToolbar() {
+        let subject = createSubject()
+
+        // Manually setup onTap handler
+        let handler = subject.createToolbarTapHandler()
+        overKeyboardContainer.onTap = handler
+
+        subject.hideToolbars(animated: false)
+        overKeyboardContainer.onTap?()
+
+        XCTAssertTrue(subject.toolbarDisplayState.isExpanded)
+    }
+
+    func testToolbarTapHandler_WhenToolbarVisible_DoesNothing() {
+        let subject = createSubject()
+
+        // Manually setup onTap handler
+        let handler = subject.createToolbarTapHandler()
+        overKeyboardContainer.onTap = handler
+
+        subject.showToolbars(animated: false)
+        overKeyboardContainer.onTap?()
+
+        XCTAssertTrue(subject.toolbarDisplayState.isExpanded)
+    }
+
     // MARK: - Setup
 
     private func createSubject(contentSize: CGSize = CGSize(width: 200, height: 2000)) -> TabScrollHandler {
@@ -380,15 +412,10 @@ final class TabScrollHandlerTests: XCTestCase {
         tabProvider = MockTabProviderProtocol(tab)
         subject.tabProvider = tabProvider
 
-        let header: BaseAlphaStackView = .build()
-        let overKeyboardContainer: BaseAlphaStackView = .build()
-        let bottomContainer: BaseAlphaStackView = .build()
-
+        header.frame = CGRect(x: 0, y: 0, width: 200, height: 100)
         overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: 100)
+        bottomContainer.frame = CGRect(x: 0, y: 0, width: 200, height: 100)
 
-        subject.configureToolbarViews(overKeyboardContainer: overKeyboardContainer,
-                                      bottomContainer: bottomContainer,
-                                      headerContainer: header)
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13525)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29388)

## :bulb: Description
Add support to show toolbars minimal address bar tab scroll controller

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
