### PR TITLE
Bugfix FXIOS-13756 - [iOS 26] - Reader view toolbar doesn't close all the way in landscape orientation

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1578,14 +1578,16 @@ class BrowserViewController: UIViewController,
 
     private func updateHeaderConstraints() {
         let isNavToolbar = toolbarHelper.shouldShowNavigationToolbar(for: traitCollection)
+        let shouldShowTopTabs = toolbarHelper.shouldShowTopTabs(for: traitCollection)
         header.snp.remakeConstraints { make in
             // TODO: [iOS 26 Bug] - Remove this workaround when Apple fixes safe area inset updates.
-            // Bug: Safe area top inset doesn't update correctly on landscape rotation (remains 20pt).
+            // Bug: Safe area top inset doesn't update correctly on landscape rotation (remains 20pt)
+            // on iOS 26. Prior to iOS 26, safe area inset was updating correctly on rotation.
             // Impact: Header remains partially visible when scrolling.
             // Workaround: Manually adjust constraints based on orientation.
             // Related Bug: https://mozilla-hub.atlassian.net/browse/FXIOS-13756
             // Apple Developer Forums: https://developer.apple.com/forums/thread/798014
-            let topConstraint = isNavToolbar ? view.safeArea.top : view.snp.top
+            let topConstraint = (isNavToolbar || shouldShowTopTabs) ? view.safeArea.top : view.snp.top
             if isBottomSearchBar {
                 make.left.right.equalTo(view)
                 make.top.equalTo(view.safeArea.top)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13756)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29818)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### Problem
- On `iOS 26`, when rotating to landscape, the top safe area inset incorrectly remains at `20pt` instead of updating. This causes the header to remain partially visible when scrolling. The issue only resolves after backgrounding the app.

### Solution
- Adjust dynamically constraints based on device orientation to work around the iOS 26 safe area bug.
[Apple Developer related issue](https://developer.apple.com/forums/thread/798014)
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
|![before](https://github.com/user-attachments/assets/3e5c9ce0-d3e5-4d38-9815-5f1ca36bd55c)|![after](https://github.com/user-attachments/assets/6761b647-f02d-466c-b791-85ee629907f5)|
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

