### PR TITLE
Bugfix FXIOS-13651 Fix leak of WKWebView

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -171,6 +171,7 @@ class BrowserCoordinator: BaseCoordinator,
         }
         self.homepageViewController = homepageController
         homepageController.scrollToTop()
+        // [FXIOS-13651] Fix for WKWebView memory leak. (See comments on related PR.)
         webviewController?.update(webView: nil)
     }
 

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -171,6 +171,7 @@ class BrowserCoordinator: BaseCoordinator,
         }
         self.homepageViewController = homepageController
         homepageController.scrollToTop()
+        webviewController?.update(webView: nil)
     }
 
     func homepageScreenshotTool() -> (any Screenshotable)? {

--- a/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -12,7 +12,7 @@ class WebviewViewController: UIViewController,
                              ContentContainable,
                              ScreenshotableView,
                              FullscreenDelegate {
-    private var webView: WKWebView
+    private var webView: WKWebView?
     var contentType: ContentType = .webview
     // TODO: FXIOS-12158 Add back after investigating why video player is broken
 //    var isFullScreen = false
@@ -32,11 +32,12 @@ class WebviewViewController: UIViewController,
     }
 
     private func setupWebView() {
+        guard let webView else { return }
         view.addSubview(webView)
         webView.pinToSuperview()
     }
 
-    func update(webView: WKWebView) {
+    func update(webView: WKWebView?) {
         self.webView = webView
 
         // Avoid updating constraints while on fullscreen mode
@@ -48,7 +49,7 @@ class WebviewViewController: UIViewController,
     // MARK: - ScreenshotableView
 
     func getScreenshotData(completionHandler: @escaping (ScreenshotData?) -> Void) {
-        guard let url = webView.url,
+        guard let webView, let url = webView.url,
               InternalURL(url) == nil else {
             completionHandler(nil)
             return


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13651)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29618)

## :bulb: Description

Fixes leak of `WKWebView`. Our `WebviewViewController` maintains a strong link to the webview, and after closing a tab to return to the home screen the VC is never updated. 

Still investigating how this is expected to be properly cleared. The fix here doesn't feel entirely right to me, it was just the first bandaid I could find. Please see inline comments.

**Note**: this is a longstanding bug. It appears to have been present at least back to March 2025.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
