### PR TITLE
Remove [Shake to Summarize] FXIOS-13630 consent for menu and toolbar entry point

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/UI/SummarizeViewModel.swift
+++ b/BrowserKit/Sources/SummarizeKit/UI/SummarizeViewModel.swift
@@ -77,11 +77,13 @@ public final class DefaultSummarizeViewModel: SummarizeViewModel {
     private var configuration: Configuration
     private let minWordsAcceptedToShow: Int
     private let minDelayToShowSummary: TimeInterval
+    private let trigger: SummarizerTrigger
     private var summarizeTask: Task<Void, Never>?
     private weak var tosAcceptor: SummarizeTermOfServiceAcceptor?
 
     public init(
         summarizerService: SummarizerService,
+        summarizerTrigger: SummarizerTrigger,
         tosAcceptor: SummarizeTermOfServiceAcceptor?,
         minWordsAcceptedToShow: Int? = nil,
         minDelayToShowSummary: TimeInterval? = nil,
@@ -92,6 +94,7 @@ public final class DefaultSummarizeViewModel: SummarizeViewModel {
         self.minDelayToShowSummary = minDelayToShowSummary ?? Constants.summaryDelay
         self.minWordsAcceptedToShow = minWordsAcceptedToShow ?? Constants.minWordsAcceptedToShow
         self.configuration = Configuration(isTosConsentAccepted: isTosAcceppted)
+        self.trigger = summarizerTrigger
     }
 
     public func summarize(webView: WKWebView,
@@ -100,7 +103,7 @@ public final class DefaultSummarizeViewModel: SummarizeViewModel {
                           onNewData: @escaping (Result<String, SummarizerError>) -> Void) {
         summarizeTask?.cancel()
         summarizeTask = Task {
-            guard configuration.isTosConsentAccepted else {
+            guard configuration.isTosConsentAccepted || trigger != .shakeGesture else {
                 await waitForUnblockSummarization()
                 onNewData(.failure(.tosConsentMissing))
                 return

--- a/BrowserKit/Tests/SummarizeKitTests/SummarizeViewModelTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/SummarizeViewModelTests.swift
@@ -63,7 +63,7 @@ final class SummarizeViewModelTests: XCTestCase {
         }
         wait(for: [newDataExpectation], timeout: 0.5)
     }
-    
+
     func test_summarizer_whenTosNotAcceppted_whenTriggerIsNotShake_startsSummarizer() {
         let newDataExpectation = expectation(description: "summarize closure should be called")
         let chunk = "This is the max words to proceed"

--- a/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
@@ -145,6 +145,7 @@ final class SummarizeCoordinator: BaseCoordinator,
             configuration: model,
             viewModel: DefaultSummarizeViewModel(
                 summarizerService: service,
+                summarizerTrigger: trigger,
                 tosAcceptor: self,
                 isTosAcceppted: prefs.boolForKey(PrefsKeys.Summarizer.didAgreeTermsOfService) ?? false
             ),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13630)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29591)

## :bulb: Description
Remove tos consent for menu and toolbar entry point shake to summarize.

## :movie_camera: Demos

https://github.com/user-attachments/assets/af75e6d6-e21b-4d27-9faa-b401260e0f4b


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
- [x] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
