### PR TITLE
Refactor FXIOS-13400 [Homepage Layout] Cache section measurements to avoid redundant recalculations

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Layout/HomepageSectionLayoutProvider.swift
@@ -728,8 +728,10 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
     }
 
     /// Creates a "dummy" header and returns its height
-    private func getHeaderHeight(headerState: SectionHeaderConfiguration,
-                                 environment: NSCollectionLayoutEnvironment) -> CGFloat {
+    private func getHeaderHeight(
+        headerState: SectionHeaderConfiguration,
+        environment: NSCollectionLayoutEnvironment
+    ) -> CGFloat {
         let width = normalizedDimension(environment.container.contentSize.width)
         let cacheKey = HeaderMeasurementKey(configuration: headerState, containerWidth: width)
 
@@ -821,7 +823,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         return result
     }
 
-                private func normalizedDimension(_ value: CGFloat) -> Double {
-                    return Double((value * 1000).rounded() / 1000)
+    private func normalizedDimension(_ value: CGFloat) -> Double {
+        return Double((value * 1000).rounded() / 1000)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Layout/HomepageSectionLayoutProvider.swift
@@ -586,7 +586,6 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
     /// Creates a "dummy" top sites section and returns its height
     private func getShortcutsSectionHeight(environment: NSCollectionLayoutEnvironment) -> CGFloat {
         guard let state = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID) else { return 0 }
-        
         let topSitesState = state.topSitesState
         let containerWidth = normalizedDimension(environment.container.contentSize.width)
         let measurementKey = LayoutMeasurementCache.TopSitesMeasurement.Key(
@@ -633,7 +632,6 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         }
 
         var totalHeight: CGFloat = 0
-        
         // Add header height
         totalHeight += getHeaderHeight(headerState: topSitesState.sectionHeaderState, environment: environment)
 
@@ -661,7 +659,6 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         // Add section insets
         totalHeight += UX.TopSitesConstants.getBottomInset()
-        
         measurementsCache.topSites = LayoutMeasurementCache.TopSitesMeasurement(
             key: measurementKey,
             height: totalHeight
@@ -672,7 +669,6 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
     /// Creates a "dummy" stories section and returns its height
     private func getStoriesSectionHeight(environment: NSCollectionLayoutEnvironment) -> CGFloat {
-        
         let cellWidth = UX.PocketConstants.getAbsoluteCellWidth(
             collectionViewWidth: environment.container.contentSize.width
         )


### PR DESCRIPTION
## :scroll: Tickets  
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13400)  
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29124)

## :bulb: Description  
This PR introduces caching for homepage layout measurements to reduce redundant recalculations:  

- **Added `LayoutMeasurementCache` helper** to store previously computed section measurements (Top Sites, Stories, Search Bar).  
- **Normalized width-dependent cache keys** so identical inputs reuse cached values instead of rebuilding views.  
- **Introduced keyed header-height caching** and shared tallest-cell results for Stories so both section layout and spacer sizing reuse the same computation.  
 

**Motivation:** Homepage refreshes often repeat the same state (same width, same visibility). Without caching, expensive layout work and view instantiation happens repeatedly. With this change, redundant work is skipped, improving CPU efficiency and reducing layout thrash.


<details>
this PR only affects internal performance 
</details>

## :pencil: Checklist  
- [x] I filled in the ticket numbers and a description of my work  
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)  
- [ ] I ensured unit tests pass and wrote tests for new code  
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)  
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review  
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n  
- [ ] If needed, I updated documentation and added comments to complex code  