### PR TITLE
Add FXIOS-13650 [Trending Searches] telemetry

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1354,6 +1354,7 @@
 		AA24AD302E7C37C6008659A3 /* TrendingSearchClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD2F2E7C37BF008659A3 /* TrendingSearchClient.swift */; };
 		AA24AD322E7C3A8F008659A3 /* TrendingSearchClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD312E7C3A85008659A3 /* TrendingSearchClientTests.swift */; };
 		AA24AD342E7C3AD2008659A3 /* MockTrendingSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD332E7C3ACC008659A3 /* MockTrendingSearchEngine.swift */; };
+		AA3CEBAD2ECB853400DDEFEF /* SearchTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CEBAC2ECB853400DDEFEF /* SearchTelemetryTests.swift */; };
 		AA4D99432E857AF300BB039D /* MockRecentSearchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4D99422E857AEE00BB039D /* MockRecentSearchProvider.swift */; };
 		AA5E81472EB12BDC00919E60 /* TranslationsMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5E81462EB12BD800919E60 /* TranslationsMiddleware.swift */; };
 		AA742C7A2E90358400CF55B3 /* MockMicrosurveyTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA742C792E90357E00CF55B3 /* MockMicrosurveyTelemetry.swift */; };
@@ -9556,6 +9557,7 @@
 		AA24AD2F2E7C37BF008659A3 /* TrendingSearchClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingSearchClient.swift; sourceTree = "<group>"; };
 		AA24AD312E7C3A85008659A3 /* TrendingSearchClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingSearchClientTests.swift; sourceTree = "<group>"; };
 		AA24AD332E7C3ACC008659A3 /* MockTrendingSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTrendingSearchEngine.swift; sourceTree = "<group>"; };
+		AA3CEBAC2ECB853400DDEFEF /* SearchTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTelemetryTests.swift; sourceTree = "<group>"; };
 		AA4D99422E857AEE00BB039D /* MockRecentSearchProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRecentSearchProvider.swift; sourceTree = "<group>"; };
 		AA5E81462EB12BD800919E60 /* TranslationsMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsMiddleware.swift; sourceTree = "<group>"; };
 		AA742C792E90357E00CF55B3 /* MockMicrosurveyTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMicrosurveyTelemetry.swift; sourceTree = "<group>"; };
@@ -13243,6 +13245,7 @@
 		8A5189C62C1B5F6C00CDB668 /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				AA3CEBAC2ECB853400DDEFEF /* SearchTelemetryTests.swift */,
 				AA4D99422E857AEE00BB039D /* MockRecentSearchProvider.swift */,
 				AAB4321C2E8189310075E47F /* DefaultRecentSearchProviderTests.swift */,
 				AAB434052E82F05C0075E47F /* MockTrendingSearchProvider.swift */,
@@ -19463,6 +19466,7 @@
 				81DAB2F92C8901AC00F4BE98 /* MainMenuStateTests.swift in Sources */,
 				8ACA8F74291987AE00D3075D /* AccountSyncHandlerTests.swift in Sources */,
 				8AAEBA0B2BF53AF6000C02B5 /* MicrosurveyStateTests.swift in Sources */,
+				AA3CEBAD2ECB853400DDEFEF /* SearchTelemetryTests.swift in Sources */,
 				8A03FFA32DB12AFF00509A72 /* MockSponsoredTelemetry.swift in Sources */,
 				8A25556D2CF0E0E6009C0989 /* InactiveTabsTelemetryTests.swift in Sources */,
 				8A09A9E32D77552C0069B005 /* HomepageMiddlewareTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -455,6 +455,7 @@ class SearchViewController: SiteTableViewController,
                   let url = defaultEngine.searchURLForQuery(recentSearch)
             else { return }
             searchDelegate?.searchViewController(self, didSelectURL: url, searchTerm: recentSearch)
+            searchTelemetry?.recentSearchesTapped(at: indexPath.row)
 
         case .trendingSearches:
             guard let defaultEngine = viewModel.searchEnginesManager?.defaultEngine else { return }
@@ -463,6 +464,7 @@ class SearchViewController: SiteTableViewController,
                   let url = defaultEngine.searchURLForQuery(trendingSearch)
             else { return }
             searchDelegate?.searchViewController(self, didSelectURL: url, searchTerm: trendingSearch)
+            searchTelemetry?.trendingSearchesTapped(at: indexPath.row)
 
         case .searchSuggestions:
             guard let defaultEngine = viewModel.searchEnginesManager?.defaultEngine else { return }

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -778,11 +778,21 @@ extension SearchSettingsTableViewController {
     @objc
     func didToggleShowTrendingSearches(_ toggle: ThemedSwitch) {
         model.shouldShowTrendingSearches = toggle.isOn
+        SettingsTelemetry().changedSetting(
+            "TrendingSearches",
+            to: "\(toggle.isOn)",
+            from: "\(!toggle.isOn)"
+        )
     }
 
     @objc
     func didToggleShowRecentSearches(_ toggle: ThemedSwitch) {
         model.shouldShowRecentSearches = toggle.isOn
+        SettingsTelemetry().changedSetting(
+            "RecentSearches",
+            to: "\(toggle.isOn)",
+            from: "\(!toggle.isOn)"
+        )
     }
 
     @objc

--- a/firefox-ios/Client/Glean/gleanProbes.xcfilelist
+++ b/firefox-ios/Client/Glean/gleanProbes.xcfilelist
@@ -15,6 +15,7 @@ $(PROJECT_DIR)/Client/Glean/probes/library.history_panel.yaml
 $(PROJECT_DIR)/Client/Glean/probes/library.reading_list_panel.yaml
 $(PROJECT_DIR)/Client/Glean/probes/metrics.yaml
 $(PROJECT_DIR)/Client/Glean/probes/microsurvey.yaml
+$(PROJECT_DIR)/Client/Glean/probes/search.yaml
 $(PROJECT_DIR)/Client/Glean/probes/settings.yaml
 $(PROJECT_DIR)/Client/Glean/probes/share_sheet.yaml
 $(PROJECT_DIR)/Client/Glean/probes/tabs_panel.yaml

--- a/firefox-ios/Client/Glean/glean_index.yaml
+++ b/firefox-ios/Client/Glean/glean_index.yaml
@@ -22,6 +22,7 @@ metrics_files:
   - firefox-ios/Client/Glean/probes/library.reading_list_panel.yaml
   - firefox-ios/Client/Glean/probes/metrics.yaml
   - firefox-ios/Client/Glean/probes/microsurvey.yaml
+  - firefox-ios/Client/Glean/probes/search.yaml
   - firefox-ios/Client/Glean/probes/settings.yaml
   - firefox-ios/Client/Glean/probes/share_sheet.yaml
   - firefox-ios/Client/Glean/probes/tabs_panel.yaml

--- a/firefox-ios/Client/Glean/probes/search.yaml
+++ b/firefox-ios/Client/Glean/probes/search.yaml
@@ -1,0 +1,113 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the metrics that are recorded by the Glean SDK. They are
+# automatically converted to Swift code at build time using the `glean_parser`
+# PyPI package.
+
+# This file is organized (roughly) alphabetically by metric names
+# for easy navigation
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+$tags:
+  - Search
+
+###############################################################################
+# Search
+###############################################################################
+
+# Add your new metrics and/or events here.
+# Trending Searches
+search.trending_searches:
+  suggestions_shown:
+    type: event
+    description: |
+      Triggered when the trending search suggestions section is shown to the user.
+    extra_keys:
+      count:
+        type: quantity
+        description: |
+          The number of trending search suggestions displayed.
+    data_sensitivity:
+      - interaction
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/29616
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/30661
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-06-01"
+    metadata:
+      tags:
+        - TrendingSearches
+
+  suggestion_tapped:
+    type: event
+    description: |
+      Triggered when the user taps a trending search suggestion.
+    extra_keys:
+      position:
+        type: quantity
+        description: |
+          The position of the clicked trending search suggestion. The first suggestion has index of 1.
+    data_sensitivity:
+      - interaction
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/29616
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/30661
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-06-01"
+    metadata:
+      tags:
+        - TrendingSearches
+
+# Recent Searches
+search.recent_searches:
+  suggestions_shown:
+    type: event
+    description: |
+      Triggered when the recent search suggestions section is shown to the user.
+    extra_keys:
+      count:
+        type: quantity
+        description: |
+          The number of recent search suggestions displayed.
+    data_sensitivity:
+      - interaction
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/29616
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/30661
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-06-01"
+    metadata:
+      tags:
+        - RecentSearches
+
+  suggestion_tapped:
+    type: event
+    description: |
+      Triggered when the user taps a recent search suggestion.
+    extra_keys:
+      position:
+        type: quantity
+        description: |
+          The position of the clicked recent search suggestion. The first suggestion has index of 1.
+    data_sensitivity:
+      - interaction
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/29616
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/30661
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-06-01"
+    metadata:
+      tags:
+        - RecentSearches

--- a/firefox-ios/Client/Glean/tags.yaml
+++ b/firefox-ios/Client/Glean/tags.yaml
@@ -72,6 +72,12 @@ ReaderMode:
 ReadingListPanel:
   description: Corresponds to the library screen's reading list panel where the user can view their reading list.
 
+RecentSearches:
+  description: Corresponds to the recent searches feature.
+
+Search:
+  description: Corresponds to all things related to search.
+
 ShortcutsLibrary:
   description: Corresponds to the shortcuts library screen where the user can interact with an expanded list of shortcuts.
 
@@ -106,6 +112,9 @@ TopSites:
 
 TrackingProtection:
   description: Corresponds to the enhanced tracking protection bottom sheet which can be displayed over a webpage.
+  
+TrendingSearches:
+  description: Corresponds to the trending searches feature.
 
 User:
   description: Corresponds to user properties and settings.

--- a/firefox-ios/Client/Telemetry/SearchTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SearchTelemetry.swift
@@ -146,6 +146,7 @@ class SearchTelemetry: @unchecked Sendable {
     var shouldSetGoogleTopSiteSearch = false
     var shouldSetUrlTypeSearch = false
     private var tabManager: TabManager
+    private let gleanWrapper: GleanWrapper
 
     var interactionType: SearchTelemetryValues.Interaction = .typed
     var selectedResult: SearchTelemetryValues.SelectedResult = .unknown
@@ -162,8 +163,9 @@ class SearchTelemetry: @unchecked Sendable {
     var searchQuery = ""
     var savedQuery = ""
 
-    init(tabManager: TabManager) {
+    init(tabManager: TabManager, gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.tabManager = tabManager
+        self.gleanWrapper = gleanWrapper
     }
 
     // MARK: Searchbar SAP
@@ -506,6 +508,28 @@ class SearchTelemetry: @unchecked Sendable {
         }
 
         return groupTypes.joined(separator: ",")
+    }
+
+    // MARK: Trending Searches
+    func trendingSearchesShown(surveyId: String) {
+        // TODO: FXIOS-14082: Fix bug in loading too many times and add telemetry
+    }
+
+    func trendingSearchesTapped(at index: Int) {
+        let position = "\(index + 1)"
+        let positionExtra = GleanMetrics.SearchTrendingSearches.SuggestionTappedExtra(position: Int32(position))
+        gleanWrapper.recordEvent(for: GleanMetrics.SearchTrendingSearches.suggestionTapped, extras: positionExtra)
+    }
+
+    // MARK: Recent Searches
+    func recentSearchesShown(surveyId: String) {
+        // TODO: FXIOS-14082: Fix bug in loading too many times and add telemetry
+    }
+
+    func recentSearchesTapped(at index: Int) {
+        let position = "\(index + 1)"
+        let positionExtra = GleanMetrics.SearchRecentSearches.SuggestionTappedExtra(position: Int32(position))
+        gleanWrapper.recordEvent(for: GleanMetrics.SearchRecentSearches.suggestionTapped, extras: positionExtra)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/SearchTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/SearchTelemetryTests.swift
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+import XCTest
+@testable import Client
+
+final class SearchTelemetryTests: XCTestCase {
+    var mockGleanWrapper: MockGleanWrapper!
+
+    override func setUp() {
+        super.setUp()
+        mockGleanWrapper = MockGleanWrapper()
+    }
+
+    override func tearDown() {
+        mockGleanWrapper = nil
+        super.tearDown()
+    }
+
+    func test_recordEvent_whenTrendingSearchTapped_thenProperEventCalled() throws {
+        let subject = createSubject()
+        let event = GleanMetrics.SearchTrendingSearches.suggestionTapped
+        typealias EventExtrasType = GleanMetrics.SearchTrendingSearches.SuggestionTappedExtra
+
+        subject.trendingSearchesTapped(at: 0)
+
+        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.position, 1)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+
+    func test_recordEvent_whenRecentSearchTapped_thenProperEventCalled() throws {
+        let subject = createSubject()
+        let event = GleanMetrics.SearchRecentSearches.suggestionTapped
+        typealias EventExtrasType = GleanMetrics.SearchRecentSearches.SuggestionTappedExtra
+
+        subject.recentSearchesTapped(at: 0)
+
+        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.position, 1)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+
+    private func createSubject() -> SearchTelemetry {
+        return SearchTelemetry(tabManager: MockTabManager(), gleanWrapper: mockGleanWrapper)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13650)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29616)

## :bulb: Description
Add initial telemetry based on spec requirements here: https://docs.google.com/spreadsheets/d/1PmekM3oubQUkd8PPhijJXIQ783WM7RzBMKfINHs310s/edit?gid=0#gid=0

Note: A separate ticket would be use to integrate telemetry for displaying trending / recent searches as well as clearing recent searches.


**Settings**
<img width="2209" height="292" alt="image" src="https://github.com/user-attachments/assets/b6b5d151-15fb-42ff-82a9-d57869123d1c" />

**Suggestions Tapped**
<img width="2710" height="185" alt="image" src="https://github.com/user-attachments/assets/59ae6b42-bef2-44ff-aaf2-bfdd8487b318" /> 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

