### PR TITLE
Bugfix FXIOS-14602 [Unit Tests] trending searches test not setup properly

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/TrendingSearchClientTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/TrendingSearchClientTests.swift
@@ -11,6 +11,7 @@ import XCTest
 final class TrendingSearchClientTest: XCTestCase, @unchecked Sendable {
     override func setUp() async throws {
         try await super.setUp()
+        setupNimbusTrendingSearchesTesting(isEnabled: true)
         clearState()
     }
 
@@ -152,6 +153,15 @@ final class TrendingSearchClientTest: XCTestCase, @unchecked Sendable {
             data: mockData,
             response: response,
             error: error
+        )
+    }
+}
+
+private func setupNimbusTrendingSearchesTesting(isEnabled: Bool) {
+    FxNimbus.shared.features.trendingSearchesFeature.with { _, _ in
+        return TrendingSearchesFeature(
+            enabled: isEnabled,
+            maxSuggestions: 5
         )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14602)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31594)

## :bulb: Description
The trending searches tests should be set up with the appropriate nimbus flag before running the tests. Not sure why it was able to pass before, but this should be how we originally set up the tests anyways.

One of the first failures for this occurring: https://app.bitrise.io/app/6c06d3a40422d10f/pipelines/d6c9bf40-bb17-47fb-b8f5-a0ff90344413?tab=tests

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

