### PR TITLE
Bugfix FXIOS-14375 [Unit Tests] fix failing `URLFormatterTests` in pipeline

### DIFF
--- a/BrowserKit/Tests/WebEngineTests/Utilities/URLFormatterTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/Utilities/URLFormatterTests.swift
@@ -35,12 +35,24 @@ final class URLFormatterTests: XCTestCase {
         XCTAssertEqual(result?.absoluteString, initialUrl)
     }
 
-    func testGetURLGivenAboutConfigSpaceURLThenValidEscapedURL() {
+    func testGetURLGivenAboutConfigSpaceURLThenValidEscapedURL_foriOS17AndBelow() throws {
+        if #available(iOS 17, *) {
+            throw XCTSkip("Skipping since test does not apply for iOS 17 and above versions")
+        } else {
+            let initialUrl = "about:%20config"
+            let subject = DefaultURLFormatter()
+            let result = subject.getURL(entry: initialUrl)
+            XCTAssertEqual(result?.absoluteString, "about:%20config")
+        }
+    }
+
+    func testGetURLGivenAboutConfigSpaceURLThenValidEscapedURL_foriOS17AndAbove() throws {
+        guard #available(iOS 17, *) else {
+            throw XCTSkip("Skipping unless iOS 17 and above versions")
+        }
         let initialUrl = "about: config"
         let subject = DefaultURLFormatter()
-
         let result = subject.getURL(entry: initialUrl)
-
         XCTAssertEqual(result?.absoluteString, "about:%20config")
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14375)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31161)

## :bulb: Description
It seems using `URL(string: xxx)`, which behaves differently from iOS 17 onwards, automatically converts spaces to their percent encoding `%20` in newer versions. We added two separate tests to clarify the issue for now. I will dig deeper into if we need to update production since it has been using this logic for a while and will add a follow up PR for this.

In the meantime, we can confirm if this addresses the failures in our pipeline.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

