### PR TITLE
Add FXIOS-14311 [Translations] Logs around fetched models for debugging

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
@@ -88,14 +88,19 @@ final class ASTranslationModelsFetcher: TranslationModelsFetcherProtocol, Sendab
                 fields.version == Constants.translatorVersion
         }
 
+        guard let record = matchingRecord else {
+            logger.log("No matching translator found", level: .warning, category: .translations)
+            return nil
+        }
+
         logger.log(
             "Translator record selected",
             level: .info,
             category: .translations,
-            extra: ["recordId": "\(record.id)"]
+            extra: ["recordId": record.id]
         )
 
-        return matchingRecord.flatMap { record in try? translatorsClient?.getAttachment(record: record) }
+        return try? translatorsClient?.getAttachment(record: record)
     }
 
     /// Fetches the translation model files for a given language pair matching the pinned version.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14311)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30989)

## :bulb: Description
We are seeing occasional weirdness around translations and our best guess right now is that somehow we end up using mismatched vocab, model and/or tokenizers. Adding logs here to see exactly what we end up using. I am logging the id since we can back track everything from it ( and not pollute our logs )

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

