### PR TITLE
Bugfix FXIOS-14039 [Japan Onboarding] [iPad]Adjust the image and the text in the Default Browser card so that it matches the responsive design

### DIFF
--- a/BrowserKit/Sources/OnboardingKit/Views/Helper/UX.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Helper/UX.swift
@@ -41,6 +41,7 @@ enum UX {
         static let horizontalPadding: CGFloat = 24
         static let verticalPadding: CGFloat = 24
         static let imageHeight: CGFloat = 150
+        static let maxImageHeight: CGFloat = 250
         static let tosImageHeight: CGFloat = 70
         static let cornerRadius: CGFloat = 20
         static let secondaryButtonBottomPadding: CGFloat = 24

--- a/BrowserKit/Sources/OnboardingKit/Views/Regular/OnboardingBasicCardViewRegular.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Regular/OnboardingBasicCardViewRegular.swift
@@ -63,8 +63,7 @@ struct OnboardingBasicCardViewRegular<ViewModel: OnboardingCardInfoModelProtocol
             Image(uiImage: img)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(height: UX.CardView.imageHeight)
-                .accessibilityLabel(viewModel.title)
+                .frame(height: min(img.size.height, UX.CardView.maxImageHeight))
                 .accessibilityHidden(true)
                 .accessibility(identifier: "\(viewModel.a11yIdRoot)ImageView")
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14039)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30435)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Set image height with a max height.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-11-12 at 10 29 19" src="https://github.com/user-attachments/assets/6353be0c-a0d8-4bc9-ad96-70f3697e580d" /> | <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2025-11-12 at 10 19 55" src="https://github.com/user-attachments/assets/92e71987-20b7-4842-b37c-f777f25c82d0" /> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

