### PR TITLE
Add FXIOS-13782 [Trending Searches] use new most recent method

### DIFF
--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Places/Places.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Places/Places.swift
@@ -358,6 +358,13 @@ public class PlacesReadConnection {
         }
     }
 
+    open func getMostRecentHistoryMetadata(limit: Int32) throws -> [HistoryMetadata] {
+        return try queue.sync {
+            try self.checkApi()
+            return try self.conn.getMostRecentHistoryMetadata(limit: limit)
+        }
+    }
+    
     open func queryHistoryMetadata(query: String, limit: Int32) throws -> [HistoryMetadata] {
         return try queue.sync {
             try self.checkApi()

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -61,8 +61,9 @@ public protocol BookmarksHandler {
 public protocol HistoryHandler {
     func applyObservation(visitObservation: VisitObservation,
                           completion: @escaping (Result<Void, any Error>) -> Void)
-    func getHistoryMetadataSince(
-        since startDate: Int64,
+
+    func getMostRecentHistoryMetadata(
+        limit: Int32,
         completion: @Sendable @escaping (Result<[HistoryMetadata], any Error>) -> Void
     )
 
@@ -550,12 +551,12 @@ public class RustPlaces: @unchecked Sendable, BookmarksHandler, HistoryHandler {
 
     // MARK: History metadata
     /// Currently only used to get the recent searches from the user's history storage.
-    public func getHistoryMetadataSince(
-        since startDate: Int64,
+    public func getMostRecentHistoryMetadata(
+        limit: Int32,
         completion: @Sendable @escaping (Result<[HistoryMetadata], any Error>) -> Void
     ) {
         withReader({ connection in
-            return try connection.getHistoryMetadataSince(since: startDate)
+            return try connection.getMostRecentHistoryMetadata(limit: limit)
         }, completion: completion)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockHistoryHandler.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockHistoryHandler.swift
@@ -16,7 +16,7 @@ final class MockHistoryHandler: HistoryHandler {
     var onApply: (() -> Void)?
 
     // MARK: History Metadata
-    var getHistoryMetadataSinceCallCount = 0
+    var getMostRecentHistoryMetadataCallCount = 0
     var noteHistoryMetadataCallCount = 0
     var result: Result<[MozillaAppServices.HistoryMetadata], Error> = .success(
         [
@@ -53,11 +53,11 @@ final class MockHistoryHandler: HistoryHandler {
         onApply?()
     }
 
-    func getHistoryMetadataSince(
-        since startDate: Int64,
+    func getMostRecentHistoryMetadata(
+        limit: Int32,
         completion: @escaping @Sendable (Result<[MozillaAppServices.HistoryMetadata], any Error>) -> Void
     ) {
-        getHistoryMetadataSinceCallCount += 1
+        getMostRecentHistoryMetadataCallCount += 1
         completion(result)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/DefaultRecentSearchProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/DefaultRecentSearchProviderTests.swift
@@ -61,6 +61,7 @@ final class DefaultRecentSearchProviderTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(mockHistoryStorage.getMostRecentHistoryMetadataCallCount, 1)
     }
 
     func test_loadRecentSearches_withError_returnsEmptyList() {
@@ -75,6 +76,7 @@ final class DefaultRecentSearchProviderTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(mockHistoryStorage.getMostRecentHistoryMetadataCallCount, 1)
     }
 
     func createSubject(for searchEngineID: String) -> RecentSearchProvider {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13782)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29858)

## :bulb: Description
Use [new method](https://github.com/mozilla/application-services/pull/7002) for fetching the most recent metadata instead of using an old existing one. PR where this discussion was held - https://github.com/mozilla-mobile/firefox-ios/pull/29797#discussion_r2402494478

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

