### PR TITLE
Bugfix FXIOS-13856 [GHA] Move ComponentLibrary publishing workflow to `macos-26` runner

### DIFF
--- a/.github/workflows/firefox-ios-publish-docc.yml
+++ b/.github/workflows/firefox-ios-publish-docc.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-26
     strategy:
       matrix:
-        xcode: ["26.0"]
+        xcode: ["26.1"]
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-13856
Github issue #30017

## :bulb: Description

The GHA pipeline to build and publish ComponentLibrary docs needs Xcode 26 and the more reliable runtimes are where it's the default — which is macOS 26 runner. It's currently in beta meaning no SLA on it, but it's good enough to be building the docs and deploying to pages.

## :movie_camera: Demos

[`@janbrasna/firefox-ios` /actions/runs/18523191730/job/52787806733](https://github.com/janbrasna/firefox-ios/actions/runs/18523191730/job/52787806733)

No change in the rendered DocC style or functionality: https://janbrasna.github.io/firefox-ios/

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code