### PR TITLE
Bugfix FXIOS-13732 [New first run onboarding] [Accesibility] Weird display of Set as default browser and Start syncing buttons with larger text

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/SwiftUI/OnboardingButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/SwiftUI/OnboardingButton.swift
@@ -43,6 +43,7 @@ public struct OnboardingButton: View {
         Button(action: action) {
             Text(title)
                 .font(.headline)
+                .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: width ?? .infinity)
                 .foregroundColor(foregroundColor)
         }

--- a/BrowserKit/Sources/OnboardingKit/Views/Common/DragCancellablePrimaryButton.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Common/DragCancellablePrimaryButton.swift
@@ -22,6 +22,7 @@ struct DragCancellablePrimaryButton: View {
             .padding(.vertical, UX.DragCancellableButton.verticalPadding)
             .padding(.horizontal, UX.DragCancellableButton.horizontalPadding)
             .frame(maxWidth: .infinity)
+            .fixedSize(horizontal: false, vertical: true)
             .background(
                 Group {
                     if #available(iOS 26.0, *) {

--- a/BrowserKit/Sources/OnboardingKit/Views/Common/DragCancellableSecondaryButton.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Common/DragCancellableSecondaryButton.swift
@@ -22,6 +22,7 @@ struct DragCancellableSecondaryButton: View {
             .padding(.vertical, UX.DragCancellableButton.verticalPadding)
             .padding(.horizontal, UX.DragCancellableButton.horizontalPadding)
             .frame(maxWidth: .infinity)
+            .fixedSize(horizontal: false, vertical: true)
             .background(
                 Group {
                     if #available(iOS 26.0, *) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13732)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29787)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Fixed layout issues in the new first run onboarding where the "Set as default browser" and "Start syncing" buttons were displayed incorrectly when using larger accessibility text sizes. Updated UI constraints to improve button appearance and accessibility support.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<img height="400" alt="Simulator Screenshot - iPad (9th generation) - 2025-10-13 at 10 57 22" src="https://github.com/user-attachments/assets/06567208-5643-48d6-aa9a-b1ed18db9e37" />

<img height="400" alt="Simulator Screenshot - iPad (9th generation) - 2025-10-13 at 10 53 02" src="https://github.com/user-attachments/assets/a048c960-f427-44e9-b715-d3dd3fe50bd0" />

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

