### PR TITLE
Refactor FXIOS-14344 [Swift 6 Migration] Fix for warnings related to Sendable and assertAsyncThrows.

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/v1/NetworkServices/WallpaperNetworkModule.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/v1/NetworkServices/WallpaperNetworkModule.swift
@@ -6,9 +6,9 @@ import Common
 import Foundation
 import Shared
 
-class WallpaperNetworkingModule: WallpaperNetworking {
-    private var urlSession: URLSessionProtocol
-    private var logger: Logger
+final class WallpaperNetworkingModule: WallpaperNetworking, Sendable {
+    private let urlSession: URLSessionProtocol
+    private let logger: Logger
 
     init(
         with urlSession: URLSessionProtocol = URLSession.sharedMPTCP,

--- a/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/v1/Protocols/WallpaperNetworking.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/v1/Protocols/WallpaperNetworking.swift
@@ -8,6 +8,6 @@ enum WallpaperServiceError: Error {
     case dataUnavailable
 }
 
-protocol WallpaperNetworking {
+protocol WallpaperNetworking: Sendable {
     func data(from url: URL) async throws -> (Data, URLResponse)
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/TrendingSearchClientTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/TrendingSearchClientTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @testable import Client
 
-final class TrendingSearchClientTest: XCTestCase {
+final class TrendingSearchClientTest: XCTestCase, @unchecked Sendable {
     override func setUp() {
         super.setUp()
         clearState()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/NetworkingMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/NetworkingMock.swift
@@ -6,7 +6,7 @@ import Foundation
 
 @testable import Client
 
-class NetworkingMock: WallpaperNetworking {
+final class NetworkingMock: WallpaperNetworking, @unchecked Sendable {
     var result = Result<Data, Error>.failure(URLError(.notConnectedToInternet))
 
     func data(from url: URL) async throws -> (Data, URLResponse) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperNetworkingModuleTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperNetworkingModuleTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @testable import Client
 
-class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
+class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider, @unchecked Sendable {
     let url = URL(string: "my.testurl.com")!
 
     func testAsyncDataCall() async {
@@ -40,7 +40,7 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
                                      and: expectedError)
         let subject = WallpaperNetworkingModule(with: session)
 
-        await assertAsyncThrowsEqual(URLError(.cannotConnectToHost)) {
+        await assertAsyncThrowsEqual(URLError(.cannotConnectToHost)) { [url] in
             _ = try await subject.data(from: url)
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/XCTestCaseExtensions.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/XCTestCaseExtensions.swift
@@ -67,12 +67,13 @@ extension XCTestCase {
 
     // MARK: Error Handling
     /// Convenience method to simplify error checking in the test cases for non Equatable types.
+    @MainActor
     func assertAsyncThrows<E: Error, T>(
         ofType expectedType: E.Type,
-        _ expression: () async throws -> T,
+        _ expression: @MainActor () async throws -> T,
         file: StaticString = #filePath,
         line: UInt = #line,
-        verify: ((E) -> Void)? = nil
+        verify: (@MainActor (E) -> Void)? = nil
     ) async {
         do {
             _ = try await expression()
@@ -85,9 +86,10 @@ extension XCTestCase {
     }
 
     /// Convenience method to simplify error checking in the test cases for Equatable types.
+    @MainActor
     func assertAsyncThrowsEqual<E: Error & Equatable, T>(
         _ expected: E,
-        _ expression: () async throws -> T,
+        _ expression: @MainActor () async throws -> T,
         file: StaticString = #filePath,
         line: UInt = #line
     ) async {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/MockFiles.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/MockFiles.swift
@@ -6,7 +6,7 @@ import Foundation
 @testable import Storage
 import XCTest
 
-class MockFiles: FileAccessor {
+class MockFiles: FileAccessor, @unchecked Sendable {
     var rootPath: String
 
     init() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14344)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31077)

## :bulb: Description
- Fixes for warnings related to Sendable and assertAsyncThrows, which turned up in `LanguageDetectorTests` but actually required fixes elsewhere.

cc @cyndichin -- Just to let you know, @lmarceau and I had to modify the `assertAsyncThrows` to isolate to a single thread to prevent some Sendable warnings in various other tests!

cc @Cramsden @lmarceau @dataports 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

