### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] FeltPrivacyMiddleware & BookmarksMiddleware

### DIFF
--- a/firefox-ios/Client/Frontend/FeltPrivacy/FeltPrivacyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/FeltPrivacy/FeltPrivacyMiddleware.swift
@@ -24,7 +24,7 @@ final class FeltPrivacyMiddleware {
             let updateAction = PrivateModeAction(isPrivate: privateState,
                                                  windowUUID: action.windowUUID,
                                                  actionType: PrivateModeActionType.privateModeUpdated)
-            store.dispatchLegacy(updateAction)
+            store.dispatch(updateAction)
         default:
             break
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- `FeltPrivacyMiddleware` is already `@MainActor`, we're just changing to use the proper `dispatch` method
- `BookmarksMiddleware` is now `@MainActor` and is now using `dispatch` instead of `dispatchLegacy`. 
    - Note that I removed the function `dispatchBookmarksAction` to avoid calling `self` and fixed a concurrency warning with that simple solution. There would be other ways to fix this, but this is to avoid any refactors.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

