### PR TITLE
Bugfix FXIOS-14581 ⁃ Swap to Homebrew install of `gcloud-cli` in Robo Test Bitrise workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1281,30 +1281,15 @@ workflows:
         - scheme: Fennec_Enterprise
         - configuration: Fennec_Enterprise
     - deploy-to-bitrise-io@2.10.0: {}
-    - cache-pull@2.7.2:
-        inputs:
-        - cache_paths: "$HOME/sdk/google-cloud-sdk"
     - script@1.2.1:
-        title: Install Google Cloud SDK
+        title: Update Google Cloud SDK Components
         inputs:
         - content: |-
             #!/usr/bin/env bash
             set -ex
 
-            if [ -e $HOME/sdk/google-cloud-sdk ]; then
-              echo "Google Cloud SDK found, skipping installation..."
-            else
-              echo "Google Cloud SDK not found, installing..."
-              curl https://sdk.cloud.google.com > install.sh
-              bash install.sh --disable-prompts --install-dir=$HOME/sdk
-              source $HOME/sdk/google-cloud-sdk/path.bash.inc
-              gcloud components install beta --quiet
-            fi
-    - cache-push@2.7.1:
-        inputs:
-        - cache_paths: "$HOME/sdk/google-cloud-sdk"
-        - ignore_check_on_paths: "!/Users/vagrant/Library/Developer/Xcode/DerivedData/**"
-        - compress_archive: "true"
+            gcloud components install beta --quiet
+            gcloud components update --quiet
     - script@1.2.1:
         title: Firebase Test Lab Execution
         inputs:
@@ -1314,15 +1299,16 @@ workflows:
             set -o pipefail
 
             curl -o /tmp/key-file.json $BITRISEIO_GOOGLE_APPLICATION_CREDENTIALS_URL
-            $HOME/sdk/google-cloud-sdk/bin/gcloud version
-            $HOME/sdk/google-cloud-sdk/bin/gcloud auth activate-service-account -q --key-file /tmp/key-file.json
-            $HOME/sdk/google-cloud-sdk/bin/gcloud config set project "$GOOGLE_CLOUD_PROJECT"
-            GCLOUD_OUTPUT=$($HOME/sdk/google-cloud-sdk/bin/gcloud beta firebase test ios run \
+            gcloud version
+            gcloud auth activate-service-account -q --key-file /tmp/key-file.json
+            gcloud config set project "$GOOGLE_CLOUD_PROJECT"
+            GCLOUD_OUTPUT=$(gcloud beta firebase test ios run \
                 --type robo \
                 --app "$BITRISE_IPA_PATH" \
-                --device=model=iphone8,version=16.6 \
+                --device=model=iphone14pro,version=16.6 \
                 --results-bucket=firefox_ios_test_artifacts \
                 --no-record-video \
+                --timeout=10m \
                 --client-details=matrixLabel="Bitrise" \
                 --quiet 2>&1)
 


### PR DESCRIPTION
For https://github.com/mozilla-mobile/firefox-ios/issues/31548

* Additions: 
*  Swap away from `iphone8` to `iphone14pro` for `HIGH` device capacity 
*  Set a default `10m` timeout to match what we use on Android