### PR TITLE
Bugfix MTE-4932 Address bar for sync integration tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -280,8 +280,6 @@ class IntegrationTests: FeatureFlaggedTestBase {
 
     func testFxADisconnectConnect() {
         app.launch()
-        waitForTabsButton()
-        navigator.nowAt(HomePanelsScreen)
         // Sign into Mozilla Account
         signInFxAccounts()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4932)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

The sync integration tests are failing on the Xcodebuild side due to the keyboard does not show up when the browser is opened:
```
    t =     3.31s Open org.mozilla.ios.Fennec
    t =     3.31s     Launch org.mozilla.ios.Fennec
    t =     7.76s         Setting up automation session
    t =     9.02s         Wait for org.mozilla.ios.Fennec to idle
    t =    13.33s Checking `Expect predicate `exists == 1` for object "AddressToolbar.address" TextField`
    t =    13.33s     Checking existence of `"AddressToolbar.address" TextField`
    t =    13.38s     Capturing element debug description
```
The `navigation.nowAt` ensure that the test does not look for the "Cancel" button to close the keyboard.

Note that this PR does not make the tests to pass right away. It's just a step. There are some ongoing issue in sync.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

