### PR TITLE
[FXIOS-13890] - fix for testAddTabByLongPressTabsButton smoke test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -588,7 +588,8 @@ class TabsTestsIphone: BaseTestCase {
         waitForTabsButton()
         navigator.performAction(Action.OpenNewTabLongPressTabsButton)
         navigator.nowAt(BrowserTab)
-        navigator.goto(URLBarOpen)
+        // Adding tapping action to avoid the test to fail in bitrise
+        app.buttons["Cancel"].tapIfExists()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/FXIOS-13890

## :bulb: Description
The test failed in bitrise because when trying to tap on the tab tray button it was actually tapping on the microphone button from the keyboard that was in front opening Enabling dictation pop up.
As a solution i have added the Cancel tapping action to make sure the keyboard is no longer visible when tab tray needs to be tapped.