### PR TITLE
Add FXIOS-14220 [perftest] Emit perfherder JSON artifact

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1283,6 +1283,8 @@ workflows:
             sed 's/.*=//;s/'\''/"/g' data.txt > test.json
             cat test.json
             python3 perfTestTransform.py
+            mkdir -p "$BITRISE_DEPLOY_DIR"
+            mv perfherder-data.json $BITRISE_DEPLOY_DIR
     - deploy-to-bitrise-io@2.10.0: {}
     before_run:
     - 1_git_clone_and_post_clone
@@ -1613,6 +1615,9 @@ workflows:
             sed 's/.*=//;s/'\''/"/g' data.txt > test.json
             cat test.json
             python3 perfTestTransform.py
+            mkdir -p "$BITRISE_DEPLOY_DIR"
+            mv perfherder-data.json $BITRISE_DEPLOY_DIR
+    - deploy-to-bitrise-io@2.10.0: {}
     meta:
       bitrise.io:
         stack: osx-xcode-16.2.x

--- a/test-fixtures/perfTestTransform.py
+++ b/test-fixtures/perfTestTransform.py
@@ -21,3 +21,6 @@ with open('test.json') as json_file:
         PERFHERDER_DATA["suites"].append(suite)
 
 print("PERFHERDER_DATA:", json.dumps(PERFHERDER_DATA))
+
+with open("perfherder-data.json", "w") as f:
+    f.write(json.dumps(PERFHERDER_DATA))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14220)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30809)

## :bulb: Description
Firefox-ios performance tests currently only output `PERFHERDER_DATA` to the log.
This PR adds support for generating a perfherder-data JSON artifact (perfherder-data.json) to enable correct ingestion in Treeherder and downstream tooling.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

