### PR TITLE
Bugfix FXIOS-13603 [iOS 26] Show status bar on launch screen

### DIFF
--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
@@ -30,7 +30,7 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
     }
 
     override var prefersStatusBarHidden: Bool {
-        return true
+        return false
     }
 
     required init?(coder: NSCoder) {

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -196,7 +196,7 @@
 		<string>armv7</string>
 	</array>
 	<key>UIStatusBarHidden</key>
-	<true/>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13603)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29546)

## :bulb: Description
- Due to a bug in iPadOS 26, when plist key `UIStatusBarHidden` (Status bar is initially hidden) is set to `true` to hide the status bar on app launch, `safeAreaInsets.top` reports a value of `0` causing our apps content to overlap the system status bar. 

- Instead of manually calculating safe area insets, we will just show the status bar on our launch screen and launch screen view controller

Reference: https://developer.apple.com/forums/thread/798014

## :movie_camera: Demos
### 🎥 Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/f1b7bd35-7c95-46d5-af29-1bcd1c7a3264

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/d80c20d0-24b7-4cec-870f-a60d603f9858

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
