### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] MainActor TopSitesMiddleware & HomepageMiddleware

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
@@ -8,6 +8,7 @@ import Common
 
 /// Middleware to handle generic homepage related actions
 /// If this gets too big, can split out notifications and feature flags
+@MainActor
 final class HomepageMiddleware: FeatureFlaggable {
     private let homepageTelemetry: HomepageTelemetry
     private let notificationCenter: NotificationProtocol
@@ -74,7 +75,7 @@ final class HomepageMiddleware: FeatureFlaggable {
     }
 
     private func dispatchSearchBarConfigurationAction(action: Action) {
-        store.dispatchLegacy(
+        store.dispatch(
             HomepageAction(
                 isSearchBarEnabled: self.shouldShowSearchBar(),
                 windowUUID: action.windowUUID,
@@ -84,7 +85,7 @@ final class HomepageMiddleware: FeatureFlaggable {
     }
 
     private func dispatchSpacerConfigurationAction(action: Action) {
-        store.dispatchLegacy(
+        store.dispatch(
             HomepageAction(
                 shouldShowSpacer: self.shouldShowSpacer(),
                 windowUUID: action.windowUUID,
@@ -134,45 +135,48 @@ final class HomepageMiddleware: FeatureFlaggable {
     }
 
     @objc
-    private func handleNotifications(_ notification: Notification) {
+    private nonisolated func handleNotifications(_ notification: Notification) {
         // This update occurs for all windows and we need to pass along
         // the windowUUID to any subsequent actions or state changes.
         // Time complexity: O(n), where n is the number of windows in windowManager.windows
         // In the case of the phone layout, there should only be one window so n = 1
 
         // TODO: FXIOS-12199 Update to improve how we handle notifications for multi-window
-        windowManager.windows.forEach { windowUUID, _ in
-            switch notification.name {
-            case UIApplication.willEnterForegroundNotification:
-                let storiesAction = HomepageAction(
-                    windowUUID: windowUUID,
-                    actionType: HomepageMiddlewareActionType.enteredForeground
-                )
-                store.dispatchLegacy(storiesAction)
+        let notificationName = notification.name
+        ensureMainThread {
+            self.windowManager.windows.forEach { windowUUID, _ in
+                switch notificationName {
+                case UIApplication.willEnterForegroundNotification:
+                    let storiesAction = HomepageAction(
+                        windowUUID: windowUUID,
+                        actionType: HomepageMiddlewareActionType.enteredForeground
+                    )
+                    store.dispatch(storiesAction)
 
-            case .PrivateDataClearedHistory,
-                    .TopSitesUpdated,
-                    .DefaultSearchEngineUpdated:
-                dispatchActionToFetchTopSites(windowUUID: windowUUID)
+                case .PrivateDataClearedHistory,
+                        .TopSitesUpdated,
+                        .DefaultSearchEngineUpdated:
+                    self.dispatchActionToFetchTopSites(windowUUID: windowUUID)
 
-            case .BookmarksUpdated, .RustPlacesOpened:
-                let bookmarksAction = HomepageAction(
-                    windowUUID: windowUUID,
-                    actionType: HomepageMiddlewareActionType.bookmarksUpdated
-                )
-                store.dispatchLegacy(bookmarksAction)
+                case .BookmarksUpdated, .RustPlacesOpened:
+                    let bookmarksAction = HomepageAction(
+                        windowUUID: windowUUID,
+                        actionType: HomepageMiddlewareActionType.bookmarksUpdated
+                    )
+                    store.dispatch(bookmarksAction)
 
-            case .ProfileDidFinishSyncing, .FirefoxAccountChanged:
-                dispatchActionToFetchTopSites(windowUUID: windowUUID)
-                dispatchActionToFetchTabs(windowUUID: windowUUID)
+                case .ProfileDidFinishSyncing, .FirefoxAccountChanged:
+                    self.dispatchActionToFetchTopSites(windowUUID: windowUUID)
+                    self.dispatchActionToFetchTabs(windowUUID: windowUUID)
 
-            default: break
+                default: break
+                }
             }
         }
     }
 
     private func dispatchActionToFetchTopSites(windowUUID: WindowUUID) {
-        store.dispatchLegacy(
+        store.dispatch(
             HomepageAction(
                 windowUUID: windowUUID,
                 actionType: HomepageMiddlewareActionType.topSitesUpdated
@@ -181,13 +185,13 @@ final class HomepageMiddleware: FeatureFlaggable {
     }
 
     private func dispatchActionToFetchTabs(windowUUID: WindowUUID) {
-        store.dispatchLegacy(
+        store.dispatch(
             HomepageAction(
                 windowUUID: windowUUID,
                 actionType: HomepageMiddlewareActionType.jumpBackInLocalTabsUpdated
             )
         )
-        store.dispatchLegacy(
+        store.dispatch(
             HomepageAction(
                 windowUUID: windowUUID,
                 actionType: HomepageMiddlewareActionType.jumpBackInRemoteTabsUpdated

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -8,6 +8,7 @@ import Redux
 import Storage
 
 /// Middleware to handle top sites related actions, if this gets too big, should split out the telemetry.
+@MainActor
 final class TopSitesMiddleware: FeatureFlaggable {
     private let topSitesManager: TopSitesManagerInterface
     private let homepageTelemetry: HomepageTelemetry
@@ -119,7 +120,7 @@ final class TopSitesMiddleware: FeatureFlaggable {
     }
 
     private func dispatchTopSitesRetrievedAction(for windowUUID: WindowUUID, topSites: [TopSiteConfiguration]) {
-        store.dispatchLegacy(
+        store.dispatch(
             TopSitesAction(
                 topSites: topSites,
                 windowUUID: windowUUID,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
TopSitesMiddleware & HomepageMiddleware migration to be `@MainActor`.
- Note that `handleNotification` is marked as `nonisolated` on the procotol `Notifiable`. To ensure we call the `dispatch` from the main thread only I added a call to `ensureMainThread`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

