### PR TITLE
Bugfix FXIOS-13251 - [Tab Tray UI Redesign] - Tab tray spacing is too big on older device

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -18,7 +18,7 @@ final class TabsSectionManager: FeatureFlaggable {
         static let iPadInset: CGFloat = 50
         static let iPadTopSiteInset: CGFloat = 25
         static let verticalInset: CGFloat = 20
-        static let experimentEstimatedTitleHeight: CGFloat = 20
+        static let experimentTitleHeight: CGFloat = 20
     }
 
     static func leadingInset(traitCollection: UITraitCollection,
@@ -88,7 +88,7 @@ final class TabsSectionManager: FeatureFlaggable {
 
         let titleSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(UX.experimentEstimatedTitleHeight)
+            heightDimension: .absolute(UX.experimentTitleHeight)
         )
 
         let titleSupplementary = NSCollectionLayoutSupplementaryItem(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13251)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28827)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
|  <img width="750" height="1334" alt="before" src="https://github.com/user-attachments/assets/ea1ac471-dddb-48e9-b361-8bcfd7843403" />| ![after](https://github.com/user-attachments/assets/3044d2cf-b7e8-440c-97db-8a81d3d530de) |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
