### PR TITLE
Add FXIOS-13587 [New first run onboarding] Add floating skip onboarding button over carousel

### DIFF
--- a/BrowserKit/Sources/OnboardingKit/Models/OnboardingFlowViewModel.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/OnboardingFlowViewModel.swift
@@ -8,6 +8,7 @@ import SwiftUI
 public final class OnboardingFlowViewModel<ViewModel: OnboardingCardInfoModelProtocol>: ObservableObject {
     @Published public var pageCount = 0
     public let onboardingCards: [ViewModel]
+    public let skipText: String
     public let onActionTap: @MainActor (
         ViewModel.OnboardingActionType,
         String,
@@ -28,6 +29,7 @@ public final class OnboardingFlowViewModel<ViewModel: OnboardingCardInfoModelPro
 
     public init(
         onboardingCards: [ViewModel],
+        skipText: String,
         onActionTap: @MainActor @escaping (
             ViewModel.OnboardingActionType,
             String,
@@ -39,6 +41,7 @@ public final class OnboardingFlowViewModel<ViewModel: OnboardingCardInfoModelPro
         onComplete: @escaping (String) -> Void
     ) {
         self.onboardingCards = onboardingCards
+        self.skipText = skipText
         self.onActionTap = onActionTap
         self.onMultipleChoiceActionTap = onMultipleChoiceActionTap
         self.onComplete = onComplete

--- a/BrowserKit/Sources/OnboardingKit/Preview/PreviewModel.swift
+++ b/BrowserKit/Sources/OnboardingKit/Preview/PreviewModel.swift
@@ -231,7 +231,9 @@ extension PreviewModel {
         themeManager: DefaultThemeManager(sharedContainerIdentifier: ""),
         viewModel: OnboardingFlowViewModel(
             onboardingCards: PreviewModel.all,
-            onActionTap: { _, _, _ in },
+            skipText: "Skip",
+            onActionTap: { _, _, _ in
+            },
             onMultipleChoiceActionTap: { _, _ in },
             onComplete: { _ in }
         )

--- a/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingViewCompact.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingViewCompact.swift
@@ -10,6 +10,7 @@ struct OnboardingViewCompact<ViewModel: OnboardingCardInfoModelProtocol>: View {
     @StateObject private var viewModel: OnboardingFlowViewModel<ViewModel>
     let windowUUID: WindowUUID
     var themeManager: ThemeManager
+    @State private var skipTextColor: Color = .clear
 
     init(
         windowUUID: WindowUUID,
@@ -24,7 +25,7 @@ struct OnboardingViewCompact<ViewModel: OnboardingCardInfoModelProtocol>: View {
     }
 
     var body: some View {
-        ZStack {
+        ZStack(alignment: .topTrailing) {
             AnimatedGradientMetalView(windowUUID: windowUUID, themeManager: themeManager)
                 .edgesIgnoringSafeArea(.all)
             VStack {
@@ -48,6 +49,21 @@ struct OnboardingViewCompact<ViewModel: OnboardingCardInfoModelProtocol>: View {
                 )
                 .padding(.bottom)
             }
+
+            Button(action: skipOnboarding) {
+                Text(viewModel.skipText)
+                    .bold()
+                    .foregroundColor(skipTextColor)
+            }
+            .buttonStyle(.plain)
+            .padding(.trailing, UX.Onboarding.Spacing.standard)
+        }
+        .onAppear {
+            applyTheme()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
+            applyTheme()
         }
     }
 
@@ -81,5 +97,16 @@ struct OnboardingViewCompact<ViewModel: OnboardingCardInfoModelProtocol>: View {
                 onMultipleChoiceAction: viewModel.handleMultipleChoiceAction
             )
         }
+    }
+
+    private func skipOnboarding() {
+        let currentIndex = min(max(viewModel.pageCount, 0), viewModel.onboardingCards.count - 1)
+        let currentCardName = viewModel.onboardingCards[currentIndex].name
+        viewModel.onComplete(currentCardName)
+    }
+
+    private func applyTheme() {
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        skipTextColor = Color(theme.colors.textInverted)
     }
 }

--- a/BrowserKit/Tests/OnboardingKitTests/Mocks/MockOnboardingType.swift
+++ b/BrowserKit/Tests/OnboardingKitTests/Mocks/MockOnboardingType.swift
@@ -48,7 +48,7 @@ enum MockOnboardingActionType: String, CaseIterable, RawRepresentable {
 }
 
 // MARK: - Mock Protocol Implementation
-class MockOnboardingCardInfoModel: OnboardingCardInfoModelProtocol {
+final class MockOnboardingCardInfoModel: OnboardingCardInfoModelProtocol {
     typealias OnboardingType = MockOnboardingType
     typealias OnboardingPopupActionType = MockOnboardingPopupActionType
     typealias OnboardingMultipleChoiceActionType = MockOnboardingMultipleChoiceActionType

--- a/BrowserKit/Tests/OnboardingKitTests/OnboardingFlowViewModelTests.swift
+++ b/BrowserKit/Tests/OnboardingKitTests/OnboardingFlowViewModelTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 @testable import OnboardingKit
 
+@MainActor
 class OnboardingFlowViewModelTests: XCTestCase {
     var viewModel: OnboardingFlowViewModel<MockOnboardingCardInfoModel>!
     var mockCards: [MockOnboardingCardInfoModel]!
@@ -44,6 +45,7 @@ class OnboardingFlowViewModelTests: XCTestCase {
     private func createViewModel() {
         viewModel = OnboardingFlowViewModel(
             onboardingCards: mockCards,
+            skipText: "Skip",
             onActionTap: { [weak self] action, cardName, completion in
                 self?.actionCallbacks.forEach { $0(action, cardName, completion) }
             },
@@ -253,6 +255,7 @@ class OnboardingFlowViewModelTests: XCTestCase {
     func testEmptyOnboardingCards() {
         let emptyViewModel = OnboardingFlowViewModel<MockOnboardingCardInfoModel>(
             onboardingCards: [],
+            skipText: "Skip",
             onActionTap: { _, _, completion in
                 completion(.success(.advance(numberOfPages: 1)))
             },
@@ -270,6 +273,7 @@ class OnboardingFlowViewModelTests: XCTestCase {
         // Start from the last card
         viewModel = OnboardingFlowViewModel(
             onboardingCards: mockCards,
+            skipText: "Skip",
             onActionTap: { _, _, completion in
                 completion(.success(.advance(numberOfPages: 1)))
             },
@@ -293,6 +297,7 @@ class OnboardingFlowViewModelTests: XCTestCase {
     func testWeakSelfInClosures() {
         var localViewModel: OnboardingFlowViewModel<MockOnboardingCardInfoModel>? = OnboardingFlowViewModel(
             onboardingCards: mockCards,
+            skipText: "Skip",
             onActionTap: { _, _, completion in
                 completion(.success(.advance(numberOfPages: 1)))
             },

--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -268,6 +268,7 @@ final class LaunchCoordinator: BaseCoordinator,
             themeManager: themeManager,
             viewModel: OnboardingFlowViewModel(
                 onboardingCards: onboardingCards,
+                skipText: .Onboarding.LaterAction,
                 onActionTap: { @MainActor [weak self] action, cardName, completion in
                     self?.onboardingService.handleAction(
                         action,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13587)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29519)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
