### PR TITLE
Bugfix FXIOS-14533 #31440 ⁃ Failing testMigration_DMA_postFirstRun_isDefaultBrowser tests in iOS 17

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/DefaultBrowserUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/DefaultBrowserUtilityTests.swift
@@ -184,6 +184,8 @@ final class DefaultBrowserUtilityTests: XCTestCase {
 
     @MainActor
     func testMigration_DMA_postFirstRun_isDefaultBrowser() {
+        guard #available(iOS 18.2, *) else { return }
+
         XCTAssertFalse(userDefaults.bool(forKey: apiOrUserSetToDefaultKey))
         XCTAssertFalse(userDefaults.bool(forKey: deeplinkValueKey))
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14533)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31440)

## :bulb: Description
- Fix failing test on iOS 17 by guarding based on OS version given the API is only available from iOS 18.2 and above
- I run the rest of the test repeatedly 500 times and there weren't more failures but let me know if we should avoid running the rest of the test also

Related PR: https://github.com/mozilla-mobile/firefox-ios/pull/31022

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

