### PR TITLE
Bugfix FXIOS-14245 [Translations] fix error for detecting page for non webpages

### DIFF
--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -29,6 +29,8 @@ final class TranslationsMiddleware {
         switch action.actionType {
         case ToolbarActionType.urlDidChange:
             guard let action = (action as? ToolbarAction) else { return }
+
+            guard action.url?.isWebPage() == true else { return }
             self.checkTranslationsAreEligible(for: action)
 
         case ToolbarMiddlewareActionType.didTapButton:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -86,6 +86,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         setTranslationsFeatureEnabled(enabled: true)
         let subject = createSubject(shouldOfferTranslationResult: true)
         let action = ToolbarAction(
+            url: URL(string: "https://www.example.com"),
             translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
             windowUUID: .XCTestDefaultUUID,
             actionType: ToolbarActionType.urlDidChange
@@ -115,6 +116,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
 
         let subject = createSubject(shouldOfferTranslationError: TestError.example)
         let action = ToolbarAction(
+            url: URL(string: "https://www.example.com"),
             translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
             windowUUID: .XCTestDefaultUUID,
             actionType: ToolbarActionType.urlDidChange


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
We were seeing errors that occurred often from this telemetry PR: https://github.com/mozilla-mobile/firefox-ios/pull/30820

This is because we were running our page detection script on non webpages. We only care about running web pages that can be potentially translated.

I also tested with reader mode and does not seem to impact it since its using the same url as webpage.

**Home Page URL**
`internal://local/about/home`

Screenshots:

<img width="1248" height="130" alt="image" src="https://github.com/user-attachments/assets/ada36b08-f1cd-4f63-b4b3-37720f12a7ca" />



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

