### PR TITLE
Add FXIOS-14206 #30791 [Addition] Cleanup ActionExtension of unused dependencies 

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2349,20 +2349,6 @@
 			remoteGlobalIDString = F84B21BD1A090F8100AAB793;
 			remoteInfo = Client;
 		};
-		8C6FADF72EC1F3620022FB5C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 43BE5774278BA4D900491291;
-			remoteInfo = RustMozillaAppServices;
-		};
-		8CB511232EC1F183004A2320 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2FCAE2191ABB51F800877008;
-			remoteInfo = Storage;
-		};
 		8CF609302EA8D46F00F069B6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
@@ -2499,16 +2485,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		8AFD6277282C51D300451BC8 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8CA9C3FE2EC1F1F80050D1B0 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
@@ -19979,16 +19955,6 @@
 			target = F84B21BD1A090F8100AAB793 /* Client */;
 			targetProxy = 7BEB64421C7345600092C02E /* PBXContainerItemProxy */;
 		};
-		8C6FADF82EC1F3620022FB5C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 43BE5774278BA4D900491291 /* RustMozillaAppServices */;
-			targetProxy = 8C6FADF72EC1F3620022FB5C /* PBXContainerItemProxy */;
-		};
-		8CB511242EC1F183004A2320 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 2FCAE2191ABB51F800877008 /* Storage */;
-			targetProxy = 8CB511232EC1F183004A2320 /* PBXContainerItemProxy */;
-		};
 		8CF609312EA8D46F00F069B6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 8CF609242EA8D46E00F069B6 /* ActionExtension */;
@@ -31529,10 +31495,6 @@
 		8C51ED732DE0A64D00B3E58A /* OnboardingKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = OnboardingKit;
-		};
-		8CB511202EC1F17D004A2320 /* Shared */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Shared;
 		};
 		AB2AC6622BCFD0A200022AAB /* X509 */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/firefox-ios/Client/Application/DefaultBrowserUtil.swift
+++ b/firefox-ios/Client/Application/DefaultBrowserUtil.swift
@@ -60,7 +60,7 @@ struct DefaultBrowserUtil {
 
             if isDefault {
                 // If the user is set to default don't ask on the home page later
-                // This is temporary until we can refactor set to default flows now that we have the ability to check 
+                // This is temporary until we can refactor set to default flows now that we have the ability to check
                 userDefault.set(true, forKey: PrefsKeys.DidDismissDefaultBrowserMessage)
             }
         }

--- a/firefox-ios/Client/Application/DefaultBrowserUtil.swift
+++ b/firefox-ios/Client/Application/DefaultBrowserUtil.swift
@@ -60,7 +60,7 @@ struct DefaultBrowserUtil {
 
             if isDefault {
                 // If the user is set to default don't ask on the home page later
-                // This is temporary until we can refactor set to default flows now that we have the ability to check
+                // This is temporary until we can refactor set to default flows now that we have the ability to check 
                 userDefault.set(true, forKey: PrefsKeys.DidDismissDefaultBrowserMessage)
             }
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30791)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Remove additional orphaned references that were supposed to be included in https://github.com/mozilla-mobile/firefox-ios/pull/30803.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


