### PR TITLE
Bugfix FXIOS-14574 [Toolbar] Overlay mode not closing on suggestion selection

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -520,8 +520,10 @@ final class LocationView: UIView,
         // Defer keyboard/first responder to next run loop (non-blocking).
         let shouldShowKeyboard = configurationIsEditing && config.shouldShowKeyboard
         if shouldShowKeyboard {
+            // cannot be added to dispatch as it would fire delayed and could trigger keyboard to be shown again
+            // despite state already requiring keyboard being dismissed (e.g. tapping on search suggestion)
+            _ = becomeFirstResponder()
             DispatchQueue.main.async { [unowned self] in
-                _ = becomeFirstResponder()
                 if config.shouldSelectSearchTerm {
                     urlTextField.text = text
                     urlTextField.selectAll(nil)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14574)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31536)

## :bulb: Description
Moved `becomeFirstResponder()` out of the dispatch block. 
This bug was introduced in a PR to fix a hang in this area. I profiled the change in this PR and didn't see any new hangs.

## :movie_camera: Demos
<details>
<summary>Demo</summary>
Before:

https://github.com/user-attachments/assets/8748de38-de26-4bde-bc11-47c3135ff9fb

After:

https://github.com/user-attachments/assets/b454f3e5-07ea-4312-a5a7-33d70807b10d 
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

