### PR TITLE
FXIOS-13729 [Terms of Use] Resolve conflicting constraints for bottom sheet

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1187,6 +1187,10 @@ class BrowserCoordinator: BaseCoordinator,
     // MARK: - Terms of Use
 
     func showTermsOfUse(context: TriggerContext = .appLaunch) {
+        guard !childCoordinators.contains(where: { $0 is TermsOfUseCoordinator }) else {
+            return // route is handled with existing child coordinator
+        }
+
         let presenter = (homepageViewController ?? legacyHomepageViewController) ?? browserViewController
 
         let router = DefaultRouter(navigationController: presenter.navigationController ?? UINavigationController())

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
@@ -66,7 +66,7 @@ final class TermsOfUseCoordinator: BaseCoordinator, TermsOfUseCoordinatorDelegat
     }
 
     func dismissTermsFlow() {
-        presentedVC?.dismiss(animated: true) { [weak self] in
+        router.dismiss(animated: true) { [weak self] in
             guard let self = self else { return }
             self.parentCoordinator?.didFinish(from: self)
         }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
@@ -67,7 +67,6 @@ final class TermsOfUseViewController: UIViewController,
         imageView.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoBall)
         imageView.contentMode = .scaleAspectFit
         imageView.heightAnchor.constraint(equalToConstant: UX.logoSize).isActive = true
-        imageView.widthAnchor.constraint(equalToConstant: UX.logoSize).isActive = true
         imageView.accessibilityIdentifier = AccessibilityIdentifiers.TermsOfUse.logo
     }
 


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13729)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29784)

## :bulb: Description
This PR solves the conflicting constrains issue for the logo image. The conflicting constrains console log can be found in the ticket. Also, the PR adds `guard`  to prevent duplicate attempts of presentation and to make sure that coordinator for terms of use is created and deallocated correctly since we have multiple trigger points for terms of use bottom sheet.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

