### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Suppress userInfo NotificationService warning

### DIFF
--- a/firefox-ios/Extensions/NotificationService/NotificationService.swift
+++ b/firefox-ios/Extensions/NotificationService/NotificationService.swift
@@ -59,7 +59,7 @@ class NotificationService: UNNotificationServiceExtension {
         }
     }
 
-    func handleEncryptedPushMessage(userInfo: sending [AnyHashable: Any],
+    func handleEncryptedPushMessage(userInfo: [AnyHashable: Any],
                                     profile: BrowserProfile,
                                     completion: @escaping @Sendable (Result<PushMessage, PushMessageError>) -> Void
     ) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description

- Suppress userInfo NotificationService warning. 

If someone has a bright idea on how to fix this (since dictionaries aren't Sendable) let me know!

cc @Cramsden @lmarceau @dataports 


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code