### PR TITLE
Add FXIOS-13648 [Trending Searches] initial recent searches UI

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -353,8 +353,9 @@ class BrowserViewController: UIViewController,
         return featureFlags.isFeatureEnabled(.tabScrollRefactorFeature, checking: .buildOnly)
     }
 
-    private var isPreSearchEnabled: Bool {
+    private var isRecentOrTrendingSearchEnabled: Bool {
         let isTrendingSearchEnabled = featureFlags.isFeatureEnabled(.trendingSearches, checking: .buildOnly)
+        let isRecentSearchEnabled = featureFlags.isFeatureEnabled(.recentSearches, checking: .buildOnly)
         return isTrendingSearchEnabled || isRecentSearchEnabled
     }
 
@@ -3815,9 +3816,11 @@ class BrowserViewController: UIViewController,
 
     /// Zero search describes the state in which the user highlights the address bar, but no
     /// text has been entered.
-    /// We only want to display if webview, user has either trending searches or recent searches enabled.
+    /// We only want to display if webview, user has either trending searches or recent searches enabled
+    /// and is not private mode.
     private func showZeroSearchView() {
-        guard contentContainer.hasWebView, isPreSearchEnabled else {
+        let isPrivateTab = tabManager.selectedTab?.isPrivate ?? false
+        guard contentContainer.hasWebView, isRecentOrTrendingSearchEnabled, !isPrivateTab else {
             hideSearchController()
             return
         }
@@ -3867,9 +3870,11 @@ class BrowserViewController: UIViewController,
                 toast.removeFromSuperview()
             }
             // Instead of showing homepage when user enters overlay mode,
-            // we want to show the zero search state if trending searches or recent searches is enabled
-            if !isPreSearchEnabled {
-                showEmbeddedHomepage(inline: false, isPrivate: tabManager.selectedTab?.isPrivate ?? false)
+            // we want to show the zero search state if trending searches or recent searches is enabled or if in private mode
+            // we handle that in `showZeroSearchView()` and avoid embedding homepage here.
+            let isPrivateMode = tabManager.selectedTab?.isPrivate ?? false
+            if !isRecentOrTrendingSearchEnabled || isPrivateMode {
+                showEmbeddedHomepage(inline: false, isPrivate: isPrivateMode)
             }
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchListSection.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchListSection.swift
@@ -5,7 +5,11 @@
 import Foundation
 
 enum SearchListSection: Int, CaseIterable {
+    // Pre search state
+    case recentSearches
     case trendingSearches
+
+    // User typed search term state
     case searchSuggestions
     case firefoxSuggestions
     case openedTabs

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -501,9 +501,14 @@ final class AddressToolbarContainer: UIView,
         let locationText = shouldShowSuggestions ? searchTerm : nil
         enterOverlayMode(locationText, pasted: false, search: false)
 
-        // We want to show suggestions if we turn on the trending searches
-        // which displays the zero search state.
-        let isZeroSearchEnabled = featureFlags.isFeatureEnabled(.trendingSearches, checking: .buildOnly)
+        // We want to show suggestions if we turn on the trending searches or recent searches
+        // which displays the zero search state. Only if not in private mode.
+        let isTrendingSearchEnabled = featureFlags.isFeatureEnabled(.trendingSearches, checking: .buildOnly)
+        let isRecentSearchEnabled = featureFlags.isFeatureEnabled(.recentSearches, checking: .buildOnly)
+        let isRecentOrTrendingSearchEnabled = isTrendingSearchEnabled || isRecentSearchEnabled
+        let isPrivateMode = model?.isPrivateMode ?? false
+        let isZeroSearchEnabled = isRecentOrTrendingSearchEnabled && !isPrivateMode
+
         if shouldShowSuggestions || isZeroSearchEnabled {
             delegate?.openSuggestions(searchTerm: locationText ?? "")
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/MockRecentSearchProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/MockRecentSearchProvider.swift
@@ -8,14 +8,13 @@ import Foundation
 /// A mock for testing that methods are called.
 final class MockRecentSearchProvider: RecentSearchProvider {
     private(set) var addRecentSearchCalledCount = 0
-    private(set) var recentSearchesCalledCount = 0
-    private(set) var loadRecentSearchesCalledCount = 0
+    private let searchTerms: [String] = ["search term 1", "search term 2"]
 
     func addRecentSearch(_ term: String, url: String?) {
         addRecentSearchCalledCount += 1
     }
 
     func loadRecentSearches(completion: @escaping ([String]) -> Void) {
-        loadRecentSearchesCalledCount += 1
+        completion(searchTerms)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13648)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29613)

## :bulb: Description
Add initial recent searches UI by creating new section with list of recent searches. 
- Updates the zero search to consider showing if either recent or trending searches is enabled.
- We also only show this state if the user is not in private mode. 

## :movie_camera: Demos
<img width="200" height="500" alt="simulator_screenshot_E2E3BC72-BD7B-42E8-AA49-0B484B73498F" src="https://github.com/user-attachments/assets/d21015cd-7b19-424e-bf9e-41a8d0ffdf40" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

