### PR TITLE
Bugfix FXIOS-14132 ⁃ iPad - "Undo" not working for the last tab closed in tab tray

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -552,11 +552,11 @@ final class TabManagerMiddleware: FeatureFlaggable,
     private func undoCloseTab(state: AppState, uuid: WindowUUID) {
         toastTelemetry.undoClosedSingleTab()
         let tabManager = tabManager(for: uuid)
-        guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: uuid),
-              tabManager.backupCloseTab != nil
-        else { return }
+        guard tabManager.backupCloseTab != nil else { return }
 
         tabManager.undoCloseTab()
+
+        guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: uuid) else { return }
 
         let model = getTabsDisplayModel(for: tabsState.isPrivateMode, uuid: uuid)
         let refreshAction = TabPanelMiddlewareAction(tabDisplayModel: model,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14132)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30645)

## :bulb: Description
Moved guard for screenState

## :movie_camera: Demos

https://github.com/user-attachments/assets/bcfd34af-ebb8-42b8-8b79-dbcd2d144759



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

