### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] SearchEngineSelectionMiddleware middleware actor isolation

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/DefaultSearchEngineProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/DefaultSearchEngineProvider.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Common
 
-typealias SearchEngineCompletion = @Sendable (SearchEnginePrefs, [OpenSearchEngine]) -> Void
+typealias SearchEngineCompletion = @MainActor @Sendable (SearchEnginePrefs, [OpenSearchEngine]) -> Void
 
 protocol SearchEngineProvider {
     /// Takes a list of custom search engines (added by the user) along with an ordered

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -5,6 +5,7 @@
 import Common
 import Redux
 
+@MainActor
 final class SearchEngineSelectionMiddleware {
     private let profile: Profile
     private let logger: Logger
@@ -38,7 +39,7 @@ final class SearchEngineSelectionMiddleware {
         case SearchEngineSelectionActionType.didTapSearchEngine:
             // Trigger editing in the toolbar
             let action = ToolbarAction(windowUUID: action.windowUUID, actionType: ToolbarActionType.didStartEditingUrl)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         default:
             break
@@ -51,6 +52,6 @@ final class SearchEngineSelectionMiddleware {
             actionType: SearchEngineSelectionActionType.didLoadSearchEngines,
             searchEngines: searchEngines.map({ $0.generateModel() })
         )
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import Client
 
-class MockSearchEngineProvider: SearchEngineProvider {
+class MockSearchEngineProvider: SearchEngineProvider, @unchecked Sendable {
     var unorderedEngines: (([OpenSearchEngine]) -> Void)?
 
     var mockEngines: [OpenSearchEngine] = [
@@ -69,12 +69,13 @@ class MockSearchEngineProvider: SearchEngineProvider {
         unorderedEngines?(mockEngines)
     }
 
-    func getOrderedEngines(
-        customEngines: [OpenSearchEngine],
-        engineOrderingPrefs: SearchEnginePrefs,
-        prefsMigrator: any SearchEnginePreferencesMigrator,
-        completion: @escaping SearchEngineCompletion) {
-        completion(engineOrderingPrefs, mockEngines)
+    func getOrderedEngines(customEngines: [OpenSearchEngine],
+                           engineOrderingPrefs: SearchEnginePrefs,
+                           prefsMigrator: any SearchEnginePreferencesMigrator,
+                           completion: @escaping SearchEngineCompletion) {
+        DispatchQueue.main.async {
+            completion(engineOrderingPrefs, self.mockEngines)
+        }
     }
 
     let preferencesVersion: SearchEngineOrderingPrefsVersion = .v1

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 @testable import Client
 
 class MockSearchEngineProvider: SearchEngineProvider, @unchecked Sendable {
@@ -73,7 +74,7 @@ class MockSearchEngineProvider: SearchEngineProvider, @unchecked Sendable {
                            engineOrderingPrefs: SearchEnginePrefs,
                            prefsMigrator: any SearchEnginePreferencesMigrator,
                            completion: @escaping SearchEngineCompletion) {
-        DispatchQueue.main.async {
+        ensureMainThread {
             completion(engineOrderingPrefs, self.mockEngines)
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-
+import Common
 @testable import Client
 
 class MockSearchEnginesManager: SearchEnginesManagerProvider {
@@ -24,7 +24,7 @@ class MockSearchEnginesManager: SearchEnginesManagerProvider {
     }
 
     func getOrderedEngines(completion: @escaping SearchEngineCompletion) {
-        DispatchQueue.main.async {
+        ensureMainThread {
             completion(
                 SearchEnginePrefs(
                     engineIdentifiers: self.searchEngines.map {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
@@ -24,14 +24,16 @@ class MockSearchEnginesManager: SearchEnginesManagerProvider {
     }
 
     func getOrderedEngines(completion: @escaping SearchEngineCompletion) {
-        completion(
-            SearchEnginePrefs(
-                engineIdentifiers: searchEngines.map {
-                    $0.shortName
-                },
-                disabledEngines: [],
-                version: .v1),
-            searchEngines
-        )
+        DispatchQueue.main.async {
+            completion(
+                SearchEnginePrefs(
+                    engineIdentifiers: self.searchEngines.map {
+                        $0.shortName
+                    },
+                    disabledEngines: [],
+                    version: .v1),
+                self.searchEngines
+            )
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
Migrate `SearchEngineSelectionMiddleware` middleware to use `@MainActor` isolation and the new isolated store `dispatch` method.

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
