### PR TITLE
Refactor FXIOS-14139 [Swift 6 migration] Wallpaper warning fix with UIDeviceDetails

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/v1/Models/Wallpaper.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/v1/Models/Wallpaper.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Shared
 
 enum WallpaperType: String {
     case none
@@ -90,7 +91,7 @@ struct Wallpaper: Equatable {
     /// identify that no image is selected.
     private static let noAssetID = "fxDefault"
     private var deviceVersionID: String {
-        return UIDevice.current.userInterfaceIdiom == .pad ? fileId.iPad : fileId.iPhone
+        return UIDeviceDetails.userInterfaceIdiom == .pad ? fileId.iPad : fileId.iPhone
     }
 
     // MARK: - Helper functions


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14139)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30656)

## :bulb: Description
Remaining wallpaper fix with UIDeviceDetails

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

