### PR TITLE
Bugfix FXIOS-13606 Remove delay while clicking "Set as Default Browser"

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -37,7 +37,7 @@ public class BottomSheetViewController: UIViewController,
     public var themeManager: ThemeManager
     public var themeListenerCancellable: Any?
 
-    private let viewModel: BottomSheetViewModel
+    internal let viewModel: BottomSheetViewModel
     private var useDimmedBackground: Bool
     private let childViewController: BottomSheetChild
 
@@ -62,7 +62,7 @@ public class BottomSheetViewController: UIViewController,
     private lazy var sheetView: UIView = .build { _ in }
     private lazy var contentView: UIView = .build { _ in }
     private lazy var scrollContentView: UIView = .build { _ in }
-    private var contentViewBottomConstraint: NSLayoutConstraint?
+    internal var contentViewBottomConstraint: NSLayoutConstraint?
     private var viewTranslation = CGPoint(x: 0, y: 0)
     private let windowUUID: WindowUUID
     private var glassEffectView: UIVisualEffectView?

--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/OnboardingBottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/OnboardingBottomSheetViewController.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import UIKit
+
+/// A specialized bottom sheet controller for onboarding flows that uses viewWillAppear for animations
+@MainActor
+public class OnboardingBottomSheetViewController: BottomSheetViewController {
+    
+    // MARK: - View lifecycle
+    
+    override public func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Move animation from viewDidAppear to viewWillAppear for onboarding
+        // We need to access the parent's properties, so we'll call the parent's viewDidAppear logic here
+        contentViewBottomConstraint?.constant = 0
+        UIView.animate(withDuration: viewModel.animationTransitionDuration) {
+            self.view.backgroundColor = self.viewModel.backgroundColor
+            self.view.layoutIfNeeded()
+        }
+    }
+    
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // No animation here - it's handled in viewWillAppear
+    }
+}

--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/OnboardingBottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/OnboardingBottomSheetViewController.swift
@@ -13,7 +13,10 @@ public class OnboardingBottomSheetViewController: BottomSheetViewController {
 
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        // Move animation from viewDidAppear to viewWillAppear for onboarding
+
+        // For onboarding flows, we animate the bottom sheet presentation earlier in the lifecycle
+        // This ensures the animation starts before the view becomes visible, creating a smoother
+        // user experience during onboarding transitions
         contentViewBottomConstraint?.constant = 0
         UIView.animate(withDuration: viewModel.animationTransitionDuration) {
             self.view.backgroundColor = self.viewModel.backgroundColor
@@ -24,6 +27,8 @@ public class OnboardingBottomSheetViewController: BottomSheetViewController {
     // swiftlint:disable:next unneeded_override
     override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        // No animation here - it's handled in viewWillAppear to prevent double animation
+        // Override viewDidAppear without additional animation logic since we handle
+        // all presentation animations in viewWillAppear. This prevents duplicate
+        // animations that could cause visual glitches in onboarding flows.
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/OnboardingBottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/OnboardingBottomSheetViewController.swift
@@ -9,22 +9,21 @@ import UIKit
 /// A specialized bottom sheet controller for onboarding flows that uses viewWillAppear for animations
 @MainActor
 public class OnboardingBottomSheetViewController: BottomSheetViewController {
-    
     // MARK: - View lifecycle
-    
+
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         // Move animation from viewDidAppear to viewWillAppear for onboarding
-        // We need to access the parent's properties, so we'll call the parent's viewDidAppear logic here
         contentViewBottomConstraint?.constant = 0
         UIView.animate(withDuration: viewModel.animationTransitionDuration) {
             self.view.backgroundColor = self.viewModel.backgroundColor
             self.view.layoutIfNeeded()
         }
     }
-    
+
+    // swiftlint:disable:next unneeded_override
     override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        // No animation here - it's handled in viewWillAppear
+        // No animation here - it's handled in viewWillAppear to prevent double animation
     }
 }

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
@@ -311,7 +311,7 @@ final class OnboardingService: FeatureFlaggable {
             closeButtonA11yIdentifier:
                 AccessibilityIdentifiers.Onboarding.bottomSheetCloseButton
         )
-        let bottomSheetVC = BottomSheetViewController(
+        let bottomSheetVC = OnboardingBottomSheetViewController(
             viewModel: bottomSheetViewModel,
             childViewController: instructionsVC,
             usingDimmedBackground: true,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13606)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29553)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Animating the view in viewDidAppear was giving the impression that the animation was slow.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

Before

https://github.com/user-attachments/assets/a1f1302b-77f8-4553-9749-ff43621e3624

After

https://github.com/user-attachments/assets/2ddc928f-8df5-4a20-9913-d169cf648edb


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
