### PR TITLE
BugFix [Swipe Tabs] FXIOS-13633 Add new tab layout not restoring when swiping in opposite sense.

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -415,6 +415,11 @@ final class AddressToolbarContainer: UIView,
             }
             let isRTL = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
             addNewTabLeadingConstraint?.constant = isRTL ? -transform.tx : transform.tx
+        // if the add new tab was modified but we are not adding a new tab then restore it.
+        } else if addNewTabLeadingConstraint?.constant != 0 {
+            addNewTabLeadingConstraint?.constant = 0
+            addNewTabTrailingConstraint?.constant = 0
+            addNewTabView.showHideAddTabIcon(shouldShow: false)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13633)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29595)

## :bulb: Description
Bug fix add new tab layout not restoring when swiping in opposite sense.

https://github.com/user-attachments/assets/1bf5d60e-dc3e-490f-8df8-0c3f55eea972



https://github.com/user-attachments/assets/bd6f07e5-d295-4879-9e8a-f6f3bfe7f754



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
