### PR TITLE
Revert "Bugfix FXIOS-14135 ⁃ Website showing as not secure while it is loading (#30976)

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2480,7 +2480,7 @@ class BrowserViewController: UIViewController,
         tab.url = url
 
         if tab === tabManager.selectedTab {
-            updateUIForReaderHomeStateForTab(tab, shouldShowLockIcon: true)
+            updateUIForReaderHomeStateForTab(tab)
         }
         // Catch history pushState navigation, but ONLY for same origin navigation,
         // for reasons above about URL spoofing risk.
@@ -2543,8 +2543,8 @@ class BrowserViewController: UIViewController,
 
     // MARK: - Update UI
 
-    func updateUIForReaderHomeStateForTab(_ tab: Tab, focusUrlBar: Bool = false, shouldShowLockIcon: Bool = false) {
-        updateURLBarDisplayURL(tab, shouldShowLockIcon)
+    func updateUIForReaderHomeStateForTab(_ tab: Tab, focusUrlBar: Bool = false) {
+        updateURLBarDisplayURL(tab)
         scrollController.showToolbars(animated: false)
 
         if let url = tab.url {
@@ -2578,7 +2578,7 @@ class BrowserViewController: UIViewController,
 
     /// Updates the URL bar text and button states.
     /// Call this whenever the page URL changes.
-    func updateURLBarDisplayURL(_ tab: Tab, _ shouldShowLockIcon: Bool = false) {
+    func updateURLBarDisplayURL(_ tab: Tab, _ navigationFinished: Bool = false) {
         var safeListedURLImageName: String? {
             return (tab.contentBlocker?.status == .safelisted) ?
             StandardImageIdentifiers.Small.notificationDotFill : nil
@@ -2593,7 +2593,7 @@ class BrowserViewController: UIViewController,
                 StandardImageIdentifiers.Small.shieldSlashFillMulticolor
             lockIconNeedsTheming = hasSecureContent
             let isWebsiteMode = tab.url?.isReaderModeURL == false
-            lockIconImageName = isWebsiteMode && shouldShowLockIcon ? lockIconImageName : nil
+            lockIconImageName = isWebsiteMode && navigationFinished ? lockIconImageName : nil
         }
 
         let action = ToolbarAction(
@@ -3451,9 +3451,6 @@ class BrowserViewController: UIViewController,
             TabEvent.post(.didChangeURL(url), for: tab)
         }
 
-        if tab == tabManager.selectedTab {
-            updateURLBarDisplayURL(tab, true)
-        }
         if webViewStatus == .finishedNavigation {
             let isSelectedTab = (tab == tabManager.selectedTab)
             let isStoriesFeed = store.state.screenState(StoriesFeedState.self, for: .storiesFeed, window: windowUUID) != nil


### PR DESCRIPTION
## :scroll: Tickets
No ticket. 

## :bulb: Description
The translation flow using the button on the toolbar broke due to this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/30976). See video captures on the icon change. Therefore, we revert the commit d17ba5409a3bda4c1eeaa517adb367cd9e708c55.

See comment on the PR for more details: https://github.com/mozilla-mobile/firefox-ios/pull/30976#discussion_r2576904337

## :movie_camera: Demos
**With PR Merged**

https://github.com/user-attachments/assets/5b012522-ba82-4914-a8fc-9e1ec6f7e88b

**Reverting the PR**

https://github.com/user-attachments/assets/a60897ac-30ef-46e9-9edb-79401ed9c75e

cc: @PARAIPAN9 @thatswinnie @dicarobinho 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

