### PR TITLE
Refactor NO_TICKET Make owners generic for Rust Components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,10 +9,10 @@
 /firefox-ios/Client/Experiments/initial_experiments.json @afurlan-firefox @mozilla-mobile/fxios-eng
 /firefox-ios/Client/Assets/CC_Script @nbhasin2 @issammani
 /firefox-ios/Client/Assets/RemoteSettingsData/ @nbhasin2 @issammani @mattreaganmozilla
-/MozillaRustComponents/Package.swift @issammani @mozilla-mobile/fxios-eng
-/MozillaRustComponents/Package.resolved @issammani @mozilla-mobile/fxios-eng
-/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated @issammani @mozilla-mobile/fxios-eng
-/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated @issammani @mozilla-mobile/fxios-eng
+/MozillaRustComponents/Package.swift @mozilla-mobile/fxios-eng
+/MozillaRustComponents/Package.resolved @mozilla-mobile/fxios-eng
+/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated @mozilla-mobile/fxios-eng
+/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated @mozilla-mobile/fxios-eng
 
 # When someone opens a pull request that only modifies those folders / files, 
 # only @mozilla-mobile/fxios-automation and not the global


### PR DESCRIPTION
## :scroll: Tickets
N/A

## :bulb: Description
In order to assign others by default, remove @issammani and allow the rotation to take its place.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

