### PR TITLE
Bugfix FXIOS-13811 #29909 ⁃ [TabScrollController refactor] Toolbar doesn't hide when reader bar is shown

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabScrollHandlerDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabScrollHandlerDelegate.swift
@@ -162,7 +162,7 @@ extension BrowserViewController: TabScrollHandler.Delegate {
         }
    }
 
-    // refers to reader mode bar and findInPage
+    // Checks if minimal address bar is enabled and tab is on reader mode bar or findInPage
     private var shouldSendAlphaChangeAction: Bool {
         guard let tab = tabManager.selectedTab,
               let tabURL = tab.url else { return false }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13811)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29909)

## :bulb: Description
- Fix bug where toolbar is not collapsed if reader mode bar is visible 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

