### PR TITLE
[MTE-5074] - fix removeApp related failures on ios 26

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -72,8 +72,14 @@ class BaseTestCase: XCTestCase {
     func removeApp() {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let icon = springboard.icons.containingText("Fennec").element(boundBy: 0)
+        let iPadIcon = springboard.icons.containingText("Fennec").element(boundBy: 1)
         if icon.exists {
-            icon.press(forDuration: 1.5)
+            if #available(iOS 26, *), iPad() {
+                iPadIcon.press(forDuration: 1.0)
+                springboard.buttons["Options"].tapWithRetry()
+            } else {
+                icon.press(forDuration: 1.0)
+            }
             springboard.buttons["Remove App"].tapWithRetry()
             mozWaitForElementToNotExist(springboard.buttons["Remove App"])
             mozWaitForElementToExist(springboard.alerts.firstMatch)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5074

## :bulb: Description
This PR fixes the tests related to removeApp() on iOS 26. 
This fix is just temporary, another approach must be implemented to uninstall the app, maybe using simctl.
According to online documentation: springboard uninstall is now heavily guarded, animated, system-verified flow and on iOS 26 Apple made it even more asynchronous and security-checked. XCUITest ends up waiting on a lot.
A new investigation will continue on a different task. 