### PR TITLE
Refactor FXIOS-14607 [Tech Debt] [Redux] Cleanup the `Store` implementation and related tests now that it is main actor isolated and single threaded

### DIFF
--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -34,7 +34,6 @@ public final class Store<State: StateType & Sendable>: DefaultDispatchStore {
         }
     }
 
-    @MainActor
     public init(state: State,
                 reducer: @escaping Reducer<State>,
                 middlewares: [Middleware<State>] = [],

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
@@ -8,10 +8,12 @@ import Foundation
 
 @MainActor
 class FakeReduxMiddleware {
+    var generateInitialCountValue: (() -> Int)?
+
     lazy var fakeProvider: Middleware<FakeReduxState> = { state, action in
         switch action.actionType {
         case FakeReduxActionType.requestInitialValue:
-            let initialValue = self.generateInitialValue()
+            let initialValue = self.generateInitialCountValue?() ?? 0
             let action = FakeReduxAction(counterValue: initialValue,
                                          windowUUID: windowUUID,
                                          actionType: FakeReduxActionType.initialValueLoaded)
@@ -44,9 +46,5 @@ class FakeReduxMiddleware {
 
     private func decreaseCounter(currentValue: Int) -> Int {
         return currentValue - 1
-    }
-
-    private func generateInitialValue() -> Int {
-        return Int.random(in: 1...9)
     }
 }

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxState.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxState.swift
@@ -19,6 +19,7 @@ struct FakeReduxState: StateType, Equatable {
             FakeReduxActionType.counterDecreased:
             return FakeReduxState(counter: action.counterValue ?? state.counter,
                                   isInPrivateMode: state.isInPrivateMode)
+
         case FakeReduxActionType.setPrivateModeTo:
             return FakeReduxState(counter: state.counter,
                                   isInPrivateMode: action.privateMode ?? state.isInPrivateMode)

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxViewController.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxViewController.swift
@@ -11,13 +11,12 @@ let windowUUID = UUID(uuidString: "D9D9D9D9-D9D9-D9D9-D9D9-CD68A019860B")!
 class FakeReduxViewController: UIViewController, StoreSubscriber {
     typealias SubscriberStateType = FakeReduxState
 
-    var label = UILabel(frame: .zero)
-    var isInPrivateMode = false
+    var receivedStateCounterValue: Int?
+    var isInPrivateMode: Bool?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         subscribeToRedux()
-        view.addSubview(label)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -39,7 +38,7 @@ class FakeReduxViewController: UIViewController, StoreSubscriber {
     }
 
     func newState(state: FakeReduxState) {
-        label.text = "\(state.counter)"
+        receivedStateCounterValue = state.counter
         isInPrivateMode = state.isInPrivateMode
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14607)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31600)

## :bulb: Description
Cleanup our Redux `Store` implementation now that it is main actor isolated and single threaded after the Swift 6 migration work.

~~There is no need for an action queue since all actions are processed immediately on the main thread.Likewise, we no longer need bools to track usage state (in fact, one of them wasn't even used).~~ 

Edit: I understand now that the event queuing is less about threading and more about ensuring _a single redux action_ is _completely_ processed before the next action starts (otherwise a middleware could fire another action and the newState methods will not have yet fired for the previous action, causing weird action interleaving issues).

Anyway, due to Redux being MT-only, we can greatly simplify our ReduxTests.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

