### PR TITLE
Refactor FXIOS-14344 [Swift 6 migration] Fixing unit tests warnings

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/HistoryDeletionUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/HistoryDeletionUtilityTests.swift
@@ -14,7 +14,7 @@ import XCTest
 // 2. History writes&deletes data correctly
 // These basic cases are not tested here as they are tested in
 // `HistoryHighlightsManagerTests` and `TestHistory` respectively
-class HistoryDeletionUtilityTests: XCTestCase {
+class HistoryDeletionUtilityTests: XCTestCase, @unchecked Sendable {
     struct SiteElements {
         let domain: String
         let path: String
@@ -45,6 +45,7 @@ class HistoryDeletionUtilityTests: XCTestCase {
     }
 
     // MARK: - Test url based deletion
+    @MainActor
     func testDeletingSingleItem() {
         let profile = profileSetup(named: "hsd_deleteSingleItem")
         let testSites = [SiteElements(domain: "mozilla")]
@@ -57,6 +58,7 @@ class HistoryDeletionUtilityTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testDeletingMultipleItemsEmptyingDatabase() {
         let profile = profileSetup(named: "hsd_deleteMultipleItemsEmptyingDB")
         let sitesToDelete = [SiteElements(domain: "mozilla"),
@@ -74,6 +76,7 @@ class HistoryDeletionUtilityTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testDeletingMultipleTopLevelItems() {
         let profile = profileSetup(named: "hsd_deleteMultipleItemsTopLevelItems")
         let sitesToRemain = [SiteElements(domain: "cnn")]
@@ -92,6 +95,7 @@ class HistoryDeletionUtilityTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testDeletingMultipleSpecificItems() {
         let profile = profileSetup(named: "hsd_deleteMultipleSpecificItems")
         let sitesToRemain = [SiteElements(domain: "cnn", path: "newsOne/test1.html")]
@@ -363,6 +367,7 @@ private extension HistoryDeletionUtilityTests {
         return profile
     }
 
+    @MainActor
     func deletionWithExpectation(
         for siteEntries: [String],
         using profile: MockProfile,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/MainThreadThrottlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/MainThreadThrottlerTests.swift
@@ -50,7 +50,7 @@ class MainThreadThrottlerTests: XCTestCase {
     func testSecondCallAfterDelayThresholdCallsBothClosures() {
         let threshold = 0.5
         let step: Double = (threshold / 2.0)
-        let throttler = createSubject(timeout: threshold)
+        nonisolated(unsafe) let throttler = createSubject(timeout: threshold)
 
         // Send one call to throttler
         let executedFirstThrottle = expectation(description: "First throttle completion fired")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14344)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31077)

## :bulb: Description
Fix warnings for:
- DefaultBookmarksSaverTests
- HistoryDeletionUtilityTests
- MainThreadThrottlerTests

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

