### PR TITLE
Refactor FXIOS-12796 [Swift 6 migration] Fix warnings that appear without the strict concurrency flag

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1111,7 +1111,7 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     func popToBVC() {
-        router.popToViewController(browserViewController, reason: .deeplink)
+        _ = router.popToViewController(browserViewController, reason: .deeplink)
     }
 
     // MARK: Microsurvey

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/AboutHomeHandler.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/AboutHomeHandler.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-class AboutHomeHandler: InternalSchemeResponse {
+final class AboutHomeHandler: InternalSchemeResponse {
     static let path = "about/home"
 
     // Return a blank page, the webview delegate will look at the current URL and load the home panel based on that
@@ -22,7 +22,7 @@ class AboutHomeHandler: InternalSchemeResponse {
     }
 }
 
-class AboutLicenseHandler: InternalSchemeResponse {
+final class AboutLicenseHandler: InternalSchemeResponse {
     static let path = "about/license"
 
     func response(forRequest request: URLRequest, useOldErrorPage: Bool = false) -> (URLResponse, Data)? {

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -148,7 +148,7 @@ private func cfErrorToName(_ err: CFNetworkErrors) -> String {
     }
 }
 
-class ErrorPageHandler: InternalSchemeResponse, FeatureFlaggable {
+final class ErrorPageHandler: InternalSchemeResponse, FeatureFlaggable {
     static let path = InternalURL.Path.errorpage.rawValue
     // When nativeErrorPage feature flag is true, only create
     // html page with gray background similar to homepage or private homepage.

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
@@ -12,6 +12,7 @@ enum InternalPageSchemeHandlerError: Error {
     case notAuthorized
 }
 
+@MainActor
 protocol InternalSchemeResponse {
     func response(forRequest: URLRequest, useOldErrorPage: Bool) -> (URLResponse, Data)?
 }

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewModel.swift
@@ -5,7 +5,7 @@
 import Foundation
 import WebKit
 
-class WebsiteDataManagementViewModel {
+final class WebsiteDataManagementViewModel {
     enum State {
         case loading
         case displayInitial

--- a/firefox-ios/Client/Frontend/StoriesFeed/StoriesFeedSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/StoriesFeed/StoriesFeedSectionLayoutProvider.swift
@@ -55,7 +55,6 @@ struct StoriesFeedSectionLayoutProvider {
         group.interItemSpacing = NSCollectionLayoutSpacing.fixed(UX.interItemSpacing)
 
         // Horizontal insets
-        let groupWidth = containerWidth * UX.groupWidthRatio
         let horizontalInsetRatio = (1 - UX.groupWidthRatio) / 2
         let horizontalInsets = containerWidth * horizontalInsetRatio
         let section = NSCollectionLayoutSection(group: group)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fix warnings in Xcode

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

