### PR TITLE
[MTE-4992] - Remove deleted tab test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
@@ -427,7 +427,6 @@
         "TabsTests\/testOpenTabsViewCurrentTabThumbnail()",
         "TabsTests\/testSwitchBetweenTabs()",
         "TabsTests\/testTabTrayCloseMultipleTabs()",
-        "TabsTests\/testTabTrayContextMenuCloseTab()",
         "TabsTestsIpad",
         "TabsTestsIpad\/testUpdateTabCounter()",
         "TabsTestsIphone",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -535,8 +535,6 @@
         "TabsTests\/testSwitchBetweenTabs_tabTrayExperimentOn()",
         "TabsTests\/testTabTrayCloseMultipleTabs()",
         "TabsTests\/testTabTrayCloseMultipleTabs_tabTrayExperimentOff()",
-        "TabsTests\/testTabTrayContextMenuCloseTab()",
-        "TabsTests\/testTabTrayContextMenuCloseTab_tabTrayExperimentOff()",
         "TabsTestsIpad",
         "TabsTestsIphone\/testAddPrivateTabByLongPressTabsButton_TAE()",
         "TabsTestsIphone\/testAddTabByLongPressTabsButton_TAE()",

--- a/firefox-ios/firefox-ios-tests/Tests/TAESmokeTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/TAESmokeTestPlan.xctestplan
@@ -606,8 +606,6 @@
         "TabsTests\/testSwitchBetweenTabs_tabTrayExperimentOn()",
         "TabsTests\/testTabTrayCloseMultipleTabs()",
         "TabsTests\/testTabTrayCloseMultipleTabs_tabTrayExperimentOff()",
-        "TabsTests\/testTabTrayContextMenuCloseTab()",
-        "TabsTests\/testTabTrayContextMenuCloseTab_tabTrayExperimentOff()",
         "TabsTestsIpad",
         "TabsTestsIpad\/testUpdateTabCounter()",
         "TabsTestsIphone\/testAddPrivateTabByLongPressTabsButton()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -515,21 +515,6 @@ class TabsTests: BaseTestCase {
         }
     }
 
-    // https://mozilla.testrail.io/index.php?/cases/view/2306869
-    func testTabTrayContextMenuCloseTab() throws {
-        if !iPad() {
-            let shouldSkipTest = true
-            try XCTSkipIf(shouldSkipTest, "Undo toast no longer available on iPhone")
-        }
-        // Have multiple tabs opened in the tab tray
-        navigator.nowAt(NewTabScreen)
-        waitForTabsButton()
-        addTabsAndUndoCloseTabAction(nrOfTabs: 3)
-        // Repeat steps for private browsing mode
-        navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
-        addTabsAndUndoCloseTabAction(nrOfTabs: 4)
-    }
-
     // https://mozilla.testrail.io/index.php?/cases/view/2306868
     func testTabTrayCloseMultipleTabs() throws {
         if !iPad() {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4992

## :bulb: Description
The test case covering testTabTrayContextMenuCloseTab auto test has been deleted because the steps are included in:

https://mozilla.testrail.io/index.php?/cases/view/2306867