### PR TITLE
Remove FXIOS-12960 [DeferredUtils] MonadicDo precedence & >>> operator

### DIFF
--- a/BrowserKit/Sources/Shared/DeferredUtils.swift
+++ b/BrowserKit/Sources/Shared/DeferredUtils.swift
@@ -4,32 +4,6 @@
 
 import Foundation
 
-precedencegroup MonadicDoPrecedence {
-    associativity: left
-    higherThan: MultiplicationPrecedence
-}
-
-infix operator >>> : MonadicDoPrecedence
-// Monadic `do` for Deferred.
-@discardableResult
-public func >>> <T, U>(x: Deferred<Maybe<T>>, f: @escaping @Sendable () -> Deferred<Maybe<U>>) -> Deferred<Maybe<U>> {
-    return x.bind { res in
-        if res.isSuccess {
-            return f()
-        }
-        return deferMaybe(res.failureValue!)
-    }
-}
-
-// Another termination case.
-public func >>> <T>(x: Deferred<Maybe<T>>, f: @escaping @Sendable () -> Void) {
-    return x.upon { res in
-        if res.isSuccess {
-            f()
-        }
-    }
-}
-
 public func deferMaybe<T>(_ s: T) -> Deferred<Maybe<T>> {
     return Deferred(value: Maybe(success: s))
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12960)

## :bulb: Description
Removed the custom MonadicDo precedence group and >>> operator overloads from DeferredUtils, leaving the remaining Deferred helper utilities intact.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

