### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] @MainActor MessageCardMiddleware & ShortcutsLibraryMiddleware

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardMiddleware.swift
@@ -12,6 +12,7 @@ struct MessageCardConfiguration: Hashable {
     let buttonLabel: String?
 }
 
+@MainActor
 final class MessageCardMiddleware {
     private var message: GleanPlumbMessage?
     private let messagingManager: GleanPlumbMessageManagerProtocol
@@ -25,35 +26,20 @@ final class MessageCardMiddleware {
         self.logger = logger
     }
 
-    // TODO: FXIOS-12831 We need this middleware isolated to the main actor (due to `onMessagePressed` call)
     lazy var messageCardProvider: Middleware<AppState> = { state, action in
-        // TODO: FXIOS-12557 We assume that we are isolated to the Main Actor
-        // because we dispatch to the main thread in the store. We will want to
-        // also isolate that to the @MainActor to remove this.
-        guard Thread.isMainThread else {
-            self.logger.log(
-                "MessageCardMiddleware is not being called from the main thread!",
-                level: .fatal,
-                category: .tabs
-            )
-            return
-        }
+        let windowUUID = action.windowUUID
 
-        MainActor.assumeIsolated {
-            let windowUUID = action.windowUUID
-
-            switch action.actionType {
-            case HomepageActionType.initialize:
-                self.handleInitializeMessageCardAction(windowUUID: windowUUID)
-            case MessageCardActionType.tappedOnActionButton:
-                guard let message = self.message else { return }
-                self.messagingManager.onMessagePressed(message, window: windowUUID, shouldExpire: true)
-            case MessageCardActionType.tappedOnCloseButton:
-                guard let message = self.message else { return }
-                self.messagingManager.onMessageDismissed(message)
-            default:
-                break
-            }
+        switch action.actionType {
+        case HomepageActionType.initialize:
+            self.handleInitializeMessageCardAction(windowUUID: windowUUID)
+        case MessageCardActionType.tappedOnActionButton:
+            guard let message = self.message else { return }
+            self.messagingManager.onMessagePressed(message, window: windowUUID, shouldExpire: true)
+        case MessageCardActionType.tappedOnCloseButton:
+            guard let message = self.message else { return }
+            self.messagingManager.onMessageDismissed(message)
+        default:
+            break
         }
     }
 
@@ -79,6 +65,6 @@ final class MessageCardMiddleware {
             windowUUID: windowUUID,
             actionType: MessageCardMiddlewareActionType.initialize
         )
-        store.dispatchLegacy(newAction)
+        store.dispatch(newAction)
     }
 }

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryMiddleware.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryMiddleware.swift
@@ -5,6 +5,7 @@
 import Common
 import Redux
 
+@MainActor
 final class ShortcutsLibraryMiddleware {
     private let logger: Logger
     private let shortcutsLibraryTelemetry: ShortcutsLibraryTelemetry
@@ -16,29 +17,15 @@ final class ShortcutsLibraryMiddleware {
     }
 
     lazy var shortcutsLibraryProvider: Middleware<AppState> = { state, action in
-        // TODO: FXIOS-12557 We assume that we are isolated to the Main Actor
-        // because we dispatch to the main thread in the store. We will want
-        // to also isolate that to the @MainActor to remove this.
-        guard Thread.isMainThread else {
-            self.logger.log(
-                "Shortcuts Library Middleware is not being called from the main thread!",
-                level: .fatal,
-                category: .shortcutsLibrary
-            )
-            return
-        }
-
-        MainActor.assumeIsolated {
-            switch action.actionType {
-            case ShortcutsLibraryActionType.tapOnShortcutCell:
-                self.shortcutsLibraryTelemetry.sendShortcutTappedEvent()
-            case ShortcutsLibraryActionType.viewDidAppear:
-                self.handleViewDidAppearAction(state: state, action: action)
-            case ShortcutsLibraryActionType.viewDidDisappear:
-                self.shortcutsLibraryTelemetry.sendShortcutsLibraryClosedEvent()
-            default:
-                break
-            }
+        switch action.actionType {
+        case ShortcutsLibraryActionType.tapOnShortcutCell:
+            self.shortcutsLibraryTelemetry.sendShortcutTappedEvent()
+        case ShortcutsLibraryActionType.viewDidAppear:
+            self.handleViewDidAppearAction(state: state, action: action)
+        case ShortcutsLibraryActionType.viewDidDisappear:
+            self.shortcutsLibraryTelemetry.sendShortcutsLibraryClosedEvent()
+        default:
+            break
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- `MessageCardMiddleware` is now `@MainActor` and use `dispatch` instead of `dispatchLegacy`
- `ShortcutsLibraryMiddleware` is now `@MainActor` and use `dispatch` instead of `dispatchLegacy`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

