### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] PasswordGeneratorMiddleware actor isolation

### DIFF
--- a/BrowserKit/Sources/Shared/Extensions/WKWebViewExtensions.swift
+++ b/BrowserKit/Sources/Shared/Extensions/WKWebViewExtensions.swift
@@ -33,7 +33,7 @@ extension WKWebView {
     public func evaluateJavascriptInDefaultContentWorld(
         _ javascript: String,
         _ frame: WKFrameInfo? = nil,
-        _ completion: @escaping (Any?, Error?) -> Void
+        _ completion: @MainActor @escaping (Any?, Error?) -> Void
     ) {
         self.evaluateJavaScript(javascript, in: frame, in: .defaultClient) { result in
             switch result {

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
@@ -80,7 +80,7 @@ final class PasswordGeneratorMiddleware {
         }
     }
 
-    private func generateNewPassword(frame: WKFrameInfo, completion: @escaping (String) -> Void) {
+    private func generateNewPassword(frame: WKFrameInfo, completion: @MainActor @escaping (String) -> Void) {
         let originRules = PasswordGeneratorMiddleware.getPasswordRule(for: frame.securityOrigin.host)
         let jsFunctionCall = "window.__firefox__.logins.generatePassword(\(originRules ?? "" ))"
         frame.webView?.evaluateJavascriptInDefaultContentWorld(jsFunctionCall, frame) { (result, error) in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
Migrate `PasswordGeneratorMiddleware` middleware to use `@MainActor` isolation and the new isolated store `dispatch` method.

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)