### PR TITLE
Bugfix MTE-4937 Flaky testZoomingActionsLandscape_tabTrayExperimentOff

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
@@ -215,8 +215,8 @@ final class ZoomingTests: FeatureFlaggedTestBase {
 
         app.swipeUp()
         app.swipeUp()
-        app.swipeDown()
-        app.swipeDown()
+        app.webViews.firstMatch.swipeDown()
+        app.webViews.firstMatch.swipeDown()
         zoomBar.tapZoomIn()
         zoomBar.assertZoomPercent("75%")
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4937)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
`testZoomingActionsLandscape_tabTrayExperimentOff` because the zoom bar may not appear after swiping up and down the page. The swipe gesture may start from the edge of the screen.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

