### PR TITLE
Bugfix NO_TICKET Add check for iOS 26 Betas 1-3 before using UIGlassEffect with new API in tab tray

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -57,8 +57,10 @@ class TabTraySelectorView: UIView,
     }
 
     private lazy var visualEffectView: UIVisualEffectView = .build { view in
-        if #available(iOS 26, *) {
+        if #available(iOS 26, *), !DefaultBrowserUtil.isRunningLiquidGlassEarlyBeta {
             view.effect = UIGlassEffect(style: .regular)
+        } else {
+            view.effect = UIBlurEffect(style: .systemUltraThinMaterial)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
No ticket.

## :bulb: Description
Related to uplift/backport for v143.1: https://github.com/mozilla-mobile/firefox-ios/pull/29510 (Change was already backported to unblock build, now we want it on main/v143.2 as well)
And original fix: https://github.com/mozilla-mobile/firefox-ios/pull/29408

We don't want the same crash from before in the tab tray here, so just applying the workaround here as well.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
