### PR TITLE
Refactor FXIOS-13944 [Swift 6] remove nonisolated from unsubscribeFromRedux 

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -49,8 +49,16 @@ class SearchEngineSelectionViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    isolated deinit {
-        unsubscribeFromRedux()
+    deinit {
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("AddressBarPanGestureHandler was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            unsubscribeFromRedux()
+        }
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -66,8 +66,16 @@ class RemoteTabsPanel: UIViewController,
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    isolated deinit {
-        unsubscribeFromRedux()
+    deinit {
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("AddressBarPanGestureHandler was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            unsubscribeFromRedux()
+        }
     }
 
     var currentWindowUUID: UUID? { return windowUUID }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabPeekViewController.swift
@@ -40,8 +40,16 @@ final class TabPeekViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    isolated deinit {
-        unsubscribeFromRedux()
+    deinit {
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("AddressBarPanGestureHandler was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            unsubscribeFromRedux()
+        }
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -88,7 +88,15 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
     }
 
     deinit {
-        unsubscribeFromRedux()
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("AddressBarPanGestureHandler was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            unsubscribeFromRedux()
+        }
     }
 
     private func setupGesture() {
@@ -107,7 +115,7 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
         })
     }
 
-    nonisolated private func unsubscribeFromRedux() {
+    private func unsubscribeFromRedux() {
         store.unsubscribe(self)
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -121,8 +121,16 @@ final class HomepageViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    isolated deinit {
-        unsubscribeFromRedux()
+    deinit {
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("AddressBarPanGestureHandler was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            unsubscribeFromRedux()
+        }
     }
 
     func stopCFRsTimer() {

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -195,8 +195,16 @@ final class MicrosurveyViewController: UIViewController,
         )
     }
 
-    isolated deinit {
-        unsubscribeFromRedux()
+    deinit {
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("AddressBarPanGestureHandler was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            unsubscribeFromRedux()
+        }
     }
 
     private func configureUI() {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -198,8 +198,16 @@ final class NativeErrorPageViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    isolated deinit {
-        unsubscribeFromRedux()
+    deinit {
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("AddressBarPanGestureHandler was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            unsubscribeFromRedux()
+        }
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -95,8 +95,16 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
         )
     }
 
-    isolated deinit {
-        unsubscribeFromRedux()
+    deinit {
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("AddressBarPanGestureHandler was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            unsubscribeFromRedux()
+        }
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13944)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Remove nonisolated from unsubscribeFromRedux. Do not leverage isolated deinits because they currently do not seem to work with uuids.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

