### PR TITLE
Refactor FXIOS-13620 #29574 ⁃ [Swift 6 Migration] Fix strict concurrency errors in TopSitesProviderImplementation

### DIFF
--- a/BrowserKit/Sources/Shared/UIDeviceDetails.swift
+++ b/BrowserKit/Sources/Shared/UIDeviceDetails.swift
@@ -9,14 +9,14 @@ import UIKit
 /// This makes it easier for code that runs on a background thread (without an asynchronous context) to use these values.
 ///
 /// **Never put values in here that might change during runtime.**
-struct UIDeviceDetails {
+public struct UIDeviceDetails {
     /// The model of the device.
     static let model = {
         getMainThreadDataSynchronously { UIDevice.current.model }
     }()
 
     /// The style of interface to use on the current device.
-    static let userInterfaceIdiom = {
+    public static let userInterfaceIdiom = {
         getMainThreadDataSynchronously { UIDevice.current.userInterfaceIdiom }
     }()
 

--- a/BrowserKit/Sources/Shared/UIDeviceDetails.swift
+++ b/BrowserKit/Sources/Shared/UIDeviceDetails.swift
@@ -9,14 +9,14 @@ import UIKit
 /// This makes it easier for code that runs on a background thread (without an asynchronous context) to use these values.
 ///
 /// **Never put values in here that might change during runtime.**
-public struct UIDeviceDetails {
+struct UIDeviceDetails {
     /// The model of the device.
     static let model = {
         getMainThreadDataSynchronously { UIDevice.current.model }
     }()
 
     /// The style of interface to use on the current device.
-    public static let userInterfaceIdiom = {
+    static let userInterfaceIdiom = {
         getMainThreadDataSynchronously { UIDevice.current.userInterfaceIdiom }
     }()
 

--- a/firefox-ios/Providers/TopSitesProvider.swift
+++ b/firefox-ios/Providers/TopSitesProvider.swift
@@ -3,10 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import BrowserKit
 import Shared
-import Storage
 import UIKit
+import Storage
 
 import enum MozillaAppServices.FrecencyThresholdOption
 
@@ -33,7 +32,7 @@ extension TopSitesProvider {
     }
 
     static var numberOfMaxItems: Int {
-        return UIDeviceDetails.userInterfaceIdiom == .pad ? 32 : 16
+        return UIDevice.current.userInterfaceIdiom == .pad ? 32 : 16
     }
 
     var defaultSuggestedSitesKey: String {

--- a/firefox-ios/Providers/TopSitesProvider.swift
+++ b/firefox-ios/Providers/TopSitesProvider.swift
@@ -26,28 +26,29 @@ protocol TopSitesProvider {
 }
 
 extension TopSitesProvider {
-    func getTopSites(numberOfMaxItems: Int = Self.numberOfMaxItems,
-                     completion: @escaping ([Site]?) -> Void) {
-        getTopSites(numberOfMaxItems: numberOfMaxItems, completion: completion)
-    }
-
+    @MainActor
     static var numberOfMaxItems: Int {
         return UIDevice.current.userInterfaceIdiom == .pad ? 32 : 16
     }
 
-    var defaultSuggestedSitesKey: String {
-        return "topSites.deletedSuggestedSites"
+    func getTopSites(numberOfMaxItems: Int = Self.numberOfMaxItems,
+                     completion: @escaping ([Site]?) -> Void) {
+        getTopSites(numberOfMaxItems: numberOfMaxItems, completion: completion)
     }
 }
 
 // TODO: FXIOS-13706 TopSitesProviderImplementation should be concurrency safe
-class TopSitesProviderImplementation: TopSitesProvider, @unchecked Sendable {
+class TopSitesProviderImplementation: @MainActor TopSitesProvider, @unchecked Sendable {
     private let pinnedSiteFetcher: PinnedSites
     private let placesFetcher: RustPlaces
     private let prefs: Prefs
 
     private var frecencySites = [Site]()
     private var pinnedSites = [Site]()
+
+    var defaultSuggestedSitesKey: String {
+        return "topSites.suggestedSites"
+    }
 
     init(
         placesFetcher: RustPlaces,

--- a/firefox-ios/Providers/TopSitesProvider.swift
+++ b/firefox-ios/Providers/TopSitesProvider.swift
@@ -3,9 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import BrowserKit
 import Shared
-import UIKit
 import Storage
+import UIKit
 
 import enum MozillaAppServices.FrecencyThresholdOption
 
@@ -32,7 +33,7 @@ extension TopSitesProvider {
     }
 
     static var numberOfMaxItems: Int {
-        return UIDevice.current.userInterfaceIdiom == .pad ? 32 : 16
+        return UIDeviceDetails.userInterfaceIdiom == .pad ? 32 : 16
     }
 
     var defaultSuggestedSitesKey: String {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
@@ -57,6 +57,7 @@ class TopSitesHelperTests: XCTestCase {
         return subject
     }
 
+    @MainActor
     func testGetTopSites_withError_completesWithZeroSites() {
         let expectation = expectation(description: "Expect top sites to be fetched")
         let subject = createSubject(mockPinnedSites: false)
@@ -73,6 +74,7 @@ class TopSitesHelperTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
+    @MainActor
     func testGetTopSites_withFrecencyError_completesWithPinnedSites() {
         let expectation = expectation(description: "Expect top sites to be fetched")
         let subject = createSubject(mockPinnedSites: true, pinnedSites: defaultPinnedSites)
@@ -89,6 +91,7 @@ class TopSitesHelperTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
+    @MainActor
     func testGetTopSites_withPinnedSitesError_completesWithFrecencySites() {
         let expectation = expectation(description: "Expect top sites to be fetched")
         let subject = createSubject(
@@ -108,6 +111,7 @@ class TopSitesHelperTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
+    @MainActor
     func testGetTopSites_filterHideSearchParam() {
         let expectation = expectation(description: "Expect top sites to be fetched")
         let sites = defaultFrecencySites + [
@@ -128,6 +132,7 @@ class TopSitesHelperTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
+    @MainActor
     func testGetTopSites_removesDuplicates() {
         let expectation = expectation(description: "Expect top sites to be fetched")
         let sites = defaultFrecencySites + defaultFrecencySites
@@ -146,6 +151,7 @@ class TopSitesHelperTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
+    @MainActor
     func testGetTopSites_defaultSitesHavePrecedenceOverFrecency() {
         let expectation = expectation(description: "Expect top sites to be fetched")
         let sites = [Site.createBasicSite(url: "https://facebook.com", title: "Facebook")]
@@ -163,6 +169,7 @@ class TopSitesHelperTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
+    @MainActor
     func testGetTopSites_pinnedSitesHasPrecedenceOverDefaultTopSites() {
         let expectation = expectation(description: "Expect top sites to be fetched")
         let subject = createSubject(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13620)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29574)

## :bulb: Description
- Fix warnings in TopSitesProviderImplementation using snapshot to avoid capturing self.
- Add `@unchecked Sendable` and follow up ticket to fix other 2 warning since required a bigger refactoring
- Use new `UIDeviceDetails` to check `userInterfaceIdiom` needed to calculate the amount of items that needs to be fetched. 
@ih-codes I found this struct in the code but it's only being used in BrowserKit I took the liberty to make it public. Please let me know if the intention was to use it in the Client too, if not I will revert the changes

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
