### PR TITLE
Bugfix FXIOS-14224 [Translations] fix sizing of loading spinner

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -132,6 +132,7 @@ class ToolbarButton: UIButton,
                 view.removeFromSuperview()
             }
         }
+        layoutIfNeeded()
     }
 
     public required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14224)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30816)

## :bulb: Description

This change was removed due this commit here: https://github.com/mozilla-mobile/firefox-ios/commit/7489a1fcdbb42423fdcfeda1a972d9b5f32c3cb1#r170987193

However, it breaks the sizing of the loading icon as well as overlaps the translation inactive with the active icon.

**Before**

https://github.com/user-attachments/assets/eb78c1de-0a60-4869-ad3c-1c57ba3b99ab

**After**


https://github.com/user-attachments/assets/a0f5b88d-a20a-4b36-abc1-268da68e7e46



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

