### PR TITLE
[MTE-5046] - improve pressWithRetry on auto tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -648,10 +648,15 @@ extension XCUIElement {
     func pressWithRetry(duration: TimeInterval, timeout: TimeInterval = TIMEOUT, element: XCUIElement) {
         BaseTestCase().mozWaitForElementToExist(self, timeout: timeout)
         self.press(forDuration: duration)
-        sleep(1)
+        if element.waitForExistence(timeout: 1.0) {
+            return
+        }
         var attempts = 5
         while !element.exists && attempts > 0 {
             self.press(forDuration: duration)
+            if element.waitForExistence(timeout: 1.0) {
+                return
+            }
             attempts -= 1
         }
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5046

## :bulb: Description
Replaced sleep() with waitForExistence. Added if condition to make sure pressWithRetry function continues to run in case the element is not visible.
