### PR TITLE
Refactor FXIOS-13907 [Deferred] Delete unused operator and simplify BrowserDB flow

### DIFF
--- a/BrowserKit/Sources/Shared/DeferredUtils.swift
+++ b/BrowserKit/Sources/Shared/DeferredUtils.swift
@@ -2,38 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-// Monadic bind/flatMap operator for Deferred.
-
 import Foundation
-
-precedencegroup MonadicBindPrecedence {
-    associativity: left
-    higherThan: MonadicDoPrecedence
-    lowerThan: BitwiseShiftPrecedence
-}
 
 precedencegroup MonadicDoPrecedence {
     associativity: left
     higherThan: MultiplicationPrecedence
 }
 
-infix operator >>== : MonadicBindPrecedence
 infix operator >>> : MonadicDoPrecedence
-
-@discardableResult
-public func >>== <T, U>(x: Deferred<Maybe<T>>, f: @escaping @Sendable (T) -> Deferred<Maybe<U>>) -> Deferred<Maybe<U>> {
-    return chainDeferred(x, f: f)
-}
-
-// A termination case.
-public func >>== <T>(x: Deferred<Maybe<T>>, f: @escaping @Sendable (T) -> Void) {
-    return x.upon { result in
-        if let v = result.successValue {
-            f(v)
-        }
-    }
-}
-
 // Monadic `do` for Deferred.
 @discardableResult
 public func >>> <T, U>(x: Deferred<Maybe<T>>, f: @escaping @Sendable () -> Deferred<Maybe<U>>) -> Deferred<Maybe<U>> {

--- a/firefox-ios/Storage/SQL/BrowserDB.swift
+++ b/firefox-ios/Storage/SQL/BrowserDB.swift
@@ -107,8 +107,9 @@ public final class BrowserDB: Sendable {
     }
 
     func queryReturnsResults(_ sql: String, args: Args? = nil) -> Deferred<Maybe<Bool>> {
-        return runQuery(sql, args: args, factory: { _ in true })
-         >>== { deferMaybe($0[0] ?? false) }
+        return chainDeferred(runQuery(sql, args: args, factory: { _ in true })) { cursor in
+            return deferMaybe(cursor[0] ?? false)
+        }
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets  
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13907)  
[GitHub issue](https://github.com/mozilla-mobile/firefox-ios/issues/30135)

## :bulb: Description  
Removed the unused `>>==` operator definitions from `DeferredUtils`, keeping only the `>>>` helpers and the shared `chainDeferred` utility for monadic-style control flow.  

Updated `BrowserDB.queryReturnsResults` to invoke `chainDeferred` directly so that it still returns the same `Deferred<Maybe<Bool>>` result without relying on the deleted operator.


## :pencil: Checklist  
- [x] I filled in the ticket numbers and a description of my work  
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)  
- [ ] I ensured unit tests pass and wrote tests for new code  
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)  
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review  
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n  
- [ ] If needed, I updated documentation and added comments to complex code  