### PR TITLE
Refactor FXIOS-14251 move isRunningLiquidGlassEarlyBeta from DefaultB…

### DIFF
--- a/BrowserKit/Sources/Shared/DeviceInfo.swift
+++ b/BrowserKit/Sources/Shared/DeviceInfo.swift
@@ -33,6 +33,24 @@ extension DeviceInfo {
         }
     }
 
+    /// Returns true for devices running iOS 26 Beta 1 to 3 (developer betas). These betas have an Apple bug with
+    /// `UIGlassEffect`. See FXIOS-13528 for details. This workaround can probably be removed soon after iOS 26 official
+    /// release and user adoption.
+    public class var isRunningLiquidGlassEarlyBeta: Bool {
+        let systemVersion = ProcessInfo.processInfo.operatingSystemVersionString
+
+        // Note: Info collected from https://betawiki.net/wiki/IOS_26. Beta 4 was the first public build.
+        let betaBlockLists: [String] = [
+            "23A257a",  // Unconfirmed early release
+            "23A5260n", // Developer Beta 1
+            "23A5260u", // Developer Beta 1 Update for iPhone 15 and 16 series
+            "23A5276f", // Developer Beta 2
+            "23A5287g", // Developer Beta 3
+        ]
+
+        return betaBlockLists.contains { systemVersion.contains($0) }
+    }
+
     // Reports portrait screen size regardless of the current orientation.
     @MainActor
     public class func screenSizeOrientationIndependent() -> CGSize {

--- a/firefox-ios/Client/Application/DefaultBrowserUtility.swift
+++ b/firefox-ios/Client/Application/DefaultBrowserUtility.swift
@@ -95,24 +95,6 @@ class DefaultBrowserUtility {
         return betaBlockLists.contains { systemVersion.contains($0) }
     }
 
-    /// Returns true for devices running iOS 26 Beta 1 to 3 (developer betas). These betas have an Apple bug with
-    /// `UIGlassEffect`. See FXIOS-13528 for details. This workaround can probably be removed soon after iOS 26 official
-    /// release and user adoption.
-    static var isRunningLiquidGlassEarlyBeta: Bool {
-        let systemVersion = ProcessInfo.processInfo.operatingSystemVersionString
-
-        // Note: Info collected from https://betawiki.net/wiki/IOS_26. Beta 4 was the first public build.
-        let betaBlockLists: [String] = [
-            "23A257a",  // Unconfirmed early release
-            "23A5260n", // Developer Beta 1
-            "23A5260u", // Developer Beta 1 Update for iPhone 15 and 16 series
-            "23A5276f", // Developer Beta 2
-            "23A5287g", // Developer Beta 3
-        ]
-
-        return betaBlockLists.contains { systemVersion.contains($0) }
-    }
-
     private func trackIfUserIsDefault(_ isDefault: Bool) {
         userDefault.set(isDefault, forKey: PrefsKeys.AppleConfirmedUserIsDefaultBrowser)
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -212,7 +212,7 @@ class BrowserViewController: UIViewController,
 
     private lazy var effect: some UIVisualEffect = {
 #if canImport(FoundationModels)
-        if #available(iOS 26, *), !DefaultBrowserUtility.isRunningLiquidGlassEarlyBeta {
+        if #available(iOS 26, *), !DeviceInfo.isRunningLiquidGlassEarlyBeta {
             return UIGlassEffect(style: .regular)
         } else {
             return UIBlurEffect(style: .systemUltraThinMaterial)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -59,7 +59,7 @@ class TabTraySelectorView: UIView,
 
     private lazy var visualEffectView: UIVisualEffectView = .build { view in
 #if canImport(FoundationModels)
-        if #available(iOS 26, *), !DefaultBrowserUtility.isRunningLiquidGlassEarlyBeta {
+        if #available(iOS 26, *), !DeviceInfo.isRunningLiquidGlassEarlyBeta {
             view.effect = UIGlassEffect(style: .regular)
         } else {
             view.effect = UIBlurEffect(style: .systemUltraThinMaterial)


### PR DESCRIPTION
move isRunningLiquidGlassEarlyBeta from DefaultBrowserUtility to DeviceInfo

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14251)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30860)

## :bulb: Description
Moved isRunningLiquidGlassEarlyBeta from DefaultBrowserUtility to DeviceInfo!

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

