### PR TITLE
Fix FXIOS-13993 [Performance] Attempt to resolve iPad constriant warnings

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -230,7 +230,9 @@ public class BrowserAddressToolbar: UIView,
             equalTo: toolbarContainerView.trailingAnchor)
         trailingBrowserActionStackConstraint?.isActive = true
 
-        locationContainerHeightConstraint = locationContainer.heightAnchor.constraint(equalToConstant: UX.locationHeight)
+        locationContainerHeightConstraint = locationContainer.heightAnchor.constraint(
+            greaterThanOrEqualToConstant: UX.locationHeight
+        )
         locationContainerHeightConstraint?.isActive = true
 
         toolbarBottomConstraint = toolbarContainerView.bottomAnchor.constraint(
@@ -388,8 +390,8 @@ public class BrowserAddressToolbar: UIView,
 
             if button.configuration?.title == nil {
                 NSLayoutConstraint.activate([
-                    button.widthAnchor.constraint(equalToConstant: UX.buttonSize.width),
-                    button.heightAnchor.constraint(equalToConstant: UX.buttonSize.height),
+                    button.widthAnchor.constraint(greaterThanOrEqualToConstant: UX.buttonSize.width),
+                    button.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.buttonSize.height),
                 ])
             } else {
                 NSLayoutConstraint.activate([

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -305,7 +305,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
         view.addSubview(privateModeButton)
 
         NSLayoutConstraint.activate([
-            view.heightAnchor.constraint(equalToConstant: UX.topTabsViewHeight),
+            view.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.topTabsViewHeight),
 
             newTab.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             newTab.widthAnchor.constraint(equalTo: view.heightAnchor),


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13993)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30322)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Skeleton tabs that are part of the swiping tab feature are somehow causing a breaking constraint of top and bottom padding (8). This conflicts with the constraint of button height which is 44 and causes autolayout to have to break the height constraint. This appears to be causing performance issues because it is happening for so many constraints. 

Questions I don't know the answer to:
Where is this top and bottom padding of 8 coming from? Skeleton toolbars only have a leading and trailing padding of 8
Why so many constraints and thus so many constraint violations. Part of the problem here is we have many violations but also constraints constantly getting readded

This PR makes all height constraints on toolbar and top tabs greater than or equal to to account for the skeleton toolbar padding and for dynamic type

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

