### PR TITLE
Refactor FXIOS-13690 [Trending Searches] one line cell used in search

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -718,14 +718,14 @@ class SearchViewController: SiteTableViewController,
         switch section {
         case .trendingSearches:
             if let trendingSearch = viewModel.trendingSearches[safe: indexPath.row] {
-                let oneLineCellViewModel = configureOneLineCellForSearch(with: trendingSearch)
+                let oneLineCellViewModel = oneLineCellModelForSearch(with: trendingSearch)
                 oneLineCell.configure(viewModel: oneLineCellViewModel)
                 cell = oneLineCell
             }
 
         case .searchSuggestions:
             if let site = viewModel.suggestions?[indexPath.row] {
-                let oneLineCellViewModel = configureOneLineCellForSearch(
+                let oneLineCellViewModel = oneLineCellModelForSearch(
                     with: site,
                     shouldShowAccessoryView: indexPath.row > 0
                 )
@@ -817,7 +817,7 @@ class SearchViewController: SiteTableViewController,
         return cell
     }
 
-    private func configureOneLineCellForSearch(
+    private func oneLineCellModelForSearch(
         with text: String,
         shouldShowAccessoryView: Bool = true
     ) -> OneLineTableViewCellViewModel {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13690)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29691)

## :bulb: Description
Refactor one line cell to use existing view model and add private method to make code more reusable between trending search and search suggestions.

Originated from a comment on this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/29692#discussion_r2388176830).

Please test existing search suggestions functionality and that it is expected. Can also test trending search append button now that it is reusing the same method as the search suggestions.

Note: To test trending searches, please revert this commit: ffb71bad058ab94b987c278b017be6e691cb4aa6

## Screenshots

| iPhone - Search Suggestions | iPhone - Trending Searches |
| ---- | ---- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-01 at 09 36 28" src="https://github.com/user-attachments/assets/012445f7-804c-403f-8cb1-3f16c698882b" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-01 at 09 36 21" src="https://github.com/user-attachments/assets/5f71d987-9842-4aa9-a36c-3df03e4fee8e" /> |

| iPad - Search Suggestions | iPad - Trending Searches |
| ---- | ---- |
| <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-10-01 at 09 40 59" src="https://github.com/user-attachments/assets/b475836e-05f2-4bb6-9c1f-798ebf030fb9" /> |  <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-10-01 at 09 41 11" src="https://github.com/user-attachments/assets/cf86f4bc-4bfa-45dc-95cd-c1886bb1b4f3" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
