### PR TITLE
Refactor FXIOS-14344 [Swift 6 migration] Fixing warnings in unit tests 

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserWebUIDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserWebUIDelegateTests.swift
@@ -21,8 +21,8 @@ final class BrowserWebUIDelegateTests: XCTestCase {
         )
     }
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         let profile = MockProfile()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
@@ -30,11 +30,11 @@ final class BrowserWebUIDelegateTests: XCTestCase {
         mockLegacyResponder = MockLegacyResponder()
     }
 
-    override func tearDown() {
+    override func tearDown()  async throws {
         DependencyHelperMock().reset()
         engineResponder = nil
         mockLegacyResponder = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testCreateWebView_respondsToEngineResponder() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
@@ -16,8 +16,8 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
     var urlBar: MockURLBarView!
     var overlayState: MockOverlayModeManager!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
         profile = MockProfile()
         urlBar = MockURLBarView()
@@ -28,14 +28,13 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
                                                    overlayState: nil)
     }
 
-    override func tearDown() {
-        super.tearDown()
-
+    override func tearDown() async throws {
         profile.shutdown()
         profile = nil
         urlBar = nil
         overlayState = nil
         subject = nil
+        try await super.tearDown()
     }
 
     // MARK: - Test should Present cases

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintViewProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintViewProviderTests.swift
@@ -13,15 +13,15 @@ class ContextualHintViewProviderTests: XCTestCase {
 
     private var profile: MockProfile!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
         profile = MockProfile()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
+        try await super.setUp()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
         profile = nil
+        try await super.tearDown()
     }
 
     // MARK: Mark Contextual Hint Configuration

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/ContextMenu/ContextMenuConfigurationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/ContextMenu/ContextMenuConfigurationTests.swift
@@ -8,6 +8,7 @@ import XCTest
 
 @testable import Client
 
+@MainActor
 final class ContextMenuConfigurationTests: XCTestCase {
     func tests_initialState_forMerinoItem_returnsExpectedState() {
         let merinoItem: HomepageItem = .merino(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/ContextMenu/ContextMenuCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/ContextMenu/ContextMenuCoordinatorTests.swift
@@ -12,16 +12,16 @@ import XCTest
 final class ContextMenuCoordinatorTests: XCTestCase {
     private var mockRouter: MockRouter!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         mockRouter = MockRouter(navigationController: MockNavigationController())
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockRouter = nil
         DependencyHelperMock().reset()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_initialState() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
@@ -8,13 +8,13 @@ import MozillaAppServices
 
 @testable import Client
 
+@MainActor
 final class HomepageDiffableDataSourceTests: XCTestCase {
     var collectionView: UICollectionView?
     var diffableDataSource: HomepageDiffableDataSource?
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-
+    override func setUp() async throws {
+        try await super.setUp()
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         let collectionView = try XCTUnwrap(collectionView)
         diffableDataSource = HomepageDiffableDataSource(
@@ -26,11 +26,11 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         diffableDataSource = nil
         collectionView = nil
         DependencyHelperMock().reset()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     // MARK: - applyInitialSnapshot

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
@@ -14,20 +14,20 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
     var mockStore: MockStoreForMiddleware<AppState>!
     var mockThrottler: MockThrottler!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
         DependencyHelperMock().bootstrapDependencies()
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockThrottler = nil
         mockNotificationCenter = nil
         mockThemeManager = nil
         DependencyHelperMock().reset()
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     // MARK: - Initial State

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/PrivateHomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/PrivateHomepageViewControllerTests.swift
@@ -7,6 +7,7 @@ import Common
 
 @testable import Client
 
+@MainActor
 final class PrivateHomepageViewControllerTests: XCTestCase {
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/BookmarksMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/BookmarksMiddlewareTests.swift
@@ -11,18 +11,18 @@ final class BookmarksMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockProfile: MockProfile!
     var mockStore: MockStoreForMiddleware<AppState>!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         mockProfile = MockProfile()
         DependencyHelperMock().bootstrapDependencies()
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockProfile = nil
         DependencyHelperMock().reset()
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_initializeAction_getBookmarksData() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
@@ -13,8 +13,8 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockStore: MockStoreForMiddleware<AppState>!
     var mockNotificationCenter: MockNotificationCenter!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         mockGleanWrapper = MockGleanWrapper()
         mockNotificationCenter = MockNotificationCenter()
         DependencyHelperMock().bootstrapDependencies()
@@ -22,12 +22,12 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         DependencyHelperMock().reset()
         mockGleanWrapper = nil
         mockNotificationCenter = nil
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_init_setsUpNotifications() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoMiddlewareTests.swift
@@ -14,18 +14,18 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockGleanWrapper: MockGleanWrapper!
     var mockStore: MockStoreForMiddleware<AppState>!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         mockGleanWrapper = MockGleanWrapper()
         DependencyHelperMock().bootstrapDependencies()
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         DependencyHelperMock().reset()
         mockGleanWrapper = nil
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_initializeHomepageAction_getPocketData() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MessageCardMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MessageCardMiddlewareTests.swift
@@ -10,16 +10,16 @@ import XCTest
 final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockStore: MockStoreForMiddleware<AppState>!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         DependencyHelperMock().reset()
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_initializeAction_getMessageCardData() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
@@ -16,19 +16,19 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockStore: MockStoreForMiddleware<AppState>!
     var appState: AppState!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
         mockGleanWrapper = MockGleanWrapper()
         DependencyHelperMock().bootstrapDependencies()
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockGleanWrapper = nil
         DependencyHelperMock().reset()
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_homepageInitializeAction_returnsTopSitesSection() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Wallpaper/WallpaperMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Wallpaper/WallpaperMiddlewareTests.swift
@@ -12,16 +12,16 @@ class WallpaperMiddlewareTests: XCTestCase, StoreTestUtility {
     let wallpaperManager = WallpaperManagerMock()
     var appState: AppState!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
 
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_hompageAction_returnsWallpaperManagerWallpaper() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryDiffableDataSourceTests.swift
@@ -7,13 +7,13 @@ import Storage
 
 @testable import Client
 
+@MainActor
 final class ShortcutsLibraryDiffableDataSourceTests: XCTestCase {
     var collectionView: UICollectionView?
     var diffableDataSource: ShortcutsLibraryDiffableDataSource?
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-
+    override func setUp() async throws {
+        try await super.setUp()
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         let collectionView = try XCTUnwrap(collectionView)
         diffableDataSource = ShortcutsLibraryDiffableDataSource(
@@ -24,11 +24,11 @@ final class ShortcutsLibraryDiffableDataSourceTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         diffableDataSource = nil
         collectionView = nil
         DependencyHelperMock().reset()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_updateSnapshot_initialSnapshotHasNoData() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryMiddlewareTests.swift
@@ -12,16 +12,16 @@ final class ShortcutsLibraryMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockGleanWrapper: MockGleanWrapper!
     var mockStore: MockStoreForMiddleware<AppState>!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         mockGleanWrapper = MockGleanWrapper()
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockGleanWrapper = nil
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_viewDidAppearAction_sendsTelemetryData_whenShouldRecordImpressionTelemetry_isTrue() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ShortcutsLibrary/ShortcutsLibraryViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ShortcutsLibrary/ShortcutsLibraryViewControllerTests.swift
@@ -9,16 +9,16 @@ import XCTest
 final class ShortcutsLibraryViewControllerTests: XCTestCase, StoreTestUtility {
     var mockStore: MockStoreForMiddleware<AppState>!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         DependencyHelperMock().reset()
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_viewDidLoad_triggersShortcutsLibraryAction() throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14344)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31077)

## :bulb: Description
Fix warnings in:
- BrowserWebUIDelegateTests
- ContextualHint tests
- ContextMenu tests
- Homepage tests
- BookmarksMiddlewareTests
- MessageCardMiddlewareTests
- TopSitesMiddlewareTests
- Middlewares tests
- ShortcutsLibrary tests

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

