### PR TITLE
Add FXIOS-29098 [Bookmarks] The Folder's name is visible

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -64,6 +64,8 @@ class OneLineTableViewCell: UITableViewCell,
     lazy var titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.textAlignment = .natural
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
     }
 
     private lazy var bottomSeparatorView: UIView = .build { separatorLine in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13386)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29098)

## Description
The PR makes The folder’s name is visible.



## Solution
<img width="302" height="656" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-14 at 13 02 25" src="https://github.com/user-attachments/assets/e9903587-2d56-4aee-a662-9e4aea2a43ab" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

