### PR TITLE
Add MTE-5053 New private tab L10n screenshot

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -280,6 +280,8 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
         snapshot("PrivateBrowsingTabsEmptyState-01")
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        snapshot("PrivateBrowsingTabsNewTab-01")
     }
 
     @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5053)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Here is the l10n screenshot test for the new private tab.
<img width="200" height="2622" alt="iPhone 17-PrivateBrowsingTabsNewTab-01" src="https://github.com/user-attachments/assets/1734fd57-8977-4158-a4d5-9c671dae5d32" />



## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

Here is the updated `testPrivateBrowsingTabsEmptyState()` in action:
https://github.com/user-attachments/assets/b465f178-a114-441c-9fee-d173f36522b5


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

