### PR TITLE
Refactor FXIOS-13808 [Danger] Update danger release check

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -10,15 +10,19 @@ import Foundation
 let danger = Danger()
 let standardImageIdentifiersPath = "./BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift"
 
-checkReleaseBranch()
-checkStringsFile()
-checkForFunMetrics()
-checkAlphabeticalOrder(inFile: standardImageIdentifiersPath)
-checkForWebEngineFileChange()
-CodeUsageDetector().checkForCodeUsage()
-CodeCoverageGate().failOnNewFilesWithoutCoverage()
-BrowserViewControllerChecker().failsOnAddedExtension()
-checkCodeCoverage()
+let releaseCheck = ReleaseBranchCheck()
+if releaseCheck.isReleaseBranch {
+    releaseCheck.postReleaseBranchComment()
+} else {
+    checkStringsFile()
+    checkForFunMetrics()
+    checkAlphabeticalOrder(inFile: standardImageIdentifiersPath)
+    checkForWebEngineFileChange()
+    CodeUsageDetector().checkForCodeUsage()
+    CodeCoverageGate().failOnNewFilesWithoutCoverage()
+    BrowserViewControllerChecker().failsOnAddedExtension()
+    checkCodeCoverage()
+}
 
 // Add some fun comments in Danger to have positive feedback on PRs
 func checkForFunMetrics() {
@@ -536,9 +540,14 @@ func commentDescriptionSection(desc: String) {
     }
 }
 
-func checkReleaseBranch() {
-    if danger.github.pullRequest.base.ref.hasPrefix("release/") {
+struct ReleaseBranchCheck {
+    var isReleaseBranch: Bool {
+        danger.github.pullRequest.base.ref.hasPrefix("release/")
+    }
+
+    func postReleaseBranchComment() -> Bool {
         markdown("""
+        # ‼️ ATTENTION ‼️
         ### 🎯 This PR targets a **release branch**.
         Please ensure you've followed the [uplift request process](https://github.com/mozilla-mobile/firefox-ios/wiki/Requesting-an-uplift-to-a-release-branch).
         """)

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -545,7 +545,7 @@ struct ReleaseBranchCheck {
         danger.github.pullRequest.base.ref.hasPrefix("release/")
     }
 
-    func postReleaseBranchComment() -> Bool {
+    func postReleaseBranchComment() {
         markdown("""
         # ‼️ ATTENTION ‼️
         ### 🎯 This PR targets a **release branch**.

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -29,5 +29,4 @@
 - [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
 - [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
 - [ ] If needed, I updated documentation and added comments to complex code
-- [ ] If creating backport, please ensure you've followed the [uplift request process](https://github.com/mozilla-mobile/firefox-ios/wiki/Requesting-an-uplift-to-a-release-branch). 
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13808)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29905)

## :bulb: Description
The release check will be really hard to miss 😆 That should work. And I remove the checklist from the PR template
<img width="450" height="175" alt="Screenshot 2025-10-08 at 9 46 46 AM" src="https://github.com/user-attachments/assets/7cd6c16f-6f74-40c9-912f-91d48391e4cf" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If creating backport, please ensure you've followed the [uplift request process](https://github.com/mozilla-mobile/firefox-ios/wiki/Requesting-an-uplift-to-a-release-branch). 

