### PR TITLE
Refactor FXIOS-14342 ⁃ OpenWithSettingsViewController should use Notifiable protocol

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -6,7 +6,7 @@ import Foundation
 import Shared
 import Common
 
-class OpenWithSettingsViewController: ThemedTableViewController {
+class OpenWithSettingsViewController: ThemedTableViewController, Notifiable {
     struct MailtoProviderEntry {
         let name: String
         let scheme: String
@@ -35,10 +35,13 @@ class OpenWithSettingsViewController: ThemedTableViewController {
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(appDidBecomeActive),
-                                               name: UIApplication.didBecomeActiveNotification,
-                                               object: nil)
+        startObservingNotifications(
+            withNotificationCenter: NotificationCenter.default,
+            forObserver: self,
+            observing: [
+                UIApplication.didBecomeActiveNotification
+            ]
+        )
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -51,7 +54,6 @@ class OpenWithSettingsViewController: ThemedTableViewController {
         self.prefs.setString(currentChoice, forKey: PrefsKeys.KeyMailToOption)
     }
 
-    @objc
     func appDidBecomeActive() {
         reloadMailProviderSource()
         updateCurrentChoice()
@@ -154,5 +156,18 @@ class OpenWithSettingsViewController: ThemedTableViewController {
         }
 
         return NSAttributedString(string: string, attributes: color)
+    }
+
+    // MARK: - Notifiable
+
+    public func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case UIApplication.didBecomeActiveNotification:
+            ensureMainThread {
+                self.appDidBecomeActive
+            }
+        default:
+            return
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14342)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31071)

## :bulb: Description
Used Notifiable protocol instead of NotificationCenter.default.addObserver 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

