### PR TITLE
Refactor FXIOS-13666 [Settings] Use FXFontStyle on Appearance settings Swift UI view

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/DarkModeToggleView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/DarkModeToggleView.swift
@@ -37,7 +37,7 @@ struct DarkModeToggleView: View {
             HStack {
                 VStack(alignment: .leading) {
                     Text(String.WebsiteDarkModeToggleTitle)
-                        .font(.body)
+                        .font(FXFontStyles.Regular.body.scaledSwiftUIFont())
                         .foregroundColor(textColor)
                 }
                 Spacer()

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericButtonCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericButtonCellView.swift
@@ -43,7 +43,7 @@ struct GenericButtonCellView: View {
         }) {
             Text(title)
                 .foregroundColor(theme.colors.textCritical.color)
-                .font(.callout)
+                .font(FXFontStyles.Regular.callout.scaledSwiftUIFont())
         }
         .padding([.top, .bottom], UX.buttonPadding)
     }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericItemCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericItemCellView.swift
@@ -34,7 +34,7 @@ struct GenericItemCellView: View {
             HStack {
                 VStack(alignment: .leading) {
                     Text(title)
-                        .font(.body)
+                        .font(FXFontStyles.Regular.body.scaledSwiftUIFont())
                         .foregroundColor(textColor)
                 }
 

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionHeaderView.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
+import Common
 
 struct GenericSectionHeaderView: View {
     private struct UX {
@@ -23,7 +24,7 @@ struct GenericSectionHeaderView: View {
     var body: some View {
         HStack {
             Text(title)
-                .font(.caption)
+                .font(FXFontStyles.Regular.caption1.scaledSwiftUIFont())
                 .foregroundColor(sectionTitleColor)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSectionView.swift
@@ -77,7 +77,7 @@ struct GenericSectionView<Content: View>: View {
     private func footerView(_ text: String) -> some View {
         HStack {
             Text(text)
-                .font(.caption)
+                .font(FXFontStyles.Regular.caption1.scaledSwiftUIFont())
                 .foregroundColor(descriptionTextColor)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSelectableItemCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSelectableItemCellView.swift
@@ -31,7 +31,7 @@ struct GenericSelectableItemCellView: View {
     var body: some View {
         HStack {
             Text(title)
-                .font(.body)
+                .font(FXFontStyles.Regular.body.scaledSwiftUIFont())
                 .foregroundColor(textColor)
 
             Spacer()

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/GenericImageOption.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/GenericImageOption.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
+import Common
 
 /// A view that represents a selectable option with an image and a radio button.
 struct GenericImageOption: View {
@@ -67,7 +68,7 @@ struct GenericImageOption: View {
     /// The text label displaying the theme option's name.
     private var selectableOptionLabel: some View {
         Text(label)
-            .font(.caption)
+            .font(FXFontStyles.Regular.caption1.scaledSwiftUIFont())
             .foregroundColor(UX.textColor)
     }
 

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelCellView.swift
@@ -22,13 +22,13 @@ struct ZoomLevelCellView: View {
     var body: some View {
         HStack {
             Text(domainZoomLevel.host)
-                .font(.body)
+                .font(FXFontStyles.Regular.body.scaledSwiftUIFont())
                 .foregroundColor(textColor)
 
             Spacer()
 
             Text(ZoomLevel(from: domainZoomLevel.zoomLevel).displayName)
-                .font(.body)
+                .font(FXFontStyles.Regular.body.scaledSwiftUIFont())
                 .foregroundColor(textColor)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomLevelPickerView.swift
@@ -86,7 +86,7 @@ struct ZoomLevelPickerView: View {
     var pickerContent: some View {
         HStack {
             Text(pickerText)
-                .font(.body)
+                .font(FXFontStyles.Regular.body.scaledSwiftUIFont())
                 .foregroundColor(theme.colors.textPrimary.color)
 
             Spacer()
@@ -105,12 +105,12 @@ struct ZoomLevelPickerView: View {
             } label: {
                 HStack(spacing: UX.pickerLabelSpacing) {
                     Text(selectedZoomLevel.displayName)
-                        .font(.body)
+                        .font(FXFontStyles.Regular.body.scaledSwiftUIFont())
                         .foregroundColor(theme.colors.textPrimary.color)
 
                     Image(systemName: UX.chevronImageIdentifier)
                         .renderingMode(.template)
-                        .font(.caption)
+                        .font(FXFontStyles.Regular.caption1.scaledSwiftUIFont())
                         .foregroundColor(theme.colors.textPrimary.color)
                         .accessibilityHidden(true)
                 }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -85,7 +85,7 @@ struct ZoomSiteListView: View {
 
             // Footer
             Text(String.Settings.Appearance.PageZoom.SpecificSiteFooterTitle)
-                .font(.caption)
+                .font(FXFontStyles.Regular.caption1.scaledSwiftUIFont())
                 .foregroundColor(theme.colors.textSecondary.color)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(EdgeInsets(top: footerTopPadding,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13666)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29645)

## :bulb: Description
Use font styles in appearance settings.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
