### PR TITLE
Refactor FXIOS-13564 - [Memory Leaks] - Retain Cycle in Nimbus `catchAll` Method

### DIFF
--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/nimbus.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/nimbus.swift
@@ -994,7 +994,7 @@ open func optOut(experimentSlug: String)throws  -> [EnrollmentChangeEvent]  {
      * This function is used to record and persist data used for the behavioral
      * targeting such as "core-active" user targeting.
      */
-open func recordEvent(eventId: String, count: Int64 = Int64(1))throws   {try rustCallWithError(FfiConverterTypeNimbusError_lift) {
+open func recordEvent(eventId: String, count: Int64 = Int64(1)) throws   {try rustCallWithError(FfiConverterTypeNimbusError_lift) {
     uniffi_nimbus_fn_method_nimbusclient_record_event(self.uniffiClonePointer(),
         FfiConverterString.lower(eventId),
         FfiConverterInt64.lower(count),$0

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/Nimbus.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/Nimbus.swift
@@ -55,8 +55,9 @@ private extension Nimbus {
 
     func catchAll(_ queue: OperationQueue, thunk: @escaping (Operation) throws -> Void) -> Operation {
         let op = BlockOperation()
-        op.addExecutionBlock {
-            self.catchAll {
+        op.addExecutionBlock { [weak self, weak op] in
+            guard let self, let op else { return }
+            catchAll {
                 try thunk(op)
             }
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13564)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29477)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Root Cause: The `catchAll(_ queue:, thunk:)` method created two distinct retain cycles:
1. Self-Reference Retain Cycle: ` Nimbus → dbQueue/fetchQueue → BlockOperation → closure → self → back to Nimbus`.
2. Operation Self-Capture Retain Cycle: `BlockOperation → addExecutionBlock closure → op → back to same BlockOperation`.

Solution: Added weak capture lists `[weak self, weak op]` to the `addExecutionBlock` closure to break both retain cycles.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
