### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix Sendable warnings in CreditCardSettingsViewModel and CreditCardInputViewModel

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -253,7 +253,7 @@ class CreditCardInputViewModel: ObservableObject {
     }
 
     func removeCreditCard(creditCard: CreditCard?,
-                          completion: @escaping (CreditCardModifiedStatus, Bool) -> Void) {
+                          completion: @escaping @Sendable (CreditCardModifiedStatus, Bool) -> Void) {
         guard let currentCreditCard = creditCard,
               !currentCreditCard.guid.isEmpty else {
             completion(.none, false)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
@@ -18,7 +18,8 @@ enum CreditCardSettingsState: String, Equatable, CaseIterable {
     case list = "List"
 }
 
-class CreditCardSettingsViewModel {
+// FIXME: FXIOS-14006 Class is not thread safe
+final class CreditCardSettingsViewModel: @unchecked Sendable {
     var autofill: RustAutofill?
     var profile: Profile
     let windowUUID: WindowUUID
@@ -67,7 +68,7 @@ class CreditCardSettingsViewModel {
         }
     }
 
-    func getCreditCardList(_ completionHandler: @escaping ([CreditCard]?) -> Void) {
+    func getCreditCardList(_ completionHandler: @escaping @Sendable ([CreditCard]?) -> Void) {
         autofill?.listCreditCards(completion: { creditCards, error in
             guard let cards = creditCards,
                   error == nil else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

Fix Sendable warnings in CreditCardSettingsViewModel and CreditCardInputViewModel

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

