### PR TITLE
Bugfix FXIOS-13713 [Homepage Redesign] Incorrect homepage layout when shortcuts are disabled

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Layout/HomepageSectionLayoutProvider.swift
@@ -524,7 +524,8 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
     /// Creates a "dummy" top sites section and returns its height
     private func getShortcutsSectionHeight(environment: NSCollectionLayoutEnvironment) -> CGFloat {
-        guard let state = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID) else { return 0 }
+        guard let state = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID),
+                  state.topSitesState.shouldShowSection else { return 0 }
         var totalHeight: CGFloat = 0
         let topSitesState = state.topSitesState
         let maxRows = topSitesState.numberOfRows


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13713)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29751)

## :bulb: Description
- Push the stories/search bar to the bottom of the redesigned homepage by ignoring the shortcuts section in the spacer calculation when shortcuts are disabled

## :movie_camera: Demos
| Before | After |
| - | - |
| <img width="1206" height="2622" alt="simulator_screenshot_3F399380-1018-4486-9E44-5F3B77ADB690" src="https://github.com/user-attachments/assets/e6e5345b-4c75-4436-9b57-1382b13bfa85" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2025-10-02 at 19 44 39" src="https://github.com/user-attachments/assets/e404daf3-29f0-439a-bd40-7c59d6ca032a" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
