### PR TITLE
Bugfix FXIOS-14291 [Unit Tests] apple intelligence test to run only for iOS 26

### DIFF
--- a/BrowserKit/Tests/SummarizeKitTests/SummarizeServiceFactoryTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/SummarizeServiceFactoryTests.swift
@@ -35,8 +35,12 @@ final class SummarizeServiceFactoryTests: XCTestCase {
         serviceLifecycle = nil
         super.tearDown()
     }
+
     #if canImport(FoundationModels)
     func test_make_whenAppleIntelligenceAvailable() throws {
+        guard #available(iOS 26, *) else {
+            throw XCTSkip("Skipping iOS 26-only test on earlier OS versions")
+        }
         let subject = createSubject()
 
         let result = subject.make(isAppleSummarizerEnabled: true, isHostedSummarizerEnabled: false, config: nil)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14291)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30945)

## :bulb: Description
Fix test that was failing on iOS 18.6, per this report: https://storage.googleapis.com/mobile-reports/public/firefox-ios-M4/firefox-ios-unit-tests/result_11/build/reports/index.html

We fix this by skipping the test unless we are running tests for iOS 26.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

