### PR TITLE
Remove FXIOS-13960 [MozillaOnline] Do not set regional mode based on locale

### DIFF
--- a/BrowserKit/Sources/Shared/AppInfo.swift
+++ b/BrowserKit/Sources/Shared/AppInfo.swift
@@ -41,7 +41,7 @@ extension AppInfo {
         if UserDefaults.standard.bool(forKey: AppInfo.debugPrefIsChinaEdition) {
             return true
         }
-        // FIXME: FXIOS-13960 China FxA is no longer available, do not enable ChinaEdition based on locale
+        // FIXME: FXIOS-14170 China FxA is no longer available, do not enable ChinaEdition based on locale
         // return Locale.current.identifier == "zh_CN"
         return false
     }()


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-13960
Github issue #30264

## :bulb: Description

Stops flipping AppInfo.isChinaEdition based on just the app/device regional locale (while keeping other testing, debug & hidden prefs intact, full removal to be ticketed separately).

Desktop and Android stopped shipping their repacks similarly configured earlier this year.

The domestic infra is going away. FxA https://github.com/mozilla/application-services/pull/7060 will point it to prod anyways soon; this accompanies it by hiding the prefs that stop having any effect. Everyone will get just the same global experience.

_(If that proves to be a viable change in behavior going forwards, all the supporting settings, screens, config, debug settings, and testing stack can be removed as a next step.)_

<!-- Please upload screenshots or video demos of your work, if applicable
## :movie_camera: Demos

| Before | After |
| - | - |

<details>
<summary>Demo</summary>

</details>
 -->

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If needed, I updated documentation and added comments to complex code