### PR TITLE
Bugfix FXIOS-14179 [Unit Tests] detection tests failing in older version

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
@@ -80,7 +80,7 @@ final class LanguageDetectorTests: XCTestCase {
 
     func test_detectLanguage_prefersDominantLanguage() async throws {
         let subject = createSubject()
-        mockLanguageSampleSource.mockResult = "Hello, bonjour, hello, hello"
+        mockLanguageSampleSource.mockResult = "Hello! This is an English sentence. A common word in French is Bonjour."
         let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
         XCTAssertEqual(result, "en")
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14179)

## :bulb: Description
This test was passing in iOS 26, but not in previous versions as per this report: https://storage.googleapis.com/mobile-reports/public/firefox-ios-M4/firefox-ios-unit-tests/result_10/build/reports/index.html

We are using Apple's NLLanguageRecognizer to detect and it seems in older version, the model changed and the text passed in could not determine that the language shouldn't be french. Therefore, modified the text so that English is the dominant one. This is now passing iOS 18.6. Will review the report to confirm if passing for other tests.

cc: @ih-codes @dataports since we discussed this in the meeting
cc: @issammani 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

