### PR TITLE
Add FXIOS-14413 [Terms of Use] Privacy Notice homepage card strings

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -993,8 +993,8 @@ extension String {
             public static let Body = MZLocalizedString(
                 key: "FirefoxHome.PrivacyNotice.Body.v148",
                 tableName: "FirefoxHomepage",
-                value: "We’ve updated our %@ to reflect the latest features in Firefox. %@",
-                comment: "Body label for the Privacy Notice card showed at the top of the homepage notifying users that the Privacy Notice has been updated. The first placeholder is for the string “Privacy Notice” which will contain a link to the updated privacy notice. The second placeholder is for the string “Learn More” which will contain a link to specifically what has changed in the updated Privacy Notice")
+                value: "We’ve updated our %@ to reflect the latest features in %@. %@",
+                comment: "Body label for the Privacy Notice card showed at the top of the homepage notifying users that the Privacy Notice has been updated. The first placeholder is for the string “Privacy Notice” which will contain a link to the updated privacy notice. The second placeholder is for the app name (e.g. Firefox). The third placeholder is for the string “Learn More” which will contain a link to specifically what has changed in the updated Privacy Notice")
             public static let PrivacyNoticeLink = MZLocalizedString(
                 key: "FirefoxHome.PrivacyNotice.PrivacyNoticeLink.v148",
                 tableName: "FirefoxHomepage",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14413)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31225)

## :bulb: Description
- Added strings for the Privacy Notice homepage card

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

