### PR TITLE
Add FXIOS-14526 [New Error Pages] Debug toggle for other error pages feature flag 

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -151,6 +151,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .otherErrorPages,
+                titleText: format(string: "Other Error Pages"),
+                statusText: format(string: "Toggle to display natively created error pages for certificate and other errors")
+                ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .relayIntegration,
                 titleText: format(string: "Relay Email Masks"),
                 statusText: format(string: "Toggle to enable Relay mask feature")


### PR DESCRIPTION
📜 Tickets

Github issue: #31424

💡 Description

This PR adds a debug toggle in the Feature Flags menu to manually enable/disable the `other_error_pages` feature flag for testing purposes.
**Note:** This PR is part of Outreachy.

**Implementation details**

- Added `FeatureFlagsBoolSetting` for `.otherErrorPages` in `FeatureFlagsDebugViewController.swift`
- Follows the same pattern as other feature flag toggles in the debug menu

📝 Checklist

- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code - N/A (UI-only change, no logic to test)
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) - N/A (uses existing FeatureFlagsBoolSetting component)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review - N/A
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n - N/A
- [ ] If needed, I updated documentation and added comments to complex code - N/A (straightforward implementation)

## Related

- Part of certificate error page implementation