### PR TITLE
Add FXIOS-13867 [Trending Searches] clear button to section header

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -543,10 +543,14 @@ class SearchViewController: SiteTableViewController,
         else { return nil }
 
         var title: String
+        var accessory: SiteTableHeaderAccessory = .none
         switch section {
         case SearchListSection.recentSearches.rawValue:
             guard !viewModel.recentSearches.isEmpty else { return nil }
             title = .SearchZero.RecentSearchesSectionTitle
+            accessory = .clear(action: {
+                // TODO: FXIOS-14100 - Add method to clear recent searches
+            })
 
         case SearchListSection.trendingSearches.rawValue:
             guard !viewModel.trendingSearches.isEmpty else { return nil }
@@ -566,9 +570,10 @@ class SearchViewController: SiteTableViewController,
         default:  title = ""
         }
 
-        let viewModel = SiteTableViewHeaderModel(title: title,
-                                                 isCollapsible: false,
-                                                 collapsibleState: nil)
+        let viewModel = SiteTableViewHeaderModel(
+            title: title,
+            accessory: accessory
+        )
         headerView.configure(viewModel)
         headerView.applyTheme(theme: currentTheme())
         return headerView

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
@@ -436,9 +436,10 @@ class RemoteTabsViewController: UIViewController,
 
         let isCollapsed = hiddenSections.contains(section)
         let collapsibleState = isCollapsed ? ExpandButtonState.trailing : ExpandButtonState.down
-        let headerModel = SiteTableViewHeaderModel(title: client.name,
-                                                   isCollapsible: true,
-                                                   collapsibleState: collapsibleState)
+        let headerModel = SiteTableViewHeaderModel(
+            title: client.name,
+            accessory: .collapsible(state: collapsibleState)
+        )
         headerView.configure(headerModel)
         headerView.showBorder(for: .bottom, true)
         headerView.showBorder(for: .top, section != 0)

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -324,9 +324,10 @@ class DownloadsPanel: UIViewController,
 
         let title = viewModel.headerTitle(for: section) ?? ""
 
-        let headerViewModel = SiteTableViewHeaderModel(title: title,
-                                                       isCollapsible: false,
-                                                       collapsibleState: nil)
+        let headerViewModel = SiteTableViewHeaderModel(
+            title: title,
+            accessory: .none
+        )
         headerView.configure(headerViewModel)
         headerView.showBorder(for: .top, !viewModel.isFirstSection(section))
         headerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -740,8 +740,7 @@ extension HistoryPanel: UITableViewDelegate {
         let isCollapsed = viewModel.isSectionCollapsed(sectionIndex: section - 1)
         let headerViewModel = SiteTableViewHeaderModel(
             title: actualSection.title ?? "",
-            isCollapsible: true,
-            collapsibleState: isCollapsed ? ExpandButtonState.trailing : ExpandButtonState.down
+            accessory: .collapsible(state: isCollapsed ? ExpandButtonState.trailing : ExpandButtonState.down)
         )
         header.configure(headerViewModel)
         header.applyTheme(theme: currentTheme())

--- a/firefox-ios/Client/Frontend/Widgets/SiteTableViewHeader.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SiteTableViewHeader.swift
@@ -6,21 +6,37 @@ import Common
 import UIKit
 import Shared
 
-struct SiteTableViewHeaderModel {
-    let title: String
-    let isCollapsible: Bool
-    let collapsibleState: ExpandButtonState?
+// Accessory that accompanies the title on the header
+enum SiteTableHeaderAccessory {
+    case collapsible(state: ExpandButtonState)
+    case clear(action: () -> Void)
+    case none
 }
 
+struct SiteTableViewHeaderModel {
+    let title: String
+    let accessory: SiteTableHeaderAccessory
+    init(title: String, accessory: SiteTableHeaderAccessory = .none) {
+        self.title = title
+        self.accessory = accessory
+    }
+}
+
+// Section header view that contains title, but also has an accessory view
+// (i.e. collapsible arrow for synced tabs, clear button for recent searches list)
 class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, ReusableCell {
     struct UX {
         static let titleTrailingLeadingMargin: CGFloat = 16
         static let titleTopBottomMargin: CGFloat = 12
-        static let imageTrailingSpace: CGFloat = 12
+        static let spacing: CGFloat = 12
         static let imageWidthHeight: CGFloat = 24
     }
 
-    var collapsibleState: ExpandButtonState?
+    private var accessoryState: SiteTableHeaderAccessory = .none
+    private var clearAction: (() -> Void)?
+    private var collapsibleState: ExpandButtonState?
+
+    private var existingAccessoryView: UIView?
 
     private let titleLabel: UILabel = .build { label in
         label.numberOfLines = 0
@@ -28,10 +44,22 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, Reusabl
         label.adjustsFontForContentSizeCategory = true
     }
 
+    private lazy var headerStack: UIStackView = .build { stack in
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = UX.spacing
+        stack.distribution = .fill
+    }
+
     private let collapsibleImageView: UIImageView = .build { _ in }
 
-    private var titleTrailingConstraint: NSLayoutConstraint?
-    private var imageViewLeadingConstraint: NSLayoutConstraint?
+    private lazy var clearButton: UIButton = .build { button in
+        button.setTitle(.SearchZero.ClearButtonTitle, for: .normal)
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.titleLabel?.font = FXFontStyles.Regular.callout.scaledFont()
+        button.addTarget(self, action: #selector(self.clearButtonTapped), for: .touchUpInside)
+    }
+
     fileprivate let bordersHelper = ThemedHeaderFooterViewBordersHelper()
 
     override var textLabel: UILabel? {
@@ -51,53 +79,86 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, Reusabl
     override func prepareForReuse() {
         super.prepareForReuse()
         setDefaultBordersValues()
+        removeAccessory()
     }
 
     func configure(_ model: SiteTableViewHeaderModel) {
         titleLabel.text = model.title
 
-        showImage(model.isCollapsible)
-        collapsibleState = model.collapsibleState
+        removeAccessory()
+
+        switch model.accessory {
+        case .collapsible(let state):
+            collapsibleState = state
+            collapsibleImageView.image = collapsibleState?.image
+            setupAccessoryView(collapsibleImageView)
+
+        case .clear(let action):
+            clearAction = action
+            setupAccessoryView(clearButton)
+
+        case .none:
+            break
+        }
     }
 
     private func setupLayout() {
         translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubviews(titleLabel, collapsibleImageView)
+        headerStack.addArrangedSubview(titleLabel)
+        contentView.addSubviews(headerStack)
 
         bordersHelper.initBorders(view: self.contentView)
         setDefaultBordersValues()
 
         backgroundView = UIView()
-
-        imageViewLeadingConstraint = titleLabel.trailingAnchor.constraint(
-            equalTo: collapsibleImageView.leadingAnchor,
-            constant: -UX.titleTrailingLeadingMargin)
-
-        titleTrailingConstraint = titleLabel.trailingAnchor.constraint(
-            equalTo: contentView.trailingAnchor,
-            constant: -UX.titleTrailingLeadingMargin)
-
         let scaledImageViewSize = UIFontMetrics.default.scaledValue(for: UX.imageWidthHeight)
-        NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor,
-                                                constant: UX.titleTrailingLeadingMargin),
-            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor,
-                                            constant: UX.titleTopBottomMargin),
-            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor,
-                                               constant: -UX.titleTopBottomMargin),
 
-            collapsibleImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            collapsibleImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
-                                                           constant: -UX.imageTrailingSpace),
-            collapsibleImageView.widthAnchor.constraint(equalToConstant: scaledImageViewSize),
-            collapsibleImageView.heightAnchor.constraint(equalToConstant: scaledImageViewSize)
-        ])
+        NSLayoutConstraint.activate(
+            [
+                headerStack.leadingAnchor.constraint(
+                    equalTo: contentView.leadingAnchor,
+                    constant: UX.titleTrailingLeadingMargin
+                ),
+                headerStack.trailingAnchor.constraint(
+                    equalTo: contentView.trailingAnchor,
+                    constant: -UX.spacing
+                ),
+                headerStack.topAnchor.constraint(
+                    equalTo: contentView.topAnchor,
+                    constant: UX.titleTopBottomMargin
+                ),
+                headerStack.bottomAnchor.constraint(
+                    equalTo: contentView.bottomAnchor,
+                    constant: -UX.titleTopBottomMargin
+                ),
+                collapsibleImageView.widthAnchor.constraint(equalToConstant: scaledImageViewSize),
+                collapsibleImageView.heightAnchor.constraint(equalToConstant: scaledImageViewSize)
+            ]
+        )
+    }
 
-        showImage(false)
+    private func removeAccessory() {
+        accessoryState = .none
+        if let accessoryView = existingAccessoryView {
+            headerStack.removeArrangedSubview(accessoryView)
+            accessoryView.removeFromSuperview()
+        }
+        existingAccessoryView = nil
+    }
+
+    private func setupAccessoryView(_ view: UIView) {
+        existingAccessoryView = view
+        headerStack.addArrangedSubview(view)
+        view.setContentHuggingPriority(.required, for: .horizontal)
+        view.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        setNeedsLayout()
+        layoutIfNeeded()
     }
 
     func applyTheme(theme: Theme) {
         titleLabel.textColor = theme.colors.textPrimary
+        clearButton.setTitleColor(theme.colors.textSecondary, for: .normal)
         backgroundView?.backgroundColor = theme.colors.layer1
         collapsibleImageView.image = collapsibleState?.image?.tinted(withColor: theme.colors.iconAccent)
         bordersHelper.applyTheme(theme: theme)
@@ -107,14 +168,13 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, Reusabl
         bordersHelper.showBorder(for: location, show)
     }
 
-    private func showImage(_ show: Bool) {
-        collapsibleImageView.isHidden = !show
-        titleTrailingConstraint?.isActive = !show
-        imageViewLeadingConstraint?.isActive = show
-    }
-
     func setDefaultBordersValues() {
         bordersHelper.showBorder(for: .top, true)
         bordersHelper.showBorder(for: .bottom, true)
+    }
+
+    @objc
+    private func clearButtonTapped() {
+        clearAction?()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13867)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30037)

## :bulb: Description
Add a new clear button to recent searches section. 
- Refactor `SiteTableViewHeader` to have an `SiteTableHeaderAccessory` so that we can now configure with adding a clear button in addition to the collapsible image that we use for Synced Tabs and History Panel.
- Update the view to simply use horizontal stack which eliminates needed to manage the constraints.

**Testing Steps**
Enable Search - Recent / Search - Trending in FF. Then navigate to a web url and tap on the address bar. Enter a search term which saves as a recent search. Go back to the zero search state and now you should see the recent searches with a Clear button.

Confirm that other views are not broken (History Panel, Synced Tabs, Downloads) that also use the `SiteTableViewHeader`
## :movie_camera: Demos
**IPad** 

| Before | After |
| - | - |
| <img width="1000" height="2000" alt="Simulator Screenshot - iPad (A16) - 2025-11-13 at 08 14 23" src="https://github.com/user-attachments/assets/ba58f88f-966e-420d-99a3-59dcedcd49ff" /> | <img width="1000" height="2000" alt="simulator_screenshot_741B4A7E-E1D3-4C39-85CA-1C2B7D874B95" src="https://github.com/user-attachments/assets/ed2fb4cf-b465-4c6b-a496-2d9cbf0a1172" />|
| <img width="1000" height="2000" alt="Simulator Screenshot - iPad (A16) - 2025-11-13 at 08 14 31" src="https://github.com/user-attachments/assets/f048217f-312b-431f-ae6b-720c25a7ae66" /> | <img width="1000" height="2000" alt="Simulator Screenshot - iPad (A16) - 2025-11-13 at 08 00 46" src="https://github.com/user-attachments/assets/89ea95e8-c5cb-4b58-86fe-94071b42d511" />|
| <img width="1000" height="2000" alt="Simulator Screenshot - iPad (A16) - 2025-11-13 at 08 26 01" src="https://github.com/user-attachments/assets/c135dc9e-5e06-4af4-b75d-e56bc184df65" /> | <img width="1000" height="2000" alt="Simulator Screenshot - iPad (A16) - 2025-11-13 at 08 01 06" src="https://github.com/user-attachments/assets/3030b6d2-f531-4be3-912f-861d43f21cdd" />|
| <img width="1000" height="2000" alt="Simulator Screenshot - iPad (A16) - 2025-11-13 at 08 25 57" src="https://github.com/user-attachments/assets/cd94165a-ea69-48a8-9794-3e6ea35e09e6" /> | <img width="1000" height="2000" alt="Simulator Screenshot - iPad (A16) - 2025-11-13 at 08 03 17" src="https://github.com/user-attachments/assets/cd9aa62a-e352-4ec6-9112-7925de683a00" />|

**Dynamic Text Demo**

https://github.com/user-attachments/assets/59bef373-2682-43de-9f0f-a3a35b7e5455

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

