### PR TITLE
Add FXIOS-13647 [Trending Search] initial UI for zero state

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
@@ -14,6 +14,7 @@ enum BrowserNavigationDestination {
     case trackingProtectionSettings
     case tabTray(TabTrayPanelType)
     case bookmarksPanel
+    case homepageZeroSearch
     case zeroSearch
     case shortcutsLibrary
     case summarizer(config: SummarizerConfig)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -137,6 +137,8 @@ struct BrowserViewControllerState: ScreenState {
         } else if let action = action as? StartAtHomeAction {
             return reduceStateForStartAtHomeAction(action: action, state: state)
         } else if let action = action as? ToolbarMiddlewareAction {
+            return reduceStateForToolbarMiddlewareAction(action: action, state: state)
+        } else if let action = action as? ToolbarAction {
             return reduceStateForToolbarAction(action: action, state: state)
         } else if let action = action as? SummarizeAction {
             return reduceStateForSummarizeAction(action: action, state: state)
@@ -216,8 +218,9 @@ struct BrowserViewControllerState: ScreenState {
 
     // MARK: - Toolbar Action
 
-    /// Navigate to zero search state after tapping on search button on navigation toolbar
-    static func reduceStateForToolbarAction(
+    /// Navigate to homepage zero search state, which is a scrim layer / dimming view,
+    /// after tapping on search button on navigation toolbar
+    static func reduceStateForToolbarMiddlewareAction(
         action: ToolbarMiddlewareAction,
         state: BrowserViewControllerState
     ) -> BrowserViewControllerState {
@@ -233,6 +236,27 @@ struct BrowserViewControllerState: ScreenState {
                 return defaultState(from: state, action: action)
             }
 
+            return BrowserViewControllerState(
+                searchScreenState: state.searchScreenState,
+                windowUUID: state.windowUUID,
+                browserViewType: state.browserViewType,
+                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
+                navigationDestination: NavigationDestination(.homepageZeroSearch)
+            )
+        default:
+            return defaultState(from: state, action: action)
+        }
+    }
+
+    /// Navigate to zero search that shows trending / recent searches state
+    /// after tapping on search button on navigation toolbar
+    static func reduceStateForToolbarAction(
+        action: ToolbarAction,
+        state: BrowserViewControllerState
+    ) -> BrowserViewControllerState {
+        switch action.actionType {
+        case ToolbarActionType.didStartEditingUrl, ToolbarActionType.didDeleteSearchTerm:
+            guard case .webview = state.browserViewType else { return defaultState(from: state, action: action) }
             return BrowserViewControllerState(
                 searchScreenState: state.searchScreenState,
                 windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4103,7 +4103,7 @@ class BrowserViewController: UIViewController,
             }
             // Instead of showing homepage when user enters overlay mode,
             // we want to show the zero search state with trending searches
-            if !featureFlags.isFeatureEnabled(.trendingSearches, checking: .buildOnly) {
+            if !isTrendingSearchEnabled {
                 showEmbeddedHomepage(inline: false, isPrivate: tabManager.selectedTab?.isPrivate ?? false)
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchListSection.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchListSection.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 enum SearchListSection: Int, CaseIterable {
+    case trendingSearches
     case searchSuggestions
     case firefoxSuggestions
     case openedTabs

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
@@ -97,8 +97,10 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
     }
 
     /// Whether to show suggestions from the search engine.
+    /// Does not show when search term in url is empty (aka zero search state).
     var shouldShowSearchEngineSuggestions: Bool {
-        return searchEnginesManager?.shouldShowSearchSuggestions ?? false
+        let shouldShowSuggestions = searchEnginesManager?.shouldShowSearchSuggestions ?? false
+        return shouldShowSuggestions && !searchQuery.isEmpty
     }
 
     var shouldShowSyncedTabsSuggestions: Bool {
@@ -136,7 +138,9 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
         hasHistorySuggestions
     }
 
+    /// Does not show when search term in url is empty (aka zero search state).
     var hasFirefoxSuggestions: Bool {
+        guard !searchQuery.isEmpty else { return false }
         return hasBookmarksSuggestions
                || hasHistorySuggestions
                || hasHistoryAndBookmarksSuggestions
@@ -173,6 +177,8 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
 
     func shouldShowHeader(for section: Int) -> Bool {
         switch section {
+        case SearchListSection.trendingSearches.rawValue:
+            return shouldShowTrendingSearches
         case SearchListSection.firefoxSuggestions.rawValue:
             return hasFirefoxSuggestions
         case SearchListSection.searchSuggestions.rawValue:

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -38,6 +38,7 @@ final class AddressToolbarContainer: UIView,
                                      AddressToolbarDelegate,
                                      Autocompletable,
                                      URLBarViewProtocol,
+                                     FeatureFlaggable,
                                      PrivateModeUI {
     private enum UX {
         static let toolbarHorizontalPadding: CGFloat = 16
@@ -482,7 +483,10 @@ final class AddressToolbarContainer: UIView,
         let locationText = shouldShowSuggestions ? searchTerm : nil
         enterOverlayMode(locationText, pasted: false, search: false)
 
-        if shouldShowSuggestions {
+        // We want to show suggestions if we turn on the trending searches
+        // which displays the zero search state.
+        let isZeroSearchEnabled = featureFlags.isFeatureEnabled(.trendingSearches, checking: .buildOnly)
+        if shouldShowSuggestions || isZeroSearchEnabled {
             delegate?.openSuggestions(searchTerm: locationText ?? "")
         }
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -921,7 +921,7 @@ final class HomepageViewController: UIViewController,
             )
         case .searchBar:
             dispatchNavigationBrowserAction(
-                with: NavigationDestination(.zeroSearch),
+                with: NavigationDestination(.homepageZeroSearch),
                 actionType: NavigationBrowserActionType.tapOnHomepageSearchBar
             )
         case .jumpBackIn(let config):

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -362,11 +362,11 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
 
         XCTAssertNil(initialState.navigationDestination)
 
-        let action = getNavigationBrowserAction(for: .tapOnHomepageSearchBar, destination: .zeroSearch)
+        let action = getNavigationBrowserAction(for: .tapOnHomepageSearchBar, destination: .homepageZeroSearch)
         let newState = reducer(initialState, action)
         let destination = newState.navigationDestination?.destination
         switch destination {
-        case .zeroSearch:
+        case .homepageZeroSearch:
             break
         default:
             XCTFail("destination is not the right type")
@@ -390,7 +390,7 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let newState = reducer(initialState, action)
         let destination = newState.navigationDestination?.destination
         switch destination {
-        case .zeroSearch:
+        case .homepageZeroSearch:
             break
         default:
             XCTFail("destination is not the right type")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -322,7 +322,7 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         let newState = BrowserViewControllerState.reducer(
             BrowserViewControllerState(windowUUID: .XCTestDefaultUUID),
             NavigationBrowserAction(
-                navigationDestination: NavigationDestination(.zeroSearch),
+                navigationDestination: NavigationDestination(.homepageZeroSearch),
                 windowUUID: .XCTestDefaultUUID,
                 actionType: NavigationBrowserActionType.tapOnHomepageSearchBar
             )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/TrendingSearchClientTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/TrendingSearchClientTests.swift
@@ -139,7 +139,7 @@ final class TrendingSearchClientTest: XCTestCase {
         [
           "",
           [
-            "funny cat videos",
+           "funny cat videos",
            "easy pasta recipes",
            "golden retriever tricks",
            "best travel destinations 2025",

--- a/firefox-ios/nimbus-features/trendingSearchesFeature.yaml
+++ b/firefox-ios/nimbus-features/trendingSearchesFeature.yaml
@@ -21,5 +21,5 @@ features:
           max-suggestions: 5
       - channel: developer
         value:
-          enabled: false
+          enabled: true
           max-suggestions: 5

--- a/firefox-ios/nimbus-features/trendingSearchesFeature.yaml
+++ b/firefox-ios/nimbus-features/trendingSearchesFeature.yaml
@@ -21,5 +21,5 @@ features:
           max-suggestions: 5
       - channel: developer
         value:
-          enabled: true
+          enabled: false
           max-suggestions: 5


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13647)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29614)

## :bulb: Description
Add initial zero search state with trending searches. 

We have two different zero search state now, one that shows the homepage and the other with list of trending and recent searches. For this feature, we want to show the trending / recent searches only when entering the address URL bar on a web page and not on the homepage or opening a new tab.

Note: This is the initial UI and did not do a thorough testing for all edge cases, but feel to pull down and point out any issues.

Test Feature: Undo this commit: af4221260a5530aed4719f4eb35c7cf330fa75f9

## :movie_camera: Demos

https://github.com/user-attachments/assets/2b7541ac-f061-45c0-975c-0faba320a69a

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
