### PR TITLE
Refactor FXIOS-13953 [Swift 6 migration] Microsurvey intro and more dispatch legacy

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -781,7 +781,7 @@ class BrowserCoordinator: BaseCoordinator,
             navigationController.sheetPresentationController?.detents = [.medium(), .large()]
             navigationController.sheetPresentationController?.prefersGrabberVisible = true
             if isEditing {
-                store.dispatchLegacy(
+                store.dispatch(
                     ToolbarAction(
                         shouldShowKeyboard: false,
                         windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -97,14 +97,14 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
 
     @objc
     func closeMicroSurvey() {
-        store.dispatchLegacy(
+        store.dispatch(
             MicrosurveyPromptAction(windowUUID: windowUUID, actionType: MicrosurveyPromptActionType.closePrompt)
         )
     }
 
     @objc
     func openMicroSurvey() {
-        store.dispatchLegacy(
+        store.dispatch(
             MicrosurveyPromptAction(windowUUID: windowUUID, actionType: MicrosurveyPromptActionType.continueToSurvey)
         )
     }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -160,7 +160,7 @@ final class MicrosurveyViewController: UIViewController,
         let action = ScreenAction(windowUUID: windowUUID,
                                   actionType: ScreenActionType.showScreen,
                                   screen: .microsurvey)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
         let uuid = windowUUID
         store.subscribe(self, transform: {
             return $0.select({ appState in
@@ -190,7 +190,7 @@ final class MicrosurveyViewController: UIViewController,
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        store.dispatchLegacy(
+        store.dispatch(
             MicrosurveyAction(surveyId: model.id, windowUUID: windowUUID, actionType: MicrosurveyActionType.surveyDidAppear)
         )
     }
@@ -330,7 +330,7 @@ final class MicrosurveyViewController: UIViewController,
     }
 
     private func sendTelemetry() {
-        store.dispatchLegacy(
+        store.dispatch(
             MicrosurveyAction(
                 surveyId: model.id,
                 userSelection: selectedOption,
@@ -356,7 +356,7 @@ final class MicrosurveyViewController: UIViewController,
         )
         confirmationView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         UIAccessibility.post(notification: .screenChanged, argument: nil)
-        store.dispatchLegacy(
+        store.dispatch(
             MicrosurveyAction(
                 surveyId: model.id,
                 windowUUID: windowUUID,
@@ -367,7 +367,7 @@ final class MicrosurveyViewController: UIViewController,
 
     @objc
     private func didTapClose() {
-        store.dispatchLegacy(
+        store.dispatch(
             MicrosurveyAction(
                 surveyId: model.id,
                 windowUUID: windowUUID,
@@ -378,7 +378,7 @@ final class MicrosurveyViewController: UIViewController,
 
     @objc
     private func didTapPrivacyPolicy() {
-        store.dispatchLegacy(
+        store.dispatch(
             MicrosurveyAction(
                 surveyId: model.id,
                 windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
@@ -147,7 +147,7 @@ class IntroViewController: UIViewController,
         let action = ScreenAction(windowUUID: windowUUID,
                                   actionType: ScreenActionType.showScreen,
                                   screen: .onboardingViewController)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
         let uuid = windowUUID
         store.subscribe(self, transform: {
             $0.select({ appState in
@@ -161,7 +161,7 @@ class IntroViewController: UIViewController,
         let action = ScreenAction(windowUUID: windowUUID,
                                   actionType: ScreenActionType.closeScreen,
                                   screen: .onboardingViewController)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     func newState(state: OnboardingViewControllerState) {
@@ -363,13 +363,13 @@ extension IntroViewController: OnboardingCardDelegate {
             let action = ThemeSettingsViewAction(manualThemeType: .dark,
                                                  windowUUID: windowUUID,
                                                  actionType: ThemeSettingsViewActionType.switchManualTheme)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .themeLight:
             turnSystemTheme(on: false)
             let action = ThemeSettingsViewAction(manualThemeType: .light,
                                                  windowUUID: windowUUID,
                                                  actionType: ThemeSettingsViewActionType.switchManualTheme)
-            store.dispatchLegacy(action)
+            store.dispatch(action)
         case .themeSystemDefault:
             turnSystemTheme(on: true)
         case .toolbarBottom:
@@ -391,7 +391,7 @@ extension IntroViewController: OnboardingCardDelegate {
         let action = ThemeSettingsViewAction(useSystemAppearance: state,
                                              windowUUID: windowUUID,
                                              actionType: ThemeSettingsViewActionType.toggleUseSystemAppearance)
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     func sendCardViewTelemetry(from cardName: String) {

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
@@ -76,7 +76,7 @@ class ShortcutsLibraryViewController: UIViewController,
         setupLayout()
         configureDataSource()
 
-        store.dispatchLegacy(
+        store.dispatch(
             ShortcutsLibraryAction(
                 windowUUID: windowUUID,
                 actionType: ShortcutsLibraryActionType.initialize
@@ -120,7 +120,7 @@ class ShortcutsLibraryViewController: UIViewController,
             actionType: ScreenActionType.showScreen,
             screen: .shortcutsLibrary
         )
-        store.dispatchLegacy(action)
+        store.dispatch(action)
 
         let uuid = windowUUID
         store.subscribe(self, transform: {
@@ -145,7 +145,7 @@ class ShortcutsLibraryViewController: UIViewController,
             actionType: ScreenActionType.closeScreen,
             screen: .shortcutsLibrary
         )
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     // MARK: - Themeable
@@ -259,7 +259,7 @@ class ShortcutsLibraryViewController: UIViewController,
             sourceView: sourceView,
             toastContainer: self.view
         )
-        store.dispatchLegacy(
+        store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(.contextMenu, contextMenuConfiguration: configuration),
                 windowUUID: windowUUID,
@@ -275,7 +275,7 @@ class ShortcutsLibraryViewController: UIViewController,
                                 theme: currentTheme,
                                 completion: { buttonPressed in
             if buttonPressed {
-                store.dispatchLegacy(
+                store.dispatch(
                     ShortcutsLibraryAction(
                         tab: tab,
                         windowUUID: self.windowUUID,
@@ -350,14 +350,14 @@ class ShortcutsLibraryViewController: UIViewController,
 
         recordTelemetryOnDisappear = false
 
-        store.dispatchLegacy(
+        store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: destination,
                 windowUUID: windowUUID,
                 actionType: NavigationBrowserActionType.tapOnCell
             )
         )
-        store.dispatchLegacy(
+        store.dispatch(
             ShortcutsLibraryAction(
                 windowUUID: windowUUID,
                 actionType: ShortcutsLibraryActionType.tapOnShortcutCell

--- a/firefox-ios/Client/Frontend/StoriesFeed/StoriesFeedViewController.swift
+++ b/firefox-ios/Client/Frontend/StoriesFeed/StoriesFeedViewController.swift
@@ -88,7 +88,7 @@ class StoriesFeedViewController: UIViewController,
         setupLayout()
         configureDataSource()
 
-        store.dispatchLegacy(
+        store.dispatch(
             StoriesFeedAction(
                 windowUUID: windowUUID,
                 actionType: StoriesFeedActionType.initialize
@@ -117,7 +117,7 @@ class StoriesFeedViewController: UIViewController,
             actionType: ScreenActionType.showScreen,
             screen: .storiesFeed
         )
-        store.dispatchLegacy(action)
+        store.dispatch(action)
 
         let uuid = windowUUID
         store.subscribe(self, transform: {
@@ -142,7 +142,7 @@ class StoriesFeedViewController: UIViewController,
             actionType: ScreenActionType.closeScreen,
             screen: .storiesFeed
         )
-        store.dispatchLegacy(action)
+        store.dispatch(action)
     }
 
     // MARK: Helper functions


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13953)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30239)

## :bulb: Description
Migrating microsurvey, intro and other classes to use `dispatch` instead of `dispatchLegacy`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

