### PR TITLE
Bugfix FXIOS-13970 [Homepage] Blank homepage on iOS 15

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -52,7 +52,7 @@ final class HomepageViewController: UIViewController,
     private let syncTabContextualHintViewController: ContextualHintViewController
     private var homepageState: HomepageState
     private var lastContentOffsetY: CGFloat = 0
-    private var hasLaidOutSubviews = false
+    private var didFinishFirstLayout = false
 
     private var currentTheme: Theme {
         themeManager.getCurrentTheme(for: windowUUID)
@@ -184,8 +184,8 @@ final class HomepageViewController: UIViewController,
         /// FXIOS-13970: Legacy homepage layout was appearing blank on iOS 15. The root cause was from applying the diffable
         /// data source snapshot before the view had finished it's first layout pass, causing the snapshot to be ignored.
         /// This issue seems to be resolved by the SDK on later iOS versions
-        if !hasLaidOutSubviews {
-            hasLaidOutSubviews = true
+        if !didFinishFirstLayout {
+            didFinishFirstLayout = true
             store.dispatchLegacy(
                 HomepageAction(
                     numberOfTopSitesPerRow: numberOfTilesPerRow(for: availableWidth),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13970)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30280)

## :bulb: Description
- Fixes an issue where the homepage would appear blank on iOS 15

### 📝 Technical Notes
- On iOS 15, applying a diffable datasource snapshot before the view controller has finished it's first layout pass caused the snapshot to be ignored, consequently leading to no updates in layout, regardless of the change in the data source. 
- Issue began when a diffing mechanism was added to `HomepageViewController::newState` to prevent excessive re-layout calculations of the homepage when there weren't any changes in state. Before this change, we were constantly applying snapshots and updating the layout unnecessarily, which prevented this issue from being noticed.
- Issue only affected users with the `stories-redesign` (legacy homepage design) flag disabled because there is [an unrelated action dispatched in BVC](https://github.com/mozilla-mobile/firefox-ios/blob/a499300f8083a79582e04f4da74c89265039ebc7/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift#L2974-L2979) that updates the homepage state when the `stories-redesign` flag is enabled that occurs after the homepage's initial layout pass.
- Issue was resolved by waiting until the first layout pass of the `HomepageViewController` has completed before dispatching the `initialize` action which updates the homepage state with new data for the collection view's datasource


## :movie_camera: Demos
| Before | After |
| ------------- | ------------- |
| <img width="1284" height="2778" alt="Simulator Screenshot - iPhone 12 Pro Max - 2025-10-30 at 16 19 47" src="https://github.com/user-attachments/assets/fed8b7b6-4ebe-45a3-9f8f-06fc2e5c7e19" /> | <img width="1284" height="2778" alt="Simulator Screenshot - iPhone 12 Pro Max - 2025-10-30 at 16 21 20" src="https://github.com/user-attachments/assets/ec6ee061-15d5-4da5-b039-76b0ed84a568" /> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

