### PR TITLE
Refactor FXIOS-14344 [Swift 6 Migration]  Fix strict concurrency warnings in `BrowserCoordinatorTests`

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -593,12 +593,8 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         let childCoordinator = subject.childCoordinators.first
         XCTAssertTrue(childCoordinator is SummarizeCoordinator)
 
-        /// Yield the main actor for one run loop, which will ensure the animations on `snapshot` finish.
-        /// This is because the `UIGraphicsImageRenderer`'s `drawHierarchy(in: bounds, afterScreenUpdates: true)` call has
-        /// `afterScreenUpdates` set to `true`, which causes UIKit to hold onto the `MockBrowserViewController` for an extra
-        /// run loop after this `@MainActor` test function and `@MainActor` tearDown() have completed, causing a crash
-        /// after the BVC's `deinit` runs and tries to unsubscribe from Redux *after* all our dependencies have been
-        /// deallocated.
+        /// Yield the main actor for one run loop, ensuring the animations on the mock BVC's `view.snapshot` can complete.
+        /// See PR #31137 for more details.
         await Task.yield()
     }
 
@@ -644,12 +640,8 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         }
         XCTAssertEqual(numberOfSummarizeCoordinators, 1)
 
-        /// Yield the main actor for one run loop, which will ensure the animations on `snapshot` finish.
-        /// This is because the `UIGraphicsImageRenderer`'s `drawHierarchy(in: bounds, afterScreenUpdates: true)` call has
-        /// `afterScreenUpdates` set to `true`, which causes UIKit to hold onto the `MockBrowserViewController` for an extra
-        /// run loop after this `@MainActor` test function and `@MainActor` tearDown() have completed, causing a crash
-        /// after the BVC's `deinit` runs and tries to unsubscribe from Redux *after* all our dependencies have been
-        /// deallocated.
+        /// Yield the main actor for one run loop, ensuring the animations on the mock BVC's `view.snapshot` can complete.
+        /// See PR #31137 for more details.
         await Task.yield()
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14344)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31077)

## :bulb: Description

- Fixes strict concurrency warnings in `BrowserCoordinatorTests`. 
- Fixes 2 failing unit tests related to the summarizer panel by adding a `Task.yield()` to wait for one run loop of the main thread so animations can finish on the `MockBrowserViewController`, allowing it to be deallocated before the `tearDown()` runs.
  - testShowSummarizePanel_whenSummarizeCoordinatorAlreadyPresent_doesntAddNewOne
  - testShowSummarizePanel_whenSummarizeFeatureEnabled_showsPanel

### Discussion
Without the `Task.yield()`, we will crash on missing dependencies when the BVC deinit tries to unsubscribe from Redux _after_ all the dependencies have been cleaned up and deallocated in the test's `tearDown()`. See the stack trace:

<img width="2032" height="1096" alt="Screenshot 2025-12-05 at 1 07 24 PM" src="https://github.com/user-attachments/assets/8ecb3465-5a8f-4223-ab83-709c237d255f" />


For more context on the crash / animation: https://github.com/mozilla-mobile/firefox-ios/pull/31024#issuecomment-3607481185

**tldr;**
The test runs on the main actor. We yield the main actor for one run loop, which will ensure the animations on the mock BVC's `view.snapshot` complete. 

**Which animations?**
The `UIGraphicsImageRenderer`'s `drawHierarchy(in: bounds, afterScreenUpdates: true)` is called with `afterScreenUpdates` set to `true`, which causes UIKit to hold onto the `MockBrowserViewController` for an extra run loop. But since the test and now (as of this PR) the `tearDown()` are both `@MainActor`, there is no chance for the animation to run before the test `tearDown()` completes and all dependencies are cleaned up. 

Without the `Task.yield()`, the `MockBrowserViewController` is retained until _after_ the `tearDown()` method completes. At this point, its `deinit` would fire and we'd be missing our injected dependencies, causing the crash pictured above.

---
cc @Cramsden @lmarceau @dataports 


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code