### PR TITLE
Bugfix FXIOS-14270 Fix crash when deleting custom search engine

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -303,12 +303,10 @@ class SearchEnginesManager: SearchEnginesManagerProvider {
         customEngines.remove(at: customEngines.firstIndex(of: engine)!)
         saveCustomEngines()
 
-        getOrderedEngines { enginePreferences, orderedEngines in
-            self.orderedEngines = orderedEngines
-            self.delegate?.searchEnginesDidUpdate()
+        orderedEngines.removeAll(where: { $0.engineID == engine.engineID })
+        delegate?.searchEnginesDidUpdate()
 
-            completion()
-        }
+        completion()
     }
 
     /// Adds an engine to the front of the search engines list.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14270)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30889)

## :bulb: Description

Fixes crash caused by a UITableView data mismatch. Summary:
- We had old code that was re-fetching orderedEngines after deleting an engine
- It shouldn't have actually been doing this, it seems it was added years ago as a lazy way of updating and refreshing the `orderedEngines` array
- Previously, this was fine, because there was no way the engine data would change during the deletion
- Now, however, it's problematic, because in some scenarios (e.g. first launches) the re-fetch of the ordered engines can actually result in new engines being pulled down from Remote Settings

So IOW, the old code that was fetching engines was actually adding in new engines from Remote Settings in some cases. The fix here is to avoid re-fetching, as it never should have been happening in `deleteCustomEngine` (I remember seeing this during RS and wondering why it was the only other place we were fetching ordered engines).

Instead, we simply update our engines array by removing the deleted engine directly, which is all that `deleteCustomEngine` should do. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

