### PR TITLE
Remove FXIOS [Danger] Remove warn and fail for big PR size

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -145,12 +145,6 @@ func checkBigPullRequest() {
 
     let additionsAndDeletions = additions + deletions
     if additionsAndDeletions > monsterPRThreshold {
-        fail("""
-        Heads up reviewers: this PR is very large (\(additionsAndDeletions) lines).
-        Consider taking extra time, asking for a high-level summary, or reviewing in focused passes.
-        Splitting into smaller PRs or using an epic branch might also help with clarity.
-        """)
-
         markdown("""
         ### 🧟‍♂️ **Monster PR**
         Wow, this PR is **huge** with \(additionsAndDeletions) lines changed!
@@ -158,11 +152,6 @@ func checkBigPullRequest() {
         Reviewers: feel free to ask for extra context, screenshots, or a breakdown to make reviewing smoother.
         """)
     } else if additionsAndDeletions > bigPRThreshold {
-        warn("""
-        Note for reviewers: this PR is larger than usual (\(additionsAndDeletions) lines).
-        It may help to request a quick overview or suggest splitting if multiple concerns are bundled together.
-        """)
-
         markdown("""
         ### 🏔️ **Summit Climber**
         This PR is a **big climb** with \(additionsAndDeletions) lines changed!


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
Danger [is failing string import PRs](https://github.com/mozilla-mobile/firefox-ios/pull/29600), we shouldn't do that. I'm fixing it with this PR

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v150.0`)
