### PR TITLE
Bugfix FXIOS-14056 [Trending Searches] google trending url

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -162,7 +162,7 @@ final class OpenSearchEngine: NSObject, NSSecureCoding, Sendable, TrendingSearch
     /// Returns the trending search URL for the specific search engine.
     func trendingURLForEngine() -> URL? {
         guard let trendingTemplate else { return nil }
-        return URL(string: trendingTemplate)
+        return getURLFromTemplate(trendingTemplate, query: "")
     }
 
     /// Returns the query that was used to construct a given search URL


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14056)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30476)

## :bulb: Description
The trending url for google was only showing a list of terms related to search terms and not the actual trending searches. We should be using  `/complete/search?q=&client=firefox&channel=ftr` instead. Added an override bool `overrideSearchArg` to avoid appending searchTerms to the search query argument.

## :movie_camera: Demos
| Before | After |
| - | - |
| <img alt="simulator_screenshot_A0427DB4-C4A5-485B-9F48-0FD3CFD82ED1" src="https://github.com/user-attachments/assets/0de32cb8-8660-4f09-a07d-1ef48f153700" /> | <img alt="Simulator Screenshot - iPhone 16e - 2025-11-07 at 12 59 56" src="https://github.com/user-attachments/assets/065c897b-a4f7-415b-80a6-7d370a7e6de8" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

