### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] MainActor TermsOfUseMiddleware & StartAtHomeMiddleware

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
@@ -7,7 +7,7 @@ import Shared
 
 // TODO: FXIOS-12947 - Add tests for TermsOfUse Feature
 @MainActor
-class TermsOfUseMiddleware {
+final class TermsOfUseMiddleware {
     private let prefs: Prefs
     private let logger: Logger
     let telemetry: TermsOfUseTelemetry
@@ -25,44 +25,30 @@ class TermsOfUseMiddleware {
     }
 
     private func handleTermsOfUseAction(_ action: Action) {
-        // TODO: FXIOS-12557 We assume that we are isolated to the Main Actor
-        // because we dispatch to the main thread in the store. We will want
-        // to also isolate that to the @MainActor to remove this.
-        guard Thread.isMainThread else {
-            self.logger.log(
-                "Terms of Use Middleware is not being called from the main thread!",
-                level: .fatal,
-                category: .coordinator
-            )
-            return
-        }
+        guard let action = action as? TermsOfUseAction,
+              let type = action.actionType as? TermsOfUseActionType else { return }
 
-        MainActor.assumeIsolated {
-            guard let action = action as? TermsOfUseAction,
-                  let type = action.actionType as? TermsOfUseActionType else { return }
-
-            switch type {
-            case TermsOfUseActionType.termsShown:
-                self.recordImpression()
-            case TermsOfUseActionType.termsAccepted:
-                self.recordAcceptance()
-            case TermsOfUseActionType.remindMeLaterTapped:
-                self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseDismissedDate)
-                self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseRemindMeLaterTapDate)
-                self.telemetry.termsOfUseRemindMeLaterButtonTapped()
-            case TermsOfUseActionType.gestureDismiss:
-                self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseDismissedDate)
-                self.telemetry.termsOfUseDismissed()
-            case TermsOfUseActionType.learnMoreLinkTapped:
-                self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseLearnMoreTapDate)
-                self.telemetry.termsOfUseLearnMoreButtonTapped()
-            case TermsOfUseActionType.privacyLinkTapped:
-                self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUsePrivacyNoticeTapDate)
-                self.telemetry.termsOfUsePrivacyNoticeLinkTapped()
-            case TermsOfUseActionType.termsLinkTapped:
-                self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseTermsLinkTapDate)
-                self.telemetry.termsOfUseTermsOfUseLinkTapped()
-            }
+        switch type {
+        case TermsOfUseActionType.termsShown:
+            self.recordImpression()
+        case TermsOfUseActionType.termsAccepted:
+            self.recordAcceptance()
+        case TermsOfUseActionType.remindMeLaterTapped:
+            self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseDismissedDate)
+            self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseRemindMeLaterTapDate)
+            self.telemetry.termsOfUseRemindMeLaterButtonTapped()
+        case TermsOfUseActionType.gestureDismiss:
+            self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseDismissedDate)
+            self.telemetry.termsOfUseDismissed()
+        case TermsOfUseActionType.learnMoreLinkTapped:
+            self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseLearnMoreTapDate)
+            self.telemetry.termsOfUseLearnMoreButtonTapped()
+        case TermsOfUseActionType.privacyLinkTapped:
+            self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUsePrivacyNoticeTapDate)
+            self.telemetry.termsOfUsePrivacyNoticeLinkTapped()
+        case TermsOfUseActionType.termsLinkTapped:
+            self.prefs.setTimestamp(Date.now(), forKey: PrefsKeys.TermsOfUseTermsLinkTapDate)
+            self.telemetry.termsOfUseTermsOfUseLinkTapped()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseMiddlewareTests.swift
@@ -31,6 +31,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
         middleware.termsOfUseProvider(AppState(), action)
         XCTAssertTrue(profile.prefs.boolForKey(PrefsKeys.TermsOfUseAccepted) == true)
     }
+
     func testMiddleware_gestureDismiss_updatesPrefsWithDate() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.gestureDismiss)
         middleware.termsOfUseProvider(AppState(), action)
@@ -42,6 +43,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
             XCTAssertTrue(Calendar.current.isDate(dismissedDate, inSameDayAs: Date()))
         }
     }
+
     func testMiddleware_remindMeLaterTapped_updatesPrefsWithDate() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.remindMeLaterTapped)
         middleware.termsOfUseProvider(AppState(), action)
@@ -53,6 +55,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
             XCTAssertTrue(Calendar.current.isDate(dismissedDate, inSameDayAs: Date()))
         }
     }
+
     func testMiddleware_termsShown_setsShownPref() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsShown)
         middleware.termsOfUseProvider(AppState(), action)
@@ -63,6 +66,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
         let dismissedTimestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUseDismissedDate)
         XCTAssertNil(dismissedTimestamp)
     }
+
     func testMiddleware_termsAccepted_recordsVersionAndDatePrefs() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsAccepted)
         middleware.termsOfUseProvider(AppState(), action)
@@ -76,6 +80,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
             XCTAssertTrue(Calendar.current.isDate(acceptedDate, inSameDayAs: Date()))
         }
     }
+
     func testMiddleware_remindMeLaterTapped_tracksTapTimestamp() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.remindMeLaterTapped)
         middleware.termsOfUseProvider(AppState(), action)
@@ -83,6 +88,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
         let timestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUseRemindMeLaterTapDate)
         XCTAssertNotNil(timestamp)
     }
+
     func testMiddleware_learnMoreLinkTapped_tracksTapTimestamp() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.learnMoreLinkTapped)
         middleware.termsOfUseProvider(AppState(), action)
@@ -90,6 +96,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
         let timestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUseLearnMoreTapDate)
         XCTAssertNotNil(timestamp)
     }
+
     func testMiddleware_privacyLinkTapped_tracksTapTimestamp() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.privacyLinkTapped)
         middleware.termsOfUseProvider(AppState(), action)
@@ -97,6 +104,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
         let timestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUsePrivacyNoticeTapDate)
         XCTAssertNotNil(timestamp)
     }
+
     func testMiddleware_termsLinkTapped_tracksTapTimestamp() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsLinkTapped)
         middleware.termsOfUseProvider(AppState(), action)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- `TermsOfUseMiddleware` was already `@MainActor`, so removed the `Thread.isMainThread` check
- `StartAtHomeMiddleware` is now `@MainActor` and use `dispatch` instead of `dispatchLegacy`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

