### PR TITLE
Bugfix FXIOS-14047 [Trending Searches] not all recent searches are being saved

### DIFF
--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -564,6 +564,8 @@ public class RustPlaces: @unchecked Sendable, BookmarksHandler, HistoryHandler {
     /// - Parameters:
     ///   - searchTerm: The search term used to find a page.
     ///   - urlString: The url of the page.
+    ///  `referrerUrl` and `viewTime` is nil because we only care about store search terms
+    ///  `.insertPage` is passed in because if we use default, it ignores and does not save the search term
     public func noteHistoryMetadata(
         for searchTerm: String,
         and urlString: String,
@@ -576,7 +578,9 @@ public class RustPlaces: @unchecked Sendable, BookmarksHandler, HistoryHandler {
                         url: urlString,
                         searchTerm: searchTerm,
                         referrerUrl: nil
-                    ), viewTime: nil
+                    ),
+                    viewTime: nil,
+                    .init(ifPageMissing: .insertPage)
                 )
             },
             completion: completion)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14047)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30449)

## :bulb: Description
There was an issue where not all of the recent searches were being saved. This is because when we note an observation, we full through the ignore observation case which doesn't insert the new search term in the database. Therefore, the fix adds the option to always insert the page and save the search term.

<img width="1116" height="318" alt="image" src="https://github.com/user-attachments/assets/58882cd1-1768-4426-92e5-aba33b949598" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

