### PR TITLE
Bugfix FXIOS-13764 [New first run onboarding][iOS 26] Incomplete title on Toolbar placement card

### DIFF
--- a/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingBasicCardViewCompact.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingBasicCardViewCompact.swift
@@ -79,6 +79,7 @@ struct OnboardingBasicCardViewCompact<ViewModel: OnboardingCardInfoModelProtocol
             .if(sizeCategory <= .large) { view in
                 view.frame(minHeight: UX.CardView.titleAlignmentMinHeightPadding, alignment: .topLeading)
             }
+            .fixedSize(horizontal: false, vertical: true)
     }
 
     @ViewBuilder

--- a/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingMultipleChoiceCardViewCompact.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingMultipleChoiceCardViewCompact.swift
@@ -93,6 +93,7 @@ struct OnboardingMultipleChoiceCardViewCompact<ViewModel: OnboardingCardInfoMode
             .if(sizeCategory <= .extraExtraLarge) { view in
                 view.frame(height: UX.CardView.titleAlignmentMinHeightPadding, alignment: .topLeading)
             }
+            .fixedSize(horizontal: false, vertical: true)
     }
 
     var primaryButton: some View {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13764)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29827)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR addresses an issue where the title on the Toolbar placement card during the new first run onboarding flow was incomplete or truncated on iOS 26. The bug was affecting user clarity and overall onboarding experience.

Navigate to firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
Change enableModernUi: false to enableModernUi: true
This enables the new SwiftUI-based onboarding framework

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

