### PR TITLE
Refactor EXP-5874 [Nimbus] Split "Run Studies" into "Feature Studies" + "Remote Improvments"

### DIFF
--- a/BrowserKit/Sources/Common/Constants/AppConstants.swift
+++ b/BrowserKit/Sources/Common/Constants/AppConstants.swift
@@ -40,6 +40,7 @@ public final class AppConstants {
     public static let prefSendCrashReports = "settings.sendCrashReports"
     public static let prefSendDailyUsagePing = "settings.sendDailyUsagePing"
     public static let prefStudiesToggle = "settings.studiesToggle"
+    public static let prefRolloutsToggle = "settings.rolloutsToggle"
 
     /// Build Channel.
     public static let buildChannel: AppBuildChannel = {

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -634,10 +634,12 @@ struct AccessibilityIdentifiers {
             static let sendCrashReportsTitle = "SendCrashReports"
             static let sendDailyUsagePingTitle = "SendDailyUsagePing"
             static let studiesTitle = "StudiesToggle"
+            static let rolloutsTitle = "RolloutsToggle"
             static let sendTechnicalDataLearnMoreButton = "SendTechnicalDataLearnMoreButton"
             static let sendCrashReportsLearnMoreButton = "SendCrashReportsLearnMoreButton"
             static let sendDailyUsagePingLearnMoreButton = "SendDailyUsagePingLearnMoreButton"
             static let studiesLearnMoreButton = "StudiesLearnMoreButton"
+            static let rolloutsLearnMoreButton = "RolloutsLearnMoreButton"
         }
 
         struct PrivacyPolicy {

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -56,10 +56,11 @@ enum Experiments {
     // TODO: FXIOS-12587 This global property is not concurrency safe
     nonisolated(unsafe) private static var studiesSetting: Bool?
     nonisolated(unsafe) private static var telemetrySetting: Bool?
+    nonisolated(unsafe) private static var rolloutsSetting: Bool?
 
     static func setStudiesSetting(_ setting: Bool) {
         studiesSetting = setting
-        updateUserParticipation()
+        updateExperimentParticipation()
     }
 
     static func setTelemetrySetting(_ setting: Bool) {
@@ -67,19 +68,29 @@ enum Experiments {
         if !setting {
             shared.resetTelemetryIdentifiers()
         }
-        updateUserParticipation()
+        updateExperimentParticipation()
     }
 
-    private static func updateUserParticipation() {
-        // we only want to reset the participation flags if both settings have been
+    static func setRolloutsSetting(_ setting: Bool) {
+        rolloutsSetting = setting
+        updateRolloutParticipation()
+    }
+
+    private static func updateExperimentParticipation() {
+        // we only want to reset the experiment participation flag if both settings have been
         // initialized.
         if let studiesSetting = studiesSetting, let telemetrySetting = telemetrySetting {
-            // we only enable experiments and rollouts if users are opting in BOTH
+            // we only enable experiments if users are opting in BOTH
             // telemetry and studies. If either is opted-out, we make
-            // sure users are not enrolled in any experiments or rollouts
-            let participationEnabled = studiesSetting && telemetrySetting
-            shared.experimentParticipation = participationEnabled
-            shared.rolloutParticipation = participationEnabled
+            // sure users are not enrolled in any experiments
+            shared.experimentParticipation = studiesSetting && telemetrySetting
+        }
+    }
+
+    private static func updateRolloutParticipation() {
+        // Rollout participation is controlled independently by its own toggle
+        if let rolloutsSetting = rolloutsSetting {
+            shared.rolloutParticipation = rolloutsSetting
         }
     }
 

--- a/focus-ios/Blockzilla/Settings/Controller/SettingsViewController.swift
+++ b/focus-ios/Blockzilla/Settings/Controller/SettingsViewController.swift
@@ -14,7 +14,7 @@ import DesignSystem
 
 final class SettingsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
     enum Section: String {
-        case defaultBrowser, general, privacy, usageData, crashReports, studies, dailyUsagePing, search, siri, integration, mozilla, secret
+        case defaultBrowser, general, privacy, usageData, crashReports, studies, rollouts, dailyUsagePing, search, siri, integration, mozilla, secret
 
         var headerText: String? {
             switch self {
@@ -23,6 +23,7 @@ final class SettingsViewController: UIViewController, UITableViewDataSource, UIT
             case .privacy: return UIConstants.strings.toggleSectionPrivacy
             case .usageData: return nil
             case .studies: return nil
+            case .rollouts: return nil
             case .search: return UIConstants.strings.settingsSearchTitle
             case .siri: return UIConstants.strings.siriShortcutsTitle
             case .integration: return UIConstants.strings.toggleSectionSafari
@@ -45,6 +46,7 @@ final class SettingsViewController: UIViewController, UITableViewDataSource, UIT
             }
 
             sections.append(contentsOf: [
+                .rollouts,
                 .dailyUsagePing,
                 .crashReports,
                 .search,
@@ -126,6 +128,8 @@ final class SettingsViewController: UIViewController, UITableViewDataSource, UIT
         let blockFontsToggle = BlockerToggle(label: UIConstants.strings.labelBlockFonts, setting: SettingsToggle.blockFonts)
         let studiesSubtitle = String(format: UIConstants.strings.detailTextStudies, AppInfo.productName)
         let studiesToggle = BlockerToggle(label: UIConstants.strings.labelStudies, setting: SettingsToggle.studies, subtitle: studiesSubtitle)
+        let rolloutsSubtitle = String(format: UIConstants.strings.detailTextRollouts, AppInfo.productName)
+        let rolloutsToggle = BlockerToggle(label: UIConstants.strings.labelRollouts, setting: SettingsToggle.rollouts, subtitle: rolloutsSubtitle)
         let usageDataSubtitle = String(format: UIConstants.strings.detailTextSendUsageData, AppInfo.productName)
         let usageDataToggle = BlockerToggle(label: UIConstants.strings.labelSendAnonymousUsageData, setting: SettingsToggle.sendAnonymousUsageData, subtitle: usageDataSubtitle)
         let crashToggle = BlockerToggle(
@@ -155,6 +159,9 @@ final class SettingsViewController: UIViewController, UITableViewDataSource, UIT
         }
         if let studiesIndex = getSectionIndex(Section.studies) {
             toggles[studiesIndex] = [0: studiesToggle]
+        }
+        if let rolloutsIndex = getSectionIndex(Section.rollouts) {
+            toggles[rolloutsIndex] = [0: rolloutsToggle]
         }
         if let dailyUsageIndex = getSectionIndex(.dailyUsagePing) {
             toggles[dailyUsageIndex] = [0: dailyUsageToggle]
@@ -342,6 +349,8 @@ final class SettingsViewController: UIViewController, UITableViewDataSource, UIT
             cell = setupToggleCell(indexPath: indexPath, navigationController: navigationController)
         case .studies:
             cell = setupToggleCell(indexPath: indexPath, navigationController: navigationController)
+        case .rollouts:
+            cell = setupToggleCell(indexPath: indexPath, navigationController: navigationController)
         case .search:
             if indexPath.row < 2 {
                 let searchCell = SettingsTableViewAccessoryCell(style: .value1, reuseIdentifier: "accessoryCell")
@@ -422,6 +431,7 @@ final class SettingsViewController: UIViewController, UITableViewDataSource, UIT
             return 2
         case .usageData: return 1
         case .studies: return 1
+        case .rollouts: return 1
         case .search: return 3
         case .siri: return 3
         case .integration: return 1
@@ -455,6 +465,7 @@ final class SettingsViewController: UIViewController, UITableViewDataSource, UIT
                 (getSectionIndex(.usageData), #selector(tappedLearnMoreFooter)),
                 (getSectionIndex(.search), #selector(tappedLearnMoreSearchSuggestionsFooter)),
                 (getSectionIndex(.studies), #selector(tappedLearnMoreStudies)),
+                (getSectionIndex(.rollouts), #selector(tappedLearnMoreRollouts)),
                 (getSectionIndex(.crashReports), #selector(tappedLearnMoreCrashReports)),
                 (getSectionIndex(.dailyUsagePing), #selector(tappedLearnMoreDailyUsagePing))
             ]
@@ -581,6 +592,11 @@ final class SettingsViewController: UIViewController, UITableViewDataSource, UIT
     }
 
     @objc
+    func tappedLearnMoreRollouts(gestureRecognizer: UIGestureRecognizer) {
+        tappedFooter(forSupportTopic: .rollouts)
+    }
+
+    @objc
     func tappedLearnMoreCrashReports() {
         tappedFooter(forSupportTopic: .mobileCrashReports)
     }
@@ -621,7 +637,6 @@ final class SettingsViewController: UIViewController, UITableViewDataSource, UIT
             sender.isEnabled = false
             sender.alpha = 0.5
             NimbusWrapper.shared.nimbus.experimentParticipation = false
-            NimbusWrapper.shared.nimbus.rolloutParticipation = false
             updateSetting(false, forToggle: .studies)
         }
 
@@ -659,10 +674,12 @@ final class SettingsViewController: UIViewController, UITableViewDataSource, UIT
             // Ensure 'studies' is disabled if 'sendAnonymousUsageData' is turned off, even when 'studies' is being enabled.
             if sendAnonymousUsageDataToggle?.isOn == true {
                 NimbusWrapper.shared.nimbus.experimentParticipation = sender.isOn
-                NimbusWrapper.shared.nimbus.rolloutParticipation = sender.isOn
             } else {
                 disableAndTurnOffStudiesToggle(sender)
             }
+        } else if toggle.setting == .rollouts {
+            // Rollouts have their own independent toggle
+            NimbusWrapper.shared.nimbus.rolloutParticipation = sender.isOn
         } else if toggle.setting == .biometricLogin {
             TipManager.biometricTip = false
         } else if toggle.setting == .dailyUsagePing {

--- a/focus-ios/Blockzilla/Utilities/SupportUtils.swift
+++ b/focus-ios/Blockzilla/Utilities/SupportUtils.swift
@@ -8,6 +8,7 @@ public enum SupportTopic: CaseIterable {
     case searchSuggestions
     case usageData
     case studies
+    case rollouts
     case autofillDomain
     case trackingProtection
     case addSearchEngine
@@ -22,6 +23,8 @@ public enum SupportTopic: CaseIterable {
             return "usage-data"
         case .studies:
             return "studies-focus-ios"
+        case .rollouts:
+            return "remote-improvements"
         case .autofillDomain:
             return "autofill-domain-ios"
         case .trackingProtection:

--- a/focus-ios/Shared/Settings.swift
+++ b/focus-ios/Shared/Settings.swift
@@ -17,6 +17,7 @@ enum SettingsToggle: String, Equatable {
     case sendAnonymousUsageData = "SendAnonymousUsageData"
     case dailyUsagePing = "DailyUsagePing"
     case studies = "Studies"
+    case rollouts = "Rollouts"
     case crashToggle = "CrashToggle"
     case enableDomainAutocomplete = "enableDomainAutocomplete"
     case enableCustomDomainAutocomplete = "enableCustomDomainAutocomplete"
@@ -62,6 +63,7 @@ struct Settings {
         case .safari: return true
         case .sendAnonymousUsageData: return AppInfo.isKlar ? false : true
         case .studies: return AppInfo.isKlar ? false : true
+        case .rollouts: return AppInfo.isKlar ? false : true
         case .enableDomainAutocomplete: return true
         case .enableCustomDomainAutocomplete: return true
         case .enableSearchSuggestions: return false


### PR DESCRIPTION
We want to separate "Run Studies" into "Feature Studies" and "Remote Improvements", to give the users more choice in either participating in studies and/or improvements. So far, if they don't participate in studies, they don't get to access experiments.

This builds on top of the underlying change in the Nimbus SDK, which was introduced in this commit:
https://github.com/mozilla-mobile/firefox-ios/commit/eb2292d0325acd7f76a743c253763a0fa959e362

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-5874)
[Bugzilla issue](https://bugzilla.mozilla.org/show_bug.cgi?id=2002871)

## :bulb: Description

| Before | After |
| - | - |
| <img width="568" height="1084" alt="Screenshot 2025-11-27 at 15 28 58" src="https://github.com/user-attachments/assets/e47eab83-3412-4430-bc7a-1d0a41f6aaeb" /> | <img width="568" height="1084" alt="Screenshot 2025-11-28 at 09 13 35" src="https://github.com/user-attachments/assets/0202dbe0-218f-48bc-bacf-6cb539d0b9d8" /> |

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

