### PR TITLE
Bugfix FXIOS-13972 #30283 ⁃ testAppleIntelligenceAvailability_whenIsAvailable fails on iOS 17 and 18

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppleIntelligenceUtilTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppleIntelligenceUtilTests.swift
@@ -20,7 +20,9 @@ final class AppleIntelligenceUtilTests: XCTestCase {
         super.tearDown()
     }
 
-    func testAppleIntelligenceAvailability_whenIsAvailable_returnsTrue() {
+    func testAppleIntelligenceAvailability_whenIsAvailable_returnsTrue() throws {
+        try XCTSkipIf(ProcessInfo.processInfo.operatingSystemVersion.majorVersion < 26,
+                      "Skipping test because it requires iOS 26 or later")
         let subject = createSubject()
         subject.processAvailabilityState(MockLanguageModel(isAvailable: true))
 
@@ -30,7 +32,9 @@ final class AppleIntelligenceUtilTests: XCTestCase {
         XCTAssertEqual(userDefaults.setCalledCount, 2)
     }
 
-    func testAppleIntelligenceAvailability_whenIsNotAvailable_returnsFalse() {
+    func testAppleIntelligenceAvailability_whenIsNotAvailable_returnsFalse() throws {
+        try XCTSkipIf(ProcessInfo.processInfo.operatingSystemVersion.majorVersion < 26,
+                      "Skipping test because it requires iOS 26 or later")
         let subject = createSubject()
         subject.processAvailabilityState(MockLanguageModel(isAvailable: false))
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13972)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30283)

## :bulb: Description
Skip test if OS  is lowerthan (iOS 26.0, *) because SystemLanguageModel.default is no available in lower OS causing crash

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

