### PR TITLE
Bugfix FXIOS-14326 [Unit Tests] `test_newState_forTriggeringImpression_withStoriesRedesignEnabled_triggersHomepageAction` failing test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
@@ -270,8 +270,6 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         subject.newState(state: populatedState)
         subject.view.layoutIfNeeded()
 
-        subject.newState(state: populatedState)
-
         subject.viewDidAppear(false)
 
         XCTAssertTrue(mockThrottler.didCallThrottle)
@@ -324,8 +322,6 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         subject.newState(state: populatedState)
         subject.view.layoutIfNeeded()
 
-        subject.newState(state: populatedState)
-
         subject.scrollViewDidEndDecelerating(UIScrollView())
 
         XCTAssertTrue(mockThrottler.didCallThrottle)
@@ -376,13 +372,6 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         let initialState = HomepageState(windowUUID: .XCTestDefaultUUID)
 
         let populatedState = await getPopulatedCollectionViewState(from: initialState)
-
-        // Need to call loadViewIfNeeded to load the view, newState to populate the datasource, and layoutIfNeeded to
-        // reload the collectionView so that it's content is visible
-        subject.loadViewIfNeeded()
-        subject.newState(state: populatedState)
-        subject.view.layoutIfNeeded()
-
         let newState = HomepageState.reducer(
             populatedState,
             GeneralBrowserAction(
@@ -390,6 +379,12 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
                 actionType: GeneralBrowserActionType.didSelectedTabChangeToHomepage
             )
         )
+
+        // Need to call loadViewIfNeeded to load the view, newState to populate the datasource, and layoutIfNeeded to
+        // reload the collectionView so that it's content is visible
+        subject.loadViewIfNeeded()
+        subject.newState(state: newState)
+        subject.view.layoutIfNeeded()
 
         subject.newState(state: newState)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14326)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31044)

## :bulb: Description
Fix `test_newState_forTriggeringImpression_withStoriesRedesignEnabled_triggersHomepageAction` that was failing consistently on devices < iOS 17, but it did catch an issue in how we were setting up the test. It seems apple may have change something under the hood, but I fix how we are setting up the test in general. We were calling `subject.view.layoutIfNeeded()` when we did not set up the state properly. I moved it down so that we set up the initial state properly before calling `subject.view.layoutIfNeeded()`. 

Workflow with failing tests: https://storage.googleapis.com/mobile-reports/public/firefox-ios-M4/firefox-ios-unit-tests/result_14/build/reports/index.html

cc: @Foxbolts since these are related to stories redesign

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

