### PR TITLE
Refactor FXIOS-13747 [Glean unit tests] Migrate WebViewLoadMeasurementTelemetry to use the GleanWrapper instead

### DIFF
--- a/firefox-ios/Client/Telemetry/WebviewTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/WebviewTelemetry.swift
@@ -8,21 +8,26 @@ import Glean
 /// Measure with a time distribution https://mozilla.github.io/glean/book/reference/metrics/timing_distribution.html
 /// how long it takes to load a webpage
 final class WebViewLoadMeasurementTelemetry {
+    private let gleanWrapper: GleanWrapper
     private var loadTimerId: GleanTimerId?
 
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
     func start() {
-        loadTimerId = GleanMetrics.Webview.pageLoad.start()
+        loadTimerId = gleanWrapper.startTiming(for: GleanMetrics.Webview.pageLoad)
     }
 
     func stop() {
         guard let timerId = loadTimerId else { return }
-        GleanMetrics.Webview.pageLoad.stopAndAccumulate(timerId)
+        gleanWrapper.stopAndAccumulateTiming(for: GleanMetrics.Webview.pageLoad, timerId: timerId)
         loadTimerId = nil
     }
 
     func cancel() {
         if let loadTimerId {
-            GleanMetrics.Webview.pageLoad.cancel(loadTimerId)
+            gleanWrapper.cancelTiming(for: GleanMetrics.Webview.pageLoad, timerId: loadTimerId)
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewTelemetryTests.swift
@@ -7,26 +7,52 @@
 import Glean
 import XCTest
 
-// TODO: FXIOS-13747 - Migrate WebviewTelemetryTests to use mock telemetry or GleanWrapper
 class WebviewTelemetryTests: XCTestCase {
+    var mockGleanWrapper: MockGleanWrapper!
+
+    override func setUp() {
+        super.setUp()
+        mockGleanWrapper = MockGleanWrapper()
+    }
+
+    override func tearDown() {
+        mockGleanWrapper = nil
+        super.tearDown()
+    }
+
     func testLoadMeasurement() throws {
-        let subject = WebViewLoadMeasurementTelemetry()
+        let subject = createSubject()
+        let metric = GleanMetrics.Webview.pageLoad
 
         subject.start()
         subject.stop()
 
-        let resultValue = try XCTUnwrap(GleanMetrics.Webview.pageLoad.testGetValue())
-        XCTAssertEqual(1, resultValue.count, "Should have been measured once")
-        XCTAssertEqual(0, GleanMetrics.Webview.pageLoad.testGetNumRecordedErrors(.invalidValue))
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents.first as? TimingDistributionMetricType
+        )
+        XCTAssertEqual(mockGleanWrapper.startTimingCalled, 1)
+        XCTAssertEqual(mockGleanWrapper.stopAndAccumulateCalled, 1)
+        XCTAssertEqual(mockGleanWrapper.cancelTimingCalled, 0)
+        XCTAssert(savedMetric === metric, "Received \(savedMetric) instead of \(metric)")
     }
 
-    func testCancelLoadMeasurement() {
-        let subject = WebViewLoadMeasurementTelemetry()
+    func testCancelLoadMeasurement() throws {
+        let subject = createSubject()
+        let metric = GleanMetrics.Webview.pageLoad
 
         subject.start()
         subject.cancel()
 
-        XCTAssertNil(GleanMetrics.Webview.pageLoad.testGetValue(), "Should not have been measured")
-        XCTAssertEqual(0, GleanMetrics.Webview.pageLoad.testGetNumRecordedErrors(.invalidValue))
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents.first as? TimingDistributionMetricType
+        )
+        XCTAssertEqual(mockGleanWrapper.startTimingCalled, 1)
+        XCTAssertEqual(mockGleanWrapper.cancelTimingCalled, 1)
+        XCTAssertEqual(mockGleanWrapper.stopAndAccumulateCalled, 0)
+        XCTAssert(savedMetric === metric, "Received \(savedMetric) instead of \(metric)")
+    }
+
+    private func createSubject() -> WebViewLoadMeasurementTelemetry {
+        return WebViewLoadMeasurementTelemetry(gleanWrapper: mockGleanWrapper)
     }
 }


### PR DESCRIPTION
## Tickets
- [JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13747) 
- Github issue: #29804

## Description
Migrates `WebViewLoadMeasurementTelemetry` to use `GleanWrapper` instead of direct `GleanMetrics` calls. This change:
- Replaces direct `GleanMetrics.Webview.pageLoad.start()`, `stopAndAccumulate()`, and `cancel()` calls with `GleanWrapper.startTiming()`, `stopAndAccumulateTiming()`, and `cancelTiming()` methods
- Updates `WebviewTelemetryTests` to use `MockGleanWrapper` for assertions

## Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example @Mergifyio backport release/v120)

Fixes #29804