### PR TITLE
Refactor FXIOS-13549 - Performance improvements for `imageConfiguredForRTL` method

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -208,6 +208,7 @@ class ToolbarButton: UIButton, ThemeApplicable, UIGestureRecognizerDelegate {
     }
 
     private func imageConfiguredForRTL(for element: ToolbarElement) -> UIImage? {
+        if let existingImage = configuration?.image { return existingImage }
         guard let iconName = element.iconName else { return nil }
         let image = UIImage(named: iconName)?.withRenderingMode(.alwaysTemplate)
         return element.isFlippedForRTL ? image?.imageFlippedForRightToLeftLayoutDirection() : image


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13549)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29446)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Optimization in `ToolbarButton` image configuration.

- Issue: While profiling the app, the Leaks instrument identified memory leaks in `ToolbarButton.swift` -> `imageConfiguredForRTL(for element: ToolbarElement)`. Investigation revealed that `UIImage(named:)` retains and caches images internally, with references being released after some delay by the cause of `autoreleasepool`, causing temporary memory accumulation.

- Solution: Added an optimization that checks if the button's configuration already contains an image before creating a new one. Since toolbar buttons use static images that don't change after initial configuration, we can safely return the existing image, preventing unnecessary image creation and reducing memory pressure.

This approach maintains the same functionality while eliminating redundant image allocations for buttons that are reconfigured multiple times.
- [Useful Link](https://developer.apple.com/documentation/uikit/uiimage/init(named:)#Discussion)
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
