### PR TITLE
Add FXIOS-13615 Browser App Installation Entitlement

### DIFF
--- a/firefox-ios/Client/Entitlements/FennecApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FennecApplication.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.browser.app-installation</key>
+	<true/>
 	<key>aps-environment</key>
 	<string>development</string>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>

--- a/firefox-ios/Client/Entitlements/FirefoxApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FirefoxApplication.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.browser.app-installation</key>
+	<true/>
 	<key>aps-environment</key>
 	<string>production</string>
 	<key>com.apple.developer.applesignin</key>

--- a/firefox-ios/Client/Entitlements/FirefoxBetaApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FirefoxBetaApplication.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.browser.app-installation</key>
+	<true/>
 	<key>aps-environment</key>
 	<string>production</string>
 	<key>com.apple.developer.associated-domains</key>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13615)  
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29569)

## :bulb: Description
Enable the `com.apple.developer.browser.app-installation` entitlement so the browser can install alternative-distribution apps from websites using MarketplaceKit on iOS 17.4+.  
This change only updates the app entitlements file.

## :movie_camera: Demos
N/A – entitlement change only.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)