### PR TITLE
Refactor FXIOS-13888 Disable testSSL test in Smoketest plan

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -340,6 +340,7 @@
         "NavigationTest\/testOpenInNewTab_tabTrayExperimentOff()",
         "NavigationTest\/testOpenInNewTab_tabTrayExperimentOn()",
         "NavigationTest\/testPopUpBlocker_tabTrayExperimentOff()",
+        "NavigationTest\/testSSL()",
         "NavigationTest\/testScrollsToTopWithMultipleTabs()",
         "NavigationTest\/testShareLink()",
         "NavigationTest\/testShareLinkPrivateMode()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -418,6 +418,7 @@ class NavigationTest: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306858
     // Smoketest
+    // FIXME: FXIOS-13888 Test disabled in the SmokeTest plan; it is failing on some Bitrise PRs but passes locally.
     func testSSL() {
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13888)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30092)

## :bulb: Description
The `testSSL()` UI test in the SmokeTest plan is failing on some Bitrise PRs but passes locally. It is blocking work so temporarily disable it.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

