### PR TITLE
Refactor FXIOS-13817 - Move home/plus button setting to Address Bar section

### DIFF
--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -160,9 +160,7 @@ final class SettingsCoordinator: BaseCoordinator,
 
         case .theme:
             if themeManager.isNewAppearanceMenuOn {
-                let appearanceView = AppearanceSettingsView(windowUUID: windowUUID,
-                                                            delegate: self,
-                                                            prefs: profile.prefs)
+                let appearanceView = AppearanceSettingsView(windowUUID: windowUUID, delegate: self)
                 return UIHostingController(rootView: appearanceView)
             } else {
                 return ThemeSettingsController(windowUUID: windowUUID)
@@ -198,7 +196,13 @@ final class SettingsCoordinator: BaseCoordinator,
         case .toolbar:
             let viewModel = SearchBarSettingsViewModel(prefs: profile.prefs)
             return LegacyFeatureFlagsManager.shared.isFeatureEnabled(.addressBarMenu, checking: .buildOnly)
-               ? UIHostingController(rootView: AddressBarSettingsView(windowUUID: windowUUID, viewModel: viewModel))
+            ? UIHostingController(
+                rootView: AddressBarSettingsView(
+                    windowUUID: windowUUID,
+                    viewModel: viewModel,
+                    prefs: profile.prefs
+                )
+            )
                : SearchBarSettingsViewController(viewModel: viewModel, windowUUID: windowUUID)
 
         case .topSites:
@@ -400,7 +404,8 @@ final class SettingsCoordinator: BaseCoordinator,
             let viewController = UIHostingController(
                 rootView: AddressBarSettingsView(
                 windowUUID: windowUUID,
-                viewModel: viewModel))
+                viewModel: viewModel,
+                prefs: profile.prefs))
             viewController.title = .Settings.AddressBar.AddressBarMenuTitle
             router.push(viewController)
         } else {
@@ -416,9 +421,7 @@ final class SettingsCoordinator: BaseCoordinator,
         store.dispatchLegacy(action)
 
         if themeManager.isNewAppearanceMenuOn {
-            let appearanceView = AppearanceSettingsView(windowUUID: windowUUID,
-                                                        delegate: self,
-                                                        prefs: profile.prefs)
+            let appearanceView = AppearanceSettingsView(windowUUID: windowUUID, delegate: self)
             let viewController = UIHostingController(rootView: appearanceView)
             viewController.title = .SettingsAppearanceTitle
             router.push(viewController)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13817)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29936)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- This PR move the home/plus button setting to Address Bar section.
- This is the PR with that initially added the setting in `Appearance` section: https://github.com/mozilla-mobile/firefox-ios/pull/29643/files#diff-67b1572b0625a4fea4b857e045bc2dd3f4699a7ebe633d3a864f196796e2a378.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| ![appearanceSection](https://github.com/user-attachments/assets/46f87cac-5630-43d4-b886-3026dc0df117) |![addressBarSection](https://github.com/user-attachments/assets/0d325f53-124a-4591-8ed1-e06fc9598300)| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

