### PR TITLE
[MTE-4948] - fixes on iPhone and iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -166,6 +166,7 @@
         "HomePageSettingsUITests\/testSetCustomURLAsHome()",
         "HomePageSettingsUITests\/testTyping()",
         "HomePageUITest",
+        "InactiveTabsTest\/testInactiveTabs()",
         "IntegrationTests",
         "IntegrationTests\/testFxASyncBookmark()",
         "JumpBackInTests\/testGroupedTabs()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
@@ -29,7 +29,9 @@ final class InactiveTabsTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307045
-    func testInactiveTabs() {
+    func testInactiveTabs() throws {
+        let shouldSkipTest = true
+        try XCTSkipIf(shouldSkipTest, "Inactive tabs are no longer available with the new tab tray")
         // Confirm we have tabs loaded
         let tabsButtonNumber = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["20"]
         waitForTabsButton()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -105,13 +105,6 @@ class PrivateBrowsingTest: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307006
     func testClosePrivateTabsOptionClosesPrivateTabs() {
-        // Check that Close Private Tabs when closing the Private Browsing Button is off by default
-        navigator.nowAt(NewTabScreen)
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
-        navigator.goto(SettingsScreen)
-
-        // FXIOS-8672: "Close Private Tabs" has been removed from the settings.
-
         //  Open a Private tab
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
         if userState.isPrivate {
@@ -124,6 +117,9 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // Go back to regular browser
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleExperimentRegularMode)
+        app.otherElements[tabsTray].cells.firstMatch.waitAndTap()
+        navigator.nowAt(BrowserTab)
+        navigator.goto(TabTray)
 
         // Go back to private browsing and check that the tab has been closed
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
@@ -308,7 +304,7 @@ fileprivate extension BaseTestCase {
         let numPrivTabs = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(
             numPrivTabs,
-            1,
+            0,
             "The private tab should have been closed"
         )
     }
@@ -375,14 +371,16 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
     func testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad() {
         if skipPlatform { return }
         waitForTabsButton()
-        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
         navigator.openURL(url2)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
 
         // Leave PM by tapping on PM shourt cut
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarHomePanel)
         waitForTabsButton()
-        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.nowAt(BrowserTab)
+        navigator.goto(TabTray)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
         checkOpenTabsBeforeClosingPrivateMode()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -324,15 +324,17 @@ class TabsTests: BaseTestCase {
         // Scroll down to view all open tabs thumbnails
         navigator.goto(TabTray)
         app.swipeUp()
-        let navBarTabTray = AccessibilityIdentifiers.TabTray.navBarSegmentedControl
-        let navBarTabTrayButton = app.segmentedControls[navBarTabTray].buttons.firstMatch
-        mozWaitForElementToExist(navBarTabTrayButton)
-        let tabsOpenTabTray: String = navBarTabTrayButton.label
-        XCTAssertTrue(tabsOpenTabTray.hasSuffix(numTab!))
+        if iPad() {
+            let navBarTabTray = AccessibilityIdentifiers.TabTray.navBarSegmentedControl
+            let navBarTabTrayButton = app.segmentedControls[navBarTabTray].buttons.firstMatch
+            mozWaitForElementToExist(navBarTabTrayButton)
+            let tabsOpenTabTray: String = navBarTabTrayButton.label
+            XCTAssertTrue(tabsOpenTabTray.hasSuffix(numTab!))
+        }
         let tabsTrayCell = app.otherElements[tabsTray].cells
         // Go to a tab that is below the fold of the scrollable “Open Tabs” view
         if !iPad() {
-            tabsTrayCell.staticTexts.element(boundBy: 3).waitAndTap()
+            tabsTrayCell.element(boundBy: 3).waitAndTap()
         } else {
             XCTAssertTrue(Int(numTab!) == 11)
             tabsTrayCell.staticTexts.element(boundBy: 6).waitAndTap()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4948

## :bulb: Description
Fixes for: 
testOpenTabsViewCurrentTabThumbnail
PrivateBrowsingTest tests
Disabled testInactiveTabs - no longer available with the new tab tray