### PR TITLE
Remove FXIOS-13614 [Unit Tests] usage of Glean testing when not needed

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
@@ -49,11 +49,6 @@ class TelemetryContextualIdentifierTests: XCTestCase {
 
     // MARK: Helper methods
     func clearTest() {
-        // Due to changes allow certain custom pings to implement their own opt-out
-        // independent of Glean, custom pings may need to be registered manually in
-        // tests in order to put them in a state in which they can collect data.
-        Glean.shared.registerPings(GleanMetrics.Pings.shared)
-        Glean.shared.resetGlean(clearStores: true)
         TelemetryContextualIdentifier.clearUserDefaults()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13614)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29566)

## :bulb: Description
Tests were crashing for this [build](https://app.bitrise.io/app/6c06d3a40422d10f/pipelines/bdc4d62c-7d35-4f38-8163-ab1a1d709831?tests_filter_status=failed&tab=tests).
I didn't see why we needed to use it and tests were able to past successfully without it, so nuked it from the test. 

**Note:** Left the production code as is in case, but if we want more robust tests, we should check the telemetry being sent in addition to the contextID

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
