### PR TITLE
Refactor FXIOS-13656 [Localization] Change OpenTabsWidget string to an existing string from widgets

### DIFF
--- a/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/firefox-ios/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -111,7 +111,7 @@ struct OpenTabsView: View {
         HStack(alignment: .center, spacing: 15) {
             Image(decorative: StandardImageIdentifiers.Small.externalLink)
                 .foregroundColor(Color("openTabsContentColor"))
-            Text("Open Firefox")
+            Text(String.OpenFirefoxLabel)
                 .foregroundColor(Color("openTabsContentColor"))
                 .lineLimit(1)
                 .font(.system(size: 13, weight: .semibold, design: .default))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13656)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29624)

## :bulb: Description
Fix that `OpenTabsWidget` is using a `Text("")` string. I found a string that works IMO since it's from the widget as well. This will be way simpler than waiting 2 months for that one string.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
