### PR TITLE
Fix FXiOS-12300 [Tab Optimization] Only persist tab data after tabs have been removed

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -251,19 +251,31 @@ class TabManagerImplementation: NSObject,
                                                 restorePosition: tabs.firstIndex(of: tab),
                                                 isSelected: selectedTab?.tabUUID == tab.tabUUID)
         }
+
+        // Backup tabs for tab undo, this is not a feature on iPhone but is on iPad
         backupCloseTabs = tabs
 
-        for (index, tab) in currentModeTabs.enumerated() {
+        // Scroll position for most tabs has been stored via session data when we navigate away,
+        // but we need to save the selected tabs session data to persist scroll position
+        saveSessionData(forTab: selectedTab)
+
+        for tab in currentModeTabs {
+            // Remove each tab without persisting changes
             self.removeTab(tab, flushToDisk: false)
             if tab == currentModeTabs.last {
-                self.updateSelectedTabAfterRemovalOf(tab, deletedIndex: index)
+                // Select tab calls preserve tabs so we don't need to call it again
+                if tab.isPrivate,
+                   let mostRecentActiveTab = mostRecentTab(inTabs: normalActiveTabs) {
+                    // We remove all private tabs so select most recent normal tab
+                    selectTab(mostRecentActiveTab)
+                } else {
+                    // For normal tabs create a new tab and select it
+                    selectTab(addTab())
+                }
             }
         }
         // Save the tab state that existed prior to removals (preserves original selected tab)
         backupCloseTab = currentSelectedTab
-
-        // Persist changes after tabs have been removed
-        commitChanges()
     }
 
     /// Remove a tab, will notify delegate of the tab removal


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13352)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29046)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12300)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26786)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Clean up remove tab logic so we are only doing the necessary tab persistence. Everywhere in the tab manager code we are persisting data more times than we need to. We should not need to re-select the tab and persist tab session data for each tab we remove. 

This update:
1. Save backup tab data for undo tab deletion (only available on iPad)
2. Persists tab session data for currently selected tab to maintain scroll position updates
3. Loop through current version tabs and delete them
4. If you are in private mode update selected tab to current recently selected normal tab
5. If you are not in private mode create a new tab and select it

There is no need to commit changes after this because select tab preserves tabs

With 200 tabs this greatly increases the tab performance.

`TabManager.removeAllTabs`
Before: 5.15 s  37.7%
After: 41.00 ms   3.4%

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

