### PR TITLE
Refactor FXIOS-14031 [Danger] Fix danger with dispatchLegacy warn instead of fail

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -372,6 +372,15 @@ class CodeUsageDetector {
                 return false
             }
         }
+
+        var shouldWarn: Bool {
+            switch self {
+            case .deferred, .dispatchLegacy:
+                return true
+            default:
+                return false
+            }
+        }
     }
     // swiftlint:enable line_length
 
@@ -422,6 +431,8 @@ class CodeUsageDetector {
                 let lineNumber = hunk.newLineStart + newLineCount - 1
                 if keyword.shouldComment {
                     markdown(String(format: message, file, lineNumber))
+                } else if keyword.shouldWarn {
+                    warn(String(format: message, file, lineNumber))
                 } else {
                     fail(String(format: message, file, lineNumber))
                 }
@@ -440,6 +451,8 @@ class CodeUsageDetector {
             let lineNumber = index + 1
             if keyword.shouldComment {
                 markdown(String(format: message, file, lineNumber))
+            } else if keyword.shouldWarn {
+                warn(String(format: message, file, lineNumber))
             } else {
                 fail(String(format: message, file, lineNumber))
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14031)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30419)

## :bulb: Description
[Its failing the PR](https://github.com/mozilla-mobile/firefox-ios/pull/30448) even thought the line was not added/modified. Let's warn instead of fail!

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

