### PR TITLE
Refactor FXIOS-10468 [SwiftLint] Fix force_unwrapping in /Licenses

### DIFF
--- a/focus-ios/BlockzillaPackage/Sources/Licenses/LicenseListView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Licenses/LicenseListView.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import UIKit
 import SwiftUI
 
 public struct LicenseListView: View {
@@ -27,15 +26,13 @@ public struct LicenseListView: View {
 
 public extension LicenseListView {
     init() {
-        let licenseListURL = Bundle.module.url(forResource: "license-list", withExtension: "plist")!
-        let focusURL = Bundle.module.url(forResource: "focus-ios", withExtension: "plist")!
-
-        let focusLicense = (try? decodePropertyList(LicenseList.self, from: focusURL).libraries) ?? []
-        let libraries = (try? decodePropertyList(LicenseList.self, from: licenseListURL).libraries) ?? []
+        let focusLicense = licenseList(for: "focus-ios")
+        let libraries = licenseList(for: "license-list")
         self.libraries = focusLicense + libraries
     }
 }
 
+// MARK: - Preview
 struct LicenseListView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
@@ -44,7 +41,13 @@ struct LicenseListView_Previews: PreviewProvider {
     }
 }
 
-func decodePropertyList<T: Decodable>(_ type: T.Type, from url: URL) throws -> T {
+// MARK: - Private
+private func licenseList(for resource: String) -> [Library] {
+    guard let url = Bundle.module.url(forResource: resource, withExtension: "plist") else { return [] }
+    return (try? decodePropertyList(LicenseList.self, from: url).libraries) ?? []
+}
+
+private func decodePropertyList<T: Decodable>(_ type: T.Type, from url: URL) throws -> T {
     let data = try Data(contentsOf: url)
     let decoder = PropertyListDecoder()
     return try decoder.decode(type.self, from: data)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10468)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22917)

## :bulb: Description
- _Focusing_ on focus-ios/ first
- Fixing `force_unwrapping` rule inside /Licenses

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
