### PR TITLE
Bugfix FXIOS-13771 ⁃ The initial menu needs to be scrolled

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -21,7 +21,7 @@ class MainMenuViewController: UIViewController,
         static let hintViewCornerRadius: CGFloat = 20
         static let hintViewHeight: CGFloat = 140
         static let hintViewMargin: CGFloat = 20
-        static let menuHeightTolerance: CGFloat = 30
+        static let menuHeightTolerance: CGFloat = 20
         static let topMarginCFR: CGFloat = 100
     }
     typealias SubscriberStateType = MainMenuState


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13771)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29839)

## :bulb: Description
Changed menuHeightTolerance

## :movie_camera: Demos
<img width="2048" height="2732" alt="Simulator Screenshot - iPad Air 13-inch (M3) - 2025-11-03 at 11 44 33" src="https://github.com/user-attachments/assets/1f44607a-5b43-4446-9649-c5016d2ffc94" />
<img width="1080" height="2340" alt="Simulator Screenshot - iPhone 12 mini - 2025-11-03 at 11 51 40" src="https://github.com/user-attachments/assets/bcbab09d-5cbb-4ed7-ae37-96d49f76d138" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

