### PR TITLE
Revert "Bugfix FXIOS-13597 ⁃ [Shake to summarize] [Intermittent] - Incorrect display of the CFR on homepage (#30267)"

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -245,12 +245,6 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         tabManager.selectTab(tabManager.addTab(isPrivate: true))
     }
 
-    /// This is a workaround for dismissing CFRs when keyboard is showing up.
-    func dismissCFRs() {
-        summarizeToolbarEntryContextHintVC.dismiss(animated: false)
-        translationContextHintVC.dismiss(animated: false)
-    }
-
     /// Setup animation for data clearance flow unless reduce motion is enabled
     /// - Parameter completion: returns the proper timing to match animation on when to close tabs and display toast
     private func setupDataClearanceAnimation(completion: @escaping (Double) -> Void) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1755,7 +1755,6 @@ class BrowserViewController: UIViewController,
     /// it's the zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
     func showEmbeddedHomepage(inline: Bool, isPrivate: Bool) {
         resetDataClearanceCFRTimer()
-        dismissCFRs()
 
         if isPrivate && featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) {
             browserDelegate?.showPrivateHomepage(overlayManager: overlayManager)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13597)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29536)

## :bulb: Description
This reverts commit 8abb4b37c034fb616ff7565ce725b3e7be30c66d.

This PR is causing a crash on iPad, so reverting commit for now and unblock v145.1.

```
*** Terminating app due to uncaught exception 'NSGenericException', reason: 'UIPopoverPresentationController (<UIPopoverPresentationController: 0x102e3ef40>) should have a non-nil sourceView or barButtonItem set before the presentation occurs.'
terminating due to uncaught exception of type NSException
CoreSimulator 1048 - Device: iPad mini (A17 Pro) (BFE6E5C3-50E6-49C0-9C2D-35574BE22AE7) - Runtime: iOS 18.3 (22D8075) - DeviceType: iPad mini (A17 Pro)
```

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

