### PR TITLE
Refactor FXIOS-12796 [Swift 6 Migration] Fix Swift 6 errors in Client unit tests for `setUp` and `tearDown` - Batch 1

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -11,16 +11,16 @@ import SummarizeKit
 final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
     let storeUtilityHelper = StoreTestUtilityHelper()
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         DependencyHelperMock().reset()
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testAddNewTabAction() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -22,8 +22,8 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
     var appState: AppState!
     var recordVisitManager: MockRecordVisitObservationManager!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         setIsSwipingTabsEnabled(false)
         setIsHostedSummarizerEnabled(false)
         tabManager = MockTabManager()
@@ -37,7 +37,7 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         profile.shutdown()
         profile = nil
         tabManager = nil
@@ -45,7 +45,7 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         recordVisitManager = nil
         resetStore()
         DependencyHelperMock().reset()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testTrackVisibleSuggestion() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CanRemoveQuickActionBookmarkTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CanRemoveQuickActionBookmarkTests.swift
@@ -13,12 +13,11 @@ class CanRemoveQuickActionBookmarkTests: XCTestCase {
     private var mockBookmarksHandler: BookmarksHandlerMock!
     private var mockQuickActions: MockQuickActions!
 
-    @MainActor
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         mockQuickActions = MockQuickActions()
         mockBookmarksHandler = BookmarksHandlerMock()
-        subject = MockCanRemoveQuickActionBookmark(bookmarksHandler: mockBookmarksHandler)
+        subject = await MockCanRemoveQuickActionBookmark(bookmarksHandler: mockBookmarksHandler)
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
@@ -8,10 +8,9 @@ import XCTest
 final class DefaultRouterTests: XCTestCase {
     var navigationController: MockNavigationController!
 
-    @MainActor
-    override func setUp() {
-        super.setUp()
-        navigationController = MockNavigationController()
+    override func setUp() async throws {
+        try await super.setUp()
+        navigationController = await MockNavigationController()
     }
 
     override func tearDown() {
@@ -53,6 +52,7 @@ final class DefaultRouterTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
+    @MainActor
     func testRunCompletion_DoesNotRunForNonExistingCompletion() {
         let subject = DefaultRouter(navigationController: navigationController)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
@@ -14,8 +14,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
     private var mockProfile: MockProfile!
     private var mockStore: MockStoreForMiddleware<AppState>!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         mockProfile = MockProfile()
         mockTabManager = MockTabManager()
         mockWindowManager = MockWindowManager(
@@ -30,14 +30,15 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockProfile = nil
         mockWindowManager = nil
         mockSummarizationChecker = nil
         DependencyHelperMock().reset()
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
+
     // TODO(FXIOS-13126): Fix and uncomment this test
 //    func test_shakeMotionAction_withFeatureFlagEnabled_dispatchesMiddlewareAction() throws {
 //        setupNimbusHostedSummarizerTesting(isEnabled: true)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
@@ -8,6 +8,7 @@ import Common
 
 @testable import Client
 
+@MainActor
 class AccountSyncHandlerTests: XCTestCase {
     private var profile: MockProfile!
     private var syncManager: ClientSyncManagerSpy!
@@ -15,9 +16,8 @@ class AccountSyncHandlerTests: XCTestCase {
     private var mockWindowManager: MockWindowManager!
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
-    @MainActor
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         self.profile = MockProfile()
         self.syncManager = profile.syncManager as? ClientSyncManagerSpy
         self.queue = MockDispatchQueue()
@@ -33,16 +33,15 @@ class AccountSyncHandlerTests: XCTestCase {
         )
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         self.syncManager = nil
         self.profile = nil
         self.queue = nil
         self.mockWindowManager = nil
         DependencyHelperMock().reset()
-        super.tearDown()
+        try await super.tearDown()
     }
 
-    @MainActor
     func testTabDidGainFocus_doesntSyncWithoutAccount() {
         let expectation = XCTestExpectation(description: "sync is not called without an account")
         expectation.isInverted = true
@@ -57,7 +56,6 @@ class AccountSyncHandlerTests: XCTestCase {
         XCTAssertEqual(profile.storeAndSyncTabsCalled, 0)
     }
 
-    @MainActor
     func testTabDidGainFocus_syncWithAccount() {
         let expectation = XCTestExpectation(description: "storeAndSyncTabs called after listed time of tab gaining focus")
         let subject = AccountSyncHandler(with: profile, debounceTime: 0.1, queue: queue, queueDelay: 0.1, onSyncCompleted: {
@@ -70,7 +68,6 @@ class AccountSyncHandlerTests: XCTestCase {
         XCTAssertEqual(profile.storeAndSyncTabsCalled, 1)
     }
 
-    @MainActor
     func testTabDidGainFocus_multipleActions_executedAtMostOnce() {
         let expectation = XCTestExpectation(
             description: "storeAndSyncTabs only called once from multiple tab actions")
@@ -87,7 +84,6 @@ class AccountSyncHandlerTests: XCTestCase {
         XCTAssertEqual(profile.storeAndSyncTabsCalled, 1)
     }
 
-    @MainActor
     func testTabDidGainFocus_multipleDebounce_withWithMultipleSyncs() {
         let expectation = XCTestExpectation(
             description: "storeAndSyncTabs called multiple times if outside of debounce time")
@@ -111,7 +107,6 @@ class AccountSyncHandlerTests: XCTestCase {
 
 // MARK: - Helper methods
 private extension AccountSyncHandlerTests {
-    @MainActor
     func createTab(profile: MockProfile,
                    urlString: String? = "www.website.com") -> Tab {
         let tab = Tab(profile: profile, windowUUID: windowUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -15,9 +15,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
     private var mockStore: MockStoreForMiddleware<AppState>!
     private var appState: AppState!
 
-    @MainActor
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         setIsHostedSummaryEnabled(false)
         mockProfile = MockProfile()
@@ -34,13 +33,13 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockProfile = nil
         mockWindowManager = nil
         summarizationChecker = nil
         DependencyHelperMock().reset()
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_screenshotAction_triggersRefresh() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -12,13 +12,12 @@ final class AddressToolbarContainerModelTests: XCTestCase {
     private var searchEnginesManager: SearchEnginesManagerProvider!
     private let windowUUID: WindowUUID = .XCTestDefaultUUID
 
-    @MainActor
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
 
         mockProfile = MockProfile()
-        searchEnginesManager = SearchEnginesManager(
+        searchEnginesManager = await SearchEnginesManager(
             prefs: mockProfile.prefs,
             files: mockProfile.files,
             engineProvider: MockSearchEngineProvider()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27871)

## :bulb: Description

- Fix common setUp and tearDown warnings across multiple files. There are errors in the Swift 6 language mode.
   - See Nov 28 pinned slack note in the migration channel for how to fix these
- Switch to async-await version of `setUp() async throws` to get `@MainActor` conformance as XCTestCase class has nonisolated `setup()`
- Likewise for `tearDown() async throws`

## setUp warnings
<img width="1442" height="663" alt="setup warnings 2" src="https://github.com/user-attachments/assets/7e558981-97a8-4378-aa10-bcc3ce779734" />

### tearDown warnings

<img width="1427" height="373" alt="Screenshot 2025-11-28 at 4 34 15 PM" src="https://github.com/user-attachments/assets/c6bd2f72-5d09-4cde-a89d-b784ef2263cf" />

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If needed, I added a backport comment (example `@Mergifyio backport release/v120`)