### PR TITLE
Add FXIOS-14450 Add new onboarding strings so we can localize before string freeze Fx 148

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1944,7 +1944,7 @@ extension String {
                     public static let LearnMoreLink = MZLocalizedString(
                         key: "Onboarding.Modern.BrandRefresh.Marketing.LearnMoreLink.v148",
                         tableName: "Onboarding",
-                        value: "How we use data",
+                        value: "How we use the data",
                         comment: "Link text for learning more about how marketing data is used in the v148 brand refresh onboarding flow.")
                     public static let SkipAction = MZLocalizedString(
                         key: "Onboarding.Modern.BrandRefresh.Marketing.Skip.Action.v148",

--- a/firefox-ios/Shared/Supporting Files/en-US.lproj/Onboarding.strings
+++ b/firefox-ios/Shared/Supporting Files/en-US.lproj/Onboarding.strings
@@ -401,7 +401,7 @@
 "Onboarding.Modern.BrandRefresh.Marketing.Description.v148" = "Share how you discovered %1$@, and that you use it, with %2$@’s marketing partners. This data is never sold.";
 
 /* Link text for learning more about how marketing data is used in the v148 brand refresh onboarding flow. */
-"Onboarding.Modern.BrandRefresh.Marketing.LearnMoreLink.v148" = "How we use data";
+"Onboarding.Modern.BrandRefresh.Marketing.LearnMoreLink.v148" = "How we use the data";
 
 /* Button to skip the marketing data sharing card in the v148 brand refresh onboarding flow. */
 "Onboarding.Modern.BrandRefresh.Marketing.Skip.Action.v148" = "Not Now";


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14450)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31296)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I changed the v148 onboarding marketing link text from "How we use data" to "How we use the data"

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

