### PR TITLE
Bugfix FXIOS-14046 ⁃ [Perplexity] The Perplexity Search Engine Selector icon displayed with visible white corners

### DIFF
--- a/firefox-ios/Client/Extensions/UIImage+RenderingUtilities.swift
+++ b/firefox-ios/Client/Extensions/UIImage+RenderingUtilities.swift
@@ -37,7 +37,7 @@ extension UIImage {
         return renderer.image { context in
             let cgContext = context.cgContext
 
-            UIColor.white.setFill()
+            UIColor.clear.setFill()
             context.fill(CGRect(origin: .zero, size: size))
 
             // Coordinate system must be flipped to match PDF rendering


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14046)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30447)

## :bulb: Description
Added clear background instead of white

## :movie_camera: Demos
![IMG_3878](https://github.com/user-attachments/assets/4ff7d189-3070-44e8-a435-0c6a3e5b7b08)


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

