### PR TITLE
Bugfix FXIOS-13315 ⁃ [iOS 26] The Appearance and Address Bar sub-menus lack a border/delimitation on the menus

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconSelectionView.swift
@@ -45,7 +45,7 @@ struct AppIconSelectionView: View, ThemeApplicable {
                         windowUUID: windowUUID,
                         setAppIcon: setAppIcon
                     )
-                }.listRowBackground(themeColors.layer2.color)
+                }.listRowBackground(themeColors.layer5.color)
             }
             .modifier(ListStyle())
             .alert(isPresented: $isShowingErrorAlert) {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
@@ -14,7 +14,7 @@ struct AddressBarSelectionView: View {
     var onSelected: ((SearchBarPosition) -> Void)?
 
     var backgroundColor: Color {
-        return Color(theme?.colors.layer2 ?? UIColor.clear)
+        return Color(theme?.colors.layer5 ?? UIColor.clear)
     }
 
     private struct UX {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/DarkModeToggleView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/DarkModeToggleView.swift
@@ -23,7 +23,7 @@ struct DarkModeToggleView: View {
     }
 
     var backgroundColor: Color {
-        return Color(theme?.colors.layer2 ?? UIColor.clear)
+        return Color(theme?.colors.layer5 ?? UIColor.clear)
     }
 
     private struct UX {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericItemCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericItemCellView.swift
@@ -26,7 +26,7 @@ struct GenericItemCellView: View {
     }
 
     var backgroundColor: Color {
-        return Color(theme?.colors.layer2 ?? UIColor.clear)
+        return Color(theme?.colors.layer5 ?? UIColor.clear)
     }
 
     var body: some View {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSelectableItemCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSelectableItemCellView.swift
@@ -25,7 +25,7 @@ struct GenericSelectableItemCellView: View {
     }
 
     var backgroundColor: Color {
-        return Color(theme?.colors.layer2 ?? UIColor.clear)
+        return Color(theme?.colors.layer5 ?? UIColor.clear)
     }
 
     var body: some View {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/NavigationBarMiddleButtonSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/NavigationBarMiddleButtonSelectionView.swift
@@ -14,7 +14,7 @@ struct NavigationBarMiddleButtonSelectionView: View {
     var onSelected: ((NavigationBarMiddleButtonType) -> Void)?
 
     var backgroundColor: Color {
-        return Color(theme?.colors.layer2 ?? UIColor.clear)
+        return Color(theme?.colors.layer5 ?? UIColor.clear)
     }
 
     private struct UX {

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/StylingViewModifiers.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/StylingViewModifiers.swift
@@ -15,7 +15,7 @@ struct SectionStyle: ViewModifier {
                 .padding()
                 .background(
                     RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .fill(Color(theme?.colors.layer2 ?? UIColor.clear))
+                        .fill(Color(theme?.colors.layer5 ?? UIColor.clear))
                 )
         } else {
             content

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/ThemeSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/ThemeSelectionView.swift
@@ -15,7 +15,7 @@ struct ThemeSelectionView: View {
     var onThemeSelected: ((ThemeOption) -> Void)?
 
     var backgroundColor: Color {
-        return Color(theme?.colors.layer2 ?? UIColor.clear)
+        return Color(theme?.colors.layer5 ?? UIColor.clear)
     }
 
     private struct UX {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13315)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28992)

## :bulb: Description
Changed from layer2 to layer5 for necessary cells

## :movie_camera: Demos

https://github.com/user-attachments/assets/547d07b4-6621-4a76-8706-ad4634a4fcd1



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
