### PR TITLE
Add FXIOS-14380 Default browser additional telemetry and improvements

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -423,6 +423,7 @@
 		39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */; };
 		392ED7E41D0AEF56009D9B62 /* NewTabAccessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392ED7E31D0AEF56009D9B62 /* NewTabAccessors.swift */; };
 		392ED7E61D0AEFEF009D9B62 /* HomePageAccessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392ED7E51D0AEFEF009D9B62 /* HomePageAccessors.swift */; };
+		3933D4F42EF3358300C0C4E3 /* DefaultBrowserUtilityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3933D4F32EF3357D00C0C4E3 /* DefaultBrowserUtilityTelemetry.swift */; };
 		3943A81D1E9807C700D4F6DC /* FxAPushMessageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */; };
 		39455F771FC83F430088A22C /* TabEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39455F761FC83F430088A22C /* TabEventHandler.swift */; };
 		394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */; };
@@ -653,7 +654,7 @@
 		5AB4237C28A1947A003BC40C /* MockNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB4237B28A1947A003BC40C /* MockNotificationCenter.swift */; };
 		5AC7110729F822E60011ED11 /* MockTabSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AC7110629F822E60011ED11 /* MockTabSessionStore.swift */; };
 		5AD3B6742CF625B000AFA1FE /* DefaultBrowserUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3B6732CF625A300AFA1FE /* DefaultBrowserUtility.swift */; };
-		5AD3B6782CF650DF00AFA1FE /* DefaultBrowserUitlityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3B6772CF650D000AFA1FE /* DefaultBrowserUitlityTests.swift */; };
+		5AD3B6782CF650DF00AFA1FE /* DefaultBrowserUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3B6772CF650D000AFA1FE /* DefaultBrowserUtilityTests.swift */; };
 		5AD3B67C2CF65DE600AFA1FE /* LocaleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3B67B2CF65DE300AFA1FE /* LocaleProvider.swift */; };
 		5AD3B67E2CF665B400AFA1FE /* UIApplicationInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3B67D2CF665AE00AFA1FE /* UIApplicationInterface.swift */; };
 		5AD3B6802CF6674F00AFA1FE /* MockUIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3B67F2CF6674B00AFA1FE /* MockUIApplication.swift */; };
@@ -3270,6 +3271,7 @@
 		39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabEventHandlerTests.swift; sourceTree = "<group>"; };
 		392ED7E31D0AEF56009D9B62 /* NewTabAccessors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NewTabAccessors.swift; path = Accessors/NewTabAccessors.swift; sourceTree = "<group>"; };
 		392ED7E51D0AEFEF009D9B62 /* HomePageAccessors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HomePageAccessors.swift; path = Accessors/HomePageAccessors.swift; sourceTree = "<group>"; };
+		3933D4F32EF3357D00C0C4E3 /* DefaultBrowserUtilityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserUtilityTelemetry.swift; sourceTree = "<group>"; };
 		394344CA90682A8640FDE3DF /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAPushMessageTest.swift; sourceTree = "<group>"; };
 		39444D13AAEACA4C6EF83703 /* my */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = my; path = my.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
@@ -8336,7 +8338,7 @@
 		5AC549C0BA565EB2B08B87EC /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		5AC7110629F822E60011ED11 /* MockTabSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabSessionStore.swift; sourceTree = "<group>"; };
 		5AD3B6732CF625A300AFA1FE /* DefaultBrowserUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserUtility.swift; sourceTree = "<group>"; };
-		5AD3B6772CF650D000AFA1FE /* DefaultBrowserUitlityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserUitlityTests.swift; sourceTree = "<group>"; };
+		5AD3B6772CF650D000AFA1FE /* DefaultBrowserUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserUtilityTests.swift; sourceTree = "<group>"; };
 		5AD3B67B2CF65DE300AFA1FE /* LocaleProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleProvider.swift; sourceTree = "<group>"; };
 		5AD3B67D2CF665AE00AFA1FE /* UIApplicationInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationInterface.swift; sourceTree = "<group>"; };
 		5AD3B67F2CF6674B00AFA1FE /* MockUIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUIApplication.swift; sourceTree = "<group>"; };
@@ -12976,9 +12978,9 @@
 			children = (
 				8A1C0B8E2E723EDC0030DCC8 /* AppLaunchUtilTests.swift */,
 				BC0723512E33D7A2005BAC05 /* AppleIntelligenceUtilTests.swift */,
-				5AD3B67F2CF6674B00AFA1FE /* MockUIApplication.swift */,
 				8A13FA882AD82BC8007527AB /* AppSendTabDelegateTests.swift */,
-				5AD3B6772CF650D000AFA1FE /* DefaultBrowserUitlityTests.swift */,
+				5AD3B6772CF650D000AFA1FE /* DefaultBrowserUtilityTests.swift */,
+				5AD3B67F2CF6674B00AFA1FE /* MockUIApplication.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -15850,33 +15852,34 @@
 		E69DB0B91E97E301008A67E6 /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
-				E51E24922EF1743D004F7785 /* ShareExtensionTelemetry.swift */,
 				8CFBC18B2ECF44D400E5B22B /* ActionExtensionTelemetry.swift */,
-				8A1AB6BA2E7B8D5C00167FF5 /* NotificationManagerTelemetry.swift */,
-				8A732A812DE8AFCA0099F575 /* FxSuggestTelemetry.swift */,
-				8A0DF2C12D6D1C670066EC00 /* AutoplaySettingTelemetry.swift */,
 				43175DB726B87D2C00C41C31 /* AdsTelemetryHelper.swift */,
 				AB3DB0C82B596739001D32CB /* AppStartupTelemetry.swift */,
+				8A0DF2C12D6D1C670066EC00 /* AutoplaySettingTelemetry.swift */,
+				C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */,
+				3933D4F32EF3357D00C0C4E3 /* DefaultBrowserUtilityTelemetry.swift */,
+				8A732A812DE8AFCA0099F575 /* FxSuggestTelemetry.swift */,
+				8CA4E80C2D22C066007207C1 /* GleanUsageReporting.swift */,
 				8AABBCFB2A0010900089941E /* GleanWrapper.swift */,
+				C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */,
+				8A44F20D2B585E1F0016BC81 /* HomepageTelemetry.swift */,
 				5A32C2B42AD8515F00A9B5A4 /* MetricKit */,
+				8A1AB6BA2E7B8D5C00167FF5 /* NotificationManagerTelemetry.swift */,
 				8ABCFEA22B45C36100C2988A /* PrivateBrowsingTelemetry.swift */,
 				8ADC2A132A33762900543DAA /* ReferringPage.swift */,
 				43F7952425795F69005AEE40 /* SearchTelemetry.swift */,
+				E51E24922EF1743D004F7785 /* ShareExtensionTelemetry.swift */,
+				C7F533192E5799AA0089DEC7 /* ShortcutsLibraryTelemetry.swift */,
 				8A04136828258DF600D20B10 /* SponsoredTileTelemetry.swift */,
+				1DD4B26D2CA4D09100B51945 /* TabErrorTelemetryHelper.swift */,
+				61CEFF5D2DA8BC78000B88A7 /* TabsPanelTelemetry.swift */,
 				8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */,
-				8A44F20D2B585E1F0016BC81 /* HomepageTelemetry.swift */,
 				8A95FF632B1E969E00AC303D /* TelemetryContextualIdentifier.swift */,
 				EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */,
-				8CA4E80C2D22C066007207C1 /* GleanUsageReporting.swift */,
-				1DD4B26D2CA4D09100B51945 /* TabErrorTelemetryHelper.swift */,
+				613489A22D942A020009AF01 /* ToastTelemetry.swift */,
+				ED232E9F2DFA3BF00046DA47 /* UserTelemetry.swift */,
 				8A0727452B4890B50071BB9F /* WebviewTelemetry.swift */,
 				8A359EF42A1FD4CF004A5BB7 /* Wrapper */,
-				613489A22D942A020009AF01 /* ToastTelemetry.swift */,
-				C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */,
-				C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */,
-				61CEFF5D2DA8BC78000B88A7 /* TabsPanelTelemetry.swift */,
-				ED232E9F2DFA3BF00046DA47 /* UserTelemetry.swift */,
-				C7F533192E5799AA0089DEC7 /* ShortcutsLibraryTelemetry.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -18948,6 +18951,7 @@
 				8A46F5AB2C9E4389005B6422 /* PasswordRuleRecord.swift in Sources */,
 				E1442FD0294782D9003680B0 /* UIAlertController+Extension.swift in Sources */,
 				ED390D222CF4DEDB00A775F9 /* TitleSubtitleActivityItemProvider.swift in Sources */,
+				3933D4F42EF3358300C0C4E3 /* DefaultBrowserUtilityTelemetry.swift in Sources */,
 				E1A6AB4828CA833000EBEBDD /* WallpaperBaseViewController.swift in Sources */,
 				8A1CBB972BE0182C008BE4D4 /* MicrosurveyPromptMiddleware.swift in Sources */,
 				4331A9BB27193DF0005E8080 /* ContextualHintViewController.swift in Sources */,
@@ -19342,7 +19346,7 @@
 				961577942A39008100391E8D /* SponsoredTileDataUtilityTests.swift in Sources */,
 				8A093D812A4B58330099ABA5 /* MockSettingsFlowDelegate.swift in Sources */,
 				431C0D1E25C9DC4D00395CE4 /* DefaultBrowserOnboardingTests.swift in Sources */,
-				5AD3B6782CF650DF00AFA1FE /* DefaultBrowserUitlityTests.swift in Sources */,
+				5AD3B6782CF650DF00AFA1FE /* DefaultBrowserUtilityTests.swift in Sources */,
 				213B67A827CE721E000542F5 /* StartAtHomeHelperTests.swift in Sources */,
 				033C94F72E2FBCDD00C2382F /* TermsOfUseMiddlewareTests.swift in Sources */,
 				8A13FA892AD82BC8007527AB /* AppSendTabDelegateTests.swift in Sources */,

--- a/firefox-ios/Client/Application/DefaultBrowserUtility.swift
+++ b/firefox-ios/Client/Application/DefaultBrowserUtility.swift
@@ -9,7 +9,7 @@ import Common
 @MainActor
 class DefaultBrowserUtility {
     let userDefault: UserDefaultsInterface
-    let telemtryWrapper: TelemetryWrapperProtocol
+    let telemetry: DefaultBrowserUtilityTelemetry
     let locale: LocaleProvider
     let application: UIApplicationInterface
     let dmaCountries = ["BE", "BG", "CZ", "DK", "DE", "EE", "IE", "EL", "ES", "FR", "HR", "IT", "CY", "LV",
@@ -19,13 +19,13 @@ class DefaultBrowserUtility {
 
     init(
         userDefault: UserDefaultsInterface = UserDefaults.standard,
-        telemetryWrapper: TelemetryWrapperProtocol = TelemetryWrapper.shared,
+        telemetry: DefaultBrowserUtilityTelemetry = DefaultBrowserUtilityTelemetry(),
         locale: LocaleProvider = SystemLocaleProvider(),
         application: UIApplicationInterface = UIApplication.shared,
         logger: Logger = DefaultLogger.shared
     ) {
         self.userDefault = userDefault
-        self.telemtryWrapper = telemetryWrapper
+        self.telemetry = telemetry
         self.locale = locale
         self.application = application
         self.logger = logger
@@ -34,6 +34,13 @@ class DefaultBrowserUtility {
     struct UserDefaultsKey {
         public static let isBrowserDefault = "com.moz.isBrowserDefault.key"
         public static let shouldNotPerformMigration = "com.moz.shouldNotPerformMigration.key"
+        public static let retryDate = "com.moz.defaultBrowserAPIRetryDate.key"
+        public static let apiQuery = "com.moz.defaultBrowserAPIQuery.key"
+    }
+
+    struct APIErrorDateKeys {
+        static let retryDate = "UIApplicationCategoryDefaultRetryAvailabilityDateErrorKey"
+        static let lastProvidedDate = "UIApplicationCategoryDefaultStatusLastProvidedDateErrorKey"
     }
 
     var isDefaultBrowser: Bool {
@@ -63,28 +70,45 @@ class DefaultBrowserUtility {
             level: .info,
             category: .setup
         )
-        guard let isDefault = try? application.isDefault(.webBrowser) else {
+
+        do {
+            trackNumberOfAPIQueries(forNewUsers: isFirstRun)
+            let isDefault = try application.isDefault(.webBrowser)
+
             logger.log(
-                "UIApplicationInterface.isDefault was not present",
+                "UIApplicationInterface.isDefault was successful",
                 level: .info,
                 category: .setup
             )
-            return
-        }
+            trackIfUserIsDefault(isDefault)
 
-        logger.log(
-            "UIApplicationInterface.isDefault was successful",
-            level: .info,
-            category: .setup
-        )
-        trackIfUserIsDefault(isDefault)
-
-        if isFirstRun {
-            trackIfNewUserIsComingFromBrowserChoiceScreen(isDefault)
-
-            if isDefault {
-                isDefaultBrowser = true
+            if isFirstRun {
+                trackIfNewUserIsComingFromBrowserChoiceScreen(isDefault)
             }
+
+            isDefaultBrowser = isDefault
+        } catch let error as UIApplication.CategoryDefaultError {
+            logger.log(
+                "UIApplicationInterface.isDefault returned retry error: \(error.localizedDescription)",
+                level: .info,
+                category: .setup
+            )
+
+            let (retryDate, lastProvidedDate) = trackDatesForErrorReporting(error.userInfo)
+            let apiQueryCount = userDefault.object(forKey: UserDefaultsKey.apiQuery) as? Int
+
+            telemetry.recordDefaultBrowserAPIError(
+                errorDescription: error.localizedDescription,
+                retryDate: retryDate,
+                lastProvidedDate: lastProvidedDate,
+                apiQueryCount: apiQueryCount
+            )
+        } catch {
+            logger.log(
+                "UIApplicationInterface.isDefault was not present with error: \(error.localizedDescription)",
+                level: .info,
+                category: .setup
+            )
         }
     }
 
@@ -97,22 +121,14 @@ class DefaultBrowserUtility {
 
     private func trackIfUserIsDefault(_ isDefault: Bool) {
         userDefault.set(isDefault, forKey: PrefsKeys.AppleConfirmedUserIsDefaultBrowser)
-
-        telemtryWrapper.recordEvent(category: .action,
-                                    method: .open,
-                                    object: .defaultBrowser,
-                                    extras: [TelemetryWrapper.EventExtraKey.isDefaultBrowser.rawValue: isDefault])
+        telemetry.recordAppIsDefaultBrowser(isDefault)
     }
 
     private func trackIfNewUserIsComingFromBrowserChoiceScreen(_ isDefault: Bool) {
         guard let regionCode = locale.localeRegionCode else { return }
         // User is in a DMA effective region
         if dmaCountries.contains(regionCode) {
-            let key = TelemetryWrapper.EventExtraKey.didComeFromBrowserChoiceScreen.rawValue
-            telemtryWrapper.recordEvent(category: .action,
-                                        method: .open,
-                                        object: .choiceScreenAcquisition,
-                                        extras: [key: isDefault])
+            telemetry.recordIsUserChoiceScreenAcquisition(isDefault)
         }
     }
 
@@ -155,5 +171,38 @@ class DefaultBrowserUtility {
         isDefaultBrowser = preAPIStatus || postAPIStatus
 
         userDefault.set(true, forKey: UserDefaultsKey.shouldNotPerformMigration)
+    }
+
+    // MARK: - API Tracking
+    /// This tracks the number of times we've queried the `isDefault` API only for new
+    /// users, in order to understand when the API returns an error. This number will only
+    /// be sent when we receive the error.
+    private func trackNumberOfAPIQueries(forNewUsers shouldStartTracking: Bool) {
+        if shouldStartTracking {
+            userDefault.set(1, forKey: UserDefaultsKey.apiQuery)
+            return
+        }
+
+        // For existing users, if the key doesn't exist, do nothing
+        guard let currentCount = userDefault.object(forKey: UserDefaultsKey.apiQuery) as? Int,
+              userDefault.object(forKey: UserDefaultsKey.apiQuery) != nil
+        else { return }
+
+        userDefault.set(currentCount + 1, forKey: UserDefaultsKey.apiQuery)
+    }
+
+    private func trackDatesForErrorReporting(
+        _ userInfoDict: [AnyHashable: Any]
+    ) -> (retryDate: Date?, lastProvidedDate: Date?) {
+        for (key, value) in userInfoDict {
+            if let keyString = key as? String, let date = value as? Date {
+                userDefault.set(date, forKey: keyString)
+            }
+        }
+
+        let retryDate = userInfoDict[APIErrorDateKeys.retryDate] as? Date
+        let lastProvidedDate = userInfoDict[APIErrorDateKeys.lastProvidedDate] as? Date
+
+        return (retryDate, lastProvidedDate)
     }
 }

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -429,6 +429,35 @@ app:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-06-01"
+  default_browser_api_error:
+    type: event
+    description: |
+      Records when the UIApplication.isDefault API returns an error,
+      capturing error details and context for debugging.
+    extra_keys:
+      error_description:
+        type: string
+        description: |
+          The localized description of the error
+      retry_date:
+        type: string
+        description: |
+          The date when the API can be retried (ISO 8601 format)
+      last_provided_date:
+        type: string
+        description: |
+          The date when the status was last provided (ISO 8601 format)
+      api_query_count:
+        type: quantity
+        description: |
+          Number of times the API has been queried for this user
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/31170
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/31365
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-06-01"
   opened_as_default_browser:
     type: counter
     description: |

--- a/firefox-ios/Client/Telemetry/DefaultBrowserUtilityTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/DefaultBrowserUtilityTelemetry.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+struct DefaultBrowserUtilityTelemetry {
+    private let gleanWrapper: GleanWrapper
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
+    func recordAppIsDefaultBrowser(_ isDefaultBrowser: Bool) {
+        gleanWrapper.setBoolean(for: GleanMetrics.App.defaultBrowser, value: isDefaultBrowser)
+    }
+
+    func recordIsUserChoiceScreenAcquisition(_ isChoiceScreenAcquisition: Bool) {
+        gleanWrapper.setBoolean(for: GleanMetrics.App.choiceScreenAcquisition, value: isChoiceScreenAcquisition)
+    }
+
+    func recordDefaultBrowserAPIError(
+        errorDescription: String,
+        retryDate: Date?,
+        lastProvidedDate: Date?,
+        apiQueryCount: Int?
+    ) {
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let extra = GleanMetrics.App.DefaultBrowserApiErrorExtra(
+            apiQueryCount: apiQueryCount.map { Int32($0) },
+            errorDescription: errorDescription,
+            lastProvidedDate: lastProvidedDate.map { dateFormatter.string(from: $0) },
+            retryDate: retryDate.map { dateFormatter.string(from: $0) }
+        )
+
+        gleanWrapper.recordEvent(for: GleanMetrics.App.defaultBrowserApiError, extras: extra)
+    }
+}

--- a/firefox-ios/Client/Telemetry/GleanWrapper.swift
+++ b/firefox-ios/Client/Telemetry/GleanWrapper.swift
@@ -64,8 +64,10 @@ struct DefaultGleanWrapper: GleanWrapper {
 
     // MARK: Glean Metrics
 
-    func recordEvent<ExtraObject>(for metric: EventMetricType<ExtraObject>,
-                                  extras: EventExtras) where ExtraObject: EventExtras {
+    func recordEvent<ExtraObject>(
+        for metric: EventMetricType<ExtraObject>,
+        extras: EventExtras
+    ) where ExtraObject: EventExtras {
         if let castedExtras = extras as? ExtraObject {
             metric.record(castedExtras)
         } else {

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -1125,14 +1125,6 @@ extension TelemetryWrapper {
             GleanMetrics.DefaultBrowserCard.goToSettingsPressed.add()
         case (.action, .open, .asDefaultBrowser, _, _):
             GleanMetrics.App.openedAsDefaultBrowser.add()
-        case (.action, .open, .defaultBrowser, _, let extras):
-            if let isDefaultBrowser = extras?[EventExtraKey.isDefaultBrowser.rawValue] as? Bool {
-                GleanMetrics.App.defaultBrowser.set(isDefaultBrowser)
-            }
-        case (.action, .open, .choiceScreenAcquisition, _, let extras):
-            if let choiceScreen = extras?[EventExtraKey.didComeFromBrowserChoiceScreen.rawValue] as? Bool {
-                GleanMetrics.App.choiceScreenAcquisition.set(choiceScreen)
-            }
         case(.action, .tap, .engagementNotification, _, _):
             GleanMetrics.Onboarding.engagementNotificationTapped.record()
         case(.action, .cancel, .engagementNotification, _, _):

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/DefaultBrowserUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/DefaultBrowserUtilityTests.swift
@@ -2,15 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import Glean
 import Shared
+import XCTest
+
 @testable import Client
 
 final class DefaultBrowserUtilityTests: XCTestCase {
     typealias DefaultKeys = DefaultBrowserUtility.UserDefaultsKey
 
     var subject: DefaultBrowserUtility!
-    var telemetryWrapper: MockTelemetryWrapper!
+    var mockGleanWrapper: MockGleanWrapper!
     var userDefaults: MockUserDefaults!
     var application: MockUIApplication!
 
@@ -20,13 +22,13 @@ final class DefaultBrowserUtilityTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        telemetryWrapper = MockTelemetryWrapper()
+        mockGleanWrapper = MockGleanWrapper()
         userDefaults = MockUserDefaults()
         application = MockUIApplication()
     }
 
     override func tearDown() {
-        telemetryWrapper = nil
+        mockGleanWrapper = nil
         userDefaults = nil
         application = nil
         subject = nil
@@ -34,55 +36,70 @@ final class DefaultBrowserUtilityTests: XCTestCase {
     }
 
     @MainActor
-    func testFirstLaunchWithDMAUser() {
+    func testFirstLaunchWithDMAUser() throws {
         guard #available(iOS 18.2, *) else { return }
 
+        let expectedBrowserEvent = GleanMetrics.App.defaultBrowser
+        let expectedChoiceEvent = GleanMetrics.App.choiceScreenAcquisition
         setupSubjectForTesting(region: "IE", setToDefault: true, isFirstRun: true)
 
         XCTAssertTrue(userDefaults.bool(forKey: DefaultKeys.isBrowserDefault))
         XCTAssertTrue(userDefaults.bool(forKey: PrefsKeys.AppleConfirmedUserIsDefaultBrowser))
-        XCTAssertTrue(telemetryWrapper.recordedObjects.contains(.defaultBrowser))
-        XCTAssertTrue(telemetryWrapper.recordedObjects.contains(.choiceScreenAcquisition))
-        XCTAssertEqual(userDefaults.setCalledCount, 2)
+
+        let savedDefaultMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? BooleanMetricType)
+        let savedChoiceScreenMetric = try XCTUnwrap(mockGleanWrapper.savedEvents[1] as? BooleanMetricType)
+        XCTAssert(savedDefaultMetric === expectedBrowserEvent)
+        XCTAssert(savedChoiceScreenMetric === expectedChoiceEvent)
+
+        XCTAssertEqual(userDefaults.setCalledCount, 3)
     }
 
     @MainActor
-    func testFirstLaunchWithNonDMAUser() {
+    func testFirstLaunchWithNonDMAUser() throws {
         guard #available(iOS 18.2, *) else { return }
 
+        let expectedBrowserEvent = GleanMetrics.App.defaultBrowser
         setupSubjectForTesting(region: "US", setToDefault: false, isFirstRun: true)
 
         XCTAssertFalse(userDefaults.bool(forKey: DefaultKeys.isBrowserDefault))
         XCTAssertFalse(userDefaults.bool(forKey: PrefsKeys.AppleConfirmedUserIsDefaultBrowser))
-        XCTAssertTrue(telemetryWrapper.recordedObjects.contains(.defaultBrowser))
-        XCTAssertFalse(telemetryWrapper.recordedObjects.contains(.choiceScreenAcquisition))
-        XCTAssertEqual(userDefaults.setCalledCount, 1)
+
+        let savedDefaultMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? BooleanMetricType)
+        XCTAssert(savedDefaultMetric === expectedBrowserEvent)
+
+        XCTAssertEqual(userDefaults.setCalledCount, 3)
     }
 
     @MainActor
-    func testSecondLaunchWithDMAUser() {
+    func testSecondLaunchWithDMAUser() throws {
         guard #available(iOS 18.2, *) else { return }
 
+        let expectedBrowserEvent = GleanMetrics.App.defaultBrowser
         setupSubjectForTesting(region: "IT", setToDefault: true, isFirstRun: false)
 
-        XCTAssertFalse(userDefaults.bool(forKey: DefaultKeys.isBrowserDefault))
+        XCTAssertTrue(userDefaults.bool(forKey: DefaultKeys.isBrowserDefault))
         XCTAssertTrue(userDefaults.bool(forKey: PrefsKeys.AppleConfirmedUserIsDefaultBrowser))
-        XCTAssertTrue(telemetryWrapper.recordedObjects.contains(.defaultBrowser))
-        XCTAssertFalse(telemetryWrapper.recordedObjects.contains(.choiceScreenAcquisition))
-        XCTAssertEqual(userDefaults.setCalledCount, 1)
+
+        let savedDefaultMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? BooleanMetricType)
+        XCTAssert(savedDefaultMetric === expectedBrowserEvent)
+
+        XCTAssertEqual(userDefaults.setCalledCount, 2)
     }
 
     @MainActor
-    func testSecondLaunchWithNonDMAUser() {
+    func testSecondLaunchWithNonDMAUser() throws {
         guard #available(iOS 18.2, *) else { return }
 
+        let expectedBrowserEvent = GleanMetrics.App.defaultBrowser
         setupSubjectForTesting(region: "US", setToDefault: false, isFirstRun: false)
 
         XCTAssertFalse(userDefaults.bool(forKey: DefaultKeys.isBrowserDefault))
         XCTAssertFalse(userDefaults.bool(forKey: PrefsKeys.AppleConfirmedUserIsDefaultBrowser))
-        XCTAssertTrue(telemetryWrapper.recordedObjects.contains(.defaultBrowser))
-        XCTAssertFalse(telemetryWrapper.recordedObjects.contains(.choiceScreenAcquisition))
-        XCTAssertEqual(userDefaults.setCalledCount, 1)
+
+        let savedDefaultMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? BooleanMetricType)
+        XCTAssert(savedDefaultMetric === expectedBrowserEvent)
+
+        XCTAssertEqual(userDefaults.setCalledCount, 2)
     }
 
     // MARK: - Migration Flag Tests
@@ -166,7 +183,7 @@ final class DefaultBrowserUtilityTests: XCTestCase {
     }
 
     @MainActor
-    func testMigration_DMA_postFirstRun_isNotDefaultBrowser() {
+    func testMigration_DMA_postFirstRun_isDefaultBrowser() {
         XCTAssertFalse(userDefaults.bool(forKey: apiOrUserSetToDefaultKey))
         XCTAssertFalse(userDefaults.bool(forKey: deeplinkValueKey))
 
@@ -174,7 +191,7 @@ final class DefaultBrowserUtilityTests: XCTestCase {
         setupSubjectForTesting(region: "IT", setToDefault: true, isFirstRun: isFirstRun)
         subject.migrateDefaultBrowserStatusIfNeeded(isFirstRun: isFirstRun)
 
-        XCTAssertFalse(subject.isDefaultBrowser)
+        XCTAssertTrue(subject.isDefaultBrowser)
     }
 
     // MARK: - Migration tests for any type of user post first run
@@ -195,10 +212,10 @@ final class DefaultBrowserUtilityTests: XCTestCase {
         XCTAssertFalse(userDefaults.bool(forKey: apiOrUserSetToDefaultKey))
         XCTAssertFalse(userDefaults.bool(forKey: deeplinkValueKey))
 
-        userDefaults.set(true, forKey: deeplinkValueKey)
-
         let isFirstRun = false
         setupSubjectForTesting(region: "US", setToDefault: false, isFirstRun: isFirstRun)
+
+        userDefaults.set(true, forKey: deeplinkValueKey)
         subject.migrateDefaultBrowserStatusIfNeeded(isFirstRun: isFirstRun)
 
         XCTAssertTrue(subject.isDefaultBrowser)
@@ -233,6 +250,66 @@ final class DefaultBrowserUtilityTests: XCTestCase {
         XCTAssertTrue(subject.isDefaultBrowser)
     }
 
+    // MARK: - API Error Tests
+    @MainActor
+    func testAPIError_recordsTelemetryWithErrorDetails() throws {
+        guard #available(iOS 18.2, *) else { return }
+
+        let expectedEvent = GleanMetrics.App.defaultBrowserApiError
+        let retryDate = Date(timeIntervalSince1970: 1700000000)
+        let lastProvidedDate = Date(timeIntervalSince1970: 1699000000)
+
+        application.setupCategoryDefaultErrorWith(userInfo: [
+            DefaultBrowserUtility.APIErrorDateKeys.retryDate: retryDate,
+            DefaultBrowserUtility.APIErrorDateKeys.lastProvidedDate: lastProvidedDate
+        ])
+
+        setupSubjectForTesting(region: "US", setToDefault: false, isFirstRun: true)
+
+        typealias EventExtra = GleanMetrics.App.DefaultBrowserApiErrorExtra
+        let savedEvent = try XCTUnwrap(mockGleanWrapper.savedEvents.last as? EventMetricType<EventExtra>)
+        let extras = try XCTUnwrap(mockGleanWrapper.savedExtras.last as? EventExtra)
+
+        XCTAssert(savedEvent === expectedEvent)
+        XCTAssertEqual(extras.apiQueryCount, 1)
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let retryDateString = try XCTUnwrap(extras.retryDate)
+        let savedRetryDate = try XCTUnwrap(formatter.date(from: retryDateString))
+        XCTAssertEqual(savedRetryDate, retryDate)
+
+        let lastProvidedDateString = try XCTUnwrap(extras.lastProvidedDate)
+        let savedLastProvidedDate = try XCTUnwrap(formatter.date(from: lastProvidedDateString))
+        XCTAssertEqual(savedLastProvidedDate, lastProvidedDate)
+    }
+
+    @MainActor
+    func testAPIError_savesDatesinUserDefaults() {
+        guard #available(iOS 18.2, *) else { return }
+
+        let retryDate = Date(timeIntervalSince1970: 1700000000)
+        let lastProvidedDate = Date(timeIntervalSince1970: 1699000000)
+
+        application.setupCategoryDefaultErrorWith(userInfo: [
+            DefaultBrowserUtility.APIErrorDateKeys.retryDate: retryDate,
+            DefaultBrowserUtility.APIErrorDateKeys.lastProvidedDate: lastProvidedDate
+        ])
+
+        setupSubjectForTesting(region: "US", setToDefault: false, isFirstRun: true)
+
+        let savedRetryDate = userDefaults.object(
+            forKey: DefaultBrowserUtility.APIErrorDateKeys.retryDate
+        ) as? Date
+        let savedLastProvidedDate = userDefaults.object(
+            forKey: DefaultBrowserUtility.APIErrorDateKeys.lastProvidedDate
+        ) as? Date
+
+        XCTAssertEqual(savedRetryDate, retryDate)
+        XCTAssertEqual(savedLastProvidedDate, lastProvidedDate)
+    }
+
     // MARK: - Helpers
     @MainActor
     private func setupSubjectForTesting(
@@ -251,7 +328,7 @@ final class DefaultBrowserUtilityTests: XCTestCase {
     private func setupSubject(with locale: LocaleProvider) {
         subject = DefaultBrowserUtility(
             userDefault: userDefaults,
-            telemetryWrapper: telemetryWrapper,
+            telemetry: DefaultBrowserUtilityTelemetry(gleanWrapper: mockGleanWrapper),
             locale: locale,
             application: application
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/MockUIApplication.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/MockUIApplication.swift
@@ -2,13 +2,29 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Foundation
 @testable import Client
 
 class MockUIApplication: UIApplicationInterface {
     var mockDefaultApplicationValue = false
 
+    private var shouldThrowCategoryDefaultError = false
+    private var mockErrorUserInfo: [String: Any] = [:]
+
     @available(iOS 18.2, *)
     func isDefault(_ category: UIApplication.Category) throws -> Bool {
+        if shouldThrowCategoryDefaultError {
+            throw NSError(
+                domain: UIApplication.CategoryDefaultError.errorDomain,
+                code: UIApplication.CategoryDefaultError.Code.rateLimited.rawValue,
+                userInfo: mockErrorUserInfo
+            )
+        }
         return mockDefaultApplicationValue
+    }
+
+    func setupCategoryDefaultErrorWith(userInfo: [String: Any]) {
+        shouldThrowCategoryDefaultError = true
+        mockErrorUserInfo = userInfo
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanWrapper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanWrapper.swift
@@ -49,8 +49,10 @@ class MockGleanWrapper: GleanWrapper, @unchecked Sendable {
 
     func enableTestingMode() {}
 
-    func recordEvent<ExtraObject>(for metric: EventMetricType<ExtraObject>,
-                                  extras: EventExtras) where ExtraObject: EventExtras {
+    func recordEvent<ExtraObject>(
+        for metric: EventMetricType<ExtraObject>,
+        extras: EventExtras
+    ) where ExtraObject: EventExtras {
         savedExtras.append(extras)
         savedEvents.append(metric)
         recordEventCalled += 1
@@ -72,7 +74,10 @@ class MockGleanWrapper: GleanWrapper, @unchecked Sendable {
         recordStringCalled += 1
     }
 
-    func incrementLabeledCounter(for metric: LabeledMetricType<CounterMetricType>, label: String) {
+    func incrementLabeledCounter(
+        for metric: LabeledMetricType<CounterMetricType>,
+        label: String
+    ) {
         savedLabel = label
         savedEvents.append(metric)
         incrementLabeledCounterCalled += 1
@@ -88,12 +93,20 @@ class MockGleanWrapper: GleanWrapper, @unchecked Sendable {
         recordQuantityCalled += 1
     }
 
-    func recordLabel(for metric: LabeledMetricType<StringMetricType>, label: String, value: String) {
+    func recordLabel(
+        for metric: LabeledMetricType<StringMetricType>,
+        label: String,
+        value: String
+    ) {
         savedEvents.append(metric)
         recordLabelCalled += 1
     }
 
-    func recordLabeledQuantity(for metric: LabeledMetricType<QuantityMetricType>, label: String, value: Int64) {
+    func recordLabeledQuantity(
+        for metric: LabeledMetricType<QuantityMetricType>,
+        label: String,
+        value: Int64
+    ) {
         savedLabel = label
         savedValues.append(value)
         savedEvents.append(metric)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -929,27 +929,6 @@ class TelemetryWrapperTests: XCTestCase {
                                           extras: extra)
         try testEventMetricRecordingSuccess(metric: GleanMetrics.Webview.showErrorPage)
     }
-
-    func testRecordIfUserDefault() {
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .open,
-                                     object: .defaultBrowser,
-                                     extras: [TelemetryWrapper.EventExtraKey.isDefaultBrowser.rawValue: true])
-        testBoolMetricSuccess(metric: GleanMetrics.App.defaultBrowser,
-                              expectedValue: true,
-                              failureMessage: "Failed to record is default browser")
-    }
-
-    func testRecordChoiceScreenAcquisition() {
-        let key = TelemetryWrapper.EventExtraKey.didComeFromBrowserChoiceScreen.rawValue
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .open,
-                                     object: .choiceScreenAcquisition,
-                                     extras: [key: true])
-        testBoolMetricSuccess(metric: GleanMetrics.App.choiceScreenAcquisition,
-                              expectedValue: true,
-                              failureMessage: "Failed to record choice screen acquisition")
-    }
 }
 
 // MARK: - Helper functions to test telemetry


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14380)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31170)

## :bulb: Description
- made a few improvements to default browser (namely that the API answer is used every time, rather than only on first run)
- move old telemetry from telemetry wrapper to dedicated telemetry utility
- added new telemetry

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

