### PR TITLE
Bugfix FXIOS-14600 - [Toolbar Translucency Refactor] - Toast notification is displayed incorrectly

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4838,6 +4838,17 @@ extension BrowserViewController: TabManagerDelegate {
             return
         }
 
+        // Due to some layout changes in the toolbar translucency refactor and
+        // reduction of `setNeedsLayout()` and `layoutIfNeeded()` calls, when the keyboard appears it breaks a constraint
+        // causing the toast message to have an incorrect animation.
+        // To fix the issue, we constrain the bottom of the toast
+        // to the top of the keyboard container when the toolbar is at the bottom.
+        let toastBottomConstraint = toast.bottomAnchor.constraint(
+            equalTo: (
+                isToolbarTranslucencyRefactorEnabled && isBottomSearchBar
+            ) ? overKeyboardContainer.topAnchor : bottomContentStackView.bottomAnchor
+        )
+
         scrollController.showToolbars(animated: false)
         toast.showToast(viewController: self, delay: delay, duration: duration) { toast in
             [
@@ -4845,7 +4856,7 @@ extension BrowserViewController: TabManagerDelegate {
                                                constant: Toast.UX.toastSidePadding),
                 toast.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor,
                                                 constant: -Toast.UX.toastSidePadding),
-                toast.bottomAnchor.constraint(equalTo: self.bottomContentStackView.bottomAnchor)
+                toastBottomConstraint
             ]
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14600)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31585)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- To solve the issue, this PR constrains the bottom of the toast to the top of the keyboard container when the toolbar is set to the bottom.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

### Before
https://github.com/user-attachments/assets/1fb094e3-fe49-41ca-8dea-87d2395f037b

### After
https://github.com/user-attachments/assets/27acdd93-3494-4815-8bad-54c06388e394

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

