### PR TITLE
Bugfix FXIOS-8212 [Autofill] Present Credit Card type consistently local+remote

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -109,7 +109,7 @@ struct CreditCardItemRow: View {
         return AdaptiveStack(horizontalAlignment: .leading,
                              spacing: isAccessibilityCategory ? 0 : 5,
                              isAccessibilityCategory: isAccessibilityCategory) {
-            Text(item.ccType)
+            Text(item.ccType.uppercased())
                 .font(.body)
                 .foregroundColor(titleTextColor)
             Text(verbatim: "••••\(item.ccNumberLast4)")


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-8212
Github issue #18240

## :bulb: Description

It doesn't seem specifically documented, but previous art would hint at saving the card type uppercase as "AMEX", "VISA", which is stored as such when validating. Then when presenting, it's used from the stored value.

Cards synced from desktop are however appearing lowercase when presented, originating from the remote data, as they probably send the type as a sort of enum key, as "amex", "visa", and are not transformed further before being used. Maybe the correct way would be to run the received type thru the local validation as well and save its metadata to somehow produce consistent results for local vs. remote, but that could add some ugly unnecessary complexity and even make opinions on card validity / applicability again on the client, when it was already been taken care of before elsewhere.

So for simplicity, and given the lowercase and uppercase card types, or their enum key and its output value currently match 1:1 exactly, just save for the case, the cheapest path would just be if the type is indeed expected to be uppercase (as seen when validating for local card additions) to make it uppercase when presenting to user, without any other structural changes, to make the local and remote data appear consistent when presented.

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="466" height="782" alt="Screenshot 2026-01-05 at 14 06 51" src="https://github.com/user-attachments/assets/3d9b6d22-1137-4109-a138-0b1b119c8da3" /> | <img width="470" height="784" alt="Screenshot 2026-01-05 at 14 11 25" src="https://github.com/user-attachments/assets/121c1521-0d5a-4409-b0c9-e5927aa161e0" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation and added comments to complex code