### PR TITLE
Refactor FXIOS [HNT] Make beta flags same as release

### DIFF
--- a/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
@@ -36,9 +36,9 @@ features:
       - channel: beta
         value:
           enabled: false
-          search-bar: true
+          search-bar: false
           shortcuts-library: false
-          stories-redesign: true
+          stories-redesign: false
           discover-more-feature-configuration:
             discover-more-v1-experience: false
             show-discover-more-button: false


### PR DESCRIPTION
## :scroll: Tickets
No tickets

## :bulb: Description
As a developer, I want to apply experiments as if I am in a release build on TestFlight builds. This way I can test experiments with confidence, reproducing the exact same setup as in production.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

