### PR TITLE
Bugfix FXIOS-13923 ⁃ [iOS 26][New Error Pages] The error page is incorrectly displayed when the app is in multitasking view

### DIFF
--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -237,12 +237,6 @@ final class NativeErrorPageViewController: UIViewController,
         showViewForCurrentOrientation()
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        adjustConstraints()
-        showViewForCurrentOrientation()
-    }
-
     private func configureUI() {
         let viewModel = PrimaryRoundedButtonViewModel(
             title: .NativeErrorPage.ButtonLabel,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13923)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30164)

## :bulb: Description
Removed traitCollectionDidChange override

## :movie_camera: Demos

https://github.com/user-attachments/assets/89175f56-7b15-4b4a-918f-0c1d89ba9b0a

<img width="2048" height="2732" alt="Simulator Screenshot - iPad Air 13-inch (M3) - 2025-11-05 at 09 57 33" src="https://github.com/user-attachments/assets/1184675c-65b4-4b12-bfff-bc75cda3a589" />



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

