### PR TITLE
Refactor FXIOS-10468 [SwiftLint] Fix force_unwrapping in /ContentBlocker

### DIFF
--- a/focus-ios/ContentBlocker/ActionRequestHandler.swift
+++ b/focus-ios/ContentBlocker/ActionRequestHandler.swift
@@ -5,7 +5,7 @@
 import UIKit
 import MobileCoreServices
 
-class ActionRequestHandler: NSObject, NSExtensionRequestHandling {
+final class ActionRequestHandler: NSObject, NSExtensionRequestHandling {
     func beginRequest(with context: NSExtensionContext) {
         // NSItemProvider apparently doesn't support multiple attachments as a way to load multiple blocking lists.
         // As a workaround, we load each list into memory, then merge them into a single attachment.
@@ -30,12 +30,13 @@ class ActionRequestHandler: NSObject, NSExtensionRequestHandling {
 
     /// Gets the dictionary form of the tracking list with the specified file name.
     private func itemsFromFile(_ name: String) -> [NSDictionary] {
-        let url = Bundle.main.url(forResource: name, withExtension: "json")
+        guard let url = Bundle.main.url(forResource: name, withExtension: "json") else { return [] }
         do {
-            let data = try Data(contentsOf: url!)
-            return try JSONSerialization.jsonObject(with: data, options: []) as! [NSDictionary]
+            let data = try Data(contentsOf: url)
+            let json = try JSONSerialization.jsonObject(with: data, options: [])
+            return json as? [NSDictionary] ?? []
         } catch {
-            fatalError("Invalid data at \(url!)")
+            fatalError("Invalid data at \(url)")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10468)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22917)

## :bulb: Description
- _Focusing_ on focus-ios/ first
- Fixing `force_unwrapping` rule inside /ContentBlocker

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
