### PR TITLE
Bugfix FXIOS-14227 [Translations] Fix unused return value warning 

### DIFF
--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
@@ -71,10 +71,9 @@ final class TranslationsService: TranslationsServiceProtocol {
     /// Translation is a living process ( e.g live chat in twitch ) so there is no single "done" state.
     /// In Gecko, we mark translations done when the engine is ready.
     /// In iOS, we will go a step further and wait for the first translation response to be received.
-    @discardableResult
-    func firstResponseReceived(for windowUUID: WindowUUID) async throws -> Bool {
+    func firstResponseReceived(for windowUUID: WindowUUID) async throws {
         let webView = try currentWebView(for: windowUUID)
-        return try await firstResponseReceivedJS(on: webView)
+        _ = try await firstResponseReceivedJS(on: webView)
     }
 
     /// Tells the engine to discard translations for a document.
@@ -121,11 +120,10 @@ final class TranslationsService: TranslationsServiceProtocol {
     }
 
     /// Evaluates the JS hook to check whether initial translation output has been produced.
-    private func firstResponseReceivedJS(on webView: WKWebView) async throws -> Bool {
+    private func firstResponseReceivedJS(on webView: WKWebView) async throws {
         let js = "return await window.__firefox__.Translations.isDone()"
         do {
-            let result = try await webView.callAsyncJavaScript(js, contentWorld: .defaultClient)
-            return (result as? Bool) ?? false
+            _ = try await webView.callAsyncJavaScript(js, contentWorld: .defaultClient)
         } catch {
             /// NOTE: It would be safe to pass in the js string directly here, but it would just add too much noise 
             /// since from and to could be any language code. We only care that firstResponseReceivedJS failed.

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceProtocol.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceProtocol.swift
@@ -21,7 +21,7 @@ protocol TranslationsServiceProtocol {
     /// NOTE: Translation is a living process ( e.g live chat in twitch ) so there is no single "done" state.
     /// In Gecko, we mark translations done when the engine is ready.
     /// In iOS, we will go a step further and wait for the first translation response to be received.
-    func firstResponseReceived(for windowUUID: WindowUUID) async throws -> Bool
+    func firstResponseReceived(for windowUUID: WindowUUID) async throws
     /// Asks the engine to discard translations and tear down state for the current document.
     func discardTranslations(for windowUUID: WindowUUID) async throws
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
@@ -53,10 +53,9 @@ final class MockTranslationsService: TranslationsServiceProtocol {
         if let error = translateError { throw error }
     }
 
-    func firstResponseReceived(for windowUUID: WindowUUID) async throws -> Bool {
+    func firstResponseReceived(for windowUUID: WindowUUID) async throws {
         firstResponseReceivedCalledWith = windowUUID
         if let error = firstResponseReceivedError { throw error }
-        return firstResponseReceivedResult
     }
 
     func discardTranslations(for windowUUID: WindowUUID) async throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14227)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR:
- Skips return value from `firstResponseReceived` since it's unsused. All we care about is if the underlying JS promise resolved or rejected which is capture by await/throw already.

<img width="1301" height="193" alt="Screenshot 2025-11-20 at 19 21 04" src="https://github.com/user-attachments/assets/f120f956-fa6c-487a-ad01-d5b5d0d16f34" />

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

