### PR TITLE
 Refactor FXIOS-14456 #31308 ⁃ Fix test failing on XCode 26.2 to enable using this version on Bitrise WebViewDelegates

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -542,7 +542,11 @@ extension BrowserViewController: WKNavigationDelegate {
 
         // Handle MarketplaceKit URL
         if url.scheme == "marketplace-kit" {
-            let shouldAllowNavigation = shouldAllowMarketplaceKitNavigation(navigationAction)
+            let isMainFrame = isMainFrameNavigation(navigationAction)
+            let shouldAllowNavigation = shouldAllowMarketplaceKitNavigation(
+                navigationType: navigationAction.navigationType,
+                isMainFrame: isMainFrame
+            )
             decisionHandler(shouldAllowNavigation ? .allow : .cancel)
             return
         }
@@ -1207,12 +1211,9 @@ private extension BrowserViewController {
 
     // Handle MarketPlaceKitNavigation
     // Allow only explicit user tap on a top level link
-    private func shouldAllowMarketplaceKitNavigation(_ navigationAction: WKNavigationAction) -> Bool {
-        guard navigationAction.navigationType == .linkActivated,
-              navigationAction.targetFrame?.isMainFrame == true else {
-            return false
-        }
-        return true
+    private func shouldAllowMarketplaceKitNavigation(navigationType: WKNavigationType,
+                                                     isMainFrame: Bool) -> Bool {
+        return navigationType == .linkActivated && isMainFrame
     }
 
     // Recognize a iTunes Store URL. These all trigger the native apps. Note that appstore.com and phobos.apple.com

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3272,6 +3272,12 @@ class BrowserViewController: UIViewController,
         store.dispatch(action)
     }
 
+    // Extract frame information from navigation action
+    // This method can be overridden in tests to avoid WKFrameInfo mocking issues
+    public func isMainFrameNavigation(_ navigationAction: WKNavigationAction) -> Bool {
+        return navigationAction.targetFrame?.isMainFrame ?? false
+    }
+
     // MARK: Opening New Tabs
 
     /// ⚠️ !! WARNING !! ⚠️

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -244,7 +244,14 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
 
     @MainActor
     func testWebViewDecidePolicyForNavigationAction_allowMarketPlaceScheme_whenUserAction() {
-        let subject = createSubject()
+        let subject = MockBrowserViewController(
+            profile: profile,
+            tabManager: tabManager,
+            userInitiatedQueue: MockDispatchQueue()
+        )
+        subject.mockIsMainFrameNavigation = true
+        trackForMemoryLeaks(subject)
+
         let url = URL(string: "marketplace-kit://install?exampleApp.com")!
         let tab = createTab()
         tabManager.tabs = [tab]
@@ -258,11 +265,18 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
 
     @MainActor
     func testWebViewDecidePolicyForNavigationAction_cancelMarketPlaceScheme_whenNotMainFrame() {
-        let subject = createSubject()
+        let subject = MockBrowserViewController(
+            profile: profile,
+            tabManager: tabManager,
+            userInitiatedQueue: MockDispatchQueue()
+        )
+        subject.mockIsMainFrameNavigation = false
+        trackForMemoryLeaks(subject)
+
         let url = URL(string: "marketplace-kit://install?exampleApp.com")!
         let tab = createTab()
         tabManager.tabs = [tab]
-        let navigationAction = MockNavigationAction(url: url, type: .linkActivated, isMainFrame: false)
+        let navigationAction = MockNavigationAction(url: url, type: .linkActivated)
 
         subject.webView(tab.webView!,
                         decidePolicyFor: navigationAction) { policy in
@@ -272,7 +286,14 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
 
     @MainActor
     func testWebViewDecidePolicyForNavigationAction_cancelMarketPlaceScheme_whenReloadAction() {
-        let subject = createSubject()
+        let subject = MockBrowserViewController(
+            profile: profile,
+            tabManager: tabManager,
+            userInitiatedQueue: MockDispatchQueue()
+        )
+        subject.mockIsMainFrameNavigation = true
+        trackForMemoryLeaks(subject)
+
         let url = URL(string: "marketplace-kit://install?exampleApp.com")!
         let tab = createTab()
         tabManager.tabs = [tab]

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -58,6 +58,9 @@ class MockBrowserViewController: BrowserViewController {
 
     var viewControllerToPresent: UIViewController?
 
+    // Mock control for frame navigation
+    var mockIsMainFrameNavigation = true
+
     var createWebViewCalled = 0
     var runJavaScriptAlertPanelCalled = 0
     var runJavaScriptConfirmPanelCalled = 0
@@ -170,6 +173,10 @@ class MockBrowserViewController: BrowserViewController {
     }
 
     override func willNavigateAway(from tab: Tab?) {}
+
+    override func isMainFrameNavigation(_ navigationAction: WKNavigationAction) -> Bool {
+        return mockIsMainFrameNavigation
+    }
 }
 
 class MockContentContainer: ContentContainer {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewControllerWebViewDelegates.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewControllerWebViewDelegates.swift
@@ -23,7 +23,6 @@ final class MockFrameInfo: WKFrameInfo {
 class MockNavigationAction: WKNavigationAction {
     private var type: WKNavigationType?
     private var urlRequest: URLRequest
-    private var frame: WKFrameInfo?
 
     override var navigationType: WKNavigationType {
         return type ?? .other
@@ -33,14 +32,9 @@ class MockNavigationAction: WKNavigationAction {
         return urlRequest
     }
 
-    override var targetFrame: WKFrameInfo? {
-       return frame
-    }
-
-    init(url: URL, type: WKNavigationType? = nil, isMainFrame: Bool = true) {
+    init(url: URL, type: WKNavigationType? = nil) {
         self.type = type
         self.urlRequest = URLRequest(url: url)
-        self.frame = MockFrameInfo(isMainFrame: isMainFrame)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14456)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31308)

## :bulb: Description
- Remove MockWKFrameInfo from MockNavigationActions added just for test related to MarketPlaceScheme that extracted if isMainFrame, added `isMainFrameNavigation` to BVC so we can override in test (I don't love it) but without a big refactoring the only other way was to skip this specific test I'm open to chat about this options.

Removing WKFrameInfo from WKNavigation also fixes the test crashing for  `StoriesWebviewViewControllerTests and `BrowserWebUIDelegateTests`


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

