### PR TITLE
Bugfix FXIOS-13608 #29555 After scaning the QR code, signing in, or pressing DONE, the user should be directed to the homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
@@ -77,7 +77,9 @@ final class OnboardingService: FeatureFlaggable {
             completion(.success(.advance(numberOfPages: 3)))
 
         case .syncSignIn:
-            handleSyncSignIn(from: cardName, with: activityEventHelper)
+            handleSyncSignIn(from: cardName, with: activityEventHelper) {
+                completion(.success(.advance(numberOfPages: 1)))
+            }
 
         case .setDefaultBrowser:
             handleSetDefaultBrowser(with: activityEventHelper)
@@ -169,13 +171,14 @@ final class OnboardingService: FeatureFlaggable {
 
     private func handleSyncSignIn(
         from cardName: String,
-        with activityEventHelper: ActivityEventHelper
+        with activityEventHelper: ActivityEventHelper,
+        completion: @escaping () -> Void
     ) {
         activityEventHelper.chosenOptions.insert(.syncSignIn)
         activityEventHelper.updateOnboardingUserActivationEvent()
 
         let fxaParams = FxALaunchParams(entrypoint: .introOnboarding, query: [:])
-        presentSignToSync(with: fxaParams, profile: profile)
+        presentSignToSync(with: fxaParams, profile: profile, completion: completion)
     }
 
     private func handleSetDefaultBrowser(with activityEventHelper: ActivityEventHelper) {
@@ -229,13 +232,14 @@ final class OnboardingService: FeatureFlaggable {
         hasRegisteredForDefaultBrowserNotification = true
     }
 
-    private func presentSignToSync(with params: FxALaunchParams, profile: Profile) {
+    private func presentSignToSync(with params: FxALaunchParams, profile: Profile, completion: @escaping () -> Void) {
         guard let delegate = delegate else { return }
 
         let signInVC = createSignInViewController(
             windowUUID: windowUUID,
             params: params,
-            profile: profile
+            profile: profile,
+            completion: completion
         )
 
         delegate.present(signInVC, animated: true, completion: nil)
@@ -268,7 +272,8 @@ final class OnboardingService: FeatureFlaggable {
     private func createSignInViewController(
         windowUUID: WindowUUID,
         params: FxALaunchParams,
-        profile: Profile
+        profile: Profile,
+        completion: @escaping () -> Void
     ) -> UIViewController {
         let singInSyncVC = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(
             params,
@@ -286,6 +291,7 @@ final class OnboardingService: FeatureFlaggable {
         (singInSyncVC as? FirefoxAccountSignInViewController)?.qrCodeNavigationHandler = qrCodeNavigationHandler
 
         let controller = DismissableNavigationViewController(rootViewController: singInSyncVC)
+        controller.onViewDismissed = completion
         return controller
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13608)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29555)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Tapping Done or successfully signing in now dismisses the onboarding process. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
