### PR TITLE
Add FXIOS-13796 [Translations] CFR strings for v145

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -354,8 +354,8 @@ extension String {
             public static let Title = MZLocalizedString(
                 key: "ContextualHints.Translations.Title.v145",
                 tableName: "ContextualHints",
-                value: "Firefox Speaks Your Language",
-                comment: "Contextual hints are little popups that appear for the users informing them of new features. This is the title of one that points the user to the new translation icon on the toolbar.")
+                value: "%@ Speaks Your Language",
+                comment: "Contextual hints are little popups that appear for the users informing them of new features. This is the title of one that points the user to the new translation icon on the toolbar. %@ is the app name (e.g. Firefox).")
             public static let Body = MZLocalizedString(
                 key: "ContextualHints.Translations.Body.v145",
                 tableName: "ContextualHints",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29883)

## :bulb: Description
This pull request adds additional strings for the new translations feature, specifically for the CFR. 

See details here: https://www.figma.com/design/JjSXAmHbsRNo2kjZIjETVK/iOS-Translations?node-id=1017-16157&m=dev

<img width="350" height="303" alt="image" src="https://github.com/user-attachments/assets/04c11494-a442-4924-a293-1c827cc13e49" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

