### PR TITLE
Bugfix Bugzilla-1993664 - [Swipe Tabs] - Swiping tabs quickly results in the transition animation twice

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2655,7 +2655,6 @@ class BrowserViewController: UIViewController,
     private func handleNavigationActions(for state: BrowserViewControllerState) {
         guard let navigationState = state.navigateTo else { return }
         updateZoomPageBarVisibility(visible: false)
-        webPagePreview.isHidden = true
 
         switch navigationState {
         case .home:


### PR DESCRIPTION

## :scroll: Tickets
[Bugzilla Issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1993664)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### Problem
- Previously, if a user lifted their finger during a tab swipe gesture and then put it back down, the gesture would continue to respond to movement. This created an inconsistent and potentially confusing user experience during tab navigation.

### Solution
- This PR prevents the address bar pan gesture from continuing to respond to touch changes after the user lifts their finger during a swipe, until the gesture reaches its final state and the transition completed.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

https://github.com/user-attachments/assets/712f18bd-e610-4793-9e97-12ddd0760337

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

