### PR TITLE
Refactor FXIOS-14344 [Swift 6 migration] Fixing unit tests warnings

### DIFF
--- a/BrowserKit/Tests/SummarizeKitTests/FoundationModelsSummarizerTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/FoundationModelsSummarizerTests.swift
@@ -37,6 +37,7 @@ final class FoundationModelsSummarizerTests: XCTestCase {
         XCTAssertEqual(result, "hello world")
     }
 
+    @MainActor
     @available(iOS 26, *)
     func testSummarizerRespondNonStreamingThrowsRateLimited() async throws {
         let rateLimitError = LanguageModelSession.GenerationError.rateLimited(.init(debugDescription: "context"))
@@ -55,6 +56,7 @@ final class FoundationModelsSummarizerTests: XCTestCase {
         }
     }
 
+    @MainActor
     @available(iOS 26, *)
     func testSummarizerRespondNonStreamingThrowsUnknown() async throws {
         let randomError = NSError(domain: "Random error", code: 1)
@@ -95,6 +97,7 @@ final class FoundationModelsSummarizerTests: XCTestCase {
         XCTAssertEqual(receivedChunks, expectedResponse)
     }
 
+    @MainActor
     @available(iOS 26, *)
     func testSummarizerRespondStreamingThrowsGuardViolation() async throws {
         let guardViolationError = LanguageModelSession.GenerationError.guardrailViolation(.init(debugDescription: "context"))
@@ -114,6 +117,7 @@ final class FoundationModelsSummarizerTests: XCTestCase {
         }
     }
 
+    @MainActor
     @available(iOS 26, *)
     func testSummarizerRespondStreamingThrowsUnknown() async throws {
         let randomError = NSError(domain: "Random error", code: 1)

--- a/BrowserKit/Tests/SummarizeKitTests/LiteLLMSummarizerTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/LiteLLMSummarizerTests.swift
@@ -12,6 +12,7 @@ final class LiteLLMSummarizerTests: XCTestCase {
         XCTAssertEqual(result, "hello world")
     }
 
+    @MainActor
     func testSummarizeNonStreamingMapsRateLimited() async throws {
         let rateLimitError = LiteLLMClientError.invalidResponse(statusCode: 429)
         let subject = createSubject(respondWithError: rateLimitError)
@@ -28,6 +29,7 @@ final class LiteLLMSummarizerTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testSummarizeNonStreamingMapsInvalidResponse() async throws {
         let rateLimitError = LiteLLMClientError.invalidResponse(statusCode: 502)
         let subject = createSubject(respondWithError: rateLimitError)
@@ -45,6 +47,7 @@ final class LiteLLMSummarizerTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testSummarizeNonStreamingMapsUnknownError() async throws {
         let randomError = NSError(domain: "Random error", code: 1)
         let subject = createSubject(respondWithError: randomError)
@@ -74,6 +77,7 @@ final class LiteLLMSummarizerTests: XCTestCase {
         XCTAssertEqual(received, chunks.joined())
     }
 
+    @MainActor
     func testSummarizeStreamedMapsRateLimited() async throws {
         let rateLimitError = LiteLLMClientError.invalidResponse(statusCode: 429)
         let subject = createSubject(respondWithError: rateLimitError)
@@ -91,6 +95,7 @@ final class LiteLLMSummarizerTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testSummarizeStreamedMapsInvalidResponse() async throws {
         let rateLimitError = LiteLLMClientError.invalidResponse(statusCode: 567)
         let subject = createSubject(respondWithError: rateLimitError)
@@ -109,6 +114,7 @@ final class LiteLLMSummarizerTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testSummarizeStreamedMapsUnknownError() async throws {
         let randomError = NSError(domain: "Random error", code: 1)
         let subject = createSubject(respondWithError: randomError)

--- a/BrowserKit/Tests/SummarizeKitTests/Mocks/XCTest+TrackMemoryLeak.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/Mocks/XCTest+TrackMemoryLeak.swift
@@ -13,6 +13,7 @@ public extension XCTestCase {
         }
     }
 
+    @MainActor
     func assertAsyncThrows<E: Error, T>(
         ofType expectedType: E.Type,
         _ expression: () async throws -> T,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Theme/ThemeableTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Theme/ThemeableTests.swift
@@ -12,19 +12,19 @@ class ThemeableTests: XCTestCaseRootViewController {
     private var testThemeable: TestsThemeable!
     private var mockThemeManager: MockThemeManager!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         mockThemeManager = MockThemeManager()
         tableViewDelegate = TestsTableView()
         testThemeable = TestsThemeable()
         testThemeable.themeManager = mockThemeManager
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockThemeManager = nil
         tableViewDelegate = nil
         testThemeable = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     // MARK: Get all subviews
@@ -123,7 +123,7 @@ class TestsTableView: NSObject, UITableViewDataSource, UITableViewDelegate {
 }
 
 // MARK: - TestsThemeable
-class TestsThemeable: UIViewController, Themeable {
+final class TestsThemeable: UIViewController, @MainActor Themeable {
     var themeManager: ThemeManager = MockThemeManager()
     var themeListenerCancellable: Any?
     var notificationCenter: NotificationProtocol = NotificationCenter.default

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
@@ -39,6 +39,7 @@ final class UserAgentBuilderTests: XCTestCase {
         return XCTAssertEqual(agent, "FXIOS1 iPhone12 Apple 5 New details 14.090")
     }
 
+    @MainActor
     func testDefaultMobileUserAgent() {
         let builder = UserAgentBuilder.defaultMobileUserAgent()
         let systemInfo = "(\(UIDevice.current.model); CPU iPhone OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14344)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31077)

## :bulb: Description
Fix warnings in:
- ThemeableTests
- UserAgentBuilderTests
- SummarizerServiceTests (this one led to add a `@MainActor` on top of `assertAsyncThrows`, which means tests using this function needs to be `@MainActor` too).

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

