### PR TITLE
Bugfix FXIOS-13645 [Terms of Use] Incorrect text color after changing the theme

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
@@ -330,6 +330,11 @@ final class TermsOfUseViewController: UIViewController,
         acceptButton.tintColor = currentTheme().colors.textOnDark
         acceptButton.backgroundColor = currentTheme().colors.actionPrimary
         remindMeLaterButton.setTitleColor(currentTheme().colors.actionPrimary, for: .normal)
+        descriptionTextView.linkTextAttributes = [
+            .foregroundColor: currentTheme().colors.textAccent,
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+        descriptionTextView.attributedText = makeAttributedDescription()
     }
 
     private func currentTheme() -> Theme {


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13645)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29610)

## :bulb: Description
This PR solves the bug that appeared after the theme is changed from settings, when the description text from Terms of Use bottom sheet does not update the color instantly. After this PR, the text color will be updated immediately after the theme change. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
