### PR TITLE
Add FXIOS-13387 [Trending Searches] initial recent searches cache

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -124,6 +124,10 @@ public struct PrefsKeys {
         public static let showSearchSuggestions = "FirefoxSuggestShowSearchSuggestions"
     }
 
+    public struct Search {
+        public static let recentSearchesCache = "recentSearchesCacheBaseKey"
+    }
+
     public struct RemoteSettings {
         public static let lastRemoteSettingsServiceSyncTimestamp =
         "LastRemoteSettingsServiceSyncTimestamp"

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1397,6 +1397,8 @@
 		AA24AD302E7C37C6008659A3 /* TrendingSearchClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD2F2E7C37BF008659A3 /* TrendingSearchClient.swift */; };
 		AA24AD322E7C3A8F008659A3 /* TrendingSearchClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD312E7C3A85008659A3 /* TrendingSearchClientTests.swift */; };
 		AA24AD342E7C3AD2008659A3 /* MockTrendingSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD332E7C3ACC008659A3 /* MockTrendingSearchEngine.swift */; };
+		AAB4321B2E8187190075E47F /* RecentSearchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB4321A2E8187130075E47F /* RecentSearchProvider.swift */; };
+		AAB4321D2E8189390075E47F /* RecentSearchProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB4321C2E8189310075E47F /* RecentSearchProviderTests.swift */; };
 		AB2AC6632BCFD0A200022AAB /* X509 in Frameworks */ = {isa = PBXBuildFile; productRef = AB2AC6622BCFD0A200022AAB /* X509 */; };
 		AB2AC6662BD15E6300022AAB /* CertificatesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2AC6652BD15E6300022AAB /* CertificatesHandler.swift */; };
 		AB3DB0C92B596739001D32CB /* AppStartupTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3DB0C82B596739001D32CB /* AppStartupTelemetry.swift */; };
@@ -9368,6 +9370,8 @@
 		AA24AD332E7C3ACC008659A3 /* MockTrendingSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTrendingSearchEngine.swift; sourceTree = "<group>"; };
 		AA80494199BED7BAA77241A9 /* zh-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/Storage.strings"; sourceTree = "<group>"; };
 		AAAB41FC97F6C8F8A1506603 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
+		AAB4321A2E8187130075E47F /* RecentSearchProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchProvider.swift; sourceTree = "<group>"; };
+		AAB4321C2E8189310075E47F /* RecentSearchProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchProviderTests.swift; sourceTree = "<group>"; };
 		AAF64ABAB8A585208603D45B /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		AB2AC6652BD15E6300022AAB /* CertificatesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatesHandler.swift; sourceTree = "<group>"; };
 		AB2B45078A7F1E09F65ACEC5 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Shared.strings; sourceTree = "<group>"; };
@@ -12832,6 +12836,7 @@
 		8A1E3BE428CBBF1E003388C4 /* SearchEngines */ = {
 			isa = PBXGroup;
 			children = (
+				AAB4321A2E8187130075E47F /* RecentSearchProvider.swift */,
 				AA24AD2F2E7C37BF008659A3 /* TrendingSearchClient.swift */,
 				ED07C0EA2CCADCD5006C0627 /* Redux */,
 				ED371A692CB885B20099F3C8 /* Views */,
@@ -13035,6 +13040,7 @@
 		8A5189C62C1B5F6C00CDB668 /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				AAB4321C2E8189310075E47F /* RecentSearchProviderTests.swift */,
 				AA24AD332E7C3ACC008659A3 /* MockTrendingSearchEngine.swift */,
 				AA24AD312E7C3A85008659A3 /* TrendingSearchClientTests.swift */,
 				8A87AEE02C1B4D17007428B2 /* SearchViewModelTests.swift */,
@@ -18251,6 +18257,7 @@
 				214099622DCE57A4004881E1 /* GenericSectionHeaderView.swift in Sources */,
 				D314E7F71A37B98700426A76 /* TabToolbar.swift in Sources */,
 				43D00493296FC48F00CB0F31 /* CreditCardSettingsEmptyView.swift in Sources */,
+				AAB4321B2E8187190075E47F /* RecentSearchProvider.swift in Sources */,
 				CEFA977E1FAA6B490016F365 /* SyncContentSettingsViewController.swift in Sources */,
 				C8CD80DC2A1E8C970097C3AE /* OnboardingTelemetryUtility.swift in Sources */,
 				8A8D277B2CBFFD710076AD3A /* BrowserNavigationType.swift in Sources */,
@@ -19470,6 +19477,7 @@
 				8A9D316A2D135EB000171502 /* EditBookmarkViewModelTests.swift in Sources */,
 				3B6F40181DC7849C00656CC6 /* TopSitesViewModelTests.swift in Sources */,
 				8A00BD882CAB401700680AF9 /* HomepageViewControllerTests.swift in Sources */,
+				AAB4321D2E8189390075E47F /* RecentSearchProviderTests.swift in Sources */,
 				C869915528917803007ACC5C /* WallpaperMetadataTestProvider.swift in Sources */,
 				8A83C58E2DDF887300FF60EF /* ProfilePrefsReaderTests.swift in Sources */,
 				BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/RecentSearchProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/RecentSearchProvider.swift
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Shared
+
+/// A provider that manages recent search terms for a specific search engine.
+struct RecentSearchProvider {
+    private let searchEngineID: String
+    private let prefs: Prefs
+
+    private let baseKey = PrefsKeys.Search.recentSearchesCache
+    private let maxNumberOfSuggestions = 5
+
+    // Namespaced key = "recentSearches.[engineID]"
+    private var recentSearchesKey: String {
+        "\(baseKey).\(searchEngineID)"
+    }
+
+    init(profile: Profile = AppContainer.shared.resolve(),
+         searchEngineID: String) {
+        self.searchEngineID = searchEngineID
+        self.prefs = profile.prefs
+    }
+
+    /// Adds a search term to the persisted recent searches list, ensuring it avoid duplicates,
+    /// and does not exceed `maxNumberOfSuggestions`.
+    ///
+    /// - Parameter term: The search term to store.
+    func addRecentSearch(_ term: String) {
+        let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        var searches = recentSearches()
+
+        searches.removeAll { $0.caseInsensitiveCompare(trimmed) == .orderedSame }
+        searches.insert(trimmed, at: 0)
+
+        if searches.count > maxNumberOfSuggestions {
+            searches = Array(searches.prefix(maxNumberOfSuggestions))
+        }
+
+        prefs.setObject(searches, forKey: recentSearchesKey)
+    }
+
+    func recentSearches() -> [String] {
+        prefs.objectForKey(recentSearchesKey) ?? []
+    }
+
+    func clearRecentSearches() {
+        prefs.removeObjectForKey(recentSearchesKey)
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/RecentSearchProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/RecentSearchProvider.swift
@@ -13,7 +13,7 @@ struct RecentSearchProvider {
     private let baseKey = PrefsKeys.Search.recentSearchesCache
     private let maxNumberOfSuggestions = 5
 
-    // Namespaced key = "recentSearches.[engineID]"
+    // Namespaced key = "recentSearchesCacheBaseKey.[engineID]"
     private var recentSearchesKey: String {
         "\(baseKey).\(searchEngineID)"
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/RecentSearchProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/RecentSearchProviderTests.swift
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Shared
+@testable import Client
+
+final class RecentSearchProviderTests: XCTestCase {
+    var mockProfile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+        mockProfile = MockProfile()
+    }
+
+    override func tearDown() {
+        mockProfile = nil
+        super.tearDown()
+    }
+
+    func test_addRecentSearch_withMultipleCalls_returnsExpectedRecentSearches() {
+        let sut = createSubject(for: "engineA")
+
+        sut.addRecentSearch("swift enums")
+        sut.addRecentSearch("combine")
+        sut.addRecentSearch("async await")
+
+        XCTAssertEqual(sut.recentSearches(), ["async await", "combine", "swift enums"])
+    }
+
+    func test_addRecentSearch_withTwoDifferentEngines_areIsolatedAndDoNotOverlap() {
+        let subjectA = createSubject(for: "engineA")
+        let subjectB = createSubject(for: "engineB")
+
+        subjectA.addRecentSearch("swift")
+        subjectB.addRecentSearch("kotlin")
+
+        XCTAssertEqual(subjectA.recentSearches(), ["swift"])
+        XCTAssertEqual(subjectB.recentSearches(), ["kotlin"])
+    }
+
+    func test_addRecentSearch_withWhitespaces_trimsAndReturnsValidSearchTerm() {
+        let sut = createSubject(for: "engineA")
+
+        sut.addRecentSearch("   swift  ")
+        sut.addRecentSearch("   ")
+        sut.addRecentSearch("")
+
+        XCTAssertEqual(sut.recentSearches(), ["swift"])
+    }
+
+    func test_addRecentSearch_withCaseSensitivity_returnsSingleSearchTerm() {
+        let sut = createSubject(for: "engineA")
+
+        sut.addRecentSearch("Swift")
+        sut.addRecentSearch("swift")
+        sut.addRecentSearch("SWIFT")
+
+        XCTAssertEqual(sut.recentSearches(), ["SWIFT"])
+    }
+
+    func test_addRecentSearch_movesExistingValueToFront_doesNotReturnDuplicateSearchTerm() {
+        let sut = createSubject(for: "engineA")
+
+        sut.addRecentSearch("a")
+        sut.addRecentSearch("b")
+        sut.addRecentSearch("c")
+        sut.addRecentSearch("b")
+
+        XCTAssertEqual(sut.recentSearches(), ["b", "c", "a"])
+    }
+
+    func test_addRecentSearch_withMoreThanMax10_returnsOnlyMostRecentSearchTerm() {
+        let sut = createSubject(for: "engineA")
+
+        for i in 1...15 { sut.addRecentSearch("search term \(i)") }
+
+        let result = sut.recentSearches()
+        XCTAssertEqual(result.count, 5)
+        XCTAssertEqual(result.first, "search term 15")
+        XCTAssertEqual(result.last, "search term 11")
+    }
+
+    func test_clearRecentSearches_returnsEmptyArray() {
+        let sut = createSubject(for: "engineA")
+
+        sut.addRecentSearch("one")
+        sut.addRecentSearch("two")
+        XCTAssertFalse(sut.recentSearches().isEmpty)
+
+        sut.clearRecentSearches()
+        XCTAssertTrue(sut.recentSearches().isEmpty)
+    }
+
+    func test_recentSearches_persistAcrossInstances() {
+        var a: RecentSearchProvider? = createSubject(for: "engineA")
+        a?.addRecentSearch("first")
+        a = nil
+
+        let b = createSubject(for: "engineA")
+        XCTAssertEqual(b.recentSearches(), ["first"])
+    }
+
+    func test_addRecentSearch_usesCorrectNameSpacedKey() {
+        let engineID = "engineA"
+        let sut = createSubject(for: "engineA")
+
+        sut.addRecentSearch("swift")
+        let expectedKey = "\(PrefsKeys.Search.recentSearchesCache).\(engineID)"
+
+        XCTAssertEqual(mockProfile.prefs.objectForKey(expectedKey), ["swift"])
+    }
+
+    func createSubject(for searchEngineID: String) -> RecentSearchProvider {
+        let subject = RecentSearchProvider(
+            profile: mockProfile,
+            searchEngineID: searchEngineID,
+        )
+        return subject
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13387)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29100)

## :bulb: Description
Create a simple cache for storing recent search terms up to a max amount. The `RecentSearchProvider` keeps track of a list of search terms for each search engine.

Note: We have a separate ticket to investigate using `RustPlaces` instead [here](https://mozilla-hub.atlassian.net/browse/FXIOS-13499). We will use this cache for now until then.

## :movie_camera: Demos
Tested with different search engines and exceeding 5 search terms:
<img width="500" height="504" alt="image" src="https://github.com/user-attachments/assets/58202518-085e-4656-a32f-a0c4d522cdbf" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
