### PR TITLE
Refactor FXIOS-13953 [Swift 6 migration] Migrate legacy dispatch to dispatch

### DIFF
--- a/BrowserKit/Tests/ReduxTests/StoreTests.swift
+++ b/BrowserKit/Tests/ReduxTests/StoreTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 @testable import Redux
 
+@MainActor
 final class StoreTests: XCTestCase {
     var mockState = MockState()
 
@@ -22,7 +23,7 @@ final class StoreTests: XCTestCase {
             windowUUID: UUID(),
             actionType: FakeReduxActionType.counterIncreased)
 
-        store.dispatchLegacy(action)
+        store.dispatch(action)
 
         XCTAssertEqual(MockState.actionsReduced[0] as? FakeReduxActionType, FakeReduxActionType.counterIncreased)
     }
@@ -35,17 +36,17 @@ final class StoreTests: XCTestCase {
         let action1 = FakeReduxAction(
             windowUUID: UUID(),
             actionType: FakeReduxActionType.counterIncreased)
-        store.dispatchLegacy(action1)
+        store.dispatch(action1)
 
         let action2 = FakeReduxAction(
             windowUUID: UUID(),
             actionType: FakeReduxActionType.counterDecreased)
-        store.dispatchLegacy(action2)
+        store.dispatch(action2)
 
         let action3 = FakeReduxAction(
             windowUUID: UUID(),
             actionType: FakeReduxActionType.increaseCounter)
-        store.dispatchLegacy(action3)
+        store.dispatch(action3)
 
         XCTAssertEqual(MockState.actionsReduced[0] as? FakeReduxActionType, FakeReduxActionType.counterIncreased)
         XCTAssertEqual(MockState.actionsReduced[1] as? FakeReduxActionType, FakeReduxActionType.counterDecreased)
@@ -64,8 +65,8 @@ final class StoreTests: XCTestCase {
             actionType: FakeReduxActionType.counterIncreased)
 
         Task.detached(priority: .background) {
-            store.dispatchLegacy(action)
             await MainActor.run {
+                store.dispatch(action)
                 expectation.fulfill()
             }
         }
@@ -86,8 +87,8 @@ final class StoreTests: XCTestCase {
             let action1 = FakeReduxAction(
                 windowUUID: UUID(),
                 actionType: FakeReduxActionType.counterIncreased)
-            store.dispatchLegacy(action1)
             await MainActor.run {
+                store.dispatch(action1)
                 expectation.fulfill()
             }
         }
@@ -95,12 +96,12 @@ final class StoreTests: XCTestCase {
         let action2 = FakeReduxAction(
             windowUUID: UUID(),
             actionType: FakeReduxActionType.counterDecreased)
-        store.dispatchLegacy(action2)
+        store.dispatch(action2)
 
         let action3 = FakeReduxAction(
             windowUUID: UUID(),
             actionType: FakeReduxActionType.increaseCounter)
-        store.dispatchLegacy(action3)
+        store.dispatch(action3)
 
         await fulfillment(of: [expectation])
 
@@ -121,18 +122,18 @@ final class StoreTests: XCTestCase {
             let action2 = FakeReduxAction(
                 windowUUID: UUID(),
                 actionType: FakeReduxActionType.increaseCounter)
-            store.dispatchLegacy(action2)
+            store.dispatch(action2)
 
             let action3 = FakeReduxAction(
                 windowUUID: UUID(),
                 actionType: FakeReduxActionType.decreaseCounter)
-            store.dispatchLegacy(action3)
+            store.dispatch(action3)
         }
         let action = FakeReduxAction(
             windowUUID: UUID(),
             actionType: FakeReduxActionType.counterIncreased)
 
-        store.dispatchLegacy(action)
+        store.dispatch(action)
 
         XCTAssertEqual(MockState.actionsReduced[0] as? FakeReduxActionType, FakeReduxActionType.counterIncreased)
         XCTAssertEqual(MockState.actionsReduced[1] as? FakeReduxActionType, FakeReduxActionType.increaseCounter)

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxViewController.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxViewController.swift
@@ -31,7 +31,7 @@ class FakeReduxViewController: UIViewController, StoreSubscriber {
         store.subscribe(self)
 
         let action = FakeReduxAction(windowUUID: windowUUID, actionType: FakeReduxActionType.requestInitialValue)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     func unsubscribeFromRedux() {
@@ -47,18 +47,18 @@ class FakeReduxViewController: UIViewController, StoreSubscriber {
 
     func increaseCounter() {
         let action = FakeReduxAction(windowUUID: windowUUID, actionType: FakeReduxActionType.increaseCounter)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     func decreaseCounter() {
         let action = FakeReduxAction(windowUUID: windowUUID, actionType: FakeReduxActionType.decreaseCounter)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     func setPrivateMode(to value: Bool) {
         let action = FakeReduxAction(privateMode: value,
                                      windowUUID: windowUUID,
                                      actionType: FakeReduxActionType.setPrivateModeTo)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
@@ -129,7 +129,7 @@ class ThemeSettingsControllerTests: XCTestCase, StoreTestUtility {
         let action = ScreenAction(windowUUID: .XCTestDefaultUUID,
                                   actionType: ScreenActionType.showScreen,
                                   screen: .themeSettings)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13953)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30239)

## :bulb: Description
Starting the migration of `dispatchLegacy` to `dispatch`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

