### PR TITLE
[MTE-4960] - multiple fixes for auto tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
@@ -12,6 +12,7 @@ class AuthenticationTest: BaseTestCase {
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)
         navigator.openURL(testBasicHTTPAuthURL)
+        waitUntilPageLoad()
 
         // Predicate to wait for element to exist
         let existsPredicate = NSPredicate(format: "exists == true")
@@ -26,6 +27,7 @@ class AuthenticationTest: BaseTestCase {
         if result != .completed {
             // User already logged, tap on reload button
             app.buttons["TabLocationView.reloadButton"].waitAndTap()
+            waitUntilPageLoad()
         }
         mozWaitForElementToExist(app.staticTexts[
             "A username and password are being requested by jigsaw.w3.org. The site says: test"
@@ -44,6 +46,7 @@ class AuthenticationTest: BaseTestCase {
         app.alerts.secureTextFields["Password"].tapAndTypeText("guest")
         mozWaitElementEnabled(element: app.alerts.buttons["Log in"], timeout: TIMEOUT)
         app.alerts.buttons["Log in"].waitAndTap()
+        waitUntilPageLoad()
         /* There is no other way to verify basic auth is successful as the webview is
          inaccessible after sign in to verify the success text. */
         waitForNoExistence(app.alerts.buttons["Cancel"], timeoutValue: 5)
@@ -54,7 +57,7 @@ class AuthenticationTest: BaseTestCase {
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)
         navigator.openURL(testBasicHTTPAuthURL)
-        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
+        waitUntilPageLoad()
         navigator.nowAt(NewTabScreen)
         mozWaitForElementToExist(app.webViews["Web content"].staticTexts["Your browser made it!"])
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -71,13 +71,13 @@ class BaseTestCase: XCTestCase {
         let icon = springboard.icons.containingText("Fennec").element(boundBy: 0)
         if icon.exists {
             icon.press(forDuration: 1.5)
-            springboard.buttons["Remove App"].waitAndTap()
+            springboard.buttons["Remove App"].tapWithRetry()
             mozWaitForElementToNotExist(springboard.buttons["Remove App"])
             mozWaitForElementToExist(springboard.alerts.firstMatch)
-            springboard.alerts.buttons["Delete App"].waitAndTap()
+            springboard.alerts.buttons["Delete App"].tapWithRetry()
             mozWaitForElementToNotExist(springboard.alerts.buttons["Delete App"])
             mozWaitForElementToExist(springboard.alerts.firstMatch)
-            springboard.alerts.buttons["Delete"].waitAndTap()
+            springboard.alerts.buttons["Delete"].tapWithRetry()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
@@ -291,7 +291,8 @@ class DesktopModeTestsIphone: BaseTestCase {
 
         navigator.nowAt(BrowserTab)
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleExperimentRegularMode)
-        navigator.goto(HomePanelsScreen)
+        navigator.nowAt(TabTray)
+        navigator.goto(NewTabScreen)
         navigator.goto(URLBarOpen)
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         waitUntilPageLoad()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4960

## :bulb: Description
Improved flaky tests: testBasicHTTPAuthenticationPromptVisibleAndLogin and testPrivateModeOnHasNoAffectOnNormalMode
Attempt to fix those flaky tests that are using removeApp().
It seems on jenkins the rate fail for these tests is higher.
My solution just adds tapWithRetry on "Remove App", "Delete App" and "Delete" buttons from the springboard alert.
I cannot tell for sure this will work until the next reports, locally these failures are hard to reproduce.
