### PR TITLE
Refactor FXIOS-13953 [Swift 6 Migration] Tracking protection is using dispatch instead of dispatchLegacy

### DIFF
--- a/firefox-ios/Client/ContentBlocker/TabContentBlocker+ContentScript.swift
+++ b/firefox-ios/Client/ContentBlocker/TabContentBlocker+ContentScript.swift
@@ -41,7 +41,7 @@ extension TabContentBlocker {
                     self.stats = self.stats.create(matchingBlocklist: listItem, host: url.host ?? "")
 
                     guard let windowUUID = self.tab?.currentWebView()?.currentWindowUUID else { return }
-                    store.dispatchLegacy(
+                    store.dispatch(
                         TrackingProtectionAction(windowUUID: windowUUID,
                                                  actionType: TrackingProtectionActionType.updateBlockedTrackerStats)
                     )

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
@@ -185,14 +185,14 @@ class TrackingProtectionModel {
             self?.selectedTab?.webView?.reload()
 
             guard let windowUUID = self?.selectedTab?.windowUUID else { return }
-            store.dispatchLegacy(
+            store.dispatch(
                 TrackingProtectionMiddlewareAction(
                     windowUUID: windowUUID,
                     actionType: TrackingProtectionMiddlewareActionType.dismissTrackingProtection
                 )
             )
 
-            store.dispatchLegacy(
+            store.dispatch(
                 GeneralBrowserAction(
                     toastType: .clearCookies,
                     windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -138,7 +138,7 @@ class TrackingProtectionViewController: UIViewController,
         subscribeToRedux()
     }
 
-    deinit {
+    isolated deinit {
         unsubscribeFromRedux()
     }
 
@@ -255,11 +255,11 @@ class TrackingProtectionViewController: UIViewController,
         })
     }
 
-    nonisolated func unsubscribeFromRedux() {
+    func unsubscribeFromRedux() {
         let action = ScreenAction(windowUUID: self.windowUUID,
                                   actionType: ScreenActionType.closeScreen,
                                   screen: .trackingProtection)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     // MARK: Content View
@@ -357,7 +357,7 @@ class TrackingProtectionViewController: UIViewController,
         constraints.append(contentsOf: trackersConnectionConstraints)
         trackersView.trackersButtonCallback = { [weak self] in
             guard let self else { return }
-            store.dispatchLegacy(
+            store.dispatch(
                 TrackingProtectionAction(
                     windowUUID: self.windowUUID,
                     actionType: TrackingProtectionActionType.tappedShowBlockedTrackers
@@ -367,7 +367,7 @@ class TrackingProtectionViewController: UIViewController,
         connectionStatusView.connectionStatusButtonCallback = { [weak self] in
             guard let self, model.connectionSecure else { return }
 
-            store.dispatchLegacy(
+            store.dispatch(
                 TrackingProtectionAction(
                     windowUUID: self.windowUUID,
                     actionType: TrackingProtectionActionType.tappedShowTrackingProtectionDetails
@@ -576,7 +576,7 @@ class TrackingProtectionViewController: UIViewController,
 
     @objc
     private func didTapClearCookiesAndSiteData() {
-        store.dispatchLegacy(
+        store.dispatch(
             TrackingProtectionAction(windowUUID: self.windowUUID,
                                      actionType: TrackingProtectionActionType.tappedShowClearCookiesAlert)
         )
@@ -584,7 +584,7 @@ class TrackingProtectionViewController: UIViewController,
 
     @objc
     func protectionSettingsTapped() {
-        store.dispatchLegacy(
+        store.dispatch(
             TrackingProtectionAction(windowUUID: self.windowUUID,
                                      actionType: TrackingProtectionActionType.tappedShowSettings)
         )
@@ -594,7 +594,7 @@ class TrackingProtectionViewController: UIViewController,
     func openSettingsTapped() {
         let isContentBlockingConfigEnabled = profile?.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? true
         if !isContentBlockingConfigEnabled {
-            store.dispatchLegacy(
+            store.dispatch(
                 TrackingProtectionAction(windowUUID: self.windowUUID,
                                          actionType: TrackingProtectionActionType.tappedShowSettings)
             )
@@ -614,7 +614,7 @@ class TrackingProtectionViewController: UIViewController,
     }
 
     private func showSettings() {
-        store.dispatchLegacy(
+        store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(.trackingProtectionSettings),
                 windowUUID: self.windowUUID,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13953)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30239)

## :bulb: Description
- We can start using `isolated deinit` which allows us to call `dispatch` instead of `dispatchLegacy`
- All tracking protections menu actions are also calling `dispatch` instead of `dispatchLegacy`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

