### PR TITLE
Bugfix MTE-4495 Fix test for iPad iOS 26

### DIFF
--- a/focus-ios/focus-ios-tests/XCUITest/CopyPasteTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/CopyPasteTest.swift
@@ -75,8 +75,14 @@ class CopyPasteTest: BaseTestCase {
         } else {
             waitForHittable(app.buttons["Forward"].firstMatch)
         }
-        XCTAssertTrue(app.menuItems["Copy"].isEnabled)
-        app.menuItems["Copy"].tap()
+        if iPad() {
+            app.buttons["Forward"].firstMatch.tap()
+            XCTAssertTrue(app.buttons["Copy"].isEnabled)
+            app.buttons["Copy"].tap()
+        } else {
+            XCTAssertTrue(app.menuItems["Copy"].isEnabled)
+            app.menuItems["Copy"].tap()
+        }
 
         // Clear and start typing on the URL field again, verify the clipboard suggestion changes
         // If it's a URL, do not prefix "Search For"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4495)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The menu on iPad 26 works a little bit differently than the rest.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
