### PR TITLE
Add FXIOS-14098 [Nimbus] Add comparison test between nimbus context and metrics

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
@@ -154,4 +154,29 @@ class RecordedNimbusContextTests: XCTestCase {
 
         XCTAssertEqual(eventQueries, RecordedNimbusContext.EVENT_QUERIES)
     }
+
+    /// This function makes sure that the items in metrics.yaml and RecordedNimbusContext
+    /// are the same, to prevent human error forgetting to enter something somewhere
+    func testRecordedNimbusContextMetricsAreEquivalent() {
+        let recordedContext = RecordedNimbusContext(
+            isFirstRun: true,
+            isDefaultBrowser: true,
+            isBottomToolbarUser: true,
+            hasEnabledTipsNotifications: true,
+            hasAcceptedTermsOfUse: true,
+            isAppleIntelligenceAvailable: true,
+            cannotUseAppleIntelligence: true
+        )
+        var recordedContextMembers = Set(Mirror(reflecting: recordedContext).children.compactMap(\.label))
+        // removing values that are not part of the metrics file
+        recordedContextMembers.remove("logger")
+        recordedContextMembers.remove("eventQueries")
+
+        let metricsObject = GleanMetrics.NimbusSystem.RecordedNimbusContextObject()
+        let metricsObjectMembers = Set(Mirror(reflecting: metricsObject).children.compactMap(\.label))
+
+        let differences = recordedContextMembers.symmetricDifference(metricsObjectMembers)
+
+        XCTAssertTrue(differences.isEmpty)
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14098)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30564)

## :bulb: Description
Because we want to make sure that there's no human error missing fields between RecordedNimbusContext and the metrics.yaml file, we ensure that with a test.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

