### PR TITLE
Add FXIOS-13574 [Trending Searches] feature flags

### DIFF
--- a/firefox-ios/nimbus-features/recentSearchesFeature.yaml
+++ b/firefox-ios/nimbus-features/recentSearchesFeature.yaml
@@ -1,0 +1,24 @@
+# The configuration for the recentSearchesFeature feature
+features:
+  recent-searches-feature:
+    description: >
+      Enables recent searches.
+    variables:
+      enabled:
+        description: >
+          Whether or not to enable recent searches.
+        type: Boolean
+        default: false
+      max-suggestions:
+        description: The number of maximum suggestions.
+        type: Int
+        default: 5
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+          max-suggestions: 5
+      - channel: developer
+        value:
+          enabled: false
+          max-suggestions: 5

--- a/firefox-ios/nimbus-features/trendingSearchesFeature.yaml
+++ b/firefox-ios/nimbus-features/trendingSearchesFeature.yaml
@@ -1,0 +1,25 @@
+# The configuration for the trendingSearchesFeature feature
+
+features:
+  trending-searches-feature:
+    description: >
+      Enables trending searches.
+    variables:
+      enabled:
+        description: >
+          Whether or not to enable trending searches.
+        type: Boolean
+        default: false
+      max-suggestions:
+        description: The number of maximum suggestions.
+        type: Int
+        default: 5
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+          max-suggestions: 5
+      - channel: developer
+        value:
+          enabled: false
+          max-suggestions: 5

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -34,6 +34,7 @@ include:
   - nimbus-features/newAppearanceMenu.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml
   - nimbus-features/pdfRefactorFeature.yaml
+  - nimbus-features/recentSearchesFeature.yaml
   - nimbus-features/revertUnsafeContinuationsRefactor.yaml
   - nimbus-features/rustFxAKeychainEnabled.yaml
   - nimbus-features/searchEngineConsolidationFeature.yaml
@@ -48,6 +49,7 @@ include:
   - nimbus-features/tosFeature.yaml
   - nimbus-features/touFeature.yaml
   - nimbus-features/trackingProtectionRefactor.yaml
+  - nimbus-features/trendingSearchesFeature.yaml
   - nimbus-features/unifiedAds.yaml
   - nimbus-features/updatedPasswordManager.yaml
   - nimbus-features/webEngineIntegrationRefactor.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13574)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29498)

## :bulb: Description
Add feature flags for trending searches and recent searches (follow similar to Android's experiment [here](https://experimenter.services.mozilla.com/nimbus/android-trending-and-recent-searches-v1-treatment-g-rollout/summary/)).

Also added to spreadsheet.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
