### PR TITLE
Add FXIOS-13938 [Translations] update icon to hide / show after changing settings

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -146,10 +146,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
         case ToolbarActionType.numberOfTabsChanged:
             return handleNumberOfTabsChangedAction(state: state, action: action)
 
+        // Translation related actions
         case ToolbarActionType.didStartTranslatingPage,
             ToolbarActionType.translationCompleted,
             ToolbarActionType.receivedTranslationLanguage,
-            ToolbarActionType.didReceiveErrorTranslating:
+            ToolbarActionType.didReceiveErrorTranslating,
+            ToolbarActionType.didTranslationSettingsChange:
             return handleLeadingPageChangedAction(state: state, action: action)
 
         case ToolbarActionType.readerModeStateChanged:

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -132,6 +132,7 @@ enum ToolbarActionType: ActionType {
     case translationCompleted
     case receivedTranslationLanguage
     case didReceiveErrorTranslating
+    case didTranslationSettingsChange
 }
 
 struct ToolbarMiddlewareAction: Action {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -150,7 +150,8 @@ struct ToolbarState: ScreenState, Sendable {
             ToolbarActionType.didStartTranslatingPage,
             ToolbarActionType.translationCompleted,
             ToolbarActionType.receivedTranslationLanguage,
-            ToolbarActionType.didReceiveErrorTranslating:
+            ToolbarActionType.didReceiveErrorTranslating,
+            ToolbarActionType.didTranslationSettingsChange:
             return handleToolbarUpdates(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsViewController.swift
@@ -32,7 +32,16 @@ final class TranslationSettingsViewController: SettingsTableViewController {
             prefKey: PrefsKeys.Settings.translationsFeature,
             defaultValue: true,
             titleText: .Settings.Translation.ToggleTitle
-        )
+        ) { [weak self] _ in
+            guard let self else { return }
+            store.dispatch(
+                ToolbarAction(
+                    translationConfiguration: TranslationConfiguration(prefs: self.prefs),
+                    windowUUID: self.windowUUID,
+                    actionType: ToolbarActionType.didTranslationSettingsChange
+                )
+            )
+        }
         return SettingSection(
             title: NSAttributedString(
                 string: .Settings.Translation.SectionTitle

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -280,7 +280,13 @@ class SettingsTests: FeatureFlaggedTestBase {
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "translations-feature")
         app.launch()
         validateTranslationSettingsUI()
-        navigator.nowAt(SettingsScreen)
+        dismissSearchScreenFromTranslation()
+
+        navigator.nowAt(HomePanelsScreen)
+        navigator.goto(URLBarOpen)
+        navigator.openURL("https://example.com")
+        waitUntilPageLoad()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.translateButton])
     }
 
     func testTranslationSettingsDoesNotAppear_translationExperimentOff() {
@@ -292,6 +298,12 @@ class SettingsTests: FeatureFlaggedTestBase {
         mozWaitForElementToExist(table)
         let translateSettings = table.cells[AccessibilityIdentifiers.Settings.Translation.title]
         mozWaitForElementToNotExist(translateSettings)
+
+        navigator.goto(HomePanelsScreen)
+        navigator.goto(URLBarOpen)
+        navigator.openURL("https://example.com")
+        waitUntilPageLoad()
+        mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Toolbar.translateButton])
     }
 
     func testTranslationSettingsWithToggleOnOff_translationExperimentOn() {
@@ -310,10 +322,28 @@ class SettingsTests: FeatureFlaggedTestBase {
         XCTAssertEqual(translationSwitch.value as? String,
                        "0",
                        "Translation feature - toggle is enabled by default")
+        dismissSearchScreenFromTranslation()
+
+        navigator.nowAt(HomePanelsScreen)
+        navigator.goto(URLBarOpen)
+        navigator.openURL("https://example.com")
+        mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Toolbar.translateButton])
+
+        navigator.goto(SettingsScreen)
+        mozWaitForElementToExist(table)
+        translationSettings.waitAndTap()
         translationSwitch.waitAndTap()
         XCTAssertEqual(translationSwitch.value as? String,
                        "1",
                        "Translation feature - toggle is enabled by default")
+        dismissSearchScreenFromTranslation()
+
+        navigator.nowAt(HomePanelsScreen)
+        navigator.goto(URLBarOpen)
+        navigator.openURL("https://example.com")
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.translateButton])
+
+        validateTranslationSettingsUI()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2951992
@@ -540,5 +570,10 @@ class SettingsTests: FeatureFlaggedTestBase {
                        "1",
                        "Translation feature - toggle is enabled by default")
         navigator.goto(SettingsScreen)
+    }
+
+    private func dismissSearchScreenFromTranslation() {
+        app.navigationBars["Translation"].buttons["Settings"].waitAndTap()
+        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13938)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30205)

## :bulb: Description
Update showing and hiding translation icon in the toolbar based on toggling the settings. We dispatch an action that is observed by the toolbar states and re-triggers configuring the leading actions for the toolbar.

## :movie_camera: Demos

https://github.com/user-attachments/assets/33330422-5051-42a7-bb0d-8d4f1cac7cc4

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

