### PR TITLE
Refactor FXIOS-13481 [Swift 6 Migration] Turn on Concurrency for CommonLibrary Tests in BrowserKit

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -130,9 +130,8 @@ let package = Package(
             name: "CommonTests",
             dependencies: ["Common"],
             swiftSettings: [
-                            .enableExperimentalFeature("StrictConcurrency")
-            ]
-        ),
+                .enableExperimentalFeature("StrictConcurrency")
+            ]),
         .target(
             name: "TabDataStore",
             dependencies: ["Common"],

--- a/BrowserKit/Tests/CommonTests/Extensions/UIViewExtensionTests.swift
+++ b/BrowserKit/Tests/CommonTests/Extensions/UIViewExtensionTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 @testable import Common
 
+@MainActor
 final class UIViewExtensionTests: XCTestCase {
     final class CustomView: UIView {
         var customProperty: String

--- a/BrowserKit/Tests/CommonTests/LoggerTests/LoggerTests.swift
+++ b/BrowserKit/Tests/CommonTests/LoggerTests/LoggerTests.swift
@@ -239,28 +239,27 @@ final class MockSwiftyBeaver: SwiftyBeaverWrapper {
         return nil
     }
 
-    static var fileDestination: URL?
-    static var savedMessage: String?
+    nonisolated(unsafe) static var savedMessage: String?
 
-    static var debugCalled = 0
+    nonisolated(unsafe) static var debugCalled = 0
     static func debug(_ message: @autoclosure () -> Any, file: String, function: String, line: Int, context: Any?) {
         debugCalled += 1
         savedMessage = "\(message())"
     }
 
-    static var infoCalled = 0
+    nonisolated(unsafe) static var infoCalled = 0
     static func info(_ message: @autoclosure () -> Any, file: String, function: String, line: Int, context: Any?) {
         infoCalled += 1
         savedMessage = "\(message())"
     }
 
-    static var warningCalled = 0
+    nonisolated(unsafe) static var warningCalled = 0
     static func warning(_ message: @autoclosure () -> Any, file: String, function: String, line: Int, context: Any?) {
         warningCalled += 1
         savedMessage = "\(message())"
     }
 
-    static var errorCalled = 0
+    nonisolated(unsafe) static var errorCalled = 0
     static func error(_ message: @autoclosure () -> Any, file: String, function: String, line: Int, context: Any?) {
         errorCalled += 1
         savedMessage = "\(message())"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13481)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29301)

## :bulb: Description
Turn on CommonLibrary Tests in BrowserKit. 
Warnings:
<img width="964" height="1236" alt="Screenshot 2025-10-02 at 8 03 09 PM" src="https://github.com/user-attachments/assets/73f589e2-deeb-48f2-84fb-875eef84bd6d" />
<img width="960" height="505" alt="Screenshot 2025-10-02 at 8 03 22 PM" src="https://github.com/user-attachments/assets/b6ed6b33-7466-41e3-86a9-8bf75c390689" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
