### PR TITLE
Bugfix FXIOS-14404 [Unit Tests] fix failing RouteTests for < iOS 17

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -7,14 +7,14 @@ import XCTest
 
 @MainActor
 class RouteTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         DependencyHelperMock().reset()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testSearchRouteWithUrl() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14404)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31211)

## :bulb: Description
Fix failing `Route` tests for < iOS 17. The issue is similar to the one described in this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/31209/files).

This two tests `testShareSheetRouteUrlTitle ` and `testShareSheetRouteUrlTitleAndSubtitle` are failing for versions < iOS 17. This is because Apple changed how `URL(string: xxx)` works under the hood. The tests are failing because of the space in `TEST TITLE` causes `URL(string:)` to return `nil` instead of the url with `TEST%20TITLE`. This is due to older versions not automatically adding the percent encoding, see more details in the doc: https://developer.apple.com/documentation/foundation/url/init(string:)

<img width="953" height="339" alt="image" src="https://github.com/user-attachments/assets/bdc32054-5df7-4bf5-8671-0643d1fa4832" />

We update the test setup to use `URLComponents` instead. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

