### PR TITLE
Bugfix NO-TICKET Unblock v143.1 build compile error

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -58,10 +58,10 @@ class TabTraySelectorView: UIView,
 
     private lazy var visualEffectView: UIVisualEffectView = .build { view in
 #if canImport(FoundationModels)
-        if #available(iOS 26, *) {
+        if #available(iOS 26, *), !DefaultBrowserUtil.isRunningLiquidGlassEarlyBeta {
             view.effect = UIGlassEffect(style: .regular)
         } else {
-            return UIBlurEffect(style: .systemUltraThinMaterial)
+            view.effect = UIBlurEffect(style: .systemUltraThinMaterial)
         }
 #else
         view.effect = UIBlurEffect(style: .systemUltraThinMaterial)


### PR DESCRIPTION
## :scroll: Tickets
No ticket.

## :bulb: Description
Not sure why there is a build error that got through Bitrise here, but I have a fix. I also wanted to make sure we added the same check as we did for iOS 26 betas 1-3 crashes, which was backported here: https://github.com/mozilla-mobile/firefox-ios/pull/29408 (backport #29423)

Otherwise we'll just see the same crash but in the tab tray, I would guess.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
