### PR TITLE
Add FXIOS-14248 [Translations] Pre-fetch `en` -> device language models

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -169,8 +169,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         /// Prewarm translation resources off the main thread
         /// This will fetch the translator WASM and model attachments for the device language.
         /// Running this on a utility QoS to avoid impacting app launch time.
-        DispatchQueue.global(qos: .utility).async {
-            ASTranslationModelsFetcher().prewarmResourcesForStartup()
+        if TranslationConfiguration(prefs: profile.prefs).canTranslate {
+            DispatchQueue.global(qos: .utility).async {
+                ASTranslationModelsFetcher().prewarmResourcesForStartup()
+            }
         }
 
         logger.log("didFinishLaunchingWithOptions end",

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
@@ -170,7 +170,7 @@ final class ASTranslationModelsFetcher: TranslationModelsFetcherProtocol, Sendab
             )
             return
         }
-        prewarmResources(for: Constants.pivotLanguage, to: pivotLanguage)
+        prewarmResources(for: Constants.pivotLanguage, to: deviceLanguage)
     }
 
     /// Pre-warms attachments for a list of records by fetching them


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14248)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30855)

## :bulb: Description
This PR:
- Adds `prewarmResourcesForStartup` that pre-fetches models for `en` -> device language.
- Runs `prewarmResourcesForStartup` after startup in a background thread.
- Only pre-fetches if feature flag is true.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

