### PR TITLE
Bugfix FXIOS-11662 #25415 ⁃ [iPhone] - "Block audio" option blocks both the audio and video 

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2990,6 +2990,7 @@
 		219AEE492E5E38B200BF5F6F /* TabProviderAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabProviderAdapter.swift; sourceTree = "<group>"; };
 		219AEECD2E5E523600BF5F6F /* MockTabProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabProviderProtocol.swift; sourceTree = "<group>"; };
 		219F27142EA2956100AE4536 /* MockBrowserViewControllerWebViewDelegates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBrowserViewControllerWebViewDelegates.swift; sourceTree = "<group>"; };
+		219F27A32EA2D96B00AE4536 /* AutoplayHelper.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AutoplayHelper.js; sourceTree = "<group>"; };
 		219F41288625C09DD40F008C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		21A1C3C62996AFF800181B7C /* OverlayModeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayModeManagerTests.swift; sourceTree = "<group>"; };
 		21A43CDC291461C700B1206D /* ReaderModeFontTypeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontTypeButton.swift; sourceTree = "<group>"; };
@@ -12349,6 +12350,7 @@
 		4336FAF9264B170F00A6B076 /* WebcompatAtDocumentStart */ = {
 			isa = PBXGroup;
 			children = (
+				219F27A32EA2D96B00AE4536 /* AutoplayHelper.js */,
 				4336FAFA264B170F00A6B076 /* FullscreenHelper.js */,
 			);
 			path = WebcompatAtDocumentStart;

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/WebcompatAtDocumentStart/AutoplayHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/WebcompatAtDocumentStart/AutoplayHelper.js
@@ -2,38 +2,43 @@
 // // License, v. 2.0. If a copy of the MPL was not distributed with this
 // // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-// Firefox iOS WebCompat patch: ensure <video> elements play inline on iPhone
+// Ensure <video> elements play inline on iPhone.
 // Required for muted autoplay to work when sites omit 'playsinline'.
-// Safe on all platforms (no effect where playsinline is ignored).
 
-console.log("[Webcompat] General console log");
-
-if (/iPhone|iPod/i.test(navigator.userAgent)) {
-  (() => {
-    if (window.__fxInlineVideoPatchApplied) return;
-    window.__fxInlineVideoPatchApplied = true;
-
-    const forceInline = (video) => {
-      if (!video) return;
-      video.setAttribute("playsinline", "");
-      video.setAttribute("webkit-playsinline", "");
-    };
-      
-    console.log("[Webcompat] Inline video patch applied");
-
-    // Apply to any <video> elements already in the DOM
-    document.querySelectorAll("video").forEach(forceInline);
-
-    // Watch for newly added videos
-    const observer = new MutationObserver((muts) => {
-      for (const m of muts) {
-        for (const node of m.addedNodes) {
-          if (node.nodeType !== 1) continue;
-          if (node.localName === "video") forceInline(node);
-          node.querySelectorAll?.("video").forEach(forceInline);
-        }
+if (/mobile/i.test(navigator.userAgent)) {
+  const forceInline = (video) => {
+    const inlineAttributes = ["playsinline", "webkit-playsinline"];
+    inlineAttributes.forEach((attr) => {
+      if (!video.hasAttribute(attr)) {
+        video.setAttribute(attr, "");
       }
     });
-    observer.observe(document, { childList: true, subtree: true });
-  })();
+  };
+
+  // Apply to any <video> elements already parsed
+  document.querySelectorAll("video").forEach(forceInline);
+
+  // Monkey-patch document.createElement so future <video> elements also get playsinline
+  const originalCreateElement = document.createElement;
+  document.createElement = function (tag) {
+    const el = originalCreateElement.call(this, tag);
+    if (el.localName === "video") {
+      forceInline(el);
+    }
+    return el;
+  };
+
+  // Observe dynamically inserted <video> elements
+  const observer = new MutationObserver((muts) => {
+    for (const m of muts) {
+      for (const node of m.addedNodes) {
+        if (node.nodeType !== 1) continue;
+        if (node.localName === "video") {
+          forceInline(node);
+        }
+        node.querySelectorAll?.("video").forEach(forceInline);
+      }
+    }
+  });
+  observer.observe(document, { childList: true, subtree: true });
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11662)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25415)

## :bulb: Description
- Create AutoplayHelper file and add `playinline` to video elements if it is a mobile user agent to ensure that the WKWebConfiguration is respected, in this case when the user selected the option to block audio the expectation is that muted videos should play automatically.

@issammani this is an attempt to add functionality to ensure autoplay settings are respected, I'm aware that we have related code in FullScreenHelper.js already so I wanted your feedback on this code, if both can be merged and where it should live
in FullScreen or this AutoplayHelper

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

