### PR TITLE
Add FXIOS-13643 [Trending Searches] nimbus configuration for number of searches to show

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/RecentSearchProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/RecentSearchProvider.swift
@@ -16,9 +16,9 @@ protocol RecentSearchProvider {
 struct DefaultRecentSearchProvider: RecentSearchProvider {
     private let searchEngineID: String
     private let prefs: Prefs
+    private let nimbus: FxNimbus
 
     private let baseKey = PrefsKeys.Search.recentSearchesCache
-    private let maxNumberOfSuggestions = 5
 
     // Namespaced key = "recentSearchesCacheBaseKey.[engineID]"
     private var recentSearchesKey: String {
@@ -29,10 +29,18 @@ struct DefaultRecentSearchProvider: RecentSearchProvider {
         prefs.objectForKey(recentSearchesKey) ?? []
     }
 
-    init(profile: Profile = AppContainer.shared.resolve(),
-         searchEngineID: String) {
+    private var maxNumberOfSuggestions: Int {
+        return nimbus.features.recentSearchesFeature.value().maxSuggestions
+    }
+
+    init(
+        profile: Profile = AppContainer.shared.resolve(),
+        searchEngineID: String,
+        nimbus: FxNimbus = FxNimbus.shared
+    ) {
         self.searchEngineID = searchEngineID
         self.prefs = profile.prefs
+        self.nimbus = nimbus
     }
 
     /// Adds a search term to the persisted recent searches list, ensuring it avoid duplicates,

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/TrendingSearchClient.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/TrendingSearchClient.swift
@@ -31,17 +31,26 @@ final class TrendingSearchClient: TrendingSearchClientProvider, Sendable {
     private let searchEngine: TrendingSearchEngine?
     private let logger: Logger
     private let urlSession: URLSession
+    private let nimbus: FxNimbus
 
-    init(searchEngine: TrendingSearchEngine?,
-         logger: Logger = DefaultLogger.shared,
-         session: URLSession = makeURLSession(
-            userAgent: UserAgent.mobileUserAgent(),
+    private var maxCount: Int {
+        return nimbus.features.trendingSearchesFeature.value().maxSuggestions
+    }
+
+    init(
+        searchEngine: TrendingSearchEngine?,
+        logger: Logger = DefaultLogger.shared,
+        session: URLSession = makeURLSession(
+            userAgent: UserAgent
+                .mobileUserAgent(),
             configuration: URLSessionConfiguration.ephemeralMPTCP
-         )
+        ),
+        nimbus: FxNimbus = FxNimbus.shared
     ) {
         self.searchEngine = searchEngine
         self.logger = logger
         self.urlSession = session
+        self.nimbus = nimbus
     }
 
     func getTrendingSearches() async throws -> [String] {
@@ -62,7 +71,7 @@ final class TrendingSearchClient: TrendingSearchClientProvider, Sendable {
                 throw TrendingSearchClientError.unableToParseJsonData
             }
 
-            return suggestions
+            return Array(suggestions.prefix(maxCount))
         } catch {
             throw error
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/TrendingSearchClientTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/TrendingSearchClientTests.swift
@@ -29,10 +29,7 @@ final class TrendingSearchClientTest: XCTestCase {
             "easy pasta recipes",
             "golden retriever tricks",
             "best travel destinations 2025",
-            "cozy coffee shops",
-            "sleepy kittens",
-            "board game night ideas",
-            "dogs wearing sunglasses"
+            "dogs wearing sunglasses",
         ]
         XCTAssertEqual(result, expectedResult)
     }
@@ -143,10 +140,10 @@ final class TrendingSearchClientTest: XCTestCase {
            "easy pasta recipes",
            "golden retriever tricks",
            "best travel destinations 2025",
-           "cozy coffee shops",
+           "dogs wearing sunglasses",
            "sleepy kittens",
            "board game night ideas",
-           "dogs wearing sunglasses"
+           "cozy coffee shops"
           ]
         ]
         """#


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13643)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29609)

## :bulb: Description
Integrate showing number of searches for trending and recent searches based on nimbus configuration instead of a hardcoded value. We default to 5 for now.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
