### PR TITLE
Bugfix FXIOS-14371 [webcompat] Spoof Safari UAstring for roku.com

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -99,6 +99,8 @@ struct CustomUserAgentConstant {
     private static let safariMobileUA = UserAgentBuilder.defaultMobileUserAgent().clone(extensions: "Version/18.6 \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
 
     static let customMobileUAForDomain = [
+        // TODO: FXIOS-14371 [webcompat] rokuchannel blocking FXIOS "this browser isn't supported" (webcompat #126427)
+        "roku.com": safariMobileUA,
         // TODO: FXIOS-13391 [webcompat] "connection error" only on FxiOS/* UA (bug 1983983)
         "tver.jp": safariMobileUA,
         // TODO: FXIOS-13096 [webcompat] UA version parsed as "Safari 0" (webcompat #170304)


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-14371
Github issue #31153

## :bulb: Description

TheRokuChannel.roku.com doesn't allow "FXIOS" in, but works fine in "request desktop" mode, so let's request it with a plain Safari user agent.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If needed, I updated documentation and added comments to complex code