### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] MerinoMiddleware actor isolation

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Merino/MerinoMiddleware.swift
@@ -7,6 +7,7 @@ import MozillaAppServices
 import Redux
 import Shared
 
+@MainActor
 final class MerinoMiddleware {
     private let merinoManager: MerinoManagerProvider
     private let homepageTelemetry: HomepageTelemetry
@@ -44,7 +45,7 @@ final class MerinoMiddleware {
     private func getHomepageStoriesAndUpdateState(for action: Action) {
         Task {
             let merinoStories = await merinoManager.getMerinoItems(source: .homepage)
-            store.dispatchLegacy(
+            store.dispatch(
                 MerinoAction(
                     merinoStories: merinoStories,
                     windowUUID: action.windowUUID,
@@ -57,7 +58,7 @@ final class MerinoMiddleware {
     private func getStoriesFeedStoriesAndUpdateState(for action: Action) {
         Task {
             let merinoStories = await merinoManager.getMerinoItems(source: .storiesFeed)
-            store.dispatchLegacy(
+            store.dispatch(
                 MerinoAction(
                     merinoStories: merinoStories,
                     windowUUID: action.windowUUID,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
Migrate `MerinoMiddleware` middleware to use `@MainActor` isolation and the new isolated store `dispatch` method.

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)