### PR TITLE
Bugfix #30159 ⁃ [New Error Pages] - The error text is not centered and fix layout when large content size is enabled

### DIFF
--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -92,9 +92,9 @@ final class NativeErrorPageViewController: UIViewController,
         button.isEnabled = true
     }
 
-    private var commonContraintsList = [NSLayoutConstraint]()
-    private var portraitContraintsList = [NSLayoutConstraint]()
-    private var landscapeContraintsList = [NSLayoutConstraint]()
+    private var commonConstraintsList = [NSLayoutConstraint]()
+    private var portraitConstraintsList = [NSLayoutConstraint]()
+    private var landscapeConstraintsList = [NSLayoutConstraint]()
 
     private var isLandscape: Bool {
         return UIDevice.current.isIphoneLandscape
@@ -118,7 +118,7 @@ final class NativeErrorPageViewController: UIViewController,
     /// - On **iPhone**, the layout is horizontal only when in **landscape** orientation.
     ///
     /// - Returns: `true` if a horizontal layout should be used; `false` if vertical.
-    var shouldUseHorizontalLayout: Bool {
+    private var shouldUseHorizontalLayout: Bool {
         guard !isLargeContentSizeCategory else { return false }
 
         if shouldUseiPadSetup() {
@@ -252,8 +252,8 @@ final class NativeErrorPageViewController: UIViewController,
     }
 
     func adjustConstraints() {
-        NSLayoutConstraint.deactivate(portraitContraintsList + landscapeContraintsList + commonContraintsList)
-        commonContraintsList = [
+        NSLayoutConstraint.deactivate(portraitConstraintsList + landscapeConstraintsList + commonConstraintsList)
+        commonConstraintsList = [
             scrollView.topAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.topAnchor
             ),
@@ -285,23 +285,23 @@ final class NativeErrorPageViewController: UIViewController,
             ),
         ]
 
-        portraitContraintsList = [
+        portraitConstraintsList = [
             foxImage.widthAnchor.constraint(equalToConstant: UX.logoSizeWidth)
         ]
 
-        landscapeContraintsList = [
+        landscapeConstraintsList = [
             foxImage.widthAnchor.constraint(equalToConstant: UX.logoSizeWidthiPad),
             reloadButton.widthAnchor.constraint(
                 equalTo: contentStack.widthAnchor
             )
         ]
 
-        NSLayoutConstraint.activate(commonContraintsList)
+        NSLayoutConstraint.activate(commonConstraintsList)
 
-        if shouldUseiPadSetup() && !isLargeContentSizeCategory {
-            NSLayoutConstraint.activate(landscapeContraintsList)
+        if shouldUseHorizontalLayout {
+            NSLayoutConstraint.activate(landscapeConstraintsList)
         } else {
-            NSLayoutConstraint.activate(portraitContraintsList)
+            NSLayoutConstraint.activate(portraitConstraintsList)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13918)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30159)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10947)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23915)

## :bulb: Description
- Update title and description label to use `center` for `textAlignment`
- Simplify UI, removing extra stackview and setup content stackView accordingly
- Add logic to use "portrait layout" with vertical axis when Large content size is enabled 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
<img width="1488" height="2266" alt="Screenshot 2025-10-27 at 4 06 55 PM" src="https://github.com/user-attachments/assets/c8c46621-39c2-438d-98ed-6e7820e4c44b" /> | <img width="1488" height="2266" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2025-10-27 at 15 36 38" src="https://github.com/user-attachments/assets/41f8abd9-22fb-4c48-9d25-ab5e232d13ab" />  




## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

