### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] MainActor SummarizerMiddleware

### DIFF
--- a/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
@@ -6,6 +6,7 @@ import Common
 import Redux
 import SummarizeKit
 
+@MainActor
 final class SummarizerMiddleware {
     private let summarizerNimbusUtils: SummarizerNimbusUtils
     private let summarizationChecker: SummarizationCheckerProtocol
@@ -66,7 +67,7 @@ final class SummarizerMiddleware {
         let result = await checkSummarizationResult(tab)
         let contentType = result?.contentType ?? .generic
         guard result?.canSummarize == true else { return }
-        store.dispatchLegacy(
+        store.dispatch(
             SummarizeAction(
                 windowUUID: action.windowUUID,
                 actionType: SummarizeMiddlewareActionType.configuredSummarizer,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
`SummarizerMiddleware` is now MainActor and use `dispatch` instead of `dispatchLegacy`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

