### PR TITLE
Add FXIOS-14177 [SYNC] new credit card verification logic

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -13,6 +13,7 @@ public struct PrefsKeys {
     // Global sync state for rust sync manager
     public static let RustSyncManagerPersistedState = "rustSyncManagerPersistedStateKey"
     public static let LoginsHaveBeenVerified = "loginsHaveBeenVerified"
+    public static let CreditCardsHaveBeenVerified = "creditCardsHaveBeenVerified"
 
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
     public static let KeyDefaultHomePageURL = "KeyDefaultHomePageURL"

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardProvider.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardProvider.swift
@@ -19,6 +19,7 @@ protocol CreditCardProvider {
         creditCard: UnencryptedCreditCardFields,
         completion: @escaping @Sendable (Bool?, Error?) -> Void
     )
+    func verifyCreditCards(key: String, completionHandler: @escaping @Sendable (Bool) -> Void)
 }
 
 extension RustAutofill: CreditCardProvider {}

--- a/firefox-ios/Providers/RustProtocols/AutofillProvider.swift
+++ b/firefox-ios/Providers/RustProtocols/AutofillProvider.swift
@@ -19,6 +19,7 @@ protocol SyncAutofillProvider {
     func getStoredKey(completion: @Sendable @escaping (Result<String, NSError>) -> Void)
     func registerWithSyncManager()
     func reportPreSyncKeyRetrievalFailure(err: String)
+    func verifyCreditCards(key: String, completionHandler: @escaping @Sendable (Bool) -> Void)
 }
 
 extension RustAutofill: AddressProvider, SyncAutofillProvider {}

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -310,6 +310,40 @@ public class RustAutofill: @unchecked Sendable {
         }
     }
 
+    /// Iterates through the stored credit cards checking that each record can be decrypted. If any records cannot be
+    /// decrypted, they are locally scrubbed to potentially be overwritten by a perviously synced server record.
+    ///
+    /// This function is meant to be executed only once (which is enforced via the `CreditCardsHaveBeenVerified` pref)
+    /// and is called before a credit card sync in `RustSyncManager`.
+    ///
+    /// - Parameters:
+    /// - Note: Scrubs undecryptable credit cards for sync users. This function is for a very specific purpose and should not
+    /// be used for general purposes.
+    public func verifyCreditCards(
+        key: String,
+        completionHandler: @escaping @Sendable (Bool) -> Void) {
+        performDatabaseOperation { error in
+            guard error == nil, let storage = self.storage else {
+                completionHandler(false)
+                return
+            }
+            do {
+                 let result = try storage.scrubUndecryptableCreditCardDataForRemoteReplacement(localEncryptionKey: key)
+
+                if result.totalScrubbedRecords > 0 {
+                    GleanMetrics.UserCreditCards.undecryptableCount.add(Int32(result.totalScrubbedRecords))
+                }
+                completionHandler(true)
+            } catch let err as NSError {
+                self.logger.log("Error verifying credit cards",
+                                level: .warning,
+                                category: .storage,
+                                description: err.localizedDescription)
+                completionHandler(false)
+            }
+        }
+    }
+
     enum AddressAutofillError: Error {
         case addAddressFailure
     }

--- a/firefox-ios/Storage/metrics.yaml
+++ b/firefox-ios/Storage/metrics.yaml
@@ -191,3 +191,20 @@ pre_sync_key_retrieval_failure:
       error_message:
         description: The error encountered retrieving the credit cards encryption key
         type: string
+
+user.credit_cards:
+  undecryptable_count:
+    type: counter
+    description: >
+      Track how many undecryptable credit cards we scrub during the credit card
+      verification process
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/30727
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/30609#issuecomment-3548892236
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - synced-client-integrations@mozilla.com
+      - lougenia@mozilla.com
+    expires: "never"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
@@ -275,6 +275,8 @@ final class MockAutofill: AddressProvider, SyncAutofillProvider {
     var getStoredKeyCalledCount = 0
     var registerWithSyncManagerCalled = 0
     var reportPreSyncKeyRetrievalFailureCalled = 0
+    var verifyCreditCardsCalled = 0
+    var creditCardsVerified = true
 
     func deleteAddress(
         id: String,
@@ -325,5 +327,10 @@ final class MockAutofill: AddressProvider, SyncAutofillProvider {
 
     func reportPreSyncKeyRetrievalFailure(err: String) {
         reportPreSyncKeyRetrievalFailureCalled += 1
+    }
+
+    func verifyCreditCards(key: String, completionHandler: @escaping @Sendable (Bool) -> Void) {
+        verifyCreditCardsCalled += 1
+        completionHandler(creditCardsVerified)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockCreditCardProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockCreditCardProvider.swift
@@ -11,6 +11,8 @@ class MockCreditCardProvider: CreditCardProvider {
     var updateCreditCardCalledCount = 0
     var listCreditCardsCalledCount = 0
     var deleteCreditCardsCalledCount = 0
+    var verifyCreditCardsCalled = 0
+    var creditCardsVerified = true
 
     var exampleCreditCard = CreditCard(
         guid: "1",
@@ -54,5 +56,10 @@ class MockCreditCardProvider: CreditCardProvider {
     ) {
         updateCreditCardCalledCount += 1
         completion(updateResult.status, updateResult.error)
+    }
+
+    func verifyCreditCards(key: String, completionHandler: @escaping @Sendable (Bool) -> Void) {
+        verifyCreditCardsCalled += 1
+        completionHandler(creditCardsVerified)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockLoginProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockLoginProvider.swift
@@ -11,7 +11,7 @@ class MockLoginProvider: LoginProvider, SyncLoginProvider {
     var getStoredKeyCalledCount = 0
     var registerWithSyncManagerCalled = 0
     var verifyLoginsCalled = 0
-    var loginsVerified = false
+    var loginsVerified = true
     var reportPreSyncKeyRetrievalFailureCalled = 0
 
     func searchLoginsWithQuery(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -73,12 +73,12 @@ class RustSyncManagerTests: XCTestCase {
         rustSyncManager.getEnginesAndKeys(engines: engines) { (engines, keys) in
             XCTAssertEqual(engines.count, 6)
 
-            XCTAssertTrue(engines.contains("bookmarks"))
-            XCTAssertTrue(engines.contains("history"))
-            XCTAssertTrue(engines.contains("passwords"))
-            XCTAssertTrue(engines.contains("tabs"))
-            XCTAssertTrue(engines.contains("addresses"))
-            XCTAssertTrue(engines.contains("creditcards"))
+            XCTAssertEqual(engines[safe: 0], "bookmarks")
+            XCTAssertEqual(engines[safe: 1], "creditcards")
+            XCTAssertEqual(engines[safe: 2], "history")
+            XCTAssertEqual(engines[safe: 3], "passwords")
+            XCTAssertEqual(engines[safe: 4], "tabs")
+            XCTAssertEqual(engines[safe: 5], "addresses")
             XCTAssertFalse(keys.isEmpty)
 
             XCTAssertNotNil(keys["creditcards"])
@@ -136,11 +136,11 @@ class RustSyncManagerTests: XCTestCase {
         rustSyncManager.getEnginesAndKeys(engines: engines) { (engines, keys) in
             XCTAssertEqual(engines.count, 5)
 
-            XCTAssertTrue(engines.contains("bookmarks"))
-            XCTAssertTrue(engines.contains("history"))
-            XCTAssertTrue(engines.contains("tabs"))
-            XCTAssertTrue(engines.contains("addresses"))
-            XCTAssertTrue(engines.contains("creditcards"))
+            XCTAssertEqual(engines[safe: 0], "bookmarks")
+            XCTAssertEqual(engines[safe: 1], "creditcards")
+            XCTAssertEqual(engines[safe: 2], "history")
+            XCTAssertEqual(engines[safe: 3], "tabs")
+            XCTAssertEqual(engines[safe: 4], "addresses")
             XCTAssertFalse(keys.isEmpty)
 
             XCTAssertNotNil(keys["creditcards"])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14177)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30727)

## :bulb: Description
This add credit card verification logic, similar to [logins](https://github.com/mozilla-mobile/firefox-ios/pull/26019), which once per user/installation iterates through the stored credit card records and locally scrubs (removes the credit card number of) any undecryptable records for potential replacement by a mirrored record on the sync server.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

