### PR TITLE
Add FXIOS-13715 [Sync] Added sync telemetry for the addresses engine

### DIFF
--- a/MozillaRustComponents/Package.resolved
+++ b/MozillaRustComponents/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "0b3b133588d441754b48063b0d4b1cd15d7db83f16087b2b639c07d634de8bfd",
   "pins" : [
     {
       "identity" : "glean-swift",
@@ -10,5 +11,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13715)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29754)

## :bulb: Description
Added sync telemetry for the addresses engine

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
