### PR TITLE
Bugfix FXIOS-14232 [Experiment] The total display number of bottom sheets should be 1 for ToU 2 points experiment

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
@@ -100,14 +100,14 @@ final class TermsOfUseCoordinator: BaseCoordinator, TermsOfUseCoordinatorDelegat
         let hasAcceptedTermsOfService = prefs.intForKey(PrefsKeys.TermsOfServiceAccepted) == 1
         guard !hasAcceptedTermsOfUse && !hasAcceptedTermsOfService else { return false }
 
-        // 3. Check reminders count limit from Nimbus
-        let currentRemindersCount = prefs.intForKey(PrefsKeys.TermsOfUseRemindersCount) ?? 0
-        guard currentRemindersCount < maxRemindersCount else { return false }
-
-        // 4. Check if this is the first time it is shown
-        // Show on fresh install or next app open for existing users
+        // 3. Check if this is the first time it is shown
+        // Always show first time - it is not a reminder
         let hasShownFirstTime = prefs.boolForKey(PrefsKeys.TermsOfUseFirstShown) ?? false
         guard hasShownFirstTime else { return true }
+
+        // 4. Check reminders count limit from Nimbus
+        let currentRemindersCount = prefs.intForKey(PrefsKeys.TermsOfUseRemindersCount) ?? 0
+        guard currentRemindersCount < maxRemindersCount else { return false }
 
         // 5. Check if user dismissed and timeout period expired
         guard let dismissedTimestamp = prefs.timestampForKey(PrefsKeys.TermsOfUseDismissedDate) else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14232)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30835)

## :bulb: Description
For Experiment with 2 ToU experience points, we want the total display number for ToU bottom sheet to be 1. It means the bottom sheet will appear only the first time, so for the max-reminders-count variable from NImbus the value is 0. This PR solves the issue for this case - before, when max-reminders-count value was 0 the bottom sheet did not appear at all. Now, we check the maximum reminders count only after we show the bottom sheet for the first time, to be sure it will always appear the first time, even if the value for reminders is 0.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

