### PR TITLE
Bugfix FXIOS-14330 #31056 ⁃ [New first run onboarding] [Show tour] System auto is selected by default, but browser dark theme is applied to onboarding cards

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingKitCardInfoModel.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingKitCardInfoModel.swift
@@ -60,7 +60,7 @@ struct OnboardingKitCardInfoModel: OnboardingKit.OnboardingCardInfoModelProtocol
 
     private func findHighestPriorityButton()
     -> OnboardingMultipleChoiceButtonModel<OnboardingMultipleChoiceAction>? {
-        if let _ = multipleChoiceButtons.first(where: { $0.action.isThemeAction }),
+        if multipleChoiceButtons.contains(where: { $0.action.isThemeAction }),
            let savedAction = savedThemeAction(),
            let matchedButton = multipleChoiceButtons.first(where: { $0.action == savedAction }) {
             return matchedButton


### PR DESCRIPTION
:scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14330)

[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31056)

:bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

The OOBE theme selection card could show an incorrect default theme when entering the onboarding flow. This happened because the logic responsible for selecting the default button did not consider the user’s previously selected theme. As a result, when 'findHighestPriorityButton()' returned no prioritized match, the UI automatically selected the first button, which could differ from the user’s actual theme preference.

❗ Issue
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

When entering the OOBE flow the theme selection card sometimes shows a default selection that does not match the user’s actual theme. Because 'findHighestPriorityButton()' returned no selection in this case, the UI fell back to selecting the first button by default.

Fix
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

- Before falling back to priority logic, check whether the user already has a saved theme.

- If a saved theme exists, select the matching theme action (themeDark / themeLight / themeSystemDefault) on the card - only if that action exists on the card.

- If no saved theme exists, default to the system/automatic theme.

- Preserve existing priority fallback for non-theme cards and toolbar actions.

- Minimal, localized changes: added savedThemeAction() and an isThemeAction helper and updated 'findHighestPriorityButton()' to prefer the saved theme when applicable.

:movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable --> <!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
|-------|--------|
| <video src="https://github.com/user-attachments/assets/1c7a4942-7222-4346-b957-a4dc206e2bfc" width="300"></video> | <video src="https://github.com/user-attachments/assets/85a05e82-e09a-40e3-b9c9-85fbb1f02c2b" width="300"></video> |

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [X] If needed, I updated documentation and added comments to complex code





