### PR TITLE
Bugfix FXIOS-13083 [Unit Tests] stories navigation unit test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -477,7 +477,13 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         let action = getNavigationBrowserAction(for: .tapOnAllStoriesButton, destination: .storiesFeed)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .storiesFeed)
+        let destination = newState.navigationDestination?.destination
+        switch destination {
+        case .storiesFeed:
+            break
+        default:
+            XCTFail("destination is not the right type")
+        }
     }
 
     // MARK: - Private


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13083)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28491)

## :bulb: Description
Issue reported by @clarmso. Quick fix for tests created in this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/29630/files#diff-f04f3d0058727f9dade7bf4bf48849ef9c46755ecdeb157a5179a4aaf4467409).

Seems due to this PR merging first - https://github.com/mozilla-mobile/firefox-ios/pull/29657/files, since we remove `NavigationDestination` from being `Equatable`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
