### PR TITLE
Add FXIOS-30299 [Stories Feed] Use standalone tab for stories web view

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1147,7 +1147,19 @@ class BrowserCoordinator: BaseCoordinator,
 
     func showStoriesWebView(url: URL?) {
         guard let url else { return }
-        let tab = tabManager.addTab(URLRequest(url: url), afterTab: nil, zombie: false, isPrivate: false)
+
+        // Creates an unmanaged tab that is destroyed once the stories webview view controller is dismissed
+        // Used to prevent persisting tab in the tab tray during and across app sessions
+        let tab = Tab(profile: profile, isPrivate: false, windowUUID: windowUUID)
+        let tabConfigurationProvider = TabConfigurationProvider(prefs: profile.prefs)
+        let tabConfiguration = tabConfigurationProvider.configuration(isPrivate: tab.isPrivate).webViewConfiguration
+        tab.url = url
+        tab.navigationDelegate = browserViewController
+        tab.tabDelegate = browserViewController
+        tab.createWebview(configuration: tabConfiguration)
+        tab.loadRequest(URLRequest(url: url))
+
+        // Present the stories web view with the tab's webview
         guard let webView = tab.webView else { return }
         let webviewViewController = StoriesWebviewViewController(windowUUID: windowUUID, webView: webView)
         router.push(webviewViewController)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -461,6 +461,14 @@ extension BrowserViewController: WKNavigationDelegate {
         // prevent the App from opening universal links
         // https://stackoverflow.com/questions/38450586/prevent-universal-links-from-opening-in-wkwebview-uiwebview
         let allowPolicy = WKNavigationActionPolicy(rawValue: WKNavigationActionPolicy.allow.rawValue + 2) ?? .allow
+
+        // Stories feed tabs are not managed by tabManager, so just allow them without any special logic
+        let isStoriesFeed = store.state.screenState(StoriesFeedState.self, for: .storiesFeed, window: windowUUID) != nil
+        if isStoriesFeed {
+            decisionHandler(.allow)
+            return
+        }
+
         guard let url = navigationAction.request.url,
               let tab = tabManager[webView]
         else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13981)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30299)

## :bulb: Description
- Use a tab in an unmanaged context to be used for the stories feed web view
- Prevents stories feed webpage tabs from showing up in the tab tray during or across sessions

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

