### PR TITLE
Bugfix FXIOS-13452 ⁃ [iOS 26] There is an inconsistency in the animation behavior of the + button between the Payment methods and Passwords sections

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -96,7 +96,9 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.placeholder = .LoginsListSearchPlaceholder
         searchController.delegate = self
-        navigationItem.hidesSearchBarWhenScrolling = false
+        if #unavailable(iOS 26.0) {
+            navigationItem.hidesSearchBarWhenScrolling = false
+        }
         navigationItem.searchController = searchController
         definesPresentationContext = true
         // No need to hide the navigation bar on iPad to make room, and hiding makes the search bar too close to the top


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13452)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29237)

## :bulb: Description
Keep `hidesSearchBarWhenScrolling = false` only for iOS versions under iOS 26

## :movie_camera: Demos

https://github.com/user-attachments/assets/29cc3360-fa8f-4409-8c16-41366b3765a1




| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
