### PR TITLE
Bugfix FXIOS-12142 ⁃ [Toast audit] Remove close all tabs undo toast and replace with new component after action is pressed

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -3573,7 +3573,7 @@ extension String {
             key: "TabTrayCloseOneTabTitle.v145",
             tableName: "TabsTray",
             value: "Close Tabs (%@)",
-            comment: "Text for a button in the tabs tray used delete current active tabs. Placeholder is for the number of tabs that will be going to be closed.")
+            comment: "Text for a button in the tabs tray used delete current active tabs. %@ is for the number of tabs that will be going to be closed.")
         public static let TabTrayCloseTabsOlderThanTitle = MZLocalizedString(
             key: "TabTrayCloseTabsOlderThanTitle.v140",
             tableName: "TabsTray",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12142)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/26413)

## :bulb: Description
Fixed placeholder

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

