### PR TITLE
Refactor FXIOS-13908 [Deferred] Replace >>== usage in TestSQLitePinnedSites and DeferredTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/DeferredTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/DeferredTests.swift
@@ -56,7 +56,9 @@ class DeferredTests: XCTestCase {
         }
 
         // Type signatures:
-        let combined: () -> Deferred<Maybe<String>> = { f1() >>== f2 }
+        let combined: () -> Deferred<Maybe<String>> = {
+            chainDeferred(f1(), f: f2)
+        }
         let result: Deferred<Maybe<String>> = combined()
 
         result.upon {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSQLitePinnedSites.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSQLitePinnedSites.swift
@@ -60,20 +60,32 @@ class TestSQLitePinnedSites: XCTestCase {
         }
 
         let checkPinnedSites: @Sendable () -> Success = {
-            return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
-                XCTAssertEqual(pinnedSites.count, 2)
-                XCTAssertEqual(pinnedSites[0]?.url, site2.url)
-                XCTAssertEqual(pinnedSites[1]?.url, site1.url, "The older pinned site should be last")
-                return succeed()
+            return pinnedSites.getPinnedTopSites().bind { result in
+                if let pinnedSites = result.successValue {
+                    XCTAssertEqual(pinnedSites.count, 2)
+                    XCTAssertEqual(pinnedSites[0]?.url, site2.url)
+                    XCTAssertEqual(pinnedSites[1]?.url, site1.url, "The older pinned site should be last")
+                    return succeed()
+                }
+
+                return deferMaybe(result.failureValue!)
             }
         }
 
         let removePinnedSites: @Sendable () -> Success = {
-            return pinnedSites.removeFromPinnedTopSites(site2) >>== {
-                return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
-                    XCTAssertEqual(pinnedSites.count, 1, "There should only be one pinned site")
-                    XCTAssertEqual(pinnedSites[0]?.url, site1.url, "Site1 should be the only pin left")
-                    return succeed()
+            return pinnedSites.removeFromPinnedTopSites(site2).bind { removalResult in
+                if removalResult.isFailure {
+                    return deferMaybe(removalResult.failureValue!)
+                }
+
+                return pinnedSites.getPinnedTopSites().bind { result in
+                    if let pinnedSites = result.successValue {
+                        XCTAssertEqual(pinnedSites.count, 1, "There should only be one pinned site")
+                        XCTAssertEqual(pinnedSites[0]?.url, site1.url, "Site1 should be the only pin left")
+                        return succeed()
+                    }
+
+                    return deferMaybe(result.failureValue!)
                 }
             }
         }
@@ -83,10 +95,14 @@ class TestSQLitePinnedSites: XCTestCase {
                 if let error = result.failureValue {
                     return deferMaybe(error)
                 }
-                return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
-                    XCTAssertEqual(pinnedSites.count, 1, "There should not be a dupe")
-                    XCTAssertEqual(pinnedSites[0]?.url, site1.url, "Site1 should still be the only pin")
-                    return succeed()
+                return pinnedSites.getPinnedTopSites().bind { result in
+                    if let pinnedSites = result.successValue {
+                        XCTAssertEqual(pinnedSites.count, 1, "There should not be a dupe")
+                        XCTAssertEqual(pinnedSites[0]?.url, site1.url, "Site1 should still be the only pin")
+                        return succeed()
+                    }
+
+                    return deferMaybe(result.failureValue!)
                 }
             }
         }
@@ -132,19 +148,31 @@ class TestSQLitePinnedSites: XCTestCase {
         }
 
         let checkPinnedSites: @Sendable () -> Success = {
-            return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
-                XCTAssertEqual(pinnedSites.count, 2)
-                XCTAssertEqual(pinnedSites[0]?.url, site2.url)
-                XCTAssertEqual(pinnedSites[1]?.url, site1.url, "The older pinned site should be last")
-                return succeed()
+            return pinnedSites.getPinnedTopSites().bind { result in
+                if let pinnedSites = result.successValue {
+                    XCTAssertEqual(pinnedSites.count, 2)
+                    XCTAssertEqual(pinnedSites[0]?.url, site2.url)
+                    XCTAssertEqual(pinnedSites[1]?.url, site1.url, "The older pinned site should be last")
+                    return succeed()
+                }
+
+                return deferMaybe(result.failureValue!)
             }
         }
 
         let removePinnedSites: @Sendable () -> Success = {
-            return pinnedSites.removeFromPinnedTopSites(site2) >>== {
-                return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
-                    XCTAssertEqual(pinnedSites.count, 0, "Duplicate pinned domains are removed with a fuzzy search")
-                    return succeed()
+            return pinnedSites.removeFromPinnedTopSites(site2).bind { removalResult in
+                if removalResult.isFailure {
+                    return deferMaybe(removalResult.failureValue!)
+                }
+
+                return pinnedSites.getPinnedTopSites().bind { result in
+                    if let pinnedSites = result.successValue {
+                        XCTAssertEqual(pinnedSites.count, 0, "Duplicate pinned domains are removed with a fuzzy search")
+                        return succeed()
+                    }
+
+                    return deferMaybe(result.failureValue!)
                 }
             }
         }
@@ -187,19 +215,31 @@ class TestSQLitePinnedSites: XCTestCase {
         }
 
         let checkPinnedSite: @Sendable () -> Success = {
-            return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
-                XCTAssertEqual(pinnedSites.count, 1)
-                XCTAssertEqual(pinnedSites[0]?.url, site.url)
-                XCTAssertEqual(pinnedSites[0]?.title, site.title)
-                return succeed()
+            return pinnedSites.getPinnedTopSites().bind { result in
+                if let pinnedSites = result.successValue {
+                    XCTAssertEqual(pinnedSites.count, 1)
+                    XCTAssertEqual(pinnedSites[0]?.url, site.url)
+                    XCTAssertEqual(pinnedSites[0]?.title, site.title)
+                    return succeed()
+                }
+
+                return deferMaybe(result.failureValue!)
             }
         }
 
         let removePinnedSite: @Sendable () -> Success = {
-            return pinnedSites.removeFromPinnedTopSites(site) >>== {
-                return pinnedSites.getPinnedTopSites() >>== { pinnedSites in
-                    XCTAssertEqual(pinnedSites.count, 0, "There should be no pinned sites")
-                    return succeed()
+            return pinnedSites.removeFromPinnedTopSites(site).bind { removalResult in
+                if removalResult.isFailure {
+                    return deferMaybe(removalResult.failureValue!)
+                }
+
+                return pinnedSites.getPinnedTopSites().bind { result in
+                    if let pinnedSites = result.successValue {
+                        XCTAssertEqual(pinnedSites.count, 0, "There should be no pinned sites")
+                        return succeed()
+                    }
+
+                    return deferMaybe(result.failureValue!)
                 }
             }
         }


### PR DESCRIPTION
Replaces usage of the custom >>== operator with the bind method in DeferredTests and TestSQLitePinnedSites. This change improves clarity and error handling by explicitly checking for success and failure cases in asynchronous test chains.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13908)  
[GitHub issue](https://github.com/mozilla-mobile/firefox-ios/issues/30136)

## :bulb: Description

### What’s updated
- Removed all uses of the custom `>>==` operator.
- Rewrote each async step using `.bind { … }` for clarity and safety.
- Updated each test block to:
  - unwrap and validate `successValue` cleanly
  - route failures through `deferMaybe(...)`
  - keep `return succeed()` consistent across success paths
- Cleaned up several places where error handling was previously implicit or unclear.
- Overall, the test flow for pinned sites (adding, removing, verifying order) is now much easier to follow.

### Why this matters
- `bind` makes control flow clearer and easier to debug.
- It ensures that no test accidentally swallows a failure.
- It removes a custom operator that wasn’t very transparent.
- Helps keep the test suite consistent with the rest of the codebase.


## :pencil: Checklist
- [x] I filled in the ticket numbers and added a clear description of the work  
- [x] I updated the PR name to follow the [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)  
- [x] I ensured all updated tests pass  
- [ ] If working on UI, I verified accessibility behavior (Dynamic Text, VoiceOver)  
- [ ] If adding telemetry, I reviewed the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events)  
- [ ] If adding or changing strings, I followed the [localization guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings)  
- [x] I added comments or documentation where needed  