### PR TITLE
Add FXIOS-13673 [Debug Menu] New item to remove credit card encryption keys for testing

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2154,6 +2154,7 @@
 		F80D53CF2A09A3350047ED14 /* RustSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */; };
 		F80DF7412703BC8E00E4C37D /* CredentialPasscodeRequirementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80DF7402703BC8E00E4C37D /* CredentialPasscodeRequirementViewController.swift */; };
 		F80DF74B270CB9CA00E4C37D /* AppAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D89171C8647420006EA35 /* AppAuthenticator.swift */; };
+		F82F68B12E86EF5F002E42D1 /* DeleteAutofillKeysSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82F68B02E86EF4D002E42D1 /* DeleteAutofillKeysSetting.swift */; };
 		F8324A072649A188007E4BFA /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8324A062649A188007E4BFA /* AuthenticationServices.framework */; };
 		F8324A0A2649A188007E4BFA /* CredentialProviderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8324A092649A188007E4BFA /* CredentialProviderViewController.swift */; };
 		F8324A122649A188007E4BFA /* CredentialProvider.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F8324A052649A188007E4BFA /* CredentialProvider.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -11024,6 +11025,7 @@
 		F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustSyncManagerTests.swift; sourceTree = "<group>"; };
 		F80DF7402703BC8E00E4C37D /* CredentialPasscodeRequirementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialPasscodeRequirementViewController.swift; sourceTree = "<group>"; };
 		F82F4AB9A3C09B181AB61F73 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Shared.strings"; sourceTree = "<group>"; };
+		F82F68B02E86EF4D002E42D1 /* DeleteAutofillKeysSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAutofillKeysSetting.swift; sourceTree = "<group>"; };
 		F8324A052649A188007E4BFA /* CredentialProvider.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = CredentialProvider.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8324A062649A188007E4BFA /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
 		F8324A092649A188007E4BFA /* CredentialProviderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialProviderViewController.swift; sourceTree = "<group>"; };
@@ -13083,6 +13085,7 @@
 		8A3EF7EE2A2FCF0000796E3A /* Debug */ = {
 			isa = PBXGroup;
 			children = (
+				F82F68B02E86EF4D002E42D1 /* DeleteAutofillKeysSetting.swift */,
 				033A61FF2E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift */,
 				0BD049CD2DFC4A9C00614E61 /* PopupHTMLSetting.swift */,
 				1DC598B52DC53CED0037D263 /* Performance */,
@@ -19157,6 +19160,7 @@
 				8A19ACB62A3290F9001C2147 /* NotificationsSetting.swift in Sources */,
 				43D16B8229831E6A009F8279 /* CreditCardInputField.swift in Sources */,
 				8187561A2BB4618500DCD1F3 /* OnboardingViewControllerState.swift in Sources */,
+				F82F68B12E86EF5F002E42D1 /* DeleteAutofillKeysSetting.swift in Sources */,
 				EB98550124226EF70040F24B /* AppDelegate+SyncSentTabs.swift in Sources */,
 				0BD049CE2DFC4AAE00614E61 /* PopupHTMLSetting.swift in Sources */,
 				744ED5611DBFEB8D00A2B5BE /* MailtoLinkHandler.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -488,6 +488,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
             FirefoxSuggestSettings(settings: self, settingsDelegate: self),
             ScreenshotSetting(settings: self),
             DeleteLoginsKeysSetting(settings: self),
+            DeleteAutofillKeysSetting(settings: self),
             ChangeRSServerSetting(settings: self),
             PopupHTMLSetting(settings: self),
             AddShortcutsSetting(settings: self, settingsDelegate: self)

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/DeleteAutofillKeysSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/DeleteAutofillKeysSetting.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Storage
+
+class DeleteAutofillKeysSetting: HiddenSetting {
+    override var title: NSAttributedString? {
+        guard let theme else { return nil }
+        return NSAttributedString(
+            string: "Delete autofill encryption keys (causes data loss) ⚠️",
+            attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]
+        )
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        KeychainManager.shared.removeAutofillKeysForDebugMenuItem()
+    }
+}

--- a/firefox-ios/Storage/MockRustKeychain.swift
+++ b/firefox-ios/Storage/MockRustKeychain.swift
@@ -26,6 +26,11 @@ class MockRustKeychain: @unchecked Sendable, KeychainProtocol {
         removeObject(key: loginsCanaryKeyIdentifier)
     }
 
+    public func removeAutofillKeysForDebugMenuItem() {
+        removeObject(key: creditCardKeyIdentifier)
+        removeObject(key: creditCardCanaryKeyIdentifier)
+    }
+
     public func removeAllKeys() {
         storage.removeAll()
     }

--- a/firefox-ios/Storage/RustKeychain.swift
+++ b/firefox-ios/Storage/RustKeychain.swift
@@ -46,6 +46,7 @@ public protocol KeychainProtocol: Sendable {
     var loginsKeyIdentifier: String { get }
     func removeObject(key: String)
     func removeLoginsKeysForDebugMenuItem()
+    func removeAutofillKeysForDebugMenuItem()
     func removeAllKeys()
     func setLoginsKeyData(keyValue: String, canaryValue: String)
     func setCreditCardsKeyData(keyValue: String, canaryValue: String)
@@ -107,6 +108,11 @@ public final class RustKeychain: KeychainProtocol {
     public func removeLoginsKeysForDebugMenuItem() {
         removeObject(key: loginsKeyIdentifier)
         removeObject(key: loginsCanaryKeyIdentifier)
+    }
+
+    public func removeAutofillKeysForDebugMenuItem() {
+        removeObject(key: creditCardKeyIdentifier)
+        removeObject(key: creditCardCanaryKeyIdentifier)
     }
 
     public func removeAllKeys() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13673)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29655)

## :bulb: Description
Similar to #26017 but for credit cards, this PR adds a new debug menu item that removes all credit card encryption key data to simulate key loss for QA testing upcoming fixes/improvements.


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
