### PR TITLE
Bugfix FXIOS-29410 [Menu] Fix overlap of “Protections are ON” label with domain name at large text sizes

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
@@ -123,16 +123,15 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         siteProtectionsContent.addArrangedSubview(siteProtectionsMoreSettingsIcon)
 
         let siteProtectionsTopFromFavicon = siteProtectionsContent.topAnchor.constraint(
-                    greaterThanOrEqualTo: favicon.bottomAnchor,
-                    constant: UX.siteProtectionsContentTopMargin
-                )
+            greaterThanOrEqualTo: favicon.bottomAnchor,
+            constant: UX.siteProtectionsContentTopMargin
+        )
 
-                let siteProtectionsTopFromLabels = siteProtectionsContent.topAnchor.constraint(
-                    equalTo: contentLabels.bottomAnchor,
-                    constant: UX.siteProtectionsContentTopMargin
-                )
-                siteProtectionsTopFromLabels.priority = .defaultHigh
-
+        let siteProtectionsTopFromLabels = siteProtectionsContent.topAnchor.constraint(
+            equalTo: contentLabels.bottomAnchor,
+            constant: UX.siteProtectionsContentTopMargin
+        )
+        siteProtectionsTopFromLabels.priority = .defaultHigh
         let iconAlignmentOffset = -UX.siteProtectionsContentHorizontalPadding
         NSLayoutConstraint.activate([
             contentLabels.topAnchor.constraint(equalTo: self.topAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket FXIOS-13531](https://mozilla-hub.atlassian.net/browse/FXIOS-13531)  
[GitHub issue #29410](https://github.com/mozilla-mobile/firefox-ios/issues/29410)

## :bulb: Description
This PR fixes a layout issue in the redesigned menu where the **“Protections are ON”** label overlapped the domain name when using larger Dynamic Text sizes.  

### Changes
- Replaced the fixed `siteProtectionsContent.topAnchor` constraint with flexible constraints relative to the favicon and content labels.  
- Added `siteProtectionsTopFromFavicon` and `siteProtectionsTopFromLabels` constraints with appropriate priorities for consistent alignment.  
- Introduced horizontal alignment offset to align the protections icon + label with the content labels.  

### Why
- Prevents overlap between the protections label and domain name.  
- Improves readability and accessibility support for users with larger text sizes.  

## :movie_camera: Demos

| Before | After |
|--------|-------|
| <img width="366" alt="Before screenshot" src="https://github.com/user-attachments/assets/3df605be-2fe4-4fb9-8541-78e7553fcfc6" /> | <img width="354" alt="After screenshot" src="https://github.com/user-attachments/assets/473fcd97-54f0-48ea-95e6-5a0a5f7e0015" /> |

<details>
<summary>Demo</summary>
<img height=400 src="<URL-to-video-or-screenshot>" />
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work  
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)  
- [x] I ensured unit tests pass locally  
- [x] Verified UI with Dynamic Type sizes and VoiceOver  
- [x] Added before/after screenshots for reviewers  