### PR TITLE
Bugfix FXIOS-13891 [webcompat] Force PayPal modals on Shopify in the same tab

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -99,9 +99,12 @@ public enum UserAgentPlatform {
 
 struct CustomUserAgentConstant {
     private static let defaultMobileUA = UserAgentBuilder.defaultMobileUserAgent().userAgent()
+    private static let focusMobileUA = UserAgentBuilder.defaultMobileUserAgent().clone(extensions: "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitMobile) Version/18.6")
     private static let safariMobileUA = UserAgentBuilder.defaultMobileUserAgent().clone(extensions: "Version/18.6 \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
 
     static let customMobileUAForDomain = [
+        // TODO: FXIOS-8027, FXIOS-11230, FXIOS-13891 PayPal buttons open blank tabs
+        "paypal.com": focusMobileUA,
         // TODO: FXIOS-13391 [webcompat] "connection error" only on FxiOS/* UA (bug 1983983)
         "tver.jp": safariMobileUA,
         // TODO: FXIOS-13096 [webcompat] UA version parsed as "Safari 0" (webcompat #170304)
@@ -111,7 +114,9 @@ struct CustomUserAgentConstant {
     ]
 
     static let customDesktopUAForDomain = [
-        "paypal.com": defaultMobileUA,
+        // TODO: FXIOS-8027, FXIOS-11230, FXIOS-13891 PayPal buttons open blank tabs
+        "paypal.com": focusMobileUA,
+        // FXIOS-10251: Do not appear as desktop/Safari for firefox.com/pair
         "firefox.com": defaultMobileUA
     ]
 }

--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -99,12 +99,9 @@ public enum UserAgentPlatform {
 
 struct CustomUserAgentConstant {
     private static let defaultMobileUA = UserAgentBuilder.defaultMobileUserAgent().userAgent()
-    private static let focusMobileUA = UserAgentBuilder.defaultMobileUserAgent().clone(extensions: "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitMobile) Version/18.6")
     private static let safariMobileUA = UserAgentBuilder.defaultMobileUserAgent().clone(extensions: "Version/18.6 \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
 
     static let customMobileUAForDomain = [
-        // TODO: FXIOS-8027, FXIOS-11230, FXIOS-13891 PayPal buttons open blank tabs
-        "paypal.com": focusMobileUA,
         // TODO: FXIOS-13391 [webcompat] "connection error" only on FxiOS/* UA (bug 1983983)
         "tver.jp": safariMobileUA,
         // TODO: FXIOS-13096 [webcompat] UA version parsed as "Safari 0" (webcompat #170304)
@@ -115,7 +112,7 @@ struct CustomUserAgentConstant {
 
     static let customDesktopUAForDomain = [
         // TODO: FXIOS-8027, FXIOS-11230, FXIOS-13891 PayPal buttons open blank tabs
-        "paypal.com": focusMobileUA,
+        "paypal.com": defaultMobileUA,
         // FXIOS-10251: Do not appear as desktop/Safari for firefox.com/pair
         "firefox.com": defaultMobileUA
     ]

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1289,7 +1289,7 @@ private extension BrowserViewController {
     // createWebViewWith. We will show Paypal popUp in page like mobile devices using the mobile User Agent
     // so we will block the creation of a new Webview with this check
     func isPayPalPopUp(_ navigationAction: WKNavigationAction) -> Bool {
-        return navigationAction.sourceFrame.request.url?.baseDomain == "paypal.com"
+        return ["paypal.com", "shopify.com"].contains(navigationAction.sourceFrame.request.url?.baseDomain)
     }
 
     func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1289,7 +1289,8 @@ private extension BrowserViewController {
     // createWebViewWith. We will show Paypal popUp in page like mobile devices using the mobile User Agent
     // so we will block the creation of a new Webview with this check
     func isPayPalPopUp(_ navigationAction: WKNavigationAction) -> Bool {
-        return ["paypal.com", "shopify.com"].contains(navigationAction.sourceFrame.request.url?.baseDomain)
+        let domain = navigationAction.sourceFrame.request.url?.baseDomain ?? ""
+        return ["paypal.com", "shopify.com"].contains(domain)
     }
 
     func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
@@ -19,4 +19,16 @@ final class UserAgentTests: XCTestCase {
             XCTAssertEqual(agent, UserAgent.getUserAgent(domain: domain, platform: .Mobile))
         }
     }
+
+    func testGetUserAgentDesktop_withPaypalDomain_returnMobileUserAgent() {
+        let paypalDomain = "paypal.com"
+        XCTAssertEqual(UserAgent.mobileUserAgent(),
+                       UserAgent.getUserAgent(domain: paypalDomain, platform: .Desktop))
+    }
+
+    func testGetUserAgentMobile_withPaypalDomain_returnProperUserAgent() {
+        let paypalDomain = "paypal.com"
+        XCTAssertEqual(UserAgent.mobileUserAgent(),
+                       UserAgent.getUserAgent(domain: paypalDomain, platform: .Mobile))
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
@@ -19,16 +19,4 @@ final class UserAgentTests: XCTestCase {
             XCTAssertEqual(agent, UserAgent.getUserAgent(domain: domain, platform: .Mobile))
         }
     }
-
-    func testGetUserAgentDesktop_withPaypalDomain_returnMobileUserAgent() {
-        let paypalDomain = "paypal.com"
-        XCTAssertEqual(UserAgent.mobileUserAgent(),
-                       UserAgent.getUserAgent(domain: paypalDomain, platform: .Desktop))
-    }
-
-    func testGetUserAgentMobile_withPaypalDomain_returnProperUserAgent() {
-        let paypalDomain = "paypal.com"
-        XCTAssertEqual(UserAgent.mobileUserAgent(),
-                       UserAgent.getUserAgent(domain: paypalDomain, platform: .Mobile))
-    }
 }


### PR DESCRIPTION
## :scroll: Tickets
FXIOS-13891
#30098

## :bulb: Description

~Using Focus/WebView-like (non-Safari) uastring seems to keep the interaction within the same page.~

When the payment button can't open new window, it will fall back to using the same page for the login+payment flow.

## :movie_camera: Demos

🙏 _Would love some assistance trying to hunt down the right approach & hostnames… The UAstring spoof currently works if applied to the whole browser only, but for domain overrides, no matter how many hosts I add, I can't trick it to do the same…_ 🙇 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If needed, I updated documentation and added comments to complex code