### PR TITLE
Add FXIOS-13940 [Tab tray] Adjust version of the new string

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -6976,7 +6976,7 @@ extension String {
         value: nil,
         comment: "Label for preview action on Tab Tray Tab to add current tab to Bookmarks")
     public static let TabPeekRemoveBookmark = MZLocalizedString(
-        key: "TabPeek.RemoveBookmark.v145",
+        key: "TabPeek.RemoveBookmark.v146",
         tableName: "3DTouchActions",
         value: "Remove Bookmark",
         comment: "Label for preview action on Tab Tray Tab to remove current tab from Bookmarks")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13940)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30209)

## :bulb: Description
Adjust version of the new string, for [this particular export](https://github.com/mozilla-l10n/firefoxios-l10n/pull/298) it needs to be v146 since we follow the [nightly train for strings](https://whattrainisitnow.com/)

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

