### PR TITLE
Fix MTE-5011 Fix credit card TAE Tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -95,7 +95,7 @@ class CreditCardsTests: BaseTestCase {
         // Add and save a valid credit card
         addCreditCardScreen.addCreditCard(name: "Test", cardNumber: cards[0], expirationDate: "0540")
 
-        creditCardScreen.assertCardSaved(containing: "1252", details: ["test", "Expires", "5/40"])
+        creditCardScreen.assertCardSaved(containing: "1252", details: ["Test", "Expires", "5/40"])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306978
@@ -876,7 +876,7 @@ class CreditCardsTests: BaseTestCase {
         addCardScreen.addCreditCard(name: "Test", cardNumber: cards[0], expirationDate: "0540")
         creditCardsScreen.openSavedCard(at: 1)
         viewCardScreen.waitForViewCardScreen(containing: "1252")
-        viewCardScreen.assertCardDetails(["test", "05 / 40"])
+        viewCardScreen.assertCardDetails(["Test", "05 / 40"])
     }
 
     private func addCreditCard(name: String, cardNumber: String, expirationDate: String) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5011)

## :bulb: Description
This PR fixes the credit card TAE tests. There was a typo in the tests. The tests were checking for "test" instead of "Test"

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

