### PR TITLE
Add FXIOS-14030 [Settings] Export Nimbus DB when copying databases

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ExportBrowserDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ExportBrowserDataSetting.swift
@@ -22,7 +22,10 @@ class ExportBrowserDataSetting: HiddenSetting {
                 fromRelativeDirectory: "",
                 toAbsoluteDirectory: documentsPath
             ) { file in
-                return file.hasPrefix("browser.") || file.hasPrefix("logins.") || file.hasPrefix("metadata.")
+                return file.hasPrefix("browser.")
+                || file.hasPrefix("logins.")
+                || file.hasPrefix("metadata.")
+                || file.hasPrefix("nimbus.")
             }
         } catch {}
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14030)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30415)

## :bulb: Description
The Nimbus RKV database is now included when copying databases into user file storage.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

