### PR TITLE
Refactor FXIOS-14282 [Trending Searches] use new rust methods specifi…

### DIFF
--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Places/Places.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Places/Places.swift
@@ -358,10 +358,10 @@ public class PlacesReadConnection {
         }
     }
 
-    open func getMostRecentHistoryMetadata(limit: Int32) throws -> [HistoryMetadata] {
+    open func getMostRecentSearchHistoryMetadata(limit: Int32) throws -> [HistoryMetadata] {
         return try queue.sync {
             try self.checkApi()
-            return try self.conn.getMostRecentHistoryMetadata(limit: limit)
+            return try self.conn.getMostRecentSearchEntriesInHistoryMetadata(limit: limit)
         }
     }
     
@@ -806,6 +806,13 @@ public class PlacesWriteConnection: PlacesReadConnection {
                 referrerUrl: key.referrerUrl,
                 searchTerm: key.searchTerm
             )
+        }
+    }
+    
+    open func deleteSearchHistoryMetadata() throws {
+        try queue.sync {
+            try self.checkApi()
+            try self.conn.metadataDeleteSearchTerms()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
@@ -405,10 +405,9 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
     func clearRecentSearches() {
         searchTelemetry.recentSearchesClearButtonTapped()
 
-        let dateProvider = SystemDateProvider()
-        recentSearchProvider.clear(with: dateProvider) { success in
+        recentSearchProvider.clear { result in
             ensureMainThread { [weak self] in
-                if success {
+                if case .success = result {
                     self?.recentSearches = []
                     self?.delegate?.reloadTableView()
                 } else {

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/RecentSearchProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/RecentSearchProvider.swift
@@ -10,7 +10,7 @@ import Storage
 protocol RecentSearchProvider {
     func addRecentSearch(_ term: String, url: String?)
     func loadRecentSearches(completion: @escaping @Sendable ([String]) -> Void)
-    func clear(with date: DateProvider, completion: @escaping @Sendable (Bool) -> Void)
+    func clear(completion: @escaping @Sendable (Result<(), any Error>) -> Void)
 }
 
 /// A provider that manages recent search terms from a user's history storage.
@@ -58,7 +58,7 @@ final class DefaultRecentSearchProvider: RecentSearchProvider {
     /// Only care about returning the `maxNumberOfSuggestions`.
     /// We don't have an interface to fetch only a certain amount, so we follow what Android does for now.
     func loadRecentSearches(completion: @escaping @Sendable ([String]) -> Void) {
-        historyStorage.getMostRecentHistoryMetadata(limit: maxNumberOfSuggestions) { result in
+        historyStorage.getMostRecentSearchHistoryMetadata(limit: maxNumberOfSuggestions) { result in
             if case .success(let historyMetadata) = result {
                 let uniqueSearchTermResult = historyMetadata.compactMap { $0.searchTerm }
                     .uniqued()
@@ -69,10 +69,8 @@ final class DefaultRecentSearchProvider: RecentSearchProvider {
         }
     }
 
-    func clear(with date: DateProvider = SystemDateProvider(), completion: @escaping @Sendable (Bool) -> Void) {
-        // TODO: FXIOS-14100 Update with new method
-        let dateInMilliseconds = date.now().toMillisecondsSince1970()
-        historyStorage.deleteHistoryMetadataOlderThan(olderThan: dateInMilliseconds) { result in
+    func clear(completion: @escaping @Sendable (Result<(), any Error>) -> Void) {
+        historyStorage.deleteSearchHistoryMetadata { result in
             completion(result)
         }
     }

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -62,7 +62,7 @@ public protocol HistoryHandler {
     func applyObservation(visitObservation: VisitObservation,
                           completion: @escaping (Result<Void, any Error>) -> Void)
 
-    func getMostRecentHistoryMetadata(
+    func getMostRecentSearchHistoryMetadata(
         limit: Int32,
         completion: @Sendable @escaping (Result<[HistoryMetadata], any Error>) -> Void
     )
@@ -73,9 +73,8 @@ public protocol HistoryHandler {
         completion: @Sendable @escaping (Result<(), any Error>) -> Void
     )
 
-    func deleteHistoryMetadataOlderThan(
-        olderThan: Int64,
-        completion: @escaping @Sendable (Bool) -> Void
+    func deleteSearchHistoryMetadata(
+        completion: @escaping @Sendable (Result<(), any Error>) -> Void
     )
 }
 
@@ -561,13 +560,13 @@ public class RustPlaces: @unchecked Sendable, BookmarksHandler, HistoryHandler {
     }
 
     // MARK: History metadata
-    /// Currently only used to get the recent searches from the user's history storage.
-    public func getMostRecentHistoryMetadata(
+    /// Fetches recent searches from the user's history storage.
+    public func getMostRecentSearchHistoryMetadata(
         limit: Int32,
         completion: @Sendable @escaping (Result<[HistoryMetadata], any Error>) -> Void
     ) {
         withReader({ connection in
-            return try connection.getMostRecentHistoryMetadata(limit: limit)
+            return try connection.getMostRecentSearchHistoryMetadata(limit: limit)
         }, completion: completion)
     }
 
@@ -606,14 +605,15 @@ public class RustPlaces: @unchecked Sendable, BookmarksHandler, HistoryHandler {
         }
     }
 
-    public func deleteHistoryMetadataOlderThan(
-        olderThan: Int64,
-        completion: @escaping @Sendable (Bool) -> Void
+    public func deleteSearchHistoryMetadata(
+        completion: @escaping @Sendable (Result<(), any Error>) -> Void
     ) {
-        let deferredResponse = deleteHistoryMetadataOlderThan(olderThan: olderThan)
-        deferredResponse.upon { result in
-            completion(result.isSuccess)
-        }
+        withWriter(
+            { connection in
+                return try connection.deleteSearchHistoryMetadata()
+            },
+            completion: completion
+        )
     }
 
     private func deleteHistoryMetadata(since startDate: Int64) -> Deferred<Maybe<Void>> {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockHistoryHandler.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockHistoryHandler.swift
@@ -16,9 +16,9 @@ final class MockHistoryHandler: HistoryHandler {
     var onApply: (() -> Void)?
 
     // MARK: History Metadata
-    var getMostRecentHistoryMetadataCallCount = 0
+    var getMostRecentSearchHistoryMetadataCallCount = 0
     var noteHistoryMetadataCallCount = 0
-    var deleteHistoryMetadataCallCount = 0
+    var deleteSearchHistoryMetadataCallCount = 0
     var result: Result<[MozillaAppServices.HistoryMetadata], Error> = .success(
         [
             HistoryMetadata(
@@ -45,10 +45,10 @@ final class MockHistoryHandler: HistoryHandler {
             )
         ]
     )
-    let clearResult: Bool
+    let clearResult: Result<(), Error>
     var searchTermList: [String] = []
 
-    init(clearResult: Bool = true) {
+    init(clearResult: Result<(), Error> = .success(())) {
         self.clearResult = clearResult
     }
 
@@ -59,11 +59,11 @@ final class MockHistoryHandler: HistoryHandler {
         onApply?()
     }
 
-    func getMostRecentHistoryMetadata(
+    func getMostRecentSearchHistoryMetadata(
         limit: Int32,
         completion: @escaping @Sendable (Result<[MozillaAppServices.HistoryMetadata], any Error>) -> Void
     ) {
-        getMostRecentHistoryMetadataCallCount += 1
+        getMostRecentSearchHistoryMetadataCallCount += 1
         completion(result)
     }
 
@@ -76,8 +76,8 @@ final class MockHistoryHandler: HistoryHandler {
         searchTermList.append(searchTerm)
     }
 
-    func deleteHistoryMetadataOlderThan(olderThan: Int64, completion: @escaping @Sendable (Bool) -> Void) {
-        deleteHistoryMetadataCallCount += 1
+    func deleteSearchHistoryMetadata(completion: @escaping @Sendable (Result<(), any Error>) -> Void) {
+        deleteSearchHistoryMetadataCallCount += 1
         completion(clearResult)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/MockRecentSearchProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/MockRecentSearchProvider.swift
@@ -20,7 +20,7 @@ final class MockRecentSearchProvider: RecentSearchProvider {
         completion(searchTerms)
     }
 
-    func clear(with date: DateProvider, completion: @escaping @Sendable (Bool) -> Void) {
+    func clear(completion: @escaping @Sendable (Result<(), any Error>) -> Void) {
         clearRecentSearchCalledCount += 1
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14282)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR replaces two methods that we were using previously to display and delete recent searches, `getMostRecentHistoryMetadata` and `deleteHistoryMetadataOlderThan` respectively. We were using these because these were the best existing methods to implement the feature. 

However, we recently added some new rust methods that are specific to showing metadata related to search queries and not the entire history metadata. The two new methods are:

- `metadataDeleteSearchTerms`: https://github.com/mozilla/application-services/pull/7101
- `getMostRecentSearchEntriesInHistoryMetadata`: https://github.com/mozilla/application-services/pull/7104

## :movie_camera: Demos

https://github.com/user-attachments/assets/4bed97fa-4c0d-4e2a-90c6-f77133e2d02f

Note: To test, ensure that you have the features on in debug menu and you navigate to the recent searches section after tapping on the address bar from a webpage.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code