### PR TITLE
Add FXIOS-14000 [Translations] translation icon to iPad

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -1008,30 +1008,54 @@ struct AddressBarState: StateType, Sendable, Equatable {
                 let shareAction = shareAction(enabled: isLoading == false,
                                               hasAlternativeLocationColor: hasAlternativeLocationColor)
                 actions.append(shareAction)
+
+                if let translationAction = configureTranslationIcon(
+                    for: action,
+                    addressBarState: addressBarState,
+                    isLoading: isLoading,
+                    hasAlternativeLocationColor: hasAlternativeLocationColor
+                ) {
+                    actions.append(translationAction)
+                }
             }
         } else if !isHomepage, isShowingNavigationToolbar {
             let shareAction = shareAction(enabled: isLoading == false,
                                           hasAlternativeLocationColor: hasAlternativeLocationColor)
             actions.append(shareAction)
 
-            // TODO: FXIOS-13930 - Add loading and active mode to the translation icon
-            // Check if action has an updated configuration, otherwise default to state.
-            let canTranslateFromAction = action.translationConfiguration?.canTranslate ?? false
-            let canTranslateFromState = addressBarState.translationConfiguration?.canTranslate ?? false
-            if canTranslateFromAction || canTranslateFromState {
-                let configuration = action.translationConfiguration ?? addressBarState.translationConfiguration
-                if let configuration {
-                    let translateAction = translateAction(
-                        enabled: isLoading == false,
-                        configuration: configuration,
-                        hasAlternativeLocationColor: hasAlternativeLocationColor
-                    )
-                    actions.append(translateAction)
-                }
+            if let translationAction = configureTranslationIcon(
+                for: action,
+                addressBarState: addressBarState,
+                isLoading: isLoading,
+                hasAlternativeLocationColor: hasAlternativeLocationColor
+            ) {
+                actions.append(translationAction)
             }
         }
 
         return actions
+    }
+
+    // Checks whether we should show the translation icon based on the translation configuration
+    // state and setups up the configuration for the translation icon on the toolbar (for iPad and iPhone)
+    private static func configureTranslationIcon(
+        for action: ToolbarAction,
+        addressBarState: AddressBarState,
+        isLoading: Bool?,
+        hasAlternativeLocationColor: Bool
+    ) -> ToolbarActionConfiguration? {
+        // Check if action has an updated configuration, otherwise default to state.
+        let canTranslateFromAction = action.translationConfiguration?.canTranslate ?? false
+        let canTranslateFromState = addressBarState.translationConfiguration?.canTranslate ?? false
+        let shouldShowTranslationIcon = canTranslateFromAction || canTranslateFromState
+        guard shouldShowTranslationIcon else { return nil }
+        let configuration = action.translationConfiguration ?? addressBarState.translationConfiguration
+        guard let configuration else { return nil }
+        return translateAction(
+            enabled: isLoading == false,
+            configuration: configuration,
+            hasAlternativeLocationColor: hasAlternativeLocationColor
+        )
     }
 
     private static func trailingPageActions(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14000)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30342)

## :bulb: Description
Add translation icon to toolbar on iPad.

## :movie_camera: Demos
<img width="500" height="1000" alt="simulator_screenshot_E1B54A91-8A7E-4812-A394-4E0F557AD83C" src="https://github.com/user-attachments/assets/833ae754-199e-4193-929c-9f4e6ed1f992" />

cc: @issammani @ih-codes 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

