### PR TITLE
Bug 2006609 - ci: migrate to d2g worker pools

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -139,7 +139,7 @@ tasks:
                                 name: "Decision Task for cron job ${cron.job_name}"
                                 description: 'Created by a [cron task](https://firefox-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
                 provisionerId: "${trustDomain}-${level}"
-                workerType: "decision-gcp"
+                workerType: "decision"
                 tags:
                     $if: 'tasks_for == "github-push" || isPullRequest'
                     then:

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -31,12 +31,12 @@ workers:
             provisioner: 'mobile-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'images-gcp'
+            worker-type: 'images'
         misc:
             provisioner: 'mobile-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-gcp'
+            worker-type: 'b-linux'
         ship-it:
             provisioner: scriptworker-k8s
             implementation: scriptworker-shipit


### PR DESCRIPTION
## :scroll: Tickets
https://bugzilla.mozilla.org/show_bug.cgi?id=2006609