### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix or suppress Sendable warnings in `BreachAlertsManager`

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/BreachAlertsManager.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/BreachAlertsManager.swift
@@ -24,7 +24,8 @@ struct BreachRecord: Codable, Equatable, Hashable {
 }
 
 /// A manager for the user's breached login information, if any.
-final class BreachAlertsManager {
+/// FIXME: FXIOS-14141 class is not Sendable / thread safe
+final class BreachAlertsManager: @unchecked Sendable {
     static let monitorAboutUrl = URL(string: "https://monitor.firefox.com/about")
     var breaches = Set<BreachRecord>()
     var client: BreachAlertsClientProtocol
@@ -43,7 +44,7 @@ final class BreachAlertsManager {
     /// Loads breaches from Monitor endpoint using BreachAlertsClient.
     ///    - Parameters:
     ///         - completion: a completion handler for the processed breaches
-    func loadBreaches(completion: @escaping (Maybe<Set<BreachRecord>>) -> Void) {
+    func loadBreaches(completion: @escaping @Sendable (Maybe<Set<BreachRecord>>) -> Void) {
         guard let cacheURL = self.cacheURL else {
             self.fetchAndSaveBreaches(completion)
             return
@@ -174,7 +175,7 @@ final class BreachAlertsManager {
         return result
     }
 
-    private func fetchAndSaveBreaches(_ completion: @escaping (Maybe<Set<BreachRecord>>) -> Void) {
+    private func fetchAndSaveBreaches(_ completion: @escaping @Sendable (Maybe<Set<BreachRecord>>) -> Void) {
         guard let cacheURL = self.cacheURL else { return }
         self.client.fetchData(endpoint: .breachedAccounts, profile: self.profile) { maybeData in
             guard let fetchedData = maybeData.successValue else { return }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
- Fix or suppress Sendable warnings in BreachAlertsManager.

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code