### PR TITLE
Refactor FXIOS-13953 [Swift 6 migration] Homepage dispatch legacy

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/ActionButtonViewModel.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ActionButtonViewModel.swift
@@ -16,13 +16,13 @@ public struct ActionButtonViewModel {
     public let a11yIdentifier: String?
     public let horizontalInset: CGFloat
     public let verticalInset: CGFloat
-    public var touchUpAction: ((UIButton) -> Void)?
+    public var touchUpAction: (@MainActor (UIButton) -> Void)?
 
     public init(title: String,
                 a11yIdentifier: String?,
                 horizontalInset: CGFloat = UX.horizontalInset,
                 verticalInset: CGFloat = UX.verticalInset,
-                touchUpAction: ((UIButton) -> Void)?) {
+                touchUpAction: (@MainActor (UIButton) -> Void)?) {
         self.title = title
         self.a11yIdentifier = a11yIdentifier
         self.horizontalInset = horizontalInset

--- a/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
+++ b/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
@@ -19,7 +19,7 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
         button.addTarget(self, action: #selector(self.touchUpInside), for: .touchUpInside)
     }
 
-    private var touchUpAction: ((UIButton) -> Void)?
+    private var touchUpAction: (@MainActor (UIButton) -> Void)?
 
     // MARK: - Initializers
     override init(frame: CGRect) {
@@ -53,7 +53,7 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
         layoutIfNeeded()
     }
 
-    func configure(onTapAction: ((UIButton) -> Void)?, theme: Theme) {
+    func configure(onTapAction: (@MainActor (UIButton) -> Void)?, theme: Theme) {
         touchUpAction = onTapAction
         let goToSettingsButtonViewModel = SecondaryRoundedButtonViewModel(
             title: .FirefoxHomepage.CustomizeHomepage.ButtonTitle,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -175,7 +175,7 @@ struct ContextMenuState {
                                      allowIconScaling: true,
                                      tapHandler: { _ in
             ContextMenuState.dispatchSettingsAction(windowUUID: windowUUID, section: .topSites)
-            store.dispatchLegacy(
+            store.dispatch(
                 ContextMenuAction(windowUUID: windowUUID, actionType: ContextMenuActionType.tappedOnSettingsAction)
             )
         }).items
@@ -206,7 +206,7 @@ struct ContextMenuState {
                     isPrivate: false,
                     selectNewTab: true
                 )
-                store.dispatchLegacy(
+                store.dispatch(
                     ContextMenuAction(windowUUID: windowUUID, actionType: ContextMenuActionType.tappedOnSponsoredAction)
                 )
             }).items
@@ -360,13 +360,15 @@ struct ContextMenuState {
 
     // MARK: Dispatch Actions
     private static func dispatchSettingsAction(windowUUID: WindowUUID, section: Route.SettingsSection) {
-        store.dispatchLegacy(
-            NavigationBrowserAction(
-                navigationDestination: NavigationDestination(.settings(section)),
-                windowUUID: windowUUID,
-                actionType: NavigationBrowserActionType.tapOnSettingsSection
+        ensureMainThread {
+            store.dispatch(
+                NavigationBrowserAction(
+                    navigationDestination: NavigationDestination(.settings(section)),
+                    windowUUID: windowUUID,
+                    actionType: NavigationBrowserActionType.tapOnSettingsSection
+                )
             )
-        )
+        }
     }
 
     private static func dispatchOpenNewTabAction(
@@ -375,38 +377,44 @@ struct ContextMenuState {
         isPrivate: Bool,
         selectNewTab: Bool = false
     ) {
-        store.dispatchLegacy(
-            NavigationBrowserAction(
-                navigationDestination: NavigationDestination(
-                    .newTab,
-                    url: siteURL,
-                    isPrivate: isPrivate,
-                    selectNewTab: selectNewTab
-                ),
-                windowUUID: windowUUID,
-                actionType: NavigationBrowserActionType.tapOnOpenInNewTab
+        ensureMainThread {
+            store.dispatch(
+                NavigationBrowserAction(
+                    navigationDestination: NavigationDestination(
+                        .newTab,
+                        url: siteURL,
+                        isPrivate: isPrivate,
+                        selectNewTab: selectNewTab
+                    ),
+                    windowUUID: windowUUID,
+                    actionType: NavigationBrowserActionType.tapOnOpenInNewTab
+                )
             )
-        )
+        }
     }
 
     private static func dispatchShareSheetAction(windowUUID: WindowUUID, shareSheetConfiguration: ShareSheetConfiguration) {
-        store.dispatchLegacy(
-            NavigationBrowserAction(
-                navigationDestination: NavigationDestination(.shareSheet(shareSheetConfiguration)),
-                windowUUID: windowUUID,
-                actionType: NavigationBrowserActionType.tapOnShareSheet
+        ensureMainThread {
+            store.dispatch(
+                NavigationBrowserAction(
+                    navigationDestination: NavigationDestination(.shareSheet(shareSheetConfiguration)),
+                    windowUUID: windowUUID,
+                    actionType: NavigationBrowserActionType.tapOnShareSheet
+                )
             )
-        )
+        }
     }
 
     private static func dispatchContextMenuAction(windowUUID: WindowUUID, site: Site, actionType: ActionType) {
-        store.dispatchLegacy(
-            ContextMenuAction(
-                site: site,
-                windowUUID: windowUUID,
-                actionType: actionType
+        ensureMainThread {
+            store.dispatch(
+                ContextMenuAction(
+                    site: site,
+                    windowUUID: windowUUID,
+                    actionType: actionType
+                )
             )
-        )
+        }
     }
 
     private static func dispatchContextMenuActionForSection(
@@ -414,12 +422,14 @@ struct ContextMenuState {
         menuType: MenuType?,
         actionType: ActionType
     ) {
-        store.dispatchLegacy(
-            ContextMenuAction(
-                menuType: menuType,
-                windowUUID: windowUUID,
-                actionType: actionType
+        ensureMainThread {
+            store.dispatch(
+                ContextMenuAction(
+                    menuType: menuType,
+                    windowUUID: windowUUID,
+                    actionType: actionType
+                )
             )
-        )
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -156,7 +156,7 @@ final class HomepageViewController: UIViewController,
         super.viewWillAppear(animated)
         /// Used as a trigger for showing a microsurvey based on viewing the homepage
         Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
-        store.dispatchLegacy(
+        store.dispatch(
             HomepageAction(
                 windowUUID: windowUUID,
                 actionType: HomepageActionType.viewWillAppear
@@ -167,7 +167,7 @@ final class HomepageViewController: UIViewController,
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        store.dispatchLegacy(
+        store.dispatch(
             HomepageAction(
                 windowUUID: windowUUID,
                 actionType: HomepageActionType.viewDidAppear
@@ -194,7 +194,7 @@ final class HomepageViewController: UIViewController,
         /// This issue seems to be resolved by the SDK on later iOS versions
         if !didFinishFirstLayout {
             didFinishFirstLayout = true
-            store.dispatchLegacy(
+            store.dispatch(
                 HomepageAction(
                     numberOfTopSitesPerRow: numberOfTilesPerRow(for: availableWidth),
                     showiPadSetup: shouldUseiPadSetup(),
@@ -207,7 +207,7 @@ final class HomepageViewController: UIViewController,
         let numberOfTilesPerRow = numberOfTilesPerRow(for: availableWidth)
         guard homepageState.topSitesState.numberOfTilesPerRow != numberOfTilesPerRow else { return }
 
-        store.dispatchLegacy(
+        store.dispatch(
             HomepageAction(
                 numberOfTopSitesPerRow: numberOfTilesPerRow,
                 windowUUID: windowUUID,
@@ -219,7 +219,7 @@ final class HomepageViewController: UIViewController,
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         wallpaperView.updateImageForOrientationChange()
-        store.dispatchLegacy(
+        store.dispatch(
             HomepageAction(
                 numberOfTopSitesPerRow: numberOfTilesPerRow(for: size.width),
                 windowUUID: windowUUID,
@@ -271,7 +271,7 @@ final class HomepageViewController: UIViewController,
         if (lastContentOffsetY > 0 && scrollView.contentOffset.y <= 0) ||
             (lastContentOffsetY <= 0 && scrollView.contentOffset.y > 0) {
             lastContentOffsetY = scrollView.contentOffset.y
-            store.dispatchLegacy(
+            store.dispatch(
                 GeneralBrowserMiddlewareAction(
                     scrollOffset: scrollView.contentOffset,
                     windowUUID: windowUUID,
@@ -282,7 +282,7 @@ final class HomepageViewController: UIViewController,
     private func handleToolbarStateOnScroll() {
         // When the user scrolls the homepage (not overlaid on a webpage when searching) we cancel edit mode
         let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.cancelEditOnHomepage)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     /// Calculates the number of tiles that can fit in a single row based on the available width.
@@ -314,7 +314,7 @@ final class HomepageViewController: UIViewController,
             actionType: ScreenActionType.showScreen,
             screen: .homepage
         )
-        store.dispatchLegacy(action)
+        store.dispatch(action)
 
         let uuid = windowUUID
         store.subscribe(self, transform: {
@@ -730,7 +730,7 @@ final class HomepageViewController: UIViewController,
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        store.dispatchLegacy(
+        store.dispatch(
             HomepageAction(
                 showiPadSetup: shouldUseiPadSetup(),
                 windowUUID: windowUUID,
@@ -750,7 +750,7 @@ final class HomepageViewController: UIViewController,
     @objc
     private func dismissKeyboard() {
         let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.cancelEdit)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     // MARK: Long Press (Photon Action Sheet)
@@ -780,7 +780,7 @@ final class HomepageViewController: UIViewController,
     }
 
     private func navigateToHomepageSettings() {
-        store.dispatchLegacy(
+        store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(.settings(.homePage)),
                 windowUUID: self.windowUUID,
@@ -790,7 +790,7 @@ final class HomepageViewController: UIViewController,
     }
 
     private func navigateToPocketLearnMore() {
-        store.dispatchLegacy(
+        store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(
                     .link,
@@ -810,7 +810,7 @@ final class HomepageViewController: UIViewController,
             sourceView: sourceView,
             toastContainer: toastContainer
         )
-        store.dispatchLegacy(
+        store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(.contextMenu, contextMenuConfiguration: configuration),
                 windowUUID: windowUUID,
@@ -837,7 +837,7 @@ final class HomepageViewController: UIViewController,
     }
 
     private func navigateToBookmarksPanel() {
-        store.dispatchLegacy(
+        store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(.bookmarksPanel),
                 windowUUID: windowUUID,
@@ -847,7 +847,7 @@ final class HomepageViewController: UIViewController,
     }
 
     private func navigateToShortcutsLibrary() {
-        store.dispatchLegacy(
+        store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(.shortcutsLibrary),
                 windowUUID: windowUUID,
@@ -857,7 +857,7 @@ final class HomepageViewController: UIViewController,
     }
 
     private func navigateToStoriesFeed() {
-        store.dispatchLegacy(
+        store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(.storiesFeed),
                 windowUUID: windowUUID,
@@ -867,7 +867,7 @@ final class HomepageViewController: UIViewController,
     }
 
     private func dispatchNavigationBrowserAction(with destination: NavigationDestination, actionType: ActionType) {
-        store.dispatchLegacy(
+        store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: destination,
                 windowUUID: self.windowUUID,
@@ -878,7 +878,7 @@ final class HomepageViewController: UIViewController,
 
     private func dispatchOpenPocketAction(at index: Int, actionType: ActionType) {
         let config = OpenPocketTelemetryConfig(isZeroSearch: homepageState.isZeroSearch, position: index)
-        store.dispatchLegacy(
+        store.dispatch(
             MerinoAction(
                 telemetryConfig: config,
                 windowUUID: self.windowUUID,
@@ -893,7 +893,7 @@ final class HomepageViewController: UIViewController,
             position: index,
             topSiteConfiguration: config
         )
-        store.dispatchLegacy(
+        store.dispatch(
             TopSitesAction(
                 telemetryConfig: config,
                 windowUUID: self.windowUUID,
@@ -950,7 +950,7 @@ final class HomepageViewController: UIViewController,
                 actionType: NavigationBrowserActionType.tapOnHomepageSearchBar
             )
         case .jumpBackIn(let config):
-            store.dispatchLegacy(
+            store.dispatch(
                 JumpBackInAction(
                     tab: config.tab,
                     windowUUID: self.windowUUID,
@@ -995,7 +995,7 @@ final class HomepageViewController: UIViewController,
             itemType: item.telemetryItemType,
             topSitesTelemetryConfig: topSitesTelemetryConfig
         )
-        store.dispatchLegacy(
+        store.dispatch(
             HomepageAction(
                 telemetryExtras: telemetryExtras,
                 windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/SyncedTabCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/SyncedTabCell.swift
@@ -16,9 +16,10 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurra
 
     private var syncedDeviceIconFirstBaselineConstraint: NSLayoutConstraint?
     private var syncedDeviceIconCenterConstraint: NSLayoutConstraint?
-    private var showAllSyncedTabsAction: (() -> Void)?
     private var tabStackTopConstraint: NSLayoutConstraint?
-    private var openSyncedTabAction: (() -> Void)?
+
+    private var showAllSyncedTabsAction: (@MainActor () -> Void)?
+    private var openSyncedTabAction: (@MainActor () -> Void)?
 
     // MARK: - UI Elements
     private var tabHeroImage: HeroImageView = .build { _ in }
@@ -110,8 +111,8 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurra
 
     func configure(configuration: JumpBackInSyncedTabConfiguration,
                    theme: Theme,
-                   onTapShowAllAction: (() -> Void)?,
-                   onOpenSyncedTabAction: ((URL) -> Void)?) {
+                   onTapShowAllAction: (@MainActor () -> Void)?,
+                   onOpenSyncedTabAction: (@MainActor (URL) -> Void)?) {
         tabItemTitle.text = configuration.titleText
         syncedDeviceLabel.text = configuration.descriptionText
         accessibilityLabel = configuration.accessibilityLabel

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/HomepageMessageCardCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/HomepageMessageCardCell.swift
@@ -218,7 +218,7 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
             )
             return
         }
-        store.dispatchLegacy(
+        store.dispatch(
             MessageCardAction(
                 windowUUID: windowUUID,
                 actionType: MessageCardActionType.tappedOnCloseButton
@@ -237,7 +237,7 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
             )
             return
         }
-        store.dispatchLegacy(
+        store.dispatch(
             MessageCardAction(
                 windowUUID: windowUUID,
                 actionType: MessageCardActionType.tappedOnActionButton

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
@@ -94,7 +94,7 @@ class LabelButtonHeaderView: UICollectionReusableView,
 
     func configure(
         state: SectionHeaderConfiguration,
-        moreButtonAction: ((UIButton) -> Void)? = nil,
+        moreButtonAction: (@MainActor (UIButton) -> Void)? = nil,
         textColor: UIColor?,
         theme: Theme
     ) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13953)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30239)

## :bulb: Description
Migrating homepage classes to use `dispatch` instead of `dispatchLegacy`. I didn't touch the legacy homepage since I have a PR to remove it.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

