### PR TITLE
Refactor FXIOS-14444 #31273 [Performance] Fix swiping skeletons constraints on startup for Top toolbar

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1395,7 +1395,8 @@ class BrowserViewController: UIViewController,
             profile: profile,
             searchEnginesManager: searchEnginesManager,
             delegate: self,
-            isUnifiedSearchEnabled: isUnifiedSearchEnabled
+            isUnifiedSearchEnabled: isUnifiedSearchEnabled,
+            isBottomSearchBar: isBottomSearchBar
         )
         addressToolbarContainer.applyTheme(theme: currentTheme())
         addressToolbarContainer.addToParent(parent: isBottomSearchBar ? overKeyboardContainer : header)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -155,7 +155,6 @@ final class AddressToolbarContainer: UIView,
         self.isMinimalAddressBarEnabled = isMinimalAddressBarEnabled
         self.toolbarHelper = toolbarHelper
         super.init(frame: .zero)
-        setupLayout()
     }
 
     required init?(coder: NSCoder) {
@@ -184,12 +183,14 @@ final class AddressToolbarContainer: UIView,
         profile: Profile,
         searchEnginesManager: SearchEnginesManagerProvider,
         delegate: AddressToolbarContainerDelegate,
-        isUnifiedSearchEnabled: Bool
+        isUnifiedSearchEnabled: Bool,
+        isBottomSearchBar: Bool
     ) {
         self.windowUUID = windowUUID
         self.profile = profile
         self.delegate = delegate
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
+        setupLayout(isBottomSearchBar: isBottomSearchBar)
         subscribeToRedux()
     }
 
@@ -412,7 +413,7 @@ final class AddressToolbarContainer: UIView,
         rightSkeletonAddressBar.alpha = alpha
     }
 
-    private func setupLayout() {
+    private func setupLayout(isBottomSearchBar: Bool) {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(onContainerTapped))
         addGestureRecognizer(tapGesture)
 
@@ -424,8 +425,8 @@ final class AddressToolbarContainer: UIView,
             progressBar.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
 
-        setupToolbarConstraints()
-        setupSkeletonAddressBarsLayout()
+        setupToolbarConstraints(isBottomSearchBar: isBottomSearchBar)
+        setupSkeletonAddressBarsLayout(isBottomSearchBar: isBottomSearchBar)
 
         addSubview(addNewTabView)
         addNewTabLeadingConstraint = addNewTabView.leadingAnchor.constraint(equalTo: trailingAnchor)
@@ -439,9 +440,9 @@ final class AddressToolbarContainer: UIView,
         addNewTabLeadingConstraint?.isActive = true
     }
 
-    private func setupToolbarConstraints() {
+    private func setupToolbarConstraints(isBottomSearchBar: Bool) {
         addSubview(toolbar)
-        if toolbarHelper.isSwipingTabsEnabled {
+        if toolbarHelper.isSwipingTabsEnabled && isBottomSearchBar {
             insertSubview(leftSkeletonAddressBar, aboveSubview: toolbar)
             insertSubview(rightSkeletonAddressBar, aboveSubview: toolbar)
 
@@ -458,8 +459,8 @@ final class AddressToolbarContainer: UIView,
         ])
     }
 
-    private func setupSkeletonAddressBarsLayout() {
-        guard toolbarHelper.isSwipingTabsEnabled else { return }
+    private func setupSkeletonAddressBarsLayout(isBottomSearchBar: Bool) {
+        guard toolbarHelper.isSwipingTabsEnabled, isBottomSearchBar else { return }
 
         NSLayoutConstraint.activate([
             leftSkeletonAddressBar.topAnchor.constraint(equalTo: topAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14444)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31273)

## :bulb: Description
- Move setupLayout to configure to check toolbar position 
- This fixes the constraints warnings at startup if the toolbar is at the top position by delaying setupLayout until a valid isBottomSearchBar value is available so we avoid setting up the skeletons views 

While testing I found a new warning when rotating from portrait to landscape but I can reproduce in main so is not related to this changes. I will investigate this

<img width="1647" height="338" alt="Screenshot 2025-12-22 at 3 35 19 PM" src="https://github.com/user-attachments/assets/e2f2bafe-d641-4e0b-ae64-faaaeb8d7dae" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

