### PR TITLE
Refactor FXIOS-13511 [Swift 6] Remove Equatable from AppState and other redux states

### DIFF
--- a/firefox-ios/Client/Coordinators/Router/Route.swift
+++ b/firefox-ios/Client/Coordinators/Router/Route.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// An enumeration representing different navigational routes in an application.
-enum Route: Equatable {
+enum Route {
     /// Represents a search route that takes a URL, a boolean value indicating whether the search
     /// is private or not and an optional set of search options.
     ///

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
@@ -7,7 +7,7 @@ import enum MozillaAppServices.VisitType
 import SummarizeKit
 
 /// View types that the browser coordinator can navigate to
-enum BrowserNavigationDestination: Equatable {
+enum BrowserNavigationDestination {
     // Native views
     case contextMenu
     case settings(Route.SettingsSection)
@@ -26,7 +26,7 @@ enum BrowserNavigationDestination: Equatable {
     case shareSheet(ShareSheetConfiguration)
 }
 
-struct ShareSheetConfiguration: Equatable {
+struct ShareSheetConfiguration {
     let shareType: ShareType
     let shareMessage: ShareMessage?
     let sourceView: UIView
@@ -36,7 +36,7 @@ struct ShareSheetConfiguration: Equatable {
 }
 
 /// This type exists as a field on the BrowserViewControllerState
-struct NavigationDestination: Equatable {
+struct NavigationDestination {
     let destination: BrowserNavigationDestination
     let url: URL?
     let isPrivate: Bool?

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -9,7 +9,7 @@ import Common
 import WebKit
 import SummarizeKit
 
-struct BrowserViewControllerState: ScreenState, Equatable {
+struct BrowserViewControllerState: ScreenState {
     enum NavigationType {
         case home
         case back

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -70,7 +70,7 @@ struct MainMenuTabInfo: Equatable {
     let accountData: AccountData
 }
 
-struct MainMenuState: ScreenState, Equatable, Sendable {
+struct MainMenuState: ScreenState, Sendable {
     let windowUUID: WindowUUID
     let menuElements: [MenuSection]
 

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
@@ -5,7 +5,7 @@
 import Common
 import Redux
 
-struct SearchEngineSelectionState: ScreenState, Equatable {
+struct SearchEngineSelectionState: ScreenState {
     var windowUUID: WindowUUID
     var shouldDismiss: Bool
     // Default search engine should appear in position 0

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -46,7 +46,7 @@ enum RemoteTabsPanelEmptyStateReason {
 }
 
 /// State for RemoteTabsPanel. WIP.
-struct RemoteTabsPanelState: ScreenState, Equatable, Sendable {
+struct RemoteTabsPanelState: ScreenState, Sendable {
     let refreshState: RemoteTabsPanelRefreshState
     let allowsRefresh: Bool
     let clientAndTabs: [ClientAndTabs]

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -5,7 +5,7 @@
 import Redux
 import Common
 
-struct TabPeekState: ScreenState, Equatable {
+struct TabPeekState: ScreenState {
     let showAddToBookmarks: Bool
     let showSendToDevice: Bool
     let showCopyURL: Bool

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
@@ -5,7 +5,7 @@
 import Common
 import Redux
 
-struct TermsOfUseState: ScreenState, Equatable {
+struct TermsOfUseState: ScreenState {
     let windowUUID: WindowUUID
     var hasAccepted: Bool
     var wasDismissed: Bool

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -6,7 +6,7 @@ import Common
 import Redux
 import ToolbarKit
 
-struct ToolbarState: ScreenState, Sendable, Equatable {
+struct ToolbarState: ScreenState, Sendable {
     var windowUUID: WindowUUID
     var toolbarPosition: AddressToolbarPosition
     var toolbarLayout: ToolbarLayoutStyle

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
@@ -5,7 +5,7 @@
 import Redux
 import Common
 
-struct MicrosurveyState: ScreenState, Equatable {
+struct MicrosurveyState: ScreenState {
     var windowUUID: WindowUUID
     var shouldDismiss: Bool
     var showPrivacy: Bool

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
@@ -5,7 +5,7 @@
 import Redux
 import Common
 
-struct NativeErrorPageState: ScreenState, Equatable {
+struct NativeErrorPageState: ScreenState {
     var windowUUID: WindowUUID
     var title: String
     var description: String

--- a/firefox-ios/Client/Frontend/Onboarding/State/OnboardingViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/State/OnboardingViewControllerState.swift
@@ -6,7 +6,7 @@ import Foundation
 import Redux
 import Common
 
-struct OnboardingViewControllerState: ScreenState, Equatable {
+struct OnboardingViewControllerState: ScreenState {
     let windowUUID: WindowUUID
 
     init(appState: AppState, uuid: WindowUUID) {

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
@@ -6,7 +6,7 @@ import Foundation
 import Redux
 import Common
 
-struct PasswordGeneratorState: ScreenState, Equatable {
+struct PasswordGeneratorState: ScreenState {
     var windowUUID: WindowUUID
     var password: String
     var passwordHidden: Bool

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -5,7 +5,7 @@
 import Common
 import Redux
 
-struct ThemeSettingsState: ScreenState, Equatable {
+struct ThemeSettingsState: ScreenState {
     var useSystemAppearance: Bool
     var isAutomaticBrightnessEnabled: Bool
     var manualThemeSelected: ThemeType

--- a/firefox-ios/Client/Frontend/Share/ShareType.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareType.swift
@@ -13,7 +13,7 @@ import Foundation
 ///           __SPECIAL NOTE__: If you download a PDF, you can view that in a tab. In that case, the URL may have a `file://`
 ///            scheme instead of `http(s)://`, so certain options, like Send to Device / Add to Home Screen, may not be
 ///            available.
-enum ShareType: Equatable {
+enum ShareType {
     case file(url: URL)
     case site(url: URL)
     case tab(url: URL, tab: any ShareTab)

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -6,7 +6,7 @@ import Foundation
 import Redux
 import Common
 
-struct TrackingProtectionState: StateType, Equatable, ScreenState {
+struct TrackingProtectionState: ScreenState {
     enum NavType {
         case home
         case back

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
@@ -6,7 +6,7 @@ import Foundation
 import Redux
 import Common
 
-enum AppScreenState: Equatable {
+enum AppScreenState {
     case browserViewController(BrowserViewControllerState)
     case homepage(HomepageState)
     case mainMenu(MainMenuState)
@@ -108,7 +108,7 @@ enum AppScreenState: Equatable {
     }
 }
 
-struct ActiveScreensState: Equatable {
+struct ActiveScreensState {
     let screens: [AppScreenState]
 
     init() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -155,7 +155,6 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .tapOnLink, destination: .link, url: url)
         let newState = reducer(initialState, action)
 
-
         let destination = newState.navigationDestination?.destination
         switch destination {
         case .link:
@@ -191,7 +190,12 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let destination = newState.navigationDestination?.destination
         switch destination {
         case .shareSheet(let configuration):
-            break
+            switch configuration.shareType {
+            case .site(let url):
+                XCTAssertEqual(url, try XCTUnwrap(URL(string: "www.example.com")))
+            default:
+                XCTFail("shareType is not the right type")
+            }
         default:
             XCTFail("destination is not the right type")
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -113,8 +113,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
 
         let action = getNavigationBrowserAction(for: .tapOnCustomizeHomepageButton, destination: .settings(.homePage))
         let newState = reducer(initialState, action)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .settings(let route):
+            XCTAssertEqual(route, .homePage)
+        default:
+            XCTFail("destination is not the right type")
+        }
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .settings(.homePage))
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -128,7 +134,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .tapOnCell, destination: .link, url: url)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .link)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .link:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url?.absoluteString, "www.example.com")
     }
 
@@ -142,7 +155,15 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .tapOnLink, destination: .link, url: url)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .link)
+
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .link:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url?.absoluteString, "www.example.com")
     }
 
@@ -167,7 +188,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         )
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .shareSheet(shareSheetConfiguration))
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .shareSheet(let configuration):
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -181,7 +209,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .longPressOnCell, destination: .link, url: url)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .link)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .link:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url?.absoluteString, "www.example.com")
     }
 
@@ -200,7 +235,13 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let newState = reducer(initialState, action)
 
         let navigationDestination = try XCTUnwrap(newState.navigationDestination)
-        XCTAssertEqual(navigationDestination.destination, .newTab)
+        switch navigationDestination.destination {
+        case .newTab:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(navigationDestination.url?.absoluteString, "www.example.com")
         XCTAssertFalse(navigationDestination.isPrivate ?? true)
         XCTAssertFalse(navigationDestination.selectNewTab ?? true)
@@ -221,7 +262,13 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let newState = reducer(initialState, action)
 
         let navigationDestination = try XCTUnwrap(newState.navigationDestination)
-        XCTAssertEqual(navigationDestination.destination, .newTab)
+        switch navigationDestination.destination {
+        case .newTab:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(navigationDestination.url?.absoluteString, "www.example.com")
         XCTAssertTrue(navigationDestination.isPrivate ?? false)
         XCTAssertTrue(navigationDestination.selectNewTab ?? false)
@@ -236,7 +283,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .tapOnSettingsSection, destination: .settings(.topSites))
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .settings(.topSites))
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .settings(let section):
+            XCTAssertEqual(section, .topSites)
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -284,8 +338,15 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
             summarizerConfig: SummarizerConfig(instructions: "Test instructions", options: [:])
         )
         let newState = reducer(initialState, action)
-        let config = SummarizerConfig(instructions: "Test instructions", options: [:])
-        XCTAssertEqual(newState.navigationDestination?.destination, .summarizer(config: config))
+        let expectedConfig = SummarizerConfig(instructions: "Test instructions", options: [:])
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .summarizer(let config):
+            XCTAssertEqual(config, expectedConfig)
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -299,8 +360,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
 
         let action = getNavigationBrowserAction(for: .tapOnHomepageSearchBar, destination: .zeroSearch)
         let newState = reducer(initialState, action)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .zeroSearch:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .zeroSearch)
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -317,8 +384,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarMiddlewareActionType.didTapButton
         )
         let newState = reducer(initialState, action)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .zeroSearch:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .zeroSearch)
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -335,8 +408,7 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         )
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, nil)
-        XCTAssertEqual(newState.navigationDestination?.url, nil)
+        XCTAssertNil(newState.navigationDestination)
     }
 
     func test_didTapButtonToolbarAction_withoutHomepageSearch_andSearchButtonType_doesNotNavigateToZeroSearch() {
@@ -352,8 +424,7 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         )
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, nil)
-        XCTAssertEqual(newState.navigationDestination?.url, nil)
+        XCTAssertNil(newState.navigationDestination)
     }
 
     func test_didTapButtonToolbarAction_withoutHomepageSearch_andNoButtonType_doesNotNavigateToZeroSearch() {
@@ -368,8 +439,7 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         )
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, nil)
-        XCTAssertEqual(newState.navigationDestination?.url, nil)
+        XCTAssertNil(newState.navigationDestination)
     }
 
     // MARK: - Shortcuts Library
@@ -383,7 +453,13 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .tapOnShortcutsShowAllButton, destination: .shortcutsLibrary)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .shortcutsLibrary)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .shortcutsLibrary:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
@@ -33,9 +33,29 @@ class RouteBuilderTests: XCTestCase {
             userActivity: randomActivity
         )
 
-        XCTAssertEqual(route, .search(url: testURL, isPrivate: false))
-        XCTAssertEqual(universalLinkRoute, .search(url: testURL, isPrivate: false))
-        XCTAssertEqual(randomRoute, .search(url: testURL, isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, testURL)
+            XCTAssertFalse(isPrivate)
+        default:
+            break
+        }
+
+        switch universalLinkRoute {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, testURL)
+            XCTAssertFalse(isPrivate)
+        default:
+            break
+        }
+
+        switch randomRoute {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, testURL)
+            XCTAssertFalse(isPrivate)
+        default:
+            break
+        }
     }
 
     func test_makeRoute_ResetsShouldOpenNewTabAfterDelay() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -13,14 +13,14 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(
-            route,
-            .search(
-                url: URL(string: "http://google.com?a=1&b=2&c=foo%20bar")!,
-                isPrivate: false,
-                options: [.focusLocationField]
-            )
-        )
+        switch route {
+        case .search(let url, let isPrivate, let options):
+            XCTAssertEqual(url, URL(string: "http://google.com?a=1&b=2&c=foo%20bar")!)
+            XCTAssertFalse(isPrivate)
+            XCTAssertEqual(options, [.focusLocationField])
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testSearchRouteWithJS_shouldReturnFalse() {
@@ -38,7 +38,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "http://google.com?a=1&b=2&c=foo%20bar"), isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, URL(string: "http://google.com?a=1&b=2&c=foo%20bar")!)
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testSearchRouteWithPrivateFlag() {
@@ -47,7 +53,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: true))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertNil(url)
+            XCTAssertTrue(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testSettingsRouteWithClearPrivateData() {
@@ -56,7 +68,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .clearPrivateData))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .clearPrivateData)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithNewTab() {
@@ -65,7 +82,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .newTab))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .newTab)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithNewTabTrailingSlash() {
@@ -74,7 +96,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .newTab))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .newTab)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithHomePage() {
@@ -83,7 +110,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .homePage))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .homePage)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithMailto() {
@@ -92,7 +124,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .mailto))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .mailto)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithSearch() {
@@ -101,7 +138,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .search))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .search)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithFxa() {
@@ -110,7 +152,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .fxa))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .fxa)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testHomepanelRouteWithBookmarks() {
@@ -119,7 +166,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .homepanel(section: .bookmarks))
+        switch route {
+        case .homepanel(let section):
+            XCTAssertEqual(section, .bookmarks)
+        default:
+            XCTFail("The route should be a homepanel route")
+        }
     }
 
     func testHomepanelRouteWithTopSites() {
@@ -128,7 +180,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .homepanel(section: .topSites))
+        switch route {
+        case .homepanel(let section):
+            XCTAssertEqual(section, .topSites)
+        default:
+            XCTFail("The route should be a homepanel route")
+        }
     }
 
     func testHomepanelRouteWithHistory() {
@@ -137,7 +194,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .homepanel(section: .history))
+        switch route {
+        case .homepanel(let section):
+            XCTAssertEqual(section, .history)
+        default:
+            XCTFail("The route should be a homepanel route")
+        }
     }
 
     func testHomepanelRouteWithReadingList() {
@@ -146,7 +208,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .homepanel(section: .readingList))
+        switch route {
+        case .homepanel(let section):
+            XCTAssertEqual(section, .readingList)
+        default:
+            XCTFail("The route should be a homepanel route")
+        }
     }
 
     func testDefaultBrowserRouteWithTutorial() {
@@ -155,7 +222,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .defaultBrowser(section: .tutorial))
+        switch route {
+        case .defaultBrowser(let section):
+            XCTAssertEqual(section, .tutorial)
+        default:
+            XCTFail("The route should be a default browser route")
+        }
     }
 
     func testDefaultBrowserRouteWithSystemSettings() {
@@ -164,7 +236,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .defaultBrowser(section: .systemSettings))
+        switch route {
+        case .defaultBrowser(let section):
+            XCTAssertEqual(section, .systemSettings)
+        default:
+            XCTFail("The route should be a default browser route")
+        }
     }
 
     func testInvalidRouteWithBadPath() {
@@ -183,8 +260,16 @@ class RouteTests: XCTestCase {
         let route = subject.makeRoute(url: url)
 
         let expectedQuery = ["signin": "coolcodes", "user": "foo", "email": "bar"]
-        XCTAssertEqual(route, .fxaSignIn(params: FxALaunchParams(entrypoint: .fxaDeepLinkNavigation,
-                                                                 query: expectedQuery)))
+
+        let expectedParams = FxALaunchParams(entrypoint: .fxaDeepLinkNavigation,
+                                             query: expectedQuery)
+
+        switch route {
+        case .fxaSignIn(let params):
+            XCTAssertEqual(params, expectedParams)
+        default:
+            XCTFail("The route should be a fxa sign in route")
+        }
     }
 
     func test_makeRoute_forFXASignIn_withJS_doesntOpenRoute() {
@@ -257,7 +342,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, URL(string: "https://google.com")!)
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forMediumTopSitesWidget_withJS_doesntOpenRoute() {
@@ -275,10 +366,14 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(
-            route,
-            .search(url: URL(string: "https://google.com"), isPrivate: true, options: [.focusLocationField])
-        )
+        switch route {
+        case .search(let url, let isPrivate, let options):
+            XCTAssertEqual(url, URL(string: "https://google.com")!)
+            XCTAssertFalse(isPrivate)
+            XCTAssertEqual(options, [.focusLocationField])
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forSmallQuickLinkWidget_withJS_doesntOpenRoute() {
@@ -296,10 +391,14 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(
-            route,
-            .search(url: URL(string: "https://google.com"), isPrivate: false, options: [.focusLocationField])
-        )
+        switch route {
+        case .search(let url, let isPrivate, let options):
+            XCTAssertEqual(url, URL(string: "https://google.com")!)
+            XCTAssertFalse(isPrivate)
+            XCTAssertEqual(options, [.focusLocationField])
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forMediumQuickLinkWidget_withJS_doesntOpenRoute() {
@@ -318,7 +417,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .searchQuery(query: "test search text", isPrivate: false))
+        switch route {
+        case .searchQuery(let query, let isPrivate):
+            XCTAssertEqual(query, "test search text")
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forSmallQuickLinkOpenCopedWidget_withJS_doesntOpenRoute() {
@@ -338,7 +443,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, URL(string: "https://google.com")!)
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forSmallQuickLinkWithURLWidgetOpenCopied_withJS_doesntOpenRoute() {
@@ -356,8 +467,12 @@ class RouteTests: XCTestCase {
         let url = URL(string: "firefox://widget-small-quicklink-close-private-tabs")!
 
         let route = subject.makeRoute(url: url)
-
-        XCTAssertEqual(route, .action(action: .closePrivateTabs))
+        switch route {
+        case .action(let action):
+            XCTAssertEqual(action, .closePrivateTabs)
+        default:
+            XCTFail("The route should be an action route")
+        }
     }
 
     func test_makeRoute_forMediumQuickLinkCloseWidget_withJS_doesntOpenRoute() {
@@ -366,7 +481,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .action(action: .closePrivateTabs))
+        switch route {
+        case .action(let action):
+            XCTAssertEqual(action, .closePrivateTabs)
+        default:
+            XCTFail("The route should be an action route")
+        }
     }
 
     func testWidgetMediumQuicklinkClosePrivateTabs() {
@@ -375,7 +495,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .action(action: .closePrivateTabs))
+        switch route {
+        case .action(let action):
+            XCTAssertEqual(action, .closePrivateTabs)
+        default:
+            XCTFail("The route should be an action route")
+        }
     }
 
     func testUnsupportedScheme() {
@@ -411,7 +536,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertNil(url)
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testInvalidFxaSignIn() {
@@ -429,7 +560,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .searchQuery(query: "google", isPrivate: false))
+        switch route {
+        case .searchQuery(let query, let isPrivate):
+            XCTAssertEqual(query, "google")
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forOpenText_withJS_doesntOpenRoute() {
@@ -448,7 +585,18 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: shareURL)
 
-        XCTAssertEqual(route, .sharesheet(shareType: .site(url: testURL), shareMessage: nil))
+        switch route {
+        case .sharesheet(let shareType, let shareMessage):
+            switch shareType {
+            case .site(let url):
+                XCTAssertEqual(url, testURL)
+            default:
+                XCTFail("The share type should be a site share type")
+            }
+            XCTAssertNil(shareMessage)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testShareSheetRouteUrlTitle() {
@@ -460,9 +608,20 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: shareURL)
 
-        let expectedShareType = ShareType.site(url: testURL)
         let expectedShareMessage = ShareMessage(message: testTitle, subtitle: nil)
-        XCTAssertEqual(route, .sharesheet(shareType: expectedShareType, shareMessage: expectedShareMessage))
+
+        switch route {
+        case .sharesheet(let shareType, let shareMessage):
+            switch shareType {
+            case .site(let url):
+                XCTAssertEqual(url, testURL)
+            default:
+                XCTFail("The share type should be a site share type")
+            }
+            XCTAssertEqual(shareMessage, expectedShareMessage)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testShareSheetRouteUrlTitleAndSubtitle() {
@@ -475,9 +634,20 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: shareURL)
 
-        let expectedShareType = ShareType.site(url: testURL)
         let expectedShareMessage = ShareMessage(message: testTitle, subtitle: testSubtitle)
-        XCTAssertEqual(route, .sharesheet(shareType: expectedShareType, shareMessage: expectedShareMessage))
+
+        switch route {
+        case .sharesheet(let shareType, let shareMessage):
+            switch shareType {
+            case .site(let url):
+                XCTAssertEqual(url, testURL)
+            default:
+                XCTFail("The share type should be a site share type")
+            }
+            XCTAssertEqual(shareMessage, expectedShareMessage)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forShareSheet_withJS_doesntOpenRoute() {
@@ -496,8 +666,12 @@ class RouteTests: XCTestCase {
         let url = URL(string: "firefox://deep-link?url=/action/show-intro-onboarding")!
 
         let route = subject.makeRoute(url: url)
-
-        XCTAssertEqual(route, .action(action: .showIntroOnboarding))
+        switch route {
+        case .action(let action):
+            XCTAssertEqual(action, .showIntroOnboarding)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     // MARK: - Helper

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
@@ -13,7 +13,14 @@ final class ShortcutRouteTests: XCTestCase {
 
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: false, options: [.focusLocationField]))
+        switch route {
+        case .search(let url, let isPrivate, let options):
+            XCTAssertNil(url)
+            XCTAssertFalse(isPrivate)
+            XCTAssertEqual(options, [.focusLocationField])
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testNewPrivateTabShortcut() {
@@ -23,7 +30,14 @@ final class ShortcutRouteTests: XCTestCase {
 
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: true, options: [.focusLocationField]))
+        switch route {
+        case .search(let url, let isPrivate, let options):
+            XCTAssertNil(url)
+            XCTAssertTrue(isPrivate)
+            XCTAssertEqual(options, [.focusLocationField])
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testOpenLastBookmarkShortcutWithValidUrl() {
@@ -37,8 +51,13 @@ final class ShortcutRouteTests: XCTestCase {
 
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"),
-                                      isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, URL(string: "https://www.example.com")!)
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     // FXIOS-8107: Disabled test as history highlights has been disabled to fix app hangs / slowness
@@ -62,7 +81,12 @@ final class ShortcutRouteTests: XCTestCase {
         let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.QRCode",
                                                      localizedTitle: "QR Code")
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
-        XCTAssertEqual(route, .action(action: .showQRCode))
+        switch route {
+        case .action(let action):
+            XCTAssertEqual(action, .showQRCode)
+        default:
+            XCTFail("Expected .action(.showQRCode)")
+        }
     }
 
     func testInvalidShortcut() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/UserActivityRouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/UserActivityRouteTests.swift
@@ -15,7 +15,13 @@ class UserActivityRouteTests: XCTestCase {
 
         let route = subject.makeRoute(userActivity: userActivity)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertFalse(isPrivate)
+            XCTAssertNil(url)
+        default:
+            XCTFail("route was not of expected type")
+        }
     }
 
     // Test the Route initializer with a deep link user activity.
@@ -26,7 +32,13 @@ class UserActivityRouteTests: XCTestCase {
 
         let route = subject.makeRoute(userActivity: userActivity)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertFalse(isPrivate)
+            XCTAssertEqual(url?.absoluteString, "https://www.example.com")
+        default:
+            XCTFail("route was not of expected type")
+        }
     }
 
     // Test the Route initializer with a CoreSpotlight user activity.
@@ -37,7 +49,13 @@ class UserActivityRouteTests: XCTestCase {
 
         let route = subject.makeRoute(userActivity: userActivity)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertFalse(isPrivate)
+            XCTAssertEqual(url?.absoluteString, "https://www.example.com")
+        default:
+            XCTFail("route was not of expected type")
+        }
     }
 
     // Test the Route initializer with an unsupported user activity.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13511)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Remove Equatable from AppState and redux states that are not using Equatable for naive diffing. These states don't require equatable for any reason and will make aspects of Swift 6 migration much easier without a larger Tab refactor. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
