### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix warnings in Download.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
@@ -156,7 +156,6 @@ class HTTPDownload: Download, URLSessionTaskDelegate, URLSessionDownloadDelegate
         })
     }
 
-    @MainActor
     override func resume() {
         cookieStore.getAllCookies { [self] cookies in
             cookies.forEach { cookie in

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadQueue.swift
@@ -52,6 +52,7 @@ class DownloadQueue: DownloadDelegate {
         delegates.removeAll(where: { $0.delegate === delegate || $0.delegate == nil })
     }
 
+    @MainActor
     func enqueue(_ download: Download) {
         // Clear the download stats if the queue was empty at the start.
         let uuid = download.originWindow
@@ -87,6 +88,7 @@ class DownloadQueue: DownloadDelegate {
         }
     }
 
+    @MainActor
     func resumeAll(for window: WindowUUID) {
         for download in downloads where !download.isComplete && download.originWindow == window {
             download.resume()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadQueueTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadQueueTests.swift
@@ -37,11 +37,13 @@ class DownloadQueueTests: XCTestCase {
         XCTAssertTrue(!queue.isEmpty)
     }
 
+    @MainActor
     func testEnqueueDownloadShouldAppendDownloadAndTriggerResume() {
         queue.enqueue(download)
         XCTAssertTrue(download.downloadTriggered)
     }
 
+    @MainActor
     func testEnqueueDownloadShouldCallDownloadQueueDidStartDownload() {
         let mockQueueDelegate = MockDownloadQueueDelegate()
         queue.addDelegate(mockQueueDelegate)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadTests.swift
@@ -51,6 +51,7 @@ class DownloadTests: XCTestCase {
         download = nil
     }
 
+    @MainActor
     func testResumeDoesNotLeak() {
         let mockDownloadDelegate = MockDownloadDelegate()
         download.delegate = mockDownloadDelegate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description

- Fix warnings in Download.swift (getAllCookies is `@MainActor`)

<img width="1202" height="333" alt="Screenshot 2025-11-14 at 2 26 04 PM" src="https://github.com/user-attachments/assets/afeffb25-a4ac-44c7-8da4-d1c3d39d3302" />

cc @Cramsden @lmarceau @dataports 


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code