### PR TITLE
Bugfix FXIOS-13757 - Firefox crashes when opening a sent tab from the "Tab received" notification

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
+++ b/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
@@ -73,7 +73,7 @@ extension AppDelegate {
     }
 }
 
-extension AppDelegate: UNUserNotificationCenterDelegate {
+extension AppDelegate: @MainActor UNUserNotificationCenterDelegate {
     // Called when the user taps on a notification while in background.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13757)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29819)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### Root Cause
The `userNotificationCenter(_:didReceive:)` method was marked as `nonisolated`, which told Swift to run it outside of the main actor's isolation domain. However, since `AppDelegate` is implicitly a `@MainActor` class:
- Thread safety conflict: Accessing notification content and UI-related properties from outside the main thread caused the crash.

### Solution
- Removed `nonisolated` and `await` keywords from the notification handling method.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
