### PR TITLE
Refactor FXIOS-12831 [Swift 6 Migration] RemoteTabsPanelMiddleware & WallpaperMiddleware MainActor

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -4,7 +4,8 @@
 
 import Redux
 
-class WallpaperMiddleware {
+@MainActor
+final class WallpaperMiddleware {
     private let wallpaperManager: WallpaperManagerInterface
     private var wallpaperConfiguration: WallpaperConfiguration {
         let currentWallpaper = wallpaperManager.currentWallpaper
@@ -31,7 +32,7 @@ class WallpaperMiddleware {
                 windowUUID: action.windowUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
             )
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         default:
             break
         }
@@ -45,7 +46,7 @@ class WallpaperMiddleware {
                 windowUUID: action.windowUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidChange
             )
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         default:
             break
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
`RemoteTabsPanelMiddleware` & `WallpaperMiddleware` are now `@MainActor`, and are using `dispatch` instead of `dispatchLegacy` where we are already main actor (so keeping dispatch legacy when we are in concurrent context, see discussion [here](https://github.com/mozilla-mobile/firefox-ios/pull/30088#discussion_r2441337086)).

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

