### PR TITLE
Refactor FXIOS-14096 [HNT - Search Bar] Disable search in the middle on beta

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -104,8 +104,6 @@ class BaseTestCase: XCTestCase {
         } else {
             app.launchArguments = [LaunchArguments.PerformanceTest] + launchArguments
         }
-        app.launchArguments.append("\(LaunchArguments.LoadExperiment)\("homepageSearchBarOn")")
-        app.launchArguments.append("\(LaunchArguments.ExperimentFeatureName)\("homepage-redesign-feature")")
     }
 
     override func setUp() {

--- a/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
@@ -46,7 +46,7 @@ features:
       - channel: developer
         value:
           enabled: false
-          search-bar: false
+          search-bar: true
           shortcuts-library: false
           stories-redesign: true
           discover-more-feature-configuration:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14096)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20559)

## :bulb: Description
- Disable search in the middle on the beta environment

### 📝 Technical notes:
- `search-bar` is not used in any first-run experiments, and is being decommissioned. 
- We should keep our beta and release flags in sync
- A lot of our UI tests were updated to support search in the middle, and need to be reverted back before turning this flag off on dev

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

