### PR TITLE
Revert "Add FXIOS-29807 [Glean] Migrate to use MockGleanWrapper. (#30100)"

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4503,17 +4503,12 @@ extension BrowserViewController: TabManagerDelegate {
     /// - Parameters:
     ///   - isHomeTab: A Boolean value indicating whether the current tab is the home page.
     ///   - webView: The `WKWebView` instance to be displayed.
-    ///   - webView: The `WKWebView` instance to be displayed.
     ///   - previousTab: The previously selected tab, used to dispatch action only if opening a new homepage
     ///   after viewing a homepage. We want to dispatch an action that triggers impression telemetry.
     private func updateEmbeddedContent(isHomeTab: Bool, with webView: WKWebView, previousTab: Tab?) {
         if isHomeTab {
             updateInContentHomePanel(webView.url)
-            // Fix for #29068: Removed guard that prevented telemetry when navigating to homepage from non-homepage tabs.
-            // The guard `previousTab?.isFxHomeTab ?? false` only allowed telemetry when switching between homepages,
-            // causing missing homepage.viewed events when opening new tabs via the "+" toolbar button from regular webpages.
-            // Telemetry should fire whenever a user lands on the homepage, regardless of the previous tab type.
-            // guard previousTab?.isFxHomeTab ?? false else { return }
+            guard previousTab?.isFxHomeTab ?? false else { return }
             store.dispatchLegacy(
                 GeneralBrowserAction(
                     windowUUID: windowUUID,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-29807)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30100)

## :bulb: Description
This reverts commit 0938097464ed2d6f58aafdf71a6392ad08a84cba. This is due to [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/30100) being merged but it seems the original changes were overwritten for a suggested fix for another [issue](https://github.com/mozilla-mobile/firefox-ios/pull/30176).

As you can see from the [PR](https://github.com/mozilla-mobile/firefox-ios/pull/30100), the changes are unrelated to the PR description.

Since the code that was merged has not been reviewed, we want to undo these changes in main.

cc: @Rinwaoluwa 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

