### PR TITLE
Add FXIOS-13844 [Translations] language detection to middleware

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1406,6 +1406,7 @@
 		AAD861A82E9E748700F6E0E0 /* TranslationSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD861A72E9E748100F6E0E0 /* TranslationSetting.swift */; };
 		AAD861AB2E9E75AB00F6E0E0 /* TranslationSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD861AA2E9E75A100F6E0E0 /* TranslationSettingsViewController.swift */; };
 		AAD9D64B2EB25B3500BFECAF /* TranslationsMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD9D64A2EB25B3200BFECAF /* TranslationsMiddlewareTests.swift */; };
+		AADBD0E42EBBA79B00F35E30 /* MockLanguageDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADBD0E32EBBA79700F35E30 /* MockLanguageDetector.swift */; };
 		AB2AC6632BCFD0A200022AAB /* X509 in Frameworks */ = {isa = PBXBuildFile; productRef = AB2AC6622BCFD0A200022AAB /* X509 */; };
 		AB2AC6662BD15E6300022AAB /* CertificatesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2AC6652BD15E6300022AAB /* CertificatesHandler.swift */; };
 		AB3DB0C92B596739001D32CB /* AppStartupTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3DB0C82B596739001D32CB /* AppStartupTelemetry.swift */; };
@@ -9520,6 +9521,7 @@
 		AAD861A72E9E748100F6E0E0 /* TranslationSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationSetting.swift; sourceTree = "<group>"; };
 		AAD861AA2E9E75A100F6E0E0 /* TranslationSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationSettingsViewController.swift; sourceTree = "<group>"; };
 		AAD9D64A2EB25B3200BFECAF /* TranslationsMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsMiddlewareTests.swift; sourceTree = "<group>"; };
+		AADBD0E32EBBA79700F35E30 /* MockLanguageDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLanguageDetector.swift; sourceTree = "<group>"; };
 		AAF64ABAB8A585208603D45B /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		AB2AC6652BD15E6300022AAB /* CertificatesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatesHandler.swift; sourceTree = "<group>"; };
 		AB2B45078A7F1E09F65ACEC5 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Shared.strings; sourceTree = "<group>"; };
@@ -14167,6 +14169,7 @@
 		AAD9D6492EB25B2700BFECAF /* TranslationsTests */ = {
 			isa = PBXGroup;
 			children = (
+				AADBD0E32EBBA79700F35E30 /* MockLanguageDetector.swift */,
 				C27EF61E2EBA395000BED719 /* MockLanguageSampleSource.swift */,
 				C27EF6142EBA2EDD00BED719 /* LanguageDetectorTests.swift */,
 				AAD9D64A2EB25B3200BFECAF /* TranslationsMiddlewareTests.swift */,
@@ -19369,6 +19372,7 @@
 				39BF0CD72EB512CD002064F5 /* ImpressionTrackingUtilityTests.swift in Sources */,
 				21FA8FB02AE856590013B815 /* RemoteTabsCoordinatorTests.swift in Sources */,
 				0E6557402D82232B00D7F017 /* DownloadProgressManagerTests.swift in Sources */,
+				AADBD0E42EBBA79B00F35E30 /* MockLanguageDetector.swift in Sources */,
 				AAB434062E82F0600075E47F /* MockTrendingSearchProvider.swift in Sources */,
 				C80C11F428B3CD580062922A /* MockUserDefaultsTests.swift in Sources */,
 				E14D6D342CCBA9FF0058B910 /* AddressBarStateTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -1054,10 +1054,10 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let shouldShowTranslationIcon = canTranslateFromAction || canTranslateFromState
         guard shouldShowTranslationIcon else { return nil }
         let configuration = action.translationConfiguration ?? addressBarState.translationConfiguration
-        guard let configuration else { return nil }
+        guard let state = configuration?.state else { return nil }
         return translateAction(
             enabled: isLoading == false,
-            configuration: configuration,
+            state: state,
             hasAlternativeLocationColor: hasAlternativeLocationColor
         )
     }
@@ -1308,22 +1308,22 @@ struct AddressBarState: StateType, Sendable, Equatable {
     // when switching from inactive icon to loading icon when user taps on it. Hence, `hasHighlightedColor: false`.
     private static func translateAction(
         enabled: Bool,
-        configuration: TranslationConfiguration,
+        state: TranslationConfiguration.IconState,
         hasAlternativeLocationColor: Bool
     ) -> ToolbarActionConfiguration {
         // We do not want to use template mode for translate active icon.
-        let isActiveState = configuration.state == .active
+        let isActiveState = state == .active
 
         return ToolbarActionConfiguration(
             actionType: .translate,
-            iconName: configuration.state.buttonImageName,
+            iconName: state.buttonImageName,
             templateModeForImage: !isActiveState,
-            shouldUseLoadingSpinner: configuration.state == .loading,
+            shouldUseLoadingSpinner: state == .loading,
             isEnabled: enabled,
             hasCustomColor: !hasAlternativeLocationColor,
             hasHighlightedColor: false,
             contextualHintType: ContextualHintType.translation.rawValue,
-            a11yLabel: configuration.state.buttonA11yLabel,
+            a11yLabel: state.buttonA11yLabel,
             a11yId: AccessibilityIdentifiers.Toolbar.translateButton
         )
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
@@ -41,9 +41,12 @@ struct TranslationConfiguration: Equatable, FeatureFlaggable {
     }
 
     let prefs: Prefs
-    let state: IconState
+    let state: IconState?
 
-    init(prefs: Prefs, state: IconState = .inactive) {
+    // We initially set icon state as nil until we can detect the
+    // web page and determine if we should show the translation icon
+    // and set the icon to .inactive state.
+    init(prefs: Prefs, state: IconState? = nil) {
         self.prefs = prefs
         self.state = state
     }

--- a/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
+++ b/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
@@ -7,22 +7,31 @@ import NaturalLanguage
 
 /// A small utility for extracting a text sample from a web page and detecting its language.
 /// The sample is extracted using JS.
-final class LanguageDetector {
+protocol LanguageDetectorProvider: Sendable {
+    func detectLanguage(from source: LanguageSampleSource) async throws -> String?
+}
+
+final class LanguageDetector: LanguageDetectorProvider {
     /// JS function that is called to get a page sample back. The function is implemented in `Summarizer.js`.
     private let languageSampleScript =
         "return await window.__firefox__.Translations.getLanguageSampleWhenReady()"
 
+    func detectLanguage(from source: LanguageSampleSource) async throws -> String? {
+        let sample = try await extractSample(from: source)
+        guard let textSample = sample else { return nil }
+        return getDominantLanguage(of: textSample)
+    }
+
     /// Extracts a text sample from the page via the JS bridge.
     /// Returns `nil` if the bridge isn’t ready or no sample is available.
-    @MainActor
-    func extractSample(from source: LanguageSampleSource) async throws -> String? {
+    private func extractSample(from source: LanguageSampleSource) async throws -> String? {
         let sample = try await source.getLanguageSample(scriptEvalExpression: languageSampleScript)
         guard let sample = sample, !sample.isEmpty else { return nil }
         return sample
     }
 
     /// Detects the dominant language of a given text and returns its BCP-47 code (e.g. `"en"`, `"fr"`).
-    func detectLanguage(of text: String) -> String? {
+    private func getDominantLanguage(of text: String) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         return NLLanguageRecognizer.dominantLanguage(for: trimmed)?.rawValue

--- a/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageSampleSource.swift
+++ b/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageSampleSource.swift
@@ -7,7 +7,7 @@ import Foundation
 /// A small abstraction for obtaining a language sample from webpage content.
 /// This is done to allow `LanguageDetector` to request text from a page without knowing
 /// whether the source is a real `WKWebView` running JavaScript or a test mock.
-protocol LanguageSampleSource {
+protocol LanguageSampleSource: Sendable {
     /// `scriptEvalExpression` is the JavaScript expression that should be evaluated
     /// by the underlying implementation.
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -391,7 +391,10 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
             initialState,
             ToolbarAction(
                 url: URL(string: "http://mozilla.com"),
-                translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+                translationConfiguration: TranslationConfiguration(
+                    prefs: mockProfile.prefs,
+                    state: .inactive
+                ),
                 windowUUID: windowUUID,
                 actionType: ToolbarActionType.urlDidChange
             )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
@@ -9,61 +9,80 @@ import XCTest
 final class LanguageDetectorTests: XCTestCase {
     var mockLanguageSampleSource = MockLanguageSampleSource()
 
-    func testExtractSampleReturnsTextSample() async throws {
+    func test_detectLanguage_withFrench_returnsProperLanguageCode() async throws {
         mockLanguageSampleSource.mockResult = "Bonjour le monde"
         let subject = createSubject()
-        let result = try await subject.extractSample(from: mockLanguageSampleSource)
-        XCTAssertEqual(result, "Bonjour le monde")
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "fr")
     }
 
-    func testExtractSampleReturnsNilForEmptyString() async throws {
+    func test_detectLanguage_withEnglish_returnsProperLanguageCode() async throws {
+        mockLanguageSampleSource.mockResult = "Hello world"
+        let subject = createSubject()
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "en")
+    }
+
+    func test_detectLanguage_withSpanish_returnsProperLanguageCode() async throws {
+        mockLanguageSampleSource.mockResult = "Hola mundo"
+        let subject = createSubject()
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "es")
+    }
+
+    func test_detectLanguage_withJapanese_returnsProperLanguageCode() async throws {
+        mockLanguageSampleSource.mockResult = "こんにちは世界"
+        let subject = createSubject()
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "ja")
+    }
+
+    func test_detectLanguage_withKorean_returnsProperLanguageCode() async throws {
+        mockLanguageSampleSource.mockResult = "안녕하세요 세계"
+        let subject = createSubject()
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "ko")
+    }
+
+    func test_detectLanguage_withEmptyString_returnsNil() async throws {
         mockLanguageSampleSource.mockResult = ""
         let subject = createSubject()
-        let result = try await subject.extractSample(from: mockLanguageSampleSource)
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
         XCTAssertNil(result)
     }
 
-    func testExtractSampleReturnsNilForNonString() async throws {
+    func test_detectLanguage_withWhitespaces_returnsNil() async throws {
+        mockLanguageSampleSource.mockResult = " \n\t "
+        let subject = createSubject()
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertNil(result)
+    }
+
+    func test_detectLanguage_returnsNilForNonString() async throws {
         mockLanguageSampleSource.mockResult = 42
         let subject = createSubject()
-        let result = try await subject.extractSample(from: mockLanguageSampleSource)
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
         XCTAssertNil(result)
     }
 
-    func testExtractSamplePropagatesError() async {
+    func test_detectLanguage_propagatesError() async {
         enum FakeError: Error, Equatable { case foo }
         mockLanguageSampleSource.mockError = FakeError.foo
         let subject = createSubject()
 
         do {
-            _ = try await subject.extractSample(from: mockLanguageSampleSource)
+            _ = try await subject.detectLanguage(from: mockLanguageSampleSource)
             XCTFail("expected error")
         } catch {
             XCTAssertEqual(error as? FakeError, .foo)
         }
     }
 
-    func testDetectLanguageReturnsLanguageCode() {
+    func test_detectLanguage_prefersDominantLanguage() async throws {
         let subject = createSubject()
-
-        XCTAssertEqual(subject.detectLanguage(of: "Hello world"), "en")
-        XCTAssertEqual(subject.detectLanguage(of: "Bonjour le monde"), "fr")
-        XCTAssertEqual(subject.detectLanguage(of: "Hola mundo"), "es")
-        XCTAssertEqual(subject.detectLanguage(of: "こんにちは世界"), "ja")
-        XCTAssertEqual(subject.detectLanguage(of: "안녕하세요 세계"), "ko")
-    }
-
-    func testDetectLanguageReturnsNilForEmptyOrWhitespace() {
-        let subject = createSubject()
-
-        XCTAssertNil(subject.detectLanguage(of: ""))
-        XCTAssertNil(subject.detectLanguage(of: " \n\t "))
-    }
-
-    func testDetectLanguagePrefersDominantLanguage() {
-        let subject = createSubject()
-        let text = "Hello, bonjour, hello, hello"
-        XCTAssertEqual(subject.detectLanguage(of: text), "en")
+        mockLanguageSampleSource.mockResult = "Hello, bonjour, hello, hello"
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "en")
     }
 
     private func createSubject() -> LanguageDetector {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockLanguageDetector.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockLanguageDetector.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import Foundation
+@testable import Client
+
+/// Test helper that simulates language detection.
+final class MockLanguageDetector: LanguageDetectorProvider, @unchecked Sendable {
+    var detectLanguageCallCount = 0
+    func detectLanguage(from source: LanguageSampleSource) async throws -> String? {
+        detectLanguageCallCount += 1
+        return "ja"
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockLanguageSampleSource.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockLanguageSampleSource.swift
@@ -6,7 +6,7 @@ import Foundation
 @testable import Client
 
 /// Test helper that simulates JS evaluation for language sample extraction.
-final class MockLanguageSampleSource: LanguageSampleSource {
+final class MockLanguageSampleSource: LanguageSampleSource, @unchecked Sendable {
     var mockResult: Any?
     var mockError: Error?
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13844)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29994)

## :bulb: Description
Thie connects the `LanguageDetector` class to the actual middleware. Instead of showing the translation icon for every single web page, we determine if we should show the icon based on whether the detected page language differs from the device language. 

You can test with this webpage: `https://ameblo.jp/ruu-blog/` or feel free to use any other webpage on wikipedia that differs from your device language. 

## :movie_camera: Demos
https://github.com/user-attachments/assets/dbc50f15-a76d-4ed0-b844-2d46b4828125

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

