### PR TITLE
Refactor FXIOS-14339 ⁃ LegacyTabScrollController should use Notifiable protocol

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -296,7 +296,7 @@ final class LegacyTabScrollController: NSObject,
         }
     }
 
-    private func applicationWillTerminate(_ notification: Notification) {
+    private func applicationWillTerminate() {
         // Ensures that we immediately de-register KVO observations for content size changes in
         // webviews if the app is about to terminate.
         observedScrollViews.forEach({ stopObserving(scrollView: $0) })
@@ -455,7 +455,7 @@ final class LegacyTabScrollController: NSObject,
 
     public func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case UIApplication.didBecomeActiveNotification:
+        case UIApplication.willTerminateNotification:
             ensureMainThread {
                 self.applicationWillTerminate
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14339)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31068)

## :bulb: Description
Applied Notifiable protocol to LegacyTabScrollController

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

