### PR TITLE
[no-ticket] Keyboard may not be dismissed on new tabs (iPad only)

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -164,7 +164,6 @@ class BrowsingPDFTests: BaseTestCase {
             .element
             .children(matching: .other)
             .element(boundBy: 0)
-        // https://github.com/mozilla-mobile/firefox-ios/issues/30424
         if iPad() {
             app.buttons["Cancel"].waitAndTap()
         }
@@ -174,7 +173,6 @@ class BrowsingPDFTests: BaseTestCase {
 
         // Remove pdf pinned site
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        // https://github.com/mozilla-mobile/firefox-ios/issues/30424
         if iPad() {
             app.buttons["Cancel"].waitAndTap()
         }


### PR DESCRIPTION


## :scroll: Tickets

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
We need to dismiss the keyboard after opening a new tab (see `testPinPDFtoTopSites` in the smoke test). 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

