### PR TITLE
[MTE-5142] - fix testCopyPasteComplete test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -179,9 +179,9 @@ class SearchTests: FeatureFlaggedTestBase {
             app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         )
         navigator.goto(URLBarOpen)
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
-        urlBarAddress.waitAndTap()
-
+        if !iPad() {
+            urlBarAddress.waitAndTap()
+        }
         app.menuItems["Paste"].waitAndTap()
 
         // Verify that the Paste shows the search controller with prompt


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5142

## :bulb: Description
Small fix for testCopyPasteComplete. Removed extra tap on the search bar in order to have "paste" option available.