### PR TITLE
Bugfix FXIOS-14489 - [Performance] - Bottom container visibility and glass effect issues with translucency refactor flag enabled

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabScrollHandlerDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabScrollHandlerDelegate.swift
@@ -15,11 +15,13 @@ extension BrowserViewController: TabScrollHandler.Delegate,
     func showToolbar() {
         updateToolbarContext()
         toolbarAnimator?.showToolbar()
+        updateToolbarTranslucency()
     }
 
     func hideToolbar() {
         updateToolbarContext()
         toolbarAnimator?.hideToolbar()
+        updateToolbarTranslucency()
     }
 
     func dispatchScrollAlphaChange(alpha: CGFloat) {
@@ -44,6 +46,17 @@ extension BrowserViewController: TabScrollHandler.Delegate,
     }
 
     // MARK: - Private
+
+    /// Updates the toolbar's translucency effects.
+    ///
+    /// This method applies blur effects to the top and bottom toolbars and updates the content
+    /// container's mask view to ensure proper visual effects during toolbar animations and state
+    /// transitions. Only executes when the toolbar translucency refactor feature flag is enabled.
+    private func updateToolbarTranslucency() {
+        guard isToolbarTranslucencyRefactorEnabled else { return }
+        updateBlurViews()
+        addOrUpdateMaskViewIfNeeded()
+    }
 
     private func updateToolbarContext() {
         guard let animator = toolbarAnimator else { return }
@@ -101,5 +114,11 @@ extension BrowserViewController: TabScrollHandler.Delegate,
         let topInset = safeAreaInsets?.top ?? .zero
 
         return hasHomeIndicator ? .zero : containerHeight - topInset
+    }
+}
+
+extension BrowserViewController: LegacyTabScrollController.Delegate {
+    func toolbarDisplayStateDidChange() {
+        updateToolbarTranslucency()
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -206,7 +206,7 @@ class BrowserViewController: UIViewController,
         if isTabScrollRefactoringEnabled {
             return TabScrollHandler(windowUUID: windowUUID, delegate: self)
         } else {
-            return LegacyTabScrollController(windowUUID: windowUUID)
+            return LegacyTabScrollController(windowUUID: windowUUID, delegate: self)
         }
     }()
 
@@ -712,7 +712,7 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    private func updateBlurViews(scrollOffset: CGFloat? = nil) {
+    func updateBlurViews(scrollOffset: CGFloat? = nil) {
         guard toolbarHelper.shouldBlur() else {
             topBlurView.alpha = 0
             bottomBlurView.isHidden = true
@@ -782,7 +782,7 @@ class BrowserViewController: UIViewController,
 
     // Adds or updates the mask for the content container that ensures the content is extending
     // under the toolbars but not leading and trailing (would show during swiping tabs)
-    private func addOrUpdateMaskViewIfNeeded() {
+    func addOrUpdateMaskViewIfNeeded() {
         guard toolbarHelper.shouldBlur() else { return }
 
         let frame = CGRect(x: 0,
@@ -3873,13 +3873,11 @@ class BrowserViewController: UIViewController,
         let isBottomSearchHomepage = isBottomSearchBar && tabManager.selectedTab?.isFxHomeTab ?? false
         let colors = currentTheme.colors
         backgroundView.backgroundColor = isBottomSearchHomepage ? colors.layer1 : colors.layerSurfaceLow
-#if canImport(FoundationModels)
         if #available(iOS 26, *), let glassEffect = effect as? UIGlassEffect {
             glassEffect.tintColor = currentTheme.colors.layer1.withAlphaComponent(0.5)
             bottomBlurView.effect = glassEffect
             topBlurView.effect = glassEffect
         }
-#endif
 
         setNeedsStatusBarAppearanceUpdate()
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -37,6 +37,11 @@ final class LegacyTabScrollController: NSObject,
         static let minimumScrollVelocity: CGFloat = 100
     }
 
+    protocol Delegate: AnyObject {
+        @MainActor
+        func toolbarDisplayStateDidChange()
+    }
+
     private var isMinimalAddressBarEnabled: Bool {
         return featureFlags.isFeatureEnabled(.toolbarMinimalAddressBar, checking: .buildOnly)
     }
@@ -104,6 +109,7 @@ final class LegacyTabScrollController: NSObject,
     private var isUserZoom = false
 
     private var didTapChangePreventScrollToTop = false
+    private weak var delegate: Delegate?
 
     // Top Toolbar offset updates related constraints
     private var headerTopOffset: CGFloat = 0 {
@@ -248,9 +254,11 @@ final class LegacyTabScrollController: NSObject,
     }
 
     init(windowUUID: WindowUUID,
+         delegate: Delegate? = nil,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          logger: Logger = DefaultLogger.shared) {
         self.windowUUID = windowUUID
+        self.delegate = delegate
         self.notificationCenter = notificationCenter
         self.logger = logger
         super.init()
@@ -362,6 +370,7 @@ final class LegacyTabScrollController: NSObject,
             overKeyboardOffset: 0,
             alpha: 1,
             completion: nil)
+        delegate?.toolbarDisplayStateDidChange()
     }
 
     func hideToolbars(animated: Bool) {
@@ -378,6 +387,7 @@ final class LegacyTabScrollController: NSObject,
             overKeyboardOffset: overKeyboardScrollHeight,
             alpha: 0,
             completion: nil)
+        delegate?.toolbarDisplayStateDidChange()
     }
 
     // MARK: - ScrollView observation


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14489)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31354)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Fixes the issues where bottom container was not hiding on scroll and missing glass effect on orientation change with translucency refactor.

| Before | After |
| - | - |
| https://github.com/user-attachments/assets/52b827fe-487f-4c85-93e3-acc197f5d632 | https://github.com/user-attachments/assets/150a2242-da45-4cab-9e1f-df06beb62ce8 |
| https://github.com/user-attachments/assets/4486b99f-9d7b-438a-8e16-fcd42412ab86 | https://github.com/user-attachments/assets/088e5ba6-cca1-4f4b-9270-193830321d39 |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

