### PR TITLE
Bugfix FXIOS-13521 [Tab Tray] [iOS 26] Weird display of the tab tray selector

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -61,7 +61,7 @@ class TabTraySelectorView: UIView,
         if #available(iOS 26, *), !DefaultBrowserUtil.isRunningLiquidGlassEarlyBeta {
             view.effect = UIGlassEffect(style: .regular)
         } else {
-            return UIBlurEffect(style: .systemUltraThinMaterial)
+            view.effect = UIBlurEffect(style: .systemUltraThinMaterial)
         }
 #else
         view.effect = UIBlurEffect(style: .systemUltraThinMaterial)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13521)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29381)

## :bulb: Description
Applies fix from [uplift to 143.1](https://github.com/mozilla-mobile/firefox-ios/pull/29470) and this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/29510) to main.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
