### PR TITLE
Refactor FXIOS-14020 [Swift 6 migration] SensitiveViewController migration

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
@@ -70,7 +70,7 @@ class AddressAutofillSettingsViewController: SensitiveViewController, Themeable 
             addressListViewModel: viewModel.addressListViewModel)
         self.addressAutofillSettingsPageView = UIHostingController(rootView: addressAutofillSettingsVC)
 
-        super.init(nibName: nil, bundle: nil)
+        super.init()
     }
 
     /// Not implemented for this view controller. Raises a fatal error.

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -61,7 +61,7 @@ class CreditCardSettingsViewController: SensitiveViewController, UIAdaptivePrese
         self.creditCardEmptyView = UIHostingController(rootView: emptyView)
         self.creditCardEmptyView.view.backgroundColor = .clear
 
-        super.init(nibName: nil, bundle: nil)
+        super.init()
         self.creditCardTableViewController.didSelectCardAtIndex = { [weak self] creditCard in
             self?.viewCreditCard(card: creditCard)
             self?.sendCreditCardsManagementCardTappedTelemetry()

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -10,8 +10,7 @@ import Common
 import struct MozillaAppServices.LoginEntry
 
 class PasswordManagerListViewController: SensitiveViewController,
-                                         Themeable,
-                                         Notifiable {
+                                         Themeable {
     private struct UX {
         static let separatorInset: CGFloat = 20
         static let selectAllButtonMargin: CGFloat = 16
@@ -65,7 +64,7 @@ class PasswordManagerListViewController: SensitiveViewController,
         } else {
             tableView = .build()
         }
-        super.init(nibName: nil, bundle: nil)
+        super.init()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -270,7 +269,8 @@ class PasswordManagerListViewController: SensitiveViewController,
     }
 
     // MARK: Notifiable
-    func handleNotifications(_ notification: Notification) {
+    override func handleNotifications(_ notification: Notification) {
+        super.handleNotifications(notification)
         let notificationName = notification.name
 
         ensureMainThread {

--- a/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -10,8 +10,7 @@ import Common
 import struct MozillaAppServices.LoginEntry
 
 class PasswordDetailViewController: SensitiveViewController,
-                                    Themeable,
-                                    Notifiable {
+                                    Themeable {
     private struct UX {
         static let horizontalMargin: CGFloat = 14
     }
@@ -55,7 +54,7 @@ class PasswordDetailViewController: SensitiveViewController,
         } else {
             tableView = UITableView(frame: .zero, style: .plain)
         }
-        super.init(nibName: nil, bundle: nil)
+        super.init()
 
         startObservingNotifications(
             withNotificationCenter: NotificationCenter.default,
@@ -132,7 +131,8 @@ class PasswordDetailViewController: SensitiveViewController,
     }
 
     // MARK: Notifiable
-    func handleNotifications(_ notification: Notification) {
+    override func handleNotifications(_ notification: Notification) {
+        super.handleNotifications(notification)
         guard notification.name == UIApplication.didEnterBackgroundNotification else { return }
 
         ensureMainThread {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14020)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30385)

## :bulb: Description
`SensitiveViewController` migration:
- Looked into making `SensitiveViewController` follow the `Notifiable` protocol, but there are some classes inheriting from the `SensitiveViewController` and they are already following the `Notifiable` protocol. So I didn't want to have to call `super`, since that would be changing existing behavior. So I chose to fix the warnings in place as they are today instead.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

