### PR TITLE
Bugfix FXIOS-13843 [Translations] settings screen

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -106,7 +106,6 @@ public struct PrefsKeys {
         public static let SearchBarPosition = "SearchBarPositionUsersPrefsKey"
         public static let SponsoredShortcuts = "SponsoredShortcutsUserPrefsKey"
         public static let StartAtHome = "StartAtHomeUserPrefsKey"
-        public static let Translation = "translationFeatureKey"
     }
 
     public struct HomepageSettings {
@@ -167,6 +166,7 @@ public struct PrefsKeys {
         public static let closePrivateTabs = "ClosePrivateTabs"
         public static let sentFromFirefoxWhatsApp = "SentFromFirefoxWhatsApp"
         public static let navigationToolbarMiddleButton = "settings.navigationToolbarMiddleButton"
+        public static let translationsFeature = "settings.translationFeature"
     }
 
     // Activity Stream

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -446,7 +446,7 @@ final class SettingsCoordinator: BaseCoordinator,
     }
 
     func pressedTranslation() {
-        let viewController = TranslationSettingsViewController(windowUUID: windowUUID)
+        let viewController = TranslationSettingsViewController(prefs: profile.prefs, windowUUID: windowUUID)
         router.push(viewController)
     }
 

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -140,8 +140,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.InactiveTabs
         case .startAtHome:
             return FlagKeys.StartAtHome
-        case .translation:
-            return FlagKeys.Translation
         // Cases where users do not have the option to manipulate a setting. Please add in alphabetical order.
         case .appearanceMenu,
                 .addressAutofillEdit,
@@ -192,6 +190,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .tosFeature,
                 .touFeature,
                 .trackingProtectionRefactor,
+                .translation,
                 .trendingSearches,
                 .unifiedAds,
                 .unifiedSearch,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/TranslationSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/TranslationSetting.swift
@@ -22,7 +22,7 @@ final class TranslationSetting: Setting {
 
     override var status: NSAttributedString? {
         guard let profile else { return nil }
-        let isSwitchOn = profile.prefs.boolForKey(PrefsKeys.FeatureFlags.Translation) ?? true
+        let isSwitchOn = profile.prefs.boolForKey(PrefsKeys.Settings.translationsFeature) ?? true
         let statusString: String = isSwitchOn ? .Settings.Translation.SettingOn : .Settings.Translation.SettingOff
         return NSAttributedString(string: statusString)
     }

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsViewController.swift
@@ -6,7 +6,9 @@ import Common
 import Shared
 
 final class TranslationSettingsViewController: SettingsTableViewController {
-    init(windowUUID: WindowUUID) {
+    let prefs: Prefs
+    init(prefs: Prefs, windowUUID: WindowUUID) {
+        self.prefs = prefs
         super.init(style: .grouped, windowUUID: windowUUID)
         self.title = .Settings.Translation.Title
     }
@@ -25,11 +27,11 @@ final class TranslationSettingsViewController: SettingsTableViewController {
 
     private var translationSection: SettingSection {
         let enableFeatureSwitch = BoolSetting(
-            with: .translation,
-            titleText: NSAttributedString(
-                string: .Settings.Translation.ToggleTitle,
-                attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]
-            )
+            prefs: prefs,
+            theme: theme,
+            prefKey: PrefsKeys.Settings.translationsFeature,
+            defaultValue: true,
+            titleText: .Settings.Translation.ToggleTitle
         )
         return SettingSection(
             title: NSAttributedString(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13843)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29992)

## :bulb: Description
Fixes issue where default value is always false at first configuration. Related to this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/30001). Decided to not use the feature flag route and instead use prefs since when we remove FF it'll be easier to remove anyways.

## :movie_camera: Demos

https://github.com/user-attachments/assets/9e38d310-2c03-4f46-9618-6220329ca89a

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

