### PR TITLE
Bugfix FXIOS-14040 [Japan Onboarding] Missing info text on the Toolbar and Theme cards

### DIFF
--- a/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingMultipleChoiceCardViewCompact.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Compact/OnboardingMultipleChoiceCardViewCompact.swift
@@ -61,8 +61,10 @@ struct OnboardingMultipleChoiceCardViewCompact<ViewModel: OnboardingCardInfoMode
                     onMultipleChoiceAction(newAction, viewModel.name)
                 }
                 Spacer(minLength: UX.CardView.minContentSpacing)
-                bodyView
-                Spacer(minLength: UX.CardView.minContentSpacing)
+                if !viewModel.body.isEmpty {
+                    bodyView
+                    Spacer(minLength: UX.CardView.minContentSpacing)
+                }
                 VStack(spacing: UX.CardView.buttonsSpacing) {
                     primaryButton
                     // Hidden spacer button to maintain consistent layout spacing

--- a/BrowserKit/Sources/OnboardingKit/Views/Regular/OnboardingMultipleChoiceCardViewRegular.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Regular/OnboardingMultipleChoiceCardViewRegular.swift
@@ -49,8 +49,10 @@ struct OnboardingMultipleChoiceCardViewRegular<ViewModel: OnboardingCardInfoMode
                     .onChange(of: selectedAction) { newAction in
                         onMultipleChoiceAction(newAction, viewModel.name)
                     }
-                    bodyView
-                    Spacer(minLength: UX.CardView.minContentSpacing)
+                    if !viewModel.body.isEmpty {
+                        bodyView
+                        Spacer(minLength: UX.CardView.minContentSpacing)
+                    }
                 }
                 .padding(UX.CardView.verticalPadding)
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14040)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30436)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add missing body view.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

