### PR TITLE
Bugfix FXIOS-00000 Fix crash in FxAWebViewModelTests

### DIFF
--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -40,7 +40,7 @@ class FxAWebViewModel: FeatureFlaggable {
     fileprivate let profile: Profile
     fileprivate var deepLinkParams: FxALaunchParams
     fileprivate(set) var baseURL: URL?
-    let fxAWebViewTelemetry = FxAWebViewTelemetry()
+    let fxAWebViewTelemetry: FxAWebViewTelemetry
     private let shouldAskForNotificationPermission: Bool
     private let logger: Logger
     // This is not shown full-screen, use mobile UA
@@ -98,12 +98,14 @@ class FxAWebViewModel: FeatureFlaggable {
                   profile: Profile,
                   deepLinkParams: FxALaunchParams,
                   shouldAskForNotificationPermission: Bool = true,
-                  logger: Logger = DefaultLogger.shared) {
+                  logger: Logger = DefaultLogger.shared,
+                  telemetry: FxAWebViewTelemetry = FxAWebViewTelemetry()) {
         self.pageType = pageType
         self.profile = profile
         self.deepLinkParams = deepLinkParams
         self.shouldAskForNotificationPermission = shouldAskForNotificationPermission
         self.logger = logger
+        self.fxAWebViewTelemetry = telemetry
     }
 
     var onDismissController: (() -> Void)?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FxAWebViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FxAWebViewModelTests.swift
@@ -14,7 +14,10 @@ class FxAWebViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         deeplinkParams = FxALaunchParams(entrypoint: .browserMenu, query: ["test_key": "test_value"])
-        viewModel = FxAWebViewModel(pageType: .settingsPage, profile: MockProfile(), deepLinkParams: deeplinkParams)
+        viewModel = FxAWebViewModel(pageType: .settingsPage,
+                                    profile: MockProfile(),
+                                    deepLinkParams: deeplinkParams,
+                                    telemetry: FxAWebViewTelemetry(telemetryWrapper: MockTelemetryWrapper()))
     }
 
     override func tearDown() {


### PR DESCRIPTION
## :scroll: Tickets
n/a

## :bulb: Description

Fix crash in `FxAWebViewModelTests`, use MockTelemetryWrapper.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

