### PR TITLE
Add FXIOS-14494 [Terms of Use] Dismiss Privacy Notice from "X" button

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -487,7 +487,9 @@ final class HomepageViewController: UIViewController,
                 return UICollectionViewCell()
             }
 
-            privacyNoticeCell.configure(theme: currentTheme)
+            privacyNoticeCell.configure(theme: currentTheme) { [weak self] in
+                self?.dispatchPrivacyNoticeCloseButtonTapped()
+            }
             return privacyNoticeCell
         case .messageCard(let config):
             guard let messageCardCell = collectionView?.dequeueReusableCell(
@@ -906,6 +908,15 @@ final class HomepageViewController: UIViewController,
                 telemetryConfig: config,
                 windowUUID: self.windowUUID,
                 actionType: actionType
+            )
+        )
+    }
+
+    private func dispatchPrivacyNoticeCloseButtonTapped() {
+        store.dispatch(
+            HomepageAction(
+                windowUUID: self.windowUUID,
+                actionType: HomepageActionType.privacyNoticeCloseButtonTapped
             )
         )
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage/PrivacyNotice/PrivacyNoticeCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/PrivacyNotice/PrivacyNoticeCell.swift
@@ -19,6 +19,8 @@ final class PrivacyNoticeCell: UICollectionViewCell,
         static let closeButtonImageSize = CGSize(width: 20, height: 20)
     }
 
+    private var closeButtonAction: (() -> Void)?
+
     // MARK: - UI Elements
 
     private let bodyTextView: UITextView = .build { textView in
@@ -33,7 +35,7 @@ final class PrivacyNoticeCell: UICollectionViewCell,
         textView.textContainer.lineFragmentPadding = 0
     }
 
-    private let closeButton: UIButton = .build { button in
+    private lazy var closeButton: UIButton = .build { button in
         var config = UIButton.Configuration.plain()
 
         let image = UIImage(named: (StandardImageIdentifiers.Medium.cross))
@@ -41,6 +43,8 @@ final class PrivacyNoticeCell: UICollectionViewCell,
 
         config.image = scaledAndTemplatedImage
         button.configuration = config
+
+        button.addTarget(self, action: #selector(self.closeButtonTapped), for: .touchUpInside)
     }
 
     override init(frame: CGRect) {
@@ -59,7 +63,8 @@ final class PrivacyNoticeCell: UICollectionViewCell,
         fatalError("init(coder:) has not been implemented")
     }
 
-    public func configure(theme: Theme) {
+    public func configure(theme: Theme, closeButtonAction: (() -> Void)?) {
+        self.closeButtonAction = closeButtonAction
         applyTheme(theme: theme)
     }
 
@@ -102,6 +107,11 @@ final class PrivacyNoticeCell: UICollectionViewCell,
         }
 
         bodyTextView.attributedText = attributedString
+    }
+
+    @objc
+    func closeButtonTapped(_ sender: Any) {
+        closeButtonAction?()
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageAction.swift
@@ -61,6 +61,7 @@ enum HomepageActionType: ActionType {
     case embeddedHomepage
     case sectionSeen
     case availableContentHeightDidChange
+    case privacyNoticeCloseButtonTapped
 }
 
 enum HomepageMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -141,6 +141,8 @@ struct HomepageState: ScreenState, Equatable {
             return handleEmbeddedHomepageAction(state: state, action: action, isZeroSearch: isZeroSearch)
         case HomepageActionType.availableContentHeightDidChange:
             return handleAvailableContentHeightChangeAction(state: state, action: action)
+        case HomepageActionType.privacyNoticeCloseButtonTapped:
+            return handlePrivacyNoticeCloseButtonTappedAction(state: state, action: action)
         case GeneralBrowserActionType.didSelectedTabChangeToHomepage:
             return handleDidTabChangeToHomepageAction(state: state, action: action)
         case HomepageMiddlewareActionType.configuredPrivacyNotice:
@@ -215,6 +217,26 @@ struct HomepageState: ScreenState, Equatable {
             shouldShowPrivacyNotice: state.shouldShowPrivacyNotice,
             shouldShowSpacer: state.shouldShowSpacer,
             availableContentHeight: availableContentHeight
+        )
+    }
+
+    @MainActor
+    private static func handlePrivacyNoticeCloseButtonTappedAction(state: HomepageState, action: Action) -> HomepageState {
+        return HomepageState(
+            windowUUID: state.windowUUID,
+            headerState: HeaderState.reducer(state.headerState, action),
+            messageState: MessageCardState.reducer(state.messageState, action),
+            topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
+            searchState: SearchBarState.reducer(state.searchState, action),
+            jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
+            bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
+            pocketState: MerinoState.reducer(state.merinoState, action),
+            wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
+            isZeroSearch: state.isZeroSearch,
+            shouldTriggerImpression: false,
+            shouldShowPrivacyNotice: false,
+            shouldShowSpacer: state.shouldShowSpacer,
+            availableContentHeight: state.availableContentHeight
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
@@ -149,6 +149,23 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
     }
 
+    @MainActor
+    func test_handlePrivacyNoticeCloseButtonTapped_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = homepageReducer()
+
+        let newState = reducer(
+            initialState,
+            HomepageAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.privacyNoticeCloseButtonTapped
+            )
+        )
+
+        XCTAssertFalse(newState.shouldShowPrivacyNotice)
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+    }
+
     // MARK: - Private
     private func createSubject() -> HomepageState {
         return HomepageState(windowUUID: .XCTestDefaultUUID)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14494)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31367)

## :bulb: Description
- Dismiss the Privacy Notice homepage card when the "X" button is tapped

## :movie_camera: Demos
<details>
<summary>Video</summary>

https://github.com/user-attachments/assets/48df1527-d2b0-4ec6-ae0e-c3445edc4fb4

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

