### PR TITLE
Bugfix FXIOS-13612 ⁃ [iOS 26] Some of the radio buttons from password edit mode are still displayed after exiting edit mode

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -342,9 +342,11 @@ private extension PasswordManagerListViewController {
         selectionButton.isHidden = true
         self.view.layoutIfNeeded()
 
-        tableView.setEditing(false, animated: true)
+        UIView.performWithoutAnimation {
+            tableView.setEditing(false, animated: false)
+            tableView.reloadData()
+        }
         setupDefaultNavButtons()
-        tableView.reloadData()
     }
 
     @objc


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13612)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29564)

## :bulb: Description
Exit from edit mode without doing some animation

## :movie_camera: Demos

https://github.com/user-attachments/assets/aa81bb8f-4d24-4d9f-911b-7a93b4f76f47



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
