### PR TITLE
Add FXIOS-14335 [Homepage Redesign] Update synced tab card corner radius

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/SyncedTabCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/SyncedTabCell.swift
@@ -6,12 +6,14 @@ import Common
 import SiteImageView
 
 /// The synced tab cell used in the homepage's Jump Back In section
-class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurrable, Notifiable {
+class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurrable, Notifiable, FeatureFlaggable {
     struct UX {
         static let heroImageSize = CGSize(width: 108, height: 80)
         static let syncedDeviceImageSize = CGSize(width: 24, height: 24)
         static let tabStackTopAnchorConstant: CGFloat = 72
         static let tabStackTopAnchorCompactPhoneConstant: CGFloat = 24
+        static let generalCornerRadius: CGFloat = 16
+        static let heroImageCornerRadius: CGFloat = 13
     }
 
     private var syncedDeviceIconFirstBaselineConstraint: NSLayoutConstraint?
@@ -20,6 +22,10 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurra
 
     private var showAllSyncedTabsAction: (@MainActor () -> Void)?
     private var openSyncedTabAction: (@MainActor () -> Void)?
+
+    private var cardCornerRadius: CGFloat {
+        return isAnyStoriesRedesignEnabled ? UX.generalCornerRadius : HomepageUX.generalCornerRadius
+    }
 
     // MARK: - UI Elements
     private var tabHeroImage: HeroImageView = .build { _ in }
@@ -120,7 +126,9 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurra
 
         syncedDeviceImage.image = configuration.syncedDeviceImage
 
+        let heroImageCornerRadius = isAnyStoriesRedesignEnabled ? UX.heroImageCornerRadius : HomepageUX.generalCornerRadius
         let heroViewModel = HomepageHeroImageViewModel(urlStringRequest: configuration.url.absoluteString,
+                                                       generalCornerRadius: heroImageCornerRadius,
                                                        heroImageSize: UX.heroImageSize)
         tabHeroImage.setHeroImage(heroViewModel)
 
@@ -174,7 +182,7 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurra
 
         contentView.layer.shadowPath = UIBezierPath(
             roundedRect: contentView.bounds,
-            cornerRadius: HomepageUX.generalCornerRadius
+            cornerRadius: cardCornerRadius
         ).cgPath
     }
 
@@ -285,9 +293,9 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurra
     }
 
     private func setupShadow(theme: Theme) {
-        contentView.layer.cornerRadius = HomepageUX.generalCornerRadius
+        contentView.layer.cornerRadius = cardCornerRadius
         contentView.layer.shadowPath = UIBezierPath(roundedRect: contentView.bounds,
-                                                    cornerRadius: HomepageUX.generalCornerRadius).cgPath
+                                                    cornerRadius: cardCornerRadius).cgPath
         contentView.layer.shadowRadius = HomepageUX.shadowRadius
         contentView.layer.shadowOffset = HomepageUX.shadowOffset
         contentView.layer.shadowColor = theme.colors.shadowDefault.cgColor
@@ -314,7 +322,7 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurra
         // Add blur
         if shouldApplyWallpaperBlur {
             contentView.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
-            contentView.layer.cornerRadius = HomepageUX.generalCornerRadius
+            contentView.layer.cornerRadius = cardCornerRadius
         } else {
             contentView.removeVisualEffectView()
             contentView.backgroundColor = theme.colors.layer5


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14335)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31064)

## :bulb: Description
- Increase the corner radius of the `SyncedTabCell` homepage card and the hero image inside of it to be more in-line with the other homepage cards 

## :movie_camera: Demos
| Before | After |
| ------------- | ------------- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2025-12-03 at 16 02 44" src="https://github.com/user-attachments/assets/b85cb5c7-e968-4c33-a846-b688a3fa3f68" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2025-12-03 at 16 03 55" src="https://github.com/user-attachments/assets/e6e135ca-c721-4678-b1d5-f09cfe8aad67" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

