### PR TITLE
Bugfix FXIOS-14565 [Reader Mode] Remove unused styles

### DIFF
--- a/firefox-ios/Client/Frontend/Reader/Resources/Reader.css
+++ b/firefox-ios/Client/Frontend/Reader/Resources/Reader.css
@@ -445,34 +445,6 @@ font-family: -apple-system, sans-serif;
   font-size: 48px !important;
 }
 
-.toolbar {
-  font-family: -apple-system, sans-serif;
-  transition-property: visibility, opacity;
-  transition-duration: 0.7s;
-  visibility: visible;
-  opacity: 1.0;
-  position: fixed;
-  width: 100%;
-  bottom: 0px;
-  left: 0px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  background-color: #EBEBF0;
-  -moz-user-select: none;
-}
-
-.toolbar-hidden {
-  transition-property: visibility, opacity;
-  transition-duration: 0.7s;
-  visibility: hidden;
-  opacity: 0.0;
-}
-
-.toolbar > * {
-  float: right;
-  width: 33%;
-}
 
 .button {
   color: white;
@@ -482,66 +454,6 @@ font-family: -apple-system, sans-serif;
   background-repeat: no-repeat;
 }
 
-.dropdown {
-  text-align: center;
-  display: inline-block;
-  list-style: none;
-  margin: 0px;
-  padding: 0px;
-}
-
-.dropdown li {
-  margin: 0px;
-  padding: 0px;
-}
-
-.dropdown-toggle {
-  margin: 0px;
-  padding: 0px;
-}
-
-.dropdown-popup {
-  text-align: start;
-  position: absolute;
-  left: 0px;
-  z-index: 1000;
-  float: left;
-  background: #EBEBF0;
-  margin-top: 12px;
-  margin-bottom: 10px;
-  padding-top: 4px;
-  padding-bottom: 8px;
-  font-size: 14px;
-  box-shadow: 0px -1px 12px #333;
-  border-radius: 3px;
-  visibility: hidden;
-}
-
-.dropdown-popup > hr {
-  width: 100%;
-  height: 0px;
-  border: 0px;
-  border-top: 1px solid #B5B5B5;
-  margin: 0;
-}
-
-.open > .dropdown-popup {
-  margin-top: 0px;
-  margin-bottom: 6px;
-  bottom: 100%;
-  visibility: visible;
-}
-
-.dropdown-arrow {
-  position: absolute;
-  width: 40px;
-  height: 18px;
-  bottom: -18px;
-  background-image: url('chrome://browser/skin/images/reader-dropdown-arrow-mdpi.png');
-  background-size: 40px 18px;
-  background-position: center;
-  display: block;
-}
 
 #font-type-buttons,
 .segmented-button {
@@ -613,81 +525,6 @@ font-family: -apple-system, sans-serif;
   font-size: 12px;
 }
 
-.toggle-button.on {
-  background-image: url('chrome://browser/skin/images/reader-toggle-on-icon-mdpi.png');
-}
-
-.toggle-button {
-  background-image: url('chrome://browser/skin/images/reader-toggle-off-icon-mdpi.png');
-}
-
-.share-button {
-  background-image: url('chrome://browser/skin/images/reader-share-icon-mdpi.png');
-}
-
-.style-button {
-  background-image: url('chrome://browser/skin/images/reader-style-icon-mdpi.png');
-}
-
-@media screen and (min-resolution: 1.25dppx) {
-  .dropdown-arrow {
-    background-image: url('chrome://browser/skin/images/reader-dropdown-arrow-hdpi.png');
-  }
-
-  .step-control > .plus-button {
-    background-image: url('chrome://browser/skin/images/reader-plus-icon-hdpi.png');
-  }
-
-  .step-control > .minus-button {
-    background-image: url('chrome://browser/skin/images/reader-minus-icon-hdpi.png');
-  }
-
-  .toggle-button.on {
-    background-image: url('chrome://browser/skin/images/reader-toggle-on-icon-hdpi.png');
-  }
-
-  .toggle-button {
-    background-image: url('chrome://browser/skin/images/reader-toggle-off-icon-hdpi.png');
-  }
-
-  .share-button {
-    background-image: url('chrome://browser/skin/images/reader-share-icon-hdpi.png');
-  }
-
-  .style-button {
-    background-image: url('chrome://browser/skin/images/reader-style-icon-hdpi.png');
-  }
-}
-
-@media screen and (min-resolution: 2dppx) {
-  .dropdown-arrow {
-    background-image: url('chrome://browser/skin/images/reader-dropdown-arrow-xhdpi.png');
-  }
-
-  .step-control > .plus-button {
-    background-image: url('chrome://browser/skin/images/reader-plus-icon-xhdpi.png');
-  }
-
-  .step-control > .minus-button {
-    background-image: url('chrome://browser/skin/images/reader-minus-icon-xhdpi.png');
-  }
-
-  .toggle-button.on {
-    background-image: url('chrome://browser/skin/images/reader-toggle-on-icon-xhdpi.png');
-  }
-
-  .toggle-button {
-    background-image: url('chrome://browser/skin/images/reader-toggle-off-icon-xhdpi.png');
-  }
-
-  .share-button {
-    background-image: url('chrome://browser/skin/images/reader-share-icon-xhdpi.png');
-  }
-
-  .style-button {
-    background-image: url('chrome://browser/skin/images/reader-style-icon-xhdpi.png');
-  }
-}
 
 @media screen and (orientation: portrait) {
   .button {
@@ -724,9 +561,5 @@ font-family: -apple-system, sans-serif;
   .button {
     width: 56px;
     height: 56px;
-  }
-
-  .toolbar > * {
-    width: 56px;
   }
 }

--- a/firefox-ios/Client/Frontend/Reader/Resources/Reader.html
+++ b/firefox-ios/Client/Frontend/Reader/Resources/Reader.html
@@ -25,22 +25,6 @@
   <div id="reader-message" class="message">
     %READER-MESSAGE%
   </div>
-
-  <ul id="reader-toolbar" class="toolbar toolbar-hidden">
-    <li><a id="share-button" class="button share-button" href="#"></a></li>
-    <ul class="dropdown">
-      <li><a class="dropdown-toggle button style-button" href="#"></a></li>
-      <li class="dropdown-popup">
-        <ul id="font-type-buttons"></ul>
-        <hr></hr>
-        <ul id="font-size-buttons" class="segmented-button"></ul>
-        <hr></hr>
-        <ul id="color-scheme-buttons" class="segmented-button"></ul>
-      </li>
-    </ul>
-    <li><a id="toggle-button" class="button toggle-button" href="#"></a></li>
-  </ul>
-
 </body>
 
 </html>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14565)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31514)

## :bulb: Description
This PR:
- Removes unused styles.
- Removes unused markup.

⚠️ The `reader-toolbar` list was always hidden. My guess is that this was copied from desktop at some point and the bar we have is built with a native view not an html one.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

