### PR TITLE
Bugfix FXIOS-12769 [Jump Back In] JBI section not showing when expected

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
@@ -21,6 +21,11 @@ struct TabManagerAction: Action {
     }
 }
 
+enum TabManagerActionType: ActionType {
+    case addedTab
+    case restoredTabs
+}
+
 enum TabManagerMiddlewareActionType: ActionType {
     case fetchedRecentTabs
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -76,6 +76,10 @@ final class TabManagerMiddleware: FeatureFlaggable,
             self.resolveScreenshotActions(action: action, state: state)
         } else if let action = action as? ShortcutsLibraryAction {
             self.resolveShortcutsLibrartActions(action: action, state: state)
+        } else if let action = action as? GeneralBrowserAction {
+            self.resolveGeneralBrowserAction(action: action)
+        } else if let action = action as? TabManagerAction {
+            self.resolveTabManagerAction(action: action)
         } else {
             self.resolveHomepageActions(with: action)
         }
@@ -85,6 +89,25 @@ final class TabManagerMiddleware: FeatureFlaggable,
         switch action.actionType {
         case ShortcutsLibraryActionType.switchTabToastButtonTapped:
             tabManager(for: action.windowUUID).selectTab(action.tab)
+        default:
+            break
+        }
+    }
+
+    private func resolveGeneralBrowserAction(action: GeneralBrowserAction) {
+        switch action.actionType {
+        case GeneralBrowserActionType.addNewTab:
+            dispatchRecentlyAccessedTabs(action: action)
+        default:
+            break
+        }
+    }
+
+    private func resolveTabManagerAction(action: TabManagerAction) {
+        switch action.actionType {
+        case TabManagerActionType.restoredTabs,
+            TabManagerActionType.addedTab:
+            dispatchRecentlyAccessedTabs(action: action)
         default:
             break
         }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -595,6 +595,13 @@ class TabManagerImplementation: NSObject,
         for delegate in delegates {
             delegate.get()?.tabManagerDidRestoreTabs(self)
         }
+
+        store.dispatch(
+            TabManagerAction(
+                windowUUID: windowUUID,
+                actionType: TabManagerActionType.restoredTabs
+            )
+        )
     }
 
     private func shouldClearPrivateTabs() -> Bool {
@@ -1115,6 +1122,13 @@ class TabManagerImplementation: NSObject,
                                  placeNextToParentTab: placeNextToParentTab,
                                  isRestoring: !tabRestoreHasFinished)
         }
+
+        store.dispatch(
+            TabManagerAction(
+                windowUUID: windowUUID,
+                actionType: TabManagerActionType.addedTab
+            )
+        )
 
         if !zombie {
             let configuration: WKWebViewConfiguration

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -20,13 +20,16 @@ class TabManagerTests: XCTestCase {
     var mockSessionStore: MockTabSessionStore!
     var mockProfile: MockProfile!
     var mockDiskImageStore: MockDiskImageStore!
+    var mockStore: MockStoreForMiddleware<AppState>!
+    var appState: AppState!
     let sleepTime: UInt64 = 1 * NSEC_PER_SEC
     let windowUUID: WindowUUID = .XCTestDefaultUUID
     /// 9 Sep 2001 8:00 pm GMT + 0
     let testDate = Date(timeIntervalSince1970: 1_000_065_600)
 
-    override func setUp() {
-        super.setUp()
+    @MainActor
+    override func setUp() async throws {
+        try await super.setUp()
 
         DependencyHelperMock().bootstrapDependencies()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
@@ -39,14 +42,18 @@ class TabManagerTests: XCTestCase {
         mockTabStore = MockTabDataStore()
         mockSessionStore = MockTabSessionStore()
         setIsDeeplinkOptimizationRefactorEnabled(false)
+        setupStore()
+        appState = setupAppState()
     }
 
-    override func tearDown() {
+    @MainActor
+    override func tearDown() async throws {
         mockProfile = nil
         mockDiskImageStore = nil
         mockTabStore = nil
         mockSessionStore = nil
-        super.tearDown()
+        resetStore()
+        try await super.tearDown()
     }
 
     @MainActor
@@ -213,6 +220,36 @@ class TabManagerTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation])
+    }
+
+    @MainActor
+    func testRestoreTabs_dispatchesAction() throws {
+        let testUUID = UUID()
+        let subject = createSubject(windowUUID: testUUID)
+        let expectation = XCTestExpectation(description: "Tab restoration should dispatch action")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        mockTabStore.fetchTabWindowData = WindowData(id: UUID(),
+                                                     activeTabId: UUID(),
+                                                     tabData: getMockTabData(count: 3))
+
+        subject.restoreTabs()
+
+        wait(for: [expectation])
+
+        let tabManagerActions = mockStore.dispatchedActions.compactMap { $0 as? TabManagerAction }
+
+        let restoredActions = tabManagerActions.filter {
+            ($0.actionType as? TabManagerActionType) == .restoredTabs
+        }
+
+        XCTAssertEqual(restoredActions.count, 1, "Expected exactly one restoredTabs action")
+
+        let restoredAction = try XCTUnwrap(restoredActions.first)
+        XCTAssertEqual(restoredAction.actionType as? TabManagerActionType, .restoredTabs)
     }
 
     @MainActor
@@ -1580,5 +1617,33 @@ class TabManagerTests: XCTestCase {
                 enabled: isEnabled
             )
         }
+    }
+
+    // MARK: StoreTestUtility
+    func setupAppState() -> Client.AppState {
+        let appState = AppState(
+            activeScreens: ActiveScreensState(
+                screens: [
+                    .tabsPanel(
+                        TabsPanelState(
+                            windowUUID: .XCTestDefaultUUID
+                        )
+                    )
+                ]
+            )
+        )
+        self.appState = appState
+        return appState
+    }
+
+    @MainActor
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    @MainActor
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -264,6 +264,81 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
     }
 
+    func test_browserActionAddNewTab_returnsRecentTabs() throws {
+        let subject = createSubject()
+        let action = GeneralBrowserAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: GeneralBrowserActionType.addNewTab
+        )
+
+        let expectation = XCTestExpectation(description: "Recent tabs should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.tabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabManagerAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? TabManagerMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
+        XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+    }
+
+    func test_tabManagerRestoredTabsAction_returnsRecentTabs() throws {
+        let subject = createSubject()
+        let action = TabManagerAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TabManagerActionType.restoredTabs
+        )
+
+        let expectation = XCTestExpectation(description: "Recent tabs should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.tabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabManagerAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? TabManagerMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
+        XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+    }
+
+    func test_tabManagerAddTabAction_returnsRecentTabs() throws {
+        let subject = createSubject()
+        let action = TabManagerAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TabManagerActionType.addedTab
+        )
+
+        let expectation = XCTestExpectation(description: "Recent tabs should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.tabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabManagerAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? TabManagerMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
+        XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+    }
+
     func test_tapOnCell_fromJumpBackInAction_selectsCorrectTabs() {
         let subject = createSubject()
         let action = JumpBackInAction(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12769)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27802)

## :bulb: Description
- Shows the jump back in homepage section when recently accessed tabs are available in the following scenarios:
  - On app launch
  - When the "+" toolbar button is tapped
  - When opening a new tab via toolbar swipe gesture 
  - When opening a shortcut/story/bookmark in a new tab via context menu 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

