### PR TITLE
Bugfix MTE-4495 Bitrise Xcode Check and Update workflow update

### DIFF
--- a/test-fixtures/update.py
+++ b/test-fixtures/update.py
@@ -1,13 +1,9 @@
 import os
-import re
-import sys
-import pathlib
 from shutil import copyfile
 from ruamel.yaml import YAML
 
 
 import requests
-import semver
 from requests.exceptions import HTTPError
 
 
@@ -28,15 +24,6 @@ WORKFLOW = 'NewXcodeVersions'
 resp = requests.get(BITRISE_STACK_INFO)
 resp.raise_for_status()
 resp_json = resp.json()
-
-
-def parse_semver(raw_str):
-    parsed = raw_str.split(pattern)[1]
-    if parsed[-1] == 'x':
-        p = parsed.split('.x')[0]
-        return '{0}.0'.format(p)
-    else:
-        return False
 
 def latest_stack():
     try:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4495)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The URL `https://app.bitrise.io/app/6c06d3a40422d10f/all_stack_info` is no longer available. (I'm not sure if it coincide with the new stack's release or not.) I found another way to query the current stack by heading over to the source of the Bitrise stack updates site (https://bitrise.io/stacks). The repo should reflect any updates to the stack accurately.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
