### PR TITLE
Refactor FXIOS-28364 [Deferred] Replace >>== operator in addPinnedTopSite

### DIFF
--- a/firefox-ios/Storage/PinnedSites.swift
+++ b/firefox-ios/Storage/PinnedSites.swift
@@ -17,4 +17,7 @@ public protocol PinnedSites {
     func addPinnedTopSite(_ site: Site) -> Success
     func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>>
     func isPinnedTopSite(_ url: String) -> Deferred<Maybe<Bool>>
+
+    // Completion handler 
+    func addPinnedTopSite(_ site: Site, completion: @escaping @Sendable (Result<Void, Error>) -> Void)
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockablePinnedSites.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockablePinnedSites.swift
@@ -16,5 +16,9 @@ class MockablePinnedSites: PinnedSites {
         addPinnedTopSiteCalledCount += 1
         return Success()
     }
+    func addPinnedTopSite(_ site: Site, completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
+        addPinnedTopSiteCalledCount += 1
+        completion(.success(()))
+    }
     func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSQLitePinnedSites.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSQLitePinnedSites.swift
@@ -50,7 +50,10 @@ class TestSQLitePinnedSites: XCTestCase {
         }
 
         let addPinnedSites: @Sendable () -> Success = {
-            return pinnedSites.addPinnedTopSite(site1) >>== {
+            return pinnedSites.addPinnedTopSite(site1).bind { result in
+                if let error = result.failureValue {
+                    return deferMaybe(error)
+                }
                 sleep(1) // Sleep to prevent intermittent issue with sorting on the timestamp
                 return pinnedSites.addPinnedTopSite(site2)
             }
@@ -76,7 +79,10 @@ class TestSQLitePinnedSites: XCTestCase {
         }
 
         let dupePinnedSite: @Sendable () -> Success = {
-            return pinnedSites.addPinnedTopSite(site1) >>== {
+            return pinnedSites.addPinnedTopSite(site1).bind { result in
+                if let error = result.failureValue {
+                    return deferMaybe(error)
+                }
                 return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
                     XCTAssertEqual(pinnedSites.count, 1, "There should not be a dupe")
                     XCTAssertEqual(pinnedSites[0]?.url, site1.url, "Site1 should still be the only pin")
@@ -116,7 +122,10 @@ class TestSQLitePinnedSites: XCTestCase {
         }
 
         let addPinnedSites: @Sendable () -> Success = {
-            return pinnedSites.addPinnedTopSite(site1) >>== {
+            return pinnedSites.addPinnedTopSite(site1).bind { result in
+                if let error = result.failureValue {
+                    return deferMaybe(error)
+                }
                 sleep(1) // Sleep to prevent intermittent issue with sorting on the timestamp
                 return pinnedSites.addPinnedTopSite(site2)
             }


### PR DESCRIPTION
## 📜 Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13009)
Github issue: #28364

## 💡 Description
Replaces the Deferred operator >>== usage in the BrowserDBSQLite.addPinnedTopSite function under the SQLitePinnedSites file, following the pattern in PR #28278.

This change removes the >>== operator from addPinnedTopSite while maintaining the exact same behavior by using the .bind pattern.

Adding a completion handler to addPinnedTopSite 

## 📝 Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass 
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example @Mergifyio backport release/v120)

Fixes #28364