### PR TITLE
Remove FXIOS-13953 [Swift 6 migration] Remove remaining dispatchLegacy

### DIFF
--- a/BrowserKit/Sources/Redux/DispatchStore.swift
+++ b/BrowserKit/Sources/Redux/DispatchStore.swift
@@ -6,7 +6,6 @@ import Foundation
 
 /// Protocol that allows to subscribe to the store and receive dispatched actions to modify the store state
 public protocol DispatchStore {
-    nonisolated func dispatchLegacy(_ action: Action)
     @MainActor
     func dispatch(_ action: Action)
 }

--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -71,21 +71,6 @@ public final class Store<State: StateType & Sendable>: DefaultDispatchStore {
         }
     }
 
-    nonisolated public func dispatchLegacy(_ action: Action) {
-        logger.log("Legacy dispatched action: \(action.debugDescription)", level: .info, category: .redux)
-
-        guard Thread.isMainThread else {
-            Task { @MainActor in
-                dispatch(action)
-            }
-            return
-        }
-
-        MainActor.assumeIsolated {
-            dispatch(action)
-        }
-    }
-
     public func dispatch(_ action: Action) {
         MainActor.assertIsolated("Expected to be called only on main actor.")
         logger.log("Dispatched action: \(action.debugDescription)", level: .info, category: .redux)

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -316,7 +316,6 @@ class CodeUsageDetector {
         case deferred
         case swiftUIText
         case task
-        case dispatchLegacy
 
         var message: String {
             switch self {
@@ -337,11 +336,6 @@ class CodeUsageDetector {
                 New `Task {}` added in file %@ at line %d.
                 Please add a concurrency reviewer on your PR: \(contacts)
                 """
-            case .dispatchLegacy:
-                return """
-                DispatchLegacy is used in file %@ at line %d.
-                Please replace with `dispatch` instead and call it from the main actor
-                """
             }
         }
 
@@ -359,8 +353,6 @@ class CodeUsageDetector {
                 return "Text(\""
             case .task:
                 return " Task {"
-            case .dispatchLegacy:
-                return ".dispatchLegacy("
             }
         }
 
@@ -375,7 +367,7 @@ class CodeUsageDetector {
 
         var shouldWarn: Bool {
             switch self {
-            case .deferred, .dispatchLegacy:
+            case .deferred:
                 return true
             default:
                 return false

--- a/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
@@ -33,7 +33,7 @@ final class AutofillAccessoryViewButtonItem: UIBarButtonItem {
     // MARK: - Properties
     private let accessoryImageView: UIImageView
     private let useAccessoryTextLabel: UILabel
-    private let tappedAccessoryButtonAction: (() -> Void)?
+    private let tappedAccessoryButtonAction: (@MainActor () -> Void)?
 
     /// Tint color for the accessory image view.
     var accessoryImageViewTintColor: UIColor? {

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -61,7 +61,7 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
     private lazy var passwordField: PasswordGeneratorPasswordFieldView = .build { [weak self] view in
         view.refreshPasswordButtonOnClick = {
             guard let self else {return}
-            store.dispatchLegacy(PasswordGeneratorAction(
+            store.dispatch(PasswordGeneratorAction(
                 windowUUID: self.windowUUID,
                 actionType: PasswordGeneratorActionType.userTappedRefreshPassword,
                 currentFrame: self.currentFrame)
@@ -179,9 +179,9 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
     // MARK: - Interaction Handlers
     @objc
     func useButtonOnClick() {
-        store.dispatchLegacy(PasswordGeneratorAction(windowUUID: windowUUID,
-                                                     actionType: PasswordGeneratorActionType.userTappedUsePassword,
-                                                     currentFrame: currentFrame))
+        store.dispatch(PasswordGeneratorAction(windowUUID: windowUUID,
+                                               actionType: PasswordGeneratorActionType.userTappedUsePassword,
+                                               currentFrame: currentFrame))
         dismiss(animated: true)
     }
 
@@ -205,7 +205,7 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
 
     // MARK: - Redux
     func subscribeToRedux() {
-        store.dispatchLegacy(
+        store.dispatch(
             ScreenAction(
                 windowUUID: windowUUID,
                 actionType: ScreenActionType.showScreen,

--- a/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
@@ -43,7 +43,7 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
         button.addTarget(self, action: #selector(self.refreshOnClick), for: .touchUpInside)
     }
 
-    var refreshPasswordButtonOnClick: (() -> Void)?
+    var refreshPasswordButtonOnClick: (@MainActor () -> Void)?
 
     convenience init(frame: CGRect, notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.init(frame: frame)

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -160,7 +160,7 @@ class LoginsHelper: @unchecked Sendable, TabContentScript, FeatureFlaggable {
                     windowUUID: tab.windowUUID,
                     actionType: GeneralBrowserActionType.showPasswordGenerator)
 
-                store.dispatchLegacy(newAction)
+                store.dispatch(newAction)
             }
             if userDefaults.value(forKey: PrefsKeys.PasswordGeneratorShown) == nil {
                 userDefaults.set(true, forKey: PrefsKeys.PasswordGeneratorShown)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
@@ -61,13 +61,4 @@ class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
         dispatchedActions.append(action)
         dispatchCalled?()
     }
-
-    /// We implemented the lock to ensure that this is thread safe
-    /// since actions can be dispatch in concurrent tasks
-    func dispatchLegacy(_ action: Redux.Action) {
-        lock.lock()
-        defer { lock.unlock() }
-        dispatchedActions.append(action)
-        dispatchCalled?()
-    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13953)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30239)

## :bulb: Description
Remove remaining `dispatchLegacy` 🎉 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

