### PR TITLE
Bugfix FXIOS-14573 [Performance Improvements] Fix rotation on iPad with Toolbar Translucency Enabled

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1608,9 +1608,9 @@ class BrowserViewController: UIViewController,
         // toolbar translucency needs to be updated
         // This also required for iPad rotation
         if isToolbarTranslucencyRefactorEnabled {
-            updateToolbarDisplay(shouldUpdateBlurViews: false)
+            addOrUpdateMaskViewIfNeeded()
         } else {
-            updateToolbarDisplay(shouldUpdateBlurViews: true)
+            updateToolbarDisplay()
         }
 
         // Update available height for the homepage


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14573)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
**Steps to Reproduce**
- Turn off `toolbarTranslucencyEnabledFlag`
- Go to homepage in portrait
- Rotate to landscape
- See things look normal
- Turn on `toolbarTranslucencyEnabledFlag`
- Go to homepage in portrait
- Rotate to landscape

**Expected**
Homepage view resizes to fit page

**Actual**
Homepage does not resize to fit the screen

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| https://github.com/user-attachments/assets/f6f07bc2-0c3c-408f-bf89-b93b0331cb17 | https://github.com/user-attachments/assets/9cde30a3-7066-483e-9b89-75cae84b2604 |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

