### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Mark HTTPDownload unchecked Sendable

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
@@ -83,7 +83,8 @@ class Download: NSObject {
      }
 }
 
-class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate {
+// FIXME: FXIOS-14051 Class is not thread safe and Sendable
+class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate, @unchecked Sendable {
     let preflightResponse: URLResponse
     let request: URLRequest
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
- Mark HTTPDownload `@unchecked Sendable`

<img width="1257" height="258" alt="Screenshot 2025-11-06 at 3 35 30 PM" src="https://github.com/user-attachments/assets/bd3fccab-0887-4b9e-9a6c-74bcbc56550e" />


cc @Cramsden @lmarceau @dataports | Swift 6 Migration

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

