### PR TITLE
Bugfix FXIOS-14321 [Unit Tests] default browser test failing on < iOS 18 versions

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/DefaultBrowserUitlityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/DefaultBrowserUitlityTests.swift
@@ -156,6 +156,8 @@ final class DefaultBrowserUtilityTests: XCTestCase {
 
     @MainActor
     func testMigration_DMA_firstRun_isSetToDefaultBrowser() {
+        guard #available(iOS 18.2, *) else { return }
+
         XCTAssertFalse(userDefaults.bool(forKey: apiOrUserSetToDefaultKey))
         XCTAssertFalse(userDefaults.bool(forKey: deeplinkValueKey))
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14321)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31020)

## :bulb: Description
This fixes the failing tests for `testMigration_DMA_firstRun_isSetToDefaultBrowser` when our test plans are running < iOS 18.2. We were seeing consistent failures from this report: https://storage.googleapis.com/mobile-reports/public/firefox-ios-M4/firefox-ios-unit-tests/result_11/build/reports/index.html

I am also able to fail locally with lower versions (i.e. 15.5). It seems when we set up the tests we are calling `processUserDefaultState`, but this method is only called for iOS versions greater than 18.2. Therefore, the test was passing because `isDefaultBrowser` was being set to true, but in the lower iOS versions, we never hit that point in the method.  

cc: @yoanarios 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

