### PR TITLE
Refactor FXIOS-13742 #29809 ⁃ [Glean] Migrate ShareTelemetryTests to use MockGleanWrapper instead

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
@@ -9,6 +9,8 @@ import XCTest
 
 final class ShareTelemetryTests: XCTestCase {
     private let testWebURL = URL(string: "https://mozilla.org")!
+    var gleanWrapper: MockGleanWrapper!
+    typealias EventExtrasType = GleanMetrics.ShareSheet.SharedToExtra
 
     // For telemetry extras
     let activityIdentifierKey = "activity_identifier"
@@ -17,15 +19,17 @@ final class ShareTelemetryTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        // Due to changes allow certain custom pings to implement their own opt-out
-        // independent of Glean, custom pings may need to be registered manually in
-        // tests in order to put them in a state in which they can collect data.
-        Glean.shared.registerPings(GleanMetrics.Pings.shared)
-        Glean.shared.resetGlean(clearStores: true)
+        gleanWrapper = MockGleanWrapper()
+    }
+
+    override func tearDown() {
+        gleanWrapper = nil
+        super.tearDown()
     }
 
     func testSharedTo_withNoActivityType() throws {
         let subject = createSubject()
+        let event = GleanMetrics.ShareSheet.sharedTo
         let testActivityType: UIActivity.ActivityType? = nil
         let testShareType: ShareType = .site(url: testWebURL)
         let testHasShareMessage = true
@@ -36,16 +40,19 @@ final class ShareTelemetryTests: XCTestCase {
             hasShareMessage: testHasShareMessage
         )
 
-        testEventMetricRecordingSuccess(metric: GleanMetrics.ShareSheet.sharedTo)
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
 
-        let resultValue = try XCTUnwrap(GleanMetrics.ShareSheet.sharedTo.testGetValue())
-        XCTAssertEqual(resultValue[0].extra?[activityIdentifierKey], "unknown")
-        XCTAssertEqual(resultValue[0].extra?[shareTypeKey], testShareType.typeName)
-        XCTAssertEqual(resultValue[0].extra?[hasShareMessageKey], String(testHasShareMessage))
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.activityIdentifier, "unknown")
+        XCTAssertEqual(savedExtras.shareType, testShareType.typeName)
+        XCTAssertEqual(savedExtras.hasShareMessage, testHasShareMessage)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
     func testSharedTo_withActivityType() throws {
         let subject = createSubject()
+        let event = GleanMetrics.ShareSheet.sharedTo
         let testActivityType = UIActivity.ActivityType("com.some.activity.identifier")
         let testShareType: ShareType = .site(url: testWebURL)
         let testHasShareMessage = true
@@ -56,26 +63,30 @@ final class ShareTelemetryTests: XCTestCase {
             hasShareMessage: testHasShareMessage
         )
 
-        testEventMetricRecordingSuccess(metric: GleanMetrics.ShareSheet.sharedTo)
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
 
-        let resultValue = try XCTUnwrap(GleanMetrics.ShareSheet.sharedTo.testGetValue())
-        XCTAssertEqual(resultValue[0].extra?[activityIdentifierKey], testActivityType.rawValue)
-        XCTAssertEqual(resultValue[0].extra?[shareTypeKey], testShareType.typeName)
-        XCTAssertEqual(resultValue[0].extra?[hasShareMessageKey], String(testHasShareMessage))
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.activityIdentifier, testActivityType.rawValue)
+        XCTAssertEqual(savedExtras.shareType, testShareType.typeName)
+        XCTAssertEqual(savedExtras.hasShareMessage, testHasShareMessage)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
+    // MARK: - Deeplink test
     func testRecordOpenDeeplinkTime_whenSendRecord_returnTimeGreaterThenZero() async throws {
         let subject = createSubject()
-
         subject.recordOpenDeeplinkTime()
         // simulate startup time
         try await Task.sleep(nanoseconds: 1_000)
         subject.sendOpenDeeplinkTimeRecord()
 
-        let metric = GleanMetrics.Share.deeplinkOpenUrlStartupTime
-        let recordedTime = try XCTUnwrap(metric.testGetValue()?.sum)
+        let event = GleanMetrics.Share.deeplinkOpenUrlStartupTime
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.last as? TimingDistributionMetricType)
 
-        XCTAssertGreaterThan(recordedTime, 0)
+        XCTAssertEqual(gleanWrapper.stopAndAccumulateCalled, 1)
+        XCTAssertEqual(gleanWrapper.savedEvents.count, 2)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
     func testRecordOpenDeeplinkTime_whenRecordCancelled_returnNilMetric() async throws {
@@ -86,12 +97,17 @@ final class ShareTelemetryTests: XCTestCase {
         try await Task.sleep(nanoseconds: 1_000)
         subject.cancelOpenURLTimeRecord()
 
-        let metric = GleanMetrics.Share.deeplinkOpenUrlStartupTime
+        let event = GleanMetrics.Share.deeplinkOpenUrlStartupTime
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.last as? TimingDistributionMetricType)
 
-        XCTAssertNil(metric.testGetValue())
+        XCTAssertEqual(gleanWrapper.cancelTimingCalled, 1)
+        XCTAssertEqual(gleanWrapper.savedEvents.count, 2)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
     func createSubject() -> ShareTelemetry {
-        return ShareTelemetry()
+        let subject = ShareTelemetry(gleanWrapper: gleanWrapper)
+        trackForMemoryLeaks(subject)
+        return subject
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13742)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29809)

## :bulb: Description
Refactor ShareTelemetryTest to use MockGleanWrapper

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
