### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Make `RemoteSettingsServiceSyncCoordinator` use `Notifiable` to fix strict concurrency warnings

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsServiceSyncCoordinator.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsServiceSyncCoordinator.swift
@@ -7,7 +7,7 @@ import MozillaAppServices
 import Shared
 import Common
 
-final class RemoteSettingsServiceSyncCoordinator {
+final class RemoteSettingsServiceSyncCoordinator: Notifiable {
     private weak var service: RemoteSettingsService?
     private let prefs: Prefs
     private let prefsKey = PrefsKeys.RemoteSettings.lastRemoteSettingsServiceSyncTimestamp
@@ -22,16 +22,27 @@ final class RemoteSettingsServiceSyncCoordinator {
         self.prefs = prefs
         self.logger = logger
 
-        NotificationCenter.default.addObserver(
-            forName: UIApplication.didBecomeActiveNotification,
-            object: nil,
-            queue: nil
-        ) { [weak self] _ in self?.didBecomeActive() }
-        NotificationCenter.default.addObserver(
-            forName: UIApplication.willResignActiveNotification,
-            object: nil,
-            queue: nil
-        ) { [weak self] _ in self?.willResignActive() }
+        startObservingNotifications(
+            withNotificationCenter: NotificationCenter.default,
+            forObserver: self,
+            observing: [
+                UIApplication.didBecomeActiveNotification,
+                UIApplication.willResignActiveNotification
+            ]
+        )
+    }
+
+    // MARK: - Notifiable
+
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case UIApplication.didBecomeActiveNotification:
+            didBecomeActive()
+        case UIApplication.willResignActiveNotification:
+            willResignActive()
+        default:
+            break
+        }
     }
 
     // This is primarily for internal testing or QA purposes.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
- Fixes some strict concurrency warnings in `RemoteSettingsServiceSyncCoordinator` by making it use `Notifiable` for notification center observation (increased safety)

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code