### PR TITLE
Bugfix FXIOS-14357 - Address bar has extra layer after minimal version is expanded again

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -456,15 +456,27 @@ final class LocationView: UIView,
         )
     }
 
+    private func removeGlassEffectImmediately() {
+        guard #available(iOS 26.0, *) else { return }
+        /// Workaround for iOS 26.0 bug: Setting `effectView.effect` to `nil` doesn't remove the glass effect.
+        /// We work around this by first setting it to `UIBlurEffect()` and then to `nil`, which forces an immediate removal.
+        effectView.effect = UIBlurEffect()
+        effectView.effect = nil
+    }
+
     private func applyToolbarAlphaIfNeeded(alpha: CGFloat, barPosition: AddressToolbarPosition) {
         guard scrollAlpha != alpha else { return }
         scrollAlpha = alpha
         if scrollAlpha.isZero {
             shrinkLocationView(barPosition: barPosition)
-            if #available(iOS 26.0, *) { effectView.effect = barPosition == .bottom ? glassEffect : nil }
+            if #available(iOS 26.0, *), barPosition == .bottom {
+                effectView.effect = glassEffect
+            } else {
+                removeGlassEffectImmediately()
+            }
         } else {
             restoreLocationViewSize()
-            effectView.effect = nil
+            removeGlassEffectImmediately()
         }
         if let theme { applyTheme(theme: theme) }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14357)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31110)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

- Workaround to an apple bug, specific to iOS 26 regarding setting glass effect to nil.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

