### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix Sendability wranings in MozillaRustComponents Nimbus files

### DIFF
--- a/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Nimbus/Nimbus.swift
+++ b/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Nimbus/Nimbus.swift
@@ -5,8 +5,9 @@
 import Foundation
 import Glean
 
-public class Nimbus: NimbusInterface {
-    private let _userDefaults: UserDefaults?
+public final class Nimbus: NimbusInterface {
+    // FIXME: FXIOS-14119 Should be thread safe
+    private nonisolated(unsafe) let _userDefaults: UserDefaults?
 
     private let nimbusClient: NimbusClientProtocol
 
@@ -14,14 +15,14 @@ public class Nimbus: NimbusInterface {
 
     private let errorReporter: NimbusErrorReporter
 
-    lazy var fetchQueue: OperationQueue = {
+    let fetchQueue: OperationQueue = {
         var queue = OperationQueue()
         queue.name = "Nimbus fetch queue"
         queue.maxConcurrentOperationCount = 1
         return queue
     }()
 
-    lazy var dbQueue: OperationQueue = {
+    let dbQueue: OperationQueue = {
         var queue = OperationQueue()
         queue.name = "Nimbus database queue"
         queue.maxConcurrentOperationCount = 1
@@ -442,7 +443,8 @@ extension Nimbus: NimbusMessagingProtocol {
     }
 }
 
-public class NimbusDisabled: NimbusApi {
+// FIXME: FXIOS-14118 Not thread safe because of mutable state
+public class NimbusDisabled: NimbusApi, @unchecked Sendable {
     public static let shared = NimbusDisabled()
 
     public var experimentParticipation: Bool = false

--- a/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Nimbus/NimbusApi.swift
+++ b/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Nimbus/NimbusApi.swift
@@ -172,7 +172,7 @@ public protocol NimbusUserConfiguration {
     func getAvailableExperiments() -> [AvailableExperiment]
 }
 
-public protocol NimbusEventStore {
+public protocol NimbusEventStore: Sendable {
     /// Records an event to the Nimbus event store.
     ///
     /// The method obtains the event counters for the `eventId` that is passed in, advances them if
@@ -266,7 +266,7 @@ public struct NimbusAppSettings {
 
 /// This error reporter is passed to `Nimbus` and any errors that are caught are reported via this type.
 ///
-public typealias NimbusErrorReporter = (Error) -> Void
+public typealias NimbusErrorReporter = @Sendable (Error) -> Void
 
 /// `ExperimentBranch` is a copy of the `Branch` without the `FeatureConfig`.
 public typealias Branch = ExperimentBranch

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusApi.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusApi.swift
@@ -177,7 +177,7 @@ public protocol NimbusUserConfiguration {
     func getAvailableExperiments() -> [AvailableExperiment]
 }
 
-public protocol NimbusEventStore {
+public protocol NimbusEventStore: Sendable {
     /// Records an event to the Nimbus event store.
     ///
     /// The method obtains the event counters for the `eventId` that is passed in, advances them if

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusMessagingHelpers.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusMessagingHelpers.swift
@@ -9,8 +9,8 @@ import Glean
  * Instances of this class are useful for implementing a messaging service based upon
  * Nimbus.
  *
- * The message helper is designed to help string interpolation and JEXL evalutaiuon against the context
- * of the attrtibutes Nimbus already knows about.
+ * The message helper is designed to help string interpolation and JEXL evaluation against the context
+ * of the attributes Nimbus already knows about.
  *
  * App-specific, additional context can be given at creation time.
  *

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -170,7 +170,7 @@ enum Experiments {
     }()
 
     private static func getAppSettings(isFirstRun: Bool) -> NimbusAppSettings {
-        let isPhone = UIDevice.current.userInterfaceIdiom == .phone
+        let isPhone = UIDeviceDetails.userInterfaceIdiom == .phone
 
         let customTargetingAttributes: [String: Any] = [
             "isFirstRun": "\(isFirstRun)",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Fixed some warnings in the MozillaRustComponents for Nimbus which were creating warnings in the Client Experiments.swift file.

Example:
<img width="1395" height="404" alt="Screenshot 2025-11-13 at 4 08 35 PM" src="https://github.com/user-attachments/assets/19df5d79-3c10-4712-9936-2a3fd27c5f3a" />

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)
