### PR TITLE
BugFix FXIOS-29178 [Toast Position] Display toast notification in the correct position with smooth animation

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
@@ -22,6 +22,7 @@ class ButtonToast: Toast {
         static let buttonBorderRadius: CGFloat = 8
         static let buttonBorderWidth: CGFloat = 1
         static let topBottomButtonPadding: CGFloat = 8
+        static let animationDuration: TimeInterval = 0.3
     }
 
     // MARK: - UI

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
@@ -296,19 +296,16 @@ class ShortcutsLibraryViewController: UIViewController,
                 toast.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
             ]
         }
-        // Position the toast slightly below its final location to set up a smooth upward slide animation
-        toast.transform = CGAffineTransform(translationX: 0, y: 80)
-        
-        // Animate the toast into place with a smooth slide-up motion
+        // Offset the toast by its height to prepare for slide-in animation
+        toast.transform = CGAffineTransform(translationX: 0, y: toast.frame.height)
         UIView.animate(
-            withDuration: 0.3,             // Duration of the animation (0.3 seconds for a smooth effect)
-            delay: 0,                      // Start immediately with no delay
-            options: [.curveEaseOut],      // Ease-out curve: slows down at the end for a natural finish
+            withDuration: ButtonToast.UX.animationDuration,
+            delay: 0,
+            options: [.curveEaseOut],
             animations: {
-                // Reset the transform to identity, bringing the toast back to its original position
                 toast.transform = .identity
             },
-            completion: nil                // No additional actions after the animation completes
+            completion: nil
         )
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29178)

##  Description
The toast notification should consistently display in the correct position with smooth animation 
[ Before](https://github.com/mozilla-mobile/firefox-ios/issues/29178#issuecomment-3356506039)
[ After](https://github.com/mozilla-mobile/firefox-ios/pull/30097#issuecomment-3418498642)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

