### PR TITLE
Bugfix FXIOS-14615 [Trending Searches] only save recent searches in normal mode

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -168,8 +168,17 @@ final class ToolbarMiddleware: FeatureFlaggable {
             store.dispatch(action)
 
         case ToolbarActionType.didSubmitSearchTerm:
-            // After a user submits a search term, we want to record it in our history storage via recent search provider
-            guard let url = action.url, let searchTerm = action.searchTerm else { return }
+            // After a user submits a search term, we want to record it in our history storage via recent search provider.
+            // We only want to record when in normal mode since recent searches is not available for private mode.
+            guard let toolbarState = state.screenState(
+                ToolbarState.self,
+                for: .toolbar,
+                window: action.windowUUID
+            ) else {
+                return
+            }
+
+            guard let url = action.url, let searchTerm = action.searchTerm, !toolbarState.isPrivateMode else { return }
             recentSearchProvider.addRecentSearch(searchTerm, url: url.absoluteString)
 
         case ToolbarActionType.navigationMiddleButtonDidChange:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -780,6 +780,51 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockRecentSearchProvider.addRecentSearchCalledCount, 0)
     }
 
+    func test_didSubmitSearchTerm_forPrivateMode_withProperPayload_addsRecentSearchToHistoryStorage() {
+        mockStore = MockStoreForMiddleware(state: setupPrivateModeAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+
+        let subject = createSubject(manager: toolbarManager)
+        let action = ToolbarAction(
+            url: URL(string: "https://example.com")!,
+            searchTerm: "cookies",
+            windowUUID: windowUUID,
+            actionType: ToolbarActionType.didSubmitSearchTerm
+        )
+
+        subject.toolbarProvider(mockStore.state, action)
+        XCTAssertEqual(mockRecentSearchProvider.addRecentSearchCalledCount, 0)
+    }
+
+    func test_didSubmitSearchTerm_forPrivateMode_withoutURL_doesNotAddRecentSearchToHistoryStorage() {
+        mockStore = MockStoreForMiddleware(state: setupPrivateModeAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+
+        let subject = createSubject(manager: toolbarManager)
+        let action = ToolbarAction(
+            searchTerm: "cookies",
+            windowUUID: windowUUID,
+            actionType: ToolbarActionType.didSubmitSearchTerm
+        )
+
+        subject.toolbarProvider(mockStore.state, action)
+        XCTAssertEqual(mockRecentSearchProvider.addRecentSearchCalledCount, 0)
+    }
+
+    func test_didSubmitSearchTerm_forPrivateMode_withoutSearchTerm_doesNotAddRecentSearchToHistoryStorage() {
+        mockStore = MockStoreForMiddleware(state: setupPrivateModeAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+
+        let subject = createSubject(manager: toolbarManager)
+        let action = ToolbarAction(
+            windowUUID: windowUUID,
+            actionType: ToolbarActionType.didSubmitSearchTerm
+        )
+
+        subject.toolbarProvider(mockStore.state, action)
+        XCTAssertEqual(mockRecentSearchProvider.addRecentSearchCalledCount, 0)
+    }
+
     // MARK: - Helpers
     private func createSubject(manager: ToolbarManager) -> ToolbarMiddleware {
         return ToolbarMiddleware(
@@ -845,11 +890,9 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         }
     }
 
-    func setupEditingAppState() -> AppState {
-        var addressBarState = AddressBarState(windowUUID: windowUUID)
-        addressBarState.isEditing = true
+    func setupPrivateModeAppState() -> AppState {
         var toolbarState = ToolbarState(windowUUID: windowUUID)
-        toolbarState.addressToolbar = addressBarState
+        toolbarState.isPrivateMode = true
 
         return AppState(
             activeScreens: ActiveScreensState(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14615)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31617)

## :bulb: Description
Only add recent searches if toolbar state is not in private mode. For now, we only want to save to recent searches if user has submitted a search in the normal address bar.

## :movie_camera: Demos

https://github.com/user-attachments/assets/7217cf22-4416-482f-82af-48006b1bf8a3

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

