### PR TITLE
Add FXIOS-14547 [Performance Improvements] Animation Improvements: Should Rasterize

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -159,7 +159,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         let snapshotContainer = UIView(frame: bvcSnapshot.frame)
         snapshotContainer.layer.cornerRadius = bvcSnapshot.layer.cornerRadius
         snapshotContainer.layer.cornerCurve = .continuous
-        bvcSnapshot.layer.shouldRasterize = true
+        snapshotContainer.layer.shouldRasterize = true
         snapshotContainer.clipsToBounds = false
         bvcSnapshot.frame = snapshotContainer.bounds
 
@@ -403,6 +403,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             toView.layer.cornerRadius = UX.zeroCornerRadius
             tabSnapshot.layer.cornerRadius = UX.zeroCornerRadius
         } completion: { _ in
+            toView.layer.shouldRasterize = false
             contentContainer.isHidden = false
             tabCell?.isHidden = false
             self.view.removeFromSuperview()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14547)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31470)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add should rasterize to complex views that we are animating. 
https://developer.apple.com/documentation/quartzcore/calayer/shouldrasterize

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

https://github.com/user-attachments/assets/ce33299a-7d86-401a-925f-d7f58d32903e


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

