### PR TITLE
Bugfix FXIOS-13298 #28945 ⁃ [Xcode 16] Failing `testStartShareSheetCoordinator_addsShareSheetCoordinator()`

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -55,7 +55,6 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         glean = nil
         scrollDelegate = nil
         browserViewController = nil
-
         DependencyHelperMock().reset()
         super.tearDown()
     }
@@ -206,7 +205,6 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(screenshotTool is LegacyHomepageViewController)
     }
 
-    @MainActor
     func testHomepageScreenshotTool_returnsPrivateHomepage_forPrivateTab() throws {
         let subject = createSubject()
         browserViewController.overrideNewTabSettings = .topSites
@@ -346,28 +344,24 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
     func testStartShareSheetCoordinator_addsShareSheetCoordinator() {
         let subject = createSubject()
 
+        let exp = expectation(description: "present called")
+        mockRouter.onPresent = { exp.fulfill() }
+
         subject.startShareSheetCoordinator(
             shareType: .site(url: URL(string: "https://www.google.com")!),
             shareMessage: ShareMessage(message: "Test Message", subtitle: "Test Subtitle"),
             sourceView: UIView(),
-            sourceRect: CGRect(),
+            sourceRect: .zero,
             toastContainer: UIView(),
             popoverArrowDirection: .up
         )
 
-        // NOTE: FXIOS-10824 We are waiting for an async call to complete. Hopefully the temporary document download will be
-        // improved in the future to make this call synchronous.
-        let predicate = NSPredicate { _, _ in
-            return self.mockRouter.presentCalled == 1
-        }
-        let exp = XCTNSPredicateExpectation(predicate: predicate, object: .none)
-
-        wait(for: [exp], timeout: 5.0)
+        wait(for: [exp], timeout: 5)
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertTrue(subject.childCoordinators.first is ShareSheetCoordinator)
-        XCTAssertEqual(self.mockRouter.presentCalled, 1)
-        XCTAssertTrue(self.mockRouter.presentedViewController is UIActivityViewController)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertTrue(mockRouter.presentedViewController is UIActivityViewController)
     }
 
     func testStartShareSheetCoordinator_isSharingTabWithTemporaryDocument_upgradesTabShareToFileShare() throws {
@@ -396,12 +390,8 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
             popoverArrowDirection: .up
         )
 
-        // NOTE: FXIOS-10824 We are waiting for an async call to complete. Hopefully the temporary document download will be
-        // improved in the future to make this call synchronous.
-        let predicate = NSPredicate { _, _ in
-            return self.mockRouter.presentCalled == 1
-        }
-        let exp = XCTNSPredicateExpectation(predicate: predicate, object: .none)
+        let exp = expectation(description: "present called")
+        mockRouter.onPresent = { exp.fulfill() }
 
         wait(for: [exp], timeout: 5.0)
 
@@ -431,7 +421,6 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(mockRouter.presentedViewController is BottomSheetViewController)
     }
 
-    @MainActor
     func testShowSavedLoginAutofill_addsCredentialAutofillCoordinator() {
         let subject = createSubject()
         let testURL = URL(string: "https://example.com")!
@@ -622,7 +611,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
     }
 
     // MARK: - Summarize Panel
-    @MainActor
+
     func testShowSummarizePanel_whenSummarizeFeatureEnabled_showsPanel() {
         setIsHostedSummarizerEnabled(true)
         let subject = createSubject()
@@ -637,7 +626,6 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(childCoordinator is SummarizeCoordinator)
     }
 
-    @MainActor
     func testShowSummarizePanel_whenSelectedTabIsHomePage_doesntShowPanel() {
         setIsHostedSummarizerEnabled(true)
         let subject = createSubject()
@@ -653,7 +641,6 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         }))
     }
 
-    @MainActor
     func testShowSummarizePanel_whenSummarizeFeatureIsDisabled_doesntShowPanel() {
         let subject = createSubject()
         subject.browserViewController = browserViewController

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
@@ -8,6 +8,7 @@ import UIKit
 class MockRouter: NSObject, Router {
     var navigationController: NavigationController
     var rootViewController: UIViewController?
+    var onPresent: (() -> Void)?
 
     var isPresenting: Bool {
         return presentCalled != 0
@@ -34,6 +35,7 @@ class MockRouter: NSObject, Router {
         savedCompletion = completion
         presentedViewController = viewController
         presentCalled += 1
+        onPresent?()
     }
 
     func present(_ viewController: UIViewController,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13298)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28945)

## :bulb: Description
- Add onPresent callback  to MockRouter
- Replace NSPredicate usage with new callback
- Class is already MainActor remove redundant function conformance

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
