### PR TITLE
Refactor #29808 ⁃ [Glean] Migrate TabsTelemetry to use the GleanWrapper instead

### DIFF
--- a/firefox-ios/Client/Telemetry/TabsTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabsTelemetry.swift
@@ -17,12 +17,12 @@ final class TabsTelemetry {
     }
 
     func startTabSwitchMeasurement() {
-        tabSwitchTimerId = GleanMetrics.Tabs.tabSwitch.start()
+        tabSwitchTimerId = gleanWrapper.startTiming(for: GleanMetrics.Tabs.tabSwitch)
     }
 
     func stopTabSwitchMeasurement() {
         guard let timerId = tabSwitchTimerId else { return }
-        GleanMetrics.Tabs.tabSwitch.stopAndAccumulate(timerId)
+        gleanWrapper.stopAndAccumulateTiming(for: GleanMetrics.Tabs.tabSwitch, timerId: timerId)
         tabSwitchTimerId = nil
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabsTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabsTelemetryTests.swift
@@ -10,32 +10,51 @@ import Common
 
 // TODO: FXIOS-13742 - Migrate TabsTelemetryTests to use mock telemetry or GleanWrapper
 class TabsTelemetryTests: XCTestCase {
-    var profile: Profile!
-    var inactiveTabsManager: MockInactiveTabsManager!
+    var gleanWrapper: MockGleanWrapper!
 
     override func setUp() {
         super.setUp()
-
-        profile = MockProfile()
-        inactiveTabsManager = MockInactiveTabsManager()
-        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
-        setupTelemetry(with: profile)
+        gleanWrapper = MockGleanWrapper()
     }
 
     override func tearDown() {
-        profile = nil
-        tearDownTelemetry()
+        gleanWrapper = nil
         super.tearDown()
     }
 
     func testTabSwitchMeasurement() throws {
-        let subject = TabsTelemetry()
+        let subject = createSubject()
 
         subject.startTabSwitchMeasurement()
         subject.stopTabSwitchMeasurement()
 
-        let resultValue = try XCTUnwrap(GleanMetrics.Tabs.tabSwitch.testGetValue())
-        XCTAssertEqual(1, resultValue.count, "Should have been measured once")
-        XCTAssertEqual(0, GleanMetrics.Tabs.tabSwitch.testGetNumRecordedErrors(.invalidValue))
+        let event = GleanMetrics.Tabs.tabSwitch
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.last as? TimingDistributionMetricType)
+
+        XCTAssertEqual(gleanWrapper.stopAndAccumulateCalled, 1)
+        XCTAssertEqual(gleanWrapper.savedEvents.count, 2)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+
+    func testrackConsecutiveCrashTelemetry() throws {
+        let subject = createSubject()
+        let numberOfCrash: UInt = 2
+        typealias EventExtrasType = GleanMetrics.Webview.ProcessDidTerminateExtra
+        let event = GleanMetrics.Webview.processDidTerminate
+
+        subject.trackConsecutiveCrashTelemetry(attemptNumber: numberOfCrash)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.consecutiveCrash, Int32(numberOfCrash))
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+
+    private func createSubject() -> TabsTelemetry {
+        let subject = TabsTelemetry(gleanWrapper: gleanWrapper)
+        trackForMemoryLeaks(subject)
+        return subject
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13743)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29808)

## :bulb: Description
- Migrate code and test to use glean wrapper
- Add test for missing call

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
