### PR TITLE
[MTE-4958] - Improve and fix several auto tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -419,7 +419,8 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         navigator.goto(URLBarOpen)
         addWebsiteToShortcut(website: url_3)
         addWebsiteToShortcut(website: path(forTestPage: url_2["url"]!))
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
+        let cancelButton = app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton]
+        cancelButton.tapWithRetry()
 
         // Verify shortcuts are displayed on the homepage
         let itemCell = app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -457,7 +457,7 @@ class BaseTestCase: XCTestCase {
 
     func openNewTabAndValidateURLisPaste(url: String) {
         app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
-        app.buttons["Cancel"].waitAndTap()
+        app.buttons["Cancel"].tapWithRetry()
         let urlBar = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
         let pasteAction = app.tables.buttons[AccessibilityIdentifiers.Photon.pasteAction]
         if !iPad() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
@@ -129,9 +129,10 @@ final class ZoomingTests: BaseTestCase {
         } else if XCUIDevice.shared.orientation == .landscapeLeft && userState.isPrivate == false {
             homepageSearchBar.tapIfExists()
             navigator.nowAt(BrowserTab)
+        } else if iPad() && userState.isPrivate == false {
+            navigator.nowAt(BrowserTab)
         } else {
             navigator.performAction(Action.OpenNewTabFromTabTray)
-            navigator.nowAt(BrowserTab)
         }
         navigator.openURL(websites[index])
         waitUntilPageLoad()
@@ -204,29 +205,17 @@ final class ZoomingTests: BaseTestCase {
         zoomBar.assertZoomPercent("100%")
 
         // Reopen the tab 0 (should be in 175%), then zoom out to 100%
-        if !iPad() || userState.isPrivate {
-            selectTabTrayWebsites(tab: 0)
-        } else {
-            selectTabTrayWebsites(tab: 1)
-        }
+        selectTabTrayWebsites(tab: 0)
         zoomBar.assertZoomPercent("175%")
         zoomBar.tapZoomOut(times: 4)
 
         // Open the tab 1 (should be in 110%), zoom out to 100%
-        if !iPad() || userState.isPrivate {
-            selectTabTrayWebsites(tab: 1)
-        } else {
-            selectTabTrayWebsites(tab: 3)
-        }
+        selectTabTrayWebsites(tab: 1)
         zoomBar.assertZoomPercent("110%")
         zoomBar.tapZoomOut(times: 1)
 
         // Open the tab 2 (should be in 100%)
-        if !iPad() || userState.isPrivate {
-            selectTabTrayWebsites(tab: 2)
-        } else {
-            selectTabTrayWebsites(tab: 5)
-        }
+        selectTabTrayWebsites(tab: 2)
         zoomBar.assertZoomPercent("100%")
     }
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4958

## :bulb: Description
Fixes for zoom tests on iPad
Noticed that sometimes on M4 machine tapping on cancel url button doesn't dismisses the keyboard, making some tests to be flaky. Adding tapWithRetry to make sure cancel button gets tapped and the keyboard dismissed.
