### PR TITLE
Bugfix MTE-4495 CreditCardsTests iOS 26 Smoke tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -46,6 +46,9 @@ class CreditCardsTests: BaseTestCase {
         )
         addCardButton.waitAndTap()
         // Add Credit Card page is displayed
+        if #available(iOS 26, *) {
+            tapCardName()
+        }
         waitForElementsToExist(
             [
                 app.staticTexts[creditCardsStaticTexts.AddCreditCard.addCreditCard],


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
`testAccessingTheCreditCardsSection` fails on iOS because  the heading "Add Card" together with "Close" and "Save" does not appear by default on iOS 26.
<img width="200" height="2622" alt="Simulator Screenshot - iPhone 17 - 2025-11-20 at 18 42 06" src="https://github.com/user-attachments/assets/81b13110-8a1f-4fd8-948f-6a231dd804ef" />
On iOS 18 and lower, the heading appears right away.
<img width="200" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-11-21 at 10 54 48" src="https://github.com/user-attachments/assets/12b313b8-4449-44a1-99c0-3b36a7440df6" />
The workaround is to tap on a field to make the heading to appear.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

