### PR TITLE
Add  [Shake to Summarize] wait when showing error

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/UI/SummarizeViewModel.swift
+++ b/BrowserKit/Sources/SummarizeKit/UI/SummarizeViewModel.swift
@@ -140,6 +140,7 @@ public final class DefaultSummarizeViewModel: SummarizeViewModel {
                 try Task.checkCancellation()
                 onNewData(.success(summaryWithNote))
             } catch {
+                await waitForUnblockSummarization()
                 handleSummarizationError(error: error, onError: onNewData)
             }
         }


### PR DESCRIPTION
## :scroll: Tickets
~~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~~
~~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~~

## :bulb: Description
Add wait for summary to be unblocked before showing any error.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
