### PR TITLE
Refactor FXIOS-14456 #31308 ⁃ Fix test failing on XCode 26.2 to enable using this version WebViewNavigationHandler

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/WebView/WebViewNavigationHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/WebViewNavigationHandler.swift
@@ -49,7 +49,15 @@ struct WebViewNavigationHandlerImplementation: WebViewNavigationHandler {
                           navigationAction: WKNavigationAction) {
         // Only filter top-level navigation, not on data URL subframes.
         // If target frame is nil, we filter as well.
-        guard navigationAction.targetFrame?.isMainFrame ?? true else {
+        let isMainFrame = navigationAction.targetFrame?.isMainFrame
+        filterDataScheme(url: url, isMainFrame: isMainFrame)
+    }
+
+    @MainActor
+    func filterDataScheme(url: URL, isMainFrame: Bool?) {
+        let shouldFilter = isMainFrame ?? true
+
+        if !shouldFilter {
             decisionHandler(.allow)
             return
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/WebView/WebViewNavigationHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/WebView/WebViewNavigationHandlerTests.swift
@@ -37,11 +37,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: false)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:text/html,")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:text/html,")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: false)
     }
 
     @MainActor
@@ -51,10 +48,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-
-        let policy = WKNavigationActionMock()
-        navigationHandler.filterDataScheme(url: URL(string: "data:text/html,")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:text/html,")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: nil)
     }
 
     @MainActor
@@ -64,11 +59,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:text/html,")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:text/html,")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -78,11 +70,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -92,11 +81,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:image/")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:image/")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -106,11 +92,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:image/svg+xml")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:image/svg+xml")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -120,11 +103,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:image/SVG+xml")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:image/SVG+xml")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -134,11 +114,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:image/jpg")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:image/jpg")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -148,11 +125,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:video/")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:video/")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -162,11 +136,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:application/pdf")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:application/pdf")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -176,11 +147,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:application/json")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:application/json")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -190,11 +158,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:;base64,")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:;base64,")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -204,11 +169,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:,")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:,")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -218,11 +180,8 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:text/plain,")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:text/plain,")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 
     @MainActor
@@ -232,10 +191,7 @@ class WebViewNavigationHandlerTests: XCTestCase {
         }
 
         let navigationHandler = WebViewNavigationHandlerImplementation(decisionHandler: handler)
-        let policy = WKNavigationActionMock()
-        policy.overridenTargetFrame = MockWKFrameInfo(isMainFrame: true)
-
-        navigationHandler.filterDataScheme(url: URL(string: "data:text/plain;")!,
-                                           navigationAction: policy)
+        let url = URL(string: "data:text/plain;")!
+        navigationHandler.filterDataScheme(url: url, isMainFrame: true)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWebKit.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWebKit.swift
@@ -5,15 +5,7 @@
 import Foundation
 import WebKit
 
-// MARK: WKNavigationActionMock
-class WKNavigationActionMock: WKNavigationAction {
-    var overridenTargetFrame: MockWKFrameInfo?
-
-    override var targetFrame: WKFrameInfo? {
-        return overridenTargetFrame
-    }
-}
-
+// TODO: FXIOS-14534 - Merge all existing MockFrameInfo
 // MARK: MockWKFrameInfo
 class MockWKFrameInfo: WKFrameInfo {
     let overridenSecurityOrigin: WKSecurityOrigin


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14456)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31308)

## :bulb: Description
- Provide an override version of filterDataScheme with a boolean value for isMainFrame instead of using `WKNavigationAction` and `WKFrameInfo` that causes crash.
- Production code doesn't change, and unit tests use the new function that uses boolean 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

