### PR TITLE
Add FXIOS-14171 [Translations] add reloading webview

### DIFF
--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -175,17 +175,11 @@ final class TranslationsMiddleware {
 
     // Reloads web view if user taps on translation button to view original page after translating
     private func reloadPage(for action: Action) {
-        guard let selectedTab = self.windowManager.tabManager(for: action.windowUUID).selectedTab,
-              let webView = selectedTab.webView
-        else {
-            logger.log(
-                "Unable to reload page after translating.",
-                level: .warning,
-                category: .translations
-            )
-            return
-        }
-        webView.reload()
+        let reloadAction = GeneralBrowserAction(
+            windowUUID: action.windowUUID,
+            actionType: GeneralBrowserActionType.reloadWebsite
+        )
+        store.dispatch(reloadAction)
     }
 
     // When we receive an error translating the page, we want to update the translation


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14171)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30715)

## :bulb: Description
When user taps on the active translation button, then we want to revert to the original source. Therefore, we simply reload the webpage. 

More tests will be added once we have the full integration.

## :movie_camera: Demos
https://github.com/user-attachments/assets/1d0de216-a53c-4e1b-8706-ef9f2f62c92c

Note: I had to hack this demo, if you want to test, then you'll need to show the toolbar button at all times.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

