### PR TITLE
Refactor FXIOS-13532 #29411 [Swift 6 Migration] AppDelegate + PushNotification

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
+++ b/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
@@ -52,25 +52,24 @@ extension AppDelegate {
             forName: .constellationStateUpdate,
             object: nil,
             queue: nil
-        ) { notification in
-            if let newState = notification.userInfo?["newState"] as? ConstellationState {
-                self.setPreferencesForSyncedAccount(for: newState)
-                if newState.localDevice?.pushEndpointExpired ?? false {
-                    NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
-                    // Our endpoint expired, we should check for missed messages
-                    self.profile.pollCommands(forcePoll: true)
-                }
+        ) { [profile] notification in
+            guard let newState = notification.userInfo?["newState"] as? ConstellationState else { return }
+            let remoteDevicesCount = newState.remoteDevices.count
+            self.setPreferencesForSyncedAccount(for: profile, count: remoteDevicesCount)
+            if newState.localDevice?.pushEndpointExpired ?? false {
+                NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
+                // Our endpoint expired, we should check for missed messages
+                profile.pollCommands(forcePoll: true)
             }
         }
     }
 
-    private func setPreferencesForSyncedAccount(for newState: ConstellationState) {
-        guard self.profile.hasSyncableAccount() else { return }
+    private nonisolated func setPreferencesForSyncedAccount(for profile: Profile, count: Int) {
+        guard profile.hasSyncableAccount() else { return }
         profile.prefs.setBool(true, forKey: PrefsKeys.Sync.signedInFxaAccount)
-        let remoteCount = newState.remoteDevices.count
         // The additional +1 is to also add a count for the local device being used
-        let devicesCount = Int32(remoteCount + 1)
-        self.profile.prefs.setInt(devicesCount, forKey: PrefsKeys.Sync.numberOfSyncedDevices)
+        let devicesCount = Int32(count + 1)
+        profile.prefs.setInt(devicesCount, forKey: PrefsKeys.Sync.numberOfSyncedDevices)
     }
 }
 

--- a/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
+++ b/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
@@ -74,18 +74,21 @@ extension AppDelegate {
 }
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    // Called when the user taps on a notification from the background.
-    func userNotificationCenter(_ center: UNUserNotificationCenter,
-                                didReceive response: UNNotificationResponse,
-                                withCompletionHandler completionHandler: @escaping () -> Void) {
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
         let content = response.notification.request.content
 
         if content.categoryIdentifier == NotificationSurfaceManager.Constant.notificationCategoryId {
+            guard let messageId = content.userInfo[NotificationSurfaceManager.Constant.messageIdKey] as? String
+            else { return }
+
             switch response.actionIdentifier {
             case UNNotificationDismissActionIdentifier:
-                notificationSurfaceManager.didDismissNotification(content.userInfo)
+                await notificationSurfaceManager.didDismissNotification(messageId)
             default:
-                notificationSurfaceManager.didTapNotification(content.userInfo)
+                await notificationSurfaceManager.didTapNotification(messageId)
             }
         } else if content.categoryIdentifier == NotificationCloseTabs.notificationCategoryId {
             switch response.actionIdentifier {
@@ -99,25 +102,22 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 break
             }
         }
-        // We don't poll for commands here because we do that once the application wakes up
-        // The notification service ensures that when the application wakes up, the application will check
-        // for commands
-        completionHandler()
     }
 
     // Called when the user receives a tab (or any other notification) while in foreground.
-    func userNotificationCenter(
+    nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) {
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        let profile = await self.profile
         if profile.prefs.boolForKey(PendingAccountDisconnectedKey) ?? false {
             profile.removeAccount()
 
             // show the notification
-            completionHandler([.list, .banner, .sound])
+            return [.list, .banner, .sound]
         } else {
             profile.pollCommands(forcePoll: true)
+            return []
         }
     }
 }

--- a/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
@@ -9,8 +9,8 @@ import Shared
 protocol NotificationSurfaceDelegate: AnyObject {
     func didDisplayMessage(_ message: GleanPlumbMessage)
     @MainActor
-    func didTapNotification(_ userInfo: [AnyHashable: Any])
-    func didDismissNotification(_ userInfo: [AnyHashable: Any])
+    func didTapNotification(_ messageId: String)
+    func didDismissNotification(_ messageId: String)
 }
 
 // TODO: FXIOS-FXIOS-13583 - NotificationSurfaceManager should be concurrency safe
@@ -69,17 +69,15 @@ class NotificationSurfaceManager: NotificationSurfaceDelegate, @unchecked Sendab
         messagingManager.onMessageDisplayed(message)
     }
 
-    func didTapNotification(_ userInfo: [AnyHashable: Any]) {
-        guard let messageId = userInfo[Constant.messageIdKey] as? String,
-              let message = messagingManager.messageForId(messageId)
+    func didTapNotification(_ messageId: String) {
+        guard let message = messagingManager.messageForId(messageId)
         else { return }
 
         messagingManager.onMessagePressed(message, window: nil, shouldExpire: true)
     }
 
-    func didDismissNotification(_ userInfo: [AnyHashable: Any]) {
-        guard let messageId = userInfo[Constant.messageIdKey] as? String,
-              let message = messagingManager.messageForId(messageId)
+    func didDismissNotification(_ messageId: String) {
+        guard let message = messagingManager.messageForId(messageId)
         else { return }
 
         messagingManager.onMessageDismissed(message)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
@@ -63,7 +63,7 @@ class NotificationSurfaceManagerTests: XCTestCase {
     @MainActor
     func testDidTapNotification_noMessageId() {
         let subject = createSubject()
-        subject.didTapNotification([:])
+        subject.didTapNotification("")
 
         XCTAssertEqual(messageManager.onMessagePressedCalled, 0)
     }
@@ -71,7 +71,7 @@ class NotificationSurfaceManagerTests: XCTestCase {
     @MainActor
     func testDidTapNotification_noMessageFound() {
         let subject = createSubject()
-        subject.didTapNotification([NotificationSurfaceManager.Constant.messageIdKey: "test"])
+        subject.didTapNotification("test")
 
         XCTAssertEqual(messageManager.onMessagePressedCalled, 0)
     }
@@ -84,7 +84,7 @@ class NotificationSurfaceManagerTests: XCTestCase {
 
         XCTAssertTrue(subject.shouldShowSurface)
 
-        subject.didTapNotification([NotificationSurfaceManager.Constant.messageIdKey: "test-notification"])
+        subject.didTapNotification("test-notification")
 
         XCTAssertEqual(messageManager.onMessagePressedCalled, 1)
     }
@@ -97,7 +97,7 @@ class NotificationSurfaceManagerTests: XCTestCase {
 
         XCTAssertTrue(subject.shouldShowSurface)
 
-        subject.didTapNotification([NotificationSurfaceManager.Constant.messageIdKey: "test-notification"])
+        subject.didTapNotification("test-notification")
 
         XCTAssertEqual(messageManager.onMessagePressedCalled, 1)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13532)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29411)

## :bulb: Description
Last PR related to the notifications area in our app 🤞 

### Warnings first part
<img width="2114" height="612" alt="Screenshot 2025-09-24 at 8 50 06 PM" src="https://github.com/user-attachments/assets/6fd29496-b2ba-4796-b303-39481934b2b3" />
- Fixed a warning above by capturing `[profile]` instead of `self` 
- `setPreferencesForSyncedAccount` is `nonisolated` and so the warning `Call to main actor-isolated instance method 'setPreferencesForSyncedAccount(for:count:)'` is fixed
- `ConstellationState` cannot be sent across boundaries, so I am only sending the `deviceCount` (which is an `int`) instead

### Warnings second part
<img width="2091" height="567" alt="Screenshot 2025-09-24 at 8 49 57 PM" src="https://github.com/user-attachments/assets/908ed2bc-7a11-481c-a739-e7f518bd8a93" />
- For this warning, I opted to use the newest `async` methods of `UNUserNotificationCenterDelegate` since that delegate cannot be `@MainActor`. This allows us to `await` some of the calls to `notificationSurfaceManager` .
- Also changed `NotificationSurfaceDelegate` to send `messageId: String` instead of `userInfo: [AnyHashable: Any]` so it can be sent across that boundary too. Otherwise we get:

<img width="2074" height="368" alt="Screenshot 2025-09-24 at 9 01 33 PM" src="https://github.com/user-attachments/assets/debf9876-b241-4d54-9807-2f2f40a78499" />

cc: @Cramsden @dataports @ih-codes 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
