### PR TITLE
Refactor FXIOS-14344 [Swift 6 migration] Fixing warnings in unit tests  

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockCreditCardProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockCreditCardProvider.swift
@@ -6,7 +6,7 @@ import Foundation
 import MozillaAppServices
 import Storage
 
-class MockCreditCardProvider: CreditCardProvider {
+final class MockCreditCardProvider: CreditCardProvider, @unchecked Sendable {
     var addCreditCardCalledCount = 0
     var updateCreditCardCalledCount = 0
     var listCreditCardsCalledCount = 0

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
@@ -60,8 +60,8 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         // Make sure the year saved is a 4 digit year and not 2 digit
         // 2000 because that is our current period
         XCTAssertTrue(decryptedCreditCard.ccExpYear > 2000)
-        subject.saveCreditCard(with: decryptedCreditCard) { creditCard, error in
-            XCTAssertEqual(self.autofill.addCreditCardCalledCount, 1)
+        subject.saveCreditCard(with: decryptedCreditCard) { [autofill] creditCard, error in
+            XCTAssertEqual(autofill?.addCreditCardCalledCount, 1)
             expectation.fulfill()
         }
         waitForExpectations(timeout: 1.0)
@@ -75,16 +75,16 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         let expectationSave = expectation(description: "wait for credit card fields to be saved")
         let expectationUpdate = expectation(description: "wait for credit card fields to be updated")
 
-        subject.saveCreditCard(with: samplePlainTextCard) { creditCard, error in
+        subject.saveCreditCard(with: samplePlainTextCard) {  [autofill, samplePlainTextCard] creditCard, error in
             DispatchQueue.main.async {
-                XCTAssertEqual(self.autofill.addCreditCardCalledCount, 1)
+                XCTAssertEqual(autofill.addCreditCardCalledCount, 1)
                 expectationSave.fulfill()
                 subject.state = .update
 
                 subject.updateCreditCard(for: creditCard?.guid,
-                                         with: self.samplePlainTextCard
+                                         with: samplePlainTextCard
                 ) { didUpdate, error in
-                    XCTAssertEqual(self.autofill.updateCreditCardCalledCount, 1)
+                    XCTAssertEqual(autofill.updateCreditCardCalledCount, 1)
                     expectationUpdate.fulfill()
                 }
             }
@@ -357,13 +357,13 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         subject.decryptedCreditCard = samplePlainTextCard
         let expectation = expectation(description: "wait for credit card fields to be saved")
 
-        subject.didTapMainButton(queue: dispatchQueue) { error in
+        subject.didTapMainButton(queue: dispatchQueue) { [autofill] error in
             guard error == nil else {
                 XCTFail("Should not have received error: \(String(describing: error?.localizedDescription))")
                 return
             }
 
-            XCTAssertEqual(self.autofill.addCreditCardCalledCount, 1)
+            XCTAssertEqual(autofill?.addCreditCardCalledCount, 1)
             expectation.fulfill()
         }
 
@@ -378,12 +378,12 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         subject.decryptedCreditCard = samplePlainTextCard
         let expectation = expectation(description: "wait for credit card fields to be updated")
 
-        subject.didTapMainButton(queue: dispatchQueue) { error in
+        subject.didTapMainButton(queue: dispatchQueue) { [autofill] error in
             guard error == nil else {
                 XCTFail("Should not have received error: \(String(describing: error?.localizedDescription))")
                 return
             }
-            XCTAssertEqual(self.autofill.updateCreditCardCalledCount, 1)
+            XCTAssertEqual(autofill?.updateCreditCardCalledCount, 1)
             expectation.fulfill()
         }
 
@@ -399,13 +399,13 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         subject.decryptedCreditCard = nil
         subject.state = .selectSavedCard
 
-        subject.updateCreditCardList { cards in
+        subject.updateCreditCardList { [autofill] cards in
             DispatchQueue.main.async {
                 XCTAssertEqual(subject.creditCards, cards)
                 XCTAssertEqual(cards?.count, 1)
                 XCTAssertEqual(cards?.first?.guid, "1")
                 XCTAssertEqual(cards?.first?.ccName, "Allen Burges")
-                XCTAssertEqual(self.autofill.listCreditCardsCalledCount, 1)
+                XCTAssertEqual(autofill.listCreditCardsCalledCount, 1)
                 expectation.fulfill()
             }
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputFieldTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputFieldTests.swift
@@ -28,6 +28,7 @@ class CreditCardInputFieldTests: XCTestCase {
         viewModel = nil
     }
 
+    @MainActor
     func testInputFieldPropertiesOnName() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .name,
@@ -42,6 +43,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertEqual(inputField.keyboardType, .alphabet)
     }
 
+    @MainActor
     func testInputFieldPropertiesOnCard() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .number,
@@ -56,6 +58,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertEqual(inputField.keyboardType, .numberPad)
     }
 
+    @MainActor
     func testInputFieldPropertiesOnExpiration() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .expiration,
@@ -76,6 +79,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    @MainActor
     func testIsNameValid() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .name,
@@ -85,6 +89,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertFalse(inputField.isNameValid(val: ""))
     }
 
+    @MainActor
     func testIsNumberValid() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .name,
@@ -99,6 +104,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertFalse(inputField.isNumberValid(val: "4242"))
     }
 
+    @MainActor
     func testIsExpirationValid() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .name,
@@ -109,6 +115,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertTrue(inputField.isExpirationValid(val: "1234"))
     }
 
+    @MainActor
     func testBlankNameInput() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .name,
@@ -118,6 +125,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertFalse(inputField.isNameValid(val: ""))
     }
 
+    @MainActor
     func testValidCardInput() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .number,
@@ -129,6 +137,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertEqual(viewModel.cardNumber, "4122400040004000")
     }
 
+    @MainActor
     func testInvalidShorterCardInput() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .number,
@@ -139,6 +148,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertFalse(inputField.isNumberValid(val: "44"))
     }
 
+    @MainActor
     func testValidExpirationInput() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .expiration,
@@ -150,6 +160,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertFalse(viewModel.showExpirationError)
     }
 
+    @MainActor
     func testInvalidShortenedExpirationInput() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .expiration,
@@ -160,6 +171,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertFalse(inputField.isExpirationValid(val: "125"))
     }
 
+    @MainActor
     func testConcealCardNum() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .number,
@@ -173,6 +185,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertEqual(result, "••••••••••••1234")
     }
 
+    @MainActor
     func testConcealCardNumOnEmpty() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .number,
@@ -185,6 +198,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertEqual(result, "")
     }
 
+    @MainActor
     func testRevealCardNumber() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .number,
@@ -198,6 +212,7 @@ class CreditCardInputFieldTests: XCTestCase {
         XCTAssertEqual(result, "4444-4444-4444-4444")
     }
 
+    @MainActor
     func testRevealCardNumberOnEmpty() {
         let inputField = CreditCardInputField(windowUUID: WindowUUID.XCTestDefaultUUID,
                                               inputType: .number,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
@@ -41,11 +41,11 @@ class CreditCardInputViewModelTests: XCTestCase {
         viewModel.cardNumber = samplePlainTextCard.ccNumber
         viewModel.expirationDate = "1288"
         let expectation = expectation(description: "wait for credit card fields to be saved")
-        viewModel.saveCreditCard { creditCard, error in
+        viewModel.saveCreditCard { [autofill] creditCard, error in
             XCTAssertNotNil(creditCard)
             XCTAssertNil(error)
             XCTAssertEqual(creditCard?.ccName, "Allen Burges")
-            XCTAssertEqual(self.autofill.addCreditCardCalledCount, 1)
+            XCTAssertEqual(autofill?.addCreditCardCalledCount, 1)
             // Note: the number for credit card is encrypted so that part
             // will get added later and for now we will check the name only
             expectation.fulfill()
@@ -213,10 +213,10 @@ class CreditCardInputViewModelTests: XCTestCase {
 
         autofill.deleteResult = (true, TestError.example)
 
-        viewModel.removeCreditCard(creditCard: exampleCreditCard) { status, success in
+        viewModel.removeCreditCard(creditCard: exampleCreditCard) { [autofill] status, success in
             XCTAssertEqual(status, .none)
             XCTAssertFalse(success)
-            XCTAssertEqual(self.autofill.deleteCreditCardsCalledCount, 1)
+            XCTAssertEqual(autofill?.deleteCreditCardsCalledCount, 1)
             expectation.fulfill()
         }
 
@@ -226,10 +226,10 @@ class CreditCardInputViewModelTests: XCTestCase {
     func test_removeCreditCard_withNoCreditCard_returnsStatusNone() {
         let expectation = expectation(description: "wait for credit card to be removed")
 
-        viewModel.removeCreditCard(creditCard: nil) { status, success in
+        viewModel.removeCreditCard(creditCard: nil) { [autofill] status, success in
             XCTAssertEqual(status, .none)
             XCTAssertFalse(success)
-            XCTAssertEqual(self.autofill.deleteCreditCardsCalledCount, 0)
+            XCTAssertEqual(autofill?.deleteCreditCardsCalledCount, 0)
             expectation.fulfill()
         }
 
@@ -245,10 +245,10 @@ class CreditCardInputViewModelTests: XCTestCase {
 
         let expectation = expectation(description: "wait for credit card to be updated")
 
-        viewModel.updateCreditCard { status, error in
+        viewModel.updateCreditCard { [autofill] status, error in
             XCTAssertNil(error)
             XCTAssertEqual(status, true)
-            XCTAssertEqual(self.autofill.updateCreditCardCalledCount, 1)
+            XCTAssertEqual(autofill?.updateCreditCardCalledCount, 1)
             expectation.fulfill()
         }
 
@@ -265,10 +265,10 @@ class CreditCardInputViewModelTests: XCTestCase {
         enum TestError: Error { case example }
         autofill.updateResult = (true, TestError.example)
 
-        viewModel.updateCreditCard { status, error in
+        viewModel.updateCreditCard { [autofill] status, error in
             XCTAssertNotNil(error)
             XCTAssertEqual(status, true)
-            XCTAssertEqual(self.autofill.updateCreditCardCalledCount, 1)
+            XCTAssertEqual(autofill?.updateCreditCardCalledCount, 1)
             expectation.fulfill()
         }
 
@@ -278,10 +278,10 @@ class CreditCardInputViewModelTests: XCTestCase {
     func test_updateCreditCard_withoutValidCrediCard_ReturnsError() {
         let expectation = expectation(description: "wait for credit card to be updated")
 
-        viewModel.updateCreditCard { status, error in
+        viewModel.updateCreditCard { [autofill] status, error in
             XCTAssertNotNil(error)
             XCTAssertEqual(status, true)
-            XCTAssertEqual(self.autofill.updateCreditCardCalledCount, 0)
+            XCTAssertEqual(autofill?.updateCreditCardCalledCount, 0)
             expectation.fulfill()
         }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardSettingsViewControllerTests.swift
@@ -51,6 +51,7 @@ final class CreditCardSettingsViewControllerTests: XCTestCase {
         XCTAssertTrue(subject.viewModel.cardInputViewModel.expirationDate.isEmpty)
     }
 
+    @MainActor
     private func createSubject() -> CreditCardSettingsViewController {
         let creditCardSettingsViewModel = CreditCardSettingsViewModel(
             profile: profile,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CustomSearchEnginesTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CustomSearchEnginesTest.swift
@@ -19,6 +19,7 @@ class CustomSearchEnginesTest: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testgetSearchTemplate() {
         let profile = MockBrowserProfile(localName: "customSearchTests")
         let customSearchEngineForm = CustomSearchViewController(windowUUID: windowUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -14,14 +14,14 @@ final class DefaultThemeManagerTests: XCTestCase {
     private var userDefaults: MockUserDefaults!
 
     // MARK: - Test lifecycle
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         userDefaults = MockUserDefaults()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
         userDefaults = nil
+        try await super.tearDown()
     }
 
     // MARK: - Initialization tests

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadHelperTests.swift
@@ -8,6 +8,7 @@ import WebKit
 @testable import Client
 
 class DownloadHelperTests: XCTestCase {
+    @MainActor
     func test_init_whenMIMETypeIsNil_initializeCorrectly() {
         let response = anyResponse(mimeType: nil)
 
@@ -17,6 +18,7 @@ class DownloadHelperTests: XCTestCase {
         XCTAssertNotNil(subject)
     }
 
+    @MainActor
     func test_shouldDownloadFile_whenMIMETypeOctetStream_isTrue() {
         let mimeType = MIMEType.OctetStream
 
@@ -30,6 +32,7 @@ class DownloadHelperTests: XCTestCase {
         XCTAssertTrue(shouldDownload ?? false)
     }
 
+    @MainActor
     func test_shouldDownloadFile_whenMIMETypeIsNotOctetStream_isFalse() {
         let mimeType = MIMEType.GIF
 
@@ -44,6 +47,7 @@ class DownloadHelperTests: XCTestCase {
         }
     }
 
+    @MainActor
     func test_shouldDownloadFile_whenContentDispositionAttachmentHeader_isTrue() {
         let response = httpURLResponse(mimeType: MIMEType.JPEG,
                                        contentDispositionHeader: true)
@@ -57,6 +61,7 @@ class DownloadHelperTests: XCTestCase {
         }
     }
 
+    @MainActor
     func test_shouldDownloadFile_whenContentDispositionAttachmentHeader_isFalse() {
         let response = httpURLResponse(mimeType: MIMEType.JPEG,
                                        contentDispositionHeader: false)
@@ -70,6 +75,7 @@ class DownloadHelperTests: XCTestCase {
         }
     }
 
+    @MainActor
     func test_shouldDownloadFile_whenCanShowInWebview_isFalse() {
         let response = anyResponse(mimeType: MIMEType.GIF)
 
@@ -83,6 +89,7 @@ class DownloadHelperTests: XCTestCase {
         }
     }
 
+    @MainActor
     func test_shouldDownloadFile_whenCanNotShowInWebview_isTrue() {
         let response = anyResponse(mimeType: MIMEType.GIF)
 
@@ -96,6 +103,7 @@ class DownloadHelperTests: XCTestCase {
         }
     }
 
+    @MainActor
     func test_shouldDownloadFile_whenNotForceDownload_isFalse() {
         let response = anyResponse(mimeType: MIMEType.GIF)
 
@@ -109,6 +117,7 @@ class DownloadHelperTests: XCTestCase {
         }
     }
 
+    @MainActor
     func test_shouldDownloadFile_whenForceDownload_isTrue() {
         let response = anyResponse(mimeType: MIMEType.GIF)
 
@@ -198,6 +207,7 @@ class DownloadHelperTests: XCTestCase {
         )
     }
 
+    @MainActor
     private func cookieStore() -> WKHTTPCookieStore {
         return WKWebsiteDataStore.`default`().httpCookieStore
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/UIStackViewExtensionsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/UIStackViewExtensionsTests.swift
@@ -5,7 +5,8 @@
 import UIKit
 import XCTest
 
-class UIStackViewExtensionsTests: XCTestCase {
+@MainActor
+final class UIStackViewExtensionsTests: XCTestCase {
     // MARK: Top
 
     func testAddArrangedViewToTop_whenEmpty() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/WKFrameInfoExtensionsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/WKFrameInfoExtensionsTest.swift
@@ -5,6 +5,7 @@
 import XCTest
 import WebKit
 
+@MainActor
 final class WKFrameInfoExtensionsTests: XCTestCase {
     let secureURL = URL(string: "https://foo.com")!
     let insecureURL = URL(string: "http://bar.com")!


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14344)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31077)

## :bulb: Description
Fixing warnings in:
- Credit card unit tests
- CustomSearchEnginesTest
- DefaultThemeManagerTests
- DownloadHelperTests
- UIStackViewExtensionsTests
- WKFrameInfoExtensionsTests

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

