### PR TITLE
Fixes issue where when downloading USDZ files, the main thread would …

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -704,9 +704,7 @@ extension BrowserViewController: WKNavigationDelegate {
     @MainActor
     func webView(
         _ webView: WKWebView,
-        decidePolicyFor navigationResponse: WKNavigationResponse,
-        decisionHandler: @escaping @MainActor (WKNavigationResponsePolicy) -> Void
-    ) {
+        decidePolicyFor navigationResponse: WKNavigationResponse) async -> WKNavigationResponsePolicy {
         let response = navigationResponse.response
         let responseURL = response.url
 
@@ -728,31 +726,19 @@ extension BrowserViewController: WKNavigationDelegate {
             mimeType: mimeType,
             forceDownload: forceDownload) {
             // Open our helper and nullifies the helper when done with it
-            Task {
-                let passBookHelper = OpenPassBookHelper(presenter: self)
-                await passBookHelper.open(response: response, cookieStore: cookieStore)
-            }
+            let passBookHelper = OpenPassBookHelper(presenter: self)
+            await passBookHelper.open(response: response, cookieStore: cookieStore)
 
             // Cancel this response from the webview.
-            decisionHandler(.cancel)
-            return
+            return .cancel
         }
 
         // For USDZ / Reality 3D model files, we can cancel this response from the webView and open the QL previewer instead
         if OpenQLPreviewHelper.shouldOpenPreviewHelper(response: response, forceDownload: forceDownload),
            let tab = tabManager[webView],
            let request = request {
-            // Certain files are too large to download before the preview presents, so block until we have something to show
-            let group = DispatchGroup()
-            // FIXME: FXIOS-14054 Should not mutate local properties in concurrent code
-            nonisolated(unsafe) var url: URL?
-            group.enter()
             let temporaryDocument = DefaultTemporaryDocument(preflightResponse: response, request: request)
-            temporaryDocument.download { docURL in
-                url = docURL
-                group.leave()
-            }
-            _ = group.wait(timeout: .distantFuture)
+            let url = await temporaryDocument.download()
 
             let previewHelper = OpenQLPreviewHelper(presenter: self, withTemporaryDocument: temporaryDocument)
             if previewHelper.canOpen(url: url) {
@@ -762,8 +748,7 @@ extension BrowserViewController: WKNavigationDelegate {
                     // Once the preview is closed, we can safely release this object and let the tempory document be deleted
                     tab.quickLookPreviewHelper = nil
                 }
-                decisionHandler(.cancel)
-                return
+                return .cancel
             }
 
             // We don't have a temporary document, fallthrough
@@ -794,8 +779,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 self.present(safariVC, animated: true, completion: nil)
             }))
             present(alert, animated: true)
-            decisionHandler(.cancel)
-            return
+            return .cancel
         }
 
         // Check if this response should be downloaded
@@ -806,8 +790,7 @@ extension BrowserViewController: WKNavigationDelegate {
             /// FXIOS-12201: Need to hold reference to downloadHelper,
             /// so we can use this later in `webView(_:navigationResponse:didBecome:)`
             self.downloadHelper = downloadHelper
-            decisionHandler(.download)
-            return
+            return .download
         }
 
         // If the content type is not HTML, create a temporary document so it can be downloaded and
@@ -818,12 +801,10 @@ extension BrowserViewController: WKNavigationDelegate {
         if navigationResponse.isForMainFrame, let tab = tabManager[webView] {
             if response.mimeType == MIMEType.PDF, let request {
                 if !tab.shouldDownloadDocument(request) {
-                    decisionHandler(.allow)
-                    return
+                    return .allow
                 }
                 handlePDFDownloadRequest(request: request, tab: tab, filename: response.suggestedFilename)
-                decisionHandler(.cancel)
-                return
+                return .cancel
             }
             if response.mimeType != MIMEType.HTML, let request {
                 tab.temporaryDocument = DefaultTemporaryDocument(preflightResponse: response, request: request)
@@ -836,7 +817,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
         // If none of our helpers are responsible for handling this response,
         // just let the webview handle it as normal.
-        decisionHandler(.allow)
+        return .allow
     }
 
     /// Handle a PDF download request by forwarding it to the provided `Tab`.


### PR DESCRIPTION
Fixes issue where when downloading USDZ files, the main thread would be locked causing the application to freeze

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13025)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28401)

## :bulb: Description
When downloading a USDZ / Reality 3D model file the main thread would be locked waiting for a download, the unlock was being called from the main (locked) thread causing the application to wait forever. Updated to handle the decision from a Task allowing usage of the asynchronous download function and alleviating the need for a lock to wait.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
