### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix Swift 6 errors in Client unit tests for `AddressListViewModelTests`

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
@@ -72,8 +72,8 @@ final class AddressListViewModelTests: XCTestCase {
         )
     ]
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         mockProfile = MockProfile()
         mockLogger = MockLogger()
         mockAutofill = MockAutofill()
@@ -87,11 +87,11 @@ final class AddressListViewModelTests: XCTestCase {
         )
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         viewModel = nil
         mockProfile = nil
         mockLogger = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testFetchAddressesSuccess() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27966)

## :bulb: Description
- Fix Swift 6 errors in Client unit tests for `AddressListViewModelTests`

<img width="1442" height="663" alt="Screenshot 2025-11-28 at 4 17 30 PM" src="https://github.com/user-attachments/assets/dcb8e81f-f5cd-4e43-ba87-ea8a28533831" />

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)