### PR TITLE
Remove FXIOS-13933 Tapping the ToU bottom sheet's background scrim should not dismiss the bottom sheet

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
@@ -283,12 +283,11 @@ final class TermsOfUseViewController: UIViewController,
     }
 
     @objc private func backgroundTapped(_ sender: UITapGestureRecognizer) {
-        // Only dismiss the view if the tap occurred outside the visible sheetContainer.
-        // This prevents dismissing the Terms of Use sheet when interacting with its content.
-        if !sheetContainer.frame.contains(sender.location(in: view)) {
-            store.dispatchLegacy(TermsOfUseAction(windowUUID: windowUUID, actionType: .gestureDismiss))
-            coordinator?.dismissTermsFlow()
-        }
+        // Only intercepts tap occurred outside the visible sheetContainer.
+        // This prevents interacting with its content.
+        guard !sheetContainer.frame.contains(sender.location(in: view)) else { return }
+        // FXIOS-30197: Intentionally no longer dismissing when tapping the background scrim.
+        // Add any other scrim interaction here
     }
 
     @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13933)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30197)

## :bulb: Description
This PR removes dismiss action that occurred when tapping the ToU bottom sheet's background scrim.


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

