### PR TITLE
Bugfix FXIOS-13205 [New first run onboarding] The onboarding flow is not continued after setting FF as a default browser

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingService.swift
@@ -107,8 +107,9 @@ final class OnboardingService: FeatureFlaggable {
                     buttonAction: popupViewModel.buttonAction,
                     a11yIdRoot: popupViewModel.a11yIdRoot
                 )
-            )
-            completion(.success(.none))
+            ) {
+                completion(.success(.advance(numberOfPages: 1)))
+            }
 
         case .readPrivacyPolicy:
             guard let infoModel = cards
@@ -188,8 +189,11 @@ final class OnboardingService: FeatureFlaggable {
         defaultApplicationHelper.openSettings()
     }
 
-    private func handleOpenInstructionsPopup(from popupViewModel: OnboardingDefaultBrowserModelProtocol) {
-        presentDefaultBrowserPopup(from: popupViewModel) {}
+    private func handleOpenInstructionsPopup(
+        from popupViewModel: OnboardingDefaultBrowserModelProtocol,
+        completion: @escaping () -> Void
+    ) {
+        presentDefaultBrowserPopup(from: popupViewModel, completion: completion)
     }
 
     private func handleReadPrivacyPolicy(from url: URL, completion: @escaping () -> Void) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28735)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR fixes an issue where the new first run onboarding flow does not continue after setting Firefox as the default browser. It ensures that users are properly guided through the onboarding process without interruption following the default browser prompt.

Navigate to firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
Change enableModernUi: false to enableModernUi: true
This enables the new SwiftUI-based onboarding framework

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

