### PR TITLE
Bugfix FXIOS-13685 [Bookmarks] Fix navigation bar partial display in New Folder screen on landscape

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -125,7 +125,7 @@ class EditFolderViewController: UIViewController,
         NSLayoutConstraint.activate([
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13685)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29684)

## :bulb: Description
Fixed the navigation bar display issue in the Bookmarks New Folder screen that was showing up partially in landscape mode. The navigation bar now displays correctly in both portrait and landscape orientations.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <img width="2622" height="1206" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-22 at 17 31 09" src="https://github.com/user-attachments/assets/35dd9bc4-de7c-4055-ada3-e2eaf4866c41" /> | <img width="786" height="363" alt="Screenshot 2025-10-27 at 14 45 28" src="https://github.com/user-attachments/assets/eb78fdeb-7691-44fb-a3d7-0702911398d0" /> |


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ✔] I filled in the ticket numbers and a description of my work
- [ ✔] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

