### PR TITLE
Add FXIOS-14450 Add new onboarding strings so we can localize before string freeze Fx 148 v2

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1826,16 +1826,28 @@ extension String {
                         tableName: "Onboarding",
                         value: "Manage settings",
                         comment: "The text for the manage settings link button in the v148 brand refresh onboarding flow.")
+                    @available(*, deprecated, message: "Use AgreementButtonTitleV2 instead")
                     public static let AgreementButtonTitle = MZLocalizedString(
                         key: "Onboarding.Modern.BrandRefresh.TermsOfUse.AgreementButtonTitle.v148",
+                        tableName: "Onboarding",
+                        value: "Agree and continue",
+                        comment: "Button title for agreeing to Terms of Use in the v148 brand refresh onboarding flow.")
+                    public static let AgreementButtonTitleV2 = MZLocalizedString(
+                        key: "Onboarding.Modern.BrandRefresh.TermsOfUse.AgreementButtonTitle.v148.v2",
                         tableName: "Onboarding",
                         value: "Continue",
                         comment: "Button title for agreeing to Terms of Use in the v148 brand refresh onboarding flow.")
                 }
 
                 public struct Welcome {
+                    @available(*, deprecated, message: "Use TitleV2 instead")
                     public static let Title = MZLocalizedString(
                         key: "Onboarding.Modern.BrandRefresh.Welcome.Title.v148",
+                        tableName: "Onboarding",
+                        value: "Say goodbye to creepy trackers",
+                        comment: "Title for the welcome card in the v148 brand refresh onboarding flow.")
+                    public static let TitleV2 = MZLocalizedString(
+                        key: "Onboarding.Modern.BrandRefresh.Welcome.Title.v148.v2",
                         tableName: "Onboarding",
                         value: "Open your links with built-in privacy",
                         comment: "Title for the welcome card in the v148 brand refresh onboarding flow.")

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1829,7 +1829,7 @@ extension String {
                     public static let AgreementButtonTitle = MZLocalizedString(
                         key: "Onboarding.Modern.BrandRefresh.TermsOfUse.AgreementButtonTitle.v148",
                         tableName: "Onboarding",
-                        value: "Agree and continue",
+                        value: "Continue",
                         comment: "Button title for agreeing to Terms of Use in the v148 brand refresh onboarding flow.")
                 }
 
@@ -1837,7 +1837,7 @@ extension String {
                     public static let Title = MZLocalizedString(
                         key: "Onboarding.Modern.BrandRefresh.Welcome.Title.v148",
                         tableName: "Onboarding",
-                        value: "Say goodbye to creepy trackers",
+                        value: "Open your links with built-in privacy",
                         comment: "Title for the welcome card in the v148 brand refresh onboarding flow.")
                     public static let Description = MZLocalizedString(
                         key: "Onboarding.Modern.BrandRefresh.Welcome.Description.v148",

--- a/firefox-ios/Shared/Supporting Files/en-US.lproj/Onboarding.strings
+++ b/firefox-ios/Shared/Supporting Files/en-US.lproj/Onboarding.strings
@@ -332,7 +332,10 @@
 "Onboarding.Modern.BrandRefresh.TermsOfUse.ManagePreferenceAgreement.v148" = "To help improve the browser, %1$@ sends diagnostic and interaction data to %2$@. %3$@";
 
 /* Button title for agreeing to Terms of Use in the v148 brand refresh onboarding flow. */
-"Onboarding.Modern.BrandRefresh.TermsOfUse.AgreementButtonTitle.v148" = "Continue";
+"Onboarding.Modern.BrandRefresh.TermsOfUse.AgreementButtonTitle.v148" = "Agree and continue";
+
+/* Button title for agreeing to Terms of Use in the v148 brand refresh onboarding flow. */
+"Onboarding.Modern.BrandRefresh.TermsOfUse.AgreementButtonTitle.v148.v2" = "Continue";
 
 /* The text for the Terms of Use link button in the v148 brand refresh onboarding flow. %@ is the app name (e.g. Firefox). */
 "Onboarding.Modern.BrandRefresh.TermsOfUse.TermsOfUseLink.v148" = "%@ Terms of Use";
@@ -344,7 +347,10 @@
 "Onboarding.Modern.BrandRefresh.TermsOfUse.ManageLink.v148" = "Manage settings";
 
 /* Title for the welcome card in the v148 brand refresh onboarding flow. */
-"Onboarding.Modern.BrandRefresh.Welcome.Title.v148" = "Open your links with built-in privacy";
+"Onboarding.Modern.BrandRefresh.Welcome.Title.v148" = "Say goodbye to creepy trackers";
+
+/* Title for the welcome card in the v148 brand refresh onboarding flow. */
+"Onboarding.Modern.BrandRefresh.Welcome.Title.v148.v2" = "Open your links with built-in privacy";
 
 /* Description for the welcome card in the v148 brand refresh onboarding flow. */
 "Onboarding.Modern.BrandRefresh.Welcome.Description.v148" = "We protect your data and automatically block companies from spying on your clicks.";

--- a/firefox-ios/Shared/Supporting Files/en-US.lproj/Onboarding.strings
+++ b/firefox-ios/Shared/Supporting Files/en-US.lproj/Onboarding.strings
@@ -332,7 +332,7 @@
 "Onboarding.Modern.BrandRefresh.TermsOfUse.ManagePreferenceAgreement.v148" = "To help improve the browser, %1$@ sends diagnostic and interaction data to %2$@. %3$@";
 
 /* Button title for agreeing to Terms of Use in the v148 brand refresh onboarding flow. */
-"Onboarding.Modern.BrandRefresh.TermsOfUse.AgreementButtonTitle.v148" = "Agree and continue";
+"Onboarding.Modern.BrandRefresh.TermsOfUse.AgreementButtonTitle.v148" = "Continue";
 
 /* The text for the Terms of Use link button in the v148 brand refresh onboarding flow. %@ is the app name (e.g. Firefox). */
 "Onboarding.Modern.BrandRefresh.TermsOfUse.TermsOfUseLink.v148" = "%@ Terms of Use";
@@ -344,7 +344,7 @@
 "Onboarding.Modern.BrandRefresh.TermsOfUse.ManageLink.v148" = "Manage settings";
 
 /* Title for the welcome card in the v148 brand refresh onboarding flow. */
-"Onboarding.Modern.BrandRefresh.Welcome.Title.v148" = "Say goodbye to creepy trackers";
+"Onboarding.Modern.BrandRefresh.Welcome.Title.v148" = "Open your links with built-in privacy";
 
 /* Description for the welcome card in the v148 brand refresh onboarding flow. */
 "Onboarding.Modern.BrandRefresh.Welcome.Description.v148" = "We protect your data and automatically block companies from spying on your clicks.";


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14450)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31296)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add missing title and button action.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


