### PR TITLE
Refactor FXIOS-14403 - [Performance] - Eliminate redundant blur view updates during BVC dismissal

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -679,6 +679,8 @@ class BrowserViewController: UIViewController,
         updateMicrosurveyConstraints()
         if isToolbarTranslucencyRefactorEnabled {
             addOrUpdateMaskViewIfNeeded()
+        } else {
+            updateToolbarDisplay()
         }
 
         let action = GeneralBrowserMiddlewareAction(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14403)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31208)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Performance profiling revealed that frequent calls to `updateBlurViews` were causing tab tray hangs during BVC dismissal. This PR eliminates unnecessary blur view updates during view controller transitions.

- Root Cause: `updateBlurViews` was invoked repeatedly during `BVC` dismissal, creating performance bottlenecks.
- As you can see, pretty bad hangs related to `updateBlurViews` method.

- Solution: Introduced a `shouldLayoutSubviews` flag that prevents blur view updates during transitions:
- When the tab tray button is tapped, `viewDidLayoutSubviews` was called approximately 2 times after `viewWillDisappear`.
- Each call triggered `updateBlurViews`, which was unnecessary during the transition animation.
- The new flag blocks these updates during BVC → Tab Tray transitions.
### Hangs before these changes:
<img width="1060" height="651" alt="updateBlurViewsHang" src="https://github.com/user-attachments/assets/ffa73dfd-f446-4141-b984-7c9f92dc4cc8" />

### Hangs with changes in this PR.
<img width="825" height="668" alt="noUpdateBlurViewsHangs" src="https://github.com/user-attachments/assets/87f9f294-2a57-410c-a14c-a66409cf9d07" />

- No more hangs related to `updateBlurViews` method, only micro hangs left to solve during presenting/dismissal animations.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

