### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] MainActor ThemeMiddleware & FakeReduxMiddleware

### DIFF
--- a/BrowserKit/Tests/ReduxTests/ReduxIntegrationTests.swift
+++ b/BrowserKit/Tests/ReduxTests/ReduxIntegrationTests.swift
@@ -5,6 +5,8 @@
 import XCTest
 
 @testable import Redux
+
+@MainActor
 let store = Store(state: FakeReduxState(),
                   reducer: FakeReduxState.reducer,
                   middlewares: [FakeReduxMiddleware().fakeProvider])

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
@@ -6,6 +6,7 @@ import Foundation
 
 @testable import Redux
 
+@MainActor
 class FakeReduxMiddleware {
     lazy var fakeProvider: Middleware<FakeReduxState> = { state, action in
         switch action.actionType {
@@ -14,7 +15,7 @@ class FakeReduxMiddleware {
             let action = FakeReduxAction(counterValue: initialValue,
                                          windowUUID: windowUUID,
                                          actionType: FakeReduxActionType.initialValueLoaded)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case FakeReduxActionType.increaseCounter:
             let existingValue = state.counter
@@ -22,7 +23,7 @@ class FakeReduxMiddleware {
             let action = FakeReduxAction(counterValue: newValue,
                                          windowUUID: windowUUID,
                                          actionType: FakeReduxActionType.counterIncreased)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         case FakeReduxActionType.decreaseCounter:
             let existingValue = state.counter
@@ -30,7 +31,7 @@ class FakeReduxMiddleware {
             let action = FakeReduxAction(counterValue: newValue,
                                          windowUUID: windowUUID,
                                          actionType: FakeReduxActionType.counterDecreased)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
 
         default:
            break

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -156,6 +156,6 @@ final class ThemeManagerMiddleware: ThemeManagerProvider {
             windowUUID: oldAction.windowUUID,
             actionType: newActionType)
 
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- `ThemeMiddleware` is already `@MainActor`, we're just changing to use the proper `dispatch` method
- `FakeReduxMiddleware` migrated, but this is just an example class and isn't used in production

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

