### PR TITLE
Refactor FXIOS-14344 [Swift 6 migration] Fixing warnings in unit tests 

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
@@ -266,7 +266,7 @@ final class AddressListViewModelTests: XCTestCase {
     }
 }
 
-final class MockAutofill: AddressProvider, SyncAutofillProvider {
+final class MockAutofill: AddressProvider, SyncAutofillProvider, @unchecked Sendable {
     var mockListAllAddressesResult: Result<[Address], Error>?
     var mockSaveAddressResult: Result<Address, Error>?
     var mockEditAddressResult: Result<Void, Error>?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockLoginProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockLoginProvider.swift
@@ -5,7 +5,7 @@
 import Foundation
 import MozillaAppServices
 
-class MockLoginProvider: LoginProvider, SyncLoginProvider {
+class MockLoginProvider: LoginProvider, SyncLoginProvider, @unchecked Sendable {
     var searchLoginsWithQueryCalledCount = 0
     var addLoginCalledCount = 0
     var getStoredKeyCalledCount = 0

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockPlaces.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockPlaces.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-class MockPlaces: SyncPlacesProvider {
+class MockPlaces: SyncPlacesProvider, @unchecked Sendable {
     var registerWithSyncManagerCalled = 0
 
     func registerWithSyncManager() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRemoteTabs.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRemoteTabs.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-class MockRemoteTabs: SyncTabsProvider {
+class MockRemoteTabs: SyncTabsProvider, @unchecked Sendable {
     var registerWithSyncManagerCalled = 0
 
     func registerWithSyncManager() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
@@ -13,14 +13,15 @@ class OnboardingButtonActionTests: XCTestCase {
     var mockDelegate: MockOnboardingCardDelegateController!
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        DependencyHelperMock().reset()
         mockDelegate = nil
+        try await super.tearDown()
     }
 
     func testMockDelegate_whenInitialized_actionIsNil() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingViewControllerProtocolTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingViewControllerProtocolTests.swift
@@ -11,16 +11,16 @@ class OnboardingViewControllerProtocolTests: XCTestCase {
     var nimbusUtility: NimbusOnboardingTestingConfigUtility!
     typealias cards = NimbusOnboardingTestingConfigUtility.CardOrder
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         nimbusUtility = NimbusOnboardingTestingConfigUtility()
         nimbusUtility.setupNimbus(withOrder: cards.allCards)
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
         nimbusUtility = nil
+        try await super.tearDown()
     }
 
     // MARK: - Test `getNextOnboardingCard` forward

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
@@ -33,6 +33,7 @@ class UpdateViewModelTests: XCTestCase {
     }
 
     // MARK: Enable cards
+    @MainActor
     func testEnabledCards_ForHasSyncAccount() {
         profile.hasSyncableAccountMock = true
         let subject = createSubject()
@@ -50,6 +51,7 @@ class UpdateViewModelTests: XCTestCase {
         waitForExpectations(timeout: 2.0)
     }
 
+    @MainActor
     func testEnabledCards_ForSyncAccountDisabled() {
         profile.hasSyncableAccountMock = false
         let subject = createSubject()
@@ -68,6 +70,7 @@ class UpdateViewModelTests: XCTestCase {
     }
 
     // MARK: Has Single card
+    @MainActor
     func testHasSingleCard_ForHasSyncAccount() {
         profile.hasSyncableAccountMock = true
         let subject = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ReaderModeStyleTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ReaderModeStyleTests.swift
@@ -11,16 +11,16 @@ class ReaderModeStyleTests: XCTestCase {
     var themeManager: ThemeManager!
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         themeManager = AppContainer.shared.resolve()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         DependencyHelperMock().reset()
         themeManager = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func test_initWithProperties_succeeds() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -70,7 +70,7 @@ class RustSyncManagerTests: XCTestCase {
             .addresses
         ]
 
-        rustSyncManager.getEnginesAndKeys(engines: engines) { (engines, keys) in
+        rustSyncManager.getEnginesAndKeys(engines: engines) { [tabs, logins, autofill, places] (engines, keys) in
             XCTAssertEqual(engines.count, 6)
 
             XCTAssertEqual(engines[safe: 0], "bookmarks")
@@ -83,10 +83,10 @@ class RustSyncManagerTests: XCTestCase {
 
             XCTAssertNotNil(keys["creditcards"])
 
-            XCTAssertEqual(self.tabs.registerWithSyncManagerCalled, 1)
-            XCTAssertEqual(self.logins.registerWithSyncManagerCalled, 1)
-            XCTAssertEqual(self.autofill.registerWithSyncManagerCalled, 1)
-            XCTAssertEqual(self.places.registerWithSyncManagerCalled, 1)
+            XCTAssertEqual(tabs?.registerWithSyncManagerCalled, 1)
+            XCTAssertEqual(logins?.registerWithSyncManagerCalled, 1)
+            XCTAssertEqual(autofill?.registerWithSyncManagerCalled, 1)
+            XCTAssertEqual(places?.registerWithSyncManagerCalled, 1)
         }
     }
 
@@ -133,7 +133,7 @@ class RustSyncManagerTests: XCTestCase {
             .addresses
         ]
 
-        rustSyncManager.getEnginesAndKeys(engines: engines) { (engines, keys) in
+        rustSyncManager.getEnginesAndKeys(engines: engines) { [tabs, logins, autofill, places] (engines, keys) in
             XCTAssertEqual(engines.count, 5)
 
             XCTAssertEqual(engines[safe: 0], "bookmarks")
@@ -145,10 +145,10 @@ class RustSyncManagerTests: XCTestCase {
 
             XCTAssertNotNil(keys["creditcards"])
 
-            XCTAssertEqual(self.tabs.registerWithSyncManagerCalled, 1)
-            XCTAssertEqual(self.logins.registerWithSyncManagerCalled, 0)
-            XCTAssertEqual(self.autofill.registerWithSyncManagerCalled, 1)
-            XCTAssertEqual(self.places.registerWithSyncManagerCalled, 1)
+            XCTAssertEqual(tabs?.registerWithSyncManagerCalled, 1)
+            XCTAssertEqual(logins?.registerWithSyncManagerCalled, 0)
+            XCTAssertEqual(autofill?.registerWithSyncManagerCalled, 1)
+            XCTAssertEqual(places?.registerWithSyncManagerCalled, 1)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ScreenshotHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ScreenshotHelperTests.swift
@@ -6,27 +6,28 @@ import XCTest
 
 @testable import Client
 
+@MainActor
 final class ScreenshotHelperTests: XCTestCase, StoreTestUtility {
     var profile: MockProfile!
     let tabManager = MockTabManager()
     var mockVC: MockBrowserViewController!
     var mockStore: MockStoreForMiddleware<AppState>!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         profile = MockProfile()
         DependencyHelperMock().bootstrapDependencies()
         mockVC = MockBrowserViewController(profile: profile, tabManager: tabManager)
         setupStore()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         profile.shutdown()
         profile = nil
         DependencyHelperMock().reset()
         mockVC = nil
         resetStore()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testTakeScreenshotForHomepage() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/SearchViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/SearchViewModelTests.swift
@@ -15,8 +15,8 @@ final class SearchViewModelTests: XCTestCase {
     var searchEnginesManager: SearchEnginesManager!
     var remoteClient: RemoteClient!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile(firefoxSuggest: MockRustFirefoxSuggest())
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
@@ -43,13 +43,12 @@ final class SearchViewModelTests: XCTestCase {
         )
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         profile = nil
         mockDelegate = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
-    @MainActor
     func testHasFirefoxSuggestionsWhenAllConditionsAreFalse() {
         let subject = createSubject()
         searchEnginesManager.shouldShowBookmarksSuggestions = false
@@ -63,7 +62,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertFalse(subject.hasFirefoxSuggestions)
     }
 
-    @MainActor
     func testHasFirefoxSuggestionsWhenFirefoxSuggestionsExistButShouldNotShowIsFalse() {
         let subject = createSubject()
         subject.firefoxSuggestions = [
@@ -74,7 +72,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertFalse(subject.hasFirefoxSuggestions)
     }
 
-    @MainActor
     func test_hasFirefoxSuggestions_whenFirefoxSuggestionsExist_andSearchTermIsNotEmpty_shouldShowIsTrue() {
         let subject = createSubject()
         subject.searchQuery = "searchTerm"
@@ -85,7 +82,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertTrue(subject.hasFirefoxSuggestions)
     }
 
-    @MainActor
     func testHasFirefoxSuggestions_whenFirefoxSuggestionsExist_andSearchTermIsEmpty_shouldShowIsTrue() {
         let subject = createSubject()
         subject.searchQuery = ""
@@ -96,7 +92,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertFalse(subject.hasFirefoxSuggestions)
     }
 
-    @MainActor
     func testFirefoxSuggestionReturnsNoSuggestions() async throws {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -117,7 +112,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(subject.firefoxSuggestions.count, 0)
     }
 
-    @MainActor
     func testFirefoxSuggestionReturnsNoSuggestionsWhenSuggestionSettingsFalse() async throws {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -134,7 +128,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
-    @MainActor
     func testFirefoxSuggestionReturnsSponsoredAndNonSponsored() async throws {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -150,7 +143,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 1)
     }
 
-    @MainActor
     func testSyncedTabsAreFilteredWhenShowSponsoredSuggestionsIsTrue() {
         searchEnginesManager.shouldShowSponsoredSuggestions = true
         let remoteTab1 = RemoteTab(
@@ -188,7 +180,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(subject.filteredRemoteClientTabs.count, 2)
     }
 
-    @MainActor
     func testSyncedTabsAreNotFilteredWhenShowSponsoredSuggestionsIsFalse() {
         searchEnginesManager.shouldShowSponsoredSuggestions = false
 
@@ -227,7 +218,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(subject.filteredRemoteClientTabs.count, 3)
     }
 
-    @MainActor
     func testSponsoredSuggestionsAreNotShownInPrivateBrowsingMode() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
         searchEnginesManager.shouldShowFirefoxSuggestions = true
@@ -238,7 +228,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
-    @MainActor
     func testNonSponsoredSuggestionsAreNotShownInPrivateBrowsingMode() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
 
@@ -251,7 +240,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
-    @MainActor
     func testNonSponsoredAndSponsoredSuggestionsInPrivateModeWithPrivateSuggestionsOn() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
 
@@ -264,7 +252,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
-    @MainActor
     func testNonSponsoredInPrivateModeWithPrivateSuggestionsOn() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
         searchEnginesManager.shouldShowFirefoxSuggestions = true
@@ -276,7 +263,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
-    @MainActor
     func testNonSponsoredAndSponsoredSuggestionsAreNotShownInPrivateBrowsingMode() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
 
@@ -287,7 +273,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 0)
     }
 
-    @MainActor
     func testLoad_forFirefoxSuggestions_doesNotTriggerReloadForSameSuggestions() async throws {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -317,7 +302,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(subject.historySites.count, 1)
     }
 
-    @MainActor
     func testLoad_forHistoryAndBookmarks_doesNotTriggerReloadForSameSuggestions() async throws {
         searchEnginesManager.shouldShowSponsoredSuggestions = false
         let subject = createSubject()
@@ -330,7 +314,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 1)
     }
 
-    @MainActor
     func testLoad_multipleTimes_doesNotTriggerReloadForSameSuggestions() async throws {
         searchEnginesManager.shouldShowSponsoredSuggestions = false
         let subject = createSubject()
@@ -343,7 +326,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didReloadTableViewCount, 1)
     }
 
-    @MainActor
     func testFirefoxSuggestionReturnsSponsored() async {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -359,7 +341,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(subject.firefoxSuggestions.count, 1)
     }
 
-    @MainActor
     func testFirefoxSuggestionReturnsNonSponsored() async {
         FxNimbus.shared.features.firefoxSuggestFeature.with(initializer: { _, _ in
             FirefoxSuggestFeature(availableSuggestionsTypes:
@@ -375,7 +356,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(subject.firefoxSuggestions.count, 1)
     }
 
-    @MainActor
     func testQuickSearchEnginesWithSearchSuggestionsEnabled() {
         let subject = createSubject()
         subject.searchEnginesManager = searchEnginesManager
@@ -388,7 +368,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(quickSearchEngines.count, 5)
     }
 
-    @MainActor
     func testQuickSearchEnginesWithSearchSuggestionsDisabled() {
         searchEnginesManager.shouldShowSearchSuggestions = false
         let subject = createSubject()
@@ -404,7 +383,6 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     // MARK: Trending Searches
-    @MainActor
     func test_shouldShowHeader_forTrendingSearches_withFFOn_andSearchTerm_doesNotShowHeader() async {
         setupNimbusTrendingSearchesTesting(isEnabled: true)
         let subject = createSubject()
@@ -414,7 +392,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertFalse(shouldShowHeader)
     }
 
-    @MainActor
     func test_shouldShowHeader_withTrendingSearches_withFFOn_andSearchTermEmpty_showsHeader() {
         setupNimbusTrendingSearchesTesting(isEnabled: true)
         let expectation = XCTestExpectation(description: "reload table view called")
@@ -435,7 +412,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertTrue(shouldShowHeader)
     }
 
-    @MainActor
     func test_shouldShowHeader_withNoTrendingSearches_withFFOn_andSearchTermEmpty_doesNotShowHeader() async {
         setupNimbusTrendingSearchesTesting(isEnabled: true)
         let subject = createSubject()
@@ -446,7 +422,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertFalse(shouldShowHeader)
     }
 
-    @MainActor
     func test_shouldShowHeader_forTrendingSearches_withoutFeatureFlagOn_doesNotShowHeader() {
         setupNimbusTrendingSearchesTesting(isEnabled: false)
         let subject = createSubject()
@@ -456,7 +431,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertFalse(shouldShowHeader)
     }
 
-    @MainActor
     func test_retrieveTrendingSearches_withSuccess_hasExpectedList() {
         setupNimbusTrendingSearchesTesting(isEnabled: true)
         let expectation = XCTestExpectation(description: "reload table view called")
@@ -491,7 +465,6 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     // MARK: - Recent Searches
-    @MainActor
     func test_shouldShowHeader_forRecentSearches_withFFOn_andSearchTerm_doesNotShowHeader() async {
         setupNimbusRecentSearchesTesting(isEnabled: true)
         let subject = createSubject()
@@ -501,7 +474,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertFalse(shouldShowHeader)
     }
 
-    @MainActor
     func test_shouldShowHeader_withRecentSearches_withFFOn_andSearchTermEmpty_showsHeader() async {
         setupNimbusRecentSearchesTesting(isEnabled: true)
         let mockRecentSearchProvider = MockRecentSearchProvider()
@@ -522,7 +494,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertTrue(shouldShowHeader)
     }
 
-    @MainActor
     func test_shouldShowHeader_withNoRecentSearches_withFFOn_andSearchTermEmpty_doesNotShowHeader() async {
         setupNimbusRecentSearchesTesting(isEnabled: true)
         let subject = createSubject()
@@ -533,7 +504,6 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertFalse(shouldShowHeader)
     }
 
-    @MainActor
     func test_shouldShowHeader_forRecentSearches_withoutFeatureFlagOn_doesNotShowHeader() async {
         setupNimbusRecentSearchesTesting(isEnabled: false)
         let subject = createSubject()
@@ -613,7 +583,7 @@ final class SearchViewModelTests: XCTestCase {
     }
 }
 
-class MockSearchDelegate: SearchViewDelegate {
+final class MockSearchDelegate: SearchViewDelegate {
     var searchData = Cursor<Site>()
     var didReloadTableViewCount = 0
     var didReloadSearchEngines = 0

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -17,8 +17,8 @@ class AppSettingsTableViewControllerTests: XCTestCase {
     private var mockParentCoordinator: MockSettingsFlowDelegate!
     private var mockGleanUsageReportingMetricsService: MockGleanUsageReportingMetricsService!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         self.profile = MockProfile()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
@@ -31,8 +31,8 @@ class AppSettingsTableViewControllerTests: XCTestCase {
         self.mockGleanUsageReportingMetricsService = MockGleanUsageReportingMetricsService(profile: MockProfile())
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
         DependencyHelperMock().reset()
         self.profile = nil
         self.tabManager = nil

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SearchBarSettingsViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SearchBarSettingsViewModelTests.swift
@@ -13,8 +13,8 @@ class SearchBarSettingsViewModelTests: XCTestCase {
     var prefs: Prefs!
     var mockNotificationCenter: MockNotificationCenter!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         let profile = MockProfile(databasePrefix: "SearchBarSettingsTests")
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         prefs = profile.prefs
@@ -22,8 +22,8 @@ class SearchBarSettingsViewModelTests: XCTestCase {
         mockNotificationCenter = MockNotificationCenter()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
         prefs.clearAll()
         prefs = nil
         mockNotificationCenter = nil

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
@@ -6,23 +6,23 @@ import XCTest
 
 @testable import Client
 
+@MainActor
 final class SummarizeSettingsViewControllerTests: XCTestCase {
     private var profile: Profile!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         self.profile = MockProfile()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         DependencyHelperMock().reset()
         self.profile = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
-    @MainActor
     func test_generateSettings_withShakeFeature_hasExpectedSections() {
         setupNimbusHostedSummarizerTesting(isEnabled: true)
         let subject = createSubject()
@@ -34,7 +34,6 @@ final class SummarizeSettingsViewControllerTests: XCTestCase {
         XCTAssertEqual(sections.last?.children.count, 1)
     }
 
-    @MainActor
     func test_generateSettings_withoutShakeFeature_hasExpectedSections() {
         setupNimbusHostedSummarizerTesting(isEnabled: false)
         let subject = createSubject()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14344)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31077)

## :bulb: Description
Fix warnings in:
- HistoryPanelViewModelTests
- OnboardingButtonActionTests
- OnboardingViewControllerProtocolTests
- UpdateViewModelTests
- ReaderModeStyleTests
- RustSyncManagerTests
- ScreenshotHelperTests
- SearchViewModelTests
- SummarizeSettingsViewControllerTests
- AppSettingsTableViewControllerTests

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

