### PR TITLE
Fix MTE-5161 Fix widget tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -125,6 +125,14 @@ private func checkFirefoxShortcutsOptions() {
     )
 }
 
+@MainActor
+private func skipOnboardingIfNeeded(app: XCUIApplication) {
+    if app.buttons["Continue"].waitForExistence(timeout: TIMEOUT) {
+        app.buttons["Continue"].waitAndTap()
+        app.buttons["CloseButton"].waitAndTap()
+    }
+}
+
 // swiftlint:disable:next type_body_length
 class TodayWidgetTests: BaseTestCase {
     private func removeFirefoxWidget() {
@@ -339,7 +347,7 @@ class TodayWidgetTests: BaseTestCase {
         if #unavailable(iOS 16) {
             throw XCTSkip("iOS 16 is required")
         }
-        XCUIDevice.shared.press(.home)
+        app.terminate()
         // Go to Today Widget Page
         goToTodayWidgetPage()
         // Remove Firefox Widget if present
@@ -386,7 +394,7 @@ class TodayWidgetTests: BaseTestCase {
             throw XCTSkip("iOS 16 is required")
         }
         // Return to the Home screen
-        XCUIDevice.shared.press(.home)
+        app.terminate()
         // Navigate to the Today Widget Page
         goToTodayWidgetPage()
         // Remove Firefox Widget if it exists
@@ -432,6 +440,7 @@ class TodayWidgetTests: BaseTestCase {
         mozWaitForElementToExist(newPrivateSearch)
         coordinate.tap()
         tapOnWidget(widgetType: "Private Tab")
+        skipOnboardingIfNeeded(app: app)
         // Verify the presence of Private Mode message
         mozWaitForElementToExist(app.staticTexts["Leave no traces on this device"])
     }
@@ -443,7 +452,7 @@ class TodayWidgetTests: BaseTestCase {
         }
         let copiedString = "mozilla.org"
         // Press Home and navigate to Today Widget Page
-        XCUIDevice.shared.press(.home)
+        app.terminate()
         goToTodayWidgetPage()
         // Remove Firefox Widget if it already exists
         if checkPresenceFirefoxWidget() {
@@ -494,6 +503,8 @@ class TodayWidgetTests: BaseTestCase {
             springboard.alerts.buttons["Allow Paste"].waitAndTap()
         }
 
+        skipOnboardingIfNeeded(app: app)
+
         // Verify the copied string is in the URL field
         mozWaitForElementToExist(urlBarAddress, timeout: TIMEOUT)
         mozWaitForValueContains(urlBarAddress, value: copiedString, timeout: TIMEOUT)
@@ -510,7 +521,7 @@ class TodayWidgetTests: BaseTestCase {
         if #unavailable(iOS 16) {
             throw XCTSkip("iOS 16 is required")
         }
-        XCUIDevice.shared.press(.home)
+        app.terminate()
         goToTodayWidgetPage()
         // Remove Firefox Widget if it already exists
         if checkPresenceFirefoxWidget() {
@@ -537,7 +548,7 @@ class TodayWidgetTests: BaseTestCase {
         if #unavailable(iOS 16) {
             throw XCTSkip("iOS 16 is required")
         }
-        XCUIDevice.shared.press(.home)
+        app.terminate()
         goToTodayWidgetPage()
         // Remove Firefox Widget if it already exists
         if checkPresenceFirefoxWidget() {
@@ -562,7 +573,7 @@ class TodayWidgetTests: BaseTestCase {
         springboard.buttons.matching(NSPredicate(
             format: "label CONTAINS[c] %@", "Private Tab")
         ).element.firstMatch.waitAndTap()
-
+        skipOnboardingIfNeeded(app: app)
         // Verify the presence of Private Mode message
         mozWaitForElementToExist(app.staticTexts["Leave no traces on this device"])
     }
@@ -574,7 +585,9 @@ class TodayWidgetTests: BaseTestCase {
         }
         let copiedString = "mozilla.org"
         UIPasteboard.general.string = copiedString
-        XCUIDevice.shared.press(.home)
+        app.terminate()
+
+        sleep(3)
 
         goToTodayWidgetPage()
         // Remove Firefox Widget if it already exists
@@ -600,8 +613,11 @@ class TodayWidgetTests: BaseTestCase {
         springboard.buttons.matching(NSPredicate(
             format: "label CONTAINS[c] %@", "Copied Link")
         ).element.waitAndTap()
+
+        sleep(2)
         mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: TIMEOUT)
         springboard.alerts.buttons["Allow Paste"].waitAndTap()
+        skipOnboardingIfNeeded(app: app)
         // Verify the copied string is in the URL field
         mozWaitForElementToExist(urlBarAddress, timeout: TIMEOUT)
         mozWaitForValueContains(urlBarAddress, value: copiedString, timeout: TIMEOUT)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5161)

## :bulb: Description
This PR fixes the widget test terminating the app instead of sending the app in background.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

