### PR TITLE
Add FXIOS-14277 [Blueprint Download Manager] Enable download live activity flag on beta

### DIFF
--- a/firefox-ios/nimbus-features/downloadLiveActivitiesFeature.yaml
+++ b/firefox-ios/nimbus-features/downloadLiveActivitiesFeature.yaml
@@ -12,7 +12,7 @@ features:
     defaults:
       - channel: beta
         value:
-          enabled: false
+          enabled: true
       - channel: developer
         value:
          enabled: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14277)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30907)

## :bulb: Description
Previously the download manager was only enabled on develop but I'm enabling it on beta at the request of Andy so QA can evaluate what has been done.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

