### PR TITLE
Refactor FXIOS-12779 [UserAgent] Use desktopUserAgent from its builder default

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -48,9 +48,7 @@ open class UserAgent {
     }
 
     public static func desktopUserAgent() -> String {
-        // swiftlint:disable line_length
-        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Safari/605.1.15"
-        // swiftlint:enable line_length
+        return UserAgentBuilder.defaultDesktopUserAgent().userAgent()
     }
 
     public static func mobileUserAgent() -> String {


### PR DESCRIPTION
## :scroll: Tickets
FXIOS-12779
#27829

## :bulb: Description

After #28651 aligned `UserAgentBuilder.defaultDesktopUserAgent` with the fixed value being actually used, the two now match — so the hard-coded value can be removed in favor of UserAgentBuilder path to only manage the constants in one single place.

NB: This doesn't touch any tests, so it shows the effective value used will stay the same as before.

<!-- 
## :movie_camera: Demos
  -->

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code