### PR TITLE
Localize FXIOS-0000 Fix string lint error

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -994,7 +994,7 @@ extension String {
                 key: "FirefoxHome.PrivacyNotice.Body.v148",
                 tableName: "FirefoxHomepage",
                 value: "We’ve updated our %@ to reflect the latest features in %@. %@",
-                comment: "Body label for the Privacy Notice card showed at the top of the homepage notifying users that the Privacy Notice has been updated. The first placeholder is for the string “Privacy Notice” which will contain a link to the updated privacy notice. The second placeholder is for the app name (e.g. Firefox). The third placeholder is for the string “Learn More” which will contain a link to specifically what has changed in the updated Privacy Notice")
+                comment: "Body label for the Privacy Notice card showed at the top of the homepage notifying users that the Privacy Notice has been updated. The %1$@ placeholder is for the string “Privacy Notice” which will contain a link to the updated privacy notice. The %2$@ placeholder is for the app name (e.g. Firefox). The %3$@ placeholder is for the string “Learn More” which will contain a link to specifically what has changed in the updated Privacy Notice")
             public static let PrivacyNoticeLink = MZLocalizedString(
                 key: "FirefoxHome.PrivacyNotice.PrivacyNoticeLink.v148",
                 tableName: "FirefoxHomepage",


### PR DESCRIPTION
## :scroll: Tickets
n/a

## :bulb: Description

Fix string lint error

```
Source errors (1)

  Identified placeables in string firefox-ios.xliff:FirefoxHome.PrivacyNotice.Body.v148: %1$@, %2$@, %3$@
  Comment does not include the following placeables: %1$@, %2$@, %3$@
  Text: 'We've updated our %1$@ to reflect the latest features in %2$@. %3$@'
  Comment: Body label for the Privacy Notice card showed at the top of the homepage notifying users that the Privacy Notice has been updated. The first placeholder is for the string "Privacy Notice" which will contain a link to the updated privacy notice. The second placeholder is for the app name (e.g. Firefox). The third placeholder is for the string "Learn More" which will contain a link to specifically what has changed in the updated Privacy Notice

Total errors: 1
```

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

