### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix strict concurrency error in NotificationService

### DIFF
--- a/firefox-ios/Extensions/NotificationService/NotificationService.swift
+++ b/firefox-ios/Extensions/NotificationService/NotificationService.swift
@@ -8,7 +8,8 @@ import Shared
 import UserNotifications
 import MozillaAppServices
 
-class NotificationService: UNNotificationServiceExtension {
+// FIXME: FXIOS-14295 Make NotificationService thread safe
+class NotificationService: UNNotificationServiceExtension, @unchecked Sendable {
     var display: SyncDataDisplay?
     var profile: BrowserProfile?
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description

Guess I have to add this `sending` back after all @Cramsden... it fixes this warning:
<img width="1433" height="277" alt="Screenshot 2025-11-26 at 2 15 39 PM" src="https://github.com/user-attachments/assets/5850dce6-d275-40c2-9b8d-105d834255f2" />

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code