### PR TITLE
Refactor FXIOS-12995 [Swift 6 Migration] Update NotificationCenter usage to use Notifiable pattern (part 2)

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -29,6 +29,7 @@ import enum MozillaAppServices.VisitType
 class BrowserViewController: UIViewController,
                              SearchBarLocationProvider,
                              Themeable,
+                             Notifiable,
                              LibraryPanelDelegate,
                              RecentlyClosedPanelDelegate,
                              QRCodeViewControllerDelegate,
@@ -525,20 +526,17 @@ class BrowserViewController: UIViewController,
         ratingPromptManager.showRatingPromptIfNeeded()
     }
 
-    @objc
     private func didAddPendingBlobDownloadToQueue() {
         pendingDownloadWebView = nil
     }
 
     /// If user manually opens the keyboard and presses undo, the app switches to the last
     /// open tab, and because of that we need to leave overlay state
-    @objc
     func didTapUndoCloseAllTabToast(notification: Notification) {
         guard windowUUID == notification.windowUUID else { return }
         overlayManager.switchTab(shouldCancelLoading: true)
     }
 
-    @objc
     func didFinishAnnouncement(notification: Notification) {
         if let userInfo = notification.userInfo,
             let announcementText =  userInfo[UIAccessibility.announcementStringValueUserInfoKey] as? String {
@@ -553,7 +551,6 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    @objc
     func searchBarPositionDidChange(notification: Notification) {
         guard let dict = notification.object as? NSDictionary,
               let newSearchBarPosition = dict[PrefsKeys.FeatureFlags.SearchBarPosition] as? SearchBarPosition
@@ -653,7 +650,6 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    @objc
     fileprivate func appMenuBadgeUpdate() {
         let isActionNeeded = RustFirefoxAccounts.shared.isActionNeeded
         let showWarningBadge = isActionNeeded
@@ -742,7 +738,6 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    @objc
     func appDidEnterBackgroundNotification() {
         displayedPopoverController?.dismiss(animated: false) {
             self.updateDisplayedPopoverProperties = nil
@@ -763,7 +758,6 @@ class BrowserViewController: UIViewController,
         scrollController.showToolbars(animated: true)
     }
 
-    @objc
     func sceneDidEnterBackgroundNotification(notification: Notification) {
         // Ensure the notification is for the current window scene
         guard let currentWindowScene = view.window?.windowScene,
@@ -774,12 +768,10 @@ class BrowserViewController: UIViewController,
         privacyWindowHelper.showWindow(windowScene: currentWindowScene, withThemedColor: currentTheme().colors.layer3)
     }
 
-    @objc
     func sceneDidActivateNotification() {
         privacyWindowHelper.removeWindow()
     }
 
-    @objc
     func appWillResignActiveNotification() {
         // Dismiss any popovers that might be visible
         displayedPopoverController?.dismiss(animated: false) {
@@ -811,7 +803,6 @@ class BrowserViewController: UIViewController,
         return self.presentedViewController == nil || presentedViewController is PhotonActionSheet
     }
 
-    @objc
     func appDidBecomeActiveNotification() {
         processAppleIntelligenceState()
         privacyWindowHelper.removeWindow()
@@ -1102,94 +1093,58 @@ class BrowserViewController: UIViewController,
         navigationItem.backButtonDisplayMode = .generic
     }
 
-    // FIXME: FXIOS-12995 Use Notifiable on all of these...
+    // MARK: - Notifiable
+    func handleNotifications(_ notification: Notification) {
+        let notificationName = notification.name
+        Task { @MainActor in
+            switch notificationName {
+            case UIApplication.willResignActiveNotification: appWillResignActiveNotification()
+            case UIApplication.didBecomeActiveNotification: appDidBecomeActiveNotification()
+            case UIApplication.didEnterBackgroundNotification: appDidEnterBackgroundNotification()
+            case UIScene.didEnterBackgroundNotification: sceneDidEnterBackgroundNotification(notification: notification)
+            case UIScene.didActivateNotification: sceneDidActivateNotification()
+            case UIAccessibility.announcementDidFinishNotification: didFinishAnnouncement(notification: notification)
+            case UIAccessibility.reduceTransparencyStatusDidChangeNotification:
+                onReduceTransparencyStatusDidChange(notification)
+            case .FirefoxAccountStateChange: appMenuBadgeUpdate()
+            case .SearchBarPositionDidChange: searchBarPositionDidChange(notification: notification)
+            case .DidTapUndoCloseAllTabToast: didTapUndoCloseAllTabToast(notification: notification)
+            case .PendingBlobDownloadAddedToQueue: didAddPendingBlobDownloadToQueue()
+            case .SearchSettingsDidUpdateDefaultSearchEngine: updateForDefaultSearchEngineDidChange(notification)
+            case .PageZoomLevelUpdated: handlePageZoomLevelUpdated(notification)
+            case .PageZoomSettingsChanged: handlePageZoomSettingsChanged(notification)
+            case .RemoteTabNotificationTapped: openRecentlyClosedTabs()
+            case .StopDownloads: onStopDownloads(notification)
+            default: break
+            }
+        }
+    }
+
     private func setupNotifications() {
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(appWillResignActiveNotification),
-            name: UIApplication.willResignActiveNotification,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(appDidBecomeActiveNotification),
-            name: UIApplication.didBecomeActiveNotification,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(appDidEnterBackgroundNotification),
-            name: UIApplication.didEnterBackgroundNotification,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(sceneDidEnterBackgroundNotification),
-            name: UIScene.didEnterBackgroundNotification,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(sceneDidActivateNotification),
-            name: UIScene.didActivateNotification,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(appMenuBadgeUpdate),
-            name: .FirefoxAccountStateChange,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(searchBarPositionDidChange),
-            name: .SearchBarPositionDidChange,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(didTapUndoCloseAllTabToast),
-            name: .DidTapUndoCloseAllTabToast,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(didFinishAnnouncement),
-            name: UIAccessibility.announcementDidFinishNotification,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(didAddPendingBlobDownloadToQueue),
-            name: .PendingBlobDownloadAddedToQueue,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(updateForDefaultSearchEngineDidChange),
-            name: .SearchSettingsDidUpdateDefaultSearchEngine,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(handlePageZoomLevelUpdated),
-            name: .PageZoomLevelUpdated,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(handlePageZoomSettingsChanged),
-            name: .PageZoomSettingsChanged,
-            object: nil)
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(openRecentlyClosedTabs),
-            name: .RemoteTabNotificationTapped,
-            object: nil
-        )
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(onStopDownloads(_:)),
-            name: .StopDownloads,
-            object: nil
-        )
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(onReduceTransparencyStatusDidChange(_:)),
-            name: UIAccessibility.reduceTransparencyStatusDidChangeNotification,
-            object: nil
+        startObservingNotifications(
+            withNotificationCenter: notificationCenter,
+            forObserver: self,
+            observing: [
+                UIApplication.willResignActiveNotification,
+                UIApplication.didBecomeActiveNotification,
+                UIApplication.didEnterBackgroundNotification,
+                UIScene.didEnterBackgroundNotification,
+                UIScene.didActivateNotification,
+                UIAccessibility.announcementDidFinishNotification,
+                UIAccessibility.reduceTransparencyStatusDidChangeNotification,
+                .FirefoxAccountStateChange,
+                .SearchBarPositionDidChange,
+                .DidTapUndoCloseAllTabToast,
+                .PendingBlobDownloadAddedToQueue,
+                .SearchSettingsDidUpdateDefaultSearchEngine,
+                .PageZoomLevelUpdated,
+                .PageZoomSettingsChanged,
+                .RemoteTabNotificationTapped,
+                .StopDownloads
+            ]
         )
     }
 
-    @objc
     private func onStopDownloads(_ notification: Notification) {
         ensureMainThread {
             guard let notiWindowUUID = notification.userInfo?["windowUUID"] as? String,
@@ -1199,7 +1154,6 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    @objc
     private func onReduceTransparencyStatusDidChange(_ notification: Notification) {
         updateToolbarDisplay()
 
@@ -3611,13 +3565,11 @@ class BrowserViewController: UIViewController,
 
     // MARK: Page Zoom
 
-    @objc
     func handlePageZoomSettingsChanged(_ notification: Notification) {
         zoomManager.updateZoomChangedInOtherWindow()
         zoomPageBar?.updateZoomLabel(zoomValue: zoomManager.getZoomLevel())
     }
 
-    @objc
     func handlePageZoomLevelUpdated(_ notification: Notification) {
         guard let uuid = notification.windowUUID,
               let zoomSetting = notification.userInfo?["zoom"] as? DomainZoomLevel,
@@ -4228,13 +4180,10 @@ extension BrowserViewController: HomePanelDelegate {
         showBookmarkToast(urlString: urlString, action: action)
     }
 
-    @objc
     func openRecentlyClosedTabs() {
-        DispatchQueue.main.async {
-            self.navigationHandler?.show(homepanelSection: .history)
-            self.notificationCenter.post(name: .OpenRecentlyClosedTabs)
-        }
-     }
+        self.navigationHandler?.show(homepanelSection: .history)
+        self.notificationCenter.post(name: .OpenRecentlyClosedTabs)
+    }
 
     // MARK: - BrowserStatusBarScrollDelegate
     func homepageScrollViewDidScroll(scrollOffset: CGFloat) {
@@ -4273,7 +4222,6 @@ extension BrowserViewController: SearchViewControllerDelegate {
         self.present(navController, animated: true, completion: nil)
     }
 
-    @objc
     func updateForDefaultSearchEngineDidChange(_ notification: Notification) {
         // Update search icon when the search engine changes
         let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.searchEngineDidChange)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12995)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28337)

## :bulb: Description
Grabbed changes from #28808 which were somehow lost, migrating BVC to use Notifiable instead of using NotificationCenter directly with `@objc` selectors.

For some reason, this work got lost on a previous epic branch, from @PARAIPAN9 : #28808

I tried to copy the changes back for this PR. Assuming I didn't miss anything, all this has been previously reviewed. 😅 

cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

