### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Enable the RegionBasedIsolation for all BrowserKit packages.

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -82,7 +82,8 @@ let package = Package(
             dependencies: ["Common"],
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
-                .enableExperimentalFeature("StrictConcurrency")
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableExperimentalFeature("RegionBasedIsolation")
             ]
         ),
         .target(
@@ -91,7 +92,8 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
                 .enableExperimentalFeature("StrictConcurrency"),
-                .enableUpcomingFeature("InferSendableFromCaptures")
+                .enableUpcomingFeature("InferSendableFromCaptures"),
+                .enableExperimentalFeature("RegionBasedIsolation")
             ]),
         .testTarget(
             name: "ComponentLibraryTests",
@@ -108,7 +110,8 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
                 .enableExperimentalFeature("StrictConcurrency"),
-                .enableUpcomingFeature("InferSendableFromCaptures")
+                .enableUpcomingFeature("InferSendableFromCaptures"),
+                .enableExperimentalFeature("RegionBasedIsolation")
             ]),
         .testTarget(
             name: "SiteImageViewTests",
@@ -127,7 +130,8 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
                 .enableExperimentalFeature("StrictConcurrency"),
-                .enableUpcomingFeature("InferSendableFromCaptures")
+                .enableUpcomingFeature("InferSendableFromCaptures"),
+                .enableExperimentalFeature("RegionBasedIsolation")
             ]
         ),
         .testTarget(
@@ -139,8 +143,11 @@ let package = Package(
         .target(
             name: "TabDataStore",
             dependencies: ["Common"],
-            swiftSettings: [.unsafeFlags(["-enable-testing"]),
-                            .enableExperimentalFeature("StrictConcurrency")]),
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"]),
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableExperimentalFeature("RegionBasedIsolation")
+            ]),
         .testTarget(
             name: "TabDataStoreTests",
             dependencies: ["TabDataStore"]),
@@ -149,7 +156,8 @@ let package = Package(
             dependencies: ["Common"],
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
-                .enableExperimentalFeature("StrictConcurrency")
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableExperimentalFeature("RegionBasedIsolation")
             ]),
         .testTarget(
             name: "ReduxTests",
@@ -158,17 +166,23 @@ let package = Package(
             name: "WebEngine",
             dependencies: ["Common",
                            .product(name: "GCDWebServers", package: "GCDWebServer")],
-            swiftSettings: [.unsafeFlags(["-enable-testing"]),
-                            .enableExperimentalFeature("StrictConcurrency")]),
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"]),
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableExperimentalFeature("RegionBasedIsolation")
+            ]),
         .testTarget(
             name: "WebEngineTests",
             dependencies: ["WebEngine"]),
         .target(
             name: "ToolbarKit",
             dependencies: ["Common"],
-            swiftSettings: [.unsafeFlags(["-enable-testing"]),
-                            .enableExperimentalFeature("StrictConcurrency"),
-                            .enableUpcomingFeature("InferSendableFromCaptures")]),
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"]),
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableUpcomingFeature("InferSendableFromCaptures"),
+                .enableExperimentalFeature("RegionBasedIsolation")
+            ]),
         .testTarget(
             name: "ToolbarKitTests",
             dependencies: ["ToolbarKit"]),
@@ -177,7 +191,8 @@ let package = Package(
             dependencies: ["Common", "ComponentLibrary"],
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
-                .enableExperimentalFeature("StrictConcurrency")
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableExperimentalFeature("RegionBasedIsolation")
             ]),
         .testTarget(
             name: "MenuKitTests",
@@ -195,7 +210,8 @@ let package = Package(
             ],
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
-                .enableExperimentalFeature("StrictConcurrency")
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableExperimentalFeature("RegionBasedIsolation")
             ]
         ),
         .testTarget(name: "SummarizeKitTests",
@@ -205,11 +221,15 @@ let package = Package(
             dependencies: ["Common", "ComponentLibrary", "MenuKit"],
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
-                .enableExperimentalFeature("StrictConcurrency")
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableExperimentalFeature("RegionBasedIsolation")
             ]),
         .target(
             name: "ContentBlockingGenerator",
-            swiftSettings: [.unsafeFlags(["-enable-testing"])]),
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"]),
+                .enableExperimentalFeature("RegionBasedIsolation")
+            ]),
         .testTarget(
             name: "ContentBlockingGeneratorTests",
             dependencies: ["ContentBlockingGenerator"],
@@ -224,7 +244,8 @@ let package = Package(
             ],
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
-                .enableExperimentalFeature("StrictConcurrency")
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableExperimentalFeature("RegionBasedIsolation")
             ],
             linkerSettings: [
                 .linkedFramework("Metal"),
@@ -234,7 +255,8 @@ let package = Package(
             name: "OnboardingKitTests",
             dependencies: ["OnboardingKit"],
             swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
+                .enableExperimentalFeature("StrictConcurrency"),
+                .enableExperimentalFeature("RegionBasedIsolation")
             ]),
         .executableTarget(
             name: "ExecutableContentBlockingGenerator",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description

- Enable the RegionBasedIsolation for all BrowserKit packages.

There didn't appear to be any new warnings so I'll see what Bitrise says... might be some in tests.

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code