### PR TITLE
Bugfix FXIOS-13780 [Terms of Use] User is not immediately enrolled after accepting ToU

### DIFF
--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -215,6 +215,10 @@ final class LaunchCoordinator: BaseCoordinator,
             manager.setAccepted(acceptedDate: acceptedDate)
             TermsOfServiceTelemetry().termsOfServiceAcceptButtonTapped(acceptedDate: acceptedDate)
 
+            // Refresh Nimbus enrollment after ToU acceptance
+            Experiments.shared.fetchExperiments()
+            _ = Experiments.shared.applyPendingExperiments()
+
             let sendTechnicalData = profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
             let sendStudies = profile.prefs.boolForKey(AppConstants.prefStudiesToggle) ?? true
             manager.shouldSendTechnicalData(telemetryValue: sendTechnicalData, studiesValue: sendStudies)

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
@@ -74,6 +74,10 @@ class TermsOfUseMiddleware {
 
         // Record telemetry for ToU acceptance
         telemetry.termsOfUseAcceptButtonTapped(surface: .bottomSheet, acceptedDate: acceptedDate)
+
+        // Refresh Nimbus enrollment after ToU acceptance
+        Experiments.shared.fetchExperiments()
+        _ = Experiments.shared.applyPendingExperiments()
     }
 
     private func recordImpression() {


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13780)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13781)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29855)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29856)

## :bulb: Description
This PR solves these issues related to user enrollment after accepting Terms of Use during onboarding. The issue was that after user accepts the Terms of Use, he is still enrolled in ToU not accepted test and is not enrolled in ToU accepted test. This PR updates the experiment immediately so the change will be reflected after acceptance instantly, no need to relaunch the app.
#29855 ⁃ [Experiment] The client is enrolled in the “iOS ToU not accepted test” experiment in the first browsing session after accepting the terms of use from the TOU Onboarding tour
#29856 ⁃ [Experiment] The client is not enrolled in the “iOS ToU accepted test” experiment in the first browsing session after accepting the terms of use from the TOU Onboarding tour

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If creating backport, please ensure you've followed the [uplift request process](https://github.com/mozilla-mobile/firefox-ios/wiki/Requesting-an-uplift-to-a-release-branch). 

