### PR TITLE
Remove [App Icons] Move unused app icon strings to old strings

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -3127,7 +3127,7 @@ extension String {
                     tableName: "AppIconSelection",
                     value: "Retro 2004",
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a retro version of the regular Firefox for iOS app icon which was default in the year 2004.")
-                
+
                 public static let Retro2017 = MZLocalizedString(
                     key: "Settings.AppIconSelection.AppIconNames.Retro2017.Title.v139",
                     tableName: "AppIconSelection",


### PR DESCRIPTION
## :scroll: Tickets
~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~
~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~

## :bulb: Description
Moves unused app icon strings to old strings for future removal.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

