### PR TITLE
Add FXIOS-14539 [Terms of Use] Privacy Notice feature flag

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -40,6 +40,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case nativeErrorPage
     case noInternetConnectionErrorPage
     case otherErrorPages
+    case privacyNotice
     case recentSearches
     case reportSiteIssue
     case relayIntegration
@@ -99,6 +100,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .nativeErrorPage,
                 .noInternetConnectionErrorPage,
                 .otherErrorPages,
+                .privacyNotice,
                 .recentSearches,
                 .relayIntegration,
                 .tabScrollRefactorFeature,
@@ -174,6 +176,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .nativeErrorPage,
                 .noInternetConnectionErrorPage,
                 .otherErrorPages,
+                .privacyNotice,
                 .recentSearches,
                 .reportSiteIssue,
                 .sentFromFirefoxTreatmentA,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -144,6 +144,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .privacyNotice,
+                titleText: format(string: "Privacy Notice"),
+                statusText: format(string: "Toggle to enable the Privacy Notice homepage card")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .relayIntegration,
                 titleText: format(string: "Relay Email Masks"),
                 statusText: format(string: "Toggle to enable Relay mask feature")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -97,6 +97,9 @@ final class NimbusFeatureFlagLayer: Sendable {
         case .otherErrorPages:
             return checkOtherErrorPagesFeature(from: nimbus)
 
+        case .privacyNotice:
+            return checkPrivacyNoticeFeature(from: nimbus)
+
         case .recentSearches:
             return checkRecentSearchesFeature(from: nimbus)
 
@@ -474,6 +477,10 @@ final class NimbusFeatureFlagLayer: Sendable {
 
     private func checkOtherErrorPagesFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.nativeErrorPageFeature.value().otherErrorPages
+    }
+
+    private func checkPrivacyNoticeFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.privacyNoticeFeature.value().enabled
     }
 
     // MARK: - Summarizer Feature

--- a/firefox-ios/Client/PrivacyNoticeHelper.swift
+++ b/firefox-ios/Client/PrivacyNoticeHelper.swift
@@ -8,7 +8,7 @@ protocol PrivacyNoticeHelperProtocol {
     func shouldShowPrivacyNotice() -> Bool
 }
 
-struct PrivacyNoticeHelper: PrivacyNoticeHelperProtocol {
+struct PrivacyNoticeHelper: PrivacyNoticeHelperProtocol, FeatureFlaggable {
     // Date of the last privacy notice update in miliseconds since epoch
     // Update this value to the latest privacy notice release date when you want to show users the
     // homepage privacy notice card
@@ -29,6 +29,7 @@ struct PrivacyNoticeHelper: PrivacyNoticeHelperProtocol {
     }
 
     func shouldShowPrivacyNotice() -> Bool {
+        guard featureFlags.isFeatureEnabled(.privacyNotice, checking: .buildOnly) else { return false }
         // 1. User has already accepted ToS (via onboarding or bottom sheet)
         let termsOfUseAcceptedDate = prefs.timestampForKey(PrefsKeys.TermsOfUseAcceptedDate)
         let termsOfServiceAcceptedDate = prefs.timestampForKey(PrefsKeys.TermsOfServiceAcceptedDate)

--- a/firefox-ios/nimbus-features/privacyNoticeFeature.yaml
+++ b/firefox-ios/nimbus-features/privacyNoticeFeature.yaml
@@ -1,0 +1,16 @@
+# The configuration for the privacy notice homepage card feature
+features:
+  privacy-notice-feature:
+    description: This feature manages the prviacy notice homepage card
+    variables:
+      enabled:
+        description: Setting 'enabled' to true will allow the privacy notice homepage card to be presented under certain conditions
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -34,6 +34,7 @@ include:
   - nimbus-features/newAddressBarMenu.yaml
   - nimbus-features/newAppearanceMenu.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml
+  - nimbus-features/privacyNoticeFeature.yaml
   - nimbus-features/recentSearchesFeature.yaml
   - nimbus-features/relayIntegrationFeature.yaml
   - nimbus-features/rustFxAKeychainEnabled.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14539)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31451)

## :bulb: Description
- Put Privacy Notice homepage card feature behind a flag so that it does not ship while it is under development. There are no plans to utilize nimbus to remotely control this flag

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

