### PR TITLE
Add FXIOS-14298 Add Nimbus flag to control dismiss gesture and grabber handle

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseCoordinator.swift
@@ -39,6 +39,10 @@ final class TermsOfUseCoordinator: BaseCoordinator, TermsOfUseCoordinatorDelegat
         return nimbus.features.touFeature.value().maxRemindersCount
     }
 
+    private var enableDragToDismiss: Bool {
+        return nimbus.features.touFeature.value().enableDragToDismiss
+    }
+
     init(windowUUID: WindowUUID,
          router: Router,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
@@ -62,7 +66,8 @@ final class TermsOfUseCoordinator: BaseCoordinator, TermsOfUseCoordinatorDelegat
         let vc = TermsOfUseViewController(
             themeManager: themeManager,
             windowUUID: windowUUID,
-            notificationCenter: notificationCenter
+            notificationCenter: notificationCenter,
+            enableDragToDismiss: enableDragToDismiss
         )
         vc.coordinator = self
         vc.modalPresentationStyle = .overFullScreen

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
@@ -46,6 +46,8 @@ final class TermsOfUseViewController: UIViewController,
 
     private var activeContainerConstraints: [NSLayoutConstraint] = []
     private var textViewHeightConstraint: NSLayoutConstraint?
+    private var grabberHeightConstraint: NSLayoutConstraint?
+    private let isDragToDismissEnabled: Bool
 
     private var sheetContainer: UIView = .build { view in
         view.layer.cornerRadius = UX.cornerRadius
@@ -114,10 +116,12 @@ final class TermsOfUseViewController: UIViewController,
 
     init(themeManager: ThemeManager = AppContainer.shared.resolve(),
          windowUUID: UUID,
-         notificationCenter: NotificationProtocol = NotificationCenter.default) {
+         notificationCenter: NotificationProtocol = NotificationCenter.default,
+         enableDragToDismiss: Bool = true) {
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
         self.windowUUID = windowUUID
+        self.isDragToDismissEnabled = enableDragToDismiss
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -192,11 +196,14 @@ final class TermsOfUseViewController: UIViewController,
         view.addSubview(sheetContainer)
         sheetContainer.addSubview(grabberView)
         sheetContainer.addSubview(stackView)
+        grabberView.isHidden = !isDragToDismissEnabled
         addStackSubviews()
         setupConstraints()
         configureTextViewScrolling()
         setupDismissGesture()
-        setupPanGesture()
+        if isDragToDismissEnabled {
+            setupPanGesture()
+        }
     }
 
     func addStackSubviews() {
@@ -233,11 +240,15 @@ final class TermsOfUseViewController: UIViewController,
         NSLayoutConstraint.activate(containerConstraints)
         activeContainerConstraints = containerConstraints
 
+        let grabberHeight = grabberView.heightAnchor.constraint(equalToConstant:
+                            isDragToDismissEnabled ? UX.grabberHeight : 0)
+        grabberHeightConstraint = grabberHeight
+
         NSLayoutConstraint.activate([
             grabberView.topAnchor.constraint(equalTo: sheetContainer.topAnchor, constant: UX.grabberTopPadding),
             grabberView.centerXAnchor.constraint(equalTo: sheetContainer.centerXAnchor),
             grabberView.widthAnchor.constraint(equalToConstant: UX.grabberWidth),
-            grabberView.heightAnchor.constraint(equalToConstant: UX.grabberHeight),
+            grabberHeight,
 
             stackView.leadingAnchor.constraint(equalTo: sheetContainer.leadingAnchor, constant: UX.stackSidePadding),
             stackView.trailingAnchor.constraint(equalTo: sheetContainer.trailingAnchor, constant: -UX.stackSidePadding),
@@ -330,6 +341,8 @@ final class TermsOfUseViewController: UIViewController,
         view.backgroundColor = currentTheme().colors.layerScrim.withAlphaComponent(UX.backgroundAlpha)
         sheetContainer.backgroundColor = currentTheme().colors.layer1
         grabberView.backgroundColor = currentTheme().colors.iconDisabled
+        grabberView.isHidden = !isDragToDismissEnabled
+        grabberView.alpha = isDragToDismissEnabled ? 1.0 : 0.0
         titleLabel.textColor = currentTheme().colors.textPrimary
         acceptButton.tintColor = currentTheme().colors.textOnDark
         acceptButton.backgroundColor = currentTheme().colors.actionPrimary

--- a/firefox-ios/nimbus-features/touFeature.yaml
+++ b/firefox-ios/nimbus-features/touFeature.yaml
@@ -14,12 +14,19 @@ features:
           Maximum number of ToU bottom sheet reminders that can be displayed
         type: Int
         default: 2
+      enable-drag-to-dismiss:
+        description: >
+          Whether to show a drag handle on the prompt and allows users to use it to dismiss the prompt.
+        type: Boolean
+        default: true
     defaults:
       - channel: beta
         value:
           status: false
           max-reminders-count: 2
+          enable-drag-to-dismiss: true
       - channel: developer
         value:
           status: false
           max-reminders-count: 2
+          enable-drag-to-dismiss: true


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14298)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30965)

## :bulb: Description
This PR adds a Nimbus flag so we can enabled/disable swipe to dismiss for the bottom sheet and show/hide grabber.




## :movie_camera: Demos
 <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2025-12-09 at 11 55 03" src="https://github.com/user-attachments/assets/6561ef5a-6117-4b85-b4b5-4842ed48989e" />
 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

