### PR TITLE
Bugfix FXIOS-13533 ⁃ [iOS 26][Onboarding] "Done" button design should be consistent throught the app

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
@@ -152,10 +152,9 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
             windowUUID: windowUUID)
         let buttonItem = UIBarButtonItem(
             title: .SettingsSearchDoneButton,
-            style: .plain,
+            style: .done,
             target: self,
             action: selector)
-        buttonItem.tintColor = themeManager.getCurrentTheme(for: windowUUID).colors.actionPrimary
         singInSyncVC.navigationItem.rightBarButtonItem = buttonItem
         (singInSyncVC as? FirefoxAccountSignInViewController)?.qrCodeNavigationHandler = qrCodeNavigationHandler
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13533)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29416)

## :bulb: Description
Modified the style of a UIBarButtonItem

## :movie_camera: Demos
<img width="603" height="1311" alt="IMG_2132" src="https://github.com/user-attachments/assets/5c51aec0-09de-4993-84c1-76b0adce2be1" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
