### PR TITLE
Fix FXIOS-13458 Fix toolbar not having visible buttons with toolbar on top

### DIFF
--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -216,6 +216,8 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
         setupSpacer(leadingFixedSpacer, width: UX.fixedLeadingSpacerWidth)
         setupSpacer(trailingFixedSpacer, width: UX.fixedTrailingSpacerWidth)
 
+        toolbar.layer.cornerRadius = 20.0
+
         toolbar.items = [
             currentAccessoryView,
             flexibleSpacer,
@@ -235,12 +237,15 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
 
         addSubview(toolbar)
 
+        let offset = CGFloat(2)
+
         NSLayoutConstraint.activate([
-            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
-            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
-            toolbar.topAnchor.constraint(equalTo: topAnchor),
-            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor)
+            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: offset),
+            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -offset),
+            toolbar.topAnchor.constraint(equalTo: topAnchor, constant: offset),
+            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -offset)
         ])
+        
     }
 
     func applyTheme() {
@@ -257,7 +262,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
             theme.colors.layer5Hover
         }
 
-        self.backgroundColor = backgroundColor
+        toolbar.backgroundColor = backgroundColor
         [previousButton, nextButton, doneButton].forEach {
             $0.tintColor = theme.colors.iconAccentBlue
             $0.customView?.tintColor = theme.colors.iconAccentBlue

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -252,15 +252,11 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
         NSLayoutConstraint.activate([
             leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
             trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
-            heightAnchor.constraint(equalToConstant: UX.accessoryViewHeight)
-        ])
+            heightAnchor.constraint(equalToConstant: UX.accessoryViewHeight),
 
-        NSLayoutConstraint.activate([
             toolbarTopHeightSpacer.topAnchor.constraint(equalTo: topAnchor),
-            toolbarTopHeightSpacer.bottomAnchor.constraint(equalTo: toolbar.topAnchor)
-        ])
+            toolbarTopHeightSpacer.bottomAnchor.constraint(equalTo: toolbar.topAnchor),
 
-        NSLayoutConstraint.activate([
             toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
             toolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
             toolbar.topAnchor.constraint(equalTo: toolbarTopHeightSpacer.bottomAnchor),

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -13,7 +13,7 @@ enum AccessoryType {
 class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, FeatureFlaggable, Notifiable {
     // MARK: - Constants
     private struct UX {
-        static let accessoryViewHeight: CGFloat = 70
+        static let accessoryViewHeight: CGFloat = 56
         static let fixedSpacerWidth: CGFloat = 10
         static let fixedSpacerHeight: CGFloat = 30
         static let fixedLeadingSpacerWidth: CGFloat = 2
@@ -45,6 +45,8 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
 
     // MARK: - UI Elements
     private let toolbar: UIToolbar = .build()
+
+    private let toolbarTopHeightSpacer: UIView = .build()
 
     private lazy var previousButton: UIBarButtonItem = {
         let button = UIButton(type: .system)
@@ -210,11 +212,20 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
         spacer.accessibilityElementsHidden = true
     }
 
+    private func setupHeightSpacer(_ spacer: UIView, height: CGFloat) {
+        NSLayoutConstraint.activate([
+            spacer.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width),
+            spacer.heightAnchor.constraint(equalToConstant: height)
+        ])
+        spacer.accessibilityElementsHidden = true
+    }
+
     private func setupLayout() {
+        setupHeightSpacer(toolbarTopHeightSpacer, height: 4)
         setupSpacer(leadingFixedSpacer, width: UX.fixedLeadingSpacerWidth)
         setupSpacer(trailingFixedSpacer, width: UX.fixedTrailingSpacerWidth)
 
-        toolbar.layer.cornerRadius = 24.0
+        layer.cornerRadius = 24.0
 
         toolbar.items = [
             currentAccessoryView,
@@ -233,20 +244,27 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
             doneButton.customView
         ].compactMap { $0 }
 
+        addSubview(toolbarTopHeightSpacer)
         addSubview(toolbar)
 
         let topBottomOffset = CGFloat(2)
-        let sideOffset = CGFloat(6)
+        let sideOffset = CGFloat(8)
 
         NSLayoutConstraint.activate([
-              widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width),
-              heightAnchor.constraint(equalToConstant: UX.accessoryViewHeight)
-          ])
+            leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: sideOffset),
+            trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -sideOffset),
+            heightAnchor.constraint(equalToConstant: UX.accessoryViewHeight)
+        ])
 
         NSLayoutConstraint.activate([
-            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: sideOffset),
-            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -sideOffset),
-            toolbar.topAnchor.constraint(equalTo: topAnchor, constant: topBottomOffset),
+            toolbarTopHeightSpacer.topAnchor.constraint(equalTo: topAnchor),
+            toolbarTopHeightSpacer.bottomAnchor.constraint(equalTo: toolbar.topAnchor)
+        ])
+
+        NSLayoutConstraint.activate([
+            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            toolbar.topAnchor.constraint(equalTo: toolbarTopHeightSpacer.bottomAnchor),
             toolbar.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -topBottomOffset)
         ])
     }
@@ -265,7 +283,8 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
             theme.colors.layer5Hover
         }
 
-        toolbar.backgroundColor = backgroundColor
+        //toolbar.backgroundColor = backgroundColor
+        self.backgroundColor = backgroundColor
         [previousButton, nextButton, doneButton].forEach {
             $0.tintColor = theme.colors.iconAccentBlue
             $0.customView?.tintColor = theme.colors.iconAccentBlue

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -282,7 +282,6 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
             theme.colors.layer5Hover
         }
 
-        // toolbar.backgroundColor = backgroundColor
         self.backgroundColor = backgroundColor
         [previousButton, nextButton, doneButton].forEach {
             $0.tintColor = theme.colors.iconAccentBlue

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -283,7 +283,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
             theme.colors.layer5Hover
         }
 
-        //toolbar.backgroundColor = backgroundColor
+        // toolbar.backgroundColor = backgroundColor
         self.backgroundColor = backgroundColor
         [previousButton, nextButton, doneButton].forEach {
             $0.tintColor = theme.colors.iconAccentBlue

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -247,7 +247,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         let backgroundColor: UIColor = if #available(iOS 26.0, *) {
             // Use the same color that uses the toolbar
-            searchBarPosition == .top ? .clear : theme.colors.layerSurfaceLow
+            theme.colors.layerSurfaceLow
         } else {
             theme.colors.layer5
         }

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -247,12 +247,9 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
         addSubview(toolbarTopHeightSpacer)
         addSubview(toolbar)
 
-        let topBottomOffset = CGFloat(2)
-        let sideOffset = CGFloat(8)
-
         NSLayoutConstraint.activate([
-            leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: sideOffset),
-            trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -sideOffset),
+            leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
             heightAnchor.constraint(equalToConstant: UX.accessoryViewHeight)
         ])
 
@@ -265,7 +262,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
             toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
             toolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
             toolbar.topAnchor.constraint(equalTo: toolbarTopHeightSpacer.bottomAnchor),
-            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -topBottomOffset)
+            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
     }
 

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -270,11 +270,11 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
 
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
-        let backgroundColor: UIColor = if #available(iOS 26.0, *) {
+        let accessoryViewBackgroundColor: UIColor = if #available(iOS 26.0, *) {
             // Use the same color that uses the toolbar
             theme.colors.layerSurfaceLow
         } else {
-            theme.colors.layer5
+            .clear
         }
         let buttonsBackgroundColor: UIColor = if #available(iOS 26.0, *) {
             .clear
@@ -282,7 +282,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
             theme.colors.layer5Hover
         }
 
-        self.backgroundColor = backgroundColor
+        self.backgroundColor = accessoryViewBackgroundColor
         [previousButton, nextButton, doneButton].forEach {
             $0.tintColor = theme.colors.iconAccentBlue
             $0.customView?.tintColor = theme.colors.iconAccentBlue

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -245,7 +245,6 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
             toolbar.topAnchor.constraint(equalTo: topAnchor, constant: offset),
             toolbar.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -offset)
         ])
-        
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -13,7 +13,7 @@ enum AccessoryType {
 class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, FeatureFlaggable, Notifiable {
     // MARK: - Constants
     private struct UX {
-        static let accessoryViewHeight: CGFloat = 50
+        static let accessoryViewHeight: CGFloat = 70
         static let fixedSpacerWidth: CGFloat = 10
         static let fixedSpacerHeight: CGFloat = 30
         static let fixedLeadingSpacerWidth: CGFloat = 2
@@ -44,9 +44,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
     }
 
     // MARK: - UI Elements
-    private let toolbar: UIToolbar = .build {
-        $0.sizeToFit()
-    }
+    private let toolbar: UIToolbar = .build()
 
     private lazy var previousButton: UIBarButtonItem = {
         let button = UIButton(type: .system)
@@ -239,6 +237,11 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
 
         let topBottomOffset = CGFloat(2)
         let sideOffset = CGFloat(6)
+
+        NSLayoutConstraint.activate([
+              widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width),
+              heightAnchor.constraint(equalToConstant: UX.accessoryViewHeight)
+          ])
 
         NSLayoutConstraint.activate([
             toolbar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: sideOffset),

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -18,6 +18,8 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
         static let fixedSpacerHeight: CGFloat = 30
         static let fixedLeadingSpacerWidth: CGFloat = 2
         static let fixedTrailingSpacerWidth: CGFloat = 3
+        static let spacerViewHeight: CGFloat = 4
+        static let cornerRadius: CGFloat = 24.0
     }
 
     // MARK: - Properties
@@ -221,11 +223,11 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
     }
 
     private func setupLayout() {
-        setupHeightSpacer(toolbarTopHeightSpacer, height: 4)
+        setupHeightSpacer(toolbarTopHeightSpacer, height: UX.spacerViewHeight)
         setupSpacer(leadingFixedSpacer, width: UX.fixedLeadingSpacerWidth)
         setupSpacer(trailingFixedSpacer, width: UX.fixedTrailingSpacerWidth)
 
-        layer.cornerRadius = 24.0
+        layer.cornerRadius = UX.cornerRadius
 
         toolbar.items = [
             currentAccessoryView,

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -13,7 +13,7 @@ enum AccessoryType {
 class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, FeatureFlaggable, Notifiable {
     // MARK: - Constants
     private struct UX {
-        static let toolbarHeight: CGFloat = 50
+        static let accessoryViewHeight: CGFloat = 50
         static let fixedSpacerWidth: CGFloat = 10
         static let fixedSpacerHeight: CGFloat = 30
         static let fixedLeadingSpacerWidth: CGFloat = 2
@@ -157,7 +157,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
         self.notificationCenter = notificationCenter
 
         super.init(frame: CGRect(width: UIScreen.main.bounds.width,
-                                 height: UX.toolbarHeight))
+                                 height: UX.accessoryViewHeight))
 
         setupLayout()
 
@@ -216,7 +216,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
         setupSpacer(leadingFixedSpacer, width: UX.fixedLeadingSpacerWidth)
         setupSpacer(trailingFixedSpacer, width: UX.fixedTrailingSpacerWidth)
 
-        toolbar.layer.cornerRadius = 20.0
+        toolbar.layer.cornerRadius = 24.0
 
         toolbar.items = [
             currentAccessoryView,
@@ -237,13 +237,14 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable, F
 
         addSubview(toolbar)
 
-        let offset = CGFloat(2)
+        let topBottomOffset = CGFloat(2)
+        let sideOffset = CGFloat(6)
 
         NSLayoutConstraint.activate([
-            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: offset),
-            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -offset),
-            toolbar.topAnchor.constraint(equalTo: topAnchor, constant: offset),
-            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -offset)
+            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: sideOffset),
+            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -sideOffset),
+            toolbar.topAnchor.constraint(equalTo: topAnchor, constant: topBottomOffset),
+            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -topBottomOffset)
         ])
     }
 

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -1185,11 +1185,6 @@ class TabWebView: WKWebView, MenuHelperWebViewInterface, ThemeApplicable, Featur
 
         translatesAutoresizingMaskIntoConstraints = false
 
-        NSLayoutConstraint.activate([
-            accessoryView.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width),
-            accessoryView.heightAnchor.constraint(equalToConstant: 50)
-        ])
-
         return accessoryView
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13458)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29245)

## :bulb: Description
On iOS 26 the background of the UIToolbar for the accessoryViewProvider was set to clear, which QA rejected because it made the buttons difficult to see over a form in the webview. I've added some styling to make the accessoryViewProvider look a little nicer on iOS 26 (these styling changes should not be visible on previous iOS versions, I verified on iOS 18.6) and fixed some broken constraints.

I couldn't find a better way to add padding or contentInsets to the UIToolbar or barButtonItems after a lot of effort, so I decided to insert a UIView in the accessoryView to add some padding for the time being.

| Before | After |
| - | - |
| <img width="472" height="1022" alt="Simulator Screenshot - iPhone 16 - 2025-09-21 at 23 04 10" src="https://github.com/user-attachments/assets/0d6aa021-1428-4907-8e91-1d8e9c7752cc" /> | <img width="472" height="1022" alt="Simulator Screenshot - iPhone 16 - 2025-09-21 at 23 56 53" src="https://github.com/user-attachments/assets/49a68a29-a776-4b65-9555-448599ed5abe" /> |
| <img width="472" height="1022" alt="Simulator Screenshot - iPhone 16 - 2025-09-22 at 00 02 18" src="https://github.com/user-attachments/assets/e698e756-f487-47ac-be2d-4e8f8d8a8384" /> | <img width="472" height="1022" alt="Simulator Screenshot - iPhone 16 - 2025-09-21 at 23 58 35" src="https://github.com/user-attachments/assets/4cd975ca-1e91-43e5-8dcd-53a52c1c11c4" />|
| <!--insert "before" image here--> | <!--insert "after" image here--> |

## :movie_camera: Demos
https://github.com/user-attachments/assets/09a6bd11-828f-445a-b094-317dbaff2bfe


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
