### PR TITLE
Refactor FXIOS-13532 [Swift 6 Migration] Fix strict concurrency errors related to Notifications 

### DIFF
--- a/firefox-ios/Client/Application/BackgroundNotificationSurfaceUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundNotificationSurfaceUtility.swift
@@ -3,11 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import BackgroundTasks
+// TODO: FXIOS-13582 - Capture of non-Sendable type BGAppRefreshTask in @Sendable closure
+@preconcurrency import BackgroundTasks
 import Common
 import Shared
 
-class BackgroundNotificationSurfaceUtility: BackgroundUtilityProtocol {
+// TODO: FXIOS-13582 - BackgroundNotificationSurfaceUtility should be concurrency safe
+class BackgroundNotificationSurfaceUtility: BackgroundUtilityProtocol, @unchecked Sendable {
     let taskIdentifier = "org.mozilla.ios.surface.notification.refresh"
     var surfaceManager: NotificationSurfaceManager
     var notificationManager: NotificationManagerProtocol

--- a/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
@@ -13,7 +13,8 @@ protocol NotificationSurfaceDelegate: AnyObject {
     func didDismissNotification(_ userInfo: [AnyHashable: Any])
 }
 
-class NotificationSurfaceManager: NotificationSurfaceDelegate {
+// TODO: FXIOS-FXIOS-13583 - NotificationSurfaceManager should be concurrency safe
+class NotificationSurfaceManager: NotificationSurfaceDelegate, @unchecked Sendable {
     struct Constant {
         static let notificationBaseId = "org.mozilla.ios.notification"
         static let notificationCategoryId = "org.mozilla.ios.notification.category"
@@ -97,6 +98,8 @@ class NotificationSurfaceManager: NotificationSurfaceDelegate {
                                      interval: TimeInterval(Constant.messageDelay),
                                      repeats: false)
 
+        // TODO: FXIOS-13583 - Capture of 'message' with non-Sendable type 'GleanPlumbMessage' in a '@Sendable' closure
+        nonisolated(unsafe) let message = message
         // Schedule notification telemetry for when notification gets displayed
         DispatchQueue.global().asyncAfter(deadline: .now() + Constant.messageDelay) { [weak self] in
             self?.didDisplayMessage(message)

--- a/firefox-ios/Client/Frontend/Settings/NotificationsSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/NotificationsSettingsViewController.swift
@@ -56,7 +56,8 @@ final class NotificationsSettingsViewController: SettingsTableViewController, Fe
     private let prefs: Prefs
     private let hasAccount: Bool
     private var footerTitle = ""
-    private var notificationManager: NotificationManagerProtocol
+    // TODO: FXIOS-13584 - NotificationsSettingsViewController sending notificationManager risks causing data races
+    private nonisolated(unsafe) var notificationManager: NotificationManagerProtocol
 
     init(prefs: Prefs,
          hasAccount: Bool,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13532)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29411)

## :bulb: Description
Basically only creating more TODOs. I might have missed something but didn't find any easy solutions for those warnings without refactoring. Let me know if I missed something obvious!

cc: @Cramsden @dataports @ih-codes  

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
