### PR TITLE
Localize FXIOS-14048 [MozillaOnline] Update DefaultSuggestedSites for zh_CN

### DIFF
--- a/firefox-ios/Storage/DefaultSuggestedSites.swift
+++ b/firefox-ios/Storage/DefaultSuggestedSites.swift
@@ -88,13 +88,6 @@ open class DefaultSuggestedSites {
         ],
         "zh_CN": [ // FXIOS-11064 Do we still want this as a special case localization? Android doesn't compile this anymore
             Site.createSuggestedSite(
-                url: "http://mozilla.com.cn",
-                title: "火狐社区",
-                trackingId: 700,
-                // FXIOS-11064 We need a higher quality favicon link
-                faviconResource: .remoteURL(url: URL(string: "http://mozilla.com.cn/favicon.ico")!)
-            ),
-            Site.createSuggestedSite(
                 url: "https://m.baidu.com/",
                 title: "百度",
                 trackingId: 701,
@@ -129,8 +122,14 @@ open class DefaultSuggestedSites {
                 trackingId: 705,
                 // FXIOS-11064 We need a higher quality favicon link
                 faviconResource: .remoteURL(url: URL(string: "https://corporate.jd.com/favicon.ico")!)
+            ),
+            Site.createSuggestedSite(
+                url: "http://douyin.com",
+                title: "抖音",
+                trackingId: 706,
+                faviconResource: .remoteURL(url: URL(string: "https://lf-douyin-pc-web.douyinstatic.com/obj/douyin-pc-web/2025_0313_logo.png")!)
             )
-         ],
+        ],
         "ja_JP": [
             Site.createSuggestedSite(
                 url: firefoxJpGuideURL,


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-14048
Github issue #30450

## :bulb: Description

With the first default home tile pointing to a site that's been shut down now, this PR removes it without a replacement, and adds a new site at the end of the list.

Consulting some sources of popular destinations and skipping potential partnerships, I ended up with the domestic TikTok as a suitable candidate. (Other that came to mind were e.g. Youku or Sohu, but I can't really judge their popularity. — NB: Weibo being included on Sina, and WeChat not really usable in a mobile browser, so I skipped these.)

<!-- Please upload screenshots or video demos of your work
## :movie_camera: Demos

| Before | After |
| - | - |

<details>
<summary>Demo</summary>
</details>
 -->

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If needed, I updated documentation and added comments to complex code