### PR TITLE
Refactor FXIOS-13821 [CredentialProvider] Change CredentialProvider Display Name

### DIFF
--- a/firefox-ios/CredentialProvider/Info.plist
+++ b/firefox-ios/CredentialProvider/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>CredentialProvider</string>
+	<string>$(MOZ_BUNDLE_DISPLAY_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13821)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29947)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

This changes the `CFBundleDisplayName` value from `CredentialProvider` to `$(MOZ_BUNDLE_DISPLAY_NAME)` which should fix the issue where password autofill in iOS 26 would show "CredntialProvider" instead of "Firefox" in the bottom sheet in Safari (for screenshots see #29947).

I chose the `MOZ_BUNDLE_DISPLAY_NAME` variable because it is already used in other `Info.plist` files for `CFBundleDisplayName`.
https://github.com/mozilla-mobile/firefox-ios/blob/a6f336d375b62bd1eb3b06c7fa1b3645de75555b/firefox-ios/Extensions/ShareTo/Info.plist#L7-L8

Its value will be "Firefox" or similar, depending on the build configuration:
https://github.com/mozilla-mobile/firefox-ios/blob/a6f336d375b62bd1eb3b06c7fa1b3645de75555b/firefox-ios/Client/Configuration/Firefox.xcconfig#L9

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

