### PR TITLE
Bugfix FXIOS-00000 [Translations] UI tests

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKEngineWebServer.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WebServer/WKEngineWebServer.swift
@@ -157,6 +157,7 @@ of Mammon shall tremble. from The Book of Mozilla, 3:31 (Red Letter Edition) </s
                              "test-mozilla-book",
                              "test-mozilla-org",
                              "test-popup-blocker",
+                             "test-translation",
                              "test-user-agent"]
         htmlFixtures.forEach {
             addHTMLFixture(name: $0, server: server)

--- a/firefox-ios/Client/Application/WebServerUtil.swift
+++ b/firefox-ios/Client/Application/WebServerUtil.swift
@@ -78,6 +78,7 @@ of Mammon shall tremble. from The Book of Mozilla, 3:31 (Red Letter Edition) </s
                              "test-mozilla-book",
                              "test-mozilla-org",
                              "test-popup-blocker",
+                             "test-translation",
                              "test-user-agent",
                              "test-cookie-store"]
         htmlFixtures.forEach {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -284,8 +284,7 @@ class SettingsTests: FeatureFlaggedTestBase {
 
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)
-        // Using real site for now since we don't have test pages
-        navigator.openURL("https://www.mozilla.jp/")
+        navigator.openURL(path(forTestPage: "test-translation.html"))
         waitUntilPageLoad()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.translateButton])
     }
@@ -302,8 +301,7 @@ class SettingsTests: FeatureFlaggedTestBase {
 
         navigator.goto(HomePanelsScreen)
         navigator.goto(URLBarOpen)
-        // Using real site for now since we don't have test pages
-        navigator.openURL("https://www.mozilla.jp/")
+        navigator.openURL(path(forTestPage: "test-translation.html"))
         waitUntilPageLoad()
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Toolbar.translateButton])
     }
@@ -328,8 +326,7 @@ class SettingsTests: FeatureFlaggedTestBase {
 
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)
-        // Using real site for now since we don't have test pages
-        navigator.openURL("https://www.mozilla.jp/")
+        navigator.openURL(path(forTestPage: "test-translation.html"))
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Toolbar.translateButton])
 
         navigator.goto(SettingsScreen)
@@ -343,8 +340,7 @@ class SettingsTests: FeatureFlaggedTestBase {
 
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)
-        // Using real site for now since we don't have test pages
-        navigator.openURL("mozilla.fr")
+        navigator.openURL(path(forTestPage: "test-translation.html"))
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.translateButton])
 
         validateTranslationSettingsUI()

--- a/test-fixtures/test-translation.html
+++ b/test-fixtures/test-translation.html
@@ -1,0 +1,49 @@
+<html>
+<head>
+    <title>例示用ドメイン</title>
+
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style type="text/css">
+    body {
+        background-color: #f0f0f2;
+        margin: 0;
+        padding: 0;
+        font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        
+    }
+    div {
+        width: 600px;
+        margin: 5em auto;
+        padding: 50px;
+        background-color: #fff;
+        border-radius: 1em;
+    }
+    a:link, a:visited {
+        color: #38488f;
+        text-decoration: none;
+    }
+    @media (max-width: 700px) {
+        body {
+            background-color: #fff;
+        }
+        div {
+            width: auto;
+            margin: 0 auto;
+            border-radius: 0;
+            padding: 1em;
+        }
+    }
+    </style>    
+</head>
+
+<body>
+<div>
+    <h1>例示用ドメイン</h1>
+    <p>このドメインは、文書内で例として使用することを目的として設立されています。事前の調整や許可を得ずに、例示目的で自由に使用できます。</p>
+    <p><a href="http://www.iana.org/domains/example">詳細情報はこちら...</a></p>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## :scroll: Tickets
No ticket associated.

## :bulb: Description
Update UI tests that were failing here: https://storage.googleapis.com/mobile-reports/public/firefox-ios-M4/firefox-ios-full-functional-iphone/result_1793/build/reports/index.html

This is because we changed requirement for showing icon all the time to only pages that differ from device language.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

