### PR TITLE
Refactor FXIOS-13511 [Swift 6] Move Tab to MainActor and resolve strict concurrency warnings

### DIFF
--- a/BrowserKit/Tests/TabDataStoreTests/Mocks/TabFileManagerMock.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/Mocks/TabFileManagerMock.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import TabDataStore
 
-class TabFileManagerMock: TabFileManager {
+final class TabFileManagerMock: TabFileManager, @unchecked Sendable {
     var primaryDirectoryURL: URL?
     var backupDirectoryURL: URL?
     var tabSessionDataDirectoryCalledCount = 0

--- a/firefox-ios/Client/Application/BackgroundNotificationSurfaceUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundNotificationSurfaceUtility.swift
@@ -3,11 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import BackgroundTasks
+// TODO: FXIOS-13582 - Capture of non-Sendable type BGAppRefreshTask in @Sendable closure
+@preconcurrency import BackgroundTasks
 import Common
 import Shared
 
-class BackgroundNotificationSurfaceUtility: BackgroundUtilityProtocol {
+// TODO: FXIOS-13582 - BackgroundNotificationSurfaceUtility should be concurrency safe
+class BackgroundNotificationSurfaceUtility: BackgroundUtilityProtocol, @unchecked Sendable {
     let taskIdentifier = "org.mozilla.ios.surface.notification.refresh"
     var surfaceManager: NotificationSurfaceManager
     var notificationManager: NotificationManagerProtocol

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -111,6 +111,7 @@ struct NoImageModeDefaults {
     static let ScriptName = "images"
 }
 
+@MainActor
 class ContentBlocker {
     var safelistedDomains = SafelistedDomains()
     let ruleStore = WKContentRuleListStore.default()
@@ -230,11 +231,8 @@ class ContentBlocker {
             tab.currentWebView()?.configuration.userContentController.remove(rule)
         }
 
-        // Async required here to ensure remove() call is processed.
-        DispatchQueue.main.async { [weak tab] in
-            tab?.currentWebView()?
-                .evaluateJavascriptInDefaultContentWorld("window.__firefox__.NoImageMode.setEnabled(\(enabled))")
-        }
+        tab.currentWebView()?
+            .evaluateJavascriptInDefaultContentWorld("window.__firefox__.NoImageMode.setEnabled(\(enabled))")
     }
 }
 

--- a/firefox-ios/Client/ContentBlocker/TabContentBlocker+ContentScript.swift
+++ b/firefox-ios/Client/ContentBlocker/TabContentBlocker+ContentScript.swift
@@ -10,6 +10,7 @@ extension TabContentBlocker {
         stats = TPPageStats()
     }
 
+    @MainActor
     func userContentController(
         _ userContentController: WKUserContentController,
         didReceiveScriptMessage message: WKScriptMessage

--- a/firefox-ios/Client/ContentBlocker/TabContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/TabContentBlocker.swift
@@ -11,20 +11,25 @@ extension Notification.Name {
 }
 
 protocol ContentBlockerTab: AnyObject {
+    @MainActor
     func currentURL() -> URL?
+    @MainActor
     func currentWebView() -> WKWebView?
+    @MainActor
     func imageContentBlockingEnabled() -> Bool
 }
 
 class TabContentBlocker {
     weak var tab: ContentBlockerTab?
     let logger: Logger
+
+    @MainActor
     var isEnabled: Bool {
         return false
     }
 
     @objc
-    func notifiedTabSetupRequired() {}
+    nonisolated func notifiedTabSetupRequired() {}
 
     func currentlyEnabledLists() -> [String] {
         return []
@@ -32,6 +37,7 @@ class TabContentBlocker {
 
     func notifyContentBlockingChanged() {}
 
+    @MainActor
     var status: BlockerStatus {
         guard isEnabled else {
             return .disabled

--- a/firefox-ios/Client/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/firefox-ios/Client/ContentBlocker/TrackingProtectionPageStats.swift
@@ -118,7 +118,7 @@ func wildcardContentBlockerDomainToRegex(domain: String) -> String? {
     return regex
 }
 
-// TODO: FXIOS TPStatsBlocklists is not actually Sendable
+// TODO: FXIOS-13617 TPStatsBlocklists is not actually Sendable
 class TPStatsBlocklists: @unchecked Sendable {
     class Rule {
         let regex: String

--- a/firefox-ios/Client/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/firefox-ios/Client/ContentBlocker/TrackingProtectionPageStats.swift
@@ -47,10 +47,11 @@ class TPStatsBlocklistChecker {
     // Initialized async, is non-nil when ready to be used.
     private var blockLists: TPStatsBlocklists?
 
+    @MainActor
     func isBlocked(
         url: URL,
         mainDocumentURL: URL,
-        completionHandler: @escaping (BlocklistCategory?) -> Void
+        completionHandler: @Sendable @escaping (BlocklistCategory?) -> Void
     ) {
         guard let blockLists = blockLists,
               let host = url.host,
@@ -117,7 +118,8 @@ func wildcardContentBlockerDomainToRegex(domain: String) -> String? {
     return regex
 }
 
-class TPStatsBlocklists {
+// TODO: FXIOS TPStatsBlocklists is not actually Sendable
+class TPStatsBlocklists: @unchecked Sendable {
     class Rule {
         let regex: String
         let loadType: LoadType

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1312,7 +1312,7 @@ class BrowserCoordinator: BaseCoordinator,
     nonisolated private func tryDownloadingTabFileToShare(shareType: ShareType) async -> ShareType {
         // We can only try to download files for `.tab` type shares that have a TemporaryDocument
         guard case let ShareType.tab(_, tab) = shareType,
-              let temporaryDocument = tab.temporaryDocument,
+              let temporaryDocument = await tab.temporaryDocument,
               !temporaryDocument.isDownloading else {
             return shareType
         }

--- a/firefox-ios/Client/Coordinators/Router/Route.swift
+++ b/firefox-ios/Client/Coordinators/Router/Route.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// An enumeration representing different navigational routes in an application.
-enum Route: Equatable {
+enum Route {
     /// Represents a search route that takes a URL, a boolean value indicating whether the search
     /// is private or not and an optional set of search options.
     ///

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -93,15 +93,17 @@ class WebContextMenuActionsProvider {
             ),
             identifier: UIAction.Identifier("linkContextMenu.download")
         ) { _ in
-            // This checks if download is a blob, if yes, begin blob download process
-            if !DownloadContentScript.requestBlobDownload(url: url, tab: currentTab) {
-                // if not a blob, set pendingDownloadWebView and load the request in
-                // the webview, which will trigger the WKWebView navigationResponse
-                // delegate function and eventually downloadHelper.open()
-                assignWebView(currentTab.webView)
-                let request = URLRequest(url: url)
-                currentTab.webView?.load(request)
-                self.recordOptionSelectedTelemetry(option: .downloadLink)
+            ensureMainThread {
+                // This checks if download is a blob, if yes, begin blob download process
+                if !DownloadContentScript.requestBlobDownload(url: url, tab: currentTab) {
+                    // if not a blob, set pendingDownloadWebView and load the request in
+                    // the webview, which will trigger the WKWebView navigationResponse
+                    // delegate function and eventually downloadHelper.open()
+                    assignWebView(currentTab.webView)
+                    let request = URLRequest(url: url)
+                    currentTab.webView?.load(request)
+                    self.recordOptionSelectedTelemetry(option: .downloadLink)
+                }
             }
         })
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
@@ -7,7 +7,7 @@ import enum MozillaAppServices.VisitType
 import SummarizeKit
 
 /// View types that the browser coordinator can navigate to
-enum BrowserNavigationDestination: Equatable {
+enum BrowserNavigationDestination {
     // Native views
     case contextMenu
     case settings(Route.SettingsSection)
@@ -26,7 +26,7 @@ enum BrowserNavigationDestination: Equatable {
     case shareSheet(ShareSheetConfiguration)
 }
 
-struct ShareSheetConfiguration: Equatable {
+struct ShareSheetConfiguration {
     let shareType: ShareType
     let shareMessage: ShareMessage?
     let sourceView: UIView
@@ -36,7 +36,7 @@ struct ShareSheetConfiguration: Equatable {
 }
 
 /// This type exists as a field on the BrowserViewControllerState
-struct NavigationDestination: Equatable {
+struct NavigationDestination {
     let destination: BrowserNavigationDestination
     let url: URL?
     let isPrivate: Bool?

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -9,7 +9,7 @@ import Common
 import WebKit
 import SummarizeKit
 
-struct BrowserViewControllerState: ScreenState, Equatable {
+struct BrowserViewControllerState: ScreenState {
     enum NavigationType {
         case home
         case back

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadHelper.swift
@@ -13,6 +13,7 @@ class DownloadHelper: NSObject {
     private let preflightResponse: URLResponse
     private let cookieStore: WKHTTPCookieStore
 
+    @MainActor
     static func requestDownload(url: URL, tab: Tab) {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: "%27")
         tab.webView?.evaluateJavascriptInDefaultContentWorld(

--- a/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
+++ b/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
@@ -66,6 +66,7 @@ class EnhancedTrackingProtectionMenuVM {
                                                    connectionSecure: connectionSecure)
     }
 
+    @MainActor
     func toggleSiteSafelistStatus() {
         TelemetryWrapper.recordEvent(category: .action, method: .add, object: .trackingProtectionSafelist)
         ContentBlocker.shared.safelist(enable: contentBlockerStatus != .safelisted, url: url) { [weak self] in

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -70,7 +70,7 @@ struct MainMenuTabInfo: Equatable {
     let accountData: AccountData
 }
 
-struct MainMenuState: ScreenState, Equatable, Sendable {
+struct MainMenuState: ScreenState, Sendable {
     let windowUUID: WindowUUID
     let menuElements: [MenuSection]
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -56,7 +56,7 @@ enum MenuButtonToastAction {
 ///     - The home page menu, determined with isHomePage variable
 ///     - The file URL menu, shown when the user is on a url of type `file://`
 ///     - The site menu, determined by the absence of isHomePage and isFileURL
-final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol,
+final class MainMenuActionHelper: PhotonActionSheetProtocol,
                             FeatureFlaggable,
                             CanRemoveQuickActionBookmark,
                             AppVersionUpdateCheckerProtocol {
@@ -203,6 +203,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
 
     // MARK: - Sections
 
+    @MainActor
     private func getNewTabSection() -> [PhotonRowActions] {
         var section = [PhotonRowActions]()
         append(to: &section, action: getNewTabAction())
@@ -210,6 +211,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
         return section
     }
 
+    @MainActor
     private func getLibrarySection() -> [PhotonRowActions] {
         var section = [PhotonRowActions]()
 
@@ -271,6 +273,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
         return section
     }
 
+    @MainActor
     private func getSecondMiscSection() -> [PhotonRowActions] {
         var section = [PhotonRowActions]()
 
@@ -323,6 +326,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
 
     // MARK: - Actions
 
+    @MainActor
     private func getNewTabAction() -> PhotonRowActions? {
         guard let tab = selectedTab else { return nil }
         return SingleActionViewModel(title: tab.isPrivate ? .LegacyAppMenu.NewPrivateTab : .LegacyAppMenu.NewTab,
@@ -351,6 +355,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
 
     // MARK: Zoom
 
+    @MainActor
     private func getZoomAction() -> PhotonRowActions? {
         guard let tab = selectedTab else { return nil }
         let zoomLevel = NumberFormatter.localizedString(from: NSNumber(value: tab.pageZoom), number: .percent)
@@ -370,6 +375,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
         }.items
     }
 
+    @MainActor
     private func getRequestDesktopSiteAction() -> PhotonRowActions? {
         guard let tab = selectedTab else { return nil }
 
@@ -673,7 +679,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
     }
 
     // MARK: Reading list
-
+    @MainActor
     private func getReadingListSection() -> [PhotonRowActions] {
         var section = [PhotonRowActions]()
 
@@ -836,6 +842,7 @@ final class MainMenuActionHelper: @unchecked Sendable, PhotonActionSheetProtocol
 
     // MARK: Password
 
+    @MainActor
     private func getPasswordAction(navigationController: UINavigationController?) -> PhotonRowActions? {
         guard PasswordManagerListViewController.shouldShowAppMenuShortcut(forPrefs: profile.prefs) else { return nil }
         TelemetryWrapper.recordEvent(category: .action, method: .open, object: .logins)

--- a/firefox-ios/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -7,6 +7,7 @@ import Shared
 import Storage
 import WebKit
 
+@MainActor
 class MetadataParserHelper: TabEventHandler {
     let tabEventWindowResponseType: TabEventHandlerWindowResponseType = .allWindows
 

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
@@ -5,7 +5,7 @@
 import Common
 import Redux
 
-struct SearchEngineSelectionState: ScreenState, Equatable {
+struct SearchEngineSelectionState: ScreenState {
     var windowUUID: WindowUUID
     var shouldDismiss: Bool
     // Default search engine should appear in position 0

--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeHelper.swift
@@ -68,6 +68,7 @@ class StartAtHomeHelper: FeatureFlaggable {
     ///   - tabs: The tabs to be scanned, either private, or normal, based on the last session
     ///   - profilePreferences: Preferences stored in the user's `Profile`
     /// - Returns: An optional tab, that matches the user's new tab preferences.
+    @MainActor
     public func scanForExistingHomeTab(in tabs: [Tab],
                                        with profilePreferences: Prefs) -> Tab? {
         let pagePreferences = NewTabAccessors.getHomePage(profilePreferences)

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -324,7 +324,6 @@ final class TabScrollHandler: NSObject,
         return isSignificantScroll  // || isFastEnough
     }
 
-    @objc
     private func reload() {
         guard let tabProvider = tabProvider else { return }
         tabProvider.reloadPage()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/InactiveTabsManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/InactiveTabsManager.swift
@@ -8,10 +8,12 @@ protocol InactiveTabsManagerProtocol {
     /// Returns inactive normal (non-private) tabs filtered from the given tabs array.
     /// - Parameter tabs: The array of tabs to filter.
     /// - Returns: The non-private, inactive tabs inside the `tabs` array.
+    @MainActor
     func getInactiveTabs(tabs: [Tab]) -> [Tab]
 }
 
 class InactiveTabsManager: InactiveTabsManagerProtocol {
+    @MainActor
     func getInactiveTabs(tabs: [Tab]) -> [Tab] {
         return tabs.filter({ !$0.isPrivate && $0.isInactive })
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -46,7 +46,7 @@ enum RemoteTabsPanelEmptyStateReason {
 }
 
 /// State for RemoteTabsPanel. WIP.
-struct RemoteTabsPanelState: ScreenState, Equatable, Sendable {
+struct RemoteTabsPanelState: ScreenState, Sendable {
     let refreshState: RemoteTabsPanelRefreshState
     let allowsRefresh: Bool
     let clientAndTabs: [ClientAndTabs]

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -5,7 +5,7 @@
 import Redux
 import Common
 
-struct TabPeekState: ScreenState, Equatable {
+struct TabPeekState: ScreenState {
     let showAddToBookmarks: Bool
     let showSendToDevice: Bool
     let showCopyURL: Bool

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
@@ -5,7 +5,7 @@
 import Common
 import Redux
 
-struct TermsOfUseState: ScreenState, Equatable {
+struct TermsOfUseState: ScreenState {
     let windowUUID: WindowUUID
     var hasAccepted: Bool
     var wasDismissed: Bool

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -1053,7 +1053,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         else { return nil }
 
         guard action.actionType as? ToolbarActionType == .toolbarPositionChanged,
-              let toolbarPosition = (action as? ToolbarAction)?.toolbarPosition
+              let toolbarPosition = action.toolbarPosition
         else {
             return toolbarState.toolbarPosition
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -6,7 +6,7 @@ import Common
 import Redux
 import ToolbarKit
 
-struct ToolbarState: ScreenState, Sendable, Equatable {
+struct ToolbarState: ScreenState, Sendable {
     var windowUUID: WindowUUID
     var toolbarPosition: AddressToolbarPosition
     var toolbarLayout: ToolbarLayoutStyle

--- a/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
@@ -105,10 +105,12 @@ class TopTabDisplayManager: NSObject {
     // Dragging on the collection view is either an 'active drag' where the item is moved, or
     // that the item has been long pressed on (and not moved yet), and this gesture recognizer
     // has been triggered
+    @MainActor
     var isDragging: Bool {
         return collectionView.hasActiveDrag || isLongPressGestureStarted
     }
 
+    @MainActor
     private var isLongPressGestureStarted: Bool {
         var started = false
         collectionView.gestureRecognizers?.forEach { recognizer in
@@ -126,6 +128,7 @@ class TopTabDisplayManager: NSObject {
         return tabManager.normalTabs.count == 1
     }
 
+    @MainActor
     func getRegularOrderedTabs() -> [Tab]? {
         // Get current order
         guard let tabDisplayOrderDecoded = TabDisplayOrder.decode() else { return nil }
@@ -157,6 +160,7 @@ class TopTabDisplayManager: NSObject {
         return !regularOrderedTabs.isEmpty ? regularOrderedTabs : nil
     }
 
+    @MainActor
     func saveRegularOrderedTabs(from tabs: [Tab]) {
         let uuids: [String] = tabs.map { $0.tabUUID }
         tabDisplayOrder.regularTabUUID = uuids
@@ -164,6 +168,7 @@ class TopTabDisplayManager: NSObject {
     }
 
     @discardableResult
+    @MainActor
     private func cancelDragAndGestures() -> Bool {
         let isActive = collectionView.hasActiveDrag || isLongPressGestureStarted
         collectionView.cancelInteractiveMovement()
@@ -308,6 +313,7 @@ class TopTabDisplayManager: NSObject {
     // unless reloadItems is explicitly called on each item.
     // Avoid calling with evenIfHidden=true, as it can cause a blink effect as the cell is updated.
     // The cause of the blinking effect is unknown (and unusual).
+    @MainActor
     private func forceReloadCollectionView() {
         var indexPaths = [IndexPath]()
         for i in 0..<self.collectionView.numberOfItems(inSection: 0) {
@@ -340,6 +346,7 @@ class TopTabDisplayManager: NSObject {
     }
 
     // When using 'Close All', hide all the tabs so they don't animate their deletion individually
+    @MainActor
     func hideDisplayedTabs( completion: @escaping () -> Void) {
         let cells = collectionView.visibleCells
 
@@ -475,6 +482,7 @@ extension TopTabDisplayManager: UICollectionViewDragDelegate {
 
 // MARK: - UICollectionViewDropDelegate
 extension TopTabDisplayManager: UICollectionViewDropDelegate {
+    @MainActor
     private func dragPreviewParameters(
         _ collectionView: UICollectionView,
         dragPreviewParametersForItemAt indexPath: IndexPath
@@ -491,6 +499,7 @@ extension TopTabDisplayManager: UICollectionViewDropDelegate {
         return previewParams
     }
 
+    @MainActor
     func collectionView(
         _ collectionView: UICollectionView,
         dragPreviewParametersForItemAt indexPath: IndexPath
@@ -588,6 +597,7 @@ extension TopTabDisplayManager: TabEventHandler {
         return IndexPath(row: index, section: 0)
     }
 
+    @MainActor
     func removeAllTabsFromView() {
         operations.removeAll()
         dataStore.removeAll()
@@ -665,6 +675,7 @@ extension TopTabDisplayManager: TabManagerDelegate {
      is the one to use, and for bulk updates where it is ok to just redraw the entire view with
      the latest state, use `refreshStore()`.
      */
+    @MainActor
     private func performChainedOperations() {
         guard !performingChainedOperations,
               let (type, operation) = operations.popLast()
@@ -684,6 +695,7 @@ extension TopTabDisplayManager: TabManagerDelegate {
         })
     }
 
+    @MainActor
     private func updateWith(animationType: TabAnimationType,
                             operation: (() -> Void)?) {
         if let op = operation {

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -35,12 +35,14 @@ class ZoomPageManager: TabEventHandler, FeatureFlaggable {
         register(self, forTabEvents: .didGainFocus, .didChangeURL)
     }
 
+    @MainActor
     func getZoomLevel() -> CGFloat {
         guard let tab else { return defaultZoomLevel}
 
         return getZoomLevel(for: tab.url?.host)
     }
 
+    @MainActor
     func zoomIn() -> CGFloat {
         guard let tab = tab,
               let host = tab.url?.host else { return defaultZoomLevel}
@@ -51,6 +53,7 @@ class ZoomPageManager: TabEventHandler, FeatureFlaggable {
         return newZoom
     }
 
+    @MainActor
     func zoomOut() -> CGFloat {
         guard let tab = tab,
               let host = tab.url?.host else { return defaultZoomLevel}
@@ -64,6 +67,7 @@ class ZoomPageManager: TabEventHandler, FeatureFlaggable {
     /// Reset zoom level for a given host and saves new value
     /// - Parameters:
     ///   - shouldSave: Only false when entering reader mode where zoom resets but we don't persist the value
+    @MainActor
     func resetZoom(shouldSave: Bool = true) {
         guard let tab, let host = tab.url?.host else { return }
 
@@ -71,22 +75,26 @@ class ZoomPageManager: TabEventHandler, FeatureFlaggable {
         saveZoomLevel(for: host, zoomLevel: ZoomConstants.defaultZoomLimit)
     }
 
+    @MainActor
     func updatePageZoom() {
         guard let tab = tab else { return }
 
         tab.pageZoom = getZoomLevel(for: tab.url?.host)
     }
 
+    @MainActor
     func updateZoomChangedInOtherWindow() {
         tab?.pageZoom = getZoomLevel()
     }
 
+    @MainActor
     func setZoomAfterLeavingReaderMode() {
         guard let host = decodeReaderModeHost() else { return }
 
         tab?.pageZoom = getZoomLevel(for: host)
     }
 
+    @MainActor
     private func decodeReaderModeHost() -> String? {
         guard let tab,
               tab.readerModeAvailableOrActive,

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -187,6 +187,7 @@ private extension JumpBackInViewModel {
 
 // MARK: - Private: Configure UI
 private extension JumpBackInViewModel {
+    @MainActor
     func configureJumpBackInCellForTab(item: Tab, cell: LegacyJumpBackInCell, indexPath: IndexPath) {
         let itemURL = item.lastKnownUrl?.absoluteString ?? ""
         let site = Site.createBasicSite(url: itemURL, title: item.displayTitle)
@@ -432,6 +433,7 @@ extension JumpBackInViewModel: HomepageSectionHandler {
         }
     }
 
+    @MainActor
     func handleLongPress(with collectionView: UICollectionView, indexPath: IndexPath) {
         guard let tileLongPressedHandler = onLongPressTileAction else { return }
 

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -930,12 +930,14 @@ extension LegacyHomepageViewController: Notifiable {
         switch notification.name {
         case .TabsPrivacyModeChanged:
             let notificationWindowUUID = notification.windowUUID
-            guard let dict = notification.object as? NSDictionary,
-                  let isPrivate = dict[Tab.privateModeKey] as? Bool
-            else { return }
+            let object = notification.object as AnyObject?
 
             ensureMainThread {
-                guard self.windowUUID == notificationWindowUUID else { return }
+                guard
+                    let dict = object as? NSDictionary,
+                    let isPrivate = dict[Tab.privateModeKey] as? Bool,
+                    self.windowUUID == notificationWindowUUID
+                else { return }
                 self.adjustPrivacySensitiveSections(isPrivate: isPrivate)
             }
         case .HomePanelPrefsChanged,

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
@@ -5,7 +5,7 @@
 import Redux
 import Common
 
-struct MicrosurveyState: ScreenState, Equatable {
+struct MicrosurveyState: ScreenState {
     var windowUUID: WindowUUID
     var shouldDismiss: Bool
     var showPrivacy: Bool

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
@@ -5,7 +5,7 @@
 import Redux
 import Common
 
-struct NativeErrorPageState: ScreenState, Equatable {
+struct NativeErrorPageState: ScreenState {
     var windowUUID: WindowUUID
     var title: String
     var description: String

--- a/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
@@ -13,7 +13,8 @@ protocol NotificationSurfaceDelegate: AnyObject {
     func didDismissNotification(_ userInfo: [AnyHashable: Any])
 }
 
-class NotificationSurfaceManager: NotificationSurfaceDelegate {
+// TODO: FXIOS-FXIOS-13583 - NotificationSurfaceManager should be concurrency safe
+class NotificationSurfaceManager: NotificationSurfaceDelegate, @unchecked Sendable {
     struct Constant {
         static let notificationBaseId = "org.mozilla.ios.notification"
         static let notificationCategoryId = "org.mozilla.ios.notification.category"
@@ -97,6 +98,8 @@ class NotificationSurfaceManager: NotificationSurfaceDelegate {
                                      interval: TimeInterval(Constant.messageDelay),
                                      repeats: false)
 
+        // TODO: FXIOS-13583 - Capture of 'message' with non-Sendable type 'GleanPlumbMessage' in a '@Sendable' closure
+        nonisolated(unsafe) let message = message
         // Schedule notification telemetry for when notification gets displayed
         DispatchQueue.global().asyncAfter(deadline: .now() + Constant.messageDelay) { [weak self] in
             self?.didDisplayMessage(message)

--- a/firefox-ios/Client/Frontend/Onboarding/State/OnboardingViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/State/OnboardingViewControllerState.swift
@@ -6,7 +6,7 @@ import Foundation
 import Redux
 import Common
 
-struct OnboardingViewControllerState: ScreenState, Equatable {
+struct OnboardingViewControllerState: ScreenState {
     let windowUUID: WindowUUID
 
     init(appState: AppState, uuid: WindowUUID) {

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
@@ -6,7 +6,7 @@ import Foundation
 import Redux
 import Common
 
-struct PasswordGeneratorState: ScreenState, Equatable {
+struct PasswordGeneratorState: ScreenState {
     var windowUUID: WindowUUID
     var password: String
     var passwordHidden: Bool

--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -63,6 +63,7 @@ class ReaderMode: TabContentScript {
         delegate?.readerMode(self, didChangeReaderModeState: state, forTab: tab)
     }
 
+    @MainActor
     fileprivate func handleReaderContentParsed(_ readabilityResult: ReadabilityResult) {
         guard let tab = tab else { return }
         logger.log("Reader content parsed",

--- a/firefox-ios/Client/Frontend/Settings/NotificationsSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/NotificationsSettingsViewController.swift
@@ -56,7 +56,8 @@ final class NotificationsSettingsViewController: SettingsTableViewController, Fe
     private let prefs: Prefs
     private let hasAccount: Bool
     private var footerTitle = ""
-    private var notificationManager: NotificationManagerProtocol
+    // TODO: FXIOS-13584 - NotificationsSettingsViewController sending notificationManager risks causing data races
+    private nonisolated(unsafe) var notificationManager: NotificationManagerProtocol
 
     init(prefs: Prefs,
          hasAccount: Bool,

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -5,7 +5,7 @@
 import Common
 import Redux
 
-struct ThemeSettingsState: ScreenState, Equatable {
+struct ThemeSettingsState: ScreenState {
     var useSystemAppearance: Bool
     var isAutomaticBrightnessEnabled: Bool
     var manualThemeSelected: ThemeType

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -19,6 +19,7 @@ class ShareManager: NSObject {
         UIActivity.ActivityType.addToReadingList
     ]
 
+    @MainActor
     static func createActivityViewController(
         shareType: ShareType,
         shareMessage: ShareMessage?,
@@ -44,6 +45,7 @@ class ShareManager: NSObject {
         return activityViewController
     }
 
+    @MainActor
     static func getActivityItems(
         forShareType shareType: ShareType,
         withExplicitShareMessage explicitShareMessage: ShareMessage?
@@ -108,11 +110,17 @@ class ShareManager: NSObject {
         }
 
         // For all share types, record basic telemetry
-        activityItems.append(ShareTelemetryActivityItemProvider(shareType: shareType, shareMessage: explicitShareMessage))
+        activityItems.append(
+            ShareTelemetryActivityItemProvider(
+                shareTypeName: shareType.typeName,
+                shareMessage: explicitShareMessage
+            )
+        )
 
         return activityItems
     }
 
+    @MainActor
     private static func getApplicationActivities(forShareType shareType: ShareType) -> [UIActivity] {
         var appActivities = [UIActivity]()
 

--- a/firefox-ios/Client/Frontend/Share/ShareTab.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTab.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-protocol ShareTab: Equatable {
+protocol ShareTab {
     @MainActor
     var displayTitle: String { get }
     @MainActor

--- a/firefox-ios/Client/Frontend/Share/ShareTab.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTab.swift
@@ -5,11 +5,16 @@
 import Foundation
 
 protocol ShareTab: Equatable {
+    @MainActor
     var displayTitle: String { get }
+    @MainActor
     var url: URL? { get }
+    @MainActor
     var canonicalURL: URL? { get }
+    @MainActor
     var webView: TabWebView? { get }
 
     // Tabs displaying content other than HTML mime type can optionally be downloaded and treated as files when shared
+    @MainActor
     var temporaryDocument: TemporaryDocument? { get }
 }

--- a/firefox-ios/Client/Frontend/Share/ShareTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTelemetry.swift
@@ -19,13 +19,13 @@ class ShareTelemetry {
 
     func sharedTo(
         activityType: UIActivity.ActivityType?,
-        shareType: ShareType,
+        shareTypeName: String,
         hasShareMessage: Bool
     ) {
         let extra = GleanMetrics.ShareSheet.SharedToExtra(
             activityIdentifier: activityType?.rawValue ?? "unknown",
             hasShareMessage: hasShareMessage,
-            shareType: shareType.typeName
+            shareType: shareTypeName
         )
         gleanWrapper.recordEvent(for: GleanMetrics.ShareSheet.sharedTo, extras: extra)
     }

--- a/firefox-ios/Client/Frontend/Share/ShareTelemetryActivityItemProvider.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTelemetryActivityItemProvider.swift
@@ -8,16 +8,16 @@ import UniformTypeIdentifiers
 /// A special `UIActivityItemProvider` which never shares additional content, but instead records telemetry based on the
 /// share activity chosen.
 class ShareTelemetryActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
-    private let shareType: ShareType
+    private let shareTypeName: String
     private let shareMessage: ShareMessage?
     private let telemetry: ShareTelemetry
 
     init(
-        shareType: ShareType,
+        shareTypeName: String,
         shareMessage: ShareMessage?,
         gleanWrapper: GleanWrapper = DefaultGleanWrapper()
     ) {
-        self.shareType = shareType
+        self.shareTypeName = shareTypeName
         self.shareMessage = shareMessage
         self.telemetry = ShareTelemetry(gleanWrapper: gleanWrapper)
 
@@ -30,7 +30,7 @@ class ShareTelemetryActivityItemProvider: UIActivityItemProvider, @unchecked Sen
     ) -> Any? {
         telemetry.sharedTo(
             activityType: activityType,
-            shareType: shareType,
+            shareTypeName: shareTypeName,
             hasShareMessage: shareMessage != nil
         )
 

--- a/firefox-ios/Client/Frontend/Share/ShareType.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareType.swift
@@ -58,8 +58,9 @@ enum ShareType {
 
 extension ShareTab {
     func isEqual(to otherShareTab: some ShareTab) -> Bool {
-        return self.displayTitle == otherShareTab.displayTitle
-        && self.url == otherShareTab.url
-        && self.webView == otherShareTab.webView
+        return true
+//        return self.displayTitle == otherShareTab.displayTitle
+//        && self.url == otherShareTab.url
+//        && self.webView == otherShareTab.webView
     }
 }

--- a/firefox-ios/Client/Frontend/Share/ShareType.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareType.swift
@@ -13,7 +13,7 @@ import Foundation
 ///           __SPECIAL NOTE__: If you download a PDF, you can view that in a tab. In that case, the URL may have a `file://`
 ///            scheme instead of `http(s)://`, so certain options, like Send to Device / Add to Home Screen, may not be
 ///            available.
-enum ShareType: Equatable {
+enum ShareType {
     case file(url: URL)
     case site(url: URL)
     case tab(url: URL, tab: any ShareTab)

--- a/firefox-ios/Client/Frontend/Share/ShareType.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareType.swift
@@ -18,19 +18,6 @@ enum ShareType {
     case site(url: URL)
     case tab(url: URL, tab: any ShareTab)
 
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        switch (lhs, rhs) {
-        case let (.file(lhsURL), .file(rhsURL)):
-            return lhsURL == rhsURL
-        case let (.site(lhsURL), .site(rhsURL)):
-            return lhsURL == rhsURL
-        case let (.tab(lhsURL, lhsTab), .tab(rhsURL, rhsTab)):
-            return lhsURL == rhsURL && lhsTab.isEqual(to: rhsTab)
-        default:
-            return false
-        }
-    }
-
     /// The share URL wrapped by the given type.
     var wrappedURL: URL {
         switch self {
@@ -53,14 +40,5 @@ enum ShareType {
         case .tab:
             return "tab"
         }
-    }
-}
-
-extension ShareTab {
-    func isEqual(to otherShareTab: some ShareTab) -> Bool {
-        return true
-//        return self.displayTitle == otherShareTab.displayTitle
-//        && self.url == otherShareTab.url
-//        && self.webView == otherShareTab.webView
     }
 }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
@@ -34,6 +34,7 @@ class DownloadContentScript: TabContentScript {
     /// - Parameters:
     ///     - url: URL of item to be downloaded
     ///     - tab: Tab item is being downloaded from
+    @MainActor
     static func requestBlobDownload(url: URL, tab: Tab) -> Bool {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: "%27")
         guard url.scheme == "blob" else {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -162,6 +162,7 @@ class FormAutofillHelper: TabContentScript {
 
     // MARK: - Injection
 
+    @MainActor
     static func injectAddressInfo(logger: Logger,
                                   address: UnencryptedAddressFields,
                                   tab: Tab,
@@ -194,6 +195,7 @@ class FormAutofillHelper: TabContentScript {
         }
     }
 
+    @MainActor
     static func injectCardInfo(logger: Logger,
                                card: UnencryptedCreditCardFields,
                                tab: Tab,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
@@ -155,12 +155,14 @@ class TrackingProtectionModel {
             .withRenderingMode(.alwaysTemplate)
     }
 
+    @MainActor
     func toggleSiteSafelistStatus() {
         TelemetryWrapper.recordEvent(category: .action, method: .add, object: .trackingProtectionSafelist)
         ContentBlocker.shared.safelist(enable: contentBlockerStatus != .safelisted, url: url) {
         }
     }
 
+    @MainActor
     func isURLSafelisted() -> Bool {
         return ContentBlocker.shared.isSafelisted(url: url)
     }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -6,7 +6,7 @@ import Foundation
 import Redux
 import Common
 
-struct TrackingProtectionState: StateType, Equatable, ScreenState {
+struct TrackingProtectionState: ScreenState {
     enum NavType {
         case home
         case back

--- a/firefox-ios/Client/Helpers/UserActivityHandler.swift
+++ b/firefox-ios/Client/Helpers/UserActivityHandler.swift
@@ -16,6 +16,7 @@ let browsingActivityType = "org.mozilla.ios.firefox.browsing"
 
 private let searchableIndex = CSSearchableIndex.default()
 
+@MainActor
 class UserActivityHandler {
     private let logger: Logger
 
@@ -32,7 +33,7 @@ class UserActivityHandler {
         )
     }
 
-    class func clearSearchIndex(completionHandler: ((Error?) -> Void)? = nil) {
+    class func clearSearchIndex(completionHandler: (@Sendable (Error?) -> Void)? = nil) {
         searchableIndex.deleteAllSearchableItems(completionHandler: completionHandler)
     }
 

--- a/firefox-ios/Client/Helpers/UserActivityHandler.swift
+++ b/firefox-ios/Client/Helpers/UserActivityHandler.swift
@@ -36,6 +36,7 @@ class UserActivityHandler {
         searchableIndex.deleteAllSearchableItems(completionHandler: completionHandler)
     }
 
+    @MainActor
     fileprivate func setUserActivityForTab(_ tab: Tab, url: URL) {
         guard !tab.isPrivate, url.isWebPage(includeDataURIs: false),
               !InternalURL.isValid(url: url)
@@ -77,7 +78,7 @@ extension UserActivityHandler: TabEventHandler {
     }
 
     func tab(_ tab: Tab, didLoadReadability page: ReadabilityResult) {
-        Task {
+        Task { @MainActor in
             await spotlightIndex(page, for: tab)
         }
     }
@@ -90,6 +91,7 @@ extension UserActivityHandler: TabEventHandler {
 }
 
 extension UserActivityHandler {
+    @MainActor
     func spotlightIndex(_ page: ReadabilityResult, for tab: Tab) async {
         guard let url = tab.url,
               !tab.isPrivate,

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
@@ -6,7 +6,7 @@ import Foundation
 import Redux
 import Common
 
-enum AppScreenState: Equatable {
+enum AppScreenState {
     case browserViewController(BrowserViewControllerState)
     case homepage(HomepageState)
     case mainMenu(MainMenuState)
@@ -108,7 +108,7 @@ enum AppScreenState: Equatable {
     }
 }
 
-struct ActiveScreensState: Equatable {
+struct ActiveScreensState {
     let screens: [AppScreenState]
 
     init() {

--- a/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
+++ b/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
@@ -8,7 +8,7 @@ import Common
 
 private let temporaryDocumentOperationQueue = OperationQueue()
 
-protocol TemporaryDocument {
+protocol TemporaryDocument: Sendable {
     var filename: String { get }
     var sourceURL: URL? { get }
     var isDownloading: Bool { get }
@@ -26,12 +26,13 @@ protocol TemporaryDocument {
     func resumeDownload()
 }
 
-class WeakURLSessionDelegate: NSObject, URLSessionDownloadDelegate {
+// TODO: FXIOS Make WeakURLSessionDelegate actually sendable
+final class WeakURLSessionDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
     init(delegate: URLSessionDownloadDelegate?) {
         self.delegate = delegate
     }
 
-    weak var delegate: URLSessionDownloadDelegate?
+    private weak var delegate: URLSessionDownloadDelegate?
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         delegate?.urlSession(session, downloadTask: downloadTask, didFinishDownloadingTo: location)
@@ -58,10 +59,11 @@ class WeakURLSessionDelegate: NSObject, URLSessionDownloadDelegate {
     }
 }
 
-class DefaultTemporaryDocument: NSObject,
+// TODO: FXIOS Make DefaultTemporaryDocument actually sendable
+final class DefaultTemporaryDocument: NSObject,
                                 TemporaryDocument,
                                 FeatureFlaggable,
-                                URLSessionDownloadDelegate {
+                                URLSessionDownloadDelegate, @unchecked Sendable {
     private let session: URLSession
     private let request: URLRequest
     private var currentDownloadTask: URLSessionDownloadTask?

--- a/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
+++ b/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
@@ -26,7 +26,7 @@ protocol TemporaryDocument: Sendable {
     func resumeDownload()
 }
 
-// TODO: FXIOS Make WeakURLSessionDelegate actually sendable
+// TODO: FXIOS-13618 Make WeakURLSessionDelegate actually sendable
 final class WeakURLSessionDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
     init(delegate: URLSessionDownloadDelegate?) {
         self.delegate = delegate
@@ -59,7 +59,7 @@ final class WeakURLSessionDelegate: NSObject, URLSessionDownloadDelegate, @unche
     }
 }
 
-// TODO: FXIOS Make DefaultTemporaryDocument actually sendable
+// TODO: FXIOS-13619 Make DefaultTemporaryDocument actually sendable
 final class DefaultTemporaryDocument: NSObject,
                                 TemporaryDocument,
                                 FeatureFlaggable,

--- a/firefox-ios/Client/TabManagement/GlobalTabEventHandlers.swift
+++ b/firefox-ios/Client/TabManagement/GlobalTabEventHandlers.swift
@@ -14,6 +14,7 @@ class GlobalTabEventHandlers {
     ///
     /// For anything that needs to react to tab events notifications (see `TabEventLabel`), the
     /// pattern is to implement a handler and specify which events to observe.
+    @MainActor
     static func configure(with profile: Profile) {
         guard globalHandlers.isEmpty else { return }
         globalHandlers = [

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -622,9 +622,8 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     }
 
     deinit {
-        deleteDownloadedDocuments(docsURL: temporaryDocumentsSession)
         webViewLoadingObserver?.invalidate()
-        webView?.navigationDelegate = nil
+        deleteDownloadedDocuments(docsURL: temporaryDocumentsSession)
 
 #if DEBUG
         debugTabCount -= 1

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -465,7 +465,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     /// tab instance, queue it for later until we become foregrounded.
     private var alertQueue = [JSAlertInfo]()
 
-    var onWebViewLoadingStateChanged: VoidReturnCallback?
+    var onWebViewLoadingStateChanged: (@MainActor () -> Void)?
     private var webViewLoadingObserver: NSKeyValueObservation?
 
     private var temporaryDocumentsSession: TemporaryDocumentSession = [:]
@@ -599,8 +599,9 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
 
             tabDelegate?.tab(self, didCreateWebView: webView)
             webViewLoadingObserver = webView.observe(\.isLoading) { [weak self] _, _ in
+                guard let self else { return }
                 ensureMainThread {
-                    self?.onWebViewLoadingStateChanged?()
+                    self.onWebViewLoadingStateChanged?()
                 }
             }
         }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -109,7 +109,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
 
     var urlType: TabUrlType = .regular
 
-    @MainActor
     var tabState: TabState {
         return TabState(isPrivate: _isPrivate, url: url, title: displayTitle)
     }
@@ -182,17 +181,14 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         return url
     }
 
-    @MainActor
     var isLoading: Bool {
         return webView?.isLoading ?? false
     }
 
-    @MainActor
     var estimatedProgress: Double {
         return webView?.estimatedProgress ?? 0
     }
 
-    @MainActor
     var backForwardList: BackForwardList? {
         guard let backForwardList = webView?.backForwardList else { return nil }
         return TabBackForwardList(
@@ -201,7 +197,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         )
     }
 
-    @MainActor
     var historyList: [URL] {
         func listToUrl(_ item: BackForwardListItem) -> URL { return item.url }
 
@@ -212,7 +207,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         return historyUrls
     }
 
-    @MainActor
     var title: String? {
         if let title = webView?.title, !title.isEmpty {
             return webView?.title
@@ -223,7 +217,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
 
     /// This property returns, ideally, the web page's title. Otherwise, based on the page being internal
     /// or not, it will resort to other displayable titles.
-    @MainActor
     var displayTitle: String {
         if self.isFxHomeTab {
             return .LegacyAppMenu.AppMenuOpenHomePageTitleString
@@ -258,7 +251,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     }
 
     /// Use the display title unless it's an empty string, then use the base domain from the url
-    @MainActor
     func getTabTrayTitle() -> String {
         let baseDomain = url?.baseDomain
         var backUpName = "" // In case display title is empty
@@ -272,7 +264,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         return displayTitle.isEmpty ? backUpName : displayTitle
     }
 
-    @MainActor
     var canGoBack: Bool {
         // FXIOS-9785 This could result in the back button never being enabled for restored tabs
         assert(webView != nil, "We should not be trying to enable or disable the back button before the webView is set")
@@ -280,7 +271,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         return webView?.canGoBack ?? false
     }
 
-    @MainActor
     var canGoForward: Bool {
         // FXIOS-9785 This could result in the forward button never being enabled for restored tabs
         assert(webView != nil, "We should not be trying to enable or disable the forward button before the webView is set")
@@ -372,7 +362,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     }
 
     // Use computed property so @available can be used to guard `noImageMode`.
-    @MainActor
     var noImageMode: Bool {
         didSet {
             guard noImageMode != oldValue else { return }
@@ -387,7 +376,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         }
     }
 
-    @MainActor
     var nightMode: Bool {
         didSet {
             guard nightMode != oldValue else { return }
@@ -469,7 +457,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     // If this tab has been opened from another, its parent will point to the tab from which it was opened
     weak var parent: Tab?
 
-    @MainActor
     private var contentScriptManager = TabContentScriptManager()
 
     private var configuration: WKWebViewConfiguration?
@@ -533,7 +520,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         )
     }
 
-    @MainActor
     func toRemoteTab() -> RemoteTab? {
         guard !isPrivate else {
             return nil
@@ -560,7 +546,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         return nil
     }
 
-    @MainActor
     weak var navigationDelegate: WKNavigationDelegate? {
         didSet {
             if let webView = webView {
@@ -569,7 +554,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         }
     }
 
-    @MainActor
     func createWebview(with restoreSessionData: Data? = nil, configuration: WKWebViewConfiguration) {
         self.configuration = configuration
         if webView == nil {
@@ -622,7 +606,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         }
     }
 
-    @MainActor
     func restore(_ webView: WKWebView, interactionState: Data? = nil) {
         if let url = url {
             if let internalURL = InternalURL(url),
@@ -663,7 +646,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     }
 
     /// When a user clears ALL history, `sessionData` and `historyList` need to be purged, and close the webView.
-    @MainActor
     func clearAndResetTabHistory() {
         guard let currentlyOpenUrl = lastKnownUrl ?? historyList.last else { return }
 
@@ -671,7 +653,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         close()
     }
 
-    @MainActor
     func close() {
         contentScriptManager.uninstall(tab: self)
         webView?.configuration.userContentController.removeAllUserScripts()
@@ -686,7 +667,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         webView = nil
     }
 
-    @MainActor
     func goBack() {
         if isPDFRefactorEnabled {
             // if the file was cancelled then return and avoid calling webView.goBack
@@ -696,7 +676,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         _ = webView?.goBack()
     }
 
-    @MainActor
     func goForward() {
         if isPDFRefactorEnabled {
             // if the file was cancelled then return and avoid calling webView.goForward
@@ -706,7 +685,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         _ = webView?.goForward()
     }
 
-    @MainActor
     func goToBackForwardListItem(_ item: WKBackForwardListItem) {
         if isPDFRefactorEnabled {
             cancelTemporaryDocumentDownload()
@@ -714,7 +692,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         _ = webView?.go(to: item)
     }
 
-    @MainActor
     @discardableResult
     func loadRequest(_ request: URLRequest) -> WKNavigation? {
         if isPDFRefactorEnabled {
@@ -740,7 +717,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         return nil
     }
 
-    @MainActor
     func stop() {
         webView?.stopLoading()
         if isPDFRefactorEnabled {
@@ -748,7 +724,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         }
     }
 
-    @MainActor
     func reload(bypassCache: Bool = false) {
         if isPDFRefactorEnabled {
             if cancelTemporaryDocumentDownload() {
@@ -792,27 +767,22 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         }
     }
 
-    @MainActor
     func reloadPage() {
         reload()
     }
 
-    @MainActor
     func addContentScript(_ helper: TabContentScript, name: String) {
         contentScriptManager.addContentScript(helper, name: name, forTab: self)
     }
 
-    @MainActor
     func addContentScriptToPage(_ helper: TabContentScript, name: String) {
         contentScriptManager.addContentScriptToPage(helper, name: name, forTab: self)
     }
 
-    @MainActor
     func addContentScriptToCustomWorld(_ helper: TabContentScript, name: String) {
         contentScriptManager.addContentScriptToCustomWorld(helper, name: name, forTab: self)
     }
 
-    @MainActor
     func getContentScript(name: String) -> TabContentScript? {
         return contentScriptManager.getContentScript(name)
     }
@@ -829,14 +799,12 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         loginAlert = nil
     }
 
-    @MainActor
     func expireLoginAlert() {
         if let loginAlert, !loginAlert.shouldPersist {
             removeLoginAlert(loginAlert)
         }
     }
 
-    @MainActor
     func setFindInPage(isBottomSearchBar: Bool, doesFindInPageBarExist: Bool) {
         if #available(iOS 16, *) {
             guard let webView = self.webView,
@@ -854,7 +822,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         self.screenshot = screenshot
     }
 
-    @MainActor
     func toggleChangeUserAgent() {
         changedUserAgent = !changedUserAgent
 
@@ -942,7 +909,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     // MARK: - Temporary Document handling - PDF Refactor
 
     /// Retrieves the session cookies attached to the current `WKWebView` managed by the `Tab`
-    @MainActor
     func getSessionCookies(_ completion: @Sendable @MainActor @escaping ([HTTPCookie]) -> Void) {
         webView?.configuration.websiteDataStore.httpCookieStore.getAllCookies(completion)
     }
@@ -951,7 +917,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     ///
     /// `forceReload` forces the reload of the page when a document is downloading.
     ///  After download cancellation reload the page to ensure clean state.
-    @MainActor
     @discardableResult
     private func cancelTemporaryDocumentDownload(forceReload: Bool = true) -> Bool {
         guard let temporaryDocument else { return false }

--- a/firefox-ios/Client/TabManagement/TabEventHandler.swift
+++ b/firefox-ios/Client/TabManagement/TabEventHandler.swift
@@ -69,11 +69,13 @@ enum TabEventHandlerWindowResponseType {
 }
 
 protocol TabEventHandler: AnyObject {
+    @MainActor
     var tabEventWindowResponseType: TabEventHandlerWindowResponseType { get }
     @MainActor
     func tab(_ tab: Tab, didChangeURL url: URL)
     @MainActor
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata)
+    @MainActor
     func tab(_ tab: Tab, didLoadReadability page: ReadabilityResult)
     @MainActor
     func tabDidGainFocus(_ tab: Tab)
@@ -200,9 +202,9 @@ extension TabEventHandler {
             center.addObserver(forName: eventType.name, object: nil, queue: .main) { notification in
                 guard let self else { return }
                 let object = notification.object
-                let eventWindowResponseType = self.tabEventWindowResponseType
                 let tabEvent = notification.userInfo?["payload"] as? TabEvent
                 ensureMainThread {
+                    let eventWindowResponseType = self.tabEventWindowResponseType
                     guard let tab = object as? Tab,
                           let event = tabEvent,
                           eventWindowResponseType.shouldSendHandlerEvent(for: tab.windowUUID)  else {

--- a/firefox-ios/Client/TabManagement/TabEventHandler.swift
+++ b/firefox-ios/Client/TabManagement/TabEventHandler.swift
@@ -70,11 +70,16 @@ enum TabEventHandlerWindowResponseType {
 
 protocol TabEventHandler: AnyObject {
     var tabEventWindowResponseType: TabEventHandlerWindowResponseType { get }
+    @MainActor
     func tab(_ tab: Tab, didChangeURL url: URL)
+    @MainActor
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata)
     func tab(_ tab: Tab, didLoadReadability page: ReadabilityResult)
+    @MainActor
     func tabDidGainFocus(_ tab: Tab)
+    @MainActor
     func tabDidLoseFocus(_ tab: Tab)
+    @MainActor
     func tabDidClose(_ tab: Tab)
     func tabDidToggleDesktopMode(_ tab: Tab)
     func tabDidChangeContentBlocking(_ tab: Tab)
@@ -124,6 +129,7 @@ enum TabEvent {
         return result
     }
 
+    @MainActor
     func handle(_ tab: Tab, with handler: TabEventHandler) {
         switch self {
         case .didChangeURL(let url):
@@ -193,13 +199,18 @@ extension TabEventHandler {
         wrapper.observers = events.map { [weak self] eventType in
             center.addObserver(forName: eventType.name, object: nil, queue: .main) { notification in
                 guard let self else { return }
-                guard let tab = notification.object as? Tab,
-                      let event = notification.userInfo?["payload"] as? TabEvent,
-                      self.tabEventWindowResponseType.shouldSendHandlerEvent(for: tab.windowUUID) else {
-                    return
-                }
+                let object = notification.object
+                let eventWindowResponseType = self.tabEventWindowResponseType
+                let tabEvent = notification.userInfo?["payload"] as? TabEvent
+                ensureMainThread {
+                    guard let tab = object as? Tab,
+                          let event = tabEvent,
+                          eventWindowResponseType.shouldSendHandlerEvent(for: tab.windowUUID)  else {
+                        return
+                    }
 
-                event.handle(tab, with: self)
+                    event.handle(tab, with: self)
+                }
             }
         }
 

--- a/firefox-ios/Client/Telemetry/SearchTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SearchTelemetry.swift
@@ -407,6 +407,7 @@ class SearchTelemetry: @unchecked Sendable {
                                      extras: extraDetails)
     }
 
+    @MainActor
     func checkSAP(for tab: Tab?) -> SearchTelemetryValues.Sap {
         guard let tab = tab else { return .urlbar }
         if tab.isFxHomeTab || tab.isCustomHomeTab {

--- a/firefox-ios/Client/Utils/SponsoredContentFilterUtility.swift
+++ b/firefox-ios/Client/Utils/SponsoredContentFilterUtility.swift
@@ -25,6 +25,7 @@ struct SponsoredContentFilterUtility {
         return url.query?.split(separator: "&").contains { $0 == hideWithSearchParam } ?? false
     }
 
+    @MainActor
     func filterSponsoredTabs(from tabs: [Tab]) -> [Tab] {
         return tabs.filter { !($0.lastKnownUrl?.absoluteString.contains(hideWithSearchParam) ?? false) }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
@@ -45,6 +45,7 @@ class FormAutofillHelperTests: XCTestCase {
         }
     """
 
+    @MainActor
     override func setUp() {
         super.setUp()
         profile = MockProfile()
@@ -280,6 +281,7 @@ class FormAutofillHelperTests: XCTestCase {
         trackForMemoryLeaks(subject)
     }
 
+    @MainActor
     func test_formAutofillHelper_foundFieldValuesClosure_doesntLeak() {
         let tab = Tab(profile: profile, windowUUID: windowUUID)
         let subject = FormAutofillHelper(tab: tab)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -113,8 +113,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
 
         let action = getNavigationBrowserAction(for: .tapOnCustomizeHomepageButton, destination: .settings(.homePage))
         let newState = reducer(initialState, action)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .settings(let route):
+            XCTAssertEqual(route, .homePage)
+        default:
+            XCTFail("destination is not the right type")
+        }
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .settings(.homePage))
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -128,7 +134,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .tapOnCell, destination: .link, url: url)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .link)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .link:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url?.absoluteString, "www.example.com")
     }
 
@@ -142,7 +155,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .tapOnLink, destination: .link, url: url)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .link)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .link:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url?.absoluteString, "www.example.com")
     }
 
@@ -167,7 +187,19 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         )
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .shareSheet(shareSheetConfiguration))
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .shareSheet(let configuration):
+            switch configuration.shareType {
+            case .site(let url):
+                XCTAssertEqual(url, try XCTUnwrap(URL(string: "www.example.com")))
+            default:
+                XCTFail("shareType is not the right type")
+            }
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -181,7 +213,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .longPressOnCell, destination: .link, url: url)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .link)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .link:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url?.absoluteString, "www.example.com")
     }
 
@@ -200,7 +239,13 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let newState = reducer(initialState, action)
 
         let navigationDestination = try XCTUnwrap(newState.navigationDestination)
-        XCTAssertEqual(navigationDestination.destination, .newTab)
+        switch navigationDestination.destination {
+        case .newTab:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(navigationDestination.url?.absoluteString, "www.example.com")
         XCTAssertFalse(navigationDestination.isPrivate ?? true)
         XCTAssertFalse(navigationDestination.selectNewTab ?? true)
@@ -221,7 +266,13 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let newState = reducer(initialState, action)
 
         let navigationDestination = try XCTUnwrap(newState.navigationDestination)
-        XCTAssertEqual(navigationDestination.destination, .newTab)
+        switch navigationDestination.destination {
+        case .newTab:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(navigationDestination.url?.absoluteString, "www.example.com")
         XCTAssertTrue(navigationDestination.isPrivate ?? false)
         XCTAssertTrue(navigationDestination.selectNewTab ?? false)
@@ -236,7 +287,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .tapOnSettingsSection, destination: .settings(.topSites))
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .settings(.topSites))
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .settings(let section):
+            XCTAssertEqual(section, .topSites)
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -284,8 +342,15 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
             summarizerConfig: SummarizerConfig(instructions: "Test instructions", options: [:])
         )
         let newState = reducer(initialState, action)
-        let config = SummarizerConfig(instructions: "Test instructions", options: [:])
-        XCTAssertEqual(newState.navigationDestination?.destination, .summarizer(config: config))
+        let expectedConfig = SummarizerConfig(instructions: "Test instructions", options: [:])
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .summarizer(let config):
+            XCTAssertEqual(config, expectedConfig)
+        default:
+            XCTFail("destination is not the right type")
+        }
+
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -299,8 +364,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
 
         let action = getNavigationBrowserAction(for: .tapOnHomepageSearchBar, destination: .zeroSearch)
         let newState = reducer(initialState, action)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .zeroSearch:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .zeroSearch)
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -317,8 +388,14 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarMiddlewareActionType.didTapButton
         )
         let newState = reducer(initialState, action)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .zeroSearch:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .zeroSearch)
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -335,8 +412,7 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         )
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, nil)
-        XCTAssertEqual(newState.navigationDestination?.url, nil)
+        XCTAssertNil(newState.navigationDestination)
     }
 
     func test_didTapButtonToolbarAction_withoutHomepageSearch_andSearchButtonType_doesNotNavigateToZeroSearch() {
@@ -352,8 +428,7 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         )
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, nil)
-        XCTAssertEqual(newState.navigationDestination?.url, nil)
+        XCTAssertNil(newState.navigationDestination)
     }
 
     func test_didTapButtonToolbarAction_withoutHomepageSearch_andNoButtonType_doesNotNavigateToZeroSearch() {
@@ -368,8 +443,7 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         )
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, nil)
-        XCTAssertEqual(newState.navigationDestination?.url, nil)
+        XCTAssertNil(newState.navigationDestination)
     }
 
     // MARK: - Shortcuts Library
@@ -383,7 +457,13 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .tapOnShortcutsShowAllButton, destination: .shortcutsLibrary)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .shortcutsLibrary)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .shortcutsLibrary:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -6,11 +6,13 @@ import XCTest
 @testable import Client
 
 final class ContentBlockerTests: XCTestCase {
+    @MainActor
     override func setUp() {
         super.setUp()
         ensureAllRulesAreRemovedFromStore()
     }
 
+    @MainActor
     private func ensureAllRulesAreRemovedFromStore() {
         let expectation = XCTestExpectation()
         ContentBlocker.shared.removeAllRulesInStore {
@@ -19,6 +21,7 @@ final class ContentBlockerTests: XCTestCase {
         wait(for: [expectation])
     }
 
+    @MainActor
     func testCompileListsNotInStore_callsCompletionHandlerSuccessfully() {
         let expectation = XCTestExpectation()
         ContentBlocker.shared.compileListsNotInStore {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
@@ -33,9 +33,29 @@ class RouteBuilderTests: XCTestCase {
             userActivity: randomActivity
         )
 
-        XCTAssertEqual(route, .search(url: testURL, isPrivate: false))
-        XCTAssertEqual(universalLinkRoute, .search(url: testURL, isPrivate: false))
-        XCTAssertEqual(randomRoute, .search(url: testURL, isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, testURL)
+            XCTAssertFalse(isPrivate)
+        default:
+            break
+        }
+
+        switch universalLinkRoute {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, testURL)
+            XCTAssertFalse(isPrivate)
+        default:
+            break
+        }
+
+        switch randomRoute {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, testURL)
+            XCTAssertFalse(isPrivate)
+        default:
+            break
+        }
     }
 
     func test_makeRoute_ResetsShouldOpenNewTabAfterDelay() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -13,14 +13,14 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(
-            route,
-            .search(
-                url: URL(string: "http://google.com?a=1&b=2&c=foo%20bar")!,
-                isPrivate: false,
-                options: [.focusLocationField]
-            )
-        )
+        switch route {
+        case .search(let url, let isPrivate, let options):
+            XCTAssertEqual(url, URL(string: "http://google.com?a=1&b=2&c=foo%20bar")!)
+            XCTAssertFalse(isPrivate)
+            XCTAssertEqual(options, [.focusLocationField])
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testSearchRouteWithJS_shouldReturnFalse() {
@@ -38,7 +38,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "http://google.com?a=1&b=2&c=foo%20bar"), isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, URL(string: "http://google.com?a=1&b=2&c=foo%20bar")!)
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testSearchRouteWithPrivateFlag() {
@@ -47,7 +53,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: true))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertNil(url)
+            XCTAssertTrue(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testSettingsRouteWithClearPrivateData() {
@@ -56,7 +68,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .clearPrivateData))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .clearPrivateData)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithNewTab() {
@@ -65,7 +82,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .newTab))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .newTab)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithNewTabTrailingSlash() {
@@ -74,7 +96,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .newTab))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .newTab)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithHomePage() {
@@ -83,7 +110,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .homePage))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .homePage)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithMailto() {
@@ -92,7 +124,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .mailto))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .mailto)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithSearch() {
@@ -101,7 +138,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .search))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .search)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testSettingsRouteWithFxa() {
@@ -110,7 +152,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .settings(section: .fxa))
+        switch route {
+        case .settings(let section):
+            XCTAssertEqual(section, .fxa)
+        default:
+            XCTFail("The route should be a settings route")
+        }
     }
 
     func testHomepanelRouteWithBookmarks() {
@@ -119,7 +166,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .homepanel(section: .bookmarks))
+        switch route {
+        case .homepanel(let section):
+            XCTAssertEqual(section, .bookmarks)
+        default:
+            XCTFail("The route should be a homepanel route")
+        }
     }
 
     func testHomepanelRouteWithTopSites() {
@@ -128,7 +180,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .homepanel(section: .topSites))
+        switch route {
+        case .homepanel(let section):
+            XCTAssertEqual(section, .topSites)
+        default:
+            XCTFail("The route should be a homepanel route")
+        }
     }
 
     func testHomepanelRouteWithHistory() {
@@ -137,7 +194,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .homepanel(section: .history))
+        switch route {
+        case .homepanel(let section):
+            XCTAssertEqual(section, .history)
+        default:
+            XCTFail("The route should be a homepanel route")
+        }
     }
 
     func testHomepanelRouteWithReadingList() {
@@ -146,7 +208,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .homepanel(section: .readingList))
+        switch route {
+        case .homepanel(let section):
+            XCTAssertEqual(section, .readingList)
+        default:
+            XCTFail("The route should be a homepanel route")
+        }
     }
 
     func testDefaultBrowserRouteWithTutorial() {
@@ -155,7 +222,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .defaultBrowser(section: .tutorial))
+        switch route {
+        case .defaultBrowser(let section):
+            XCTAssertEqual(section, .tutorial)
+        default:
+            XCTFail("The route should be a default browser route")
+        }
     }
 
     func testDefaultBrowserRouteWithSystemSettings() {
@@ -164,7 +236,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .defaultBrowser(section: .systemSettings))
+        switch route {
+        case .defaultBrowser(let section):
+            XCTAssertEqual(section, .systemSettings)
+        default:
+            XCTFail("The route should be a default browser route")
+        }
     }
 
     func testInvalidRouteWithBadPath() {
@@ -183,8 +260,16 @@ class RouteTests: XCTestCase {
         let route = subject.makeRoute(url: url)
 
         let expectedQuery = ["signin": "coolcodes", "user": "foo", "email": "bar"]
-        XCTAssertEqual(route, .fxaSignIn(params: FxALaunchParams(entrypoint: .fxaDeepLinkNavigation,
-                                                                 query: expectedQuery)))
+
+        let expectedParams = FxALaunchParams(entrypoint: .fxaDeepLinkNavigation,
+                                             query: expectedQuery)
+
+        switch route {
+        case .fxaSignIn(let params):
+            XCTAssertEqual(params, expectedParams)
+        default:
+            XCTFail("The route should be a fxa sign in route")
+        }
     }
 
     func test_makeRoute_forFXASignIn_withJS_doesntOpenRoute() {
@@ -257,7 +342,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, URL(string: "https://google.com")!)
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forMediumTopSitesWidget_withJS_doesntOpenRoute() {
@@ -275,10 +366,14 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(
-            route,
-            .search(url: URL(string: "https://google.com"), isPrivate: true, options: [.focusLocationField])
-        )
+        switch route {
+        case .search(let url, let isPrivate, let options):
+            XCTAssertEqual(url, URL(string: "https://google.com")!)
+            XCTAssertTrue(isPrivate)
+            XCTAssertEqual(options, [.focusLocationField])
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forSmallQuickLinkWidget_withJS_doesntOpenRoute() {
@@ -296,10 +391,14 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(
-            route,
-            .search(url: URL(string: "https://google.com"), isPrivate: false, options: [.focusLocationField])
-        )
+        switch route {
+        case .search(let url, let isPrivate, let options):
+            XCTAssertEqual(url, URL(string: "https://google.com")!)
+            XCTAssertFalse(isPrivate)
+            XCTAssertEqual(options, [.focusLocationField])
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forMediumQuickLinkWidget_withJS_doesntOpenRoute() {
@@ -318,7 +417,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .searchQuery(query: "test search text", isPrivate: false))
+        switch route {
+        case .searchQuery(let query, let isPrivate):
+            XCTAssertEqual(query, "test search text")
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forSmallQuickLinkOpenCopedWidget_withJS_doesntOpenRoute() {
@@ -338,7 +443,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, URL(string: "https://google.com")!)
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forSmallQuickLinkWithURLWidgetOpenCopied_withJS_doesntOpenRoute() {
@@ -356,8 +467,12 @@ class RouteTests: XCTestCase {
         let url = URL(string: "firefox://widget-small-quicklink-close-private-tabs")!
 
         let route = subject.makeRoute(url: url)
-
-        XCTAssertEqual(route, .action(action: .closePrivateTabs))
+        switch route {
+        case .action(let action):
+            XCTAssertEqual(action, .closePrivateTabs)
+        default:
+            XCTFail("The route should be an action route")
+        }
     }
 
     func test_makeRoute_forMediumQuickLinkCloseWidget_withJS_doesntOpenRoute() {
@@ -366,7 +481,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .action(action: .closePrivateTabs))
+        switch route {
+        case .action(let action):
+            XCTAssertEqual(action, .closePrivateTabs)
+        default:
+            XCTFail("The route should be an action route")
+        }
     }
 
     func testWidgetMediumQuicklinkClosePrivateTabs() {
@@ -375,7 +495,12 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .action(action: .closePrivateTabs))
+        switch route {
+        case .action(let action):
+            XCTAssertEqual(action, .closePrivateTabs)
+        default:
+            XCTFail("The route should be an action route")
+        }
     }
 
     func testUnsupportedScheme() {
@@ -411,7 +536,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertNil(url)
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testInvalidFxaSignIn() {
@@ -429,7 +560,13 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .searchQuery(query: "google", isPrivate: false))
+        switch route {
+        case .searchQuery(let query, let isPrivate):
+            XCTAssertEqual(query, "google")
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forOpenText_withJS_doesntOpenRoute() {
@@ -448,7 +585,18 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: shareURL)
 
-        XCTAssertEqual(route, .sharesheet(shareType: .site(url: testURL), shareMessage: nil))
+        switch route {
+        case .sharesheet(let shareType, let shareMessage):
+            switch shareType {
+            case .site(let url):
+                XCTAssertEqual(url, testURL)
+            default:
+                XCTFail("The share type should be a site share type")
+            }
+            XCTAssertNil(shareMessage)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testShareSheetRouteUrlTitle() {
@@ -460,9 +608,20 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: shareURL)
 
-        let expectedShareType = ShareType.site(url: testURL)
         let expectedShareMessage = ShareMessage(message: testTitle, subtitle: nil)
-        XCTAssertEqual(route, .sharesheet(shareType: expectedShareType, shareMessage: expectedShareMessage))
+
+        switch route {
+        case .sharesheet(let shareType, let shareMessage):
+            switch shareType {
+            case .site(let url):
+                XCTAssertEqual(url, testURL)
+            default:
+                XCTFail("The share type should be a site share type")
+            }
+            XCTAssertEqual(shareMessage, expectedShareMessage)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testShareSheetRouteUrlTitleAndSubtitle() {
@@ -475,9 +634,20 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: shareURL)
 
-        let expectedShareType = ShareType.site(url: testURL)
         let expectedShareMessage = ShareMessage(message: testTitle, subtitle: testSubtitle)
-        XCTAssertEqual(route, .sharesheet(shareType: expectedShareType, shareMessage: expectedShareMessage))
+
+        switch route {
+        case .sharesheet(let shareType, let shareMessage):
+            switch shareType {
+            case .site(let url):
+                XCTAssertEqual(url, testURL)
+            default:
+                XCTFail("The share type should be a site share type")
+            }
+            XCTAssertEqual(shareMessage, expectedShareMessage)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func test_makeRoute_forShareSheet_withJS_doesntOpenRoute() {
@@ -496,8 +666,12 @@ class RouteTests: XCTestCase {
         let url = URL(string: "firefox://deep-link?url=/action/show-intro-onboarding")!
 
         let route = subject.makeRoute(url: url)
-
-        XCTAssertEqual(route, .action(action: .showIntroOnboarding))
+        switch route {
+        case .action(let action):
+            XCTAssertEqual(action, .showIntroOnboarding)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     // MARK: - Helper

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
@@ -13,7 +13,14 @@ final class ShortcutRouteTests: XCTestCase {
 
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: false, options: [.focusLocationField]))
+        switch route {
+        case .search(let url, let isPrivate, let options):
+            XCTAssertNil(url)
+            XCTAssertFalse(isPrivate)
+            XCTAssertEqual(options, [.focusLocationField])
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testNewPrivateTabShortcut() {
@@ -23,7 +30,14 @@ final class ShortcutRouteTests: XCTestCase {
 
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: true, options: [.focusLocationField]))
+        switch route {
+        case .search(let url, let isPrivate, let options):
+            XCTAssertNil(url)
+            XCTAssertTrue(isPrivate)
+            XCTAssertEqual(options, [.focusLocationField])
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     func testOpenLastBookmarkShortcutWithValidUrl() {
@@ -37,8 +51,13 @@ final class ShortcutRouteTests: XCTestCase {
 
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"),
-                                      isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertEqual(url, URL(string: "https://www.example.com")!)
+            XCTAssertFalse(isPrivate)
+        default:
+            XCTFail("The route should be a search route")
+        }
     }
 
     // FXIOS-8107: Disabled test as history highlights has been disabled to fix app hangs / slowness
@@ -62,7 +81,12 @@ final class ShortcutRouteTests: XCTestCase {
         let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.QRCode",
                                                      localizedTitle: "QR Code")
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
-        XCTAssertEqual(route, .action(action: .showQRCode))
+        switch route {
+        case .action(let action):
+            XCTAssertEqual(action, .showQRCode)
+        default:
+            XCTFail("Expected .action(.showQRCode)")
+        }
     }
 
     func testInvalidShortcut() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/UserActivityRouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/UserActivityRouteTests.swift
@@ -15,7 +15,13 @@ class UserActivityRouteTests: XCTestCase {
 
         let route = subject.makeRoute(userActivity: userActivity)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertFalse(isPrivate)
+            XCTAssertNil(url)
+        default:
+            XCTFail("route was not of expected type")
+        }
     }
 
     // Test the Route initializer with a deep link user activity.
@@ -26,7 +32,13 @@ class UserActivityRouteTests: XCTestCase {
 
         let route = subject.makeRoute(userActivity: userActivity)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertFalse(isPrivate)
+            XCTAssertEqual(url?.absoluteString, "https://www.example.com")
+        default:
+            XCTFail("route was not of expected type")
+        }
     }
 
     // Test the Route initializer with a CoreSpotlight user activity.
@@ -37,7 +49,13 @@ class UserActivityRouteTests: XCTestCase {
 
         let route = subject.makeRoute(userActivity: userActivity)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), isPrivate: false))
+        switch route {
+        case .search(let url, let isPrivate, _):
+            XCTAssertFalse(isPrivate)
+            XCTAssertEqual(url?.absoluteString, "https://www.example.com")
+        default:
+            XCTFail("route was not of expected type")
+        }
     }
 
     // Test the Route initializer with an unsupported user activity.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -310,6 +310,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         return tab
     }
 
+    @MainActor
     private func createTab(isPrivate: Bool = false) -> Tab {
         let tab = Tab(
             profile: profile,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserWebUIDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserWebUIDelegateTests.swift
@@ -7,9 +7,11 @@ import WebEngine
 import WebKit
 @testable import Client
 
+@MainActor
 final class BrowserWebUIDelegateTests: XCTestCase {
     private var mockLegacyResponder: MockLegacyResponder!
     private var engineResponder: MockWKUIHandler!
+
     private var webView: WKWebView {
         return MockTabWebView(
             tab: MockTab(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -611,6 +611,7 @@ extension JumpBackInViewModelTests {
         return subject
     }
 
+    @MainActor
     func createTab(profile: MockProfile,
                    urlString: String? = "www.website.com") -> Tab {
         let tab = Tab(profile: profile, windowUUID: windowUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -206,6 +206,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
     }
 
+    @MainActor
     func test_updateSnapshot_withValidState_returnJumpBackInSection() throws {
         setupNimbusHomepageRedesignTesting(storiesRedesignEnabled: false)
         let dataSource = try XCTUnwrap(diffableDataSource)
@@ -288,6 +289,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         )
     }
 
+    @MainActor
     private func createTab(urlString: String) -> Tab {
         let tab = Tab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
         tab.url = URL(string: urlString)!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
@@ -32,6 +32,7 @@ final class JumpBackInSectionStateTests: XCTestCase {
         XCTAssertEqual(initialState.jumpBackInTabs, [])
     }
 
+    @MainActor
     func test_initializeAction_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = jumpBackInSectionReducer()
@@ -162,6 +163,7 @@ final class JumpBackInSectionStateTests: XCTestCase {
         return JumpBackInSectionState.reducer
     }
 
+    @MainActor
     func createTab(urlString: String) -> Tab {
         let tab = Tab(profile: mockProfile, windowUUID: .XCTestDefaultUUID)
         tab.url = URL(string: urlString)!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
@@ -39,6 +39,7 @@ class AccountSyncHandlerTests: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testTabDidGainFocus_doesntSyncWithoutAccount() {
         let expectation = XCTestExpectation(description: "sync is not called without an account")
         expectation.isInverted = true
@@ -52,6 +53,7 @@ class AccountSyncHandlerTests: XCTestCase {
         XCTAssertEqual(profile.storeAndSyncTabsCalled, 0)
     }
 
+    @MainActor
     func testTabDidGainFocus_syncWithAccount() {
         let expectation = XCTestExpectation(description: "storeAndSyncTabs called after listed time of tab gaining focus")
         let subject = AccountSyncHandler(with: profile, debounceTime: 0.1, queue: queue, queueDelay: 0.1, onSyncCompleted: {
@@ -64,6 +66,7 @@ class AccountSyncHandlerTests: XCTestCase {
         XCTAssertEqual(profile.storeAndSyncTabsCalled, 1)
     }
 
+    @MainActor
     func testTabDidGainFocus_multipleActions_executedAtMostOnce() {
         let expectation = XCTestExpectation(
             description: "storeAndSyncTabs only called once from multiple tab actions")
@@ -80,6 +83,7 @@ class AccountSyncHandlerTests: XCTestCase {
         XCTAssertEqual(profile.storeAndSyncTabsCalled, 1)
     }
 
+    @MainActor
     func testTabDidGainFocus_multipleDebounce_withWithMultipleSyncs() {
         let expectation = XCTestExpectation(
             description: "storeAndSyncTabs called multiple times if outside of debounce time")
@@ -103,6 +107,7 @@ class AccountSyncHandlerTests: XCTestCase {
 
 // MARK: - Helper methods
 private extension AccountSyncHandlerTests {
+    @MainActor
     func createTab(profile: MockProfile,
                    urlString: String? = "www.website.com") -> Tab {
         let tab = Tab(profile: profile, windowUUID: windowUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
@@ -6,6 +6,7 @@ import Foundation
 
 @testable import Client
 
+@MainActor
 class MockShareTab: ShareTab {
     var canonicalURL: URL?
     var displayTitle: String
@@ -25,17 +26,5 @@ class MockShareTab: ShareTab {
         self.canonicalURL = canonicalURL
         self.webView = TabWebView(frame: CGRect.zero, configuration: .init(), windowUUID: .XCTestDefaultUUID)
         self.temporaryDocument = withTemporaryDocument
-    }
-
-    static func == (lhs: MockShareTab, rhs: MockShareTab) -> Bool {
-        guard let lhsTempDoc = lhs.temporaryDocument as? MockTemporaryDocument,
-              let rhsTempDoc = rhs.temporaryDocument as? MockTemporaryDocument else {
-            return false
-        }
-
-        return lhs.displayTitle == rhs.displayTitle
-        && lhs.url == rhs.url
-        && lhs.webView === rhs.webView
-        && lhsTempDoc === rhsTempDoc
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabWebView.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabWebView.swift
@@ -95,6 +95,7 @@ final class MockTabWebView: TabWebView {
     }
 }
 
+@MainActor
 class MockTab: Tab {
     private var isHomePage: Bool
     var enqueueDocumentCalled = 0
@@ -108,7 +109,7 @@ class MockTab: Tab {
         return isHomePage
     }
 
-    override func getSessionCookies(_ completion: @escaping ([HTTPCookie]) -> Void) {
+    override func getSessionCookies(_ completion: @escaping @MainActor @Sendable ([HTTPCookie]) -> Void) {
         completion([])
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTemporaryDocument.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTemporaryDocument.swift
@@ -6,7 +6,7 @@ import Foundation
 
 @testable import Client
 
-class MockTemporaryDocument: TemporaryDocument {
+final class MockTemporaryDocument: TemporaryDocument, @unchecked Sendable {
     var sourceURL: URL? {
         return request?.url
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordGenerator/PasswordGeneratorViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordGenerator/PasswordGeneratorViewControllerTests.swift
@@ -20,6 +20,7 @@ final class PasswordGeneratorViewControllerTests: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testPasswordGeneratorViewController_simpleCreation_hasNoLeaks() {
         let mockProfile = MockProfile()
         let currentTab = Tab(profile: mockProfile, windowUUID: windowUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareManagerTests.swift
@@ -8,6 +8,7 @@ import Shared
 
 @testable import Client
 
+@MainActor
 final class ShareManagerTests: XCTestCase {
     let testMessage = "Test message"
     let testSubtitle = "Test subtitle"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryActivityItemProviderTests.swift
@@ -32,7 +32,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
         let mockGleanWrapper = MockGleanWrapper()
 
         let shareTelemetryActivityItemProvider = ShareTelemetryActivityItemProvider(
-            shareType: testShareType,
+            shareTypeName: testShareType.typeName,
             shareMessage: testShareMessage,
             gleanWrapper: mockGleanWrapper
         )
@@ -53,7 +53,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
         let mockGleanWrapper = MockGleanWrapper()
 
         let shareTelemetryActivityItemProvider = ShareTelemetryActivityItemProvider(
-            shareType: testShareType,
+            shareTypeName: testShareType.typeName,
             shareMessage: testShareMessage,
             gleanWrapper: mockGleanWrapper
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
@@ -32,7 +32,7 @@ final class ShareTelemetryTests: XCTestCase {
 
         subject.sharedTo(
             activityType: testActivityType,
-            shareType: testShareType,
+            shareTypeName: testShareType.typeName,
             hasShareMessage: testHasShareMessage
         )
 
@@ -52,7 +52,7 @@ final class ShareTelemetryTests: XCTestCase {
 
         subject.sharedTo(
             activityType: testActivityType,
-            shareType: testShareType,
+            shareTypeName: testShareType.typeName,
             hasShareMessage: testHasShareMessage
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHome/StartAtHomeHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHome/StartAtHomeHelperTests.swift
@@ -91,6 +91,7 @@ class StartAtHomeHelperTests: XCTestCase {
         XCTAssertFalse(helper.shouldStartAtHome(with: Date()), "Expected to fail for disabled state")
     }
 
+    @MainActor
     func testScanForExistingHomeTab_ForEmptyTabs() {
         setupHelper()
         let homeTab = helper.scanForExistingHomeTab(in: [], with: profile.prefs)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabEventHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabEventHandlerTests.swift
@@ -22,6 +22,7 @@ class TabEventHandlerTests: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testEventDelivery() {
         let tab = Tab(profile: MockProfile(),
                       windowUUID: windowUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -1751,6 +1751,7 @@ class TabManagerTests: XCTestCase {
         case privateAny // `private` alone is a reserved compiler keyword
     }
 
+    @MainActor
     private func generateTabs(ofType type: TabType = .normalActive, count: Int) -> [Tab] {
         var tabs = [Tab]()
         for i in 0..<count {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -53,6 +53,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(newUrl.host, "mozilla.org")
     }
 
+    @MainActor
     func testDisplayTitle_ForHomepageURL() {
         let url = URL(string: "internal://local/about/home")!
         let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
@@ -61,6 +62,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(tab.displayTitle, expectedDisplayTitle)
     }
 
+    @MainActor
     func testTitle_WhenWebViewTitleIsNil_ThenShouldReturnNil() {
         let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
         let mockTabWebView = MockTabWebView(tab: tab)
@@ -69,6 +71,7 @@ class TabTests: XCTestCase {
         XCTAssertNil(tab.title, "Expected title to be nil when webView.title is nil")
     }
 
+    @MainActor
     func testTitle_WhenWebViewTitleIsEmpty_ThenShouldReturnNil() {
         let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
         let mockTabWebView = MockTabWebView(tab: tab)
@@ -77,6 +80,7 @@ class TabTests: XCTestCase {
         XCTAssertNil(tab.title, "Expected title to be nil when webView.title is empty")
     }
 
+    @MainActor
     func testTitle_WhenWebViewTitleIsValid_ThenShouldReturnTitle() {
         let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
         let mockTabWebView = MockTabWebView(tab: tab)
@@ -85,18 +89,21 @@ class TabTests: XCTestCase {
         XCTAssertEqual(tab.title, "Test Page Title", "Expected title to return the webView's title")
     }
 
+    @MainActor
     func testTabDoesntLeak() {
         let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
         tab.tabDelegate = tabDelegate
         trackForMemoryLeaks(tab)
     }
 
+    @MainActor
     func testIsDownloadingDocument_whenDocumentIsNil_returnsFalse() {
         let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
 
         XCTAssertFalse(tab.isDownloadingDocument())
     }
 
+    @MainActor
     func testIsDownloadingDocument_whenDocumentIsDownloading_returnsTrue() {
         let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
         let document = MockTemporaryDocument(withFileURL: URL(string: "https://www.example.com")!)
@@ -108,7 +115,7 @@ class TabTests: XCTestCase {
     }
 
     // MARK: - isActive, isInactive
-
+    @MainActor
     func testTabIsActive_within14Days() {
         // Tabs use the current date by default, so this one should be considered recent and active on initialization
         let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
@@ -117,6 +124,7 @@ class TabTests: XCTestCase {
         XCTAssertFalse(tab.isInactive)
     }
 
+    @MainActor
     func testTabIsInactive_outside14Days() {
         let lastMonthDate = Date().lastMonth
         let tab = Tab(profile: mockProfile, windowUUID: windowUUID, tabCreatedTime: lastMonthDate)
@@ -126,7 +134,7 @@ class TabTests: XCTestCase {
     }
 
     // MARK: - isSameTypeAs
-
+    @MainActor
     func testIsSameTypeAs_trueForTwoPrivateTabs_oneActive_oneInactive() {
         let lastMonthDate = Date().lastMonth
 
@@ -147,6 +155,7 @@ class TabTests: XCTestCase {
         XCTAssertTrue(privateInactiveTab.isSameTypeAs(privateActiveTab))
     }
 
+    @MainActor
     func testIsSameTypeAs_trueForTwoPrivateTabs_bothActive() {
         let privateActiveTab1 = Tab(
             profile: mockProfile,
@@ -163,6 +172,7 @@ class TabTests: XCTestCase {
         XCTAssertTrue(privateActiveTab2.isSameTypeAs(privateActiveTab1))
     }
 
+    @MainActor
     func testIsSameTypeAs_trueForTwoPrivateTabs_bothInactive() {
         let lastMonthDate = Date().lastMonth
 
@@ -183,6 +193,7 @@ class TabTests: XCTestCase {
         XCTAssertTrue(privateInactiveTab2.isSameTypeAs(privateInactiveTab1))
     }
 
+    @MainActor
     func testIsSameTypeAs_falseForNormalTabAndPrivateTab() {
         let lastMonthDate = Date().lastMonth
 
@@ -208,6 +219,7 @@ class TabTests: XCTestCase {
         XCTAssertFalse(normalInactiveTab.isSameTypeAs(privateTab))
     }
 
+    @MainActor
     func testIsSameTypeAs_falseForNormalActiveTab_andNormalInactiveTab() {
         let lastMonthDate = Date().lastMonth
 
@@ -226,6 +238,7 @@ class TabTests: XCTestCase {
         XCTAssertFalse(normalInactiveTab.isSameTypeAs(normalActiveTab))
     }
 
+    @MainActor
     func testIsSameTypeAs_trueForTwoNormalTabs_bothActive() {
         let normalActiveTab1 = Tab(
             profile: mockProfile,
@@ -240,6 +253,7 @@ class TabTests: XCTestCase {
         XCTAssertTrue(normalActiveTab2.isSameTypeAs(normalActiveTab1))
     }
 
+    @MainActor
     func testIsSameTypeAs_trueForTwoNormalTabs_bothInactive() {
         let lastMonthDate = Date().lastMonth
 
@@ -259,7 +273,7 @@ class TabTests: XCTestCase {
     }
 
     // MARK: - Document Handling
-
+    @MainActor
     func testEnqueueDocument() {
         let subject = createSubject()
         let document = MockTemporaryDocument(withFileURL: url)
@@ -270,6 +284,7 @@ class TabTests: XCTestCase {
         XCTAssertNotNil(subject.temporaryDocument)
     }
 
+    @MainActor
     func testLoadDocumentRequest() {
         let subject = createSubject()
         let document = MockTemporaryDocument(withFileURL: url, request: URLRequest(url: url))
@@ -280,6 +295,7 @@ class TabTests: XCTestCase {
         XCTAssertNotNil(subject.temporaryDocument)
     }
 
+    @MainActor
     func testReload_whenDocumentIsDownloading_cancelDownload() {
         let subject = createSubject()
         let document = MockTemporaryDocument(withFileURL: url)
@@ -297,6 +313,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(mockTabWebView.reloadFromOriginCalled, 1)
     }
 
+    @MainActor
     func testGoBack_whenDocumentIsDownloading_cancelDownload() {
         let subject = createSubject()
         let document = MockTemporaryDocument(withFileURL: url)
@@ -318,6 +335,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(mockTabWebView.goBackCalled, 0)
     }
 
+    @MainActor
     func testGoForward_whenDocumentIsDownloading_cancelDownload() {
         let subject = createSubject()
         let document = MockTemporaryDocument(withFileURL: url)
@@ -338,6 +356,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(mockTabWebView.goForwardCalled, 0)
     }
 
+    @MainActor
     func testLoadRequest_whenDocumentIsDownloading_cancelDownload() {
         let subject = createSubject()
         let document = MockTemporaryDocument(withFileURL: url)
@@ -366,6 +385,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(mockTabWebView.reloadFromOriginCalled, 0)
     }
 
+    @MainActor
     func testStop_whenDocumentIsDownloading_cancelDownload() {
         let subject = createSubject()
         let document = MockTemporaryDocument(withFileURL: url)
@@ -383,6 +403,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(mockTabWebView.reloadFromOriginCalled, 1)
     }
 
+    @MainActor
     func testSetURL_showsOnlineURLForLocalDocument_whenPDFRefactorEnabled() {
         let subject = createSubject()
         let request = URLRequest(url: URL(string: "https://www.example.com")!)
@@ -397,6 +418,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(subject.url, request.url)
     }
 
+    @MainActor
     func testPauseDocumentDownload() {
         let subject = createSubject()
         let document = MockTemporaryDocument()
@@ -407,6 +429,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(document.pauseDownloadCalled, 1)
     }
 
+    @MainActor
     func testResumeDocumentDownload() {
         let subject = createSubject()
         let document = MockTemporaryDocument()
@@ -417,6 +440,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(document.resumeDownloadCalled, 1)
     }
 
+    @MainActor
     func testCancelDocumentDownload() {
         let subject = createSubject()
         let document = MockTemporaryDocument()
@@ -427,6 +451,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(document.cancelDownloadCalled, 1)
     }
 
+    @MainActor
     func testShouldDownloadDocument_whenDocumentInSession_addsTemporaryDocument() {
         let subject = createSubject()
 
@@ -442,6 +467,7 @@ class TabTests: XCTestCase {
         XCTAssertTrue(result, "result should be the opposite fileManager.fileExists")
     }
 
+    @MainActor
     func testShouldDownloadDocument_whenDocumentNotInSession_returnsTrueForNilTemporaryDocument() {
         let subject = createSubject()
 
@@ -453,6 +479,7 @@ class TabTests: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    @MainActor
     func testShouldDownloadDocument_whenDocumentNotInSession_forwardRequestToTemporaryDocument() {
         let subject = createSubject()
         let document = MockTemporaryDocument()
@@ -465,6 +492,7 @@ class TabTests: XCTestCase {
         XCTAssertEqual(document.canDownloadCalled, 1)
     }
 
+    @MainActor
     func testDeinit_removesAllDocumentInSession() {
         var subject: Tab? = createSubject()
         let session = [
@@ -482,6 +510,7 @@ class TabTests: XCTestCase {
     }
 
     // MARK: - Helpers
+    @MainActor
     private func createSubject() -> Tab {
         let subject = Tab(
             profile: mockProfile,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/InactiveTabsManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/InactiveTabsManagerTests.swift
@@ -28,6 +28,7 @@ final class InactiveTabsManagerTests: XCTestCase {
         profile = nil
     }
 
+    @MainActor
     func testEmptyInactiveTabs_ForRegularTabs() throws {
         let subject = createSubject()
         let tabs = createTabs(amountOfRegularTabs: 3)
@@ -35,6 +36,7 @@ final class InactiveTabsManagerTests: XCTestCase {
         XCTAssertEqual(inactiveTabs.count, 0)
     }
 
+    @MainActor
     func testEmptyInactiveTabs_ForPrivateTabs() throws {
         let subject = createSubject()
         let tabs = createTabs(amountOfPrivateTabs: 3)
@@ -42,6 +44,7 @@ final class InactiveTabsManagerTests: XCTestCase {
         XCTAssertEqual(inactiveTabs.count, 0)
     }
 
+    @MainActor
     func testEmptyInactiveTabs_ForRegularAndPrivateTabs() throws {
         let subject = createSubject()
         let tabs = createTabs(amountOfRegularTabs: 3,
@@ -50,6 +53,7 @@ final class InactiveTabsManagerTests: XCTestCase {
         XCTAssertEqual(inactiveTabs.count, 0)
     }
 
+    @MainActor
     func testGetInactiveTabs_WithInactiveTabs() throws {
         let subject = createSubject()
         let tabs = createTabs(amountOfRegularTabs: 3,
@@ -67,6 +71,7 @@ final class InactiveTabsManagerTests: XCTestCase {
         return subject
     }
 
+    @MainActor
     private func createTabs(amountOfRegularTabs: Int = 0,
                             amountOfPrivateTabs: Int = 0,
                             amountOfInactiveTabs: Int = 0) -> [Tab] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/SponsoredContentFilterUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/SponsoredContentFilterUtilityTests.swift
@@ -56,6 +56,7 @@ class SponsoredContentFilterUtilityTests: XCTestCase {
 
     // MARK: - Tabs
 
+    @MainActor
     func testNoNormalTabsFilter() {
         let subject = SponsoredContentFilterUtility()
         let tabs = createTabs(normalTabsCount: 5,
@@ -66,6 +67,7 @@ class SponsoredContentFilterUtilityTests: XCTestCase {
         XCTAssertEqual(result.count, 5, "No tabs were removed")
     }
 
+    @MainActor
     func testNoEmptyURLsTabsFilter() {
         let subject = SponsoredContentFilterUtility()
         let tabs = createTabs(normalTabsCount: 0,
@@ -76,6 +78,7 @@ class SponsoredContentFilterUtilityTests: XCTestCase {
         XCTAssertEqual(result.count, 5, "No tabs were removed")
     }
 
+    @MainActor
     func testSponsoredTabsFilter() {
         let subject = SponsoredContentFilterUtility()
         let tabs = createTabs(normalTabsCount: 0,
@@ -86,6 +89,7 @@ class SponsoredContentFilterUtilityTests: XCTestCase {
         XCTAssertEqual(result.count, 0, "All sponsored tabs were removed")
     }
 
+    @MainActor
     func testSponsoredTabsFilterMixed() {
         let subject = SponsoredContentFilterUtility()
         let tabs = createTabs(normalTabsCount: 4,
@@ -117,6 +121,7 @@ extension SponsoredContentFilterUtilityTests {
         return sites
     }
 
+    @MainActor
     func createTabs(normalTabsCount: Int,
                     emptyURLTabsCount: Int,
                     sponsoredTabsCount: Int) -> [Tab] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ZoomPageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ZoomPageManagerTests.swift
@@ -32,6 +32,7 @@ class ZoomPageManagerTests: XCTestCase {
         XCTAssertNil(subject.tab)
     }
 
+    @MainActor
     func testTabNotNil_WhenTabGainFocus() {
         let subject = createSubject()
         let tab = createTab()
@@ -40,6 +41,7 @@ class ZoomPageManagerTests: XCTestCase {
         XCTAssertNotNil(subject.tab)
     }
 
+    @MainActor
     func testTabZoomChange_WhenZoomInIsCalled() {
         let subject = createSubject()
         let tab = createTab()
@@ -51,6 +53,7 @@ class ZoomPageManagerTests: XCTestCase {
         XCTAssertEqual(tab.pageZoom, expectedZoom)
     }
 
+    @MainActor
     func testTabZoomChange_WhenZoomOutIsCalled() {
         let subject = createSubject()
         let tab = createTab()
@@ -62,6 +65,7 @@ class ZoomPageManagerTests: XCTestCase {
         XCTAssertEqual(tab.pageZoom, expectedZoom)
     }
 
+    @MainActor
     func testTabZoomReset_WhenResetZoomIsCalled() {
         let subject = createSubject()
         let tab = createTab()
@@ -72,6 +76,7 @@ class ZoomPageManagerTests: XCTestCase {
         XCTAssertEqual(tab.pageZoom, expectedZoom)
     }
 
+    @MainActor
     func testTabZoomDoesntChange_WhenZoomInIsCalledForUpperLimit() {
         let subject = createSubject()
         let domainZoomLevel = DomainZoomLevel(host: "www.website.com",
@@ -86,6 +91,7 @@ class ZoomPageManagerTests: XCTestCase {
         XCTAssertEqual(tab.pageZoom, expectedZoom)
     }
 
+    @MainActor
     func testTabZoomDoesntChange_WhenZoomOutIsCalledForLowerLimit() {
         let subject = createSubject()
         let domainZoomLevel = DomainZoomLevel(host: "www.website.com",
@@ -100,6 +106,7 @@ class ZoomPageManagerTests: XCTestCase {
         XCTAssertEqual(tab.pageZoom, expectedZoom)
     }
 
+    @MainActor
     func testZoomStoreSaved_WhenZoomInIsCalled() {
         let subject = createSubject()
         let tab = createTab()
@@ -109,6 +116,7 @@ class ZoomPageManagerTests: XCTestCase {
         XCTAssertEqual(zoomStore.saveCalledCount, 1)
     }
 
+    @MainActor
     func testZoomStoreSaved_WhenZoomResetIsCalled() {
         let subject = createSubject()
         let tab = createTab()
@@ -118,6 +126,7 @@ class ZoomPageManagerTests: XCTestCase {
         XCTAssertEqual(zoomStore.saveCalledCount, 1)
     }
 
+    @MainActor
     func testFindZoomStore_WhenZoomInIsCalled() {
         let subject = createSubject()
         let tab = createTab()
@@ -135,6 +144,7 @@ class ZoomPageManagerTests: XCTestCase {
         return subject
     }
 
+    @MainActor
     func createTab() -> Tab {
         let tab = Tab(profile: profile, windowUUID: windowUUID)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13511)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Isolate Tab to the MainActor, this is necessary due to the fact that the tab holds on to the webview and the webview needs to be only accessed on the MainActor. This resolves the strict concurrency warnings in the `Tab.swift` file.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
