### PR TITLE
Remove FXIOS [Cleanup] Unused code under DeviceInfo.swift

### DIFF
--- a/BrowserKit/Sources/Shared/DeviceInfo.swift
+++ b/BrowserKit/Sources/Shared/DeviceInfo.swift
@@ -6,66 +6,8 @@ import Common
 import UIKit
 
 extension DeviceInfo {
-    // List of device names that don't support advanced visual settings
-    static let lowGraphicsQualityModels = ["iPad",
-                                           "iPad1,1",
-                                           "iPhone1,1",
-                                           "iPhone1,2",
-                                           "iPhone2,1",
-                                           "iPhone3,1",
-                                           "iPhone3,2",
-                                           "iPhone3,3",
-                                           "iPod1,1",
-                                           "iPod2,1",
-                                           "iPod2,2",
-                                           "iPod3,1",
-                                           "iPod4,1",
-                                           "iPad2,1",
-                                           "iPad2,2",
-                                           "iPad2,3",
-                                           "iPad2,4",
-                                           "iPad3,1",
-                                           "iPad3,2",
-                                           "iPad3,3"]
-
-    public static var specificModelName: String {
-        var systemInfo = utsname()
-        uname(&systemInfo)
-
-        let machine = systemInfo.machine
-        let mirror = Mirror(reflecting: machine)
-        var identifier = ""
-
-        // Parses the string for the model name via NSUTF8StringEncoding, refer to
-        // http://stackoverflow.com/questions/26028918/ios-how-to-determine-iphone-model-in-swift
-        for child in mirror.children.enumerated() {
-            if let value = child.1.value as? Int8, value != 0 {
-                identifier.append(String(UnicodeScalar(UInt8(value))))
-            }
-        }
-        return identifier
-    }
-
-    public class func clientIdentifier(_ prefs: Prefs) -> String {
-        if let id = prefs.stringForKey("clientIdentifier") {
-            return id
-        }
-        let id = UUID().uuidString
-        prefs.setString(id, forKey: "clientIdentifier")
-        return id
-    }
-
     public class func deviceModel() -> String {
         return UIDeviceDetails.model
-    }
-
-    public class func isBlurSupported() -> Bool {
-        // We've tried multiple ways to make this change visible on simulators, but we
-        // haven't found a solution that worked:
-        // 1. http://stackoverflow.com/questions/21603475/how-can-i-detect-if-the-iphone-my-app-is-on-is-going-to-use-a-simple-transparen
-        // 2. https://gist.github.com/conradev/8655650
-        // Thus, testing has to take place on actual devices.
-        return !lowGraphicsQualityModels.contains(specificModelName)
     }
 
     public class func hasConnectivity() -> Bool {


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
As title says, unused code under `DeviceInfo.swift`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
