### PR TITLE
Bugfix FXIOS-14504 - Zoom control pill loses separators after scrolling

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -313,10 +313,11 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         let backgroundAlpha = toolbarHelper.glassEffectAlpha
         backgroundColor = colors.layer2.withAlphaComponent(backgroundAlpha)
 
+        let separatorBackgroundColor: UIColor = if #available(iOS 26.0, *) { .systemGray2 } else { colors.borderPrimary }
         stepperContainer.backgroundColor = if #available(iOS 26.0, *) { .clear } else { colors.layer5 }
         stepperContainer.layer.shadowColor = colors.shadowDefault.cgColor
-        leftSeparator.backgroundColor = colors.borderPrimary
-        rightSeparator.backgroundColor = colors.borderPrimary
+        leftSeparator.backgroundColor = separatorBackgroundColor
+        rightSeparator.backgroundColor = separatorBackgroundColor
         zoomLevel.tintColor = colors.textPrimary
         zoomInButton.tintColor = colors.iconPrimary
         let zoomInButtonImageColorTransformer = UIConfigurationColorTransformer({ [weak zoomInButton] baseColor in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14504)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31386)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Use native colors for iOS 26+ devices that have glass effect to make sure the colors blend well and are visible.
 
## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

