### PR TITLE
Add FXIOS-13844 [Translations] language detection error handling

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -84,6 +84,9 @@ public enum LoggerCategory: String {
     /// Related to Glean telemetry pings and events
     case telemetry
 
+    /// Related to translations feature
+    case translations
+
     /// Webview scripts, webview delegate, webserver like GCDWebserver, showing webview alerts, webview navigation
     case webview
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockLanguageDetector.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockLanguageDetector.swift
@@ -6,9 +6,11 @@ import Foundation
 
 /// Test helper that simulates language detection.
 final class MockLanguageDetector: LanguageDetectorProvider, @unchecked Sendable {
-    var detectLanguageCallCount = 0
+    var detectedLanguage = "ja"
+    var mockError: Error?
+
     func detectLanguage(from source: LanguageSampleSource) async throws -> String? {
-        detectLanguageCallCount += 1
-        return "ja"
+        if let error = mockError { throw error }
+        return detectedLanguage
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13844)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29994)

## :bulb: Description
Add log to capture error from page detection. Also add tests when facing error as well as if page detection matches device locale. 

Related to PR: https://github.com/mozilla-mobile/firefox-ios/pull/30407

cc: @issammani 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

