### PR TITLE
Bugfix #29536 ⁃ [Shake to summarize] [Intermittent] - Incorrect display of the CFR on homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -190,8 +190,12 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
     /// This is a workaround for dismissing CFRs when keyboard is showing up.
     func dismissCFRs() {
-        summarizeToolbarEntryContextHintVC.dismiss(animated: false)
-        translationContextHintVC.dismiss(animated: false)
+        if summarizeToolbarEntryContextHintVC.isPresenting {
+            summarizeToolbarEntryContextHintVC.dismiss(animated: false)
+        }
+        if translationContextHintVC.isPresenting {
+            translationContextHintVC.dismiss(animated: false)
+        }
     }
 
     /// Triggers clearing the users private session data, an alert is shown once and then, deletion is done directly after

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1755,6 +1755,7 @@ class BrowserViewController: UIViewController,
     /// it's the zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
     func showEmbeddedHomepage(inline: Bool, isPrivate: Bool) {
         resetDataClearanceCFRTimer()
+        dismissCFRs()
 
         if isPrivate && featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) {
             browserDelegate?.showPrivateHomepage(overlayManager: overlayManager)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13597)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29536)

## :bulb: Description
- I kept the function `dismissCFRs` but I move to trigger based on user interaction that causes the tab that originated the CFR not to be visible, if the user opens a new tab or if the user press the URL bar, which is also known as enter overlay mode.
- I tested multiple times on iPhone and iPad and I couldn't reproduce the crash but I'm a bit worried due to the previous crash that might still happen, so please test if possible.
Note:
- I added debug and I notice that `showEmbeddedHomepage` is called multiple times hence the CFR dismiss code was also called to many time, the new calls are more strategic and happens only once base in user interaction

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

