### PR TITLE
Add FXIOS-14547 [Performance] Add back rasterization

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -147,6 +147,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         bvcSnapshot.contentMode = .scaleAspectFill
         bvcSnapshot.frame = browserVC.view.frame
         bvcSnapshot.clipsToBounds = true
+        bvcSnapshot.layer.shouldRasterize = true
 
         // Dimmed background view
         let backgroundView = UIView()
@@ -300,6 +301,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         toView.layer.cornerRadius = ExperimentTabCell.UX.cornerRadius
         toView.clipsToBounds = true
         toView.alpha = UX.clearAlpha
+        toView.layer.shouldRasterize = true
 
         context.containerView.addSubview(toView)
         context.containerView.addSubview(tabSnapshot)
@@ -327,6 +329,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         } completion: { _ in
             contentContainer.isHidden = false
             tabCell?.isHidden = false
+            toView.layer.shouldRasterize = false
             self.view.removeFromSuperview()
             tabSnapshot.removeFromSuperview()
             toView.removeFromSuperview()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14547)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31470)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Rasterization was added as a performance improvement in [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/31471)
- It was removed as additional tab animation as part of [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/31578)
- Unfortunately the performance is wayyyy worse without rasterization even with the additional improvements so we are adding it back

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

Without Rasterization:
<img width="827" height="360" alt="Screenshot 2026-01-15 at 11 30 01 AM" src="https://github.com/user-attachments/assets/f680b9f9-08a9-4f58-8dcd-7d7d93182cf5" />

With Rasterization:
<img width="835" height="364" alt="Screenshot 2026-01-15 at 11 31 07 AM" src="https://github.com/user-attachments/assets/dd330125-ae2a-4c47-9ee1-6a5c837535a5" />


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

