### PR TITLE
Add FXIOS-14372 [Translations] more coverage for middleware

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
@@ -8,58 +8,43 @@ import Common
 
 /// Test helper that simulates the translations service.
 final class MockTranslationsService: TranslationsServiceProtocol {
-    private let shouldOfferTranslationResult: Bool
-    private let shouldOfferTranslationError: Error?
+    // MARK: - Results
+    private let shouldOfferTranslationResult: Result<Bool, Error>
+    private let translateResult: Result<Void, Error>
+    private let firstResponseReceivedResult: Result<Void, Error>
+    private let discardResult: Result<Void, Error>
 
-    private let translateError: Error?
-
-    private let firstResponseReceivedResult: Bool
-    private let firstResponseReceivedError: Error?
-
-    private let discardError: Error?
-
-    private(set) var shouldOfferTranslationCalledWith: WindowUUID?
-    private(set) var translateCalledWith: WindowUUID?
-    private(set) var firstResponseReceivedCalledWith: WindowUUID?
-    private(set) var discardCalledWith: WindowUUID?
-
+    // MARK: - Init
     init(
-        shouldOfferTranslationResult: Bool = false,
-        shouldOfferTranslationError: Error? = nil,
-        translateError: Error? = nil,
-        firstResponseReceivedResult: Bool = true,
-        firstResponseReceivedError: Error? = nil,
-        discardError: Error? = nil
+        shouldOfferTranslationResult: Result<Bool, Error> = .success(false),
+        translateResult: Result<Void, Error> = .success(()),
+        firstResponseReceivedResult: Result<Void, Error> = .success(()),
+        discardResult: Result<Void, Error> = .success(())
     ) {
         self.shouldOfferTranslationResult = shouldOfferTranslationResult
-        self.shouldOfferTranslationError = shouldOfferTranslationError
-        self.translateError = translateError
+        self.translateResult = translateResult
         self.firstResponseReceivedResult = firstResponseReceivedResult
-        self.firstResponseReceivedError = firstResponseReceivedError
-        self.discardError = discardError
+        self.discardResult = discardResult
     }
 
+    // MARK: - TranslationsServiceProtocol
     func shouldOfferTranslation(for windowUUID: WindowUUID) async throws -> Bool {
-        shouldOfferTranslationCalledWith = windowUUID
-        if let error = shouldOfferTranslationError { throw error }
-        return shouldOfferTranslationResult
+        return try shouldOfferTranslationResult.get()
     }
 
     func translateCurrentPage(
         for windowUUID: WindowUUID,
         onLanguageIdentified: ((String, String) -> Void)?
     ) async throws {
-        translateCalledWith = windowUUID
-        if let error = translateError { throw error }
+        try translateResult.get()
+        onLanguageIdentified?("en", "de")
     }
 
     func firstResponseReceived(for windowUUID: WindowUUID) async throws {
-        firstResponseReceivedCalledWith = windowUUID
-        if let error = firstResponseReceivedError { throw error }
+        try firstResponseReceivedResult.get()
     }
 
     func discardTranslations(for windowUUID: WindowUUID) async throws {
-        discardCalledWith = windowUUID
-        if let error = discardError { throw error }
+        try discardResult.get()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -45,6 +45,8 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         try await super.tearDown()
     }
 
+    // MARK: - urlDidChangeAction tests
+
     func test_urlDidChangeAction_withoutTranslationConfiguration_doesNotDispatchAction() throws {
         setTranslationsFeatureEnabled(enabled: true)
         let subject = createSubject()
@@ -56,6 +58,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         subject.translationsProvider(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
     }
 
     func test_urlDidChangeAction_withoutFF_doesNotDispatchAction() throws {
@@ -69,6 +72,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         subject.translationsProvider(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
     }
 
     func test_urlDidChangeAction_withoutWebView_doesDispatchAction() throws {
@@ -83,11 +87,15 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         subject.translationsProvider(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
     }
 
     func test_urlDidChangeAction_withTranslationConfiguration_doesDispatchAction() throws {
         setTranslationsFeatureEnabled(enabled: true)
-        let subject = createSubject(shouldOfferTranslationResult: true)
+        let mockTranslationService = MockTranslationsService(
+            shouldOfferTranslationResult: .success(true)
+        )
+        let subject = createSubject(translationsService: mockTranslationService)
         let action = ToolbarAction(
             url: URL(string: "https://www.example.com"),
             translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
@@ -111,13 +119,17 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(actionCalled.translationConfiguration?.state, .inactive)
         XCTAssertEqual(actionType, ToolbarActionType.receivedTranslationLanguage)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
+        XCTAssertEqual(mockTranslationsTelemetry.pageLanguageIdentificationFailedCalledCount, 0)
     }
 
     func test_urlDidChangeAction_withError_doesNotDispatchActionAndLogsError() throws {
         setTranslationsFeatureEnabled(enabled: true)
         enum TestError: Error { case example }
-
-        let subject = createSubject(shouldOfferTranslationError: TestError.example)
+        let mockTranslationService = MockTranslationsService(
+            shouldOfferTranslationResult: .failure(TestError.example)
+        )
+        let subject = createSubject(translationsService: mockTranslationService)
         let action = ToolbarAction(
             url: URL(string: "https://www.example.com"),
             translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
@@ -142,12 +154,17 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             mockLogger.savedMessage,
             "Unable to detect language from page to determine if eligible for translations."
         )
+        XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
+        XCTAssertEqual(mockTranslationsTelemetry.pageLanguageIdentificationFailedCalledCount, 1)
+        XCTAssertNotNil(mockTranslationsTelemetry.lastErrorType)
     }
 
     func test_urlDidChangeAction_withSamePageLanguage_doesNotDispatchAction() throws {
         setTranslationsFeatureEnabled(enabled: true)
-
-        let subject = createSubject(shouldOfferTranslationResult: false)
+        let mockTranslationService = MockTranslationsService(
+            shouldOfferTranslationResult: .success(false)
+        )
+        let subject = createSubject(translationsService: mockTranslationService)
         let action = ToolbarAction(
             translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
             windowUUID: .XCTestDefaultUUID,
@@ -168,16 +185,387 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
     }
 
-    // MARK: - Helpers
-    private func createSubject(
-        shouldOfferTranslationResult: Bool = false,
-        shouldOfferTranslationError: Error? = nil
-    ) -> TranslationsMiddleware {
-        let translationsService = MockTranslationsService(
-            shouldOfferTranslationResult: shouldOfferTranslationResult,
-            shouldOfferTranslationError: shouldOfferTranslationError
+    // MARK: - didTapButton tests
+    func test_didTapButtonAction_withoutFF_doesNotDispatchAction() throws {
+        setTranslationsFeatureEnabled(enabled: false)
+        let subject = createSubject()
+        let action = ToolbarMiddlewareAction(
+            buttonType: .translate,
+            gestureType: .tap,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
         )
 
+        subject.translationsProvider(mockStore.state, action)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertEqual(mockTranslationsTelemetry.translateButtonTappedCalledCount, 0)
+    }
+
+    func test_didTapButtonAction_withTranslationConfiguration_dispatchAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let subject = createSubject()
+
+        let action = ToolbarMiddlewareAction(
+            buttonType: .translate,
+            gestureType: .tap,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
+        )
+
+        let expectation = XCTestExpectation(
+            description: "expect didStartTranslatingPage, translationCompleted action to be fired"
+        )
+
+        expectation.expectedFulfillmentCount = 2
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+        subject.translationsProvider(setupAppStateWithTranslationConfig(), action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
+
+        let firstActionCalled = try XCTUnwrap(mockStore.dispatchedActions[0] as? ToolbarAction)
+        let firstActionType = try XCTUnwrap(firstActionCalled.actionType as? ToolbarActionType)
+
+        let secondActionCalled = try XCTUnwrap(mockStore.dispatchedActions[1] as? ToolbarAction)
+        let secondActionType = try XCTUnwrap(secondActionCalled.actionType as? ToolbarActionType)
+
+        XCTAssertEqual(firstActionCalled.translationConfiguration?.state, .loading)
+        XCTAssertEqual(firstActionType, ToolbarActionType.didStartTranslatingPage)
+        XCTAssertEqual(secondActionCalled.translationConfiguration?.state, .active)
+        XCTAssertEqual(secondActionType, ToolbarActionType.translationCompleted)
+
+        XCTAssertEqual(mockTranslationsTelemetry.translateButtonTappedCalledCount, 1)
+        XCTAssertEqual(mockTranslationsTelemetry.lastActionType, .willTranslate)
+        XCTAssertEqual(mockTranslationsTelemetry.pageLanguageIdentifiedCalledCount, 1)
+    }
+
+    func test_didTapButtonAction_withoutTranslationConfiguration_doesNotDispatchAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let subject = createSubject()
+        let action = ToolbarMiddlewareAction(
+            buttonType: .translate,
+            gestureType: .tap,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
+        )
+
+        subject.translationsProvider(mockStore.state, action)
+
+        XCTAssertEqual(mockTranslationsTelemetry.translateButtonTappedCalledCount, 0)
+        XCTAssertEqual(mockTranslationsTelemetry.pageLanguageIdentifiedCalledCount, 0)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+    }
+
+    func test_didTapButtonAction_withError_dispatchToastAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        enum TestError: Error { case example }
+        let mockTranslationsService = MockTranslationsService(
+            translateResult: .failure(TestError.example)
+        )
+        let subject = createSubject(translationsService: mockTranslationsService)
+        let action = ToolbarMiddlewareAction(
+            buttonType: .translate,
+            gestureType: .tap,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
+        )
+
+        let expectation = XCTestExpectation(
+            description: "expect didStartTranslatingPage, didReceiveErrorTranslating, showToast action to be fired"
+        )
+        expectation.expectedFulfillmentCount = 3
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.translationsProvider(setupAppStateWithTranslationConfig(), action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 3)
+
+        let firstActionCalled = try XCTUnwrap(mockStore.dispatchedActions[0] as? ToolbarAction)
+        let firstActionType = try XCTUnwrap(firstActionCalled.actionType as? ToolbarActionType)
+
+        let secondActionCalled = try XCTUnwrap(mockStore.dispatchedActions[1] as? ToolbarAction)
+        let secondActionType = try XCTUnwrap(secondActionCalled.actionType as? ToolbarActionType)
+
+        let thirdActionCalled = try XCTUnwrap(mockStore.dispatchedActions[2] as? GeneralBrowserAction)
+        let thirdActionType = try XCTUnwrap(thirdActionCalled.actionType as? GeneralBrowserActionType)
+
+        XCTAssertEqual(firstActionCalled.translationConfiguration?.state, .loading)
+        XCTAssertEqual(firstActionType, ToolbarActionType.didStartTranslatingPage)
+        XCTAssertEqual(secondActionCalled.translationConfiguration?.state, .inactive)
+        XCTAssertEqual(secondActionType, ToolbarActionType.didReceiveErrorTranslating)
+        XCTAssertEqual(thirdActionCalled.toastType, .retryTranslatingPage)
+        XCTAssertEqual(thirdActionType, GeneralBrowserActionType.showToast)
+
+        XCTAssertEqual(mockTranslationsTelemetry.translateButtonTappedCalledCount, 1)
+        XCTAssertEqual(mockTranslationsTelemetry.lastActionType, .willTranslate)
+        XCTAssertNotNil(mockTranslationsTelemetry.lastTranslationFlowId)
+        XCTAssertEqual(mockTranslationsTelemetry.translationFailedCalledCount, 1)
+    }
+
+    func test_didTapButtonAction_withFirstResponseReceivedError_dispatchToastAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        enum TestError: Error { case example }
+        let mockTranslationsService = MockTranslationsService(
+            firstResponseReceivedResult: .failure(TestError.example)
+        )
+        let subject = createSubject(translationsService: mockTranslationsService)
+        let action = ToolbarMiddlewareAction(
+            buttonType: .translate,
+            gestureType: .tap,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
+        )
+        let expectation = XCTestExpectation(
+            description: "expect didStartTranslatingPage, didReceiveErrorTranslating, showToast action to be fired"
+        )
+        expectation.expectedFulfillmentCount = 3
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.translationsProvider(setupAppStateWithTranslationConfig(), action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 3)
+
+        let firstActionCalled = try XCTUnwrap(mockStore.dispatchedActions[0] as? ToolbarAction)
+        let firstActionType = try XCTUnwrap(firstActionCalled.actionType as? ToolbarActionType)
+
+        let secondActionCalled = try XCTUnwrap(mockStore.dispatchedActions[1] as? ToolbarAction)
+        let secondActionType = try XCTUnwrap(secondActionCalled.actionType as? ToolbarActionType)
+
+        let thirdActionCalled = try XCTUnwrap(mockStore.dispatchedActions[2] as? GeneralBrowserAction)
+        let thirdActionType = try XCTUnwrap(thirdActionCalled.actionType as? GeneralBrowserActionType)
+
+        XCTAssertEqual(firstActionCalled.translationConfiguration?.state, .loading)
+        XCTAssertEqual(firstActionType, ToolbarActionType.didStartTranslatingPage)
+        XCTAssertEqual(secondActionCalled.translationConfiguration?.state, .inactive)
+        XCTAssertEqual(secondActionType, ToolbarActionType.didReceiveErrorTranslating)
+        XCTAssertEqual(thirdActionCalled.toastType, .retryTranslatingPage)
+        XCTAssertEqual(thirdActionType, GeneralBrowserActionType.showToast)
+
+        XCTAssertEqual(mockTranslationsTelemetry.translateButtonTappedCalledCount, 1)
+        XCTAssertEqual(mockTranslationsTelemetry.lastActionType, .willTranslate)
+        XCTAssertNotNil(mockTranslationsTelemetry.lastTranslationFlowId)
+        XCTAssertEqual(mockTranslationsTelemetry.translationFailedCalledCount, 1)
+    }
+
+    func test_didTapButtonAction_withActiveButton_restoresWebPage() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let subject = createSubject()
+
+        let action = ToolbarMiddlewareAction(
+            buttonType: .translate,
+            gestureType: .tap,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
+        )
+
+        let expectation = XCTestExpectation(
+            description: "expect didStartTranslatingPage, translationCompleted action to be fired"
+        )
+
+        expectation.expectedFulfillmentCount = 2
+
+        mockStore.dispatchCalled = {
+             expectation.fulfill()
+        }
+        subject.translationsProvider(
+            setupAppStateWithTranslationConfig(for: .active),
+            action
+        )
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
+
+        let firstActionCalled = try XCTUnwrap(mockStore.dispatchedActions[0] as? ToolbarAction)
+        let firstActionType = try XCTUnwrap(firstActionCalled.actionType as? ToolbarActionType)
+
+        let secondActionCalled = try XCTUnwrap(mockStore.dispatchedActions[1] as? GeneralBrowserAction)
+        let secondActionType = try XCTUnwrap(secondActionCalled.actionType as? GeneralBrowserActionType)
+
+        XCTAssertEqual(firstActionCalled.translationConfiguration?.state, .inactive)
+        XCTAssertEqual(firstActionType, ToolbarActionType.didStartTranslatingPage)
+        XCTAssertEqual(secondActionType, GeneralBrowserActionType.reloadWebsite)
+        XCTAssertEqual(mockTranslationsTelemetry.lastActionType, .willRestore)
+        XCTAssertEqual(mockTranslationsTelemetry.webpageRestoredCalledCount, 1)
+    }
+
+    // MARK: - didTapRetryFailedTranslation tests
+    func test_didTapRetryFailedTranslationAction_withoutFF_doesNotDispatchAction() throws {
+        setTranslationsFeatureEnabled(enabled: false)
+        let subject = createSubject()
+        let action = ToolbarAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.urlDidChange
+        )
+
+        subject.translationsProvider(mockStore.state, action)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+    }
+
+    func test_didTapRetryFailedTranslationAction_withSuccess_doesDispatchAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let subject = createSubject()
+        let action = TranslationsAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TranslationsActionType.didTapRetryFailedTranslation
+        )
+
+        let expectation = XCTestExpectation(
+            description: "expect didStartTranslatingPage and translationCompleted action to be fired"
+        )
+        expectation.expectedFulfillmentCount = 2
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.translationsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
+
+        let firstActionCalled = try XCTUnwrap(mockStore.dispatchedActions[0] as? ToolbarAction)
+        let firstActionType = try XCTUnwrap(firstActionCalled.actionType as? ToolbarActionType)
+
+        let secondActionCalled = try XCTUnwrap(mockStore.dispatchedActions[1] as? ToolbarAction)
+        let secondActionType = try XCTUnwrap(secondActionCalled.actionType as? ToolbarActionType)
+
+        XCTAssertEqual(firstActionCalled.translationConfiguration?.state, .loading)
+        XCTAssertEqual(firstActionType, ToolbarActionType.didStartTranslatingPage)
+
+        XCTAssertEqual(secondActionCalled.translationConfiguration?.state, .active)
+        XCTAssertEqual(secondActionType, ToolbarActionType.translationCompleted)
+
+        XCTAssertEqual(mockTranslationsTelemetry.pageLanguageIdentifiedCalledCount, 1)
+    }
+
+    func test_didTapRetryFailedTranslationAction_withTranslateCurrentPageError_dispatchToastAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        enum TestError: Error { case example }
+        let mockTranslationsService = MockTranslationsService(
+            translateResult: .failure(TestError.example)
+        )
+        let subject = createSubject(translationsService: mockTranslationsService)
+        let action = TranslationsAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TranslationsActionType.didTapRetryFailedTranslation
+        )
+
+        let expectation = XCTestExpectation(
+            description: "expect didStartTranslatingPage, didReceiveErrorTranslating, showToast action to be fired"
+        )
+        expectation.expectedFulfillmentCount = 3
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.translationsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        let firstActionCalled = try XCTUnwrap(mockStore.dispatchedActions[0] as? ToolbarAction)
+        let firstActionType = try XCTUnwrap(firstActionCalled.actionType as? ToolbarActionType)
+
+        let secondActionCalled = try XCTUnwrap(mockStore.dispatchedActions[1] as? ToolbarAction)
+        let secondActionType = try XCTUnwrap(secondActionCalled.actionType as? ToolbarActionType)
+
+        let thirdActionCalled = try XCTUnwrap(mockStore.dispatchedActions[2] as? GeneralBrowserAction)
+        let thirdActionType = try XCTUnwrap(thirdActionCalled.actionType as? GeneralBrowserActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 3)
+
+        XCTAssertEqual(firstActionCalled.translationConfiguration?.state, .loading)
+        XCTAssertEqual(firstActionType, ToolbarActionType.didStartTranslatingPage)
+        XCTAssertEqual(secondActionCalled.translationConfiguration?.state, .inactive)
+        XCTAssertEqual(secondActionType, ToolbarActionType.didReceiveErrorTranslating)
+        XCTAssertEqual(thirdActionCalled.toastType, .retryTranslatingPage)
+        XCTAssertEqual(thirdActionType, GeneralBrowserActionType.showToast)
+
+        XCTAssertNotNil(mockTranslationsTelemetry.lastTranslationFlowId)
+        XCTAssertEqual(mockTranslationsTelemetry.translationFailedCalledCount, 1)
+    }
+
+    func test_didTapRetryFailedTranslationAction_withFirstResponseReceivedError_dispatchToastAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        enum TestError: Error { case example }
+        let mockTranslationsService = MockTranslationsService(
+            firstResponseReceivedResult: .failure(TestError.example)
+        )
+        let subject = createSubject(translationsService: mockTranslationsService)
+        let action = TranslationsAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TranslationsActionType.didTapRetryFailedTranslation
+        )
+
+        let expectation = XCTestExpectation(
+            description: "expect didStartTranslatingPage, didReceiveErrorTranslating, showToast action to be fired"
+        )
+        expectation.expectedFulfillmentCount = 3
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.translationsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 3)
+
+        let firstActionCalled = try XCTUnwrap(mockStore.dispatchedActions[0] as? ToolbarAction)
+        let firstActionType = try XCTUnwrap(firstActionCalled.actionType as? ToolbarActionType)
+
+        let secondActionCalled = try XCTUnwrap(mockStore.dispatchedActions[1] as? ToolbarAction)
+        let secondActionType = try XCTUnwrap(secondActionCalled.actionType as? ToolbarActionType)
+
+        let thirdActionCalled = try XCTUnwrap(mockStore.dispatchedActions[2] as? GeneralBrowserAction)
+        let thirdActionType = try XCTUnwrap(thirdActionCalled.actionType as? GeneralBrowserActionType)
+
+        XCTAssertEqual(firstActionCalled.translationConfiguration?.state, .loading)
+        XCTAssertEqual(firstActionType, ToolbarActionType.didStartTranslatingPage)
+        XCTAssertEqual(secondActionCalled.translationConfiguration?.state, .inactive)
+        XCTAssertEqual(secondActionType, ToolbarActionType.didReceiveErrorTranslating)
+        XCTAssertEqual(thirdActionCalled.toastType, .retryTranslatingPage)
+        XCTAssertEqual(thirdActionType, GeneralBrowserActionType.showToast)
+
+        XCTAssertNotNil(mockTranslationsTelemetry.lastTranslationFlowId)
+        XCTAssertEqual(mockTranslationsTelemetry.translationFailedCalledCount, 1)
+    }
+
+    private func setupAppStateWithTranslationConfig(
+        for translationIconState: TranslationConfiguration.IconState = .inactive
+    ) -> AppState {
+        let initialAction = ToolbarAction(
+            url: URL(string: "https://www.example.com"),
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs, state: translationIconState),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.urlDidChange
+        )
+        return AppState.reducer(mockStore.state, initialAction)
+    }
+
+    // MARK: - Helpers
+    private func createSubject(
+        translationsService: TranslationsServiceProtocol = MockTranslationsService()
+    ) -> TranslationsMiddleware {
         return TranslationsMiddleware(
             profile: mockProfile,
             logger: mockLogger,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14372)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31155)

## :bulb: Description
Add more test coverage for translations middleware, which handles telemetry and interacting with the translation service. Also refactor the mock to use Result instead of separating into Bool + Error.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

