### PR TITLE
Bugfix FXIOS-14442 - CFR points to wrong location when minimal address bar is shown

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
@@ -26,7 +26,9 @@ extension BrowserViewController: PhotonActionSheetProtocol {
             anchor: view,
             withArrowDirection: toolbarHelper.shouldShowNavigationToolbar(for: traitCollection) ? .down : .up,
             andDelegate: self,
-            presentedUsing: { [weak self] in self?.presentDataClearanceContextualHint() },
+            presentedUsing: { [weak self] in
+                self?.presentContextualHint(for: .dataClearance)
+            },
             andActionForButton: { },
             overlayState: overlayManager)
     }
@@ -58,7 +60,9 @@ extension BrowserViewController: PhotonActionSheetProtocol {
             anchor: view,
             withArrowDirection: toolbarHelper.shouldShowNavigationToolbar(for: traitCollection) ? .down : .up,
             andDelegate: self,
-            presentedUsing: { [weak self] in self?.presentNavigationContextualHint() },
+            presentedUsing: { [weak self] in
+                self?.presentContextualHint(for: .navigation)
+            },
             actionOnDismiss: {
                 let action = ToolbarAction(windowUUID: self.windowUUID,
                                            actionType: ToolbarActionType.navigationHintFinishedPresenting)
@@ -107,7 +111,9 @@ extension BrowserViewController: PhotonActionSheetProtocol {
             anchor: view,
             withArrowDirection: arrowDirection,
             andDelegate: self,
-            presentedUsing: { [weak self] in self?.presentToolbarUpdateContextualHint() },
+            presentedUsing: { [weak self] in
+                self?.presentContextualHint(for: .toolbarUpdate)
+            },
             andActionForButton: { },
             overlayState: overlayManager)
     }
@@ -134,7 +140,7 @@ extension BrowserViewController: PhotonActionSheetProtocol {
             withArrowDirection: shouldShowUpArrow ? .up : .down,
             andDelegate: self,
             presentedUsing: { [weak self] in
-                self?.presentSummarizeToolbarEntryContextualHint()
+                self?.presentContextualHint(for: .summarizeToolbarEntry)
             },
             andActionForButton: { },
             overlayState: overlayManager)
@@ -163,7 +169,7 @@ extension BrowserViewController: PhotonActionSheetProtocol {
             withArrowDirection: shouldShowUpArrow ? .up : .down,
             andDelegate: self,
             presentedUsing: { [weak self] in
-                self?.presentTranslationContextualHint()
+                self?.presentContextualHint(for: .translation)
             },
             andActionForButton: { },
             overlayState: overlayManager)
@@ -172,6 +178,18 @@ extension BrowserViewController: PhotonActionSheetProtocol {
     private func presentTranslationContextualHint() {
         present(translationContextHintVC, animated: true)
         UIAccessibility.post(notification: .layoutChanged, argument: translationContextHintVC)
+    }
+
+    private func presentContextualHint(for hintType: ContextualHintType) {
+        scrollController.showToolbars(animated: true)
+        switch hintType {
+        case .summarizeToolbarEntry: presentSummarizeToolbarEntryContextualHint()
+        case .translation: presentTranslationContextualHint()
+        case .dataClearance: presentDataClearanceContextualHint()
+        case .navigation: presentNavigationContextualHint()
+        case .toolbarUpdate: presentToolbarUpdateContextualHint()
+        default: break
+        }
     }
 
     func dismissToolbarCFRs(with windowUUID: WindowUUID) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14441)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31269)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Show toolbar just before CFR is presented to make sure it anchors to a visible element.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

https://github.com/user-attachments/assets/009289e3-fbfa-49a5-9ea0-f06695e22d9d

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

