### PR TITLE
Revert "Bugfix FXIOS-14135 ⁃ Website showing as not secure while it i…s loading (#30746)"

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1181,10 +1181,6 @@ extension BrowserViewController: WKNavigationDelegate {
                     }
                 }
             }
-
-            if tabManager.selectedTab === tab {
-                updateURLBarDisplayURL(tab, true)
-            }
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2586,7 +2586,7 @@ class BrowserViewController: UIViewController,
 
     /// Updates the URL bar text and button states.
     /// Call this whenever the page URL changes.
-    func updateURLBarDisplayURL(_ tab: Tab, _ navigationFinished: Bool = false) {
+    fileprivate func updateURLBarDisplayURL(_ tab: Tab) {
         var safeListedURLImageName: String? {
             return (tab.contentBlocker?.status == .safelisted) ?
             StandardImageIdentifiers.Small.notificationDotFill : nil
@@ -2601,7 +2601,7 @@ class BrowserViewController: UIViewController,
                 StandardImageIdentifiers.Small.shieldSlashFillMulticolor
             lockIconNeedsTheming = hasSecureContent
             let isWebsiteMode = tab.url?.isReaderModeURL == false
-            lockIconImageName = isWebsiteMode && navigationFinished ? lockIconImageName : nil
+            lockIconImageName = isWebsiteMode ? lockIconImageName : nil
         }
 
         let action = ToolbarAction(
@@ -4620,7 +4620,7 @@ extension BrowserViewController: TabManagerDelegate {
             selectedTab.webView?.applyTheme(theme: currentTheme())
         }
 
-        updateURLBarDisplayURL(selectedTab, selectedTab.isLoading == false)
+        updateURLBarDisplayURL(selectedTab)
         if addressToolbarContainer.inOverlayMode, selectedTab.url?.displayURL != nil {
             addressToolbarContainer.leaveOverlayMode(reason: .finished, shouldCancelLoading: false)
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -403,7 +403,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
             borderPosition: state.borderPosition,
             url: toolbarAction.url,
             searchTerm: nil,
-            lockIconImageName: toolbarAction.lockIconImageName,
+            lockIconImageName: toolbarAction.lockIconImageName ?? state.lockIconImageName,
             lockIconNeedsTheming: toolbarAction.lockIconNeedsTheming ?? state.lockIconNeedsTheming,
             safeListedURLImageName: toolbarAction.safeListedURLImageName,
             isEditing: state.isEditing,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -185,42 +185,6 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
 //        XCTAssertEqual(action.readerModeState, .active)
 //    }
 
-    func testUpdateURLBarDisplayURL_whenNavigationNotFinished_shouldHideLockIcon() throws {
-        let expectation = XCTestExpectation(description: "expect mock store to dispatch an action")
-        let subject = createSubject()
-        let tab = MockTab(profile: profile, windowUUID: .XCTestDefaultUUID)
-        tab.url = URL(string: "https://google.com")
-        let mockTabWebView = MockTabWebView(tab: tab)
-        tab.webView = mockTabWebView
-
-        mockStore.dispatchCalled = {
-            expectation.fulfill()
-        }
-        subject.updateURLBarDisplayURL(tab, false)
-        wait(for: [expectation])
-
-        let action = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
-        XCTAssertEqual(action.lockIconImageName, nil)
-    }
-
-    func testUpdateURLBarDisplayURL_whenNavigationIsFinished_shouldShowLockIcon() throws {
-        let expectation = XCTestExpectation(description: "expect mock store to dispatch an action")
-        let subject = createSubject()
-        let tab = MockTab(profile: profile, windowUUID: .XCTestDefaultUUID)
-        tab.url = URL(string: "https://google.com")
-        let mockTabWebView = MockTabWebView(tab: tab)
-        tab.webView = mockTabWebView
-
-        mockStore.dispatchCalled = {
-            expectation.fulfill()
-        }
-        subject.updateURLBarDisplayURL(tab, true)
-        wait(for: [expectation])
-
-        let action = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
-        XCTAssertEqual(action.lockIconImageName, StandardImageIdentifiers.Small.shieldSlashFillMulticolor)
-    }
-
     // MARK: - Handle PDF
 
     func testHandlePDFDownloadRequest_doesntDocumentLoadingView_whenTabNotSelected() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -346,7 +346,7 @@ class TabsTests: BaseTestCase {
 
         // Open New Tab
         app.cells.buttons[StandardImageIdentifiers.Large.plus].waitAndTap()
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tapWithRetry()
+        navigator.performAction(Action.CloseURLBarOpen)
 
         waitForTabsButton()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
@@ -377,7 +377,7 @@ class TabsTests: BaseTestCase {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
         app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].press(forDuration: 1)
         app.tables.cells.buttons["New Private Tab"].waitAndTap()
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tapWithRetry()
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(tabsButton)
         navigator.nowAt(NewTabScreen)


### PR DESCRIPTION
This reverts commit d9609ede9498dae0dcf7a5b77cd8155f9c7debac.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This is related to reverting this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/31017). While the other PR is the actual issue that impacted the translation feature, this is the original PR that contain most of the work for the feature. After discussing with @dicarobinho, he mentioned that merging this work without the other would lead to a poorer experience for the users, so we are reverting here as well. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

