### PR TITLE
Revert "[no ticket] Enable parallel simulators for smoke tests"

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -197,7 +197,7 @@ workflows:
     - xcode-test-without-building@0.4.0:
         timeout: 1200
         inputs:
-        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.0,isHeadless=YES
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.0
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.0-arm64.xctestrun
         - maximum_test_repetitions: 2
@@ -305,15 +305,17 @@ workflows:
         timeout: 1200
         inputs:
         - only_testing: |
+            XCUITests/OnboardingTests
             XCUITests/BookmarksTests
+            XCUITests/BrowsingPDFTests
             XCUITests/FindInPageTests
             XCUITests/HomePageSettingsUITests
             XCUITests/NavigationTest
-            XCUITests/OnboardingTests
             XCUITests/PhotonActionSheetTests
+            XCUITests/SearchTests
             XCUITests/SettingsTests
-        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.0,isHeadless=YES
-        - xcodebuild_options: '"-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2" "COMPILER_INDEX_STORE_ENABLE=NO"'
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.0
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO"'
         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_Smoketest_iphonesimulator26.0-arm64.xctestrun
     - deploy-to-bitrise-io@2.10.0: {}
 
@@ -327,8 +329,8 @@ workflows:
         timeout: 1200
         inputs:
         - only_testing: $BITRISE_TEST_SHARDS_PATH_FIREFOX/$BITRISE_IO_PARALLEL_INDEX
-        - destination: platform=iOS Simulator,name=iPhone 16,OS=18.6,isHeadless=YES
-        - xcodebuild_options: '"-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2" "COMPILER_INDEX_STORE_ENABLE=NO"'
+        - destination: platform=iOS Simulator,name=iPhone 16,OS=18.6
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO"'
         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_Smoketest_iphonesimulator26.0-arm64.xctestrun
     - deploy-to-bitrise-io@2.10.0: {}
   determine_apps_affected:
@@ -1615,7 +1617,7 @@ workflows:
         - project_path: firefox-ios/Client.xcodeproj
         - scheme: Fennec
         - configuration: Fennec_Testing
-        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.0,isHeadless=YES
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.0
         - test_plan: UnitTest
         - test_repetition_mode: until_failure
         - maximum_test_repetitions: 3


### PR DESCRIPTION
Let me create this PR just in case there are too many failures. Should we continue to run the smoketest in parallel?