### PR TITLE
Bugfix FXIOS-13531 ⁃ [Menu Redesign] “Protections are ON” overlaps the domain name in the menu when using larger text size

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
@@ -132,7 +132,6 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
             constant: UX.siteProtectionsContentTopMargin
         )
         siteProtectionsTopFromLabels.priority = .defaultHigh
-        let iconAlignmentOffset = -UX.siteProtectionsContentHorizontalPadding
         NSLayoutConstraint.activate([
             contentLabels.topAnchor.constraint(equalTo: self.topAnchor),
             contentLabels.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor,
@@ -157,10 +156,7 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
 
             closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
             closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
-            siteProtectionsContent.leadingAnchor.constraint(
-                equalTo: contentLabels.leadingAnchor,
-                constant: iconAlignmentOffset
-            )
+            siteProtectionsContent.leadingAnchor.constraint(equalTo: favicon.leadingAnchor)
         ])
 
         closeButton.layer.cornerRadius = 0.5 * UX.closeButtonSize


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13531)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29410)

## :bulb: Description
Left aligned Site Protections label

## :movie_camera: Demos
<img width="603" height="1311" alt="IMG_1804" src="https://github.com/user-attachments/assets/222353b4-77a5-4523-bb6c-41d3540f1365" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
