### PR TITLE
Add FXIOS-13966 [Translations] initial CFR for translation icon

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -157,6 +157,7 @@ public struct PrefsKeys {
         case mainMenuRedesignKey = "mainMenuRedesignHintKey"
         case navigationKey = "ContextualHintNavigation"
         case toolbarUpdateKey = "ContextualHintToolbarUpdate"
+        case translationKey = "ContextualHintTranslationKey"
         case summarizerToolbarEntryKey = "summarizerToolbarEntryKey"
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -145,6 +145,48 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         UIAccessibility.post(notification: .layoutChanged, argument: summarizeToolbarEntryContextHintVC)
     }
 
+    // MARK: - Translation CFR
+    func configureTranslationContextualHint(for view: UIView) {
+        guard let state = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID) else { return }
+        // Show up arrow for iPad and landscape or top address bar; otherwise show down arrow
+        let showNavToolbar = toolbarHelper.shouldShowNavigationToolbar(for: traitCollection)
+        let shouldShowUpArrow = state.toolbarPosition == .top || !showNavToolbar
+
+        translationContextHintVC.configure(
+            anchor: view,
+            withArrowDirection: shouldShowUpArrow ? .up : .down,
+            andDelegate: self,
+            presentedUsing: { [weak self] in
+                self?.presentTranslationContextualHint()
+            },
+            andActionForButton: { },
+            overlayState: overlayManager)
+    }
+
+    private func presentTranslationContextualHint() {
+        present(translationContextHintVC, animated: true)
+        UIAccessibility.post(notification: .layoutChanged, argument: translationContextHintVC)
+    }
+
+    func dismissToolbarCFRs(with windowUUID: WindowUUID) {
+        guard let toolbarState = store.state.screenState(
+            ToolbarState.self,
+            for: .toolbar,
+            window: windowUUID
+        ) else {
+            return
+        }
+        let translationAction = toolbarState.addressToolbar.leadingPageActions.first(where: { $0.actionType == .translate })
+        if translationAction == nil {
+            resetTranslationCFRTimer()
+        }
+    }
+    // Reset the CFR timer for the translation button to avoid presenting the CFR
+    // In cases, such as if translation icon is not available
+    private func resetTranslationCFRTimer() {
+        translationContextHintVC.stopTimer()
+    }
+
     func tabToolbarDidPressHome(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         didTapOnHome()
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -257,6 +257,11 @@ class BrowserViewController: UIViewController,
         return ContextualHintViewController(with: toolbarViewProvider, windowUUID: windowUUID)
     }()
 
+    private(set) lazy var translationContextHintVC: ContextualHintViewController = {
+        let translationProvider = ContextualHintViewProvider(forHintType: .translation, with: profile)
+        return ContextualHintViewController(with: translationProvider, windowUUID: windowUUID)
+    }()
+
     private(set) lazy var summarizeToolbarEntryContextHintVC: ContextualHintViewController = {
         let summarizeViewProvider = ContextualHintViewProvider(forHintType: .summarizeToolbarEntry, with: profile)
         return ContextualHintViewController(with: summarizeViewProvider, windowUUID: windowUUID)
@@ -929,6 +934,7 @@ class BrowserViewController: UIViewController,
 
         dismissModalsIfStartAtHome()
         shouldHideAddressToolbar()
+        dismissToolbarCFRs(with: windowUUID)
     }
 
     private func showToastType(toast: ToastType) {
@@ -1505,6 +1511,10 @@ class BrowserViewController: UIViewController,
             // In general we want to dismiss when changing layout on iPhone
             if summarizeToolbarEntryContextHintVC.isPresenting || UIDevice.current.userInterfaceIdiom == .phone {
                 summarizeToolbarEntryContextHintVC.dismiss(animated: true)
+            }
+
+            if translationContextHintVC.isPresenting || UIDevice.current.userInterfaceIdiom == .phone {
+                translationContextHintVC.dismiss(animated: true)
             }
         }
 
@@ -3830,6 +3840,8 @@ class BrowserViewController: UIViewController,
             configureNavigationContextualHint(button)
         case ContextualHintType.summarizeToolbarEntry.rawValue:
             configureSummarizeToolbarEntryContextualHint(for: button)
+        case ContextualHintType.translation.rawValue:
+            configureTranslationContextualHint(for: button)
         default:
             return
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -1318,6 +1318,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
             isEnabled: enabled,
             hasCustomColor: !hasAlternativeLocationColor,
             hasHighlightedColor: false,
+            contextualHintType: ContextualHintType.translation.rawValue,
             a11yLabel: configuration.state.buttonA11yLabel,
             a11yId: AccessibilityIdentifiers.Toolbar.translateButton
         )

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintCopyProvider.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintCopyProvider.swift
@@ -58,6 +58,9 @@ struct ContextualHintCopyProvider: FeatureFlaggable {
         case .toolbarUpdate:
             return CFRStrings.Toolbar.ToolbarUpdateTitle
 
+        case .translation:
+            return String(format: CFRStrings.Translations.Title, AppName.shortName.rawValue)
+
         default: return ""
         }
     }
@@ -87,6 +90,9 @@ struct ContextualHintCopyProvider: FeatureFlaggable {
         case .toolbarUpdate:
             descriptionCopy = CFRStrings.Toolbar.ToolbarUpdateBody
 
+        case .translation:
+            descriptionCopy = CFRStrings.Translations.Body
+
         case .summarizeToolbarEntry:
             descriptionCopy = CFRStrings.Summarize.Description
         }
@@ -110,6 +116,8 @@ struct ContextualHintCopyProvider: FeatureFlaggable {
         case .navigation:
             actionCopy = ""
         case .toolbarUpdate:
+            actionCopy = ""
+        case .translation:
             actionCopy = ""
         case .summarizeToolbarEntry:
             actionCopy = ""

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintEligibilityUtility.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintEligibilityUtility.swift
@@ -47,6 +47,8 @@ struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtoco
             hintTypeShouldBePresented = true
         case .toolbarUpdate:
             hintTypeShouldBePresented = canToolbarUpdateCFRBePresented
+        case .translation:
+            hintTypeShouldBePresented = canTranslationCFRBePresented
         case .summarizeToolbarEntry:
             hintTypeShouldBePresented = true
         }
@@ -76,6 +78,10 @@ struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtoco
     /// - toolbar-update-hint flag is enabled
     private var canToolbarUpdateCFRBePresented: Bool {
         return isToolbarUpdateCFRFeatureEnabled
+    }
+
+    private var canTranslationCFRBePresented: Bool {
+        return featureFlags.isFeatureEnabled(.translation, checking: .buildOnly) ? true : false
     }
 
     /// We present JumpBackIn and SyncTab CFRs only after Toolbar CFR has been

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintPrefsKeysProvider.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintPrefsKeysProvider.swift
@@ -21,6 +21,7 @@ extension ContextualHintPrefsKeysProvider {
         case .mainMenu: return CFRPrefsKeys.mainMenuRedesignKey.rawValue
         case .navigation: return CFRPrefsKeys.navigationKey.rawValue
         case .toolbarUpdate: return CFRPrefsKeys.toolbarUpdateKey.rawValue
+        case .translation: return CFRPrefsKeys.translationKey.rawValue
         case .summarizeToolbarEntry: return CFRPrefsKeys.summarizerToolbarEntryKey.rawValue
         }
     }

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewProvider.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewProvider.swift
@@ -20,6 +20,7 @@ enum ContextualHintType: String {
     case dataClearance = "DataClearance"
     case navigation = "Navigation"
     case toolbarUpdate = "ToolbarUpdate"
+    case translation = "Translation"
     case summarizeToolbarEntry = "SummarizeToolbarEntry"
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13966)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30272)

## :bulb: Description
Add initial CFR for translation icon

Note: There are some issues when scrolling the website and entering the address bar. This seems to be due to timing issue as well as CFR being attached to the translation icon when it is no longer visible to the user. This will be handled by a separate ticket since this is impacting summarizer as well.

## :movie_camera: Demos
<img width="250" height="500" alt="simulator_screenshot_666EBB62-ADD2-4986-A156-5F855DC475D9" src="https://github.com/user-attachments/assets/a8872a07-2276-4a80-a15e-bd5029222a26" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

