### PR TITLE
Add NO_TICKET Add a test to confirm previous fix for deleting multiple Rust logins

### DIFF
--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -357,8 +357,8 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
             do {
                 let record = try self.storage?.get(id: id)
                 completionHandler(.success(record))
-            } catch let err as NSError {
-                completionHandler(.failure(err))
+            } catch {
+                completionHandler(.failure(error))
             }
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
No ticket.

## :bulb: Description
Adding a unit test to ensure we don't regress on the fix for #30972.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

