### PR TITLE
Refactor FXIOS-14219 [Swift 6 Migration] Summarizer service strict concurrency warnings

### DIFF
--- a/BrowserKit/Tests/SummarizeKitTests/SummarizeServiceFactoryTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/SummarizeServiceFactoryTests.swift
@@ -23,7 +23,6 @@ final class MockSummarizerServiceLifecycle: SummarizerServiceLifecycle, @uncheck
     }
 }
 
-@MainActor
 final class SummarizeServiceFactoryTests: XCTestCase {
     var serviceLifecycle: MockSummarizerServiceLifecycle!
 

--- a/BrowserKit/Tests/SummarizeKitTests/SummarizerServiceTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/SummarizerServiceTests.swift
@@ -5,7 +5,6 @@
 @testable import SummarizeKit
 import XCTest
 
-@MainActor
 final class SummarizerServiceTests: XCTestCase {
     static let mockResponse = ["Summarized", "content"]
     static let maxWords = 100
@@ -33,6 +32,7 @@ final class SummarizerServiceTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testSummarizerServiceReturnsStreamedSummary() async throws {
         let subject = createSubject()
         var streamedChunks: [String] = []
@@ -44,6 +44,7 @@ final class SummarizerServiceTests: XCTestCase {
         XCTAssertEqual(streamedChunks, ["Summarized", "content"] )
     }
 
+    @MainActor
     func testSummarizerServiceThrowsWhenSummarizerFails() async {
         let summarizer = MockSummarizer(
             shouldRespond: [],


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14219)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30808)

## :bulb: Description
Does it make sense to have the `SummarizerService` isolated to the `@MainActor` since the `SummarizationCheckerProtocol` work is also isolated to the main actor since we access webview javascript code?

Fixes warnings:
<img width="1868" height="811" alt="Screenshot 2025-11-20 at 1 09 44 PM" src="https://github.com/user-attachments/assets/d71b5396-ec88-4f3e-bca0-7ab248cbeec0" />

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

