### PR TITLE
Bugfix FXIOS-14416 - Dismissing the keyboard on the homepage no longer returns to the current web page

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4150,9 +4150,7 @@ class BrowserViewController: UIViewController,
             }
         }
         destroySearchController()
-        if !isToolbarTranslucencyRefactorEnabled {
-            updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
-        }
+        updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
 
         (view as? ThemeApplicable)?.applyTheme(theme: currentTheme())
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14416)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31228)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- The bug was occurring when `isToolbarTranslucencyRefactorEnabled` flag was set to `true` because when leaving overlay, the selected tab was not being selected anymore so it would remained stuck in overlay mode.
- This PR removes the `isToolbarTranslucencyRefactorEnabled` wrap for `updateInContentHomePanel` as from what I've seen was added to reduce 2 redundant calls of `updateBlurViews` method.
- This case is handled in this PR: https://github.com/mozilla-mobile/firefox-ios/pull/31210, where the `updateToolbarDisplay()` is no longer called when the flag is `true`.

## :pencil: Checklist 
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

