### PR TITLE
Bug 2006024 [Glean] Remove `adjust.deeplink_received` event from the metrics ping

### DIFF
--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -1973,7 +1973,7 @@ tabs:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
-  
+
 # iOS 14 widget metrics
 # m: medium, s: small, l: large
 widget:
@@ -2627,7 +2627,6 @@ adjust:
         type: string
     send_in_pings:
       - first-session
-      - metrics
       - events
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/11089


### PR DESCRIPTION
This will soon [be linted by glean-parser](https://github.com/mozilla/glean_parser/pull/823) and thus become a warning. Events on the metrics ping are rarely useful.
None of our automatic tooling assumes there are events on the `metrics` ping. No other events are on the `metrics` ping, thus no event timeline can be established anyway.

This event is also the only event on the `first-session` ping, so it's not clear how useful the event is there either.
However the `first-session` is a custom ping, so it's not getting linted. It also has a test for it specifically, so I'm keeping it for now.

## :scroll: Tickets

https://bugzilla.mozilla.org/show_bug.cgi?id=2006024