### PR TITLE
Bugfix FXIOS-13543 ⁃ [iOS 26][iPad] Tab name bar color differs from the rest of the toolbar

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -216,10 +216,10 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
         if isToolbarRefactorEnabled,
            let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID),
            toolbarState.isTranslucent {
-            view.backgroundColor = colors.layerSurfaceLow.withAlphaComponent(toolbarHelper.backgroundAlpha())
+            view.backgroundColor = .clear
             collectionView.backgroundColor = .clear
         } else {
-            view.backgroundColor = colors.layer3
+            view.backgroundColor = .clear
             collectionView.backgroundColor = view.backgroundColor
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13543)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29439)

## :bulb: Description
Added .clear background

## :movie_camera: Demos
<img width="2064" height="2752" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-10-07 at 15 42 10" src="https://github.com/user-attachments/assets/42235a4a-e870-4047-bf39-68ac31d13c38" />
<img width="2064" height="2752" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-10-07 at 16 32 27" src="https://github.com/user-attachments/assets/fc9bd6e2-5786-47f7-9f7d-24b6edcb84dd" />



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
