### PR TITLE
Bugfix FXIOS-13521 [Tab Tray] [iOS 26] Weird display of the tab tray selector

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -37,10 +37,16 @@ class TabTraySelectorView: UIView,
 
     private var tabTrayUtils: TabTrayUtils
 
-    private lazy var containerView: UIView = .build()
+    private lazy var containerView: UIView = .build { view in
+        if #available(iOS 26, *) {
+            view.clipsToBounds = true
+        }
+    }
 
     private lazy var selectionBackgroundView: UIView = .build { view in
-        view.layer.cornerRadius = TabTraySelectorUX.cornerRadius
+        if #unavailable(iOS 26) {
+            view.layer.cornerRadius = TabTraySelectorUX.cornerRadius
+        }
     }
 
     private lazy var stackView: UIStackView = .build { stackView in
@@ -48,6 +54,12 @@ class TabTraySelectorView: UIView,
         stackView.spacing = TabTraySelectorUX.horizontalSpacing
         stackView.distribution = .fill
         stackView.alignment = .center
+    }
+
+    private lazy var visualEffectView: UIVisualEffectView = .build { view in
+        if #available(iOS 26, *) {
+            view.effect = UIGlassEffect(style: .regular)
+        }
     }
 
     init(selectedIndex: Int,
@@ -69,6 +81,11 @@ class TabTraySelectorView: UIView,
     override func layoutSubviews() {
         super.layoutSubviews()
         updateEdgeFadeMask()
+
+        if #available(iOS 26, *) {
+            selectionBackgroundView.layer.cornerRadius = selectionBackgroundView.frame.height / 2
+            visualEffectView.layer.cornerRadius = containerView.frame.height / 2
+        }
     }
 
     func updateSelectionProgress(fromIndex: Int, toIndex: Int, progress: CGFloat) {
@@ -82,6 +99,9 @@ class TabTraySelectorView: UIView,
     }
 
     private func setup() {
+        if #available(iOS 26, *) {
+            addSubview(visualEffectView)
+        }
         addSubview(containerView)
         containerView.addSubview(selectionBackgroundView)
         containerView.addSubview(stackView)
@@ -114,6 +134,15 @@ class TabTraySelectorView: UIView,
             selectionBackgroundView.centerYAnchor.constraint(equalTo: stackView.centerYAnchor),
             selectionBackgroundView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor)
         ])
+
+        if #available(iOS 26, *) {
+            NSLayoutConstraint.activate([
+                visualEffectView.topAnchor.constraint(equalTo: containerView.topAnchor),
+                visualEffectView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+                visualEffectView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+                visualEffectView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
+            ])
+        }
 
         applyInitialConstraints()
         addSwipeGestureRecognizer(direction: .right)
@@ -338,8 +367,11 @@ class TabTraySelectorView: UIView,
     func applyTheme(theme: Theme) {
         self.theme = theme
 
-        let backgroundAlpha: CGFloat = tabTrayUtils.backgroundAlpha()
-        backgroundColor = theme.colors.layer1.withAlphaComponent(backgroundAlpha)
+        if #unavailable(iOS 26) {
+            let backgroundAlpha: CGFloat = tabTrayUtils.backgroundAlpha()
+            backgroundColor = theme.colors.layer1.withAlphaComponent(backgroundAlpha)
+        }
+
         selectionBackgroundView.backgroundColor = theme.colors.layerEmphasis
 
         for button in buttons {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -473,6 +473,8 @@ final class TabTrayViewController: UIViewController,
     private func setupToolBarAppearance(theme: Theme) {
         guard tabTrayUtils.isTabTrayUIExperimentsEnabled else { return }
 
+        if #available(iOS 26, *) { return }
+
         let backgroundAlpha = tabTrayUtils.backgroundAlpha()
         let color = theme.colors.layer1.withAlphaComponent(backgroundAlpha)
 
@@ -579,6 +581,8 @@ final class TabTrayViewController: UIViewController,
     private func setupBlurView() {
         guard tabTrayUtils.isTabTrayUIExperimentsEnabled, tabTrayUtils.isTabTrayTranslucencyEnabled else { return }
 
+        if #available(iOS 26, *) { return }
+
         // Should use Regular layout used for iPad
         if isRegularLayout {
             containerView.insertSubview(blurView, aboveSubview: containerView)
@@ -604,8 +608,10 @@ final class TabTrayViewController: UIViewController,
     }
 
     private func updateBlurView() {
-        blurView.isHidden = !tabTrayUtils.shouldBlur()
         applyTheme()
+
+        if #available(iOS 26, *) { return }
+        blurView.isHidden = !tabTrayUtils.shouldBlur()
     }
 
     private func updateTitle() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13521)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29381)

## :bulb: Description
Use glass effect for tab tray selector view

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-19 at 17 14 41" src="https://github.com/user-attachments/assets/d87682db-49f2-4b34-bec4-93fb8f86bff7" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-19 at 17 11 38" src="https://github.com/user-attachments/assets/aca79da0-7b55-4700-b477-50d21211fd84" /> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>

https://github.com/user-attachments/assets/1af350af-f2dd-48ff-bb96-50c55898c039


</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
