### PR TITLE
Bugfix MTE-4938 Flaky ShareLongPressTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
@@ -271,6 +271,7 @@ class ShareLongPressTests: FeatureFlaggedTestBase {
         app.tables["Context Menu"].buttons["shareLarge"].waitAndTap()
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.collectionViews.cells[option])
+            mozWaitElementHittable(element: app.collectionViews.cells[option], timeout: 10)
             app.collectionViews.cells[option].tapOnApp()
         } else {
             app.buttons[option].waitAndTap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4938)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The “Share” options may be tapped too early. This line does not check if the option is hittable or not.

https://github.com/mozilla-mobile/firefox-ios/blob/main/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift#L273

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

