### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix 2 `@Sendable` warnings with region based isolation

### DIFF
--- a/firefox-ios/WidgetKit/OpenTabs/TabProvider.swift
+++ b/firefox-ios/WidgetKit/OpenTabs/TabProvider.swift
@@ -17,7 +17,7 @@ struct TabProvider: TimelineProvider {
         OpenTabsEntry(date: Date(), favicons: [String: Image](), tabs: [])
     }
 
-    func getSnapshot(in context: Context, completion: @escaping (OpenTabsEntry) -> Void) {
+    func getSnapshot(in context: Context, completion: @escaping @Sendable (OpenTabsEntry) -> Void) {
         let openTabs = SimpleTab.getSimpleTabs().values.filter {
             !$0.isPrivate
         }

--- a/firefox-ios/WidgetKit/TopSites/TopSitesProvider.swift
+++ b/firefox-ios/WidgetKit/TopSites/TopSitesProvider.swift
@@ -23,7 +23,7 @@ struct TopSitesProvider: TimelineProvider {
         return TopSitesEntry(date: Date(), favicons: [String: Image](), sites: [])
     }
 
-    func getSnapshot(in context: Context, completion: @escaping (TopSitesEntry) -> Void) {
+    func getSnapshot(in context: Context, completion: @escaping @Sendable (TopSitesEntry) -> Void) {
         let topSites = getStoredTopSites()
         let siteImageFetcher = DefaultSiteImageHandler.factory()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description

- Fix 2 `@Sendable` warnings with region based isolation

cc @Cramsden @lmarceau @dataports 


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code