### PR TITLE
Bugfix FXIOS-0000 [RELAY] Fix MT thread hang

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/RelayController.swift
+++ b/firefox-ios/Client/Frontend/Browser/RelayController.swift
@@ -198,6 +198,7 @@ final class RelayController: RelayControllerProtocol, Notifiable {
     func handleNotifications(_ notification: Notification) {
         logger.log("[RELAY] Received notification '\(notification.name.rawValue)'.", level: .info, category: .autofill)
         Task { @MainActor in
+            guard Self.isFeatureEnabled else { return }
             if hasRelayAccount() {
                 createRelayClient()
             }


### PR DESCRIPTION
## :scroll: Tickets
n/a

## :bulb: Description

Ensures the background client setup for Relay isn't called while the feature is off. This is causing a MT hang due to this issue: https://mozilla.slack.com/archives/C09A0SMGUVA/p1763485535038999.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

