### PR TITLE
Refactor FXIOS-14196 [Translations] rename bool to proper name

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -169,7 +169,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         /// Prewarm translation resources off the main thread
         /// This will fetch the translator WASM and model attachments for the device language.
         /// Running this on a utility QoS to avoid impacting app launch time.
-        if TranslationConfiguration(prefs: profile.prefs).canTranslate {
+        if featureFlags.isFeatureEnabled(.translation, checking: .buildOnly) {
             DispatchQueue.global(qos: .utility).async {
                 ASTranslationModelsFetcher().prewarmResourcesForStartup()
             }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -1068,9 +1068,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
         hasAlternativeLocationColor: Bool
     ) -> ToolbarActionConfiguration? {
         // Check if action has an updated configuration, otherwise default to state.
-        let canTranslateFromAction = action.translationConfiguration?.canTranslate ?? false
-        let canTranslateFromState = addressBarState.translationConfiguration?.canTranslate ?? false
-        let shouldShowTranslationIcon = canTranslateFromAction || canTranslateFromState
+        // We need to do this check because of existing architecture
+        // in which the state is updated after
+        // we configure the button, so we need to check action too.
+        let isFeatureEnabledFromAction = action.translationConfiguration?.isTranslationFeatureEnabled ?? false
+        let isFeatureEnabledFromState = addressBarState.translationConfiguration?.isTranslationFeatureEnabled ?? false
+        let shouldShowTranslationIcon = isFeatureEnabledFromAction || isFeatureEnabledFromState
         guard shouldShowTranslationIcon else { return nil }
         let configuration = action.translationConfiguration ?? addressBarState.translationConfiguration
         guard let state = configuration?.state else { return nil }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
@@ -54,13 +54,13 @@ struct TranslationConfiguration: Equatable, FeatureFlaggable {
     /// Determines whether to show the translate icon on the toolbar
     /// The experiment needs to be turned on and the user settings needs to be enabled
     /// If user has not toggled the settings, then we enable the feature by default
-    var canTranslate: Bool {
+    var isTranslationFeatureEnabled: Bool {
         let isExperimentOn = featureFlags.isFeatureEnabled(.translation, checking: .buildOnly)
         let isSettingsEnabled = prefs.boolForKey(PrefsKeys.Settings.translationsFeature) ?? true
         return isExperimentOn && isSettingsEnabled
     }
 
     static func == (lhs: TranslationConfiguration, rhs: TranslationConfiguration) -> Bool {
-        return lhs.canTranslate == rhs.canTranslate
+        return lhs.isTranslationFeatureEnabled == rhs.isTranslationFeatureEnabled
     }
 }

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -129,7 +129,7 @@ final class TranslationsMiddleware {
     /// and if so, dispatches a toolbar action to update the translation state.
     private func checkTranslationsAreEligible(for action: ToolbarAction) {
         Task { @MainActor in
-            guard action.translationConfiguration?.canTranslate == true else { return }
+            guard action.translationConfiguration?.isTranslationFeatureEnabled == true else { return }
 
             do {
                 guard try await translationsService.shouldOfferTranslation(for: action.windowUUID) else { return }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14196)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Rename `canTranslate` to `isTranslationFeatureEnabled` so that its less misleading. Now it is more clear that the Bool checks for whether the user can see translations based on settings and nimbus feature flags as opposed to eligibility of the page being translated.

- Also change logic for when we call `.prewarmResourcesForStartup` to be triggered only based on nimbus feature flag only and not based on user setting.  We want to ensure that if a user disables the setting and decides to enable settings afterwards, they will have the latest resources. Discussed with #issammani that the prewarm logic is not too expensive if we run without nimbus FF but user setting may be off.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

