### PR TITLE
Bugfix MTE-4495 Revert changes on mozWait and waitAndTap

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
@@ -42,6 +42,7 @@ class AuthenticationTest: BaseTestCase {
         )
         app.alerts.textFields["Username"].typeText("guest")
         app.alerts.secureTextFields["Password"].tapAndTypeText("guest")
+        mozWaitElementEnabled(element: app.alerts.buttons["Log in"], timeout: TIMEOUT)
         app.alerts.buttons["Log in"].waitAndTap()
         /* There is no other way to verify basic auth is successful as the webview is
          inaccessible after sign in to verify the success text. */

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -610,17 +610,13 @@ extension XCUIElement {
     }
     /// Waits for the UI element and then taps if it exists.
     func waitAndTap(timeout: TimeInterval? = TIMEOUT) {
-        BaseTestCase().mozWaitForElementToExist(self, timeout: timeout ?? TIMEOUT)
-        if self.elementType == .button || self.elementType == .link {
-            BaseTestCase().mozWaitElementHittable(element: self, timeout: timeout ?? TIMEOUT)
-        }
+        BaseTestCase().mozWaitForElementToExist(self, timeout: timeout)
         self.tap()
     }
     /// Waits for the UI element and then taps and types the provided text if it exists.
     func tapAndTypeText(_ text: String, timeout: TimeInterval? = TIMEOUT) {
         BaseTestCase().mozWaitForElementToExist(self, timeout: timeout)
         self.tap()
-        BaseTestCase().mozWaitElementEnabled(element: self, timeout: timeout ?? TIMEOUT)
         self.typeText(text)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
@@ -319,6 +319,7 @@ class O_AddressesTests: BaseTestCase {
         addNewAddress()
         tapSave()
         let addresses = AccessibilityIdentifiers.Settings.Address.Addresses.self
+        mozWaitElementEnabled(element: app.navigationBars[addresses.title], timeout: TIMEOUT)
         app.buttons[addresses.addAddress].waitAndTap()
         addNewAddress()
         tapSave()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
@@ -19,6 +19,7 @@ class DataManagementTests: BaseTestCase {
         mozWaitForElementToNotExist(app.alerts.buttons["OK"])
         XCTAssertEqual(app.cells.buttons.images.count, 0, "The Website data has not cleared correctly")
         // Navigate back to the browser
+        mozWaitElementEnabled(element: app.buttons["Data Management"], timeout: TIMEOUT)
         app.buttons["Data Management"].waitAndTap()
         app.buttons["Settings"].waitAndTap()
         app.buttons["Done"].waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -140,8 +140,10 @@ class TodayWidgetTests: BaseTestCase {
                 return
         }
         if #unavailable(iOS 16) {
+            mozWaitElementHittable(element: springboard.buttons["Remove Widget"], timeout: TIMEOUT)
             springboard.buttons["Remove Widget"].waitAndTap()
         } else {
+            mozWaitElementHittable(element: springboard.buttons[removeWidgetButton], timeout: TIMEOUT)
             springboard.buttons[removeWidgetButton].waitAndTap()
         }
 
@@ -152,6 +154,7 @@ class TodayWidgetTests: BaseTestCase {
             ]
         )
 
+        mozWaitElementHittable(element: springboard.alerts.buttons["Remove"], timeout: TIMEOUT)
         springboard.alerts.buttons["Remove"].waitAndTap()
     }
 
@@ -207,11 +210,13 @@ class TodayWidgetTests: BaseTestCase {
             pressAndHoldWidget(matching: "Firefox")
         }
 
+        mozWaitElementHittable(element: springboard.buttons[removeWidgetButton], timeout: TIMEOUT)
         springboard.buttons[removeWidgetButton].waitAndTap()
 
         mozWaitForElementToExist(springboard.alerts.buttons["Remove"])
         mozWaitForElementToExist(springboard.alerts.buttons["Cancel"])
 
+        mozWaitElementHittable(element: springboard.alerts.buttons["Remove"], timeout: TIMEOUT)
         springboard.alerts.buttons["Remove"].waitAndTap()
     }
 
@@ -252,6 +257,7 @@ class TodayWidgetTests: BaseTestCase {
 
     private func tapOnWidget(widgetType: String) {
         let widget = springboard.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", widgetType)).element
+        mozWaitElementHittable(element: widget, timeout: TIMEOUT)
         widget.waitAndTap()
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4495)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Waiting for element to be enabled adds about 5 minutes to the overall Bitrise pipeline runtime.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

