### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] MainActor ToolbarMiddleware

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -8,6 +8,7 @@ import ToolbarKit
 import SummarizeKit
 import Shared
 
+@MainActor
 final class ToolbarMiddleware: FeatureFlaggable {
     private let manager: ToolbarManager
     private let toolbarHelper: ToolbarHelperInterface
@@ -52,30 +53,16 @@ final class ToolbarMiddleware: FeatureFlaggable {
     }
 
     lazy var toolbarProvider: Middleware<AppState> = { state, action in
-        // TODO: FXIOS-12557 We assume that we are isolated to the Main Actor
-        // because we dispatch to the main thread in the store. We will want to
-        // also isolate that to the @MainActor to remove this.
-        guard Thread.isMainThread else {
-            self.logger.log(
-                "MessageCardMiddleware is not being called from the main thread!",
-                level: .fatal,
-                category: .tabs
-            )
-            return
-        }
-
-        MainActor.assumeIsolated {
-            if let action = action as? GeneralBrowserMiddlewareAction {
-                self.resolveGeneralBrowserMiddlewareActions(action: action, state: state)
-            } else if let action = action as? MicrosurveyPromptMiddlewareAction {
-                self.resolveMicrosurveyActions(windowUUID: action.windowUUID, actionType: action.actionType, state: state)
-            } else if let action = action as? MicrosurveyPromptAction {
-                self.resolveMicrosurveyActions(windowUUID: action.windowUUID, actionType: action.actionType, state: state)
-            } else if let action = action as? ToolbarMiddlewareAction {
-                self.resolveToolbarMiddlewareActions(action: action, state: state)
-            } else if let action = action as? ToolbarAction {
-                self.resolveToolbarActions(action: action, state: state)
-            }
+        if let action = action as? GeneralBrowserMiddlewareAction {
+            self.resolveGeneralBrowserMiddlewareActions(action: action, state: state)
+        } else if let action = action as? MicrosurveyPromptMiddlewareAction {
+            self.resolveMicrosurveyActions(windowUUID: action.windowUUID, actionType: action.actionType, state: state)
+        } else if let action = action as? MicrosurveyPromptAction {
+            self.resolveMicrosurveyActions(windowUUID: action.windowUUID, actionType: action.actionType, state: state)
+        } else if let action = action as? ToolbarMiddlewareAction {
+            self.resolveToolbarMiddlewareActions(action: action, state: state)
+        } else if let action = action as? ToolbarAction {
+            self.resolveToolbarActions(action: action, state: state)
         }
     }
 
@@ -111,7 +98,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
                 middleButton: middleButton,
                 windowUUID: uuid,
                 actionType: ToolbarActionType.didLoadToolbars)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case GeneralBrowserMiddlewareActionType.websiteDidScroll:
             guard let scrollOffset = action.scrollOffset else { return }
@@ -153,7 +140,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
             guard let toolbarState = state.screenState(ToolbarState.self, for: .toolbar, window: action.windowUUID)
             else { return }
             let action = ToolbarAction(windowUUID: action.windowUUID, actionType: ToolbarActionType.clearSearch)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
             toolbarTelemetry.clearSearchButtonTapped(isPrivate: toolbarState.isPrivateMode)
 
         case ToolbarMiddlewareActionType.didStartDragInteraction:
@@ -175,7 +162,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
                 windowUUID: action.windowUUID,
                 actionType: SearchEngineSelectionMiddlewareActionType.didClearAlternativeSearchEngine
             )
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case ToolbarActionType.didSubmitSearchTerm:
             // After a user submits a search term, we want to record it in our history storage via recent search provider
@@ -204,7 +191,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
         case .readerMode:
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.addToReadingListLongPressAction)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         default: break
         }
     }
@@ -219,13 +206,13 @@ final class ToolbarMiddleware: FeatureFlaggable {
             toolbarTelemetry.homeButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.goToHomepage)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .newTab:
             toolbarTelemetry.oneTapNewTabButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.addNewTab)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .qrCode:
             toolbarTelemetry.qrCodeButtonTapped(isPrivate: toolbarState.isPrivateMode)
@@ -233,24 +220,24 @@ final class ToolbarMiddleware: FeatureFlaggable {
             if toolbarState.addressToolbar.isEditing {
                 let toolbarAction = ToolbarAction(windowUUID: action.windowUUID,
                                                   actionType: ToolbarActionType.cancelEdit)
-                store.dispatchLegacy(toolbarAction)
+                store.dispatch(toolbarAction)
             }
 
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showQRcodeReader)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .back:
             toolbarTelemetry.backButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.navigateBack)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .forward:
             toolbarTelemetry.forwardButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.navigateForward)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .tabs:
             cancelEditMode(windowUUID: action.windowUUID)
@@ -258,14 +245,14 @@ final class ToolbarMiddleware: FeatureFlaggable {
             toolbarTelemetry.tabTrayButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showTabTray)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .trackingProtection:
             toolbarTelemetry.siteInfoButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(buttonTapped: action.buttonTapped,
                                               windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showTrackingProtectionDetails)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .menu:
             cancelEditMode(windowUUID: action.windowUUID)
@@ -274,7 +261,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
             let action = GeneralBrowserAction(buttonTapped: action.buttonTapped,
                                               windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showMenu)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .cancelEdit:
             cancelEditMode(windowUUID: action.windowUUID)
@@ -283,36 +270,36 @@ final class ToolbarMiddleware: FeatureFlaggable {
             recordReaderModeTelemetry(state: state, windowUUID: action.windowUUID)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showReaderMode)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .reload:
             toolbarTelemetry.refreshButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.reloadWebsite)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .stopLoading:
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.stopLoadingWebsite)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .share:
             toolbarTelemetry.shareButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(buttonTapped: action.buttonTapped,
                                               windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showShare)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .search:
             toolbarTelemetry.searchButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = ToolbarAction(windowUUID: action.windowUUID, actionType: ToolbarActionType.didStartEditingUrl)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case .dataClearance:
             toolbarTelemetry.dataClearanceButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.clearData)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .summarizer:
             Task { @MainActor in
                 guard let tab = windowManager.tabManager(for: action.windowUUID).selectedTab else { return }
@@ -322,7 +309,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
                 let action = GeneralBrowserAction(summarizerConfig: summarizeMiddleware.getConfig(for: contentType),
                                                   windowUUID: action.windowUUID,
                                                   actionType: GeneralBrowserActionType.showSummarizer)
-                store.dispatchLegacy(action)
+                store.dispatch(action)
             }
         default:
             break
@@ -338,39 +325,39 @@ final class ToolbarMiddleware: FeatureFlaggable {
             toolbarTelemetry.backButtonLongPressed(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showBackForwardList)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .forward:
             toolbarTelemetry.forwardButtonLongPressed(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showBackForwardList)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .tabs:
             toolbarTelemetry.tabTrayButtonLongPressed(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showTabsLongPressActions)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .locationView:
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showLocationViewLongPressActionSheet)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .reload:
             let action = GeneralBrowserAction(buttonTapped: action.buttonTapped,
                                               windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showReloadLongPressAction)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .newTab:
             toolbarTelemetry.oneTapNewTabButtonLongPressed(isPrivate: toolbarState.isPrivateMode)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showNewTabLongPressActions)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .readerMode:
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.addToReadingListLongPressAction)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .summarizer:
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showReaderMode)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         default:
             break
         }
@@ -396,7 +383,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
             windowUUID: windowUUID,
             actionType: ToolbarActionType.borderPositionChanged
         )
-        store.dispatchLegacy(toolbarAction)
+        store.dispatch(toolbarAction)
     }
 
     private func isMicrosurveyShown(action: GeneralBrowserMiddlewareAction, state: AppState) -> Bool {
@@ -424,13 +411,13 @@ final class ToolbarMiddleware: FeatureFlaggable {
             let toolbarAction = ToolbarAction(displayNavBorder: !isMicrosurveyShown,
                                               windowUUID: windowUUID,
                                               actionType: ToolbarActionType.borderPositionChanged)
-            store.dispatchLegacy(toolbarAction)
+            store.dispatch(toolbarAction)
         } else {
             let toolbarAction = ToolbarAction(addressBorderPosition: isMicrosurveyShown ? .none : .top,
                                               displayNavBorder: false,
                                               windowUUID: windowUUID,
                                               actionType: ToolbarActionType.borderPositionChanged)
-            store.dispatchLegacy(toolbarAction)
+            store.dispatch(toolbarAction)
         }
     }
 
@@ -463,7 +450,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
                                           displayNavBorder: displayNavToolbarBorder,
                                           windowUUID: action.windowUUID,
                                           actionType: ToolbarActionType.toolbarPositionChanged)
-        store.dispatchLegacy(toolbarAction)
+        store.dispatch(toolbarAction)
     }
 
     @MainActor
@@ -473,12 +460,12 @@ final class ToolbarMiddleware: FeatureFlaggable {
         else { return }
         let maxWords = summarizerServiceFactory.maxWords(isAppleSummarizerEnabled: isAppleSummarizerEnabled,
                                                          isHostedSummarizerEnabled: isHostedSummaryEnabled)
-        Task {
+        Task { @MainActor in
             let result = await summarizationChecker.check(
                 on: webView,
                 maxWords: maxWords
             )
-            store.dispatchLegacy(
+            store.dispatch(
                 ToolbarAction(
                     canSummarize: result.canSummarize,
                     readerModeState: action.readerModeState,
@@ -497,12 +484,12 @@ final class ToolbarMiddleware: FeatureFlaggable {
             url = (currentURL.isWebPage() && !currentURL.isReaderModeURL) ? url : nil
         }
         let action = ToolbarAction(url: url, windowUUID: windowUUID, actionType: ToolbarActionType.cancelEdit)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
 
         let browserAction = GeneralBrowserAction(showOverlay: false,
                                                  windowUUID: windowUUID,
                                                  actionType: GeneralBrowserActionType.leaveOverlay)
-        store.dispatchLegacy(browserAction)
+        store.dispatch(browserAction)
     }
 
     private func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition) -> AddressToolbarPosition {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
ToolbarMiddleware is now `@MainActor` and use `dispatch` instead of `dispatchLegacy`.

I couldn't get the microsurvey code to trigger (@cyndichin could you help me with this? 🙏 ), but the rest was checked.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

