### PR TITLE
Add FXIOS-29089 [Bookmarks] The Folder's name is visible 

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -66,7 +66,6 @@ class OneLineTableViewCell: UITableViewCell,
         label.textAlignment = .natural
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.adjustsFontForContentSizeCategory = true
         label.setContentCompressionResistancePriority(.required, for: .vertical)
         label.setContentHuggingPriority(.defaultHigh, for: .vertical)
     }
@@ -109,8 +108,6 @@ class OneLineTableViewCell: UITableViewCell,
                     - safeAreaInsets.right
             }
         }
-        // ✅ Fix wrapping on large screens
-        titleLabel.preferredMaxLayoutWidth = titleLabel.frame.width
     }
 
     private func updateReorderControl() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13386)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29098)

## Description
The PR makes The folder’s name is visible.



## Solution
 
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 14 Pro Max - 2025-11-05 at 13 45 09" src="https://github.com/user-attachments/assets/f305d7be-0408-4b63-9fb5-991878156a0f" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

