### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Hosting cell and section header deinit workarounds

### DIFF
--- a/firefox-ios/Client/Frontend/HostingTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/HostingTableViewCell.swift
@@ -19,8 +19,17 @@ final class HostingTableViewCell<Content: View>: UITableViewCell, ReusableCell {
     }
 
     deinit {
-        // remove parent
-        removeHostingControllerFromParent()
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("AddressBarPanGestureHandler was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            // FIXME: FXIOS-14153 This doesn't seem like it should be necessary, investigate later
+            // remove parent
+            removeHostingControllerFromParent()
+        }
     }
 
     @available(*, unavailable)

--- a/firefox-ios/Client/Frontend/HostingTableViewSectionHeader.swift
+++ b/firefox-ios/Client/Frontend/HostingTableViewSectionHeader.swift
@@ -20,8 +20,17 @@ final class HostingTableViewSectionHeader<Content: View>: UITableViewHeaderFoote
     }
 
     deinit {
-        // remove parent
-        removeHostingControllerFromParent()
+        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
+        guard Thread.isMainThread else {
+            assertionFailure("AddressBarPanGestureHandler was not deallocated on the main thread. Observer was not removed")
+            return
+        }
+
+        MainActor.assumeIsolated {
+            // FIXME: FXIOS-14153 This doesn't seem like it should be necessary, investigate later
+            // remove parent
+            removeHostingControllerFromParent()
+        }
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description

- Fix warnings for using `isolated` method in `nonisolated` `deinit`

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code