### PR TITLE
Bugfix NO_TICKET Exclude `CFBundleDisplayName` from string linter

### DIFF
--- a/.github/l10n/linter_config_ios.json
+++ b/.github/l10n/linter_config_ios.json
@@ -20,6 +20,7 @@
             "Pocket"
         ],
         "exclusions": [
+            "firefox-ios.xliff:CFBundleDisplayName",
             "firefox-ios.xliff:ctDNmu",
             "firefox-ios.xliff:DefaultBrowserCard.BetterInternet.Description.v108",
             "firefox-ios.xliff:DefaultBrowserCard.Description",


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR adds `CFBundleDisplayName` to exlusion array for string linter
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

