### PR TITLE
Refactor FXIOS-13481 [Swift 6 Migration] Turn on Concurrency for MenuKitTests in BrowserKit

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -174,7 +174,11 @@ let package = Package(
             ]),
         .testTarget(
             name: "MenuKitTests",
-            dependencies: ["MenuKit"]),
+            dependencies: ["MenuKit"],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
         .target(
             name: "SummarizeKit",
             dependencies: [

--- a/BrowserKit/Tests/MenuKitTests/MenuMainViewTests.swift
+++ b/BrowserKit/Tests/MenuKitTests/MenuMainViewTests.swift
@@ -5,18 +5,19 @@
 import XCTest
 @testable import MenuKit
 
+@MainActor
 final class MenuMainViewTests: XCTestCase {
     var menuView: MenuMainView!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         menuView = MenuMainView()
         menuView.frame = CGRect(x: 0, y: 0, width: 375, height: 812)
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         menuView = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testShouldNotDisplayBanner_onSiteMenu() {

--- a/BrowserKit/Tests/MenuKitTests/MenuTableViewHelperTests.swift
+++ b/BrowserKit/Tests/MenuKitTests/MenuTableViewHelperTests.swift
@@ -10,16 +10,16 @@ final class MenuTableViewHelperTests: XCTestCase {
     var tableView: UITableView!
     var helper: MenuTableViewHelper!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         tableView = UITableView()
         helper = MenuTableViewHelper(tableView: tableView)
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         tableView = nil
         helper = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testReload_withMenuData() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13481)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29301)

## :bulb: Description
Turn on strict concurrency for MenuKitTests
Warnings
<img width="815" height="748" alt="Screenshot 2025-10-02 at 6 33 36 PM" src="https://github.com/user-attachments/assets/bb2f48d4-95d8-4889-aef6-2538b8a5c4d1" />

cc: @lmarceau @Cramsden 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
