### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] TabPrintPageRenderer strict concurrency warning

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabPrintPageRenderer.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabPrintPageRenderer.swift
@@ -5,24 +5,22 @@
 import Foundation
 import Common
 
-class TabPrintPageRenderer: UIPrintPageRenderer {
+final class TabPrintPageRenderer: UIPrintPageRenderer {
     private struct UX {
         static let insets = CGFloat(36.0)
         static let textFont = FXFontStyles.Regular.caption1.scaledFont()
         static let marginScale = CGFloat(0.5)
     }
 
-    fileprivate var tabDisplayTitle: String
-    fileprivate var tabURL: URL?
-    fileprivate weak var webView: TabWebView?
+    private let tabDisplayTitle: String
+    private let tabURL: URL?
 
     let textAttributes = [NSAttributedString.Key.font: UX.textFont]
     let dateString: String
 
-    required init(tabDisplayTitle: String, tabURL: URL?, webView: TabWebView?) {
+    required init(tabDisplayTitle: String, tabURL: URL?, viewPrintFormatter: UIViewPrintFormatter?) {
         self.tabDisplayTitle = tabDisplayTitle
         self.tabURL = tabURL
-        self.webView = webView
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .short
         dateFormatter.timeStyle = .short
@@ -33,7 +31,7 @@ class TabPrintPageRenderer: UIPrintPageRenderer {
         self.footerHeight = UX.marginScale * UX.insets
         self.headerHeight = UX.marginScale * UX.insets
 
-        if let formatter = webView?.viewPrintFormatter() {
+        if let formatter = viewPrintFormatter {
             formatter.perPageContentInsets = UIEdgeInsets(equalInset: UX.insets)
             addPrintFormatter(formatter, startingAtPageAt: 0)
         }

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -81,11 +81,12 @@ class ShareManager: NSObject {
 
             // Only show the print activity if the tab's webview is loaded
             if tab.webView != nil {
+                let viewPrintFormatter = tab.webView?.viewPrintFormatter()
                 activityItems.append(
                     TabPrintPageRenderer(
                         tabDisplayTitle: tab.displayTitle,
                         tabURL: tab.url,
-                        webView: tab.webView
+                        viewPrintFormatter: viewPrintFormatter
                     )
                 )
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description
Tried to make `TabPrintPageRenderer` Sendable but:
- Couldn't since it's inheriting from `UIPrintPageRenderer`
- This made me then figure out that we can just pass the `viewPrintFormatter` instead of the whole `webView`, which avoids us to make the `TabPrintPageRenderer` `@MainActor`.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

