### PR TITLE
Bugfix [FXIOS-13268] [Downloads] File download doesn't format correctly original file extension

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
@@ -75,6 +75,12 @@ class Download: NSObject {
         }
         return true
     }
+
+    // Used to avoid name spoofing using Unicode RTL char to change file extension
+    public static func stripUnicode(fromFilename string: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet.punctuationCharacters)
+        return string.components(separatedBy: allowed.inverted).joined()
+     }
 }
 
 class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate {
@@ -90,12 +96,6 @@ class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate
     fileprivate(set) var cookieStore: WKHTTPCookieStore
 
     private var resumeData: Data?
-
-    // Used to avoid name spoofing using Unicode RTL char to change file extension
-    public static func stripUnicode(fromFilename string: String) -> String {
-        let allowed = CharacterSet.alphanumerics.union(CharacterSet.punctuationCharacters)
-        return string.components(separatedBy: allowed.inverted).joined()
-     }
 
     init?(originWindow: WindowUUID,
           cookieStore: WKHTTPCookieStore,
@@ -119,7 +119,7 @@ class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate
         super.init(originWindow: originWindow)
 
         if let filename = preflightResponse.suggestedFilename {
-            self.filename = HTTPDownload.stripUnicode(fromFilename: filename)
+            self.filename = Download.stripUnicode(fromFilename: filename)
         }
 
         if let mimeType = preflightResponse.mimeType {
@@ -214,7 +214,7 @@ class BlobDownload: Download {
 
         super.init(originWindow: originWindow)
 
-        self.filename = filename
+        self.filename = Download.stripUnicode(fromFilename: filename)
         self.mimeType = mimeType
 
         self.totalBytesExpected = size

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StringExtensionsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StringExtensionsTests.swift
@@ -39,7 +39,7 @@ class StringExtensionsTests: XCTestCase {
         let file = "foo-\u{200F}cod.jpg" // Unicode RTL-switch code, becomes "foo-gpj.doc"
         let nounicode = "foo-cod.jpg"
         XCTAssert(file != nounicode)
-        let strip = HTTPDownload.stripUnicode(fromFilename: file)
+        let strip = Download.stripUnicode(fromFilename: file)
         XCTAssert(strip == nounicode)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13268)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28882)

## :bulb: Description
Currently, non-allowed Unicode characters in the filename of `HTTPDownload` are stripped out. However, this did not apply to `BlobDownload` causing the file extension to be incorrectly displayed when certain control character is in the filename. I modified the existing code to strip the Unicode characters from the filename of`BlobDownload` as well.

## :movie_camera: Demos
I created a test file with `touch $'test\u202efdp.exe'` and filled it with test data. The bug reporter noted that Google Drive does server side sanitisation of Unicode characters so I used Limewire to host the file for download.

Before

 https://github.com/user-attachments/assets/27e3e0f4-4b62-4469-b9b0-082ca7a3f1b5

After

 https://github.com/user-attachments/assets/b5d7d501-a226-49fa-a7ad-2cc71b648a24

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation and added comments to complex code
