### PR TITLE
Bugfix FXIOS-14398 [webcompat] Spoof Safari UAstring on lta.go.jp

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -103,6 +103,8 @@ struct CustomUserAgentConstant {
         "roku.com": safariMobileUA,
         // TODO: FXIOS-13391 [webcompat] "connection error" only on FxiOS/* UA (bug 1983983)
         "tver.jp": safariMobileUA,
+        // TODO: FXIOS-14398 [webcompat] ServiceNow rejects Mobile Safari version "null" (bug 1978984)
+        "lta.go.jp": safariMobileUA,
         // TODO: FXIOS-13096 [webcompat] UA version parsed as "Safari 0" (webcompat #170304)
         "epic.com": safariMobileUA,
         "athenahealth.com": safariMobileUA,


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-14398
Github issue #31199

## :bulb: Description

ServiceNow–based tax portal at payment.eltax.lta.go.jp can't parse FxiOS versions correctly, insisting it's unsupported Mobile Safari version "null". Works fine in "desktop site" mode, so let's request it with just plain Safari user agent.

<!-- Please upload screenshots or video demos of your work, if applicable
## :movie_camera: Demos
| Before | After |
| - | - |

<details>
<summary>Demo</summary>
</details>
 -->

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If needed, I updated documentation and added comments to complex code