### PR TITLE
Refactor FXIOS-13235 [Swift 6 Migration] Enable strict concurrency checking in SummarizerKit

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -181,7 +181,10 @@ let package = Package(
                 "ComponentLibrary",
                 "Down"
             ],
-            swiftSettings: [.unsafeFlags(["-enable-testing"])]
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"]),
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
         ),
         .testTarget(name: "SummarizeKitTests",
                     dependencies: ["SummarizeKit"]),

--- a/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/FoundationModelsSummarizer.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/FoundationModelsSummarizer.swift
@@ -14,7 +14,7 @@ import Foundation
 /// TODO(FXIOS-12927): This should only be called when the model is available.
 @available(iOS 26, *)
 final class FoundationModelsSummarizer: SummarizerProtocol {
-    typealias SessionFactory = (String) -> LanguageModelSessionProtocol
+    typealias SessionFactory = @Sendable (String) -> LanguageModelSessionProtocol
 
     public let modelName: SummarizerModel = .appleSummarizer
 
@@ -29,7 +29,7 @@ final class FoundationModelsSummarizer: SummarizerProtocol {
         self.config = config
     }
 
-    private static func defaultSessionFactory(modelInstructions: String) -> LanguageModelSessionProtocol {
+    private static var defaultSessionFactory: SessionFactory = { modelInstructions in
         LanguageModelSessionAdapter(instructions: modelInstructions)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13235)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28790)

## :bulb: Description
Ok, locally the errors seem to be gone after this 1 small fix, so I think we can migrate the SummarizerKit package now! 🙌  We'll see what Bitrise says.

If there are no more warnings, I will close the tickets I previously opened: 
- https://mozilla-hub.atlassian.net/browse/FXIOS-13418
- https://mozilla-hub.atlassian.net/browse/FXIOS-13419

Here is the 1 warning I fixed:

<img width="1539" height="347" alt="Screenshot 2025-09-24 at 1 50 13 PM" src="https://github.com/user-attachments/assets/f8035a00-821f-4afc-a82b-4289b06ab361" />


cc @Cramsden @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
