### PR TITLE
Bugfix FXIOS-14306 [Translations] display icon after toggling settings ON

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsViewController.swift
@@ -36,7 +36,7 @@ final class TranslationSettingsViewController: SettingsTableViewController {
             guard let self else { return }
             store.dispatch(
                 ToolbarAction(
-                    translationConfiguration: TranslationConfiguration(prefs: self.prefs),
+                    translationConfiguration: TranslationConfiguration(prefs: self.prefs, state: .inactive),
                     windowUUID: self.windowUUID,
                     actionType: ToolbarActionType.didTranslationSettingsChange
                 )

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -353,6 +353,9 @@ class SettingsTests: FeatureFlaggedTestBase {
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "translations-feature")
         app.launch()
         navigator.nowAt(HomePanelsScreen)
+        navigator.openURL(path(forTestPage: "test-translation.html"))
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.translateButton])
+
         navigator.goto(SettingsScreen)
         let table = app.tables.element(boundBy: 0)
         mozWaitForElementToExist(table)
@@ -368,7 +371,6 @@ class SettingsTests: FeatureFlaggedTestBase {
         dismissSearchScreenFromTranslation()
 
         navigator.nowAt(BrowserTab)
-        navigator.openURL(path(forTestPage: "test-translation.html"))
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Toolbar.translateButton])
 
         navigator.goto(SettingsScreen)
@@ -381,7 +383,6 @@ class SettingsTests: FeatureFlaggedTestBase {
         dismissSearchScreenFromTranslation()
 
         navigator.nowAt(BrowserTab)
-        navigator.openURL(path(forTestPage: "test-translation.html"))
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.translateButton])
         navigator.nowAt(BrowserTab)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14306)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30979)

## :bulb: Description
Fix issue where translations icon is not instantly displayed after reenabling the settings toggle. This is due to not setting the state properly. I updated the UI tests to capture this issue as well. 

The issue only occurs when on the webpage and then toggling settings. If the user navigates away, then the translation icon will be updated.

**Before**
See video capture attached for issue.

**After**

https://github.com/user-attachments/assets/544d6ab8-c5eb-4046-a749-8e5d5502caa4

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

