### PR TITLE
Bugfix FXIOS-14560 [Swift 6 Migration] [Reader Mode] Workaround for broken Reader Mode after Swift 6 is enabled

### DIFF
--- a/firefox-ios/Client/Application/WebServer.swift
+++ b/firefox-ios/Client/Application/WebServer.swift
@@ -13,14 +13,12 @@ protocol WebServerProtocol {
     func start() throws -> Bool
 }
 
-// FIXME: FXIOS-13989 Make truly thread safe
+/// FIXME: FXIOS-13989 Make truly thread safe
+/// NOTE: FXIOS-14560 -- Be careful; `@MainActor` will cause crashes with GCDWebServer dependency.
 final class WebServer: WebServerProtocol, @unchecked Sendable {
-    private let logger: Logger
-    static let WebServerSharedInstance = WebServer()
+    static let sharedInstance = WebServer()
 
-    class var sharedInstance: WebServer {
-        return WebServerSharedInstance
-    }
+    private let logger: Logger
 
     let server = GCDWebServer()
 
@@ -48,8 +46,6 @@ final class WebServer: WebServerProtocol, @unchecked Sendable {
                 GCDWebServerOption_Port: AppInfo.webserverPort,
                 GCDWebServerOption_BindToLocalhost: true,
                 GCDWebServerOption_AutomaticallySuspendInBackground: false, // done by the app in AppDelegate
-                GCDWebServerOption_AuthenticationMethod: GCDWebServerAuthenticationMethod_Basic,
-                GCDWebServerOption_AuthenticationAccounts: [sessionToken: ""]
             ])
         }
         return server.isRunning


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14560)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31492)

## :bulb: Description
Workaround for the fact Reader Mode breaks once strict concurrency checking and/or Swift 6 is enabled.

We were getting a black screen when showing ReaderMode

Turns out we are getting a 401 in the JavaScript console, presumably from the GCDWebServer (in the Safari JavaScript console... see FXIOS-14565 for instructions on setting that up if you're curious). **This only happens when building release builds (e.g. build FirefoxBeta).**

@issammani realized we can just disable the basic auth (which isn't doing anything anyway for reader mode).

However, we should look toward actually fixing this tech debt this year (epic: FXIOS-14566). It's better to use the regular [WebKit WKURLSchemeHandler](https://developer.apple.com/documentation/webkit/wkurlschemehandler) and ditch GCDWebServers (old unsupported objective C library that's preconcurrency).

e.g. We can follow what Translations does:
https://github.com/mozilla-mobile/firefox-ios/blob/main/firefox-ios/Client/Frontend/Translations/SchemeHandler/TranslationsSchemeHandler.swift#L8-L40


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

