### PR TITLE
Add FXIOS-14001 [Stories Feed] Shield icon states

### DIFF
--- a/firefox-ios/Client/Frontend/StoriesFeed/StoriesWebviewViewController.swift
+++ b/firefox-ios/Client/Frontend/StoriesFeed/StoriesWebviewViewController.swift
@@ -41,7 +41,9 @@ class StoriesWebviewViewController: UIViewController,
         label.numberOfLines = 1
     }
 
-    private let shieldImageView: UIImageView = .build()
+    private let shieldImageView: UIImageView = .build { imageView in
+        imageView.image = UIImage.templateImageNamed(StandardImageIdentifiers.Small.shieldCheckmarkFill)
+    }
 
     private lazy var reloadToolbarButton: UIBarButtonItem = {
         let button = UIBarButtonItem(
@@ -163,9 +165,11 @@ class StoriesWebviewViewController: UIViewController,
         // Update domain label when navigation finishes (in the same window)
         domainLabel.text = webView.url?.normalizedHost
 
-        shieldImageView.image = webView.hasOnlySecureContent ?
+        shieldImageView.image = if webView.hasOnlySecureContent {
             UIImage.templateImageNamed(StandardImageIdentifiers.Small.shieldCheckmarkFill)
-            : UIImage(named: StandardImageIdentifiers.Small.shieldSlashFillMulticolor)
+        } else {
+            UIImage(named: StandardImageIdentifiers.Small.shieldSlashFillMulticolor)
+        }
     }
 
     // MARK: - WKUIDelegate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14001)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30344)

## :bulb: Description
- Update the shield icon state in the navigation bar when webpage content security changes

## :movie_camera: Demos
| Before | After |
| ------------- | ------------- |
| <img width="1206" height="2622" alt="simulator_screenshot_4B92C760-0950-497B-9383-382C3E92E432" src="https://github.com/user-attachments/assets/ccdf7765-7fbe-4cc5-b8e3-c891be01fb73" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2025-11-05 at 16 01 33" src="https://github.com/user-attachments/assets/45314301-98b6-477b-b0cb-02a609c127fc" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

