### PR TITLE
Remove EXP-6082 [Nimbus] Remove nimbus_events.enrollment_status metric tests

### DIFF
--- a/MozillaRustComponents/Tests/MozillaRustComponentsTests/NimbusTests.swift
+++ b/MozillaRustComponents/Tests/MozillaRustComponentsTests/NimbusTests.swift
@@ -498,26 +498,6 @@ class NimbusTests: XCTestCase {
         XCTAssertFalse(try helper.evalJexl(expression: "is_first_run"))
     }
 
-    func testNimbusRecordsEnrollmentStatusMetrics() throws {
-        let appSettings = NimbusAppSettings(appName: "test", channel: "nightly")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
-
-        try nimbus.setExperimentsLocallyOnThisThread(minimalExperimentJSON())
-        try nimbus.applyPendingExperimentsOnThisThread()
-
-        XCTAssertNotNil(GleanMetrics.NimbusEvents.enrollmentStatus.testGetValue(), "EnrollmentStatus event must exist")
-        let enrollmentStatusEvents = GleanMetrics.NimbusEvents.enrollmentStatus.testGetValue()!
-        XCTAssertEqual(enrollmentStatusEvents.count, 1, "event count must match")
-
-        let enrolledExtra = enrollmentStatusEvents[0].extra!
-        XCTAssertNotEqual(nil, enrolledExtra["branch"], "branch must not be nil")
-        XCTAssertEqual("secure-gold", enrolledExtra["slug"], "slug must match")
-        XCTAssertEqual("Enrolled", enrolledExtra["status"], "status must match")
-        XCTAssertEqual("Qualified", enrolledExtra["reason"], "reason must match")
-        XCTAssertEqual(nil, enrolledExtra["error_string"], "errorString must match")
-        XCTAssertEqual(nil, enrolledExtra["conflict_slug"], "conflictSlug must match")
-    }
-
     class TestRecordedContext: RecordedContext, @unchecked Sendable {
         var recorded: [[String: Any]] = []
         var enabled: Bool


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-6082)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30154)

## :bulb: Description
As of https://bugzilla.mozilla.org/show_bug.cgi?id=1996105, the nimbus_events.enrollment_status metric will be disabled by default. The metric is going to be reworked as an object metric in https://bugzilla.mozilla.org/show_bug.cgi?id=1996120, at which point tests will have to be rewritten.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

