### PR TITLE
Add FXIOS-13719 Add test plan to MozillaRustComponents package's main target

### DIFF
--- a/MozillaRustComponents/.swiftpm/xcode/xcshareddata/xcschemes/MozillaRustComponents.xcscheme
+++ b/MozillaRustComponents/.swiftpm/xcode/xcshareddata/xcschemes/MozillaRustComponents.xcscheme
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MozillaRustComponents"
+               BuildableName = "MozillaRustComponents"
+               BlueprintName = "MozillaRustComponents"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:MozillaRustComponents.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "MozillaRustComponents"
+            BuildableName = "MozillaRustComponents"
+            BlueprintName = "MozillaRustComponents"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MozillaRustComponents/MozillaRustComponents.xctestplan
+++ b/MozillaRustComponents/MozillaRustComponents.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "04DFFAE1-C4CD-4EA2-A23F-DFB91B5392BF",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "performanceAntipatternCheckerEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "MozillaRustComponentsTests",
+        "name" : "MozillaRustComponentsTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/MozillaRustComponents/Package.resolved
+++ b/MozillaRustComponents/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "f5b0ca43b5b3b25bdb9c6d8abe1150350ebee0a9",
+        "revision" : "fe1b951f1e89ce182a56982234f6803f0c16e8ea",
         "version" : "65.1.1"
       }
     }

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountDeviceConstellation.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountDeviceConstellation.swift
@@ -19,7 +19,7 @@ public enum SendEventError: Error {
 }
 
 // FIXME: FXIOS-13537 Make this type actually Sendable, or isolate or otherwise protect any mutable state
-public final class DeviceConstellation: @unchecked Sendable {
+public class DeviceConstellation: @unchecked Sendable {
     var constellationState: ConstellationState?
     let account: PersistedFirefoxAccount
 

--- a/MozillaRustComponents/Tests/MozillaRustComponentsTests/FxAccountManagerTests.swift
+++ b/MozillaRustComponents/Tests/MozillaRustComponentsTests/FxAccountManagerTests.swift
@@ -190,7 +190,7 @@ class FxAccountManagerTests: XCTestCase {
     func testNewAccountLogIn() {
         let mgr = mockFxAManager()
         let beginAuthDone = expectation(description: "beginAuthDone")
-        var authURL: String?
+        nonisolated(unsafe) var authURL: String?
         mgr.initialize { _ in
             mgr.beginAuthentication(entrypoint: "test_new_account_log_in") { url in
                 authURL = try! url.get().absoluteString
@@ -223,7 +223,7 @@ class FxAccountManagerTests: XCTestCase {
     func testAuthStateVerification() {
         let mgr = mockFxAManager()
         let beginAuthDone = expectation(description: "beginAuthDone")
-        var authURL: String?
+        nonisolated(unsafe) var authURL: String?
         mgr.initialize { _ in
             mgr.beginAuthentication(entrypoint: "test_auth_state_verification") { url in
                 authURL = try! url.get().absoluteString

--- a/MozillaRustComponents/Tests/MozillaRustComponentsTests/FxAccountMocks.swift
+++ b/MozillaRustComponents/Tests/MozillaRustComponentsTests/FxAccountMocks.swift
@@ -78,7 +78,7 @@ class MockFxAccount: PersistedFirefoxAccount {
     }
 }
 
-class MockFxAccountManager: FxAccountManager {
+final class MockFxAccountManager: FxAccountManager, @unchecked Sendable {
     var storedAccount: PersistedFirefoxAccount?
 
     override func createAccount() -> PersistedFirefoxAccount {
@@ -94,7 +94,7 @@ class MockFxAccountManager: FxAccountManager {
     }
 }
 
-class MockDeviceConstellation: DeviceConstellation {
+final class MockDeviceConstellation: DeviceConstellation, @unchecked Sendable {
     var invocations: [MethodInvocation] = []
     enum MethodInvocation {
         case ensureCapabilities

--- a/MozillaRustComponents/Tests/MozillaRustComponentsTests/NimbusTests.swift
+++ b/MozillaRustComponents/Tests/MozillaRustComponentsTests/NimbusTests.swift
@@ -518,7 +518,7 @@ class NimbusTests: XCTestCase {
         XCTAssertEqual(nil, enrolledExtra["conflict_slug"], "conflictSlug must match")
     }
 
-    class TestRecordedContext: RecordedContext {
+    class TestRecordedContext: RecordedContext, @unchecked Sendable {
         var recorded: [[String: Any]] = []
         var enabled: Bool
         var eventQueries: [String: String]? = nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13719)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29758)

## :bulb: Description

Looks like the unit tests don't run properly with CMD + U on the MozillaRustComponents target, so I added a test plan and updated the scheme to run it for Testing.

I also fixed some unit test build errors from the recent strict concurrency / swift 6 migration work.

### Summary
- Add test plan to MozillaRustComponents package's main target. 
- Fix compile errors in unit tests after strict concurrency migrations.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
