### PR TITLE
Refactor FXIOS-13594 - [Memory Leaks] - Memory leak in our SQLite parameter binding logic when handling String values

### DIFF
--- a/firefox-ios/Storage/ThirdParty/SwiftData.swift
+++ b/firefox-ios/Storage/ThirdParty/SwiftData.swift
@@ -294,7 +294,9 @@ private class SQLiteDBStatement {
             } else if obj is String {
                 typealias CFunction = @convention(c) (UnsafeMutableRawPointer?) -> Void
                 let transient = unsafeBitCast(-1, to: CFunction.self)
-                status = sqlite3_bind_text(pointer, Int32(index+1), makeUtf8CString(from: (obj as! String)), -1, transient)
+                (obj as! String).withCString { cString in
+                    status = sqlite3_bind_text(pointer, Int32(index+1), cString, -1, transient)
+                }
             } else if obj is Data {
                 status = sqlite3_bind_blob(pointer, Int32(index+1), ((obj as! Data) as NSData).bytes, -1, nil)
             } else if obj is Date {
@@ -325,14 +327,6 @@ private class SQLiteDBStatement {
         if nil != self.pointer {
             sqlite3_finalize(self.pointer)
         }
-    }
-
-    func makeUtf8CString(from str: String) -> UnsafeMutablePointer<Int8> {
-        let count = str.utf8CString.count
-        let result: UnsafeMutableBufferPointer<Int8> = UnsafeMutableBufferPointer<Int8>.allocate(capacity: count)
-        // func initialize<S>(from: S) -> (S.Iterator, UnsafeMutableBufferPointer<Element>.Index)
-        _ = result.initialize(from: str.utf8CString)
-        return result.baseAddress!
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13594)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29530)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Summary:
- Fix SQLite string binding memory leak by replacing manual allocation with `withCString` Swift built in method.

Previously, `String` parameters were converted to C strings using a custom `makeUtf8CString()` helper. That helper allocated raw memory for the `UTF-8` buffer, passed it to `sqlite3_bind_text`, and never freed it. Since `SQLITE_TRANSIENT` was used, `SQLite` copied the string internally, but our allocated buffer was left behind, causing a leak for every string binding.

To solve the leak I did the following changes:
- Removed the makeUtf8CString helper entirely.
- Replaced string binding logic with `String.withCString,` which safely exposes a temporary `UTF-8` buffer for the duration of the binding call.

[SQLITE_TRANSIENT documentation](https://www.sqlite.org/c3ref/c_static.html)
[withCString documentation](https://developer.apple.com/documentation/swift/string/withcstring(_:))
## :movie_camera: Demos

<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
