### PR TITLE
Bugfix FXIOS-14135 ⁃ Website showing as not secure while it is loading

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2492,7 +2492,7 @@ class BrowserViewController: UIViewController,
         tab.url = url
 
         if tab === tabManager.selectedTab {
-            updateUIForReaderHomeStateForTab(tab)
+            updateUIForReaderHomeStateForTab(tab, shouldShowLockIcon: true)
         }
         // Catch history pushState navigation, but ONLY for same origin navigation,
         // for reasons above about URL spoofing risk.
@@ -2555,8 +2555,8 @@ class BrowserViewController: UIViewController,
 
     // MARK: - Update UI
 
-    func updateUIForReaderHomeStateForTab(_ tab: Tab, focusUrlBar: Bool = false) {
-        updateURLBarDisplayURL(tab)
+    func updateUIForReaderHomeStateForTab(_ tab: Tab, focusUrlBar: Bool = false, shouldShowLockIcon: Bool = false) {
+        updateURLBarDisplayURL(tab, shouldShowLockIcon)
         scrollController.showToolbars(animated: false)
 
         if let url = tab.url {
@@ -2590,7 +2590,7 @@ class BrowserViewController: UIViewController,
 
     /// Updates the URL bar text and button states.
     /// Call this whenever the page URL changes.
-    func updateURLBarDisplayURL(_ tab: Tab, _ navigationFinished: Bool = false) {
+    func updateURLBarDisplayURL(_ tab: Tab, _ shouldShowLockIcon: Bool = false) {
         var safeListedURLImageName: String? {
             return (tab.contentBlocker?.status == .safelisted) ?
             StandardImageIdentifiers.Small.notificationDotFill : nil
@@ -2605,7 +2605,7 @@ class BrowserViewController: UIViewController,
                 StandardImageIdentifiers.Small.shieldSlashFillMulticolor
             lockIconNeedsTheming = hasSecureContent
             let isWebsiteMode = tab.url?.isReaderModeURL == false
-            lockIconImageName = isWebsiteMode && navigationFinished ? lockIconImageName : nil
+            lockIconImageName = isWebsiteMode && shouldShowLockIcon ? lockIconImageName : nil
         }
 
         let action = ToolbarAction(
@@ -3463,6 +3463,9 @@ class BrowserViewController: UIViewController,
             TabEvent.post(.didChangeURL(url), for: tab)
         }
 
+        if tab == tabManager.selectedTab {
+            updateURLBarDisplayURL(tab, true)
+        }
         if webViewStatus == .finishedNavigation {
             let isSelectedTab = (tab == tabManager.selectedTab)
             let isStoriesFeed = store.state.screenState(StoriesFeedState.self, for: .storiesFeed, window: windowUUID) != nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14135)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30651)

## :bulb: Description
Display lock icon when navigate in tab

## :movie_camera: Demos

https://github.com/user-attachments/assets/22cc4963-2144-45cb-b438-be0afcc260a4



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

