### PR TITLE
Bugfix FXIOS-14556 [Memory leaks] Fix for memory leak retain cycle in downloading documents

### DIFF
--- a/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
+++ b/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
@@ -8,7 +8,7 @@ import Common
 
 private let temporaryDocumentOperationQueue = OperationQueue()
 
-protocol TemporaryDocument: Sendable, AnyObject {
+protocol TemporaryDocument: Sendable {
     var filename: String { get }
     var sourceURL: URL? { get }
     var isDownloading: Bool { get }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -914,9 +914,11 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
 
     func enqueueDocument(_ document: TemporaryDocument) {
         temporaryDocument = document
+        let sourceURL = document.sourceURL
+        let isSourceFileURL = sourceURL?.isFileURL == true
 
-        temporaryDocument?.download { [weak self, weak document] url in
-            ensureMainThread { [weak self, weak document] in
+        temporaryDocument?.download { [weak self] url in
+            ensureMainThread { [weak self] in
                 guard let url else { return }
 
                 // Prevent the WebView to load a new item so it doesn't add a new entry to the back and forward list.
@@ -927,7 +929,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
                 }
 
                 // Don't add a source URL if it is a local one. Thats happen when reloading the PDF content
-                guard let sourceURL = document?.sourceURL, document?.sourceURL?.isFileURL == false else { return }
+                guard let sourceURL, !isSourceFileURL else { return }
                 self?.temporaryDocumentsSession[url] = sourceURL
                 self?.documentLogger.registerDownloadFinish(url: sourceURL)
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14556)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31487)

## :bulb: Description
The complete closure of document download strongly refers document and tab due to which both of them create a retain cycle. I have refactored to weakly refer the document and tab both. We can also get the sourceUrl and the boolean outside the closure instead of making it a weak reference but I realized its a var, so there might be some state involved. 

Hence just changing this to weak reference.

Verified that we don't get this leak in the test after this.

## :movie_camera: Demos
N/A

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

