### PR TITLE
Bugfix FXIOS-13697 Crash on homepage when syncing Bookmarks from Sync

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarkConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarkConfiguration.swift
@@ -5,7 +5,8 @@
 import Foundation
 import Storage
 
-struct BookmarkConfiguration: Equatable, Hashable {
+struct BookmarkConfiguration: Identifiable, Equatable, Hashable {
+    let id = UUID()
     let site: Site
     var accessibilityLabel: String {
         return "\(site.title)"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13679)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29701)

## :bulb: Description
Bugfix FXIOS Crash on homepage when syncing Bookmarks from Sync.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code