### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix more under-specified protocols

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarDelegate.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarDelegate.swift
@@ -6,16 +6,26 @@ import Foundation
 import UIKit
 
 public protocol AddressToolbarDelegate: AnyObject {
+    @MainActor
     func searchSuggestions(searchTerm: String)
+    @MainActor
     func didClearSearch()
+    @MainActor
     func openBrowser(searchTerm: String)
+    @MainActor
     func addressToolbarDidBeginEditing(searchTerm: String, shouldShowSuggestions: Bool)
+    @MainActor
     func addressToolbarAccessibilityActions() -> [UIAccessibilityCustomAction]?
+    @MainActor
     func configureContextualHint(_ addressToolbar: BrowserAddressToolbar,
                                  for button: UIButton,
                                  with contextualHintType: String)
+    @MainActor
     func addressToolbarDidBeginDragInteraction()
+    @MainActor
     func addressToolbarDidProvideItemsForDragInteraction()
+    @MainActor
     func addressToolbarDidTapSearchEngine(_ searchEngineView: UIView)
+    @MainActor
     func addressToolbarNeedsSearchReset()
 }

--- a/BrowserKit/Sources/ToolbarKit/NavigationToolbar/BrowserNavigationToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/NavigationToolbar/BrowserNavigationToolbar.swift
@@ -6,6 +6,7 @@ import UIKit
 import Common
 
 public protocol BrowserNavigationToolbarDelegate: AnyObject {
+    @MainActor
     func configureContextualHint(for button: UIButton, with contextualHintType: String)
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
@@ -8,10 +8,9 @@ import Foundation
 import Shared
 import ComponentLibrary
 
+@MainActor
 protocol EmptyPrivateTabView: UIView, ThemeApplicable, InsetUpdatable {
     var needsSafeArea: Bool { get }
-
-    @MainActor
     var delegate: EmptyPrivateTabsViewDelegate? { get set }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
@@ -7,10 +7,9 @@ import ComponentLibrary
 import UIKit
 import Shared
 
+@MainActor
 protocol RemoteTabsEmptyViewProtocol: UIView, ThemeApplicable, InsetUpdatable {
     var needsSafeArea: Bool { get }
-
-    @MainActor
     func configure(config: RemoteTabsPanelEmptyStateReason,
                    delegate: RemoteTabsEmptyViewDelegate?)
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/InsetUpdatable.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/InsetUpdatable.swift
@@ -3,5 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 protocol InsetUpdatable {
+    @MainActor
     func updateInsets(top: CGFloat, bottom: CGFloat)
 }

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetContainerCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetContainerCell.swift
@@ -6,6 +6,7 @@ import Common
 import Foundation
 
 protocol PhotonActionSheetContainerCellDelegate: AnyObject {
+    @MainActor
     func didClick(item: SingleActionViewModel?, animationCompletion: @escaping () -> Void)
 }
 

--- a/firefox-ios/Client/Protocols/NavigationController.swift
+++ b/firefox-ios/Client/Protocols/NavigationController.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+@MainActor
 protocol NavigationController {
     var viewControllers: [UIViewController] { get }
     var delegate: UINavigationControllerDelegate? { get set }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
@@ -8,6 +8,7 @@ import XCTest
 final class DefaultRouterTests: XCTestCase {
     var navigationController: MockNavigationController!
 
+    @MainActor
     override func setUp() {
         super.setUp()
         navigationController = MockNavigationController()
@@ -18,6 +19,7 @@ final class DefaultRouterTests: XCTestCase {
         navigationController = nil
     }
 
+    @MainActor
     func testInitialState() {
         let subject = DefaultRouter(navigationController: navigationController)
 
@@ -26,6 +28,7 @@ final class DefaultRouterTests: XCTestCase {
         XCTAssertEqual(subject.completions.count, 0)
     }
 
+    @MainActor
     func testPresentViewController_presentCalled() {
         let subject = DefaultRouter(navigationController: navigationController)
         let viewController = UIViewController()
@@ -58,6 +61,7 @@ final class DefaultRouterTests: XCTestCase {
         XCTAssertEqual(subject.completions.count, 0)
     }
 
+    @MainActor
     func testDismissModule() {
         let subject = DefaultRouter(navigationController: navigationController)
         subject.dismiss()
@@ -76,6 +80,7 @@ final class DefaultRouterTests: XCTestCase {
         XCTAssertEqual(subject.completions.count, 0)
     }
 
+    @MainActor
     func testPushModule_pushViewController() {
         let subject = DefaultRouter(navigationController: navigationController)
         let viewController = UIViewController()
@@ -86,6 +91,7 @@ final class DefaultRouterTests: XCTestCase {
         XCTAssertEqual(subject.completions.count, 1)
     }
 
+    @MainActor
     func testPopViewController() {
         let subject = DefaultRouter(navigationController: navigationController)
         let viewController = UIViewController()
@@ -100,6 +106,7 @@ final class DefaultRouterTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
+    @MainActor
     func testSetRootViewController() {
         let subject = DefaultRouter(navigationController: navigationController)
         let viewController = UIViewController()
@@ -109,6 +116,7 @@ final class DefaultRouterTests: XCTestCase {
         XCTAssertEqual(navigationController.isNavigationBarHidden, true)
     }
 
+    @MainActor
     func testSetRootViewController_withPushedViewController_completionIsCalled() {
         let subject = DefaultRouter(navigationController: navigationController)
         let viewController = UIViewController()
@@ -139,6 +147,7 @@ final class DefaultRouterTests: XCTestCase {
         waitForExpectations(timeout: 0.1, handler: nil)
     }
 
+    @MainActor
     func testNavigationControllerDelegate_runsCompletionForPoppedViewController() {
         let subject = DefaultRouter(navigationController: navigationController)
         let expectation = expectation(description: "Completion is called")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix under-specified protocols by adding isolation details: AddressToolbarDelegate, EmptyPrivateTabView, InsetUpdatable, PhotonActionSheetContainerCellDelegate, NavigationController.

<img width="1405" height="250" alt="Screenshot 2025-09-25 at 4 02 45 PM" src="https://github.com/user-attachments/assets/66f167c1-9e7f-4ccb-b4bd-2d6f377c8231" />

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
