### PR TITLE
Bugfix #31040 ⁃ Fix testOnboardingCard_viewDidAppear_viewSendsCardView failing test on iOS 17.5

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
@@ -31,7 +31,13 @@ class OnboardingTelemetryDelegationTests: XCTestCase {
             XCTFail("expected a view controller, but got nothing")
             return
         }
-        firstVC.viewDidAppear(true)
+
+        // On iOS 17 and earlier, the system already triggers a viewDidAppear call,
+        // so calling it manually would cause the expected count to fail.
+        // In iOS 18 and later, this behavior changed and we must call viewDidAppear manually.
+        if #available(iOS 18, *) {
+            firstVC.viewDidAppear(true)
+        }
 
         try testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14325)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31040)

## :bulb: Description
- Call manually to viewDidAppear on iOS 18 and above
- Documentation

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

