### PR TITLE
Add FXIOS_12398 [Experiment ] Advanced targeting for ToU acceptance status

### DIFF
--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -200,6 +200,11 @@ enum Experiments {
         return prefsReader.hasEnabledTipsNotifications()
     }
 
+    private static func hasAcceptedTermsOfUse() -> Bool {
+        let prefsReader = ProfilePrefsReader()
+        return prefsReader.hasAcceptedTermsOfUse()
+    }
+
     private static func isAppleIntelligenceAvailable() -> Bool {
         guard #available(iOS 26, *) else { return false }
         #if canImport(FoundationModels)
@@ -233,6 +238,7 @@ enum Experiments {
             isDefaultBrowser: isDefaultBrowser(),
             isBottomToolbarUser: isBottomToolbarUser(),
             hasEnabledTipsNotifications: hasEnabledTipsNotifications(),
+            hasAcceptedTermsOfUse: hasAcceptedTermsOfUse(),
             isAppleIntelligenceAvailable: isAppleIntelligenceAvailable(),
             cannotUseAppleIntelligence: cannotUseAppleIntelligence()
         )

--- a/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
+++ b/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
@@ -45,6 +45,7 @@ final class RecordedNimbusContext: RecordedContext, @unchecked Sendable {
     var isDefaultBrowser: Bool
     var isBottomToolbarUser: Bool
     var hasEnabledTipsNotifications: Bool
+    var hasAcceptedTermsOfUse: Bool
     var isAppleIntelligenceAvailable: Bool
     var cannotUseAppleIntelligence: Bool
     var appVersion: String?
@@ -63,6 +64,7 @@ final class RecordedNimbusContext: RecordedContext, @unchecked Sendable {
          isDefaultBrowser: Bool,
          isBottomToolbarUser: Bool,
          hasEnabledTipsNotifications: Bool,
+         hasAcceptedTermsOfUse: Bool,
          isAppleIntelligenceAvailable: Bool,
          cannotUseAppleIntelligence: Bool,
          eventQueries: [String: String] = RecordedNimbusContext.EVENT_QUERIES,
@@ -78,6 +80,7 @@ final class RecordedNimbusContext: RecordedContext, @unchecked Sendable {
         self.isDefaultBrowser = isDefaultBrowser
         self.isBottomToolbarUser = isBottomToolbarUser
         self.hasEnabledTipsNotifications = hasEnabledTipsNotifications
+        self.hasAcceptedTermsOfUse = hasAcceptedTermsOfUse
         self.isAppleIntelligenceAvailable = isAppleIntelligenceAvailable
         self.cannotUseAppleIntelligence = cannotUseAppleIntelligence
 
@@ -149,6 +152,7 @@ final class RecordedNimbusContext: RecordedContext, @unchecked Sendable {
                 isDefaultBrowser: isDefaultBrowser,
                 isBottomToolbarUser: isBottomToolbarUser,
                 hasEnabledTipsNotifications: hasEnabledTipsNotifications,
+                hasAcceptedTermsOfUse: hasAcceptedTermsOfUse,
                 isAppleIntelligenceAvailable: isAppleIntelligenceAvailable,
                 cannotUseAppleIntelligence: cannotUseAppleIntelligence
             )
@@ -193,6 +197,7 @@ final class RecordedNimbusContext: RecordedContext, @unchecked Sendable {
             "is_default_browser": isDefaultBrowser,
             "is_bottom_toolbar_user": isBottomToolbarUser,
             "has_enabled_tips_notifications": hasEnabledTipsNotifications,
+            "has_accepted_terms_of_use": hasAcceptedTermsOfUse,
             "is_apple_intelligence_available": isAppleIntelligenceAvailable,
             "cannot_use_apple_intelligence": cannotUseAppleIntelligence
         ]),

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -3596,6 +3596,8 @@ nimbus_system:
           type: boolean
         has_enabled_tips_notifications:
           type: boolean
+        has_accepted_terms_of_use:
+          type: boolean
         is_apple_intelligence_available:
           type: boolean
         cannot_use_apple_intelligence:

--- a/firefox-ios/Client/ProfilePrefsReader.swift
+++ b/firefox-ios/Client/ProfilePrefsReader.swift
@@ -44,4 +44,19 @@ struct ProfilePrefsReader {
         let key = ProfilePrefsReader.prefix + PrefsKeys.Notifications.TipsAndFeaturesNotifications
         return userDefaults.bool(forKey: key)
     }
+
+    /// Returns `true` if the user has accepted the Terms of Use(from onboarding or bottom sheet).
+    ///
+    /// This checks both the `TermsOfUseAccepted` boolean preference and the
+    /// `TermsOfServiceAccepted` integer preference.
+    /// If either indicates acceptance, returns `true`. Otherwise returns `false`.
+    func hasAcceptedTermsOfUse() -> Bool {
+        let touKey = ProfilePrefsReader.prefix + PrefsKeys.TermsOfUseAccepted
+        let tosKey = ProfilePrefsReader.prefix + PrefsKeys.TermsOfServiceAccepted
+
+        let hasAcceptedToU = userDefaults.bool(forKey: touKey)
+        let hasAcceptedToS = userDefaults.object(forKey: tosKey) as? Int == 1
+
+        return hasAcceptedToU || hasAcceptedToS
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
@@ -24,6 +24,7 @@ class RecordedNimbusContextTests: XCTestCase {
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
             hasEnabledTipsNotifications: true,
+            hasAcceptedTermsOfUse: true,
             isAppleIntelligenceAvailable: true,
             cannotUseAppleIntelligence: true
         )
@@ -36,6 +37,7 @@ class RecordedNimbusContextTests: XCTestCase {
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
             hasEnabledTipsNotifications: true,
+            hasAcceptedTermsOfUse: true,
             isAppleIntelligenceAvailable: true,
             cannotUseAppleIntelligence: true
         )
@@ -63,6 +65,10 @@ class RecordedNimbusContextTests: XCTestCase {
             recordedContext.hasEnabledTipsNotifications
         )
         XCTAssertEqual(
+            json?.removeValue(forKey: "has_accepted_terms_of_use") as? Bool,
+            recordedContext.hasAcceptedTermsOfUse
+        )
+        XCTAssertEqual(
             json?.removeValue(forKey: "is_apple_intelligence_available") as? Bool,
             recordedContext.isAppleIntelligenceAvailable
         )
@@ -85,6 +91,7 @@ class RecordedNimbusContextTests: XCTestCase {
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
             hasEnabledTipsNotifications: true,
+            hasAcceptedTermsOfUse: true,
             isAppleIntelligenceAvailable: true,
             cannotUseAppleIntelligence: true
         )
@@ -116,6 +123,10 @@ class RecordedNimbusContextTests: XCTestCase {
             value?.hasEnabledTipsNotifications,
             recordedContext.hasEnabledTipsNotifications
         )
+        XCTAssertEqual(
+            value?.hasAcceptedTermsOfUse,
+            recordedContext.hasAcceptedTermsOfUse
+        )
 
         XCTAssertNotNil(value?.eventQueryValues)
         XCTAssertEqual(value?.eventQueryValues?.daysOpenedInLast28, 1)
@@ -127,6 +138,7 @@ class RecordedNimbusContextTests: XCTestCase {
             isDefaultBrowser: true,
             isBottomToolbarUser: true,
             hasEnabledTipsNotifications: true,
+            hasAcceptedTermsOfUse: true,
             isAppleIntelligenceAvailable: true,
             cannotUseAppleIntelligence: true
         )


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12398)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27373)

## :bulb: Description
This PR adds advanced targeting for terms of use acceptance status in order to be able to run Nimbus experiments for
- users that already accepted terms of use (has_accepted_terms_of_use is true)
- users that did not accepted terms of use (has_accepted_terms_of_use is false)

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
