### PR TITLE
Add FXIOS-14110 [Nimbus] Add nimbus client lifecycle logging

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -45,9 +45,6 @@ public enum LoggerCategory: String {
     /// Related to Merino AS.
     case merino
 
-    /// Related to Nimubs.
-    case nimbus
-
     /// Related to onboarding
     case onboarding
 

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -260,6 +260,27 @@ enum Experiments {
             .with(featureManifest: FxNimbus.shared)
             .with(commandLineArgs: CommandLine.arguments)
             .with(recordedContext: nimbusRecordedContext)
+            .onCreate(callback: { _ in
+                    DefaultLogger.shared.log(
+                        "Nimbus is ready",
+                        level: .info,
+                        category: .experiments
+                    )
+            })
+            .onApply(callback: { _ in
+                    DefaultLogger.shared.log(
+                        "Nimbus enrollment and experiments application complete",
+                        level: .info,
+                        category: .experiments
+                    )
+            })
+            .onFetch(callback: { _ in
+                DefaultLogger.shared.log(
+                    "Nimbus fetch of new experiments has completed",
+                    level: .info,
+                    category: .experiments
+                )
+            })
             .build(appInfo: getAppSettings(isFirstRun: isFirstRun))
     }
 
@@ -277,7 +298,7 @@ enum Experiments {
         // Getting the singleton first time initializes it.
         let nimbus = Experiments.shared
 
-        DefaultLogger.shared.log("Nimbus is ready!",
+        DefaultLogger.shared.log("Nimbus singleton initialized successfully",
                                  level: .info,
                                  category: .experiments)
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -305,7 +305,7 @@ class BrowserViewController: UIViewController,
         logger.log(
             "Feature flag status",
             level: .info,
-            category: .nimbus,
+            category: .experiments,
             extra: [flagToCheck.rawValue: "\(featureFlagStatus)"]
         )
         return featureFlagStatus && UIDevice.current.userInterfaceIdiom != .pad
@@ -318,7 +318,7 @@ class BrowserViewController: UIViewController,
         logger.log(
             "Feature flag status",
             level: .info,
-            category: .nimbus,
+            category: .experiments,
             extra: [flagToCheck.rawValue: "\(featureFlagStatus)"]
         )
         return featureFlagStatus
@@ -331,7 +331,7 @@ class BrowserViewController: UIViewController,
         logger.log(
             "Feature flag status",
             level: .info,
-            category: .nimbus,
+            category: .experiments,
             extra: [flagToCheck.rawValue: "\(featureFlagStatus)"]
         )
         return featureFlagStatus
@@ -344,7 +344,7 @@ class BrowserViewController: UIViewController,
         logger.log(
             "Feature flag status",
             level: .info,
-            category: .nimbus,
+            category: .experiments,
             extra: [flagToCheck.rawValue: "\(featureFlagStatus)"]
         )
         return featureFlagStatus
@@ -361,7 +361,7 @@ class BrowserViewController: UIViewController,
         logger.log(
             "Feature flag status",
             level: .info,
-            category: .nimbus,
+            category: .experiments,
             extra: [flagToCheck.rawValue: "\(featureFlagStatus)"]
         )
         return featureFlagStatus
@@ -374,7 +374,7 @@ class BrowserViewController: UIViewController,
         logger.log(
             "Feature flag status",
             level: .info,
-            category: .nimbus,
+            category: .experiments,
             extra: [flagToCheck.rawValue: "\(featureFlagStatus)"]
         )
         return featureFlagStatus
@@ -387,7 +387,7 @@ class BrowserViewController: UIViewController,
         logger.log(
             "Feature flag status",
             level: .info,
-            category: .nimbus,
+            category: .experiments,
             extra: [flagToCheck.rawValue: "\(featureFlagStatus)"]
         )
         return featureFlagStatus
@@ -427,7 +427,7 @@ class BrowserViewController: UIViewController,
         logger.log(
             "Feature flag status",
             level: .info,
-            category: .nimbus,
+            category: .experiments,
             extra: [NimbusFeatureFlagID.trendingSearches.rawValue: "\(isTrendingSearchEnabled)"]
         )
 
@@ -435,7 +435,7 @@ class BrowserViewController: UIViewController,
         logger.log(
             "Feature flag status",
             level: .info,
-            category: .nimbus,
+            category: .experiments,
             extra: [NimbusFeatureFlagID.recentSearches.rawValue: "\(isRecentSearchEnabled)"]
         )
         return isTrendingSearchEnabled || isRecentSearchEnabled
@@ -448,7 +448,7 @@ class BrowserViewController: UIViewController,
         logger.log(
             "Feature flag status",
             level: .info,
-            category: .nimbus,
+            category: .experiments,
             extra: [flagToCheck.rawValue: "\(featureFlagStatus)"]
         )
         return featureFlagStatus
@@ -1418,7 +1418,7 @@ class BrowserViewController: UIViewController,
         logger.log(
             "Current Nimbus available experiments configuration",
             level: .info,
-            category: .nimbus,
+            category: .experiments,
             extra: currentExperimentsDictionary,
         )
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14110)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30594)

## :bulb: Description
Adds some logging callbacks to `onCreate`, `onApply`, and `onFetch` so we can have a better understanding of what's happening.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

