### PR TITLE
Refactor FXIOS-12796, FXIOS-14276 [Swift 6 Migration] Isolate state to main actor to fix region based isolation warnings in `CredentialProviderPresenter`

### DIFF
--- a/firefox-ios/CredentialProvider/CredentialProviderPresenter.swift
+++ b/firefox-ios/CredentialProvider/CredentialProviderPresenter.swift
@@ -111,6 +111,7 @@ final class CredentialProviderPresenter: @unchecked Sendable {
         }
     }
 
+    @MainActor
     func credentialList(for serviceIdentifiers: [ASCredentialServiceIdentifier]) {
         // Force a short delay before we trigger authentication.
         // See https://github.com/mozilla-mobile/firefox-ios/issues/9354
@@ -118,10 +119,7 @@ final class CredentialProviderPresenter: @unchecked Sendable {
             self.appAuthenticator.authenticateWithDeviceOwnerAuthentication { result in
                 switch result {
                 case .success:
-                    // Move to the main thread because a state update triggers UI changes.
-                    DispatchQueue.main.async { [unowned self] in
-                        self.showCredentialList(for: serviceIdentifiers)
-                    }
+                    self.showCredentialList(for: serviceIdentifiers)
                 case .failure:
                     self.cancel(with: .userCanceled)
                 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

Subticket: FXIOS-14276 / #30903 (I made a ticket for QA because I wasn't sure how to test this area...)

## :bulb: Description

Isolate state to main actor to fix region based isolation warnings in CredentialProviderPresenter.

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code