### PR TITLE
Bugfix FXIOS-13968 [Trending Searches] not loading trending searches after google search and then clearing text

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -353,19 +353,8 @@ class SearchViewController: SiteTableViewController,
     /// - Trending searches: popular or curated terms shown to inspire discovery.
     /// - Recent searches: the user’s own past searches for quick re-access.
     private func loadZeroSearchData() {
-        loadTrendingSearches()
-        loadRecentSearches()
-    }
-
-    private func loadRecentSearches() {
+        viewModel.loadTrendingSearches()
         viewModel.retrieveRecentSearches()
-    }
-
-    private func loadTrendingSearches() {
-        Task {
-            await viewModel.retrieveTrendingSearches()
-            reloadTableView()
-        }
     }
 
     func didSelectEngine(_ sender: UIButton) {
@@ -919,7 +908,7 @@ class SearchViewController: SiteTableViewController,
             case .SearchSettingsChanged:
                 self.reloadSearchEngines()
                 // We fetch new list since trending searches are specific to the search engine.
-                self.loadTrendingSearches()
+                self.viewModel.loadTrendingSearches()
             case .SponsoredAndNonSponsoredSuggestionsChanged:
                 guard !self.viewModel.searchQuery.isEmpty else { return }
                 Task {

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -163,6 +163,7 @@
         "SearchTests\/testTrendingSearchesAndRecentSearchesSettingsToggleOn_trendingSearchesAndRecentSearchesExperimentOn()",
         "SearchTests\/testTrendingSearchesSettingsToggleOff_trendingSearchesExperimentOn()",
         "SearchTests\/testTrendingSearchesSettingsToggleOn_trendingSearchesExperimentOn()",
+        "SearchTests\/testTrendingSearches_afterClearingURL_trendingSearchesExperimentOn()",
         "SearchTests\/testTrendingSearches_trendingSearchesExperimentOn()",
         "SettingsTests\/testSummarizeContentSettingsDoesNotAppear_hostedSummarizeExperimentOff()",
         "SettingsTests\/testSummarizeContentSettingsShouldShow_hostedSummarizeExperimentOn()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -471,6 +471,7 @@
         "SearchTests\/testTrendingSearchesAndRecentSearchesSettingsToggleOn_trendingSearchesAndRecentSearchesExperimentOn()",
         "SearchTests\/testTrendingSearchesSettingsToggleOff_trendingSearchesExperimentOn()",
         "SearchTests\/testTrendingSearchesSettingsToggleOn_trendingSearchesExperimentOn()",
+        "SearchTests\/testTrendingSearches_afterClearingURL_trendingSearchesExperimentOn()",
         "SearchTests\/testTrendingSearches_trendingSearchesExperimentOn()",
         "SettingsTests\/testAutofillPasswordSettingsOptionSubtitles()",
         "SettingsTests\/testAutoplayOptionUI()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -708,4 +708,28 @@ class SearchTests: FeatureFlaggedTestBase {
 
         mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Trending on Google"])
     }
+
+    func testTrendingSearches_afterClearingURL_trendingSearchesExperimentOn() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "trending-searches-feature")
+        app.launch()
+        navigator.nowAt(HomePanelsScreen)
+        navigator.openURL("https://www.mozilla.org/en-US/")
+        waitUntilPageLoad()
+
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
+        let testString = "example"
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tapAndTypeText(testString)
+
+        // Search Term suggestions appears
+        mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["Google Search"])
+        app.typeText(XCUIKeyboardKey.return.rawValue)
+
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
+        app.buttons["Clear text"].firstMatch.waitAndTap()
+
+        // Trending Search appears
+        mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["Trending on Google"])
+        app.tables["SiteTable"].cells.firstMatch.waitAndTap()
+        waitUntilPageLoad()
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13968)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30275)

## :bulb: Description
Fix an issue where trending searches were not showing up after submitting a search term and then enter url bar again to clear the text and return back to zero search mode where user should see trending searches.

- Move where we are loading trending searches into view model instead of the view controller and reload when searchquery is empty.

## :movie_camera: Demos

https://github.com/user-attachments/assets/143bb495-ce7a-43c2-b7c8-26ee7571cb30


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

