### PR TITLE
Bugfix FXIOS-14218 [New onboarding experience] [iPad] Skip button is displayed too high

### DIFF
--- a/BrowserKit/Sources/OnboardingKit/Views/Regular/OnboardingViewRegular.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Regular/OnboardingViewRegular.swift
@@ -45,6 +45,7 @@ struct OnboardingViewRegular<ViewModel: OnboardingCardInfoModelProtocol>: Themea
                 Text(viewModel.skipText)
                     .font(FXFontStyles.Bold.body.scaledSwiftUIFont(sizeCap: UX.Onboarding.Font.skipButtonSizeCap))
             }
+            .padding(.top, UX.Onboarding.Spacing.standard)
             .padding(.trailing, UX.Onboarding.Spacing.standard)
             .skipButtonStyle(theme: theme)
             .accessibilityLabel(viewModel.skipText)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14218)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30805)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Update top padding for `Skip` button.
<img height="500" alt="Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-11-27 at 16 02 27" src="https://github.com/user-attachments/assets/477036b2-4c53-43cd-aae4-9c8acd4cd2f5" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

