### PR TITLE
BugFix FXIOS-13562 iPads tops tabs not working

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1110,8 +1110,7 @@ class BrowserViewController: UIViewController,
                                                    headerContainer: header)
         }
         let tapHandler = scrollController.createToolbarTapHandler()
-        overKeyboardContainer.onTap = tapHandler
-        header.onTap = tapHandler
+        addressToolbarContainer.onContainerTap = tapHandler
 
         // Setup UIDropInteraction to handle dragging and dropping
         // links into the view from other apps.

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -327,7 +327,7 @@ final class AddressToolbarContainer: UIView,
     private func setupLayout() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(onContainerTapped))
         addGestureRecognizer(tapGesture)
-        
+
         addSubview(progressBar)
 
         NSLayoutConstraint.activate([
@@ -428,7 +428,7 @@ final class AddressToolbarContainer: UIView,
         }
         applyProgressBarTheme(isPrivateMode: model?.isPrivateMode ?? false, theme: theme)
     }
-    
+
     // MARK: - GestureRecognizer
     @objc
     private func onContainerTapped() {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -85,6 +85,7 @@ final class AddressToolbarContainer: UIView,
     }
 
     var parent: UIStackView?
+    var onContainerTap: (() -> Void)?
     private lazy var regularToolbar: RegularBrowserAddressToolbar = .build()
     private lazy var leftSkeletonAddressBar: RegularBrowserAddressToolbar = .build()
     private lazy var rightSkeletonAddressBar: RegularBrowserAddressToolbar = .build()
@@ -324,6 +325,9 @@ final class AddressToolbarContainer: UIView,
     }
 
     private func setupLayout() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(onContainerTapped))
+        addGestureRecognizer(tapGesture)
+        
         addSubview(progressBar)
 
         NSLayoutConstraint.activate([
@@ -423,6 +427,12 @@ final class AddressToolbarContainer: UIView,
             addNewTabView.applyTheme(theme: theme)
         }
         applyProgressBarTheme(isPrivateMode: model?.isPrivateMode ?? false, theme: theme)
+    }
+    
+    // MARK: - GestureRecognizer
+    @objc
+    private func onContainerTapped() {
+        onContainerTap?()
     }
 
     // MARK: - AddressToolbarDelegate

--- a/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
+++ b/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
@@ -14,8 +14,7 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
     var isClearBackground = false
     var isSpacerClearBackground = false
     lazy var toolbarHelper: ToolbarHelperInterface = ToolbarHelper()
-    var onTap: (() -> Void)?
-
+    
     private var isToolbarRefactorEnabled: Bool {
         return FxNimbus.shared.features.toolbarRefactorFeature.value().enabled
     }

--- a/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
+++ b/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
@@ -28,7 +28,6 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
         super.init(frame: frame)
 
         setupStyle()
-        setupTapGesture()
     }
 
     required init(coder: NSCoder) {
@@ -46,16 +45,6 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
         axis = .vertical
         distribution = .fill
         alignment = .fill
-    }
-
-    private func setupTapGesture() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
-        addGestureRecognizer(tapGesture)
-    }
-
-    @objc
-    private func handleTap() {
-        onTap?()
     }
 
     // MARK: - Spacer view

--- a/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
+++ b/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
@@ -14,7 +14,7 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
     var isClearBackground = false
     var isSpacerClearBackground = false
     lazy var toolbarHelper: ToolbarHelperInterface = ToolbarHelper()
-    
+
     private var isToolbarRefactorEnabled: Bool {
         return FxNimbus.shared.features.toolbarRefactorFeature.value().enabled
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
@@ -316,7 +316,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         setupTabScroll(with: subject)
 
         subject.toolbarState = .visible
-        
+
         let handler = subject.createToolbarTapHandler()
         handler()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
@@ -303,13 +303,10 @@ final class LegacyTabScrollControllerTests: XCTestCase {
     func testToolbarTapHandler_WhenMinimalAddressBarEnabledAndCollapsed_ShowsToolbar() {
         let subject = createSubject()
         setupTabScroll(with: subject)
-
-        // Manually setup onTap handler
-        let handler = subject.createToolbarTapHandler()
-        overKeyboardContainer.onTap = handler
-
         subject.toolbarState = .collapsed
-        overKeyboardContainer.onTap?()
+
+        let handler = subject.createToolbarTapHandler()
+        handler()
 
         XCTAssertEqual(subject.toolbarState, .visible)
     }
@@ -318,12 +315,10 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         let subject = createSubject()
         setupTabScroll(with: subject)
 
-        // Manually setup onTap handler
-        let handler = subject.createToolbarTapHandler()
-        overKeyboardContainer.onTap = handler
-
         subject.toolbarState = .visible
-        overKeyboardContainer.onTap?()
+        
+        let handler = subject.createToolbarTapHandler()
+        handler()
 
         XCTAssertEqual(subject.toolbarState, .visible)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
@@ -375,26 +375,20 @@ final class TabScrollHandlerTests: XCTestCase {
 
     func testToolbarTapHandler_WhenMinimalAddressBarEnabledAndCollapsed_ShowsToolbar() {
         let subject = createSubject()
-
-        // Manually setup onTap handler
-        let handler = subject.createToolbarTapHandler()
-        overKeyboardContainer.onTap = handler
-
         subject.hideToolbars(animated: false)
-        overKeyboardContainer.onTap?()
+        
+        let handler = subject.createToolbarTapHandler()
+        handler()
 
         XCTAssertTrue(subject.toolbarDisplayState.isExpanded)
     }
 
     func testToolbarTapHandler_WhenToolbarVisible_DoesNothing() {
         let subject = createSubject()
-
-        // Manually setup onTap handler
-        let handler = subject.createToolbarTapHandler()
-        overKeyboardContainer.onTap = handler
-
         subject.showToolbars(animated: false)
-        overKeyboardContainer.onTap?()
+
+        let handler = subject.createToolbarTapHandler()
+        handler()
 
         XCTAssertTrue(subject.toolbarDisplayState.isExpanded)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
@@ -376,7 +376,7 @@ final class TabScrollHandlerTests: XCTestCase {
     func testToolbarTapHandler_WhenMinimalAddressBarEnabledAndCollapsed_ShowsToolbar() {
         let subject = createSubject()
         subject.hideToolbars(animated: false)
-        
+
         let handler = subject.createToolbarTapHandler()
         handler()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13562)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29471)

## :bulb: Description
Remove onTap handler from `BaseAlphaStackView` which was retaining all the tap gesture and not forwarding them to the tops tabs.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
