### PR TITLE
Bugfix FXIOS-14239 - The X button does not clear text in address bar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -464,7 +464,7 @@ final class LocationView: UIView,
         guard scrollAlpha != alpha else { return }
         scrollAlpha = alpha
         if #available(iOS 26.0, *) {
-            effectView.effect = scrollAlpha.isZero && barPosition == .bottom ? glassEffect : nil
+            effectView.effect = scrollAlpha.isZero && barPosition == .bottom && !isKeyboardVisible ? glassEffect : nil
         }
         if scrollAlpha.isZero {
             shrinkLocationView(barPosition: barPosition, isKeyboardVisible: isKeyboardVisible)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14239)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30840)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Fix constraint issue and show the glass effect based on toolbar position and `scrollAlpha` property.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

