### PR TITLE
Add FXIOS-14101 [Trending Searches] handling for Perplexity engine

### DIFF
--- a/firefox-ios/Client/Extensions/Locale+Extension.swift
+++ b/firefox-ios/Client/Extensions/Locale+Extension.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+// TODO: FXIOS-14268 - Clean up locale interfaces + extensions
 extension Locale {
     func regionCode() -> String {
         let systemRegion: String?

--- a/firefox-ios/Client/Extensions/Locale+possibilitiesForLanguageIdentifier.swift
+++ b/firefox-ios/Client/Extensions/Locale+possibilitiesForLanguageIdentifier.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+// TODO: FXIOS-14268 - Clean up locale interfaces + extensions
 extension Locale {
     func possibilitiesForLanguageIdentifier() -> [String] {
         var possibilities: [String] = []

--- a/firefox-ios/Client/Utils/LocaleInterface.swift
+++ b/firefox-ios/Client/Utils/LocaleInterface.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+// TODO: FXIOS-14268 - Clean up locale interfaces + extensions
 protocol LocaleInterface {
     var localeRegionCode: String? { get }
 }
@@ -11,5 +12,30 @@ protocol LocaleInterface {
 extension Locale: LocaleInterface {
     var localeRegionCode: String? {
         return self.regionCode
+    }
+}
+
+protocol LocaleProvider {
+    var current: Locale { get }
+    var preferredLanguages: [String] { get }
+    var regionCode: String { get }
+    var possibleLanguageIdentifier: [String] { get }
+}
+
+struct SystemLocaleProvider: LocaleProvider {
+    var current: Locale {
+        .current
+    }
+
+    var preferredLanguages: [String] {
+        Locale.preferredLanguages
+    }
+
+    var regionCode: String {
+        Locale.current.regionCode()
+    }
+
+    var possibleLanguageIdentifier: [String] {
+        Locale.current.possibilitiesForLanguageIdentifier()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/ASSearchEngineUtilitiesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/ASSearchEngineUtilitiesTests.swift
@@ -146,6 +146,60 @@ class ASSearchEngineUtilitiesTests: XCTestCase {
         clickUrl: nil
     )
 
+    private let perplexity_testEngine =
+    SearchEngineDefinition(
+        aliases: ["perplexity"],
+        charset: "UTF-8",
+        classification: .general,
+        identifier: "perplexity",
+        isNewUntil: nil,
+        name: "Perplexity",
+        optional: false,
+        partnerCode: "firefox",
+        telemetrySuffix: "",
+        urls: SearchEngineUrls(
+            search: SearchEngineUrl(
+                base: "https://www.perplxity.ai/search",
+                method: "GET",
+                params: [
+                    SearchUrlParam(
+                        name: "pc",
+                        value: "{partnerCode}",
+                        enterpriseValue: nil,
+                        experimentConfig: nil
+                    )
+                ],
+                searchTermParamName: "q",
+                displayName: nil
+            ),
+            suggestions: SearchEngineUrl(
+                base: "https://www.suggest.perplxity.ai/suggest",
+                method: "GET",
+                params: [],
+                searchTermParamName: "q",
+                displayName: nil
+            ),
+            trending: SearchEngineUrl(
+                base: "https://www.perplexity.ai/rest/autosuggest/list-trending-suggest",
+                method: "GET",
+                params: [
+                    SearchUrlParam(
+                        name: "lang",
+                        value: "{acceptLanguages}",
+                        enterpriseValue: nil,
+                        experimentConfig: nil
+                    )
+                ],
+                searchTermParamName: "q",
+                displayName: nil
+            ),
+            searchForm: nil,
+            visualSearch: nil
+        ),
+        orderHint: nil,
+        clickUrl: nil
+    )
+
     func testConvertGoogleEngineSearchURL() {
         let engine = google_US_testEngine
         let result = ASSearchEngineUtilities.convertASSearchURLToOpenSearchURL(engine.urls.search,
@@ -199,4 +253,46 @@ class ASSearchEngineUtilitiesTests: XCTestCase {
         let expected = "https://dict.leo.org/englisch-deutsch/{searchTerms}?foo=bar"
         XCTAssertEqual(result, expected)
     }
+
+    func testPerplexityTrendingURLWithUS() {
+        let engine = perplexity_testEngine
+        let localeProvider = FakeLocaleProvider(
+            current: Locale(identifier: "en-US"),
+            preferredLanguages: ["en-US"],
+            regionCode: "",
+            possibleLanguageIdentifier: []
+        )
+        let result = ASSearchEngineUtilities.convertASSearchURLToOpenSearchURL(
+            engine.urls.trending,
+            for: engine,
+            with: localeProvider
+        )
+        let expected = "https://www.perplexity.ai/rest/autosuggest/list-trending-suggest?lang=en-US&q={searchTerms}"
+        XCTAssertEqual(result, expected)
+    }
+
+    func testPerplexityTrendingURLWithDE() {
+        let engine = perplexity_testEngine
+        let localeProvider = FakeLocaleProvider(
+            current: Locale(identifier: "de-US"),
+            preferredLanguages: ["de"],
+            regionCode: "",
+            possibleLanguageIdentifier: []
+        )
+        let result = ASSearchEngineUtilities.convertASSearchURLToOpenSearchURL(
+            engine.urls.trending,
+            for: engine,
+            with: localeProvider
+        )
+        let expected = "https://www.perplexity.ai/rest/autosuggest/list-trending-suggest?lang=de&q={searchTerms}"
+        XCTAssertEqual(result, expected)
+    }
+}
+
+// TODO: FXIOS-14268 - Clean up locale interfaces + extensions
+private struct FakeLocaleProvider: LocaleProvider {
+    let current: Locale
+    let preferredLanguages: [String]
+    let regionCode: String
+    let possibleLanguageIdentifier: [String]
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14101)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30572)

## :bulb: Description
Handle Perplexity Engine for Trending Searches. With this PR, we should now see Perplexity trending searches using the locale based on user setting.
- Moved `localeCode` method to `ASSearchEngineUtilities` so it can be used in multiple places and is more of a utility
- Add check for handling the lang parameter, similar to what we do for partner code
- Refactor how we are using locale so that it can be more testable. Created a separate follow up [ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14268).

## :movie_camera: Demos
<img width="250" height="500" alt="Simulator Screenshot - iPhone 16e - 2025-11-21 at 13 49 06" src="https://github.com/user-attachments/assets/e815bca9-74c2-472d-a0da-4366d0211ee4" />

Note: To test the Perplexity trending searches, you will need to be in our Dev environment for Remote Settings. Please use the debugger setting to test that. Also trending searches only appear after navigating to the address bar from a webpage

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

