### PR TITLE
Refactor FXIOS-14061 [Tabs Optimization] Remove each tab without persisting changes

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -211,13 +211,6 @@ class TabManagerImplementation: NSObject,
         guard let index = tabs.firstIndex(where: { $0.tabUUID == tabUUID }) else { return }
 
         let tab = tabs[index]
-        tab.cancelDocumentDownload()
-
-        backupCloseTab = BackupCloseTab(
-            tab: tab,
-            restorePosition: index,
-            isSelected: selectedTab?.tabUUID == tab.tabUUID)
-
         self.removeTab(tab, flushToDisk: true)
         self.updateSelectedTabAfterRemovalOf(tab, deletedIndex: index)
     }
@@ -296,6 +289,7 @@ class TabManagerImplementation: NSObject,
             saveSessionData(forTab: tab)
         }
 
+        tab.cancelDocumentDownload()
         backupCloseTab = BackupCloseTab(tab: tab,
                                         restorePosition: removalIndex,
                                         isSelected: selectedTab?.tabUUID == tab.tabUUID)
@@ -345,10 +339,15 @@ class TabManagerImplementation: NSObject,
 
         guard !tabsToRemove.isEmpty else { return }
 
+        let selectedTab = selectedTab
         for tab in tabsToRemove {
             // Remove each tab without persisting changes
             removeTab(tab, flushToDisk: false)
         }
+        // We need to reselect the tab and adjust the selected index after tabs removal.
+        // The selected tab will not be removed with `removeNormalTabsOlderThan` since it's
+        // `lastExecutedTime` won't be less than the `cutoffDate`.
+        selectTab(selectedTab)
         commitChanges()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -1620,6 +1620,46 @@ class TabManagerTests: XCTestCase {
         XCTAssertEqual(tabManager.normalTabs.count, numberTabs)
     }
 
+    @MainActor
+    func testRemoveNormalsTabsOlderThan_whenSelectedTabIsInTheMiddle_thenOrderIsProper() {
+        let inactiveTabs1 = generateTabs(ofType: .normalInactive2Weeks, count: 10)
+        let normalTabs = generateTabs(ofType: .normalActive, count: 3)
+        let inactiveTabs2 = generateTabs(ofType: .normalInactive2Weeks, count: 10)
+        let tabManager = createSubject(tabs: inactiveTabs1 + normalTabs + inactiveTabs2)
+        tabManager.selectTab(normalTabs[safe: 0])
+
+        tabManager.removeNormalTabsOlderThan(period: .oneDay, currentDate: testDate)
+
+        XCTAssertEqual(tabManager.normalTabs.count, 3)
+        XCTAssertEqual(tabManager.selectedIndex, 0)
+    }
+
+    @MainActor
+    func testRemoveNormalsTabsOlderThan_whenSelectedTabIsLast_thenOrderIsProper() {
+        let inactiveTabs1 = generateTabs(ofType: .normalInactive2Weeks, count: 10)
+        let normalTabs = generateTabs(ofType: .normalActive, count: 3)
+        let tabManager = createSubject(tabs: inactiveTabs1 + normalTabs)
+        tabManager.selectTab(normalTabs[safe: 2])
+
+        tabManager.removeNormalTabsOlderThan(period: .oneDay, currentDate: testDate)
+
+        XCTAssertEqual(tabManager.normalTabs.count, 3)
+        XCTAssertEqual(tabManager.selectedIndex, 2)
+    }
+
+    @MainActor
+    func testRemoveNormalsTabsOlderThan_whenSelectedTabIsFirst_thenOrderIsProper() {
+        let inactiveTabs1 = generateTabs(ofType: .normalInactive2Weeks, count: 10)
+        let normalTabs = generateTabs(ofType: .normalActive, count: 3)
+        let tabManager = createSubject(tabs: normalTabs + inactiveTabs1)
+        tabManager.selectTab(normalTabs[safe: 0])
+
+        tabManager.removeNormalTabsOlderThan(period: .oneDay, currentDate: testDate)
+
+        XCTAssertEqual(tabManager.normalTabs.count, 3)
+        XCTAssertEqual(tabManager.selectedIndex, 0)
+    }
+
     // MARK: - removeAllInactiveTabs (removing unselected tabs at array bounds)
 
     @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14061)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30492)

## :bulb: Description
Had a look into `removeTabsOlderThan` and since that function [is simpler than `removeAllTabs`](https://github.com/mozilla-mobile/firefox-ios/pull/29911), I think we can get away with this slight change to improve performance. 

### Performance
Measured with 250 tabs:
- **Before:** 22733.88 ms (22.73 seconds)
- **After:** 72.90 ms

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

