### PR TITLE
Bugfix FXIOS-13445 [New first run onboarding][iOS 26] Scroll bar appears when tapping the onboarding card to set Firefox as default browser

### DIFF
--- a/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingBasicCardViewCompact.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingBasicCardViewCompact.swift
@@ -50,7 +50,7 @@ struct OnboardingBasicCardViewCompact<ViewModel: OnboardingCardInfoModelProtocol
     @ViewBuilder
     private func cardContent(geometry: GeometryProxy) -> some View {
         VStack {
-            ScrollView {
+            ScrollView(showsIndicators: false) {
                 VStack(spacing: UX.CardView.spacing) {
                     titleView
                         .padding(.top, UX.CardView.titleTopPadding(for: geometry.size.height))

--- a/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingMultipleChoiceCardViewCompact.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingMultipleChoiceCardViewCompact.swift
@@ -53,7 +53,7 @@ struct OnboardingMultipleChoiceCardViewCompact<ViewModel: OnboardingCardInfoMode
 
     private func scrollViewContent(geometry: GeometryProxy) -> some View {
         VStack {
-            ScrollView {
+            ScrollView(showsIndicators: false) {
                 VStack(spacing: UX.CardView.spacing) {
                     titleView
                         .padding(.top, UX.CardView.titleTopPadding(for: geometry.size.height))

--- a/BrowserKit/Sources/OnboardingKit/Views/Regular/OnboardingBasicCardViewRegular.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Regular/OnboardingBasicCardViewRegular.swift
@@ -31,7 +31,7 @@ struct OnboardingBasicCardViewRegular<ViewModel: OnboardingCardInfoModelProtocol
 
     var body: some View {
         VStack {
-            ScrollView {
+            ScrollView(showsIndicators: false) {
                 VStack(spacing: UX.CardView.regularSizeSpacing) {
                     titleView
                         .padding(.top, UX.CardView.titleTopPadding)

--- a/BrowserKit/Sources/OnboardingKit/Views/Regular/OnboardingMultipleChoiceCardViewRegular.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Regular/OnboardingMultipleChoiceCardViewRegular.swift
@@ -37,7 +37,7 @@ struct OnboardingMultipleChoiceCardViewRegular<ViewModel: OnboardingCardInfoMode
 
     var body: some View {
         VStack {
-            ScrollView {
+            ScrollView(showsIndicators: false) {
                 VStack(spacing: UX.CardView.regularSizeSpacing) {
                     titleView
                         .padding(.top, UX.CardView.titleTopPadding)

--- a/BrowserKit/Sources/OnboardingKit/Views/TermsOfServiceView/TermsOfServiceCompactView.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/TermsOfServiceView/TermsOfServiceCompactView.swift
@@ -60,7 +60,7 @@ public struct TermsOfServiceCompactView<ViewModel: OnboardingCardInfoModelProtoc
     private func cardContent(geometry: GeometryProxy, scale: CGFloat) -> some View {
         VStack {
             GeometryReader { geometry in
-                ScrollView(.vertical) {
+                ScrollView(showsIndicators: false) {
                     VStack(spacing: UX.CardView.spacing * scale) {
                         Spacer()
                         imageView(scale: scale)

--- a/BrowserKit/Sources/OnboardingKit/Views/TermsOfServiceView/TermsOfServiceCompactView.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/TermsOfServiceView/TermsOfServiceCompactView.swift
@@ -60,7 +60,7 @@ public struct TermsOfServiceCompactView<ViewModel: OnboardingCardInfoModelProtoc
     private func cardContent(geometry: GeometryProxy, scale: CGFloat) -> some View {
         VStack {
             GeometryReader { geometry in
-                ScrollView(showsIndicators: false) {
+                ScrollView(showsIndicators: false ) {
                     VStack(spacing: UX.CardView.spacing * scale) {
                         Spacer()
                         imageView(scale: scale)

--- a/BrowserKit/Sources/OnboardingKit/Views/TermsOfServiceView/TermsOfServiceCompactView.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/TermsOfServiceView/TermsOfServiceCompactView.swift
@@ -60,7 +60,7 @@ public struct TermsOfServiceCompactView<ViewModel: OnboardingCardInfoModelProtoc
     private func cardContent(geometry: GeometryProxy, scale: CGFloat) -> some View {
         VStack {
             GeometryReader { geometry in
-                ScrollView(showsIndicators: false ) {
+                ScrollView(showsIndicators: false) {
                     VStack(spacing: UX.CardView.spacing * scale) {
                         Spacer()
                         imageView(scale: scale)

--- a/BrowserKit/Sources/OnboardingKit/Views/TermsOfServiceView/TermsOfServiceRegularView.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/TermsOfServiceView/TermsOfServiceRegularView.swift
@@ -52,7 +52,7 @@ public struct TermsOfServiceRegularView<ViewModel: OnboardingCardInfoModelProtoc
     private var termsContent: some View {
         SheetSizedCard {
             GeometryReader { geometry in
-                ScrollView(.vertical) {
+                ScrollView(showsIndicators: false) {
                     VStack {
                         VStack(spacing: UX.CardView.tosSpacing) {
                             VStack(spacing: UX.CardView.spacing) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13445)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29223)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

- Modified 6 files to address the scroll bar appearance issue
- Changes focus on the onboarding card interaction behavior
- Ensures a cleaner, more polished onboarding experience

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
