### PR TITLE
Bugfix FXIOS-13602 [webcompat] Remove "iPhone" identification from OS bit when on iPad

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -170,9 +170,11 @@ public struct UserAgentBuilder {
     }
 
     public static func defaultMobileUserAgent() -> UserAgentBuilder {
+        let device = UIDeviceDetails.model
+        let system = device == "iPad" ? "CPU" : "CPU iPhone"
         return UserAgentBuilder(
             product: UserAgent.product,
-            systemInfo: "(\(UIDeviceDetails.model); CPU iPhone OS 18_7 like Mac OS X)",
+            systemInfo: "(\(device); \(system) OS 18_7 like Mac OS X)",
             platform: UserAgent.platform,
             platformDetails: UserAgent.platformDetails,
             extensions: "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
@@ -42,7 +42,9 @@ final class UserAgentBuilderTests: XCTestCase {
     @MainActor
     func testDefaultMobileUserAgent() {
         let builder = UserAgentBuilder.defaultMobileUserAgent()
-        let systemInfo = "(\(UIDevice.current.model); CPU iPhone OS 18_7 like Mac OS X)"
+        let device = UIDevice.current.model
+        let system = device == "iPad" ? "CPU" : "CPU iPhone"
+        let systemInfo = "(\(device); \(system) OS 18_7 like Mac OS X)"
         let extensions = "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)"
         let testAgent = "\(UserAgent.product) \(systemInfo) \(UserAgent.platform) \(UserAgent.platformDetails) \(extensions)"
         XCTAssertEqual(builder.userAgent(), testAgent)


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-13602
GitHub issue #29545

## :bulb: Description

iPads, HomePods, AppleTVs et al. don't identify as "iPhone" — only iPhones and iPod touch WebKits do.

This uses `(iPad; CPU OS 18_6` instead of `(iPad; CPU iPhone OS 18_6` when not using desktop mode.

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="455" height="689" alt="iPhone OS" src="https://github.com/user-attachments/assets/33508d4a-dbec-4d29-9844-240818ce7225" /> | <img width="455" height="690" alt="iPad OS" src="https://github.com/user-attachments/assets/9fd73db8-b745-4272-af5e-4196ee85dfca" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If needed, I updated documentation and added comments to complex code