### PR TITLE
Revert FXIOS-14239 [Toolbar] The “X” Button does not clear typed text while being in Website view in URL bar on iOS 26

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -126,9 +126,6 @@ public class BrowserAddressToolbar: UIView,
         [navigationActionStack, leadingPageActionStack, pageActionStack, browserActionStack].forEach {
             $0.isHidden = config.uxConfiguration.scrollAlpha.isZero
         }
-        if #available(iOS 26.0, *) {
-            toolbarTopBorderView.isHidden = config.uxConfiguration.scrollAlpha.isZero
-        }
         self.toolbarDelegate = toolbarDelegate
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
         addressBarPosition = toolbarPosition

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -20,15 +20,11 @@ final class LocationView: UIView,
         static let iconContainerNoLockLeadingSpace: CGFloat = 16
         static let iconAnimationTime: CGFloat = 0.1
         static let iconAnimationDelay: CGFloat = 0.03
-        static let bottomAddressBarYoffset: CGFloat = -16
-        static let bottomAddressBarYoffsetForHomeButton: CGFloat = -28
+        static let bottomAddressBarYoffset: CGFloat = -28
         static let bottomAddressBarYoffsetForDefaultScale: CGFloat = -10
         static let topAddressBarYoffset: CGFloat = 26
         static let smallScale: CGFloat = 0.7
         static let identityResetAnimationDuration: TimeInterval = 0.2
-        static let effectViewCornerRadius: CGFloat = 24
-        static let effectViewLeadingPadding: CGFloat = -12
-        static let effectViewTrailingPadding: CGFloat = 18
     }
 
     private var urlAbsolutePath: String?
@@ -43,16 +39,10 @@ final class LocationView: UIView,
     private var safeListedURLImageName: String?
     private var scrollAlpha: CGFloat = 1
     private var hasAlternativeLocationColor = false
-    private var config: LocationViewConfiguration?
 
     private var isEditing = false
     private var isURLTextFieldEmpty: Bool {
         urlTextField.text?.isEmpty == true
-    }
-    private var hasHomeIndicator: Bool {
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-              let window = windowScene.windows.first else { return false }
-        return window.safeAreaInsets.bottom > 0
     }
 
     private var tapGestureRecognizer: UITapGestureRecognizer?
@@ -78,7 +68,7 @@ final class LocationView: UIView,
         return CGFloat(width)
     }
 
-    private lazy var urlTextFieldColor: UIColor = .label
+    private lazy var urlTextFieldColor: UIColor = .black
     private lazy var urlTextFieldSubdomainColor: UIColor = .clear
     private lazy var lockIconImageColor: UIColor = .clear
     private lazy var safeListedURLImageColor: UIColor = .clear
@@ -86,8 +76,7 @@ final class LocationView: UIView,
     private lazy var gradientView: UIView = .build()
     private lazy var containerView: UIView = .build()
 
-    private var containerViewConstraints: [NSLayoutConstraint] = []
-    private var effectViewBottomConstraint: NSLayoutConstraint?
+    private var containerViewConstrains: [NSLayoutConstraint] = []
     private var urlTextFieldLeadingConstraint: NSLayoutConstraint?
     private var urlTextFieldTrailingConstraint: NSLayoutConstraint?
     private var iconContainerStackViewLeadingConstraint: NSLayoutConstraint?
@@ -106,13 +95,6 @@ final class LocationView: UIView,
     private lazy var lockIconButton: UIButton = .build { button in
         button.contentMode = .scaleAspectFit
         button.addTarget(self, action: #selector(self.didTapLockIcon), for: .touchUpInside)
-    }
-
-    private lazy var effectView: UIVisualEffectView = .build {
-        if #available(iOS 26.0, *) {
-            $0.effect = UIGlassEffect()
-            $0.layer.cornerRadius = UX.effectViewCornerRadius
-        }
     }
 
     // MARK: - URL Text Field
@@ -163,9 +145,9 @@ final class LocationView: UIView,
                    isUnifiedSearchEnabled: Bool,
                    uxConfig: AddressToolbarUXConfiguration,
                    addressBarPosition: AddressToolbarPosition) {
-        self.config = config
         isURLTextFieldCentered = uxConfig.isLocationTextCentered
         hasAlternativeLocationColor = uxConfig.hasAlternativeLocationColor
+
         // TODO FXIOS-10210 Once the Unified Search experiment is complete, we won't need this extra layout logic and can
         // simply use the `.build` method on `DropDownSearchEngineView` on `LocationView`'s init.
         searchEngineContentView = isUnifiedSearchEnabled
@@ -232,9 +214,9 @@ final class LocationView: UIView,
         // Only update the constraints if necessary
         guard !newConstraints.isEmpty else { return }
 
-        NSLayoutConstraint.deactivate(containerViewConstraints)
-        containerViewConstraints = newConstraints
-        NSLayoutConstraint.activate(containerViewConstraints)
+        NSLayoutConstraint.deactivate(containerViewConstrains)
+        containerViewConstrains = newConstraints
+        NSLayoutConstraint.activate(containerViewConstrains)
     }
 
     func setAutocompleteSuggestion(_ suggestion: String?) {
@@ -260,24 +242,8 @@ final class LocationView: UIView,
     }
 
     private func setupLayout() {
-        if #available(iOS 26.0, *) {
-            addSubview(effectView)
-            effectView.contentView.addSubview(urlTextField)
-        } else {
-            containerView.addSubview(urlTextField)
-        }
         addSubview(containerView)
-        containerView.addSubviews(iconContainerStackView, gradientView)
-        if #available(iOS 26.0, *) {
-            NSLayoutConstraint.activate([
-                effectView.topAnchor.constraint(equalTo: urlTextField.topAnchor),
-                effectView.leadingAnchor.constraint(equalTo: iconContainerStackView.leadingAnchor,
-                                                    constant: UX.effectViewLeadingPadding),
-                effectView.trailingAnchor.constraint(equalTo: urlTextField.trailingAnchor,
-                                                     constant: UX.effectViewTrailingPadding)
-            ])
-            effectViewBottomConstraint = effectView.bottomAnchor.constraint(equalTo: urlTextField.bottomAnchor)
-        }
+        containerView.addSubviews(urlTextField, iconContainerStackView, gradientView)
         iconContainerStackView.addArrangedSubview(searchEngineContentView)
 
         urlTextFieldLeadingConstraint = urlTextField.leadingAnchor.constraint(equalTo: iconContainerStackView.trailingAnchor)
@@ -291,12 +257,12 @@ final class LocationView: UIView,
         )
         iconContainerStackViewLeadingConstraint?.isActive = true
 
-        containerViewConstraints = [
+        containerViewConstrains = [
             containerView.leadingAnchor.constraint(equalTo: leadingAnchor),
             containerView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ]
 
-        NSLayoutConstraint.activate(containerViewConstraints)
+        NSLayoutConstraint.activate(containerViewConstrains)
         NSLayoutConstraint.activate([
             gradientView.topAnchor.constraint(equalTo: urlTextField.topAnchor),
             gradientView.bottomAnchor.constraint(equalTo: urlTextField.bottomAnchor),
@@ -436,12 +402,7 @@ final class LocationView: UIView,
     // MARK: - LocationView Scaling
     private func shrinkLocationView(barPosition: AddressToolbarPosition, isKeyboardVisible: Bool) {
         let isiPad = UIDevice.current.userInterfaceIdiom == .pad
-        let bottomAddressBarYoffset = if #available(iOS 26.0, *) {
-            UX.bottomAddressBarYoffset
-        } else {
-            hasHomeIndicator ? UX.bottomAddressBarYoffset : UX.bottomAddressBarYoffsetForHomeButton
-        }
-        let yOffset: CGFloat = (barPosition == .bottom && !isiPad) ? bottomAddressBarYoffset : UX.topAddressBarYoffset
+        let yOffset: CGFloat = (barPosition == .bottom && !isiPad) ? UX.bottomAddressBarYoffset : UX.topAddressBarYoffset
         let scaledTransformation = CGAffineTransform(scaleX: UX.smallScale, y: UX.smallScale).translatedBy(x: 0, y: yOffset)
         transform = isKeyboardVisible ? CGAffineTransform(
             translationX: 0,
@@ -467,9 +428,6 @@ final class LocationView: UIView,
     private func applyToolbarAlphaIfNeeded(alpha: CGFloat, barPosition: AddressToolbarPosition, isKeyboardVisible: Bool) {
         guard scrollAlpha != alpha else { return }
         scrollAlpha = alpha
-        if #available(iOS 26.0, *) {
-            effectViewBottomConstraint?.isActive = scrollAlpha.isZero && barPosition == .bottom && !isKeyboardVisible
-        }
         if scrollAlpha.isZero {
             shrinkLocationView(barPosition: barPosition, isKeyboardVisible: isKeyboardVisible)
         } else {
@@ -723,17 +681,8 @@ final class LocationView: UIView,
         let colors = theme.colors
 
         let mainBackgroundColor = hasAlternativeLocationColor ? colors.layerSurfaceMediumAlt : colors.layerSurfaceMedium
-        if #available(iOS 26.0, *), scrollAlpha.isZero, config?.shouldShowKeyboard == false {
-            // We want to use system colors when the location view is fully transparent
-            // To make sure it blends well with the background when using glass effect.
-            urlTextFieldColor =  .label
-            urlTextFieldSubdomainColor = .systemGray
-            lockIconButton.tintColor = .systemGray
-        } else {
-            urlTextFieldColor = colors.textPrimary
-            urlTextFieldSubdomainColor = colors.textSecondary
-            lockIconButton.tintColor = colors.textSecondary
-        }
+        urlTextFieldColor = colors.textPrimary
+        urlTextFieldSubdomainColor = colors.textSecondary
         gradientLayer.colors = Gradient(
             colors: [
                 mainBackgroundColor.withAlphaComponent(1),
@@ -749,6 +698,7 @@ final class LocationView: UIView,
         )
 
         safeListedURLImageColor = colors.iconAccentBlue
+        lockIconButton.tintColor = colors.textSecondary
         lockIconImageColor = colors.textSecondary
 
         setLockIconImage()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -702,17 +702,6 @@ class BrowserViewController: UIViewController,
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         let isKeyboardShowing = keyboardState != nil
 
-        var isToolbarCollapsed: Bool {
-            guard #available(iOS 26.0, *) else { return false }
-            switch scrollController {
-            case let legacy as LegacyTabScrollController:
-                return legacy.toolbarState == .collapsed
-            case let handler as TabScrollHandler:
-                return handler.toolbarDisplayState.isCollapsed
-            default: return false
-            }
-        }
-
         if isBottomSearchBar {
             header.isClearBackground = false
 
@@ -729,8 +718,7 @@ class BrowserViewController: UIViewController,
         }
 
         bottomContainer.isClearBackground = showNavToolbar && enableBlur
-        bottomBlurView.isHidden = (!showNavToolbar && !isBottomSearchBar && enableBlur) || isToolbarCollapsed
-        bottomContainer.isHidden = isToolbarCollapsed
+        bottomBlurView.isHidden = !showNavToolbar && !isBottomSearchBar && enableBlur
 
         let maskView = UIView(frame: CGRect(x: 0,
                                             y: -contentContainer.frame.origin.y,

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -37,7 +37,7 @@ final class LegacyTabScrollController: NSObject,
     }
 
     private var isMinimalAddressBarEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.toolbarMinimalAddressBar, checking: .buildAndUser)
+        return featureFlags.isFeatureEnabled(.toolbarMinimalAddressBar, checking: .buildOnly)
     }
 
     enum ScrollDirection {
@@ -167,12 +167,8 @@ final class LegacyTabScrollController: NSObject,
         // Devices with home indicator (newer iPhones) vs physical home button (older iPhones).
         let hasHomeIndicator = safeAreaInsets?.bottom ?? .zero > 0
         let topInset = safeAreaInsets?.top ?? .zero
-        let containerHeightAdjusted: CGFloat = if #available(iOS 26.0, *) {
-            .zero
-        } else {
-            hasHomeIndicator ? .zero : containerHeight - topInset
-        }
-        return containerHeightAdjusted
+
+        return hasHomeIndicator ? .zero : containerHeight - topInset
     }
 
     private var overKeyboardScrollHeight: CGFloat {
@@ -589,7 +585,7 @@ private extension LegacyTabScrollController {
     /// - Parameter delta: The amount by which to scroll, where a positive delta scrolls down and
     ///   a negative delta scrolls up.
     func scrollWithDelta(_ delta: CGFloat) {
-        guard isMinimalAddressBarEnabled, hasScrollableContent else { return }
+        guard hasScrollableContent else { return }
 
         let updatedOffset = headerTopOffset - delta
         headerTopOffset = clamp(offset: updatedOffset, min: headerOffset, max: 0)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -42,7 +42,11 @@ final class ToolbarHelper: ToolbarHelperInterface {
     @MainActor
     var glassEffectAlpha: CGFloat {
         guard shouldBlur() else { return 1 }
+        #if canImport(FoundationModels)
         if #available(iOS 26, *) { return .zero } else { return UX.backgroundAlphaForBlur }
+        #else
+            return UX.backgroundAlphaForBlur
+        #endif
     }
 
     func shouldShowNavigationToolbar(for traitCollection: UITraitCollection) -> Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
@@ -182,7 +182,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
             isBottomSearchBar: true
         )
 
-        let expectedResult: CGFloat = if #available(iOS 26.0, *) { .zero } else { containerHeight - topInset }
+        let expectedResult = containerHeight - topInset
         XCTAssertEqual(result, expectedResult)
     }
 
@@ -213,8 +213,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
             isBottomSearchBar: true
         )
 
-        let expectedResult: CGFloat = if #available(iOS 26.0, *) { .zero } else { containerHeight }
-        XCTAssertEqual(result, expectedResult)
+        XCTAssertEqual(result, containerHeight)
     }
 
     func testOverKeyboardScrollHeight_zeroSafeAreaInsets_returnsContainerHeight() {
@@ -228,8 +227,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
             isBottomSearchBar: true
         )
 
-        let expectedResult: CGFloat = if #available(iOS 26.0, *) { .zero } else { containerHeight }
-        XCTAssertEqual(result, expectedResult)
+        XCTAssertEqual(result, containerHeight)
     }
 
     func testOverKeyboardScrollHeight_minimalEnabledIsNotBottomSearchBar_returnsContainerHeight() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14239)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30840)

## :bulb: Description
This reverts "Refactor - FXIOS-14105 -  [Minimal Address Bar] - Update To The New Design (#30581)" (commit 809ba24da3313472c4e61a585f939c1885e47981).

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

