### PR TITLE
Refactor FXIOS-13939 [Toolbar] Enable Homepage/New Tab button in Fx 145 by default

### DIFF
--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -48,7 +48,7 @@ features:
         description: >
           Enables the middle button customization for navigation toolbar.
         type: Boolean
-        default: false
+        default: true
       layout:
         description: >
           The type of layout of the toolbars.
@@ -66,7 +66,7 @@ features:
           swiping_tabs: true
           translucency: true
           minimal_address_bar: false
-          middle_button_customization: false
+          middle_button_customization: true
           layout: version1
       - channel: developer
         value:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13939)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30207)

## :bulb: Description
Enable middle toolbar customization by default.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

