### PR TITLE
Remove FXIOS-14647 [Homepage Redesign] Unused homepage redesign flag

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -23,7 +23,6 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case firefoxJpGuideDefaultSite
     case firefoxSuggestFeature
     case hntSponsoredShortcuts
-    case homepageRedesign
     case homepageSearchBar
     case homepageShortcutsLibrary
     case homepageStoriesRedesign
@@ -160,7 +159,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .feltPrivacyFeltDeletion,
                 .feltPrivacySimplifiedUI,
                 .firefoxJpGuideDefaultSite,
-                .homepageRedesign,
                 .homepageSearchBar,
                 .homepageShortcutsLibrary,
                 .homepageStoriesRedesign,

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -49,9 +49,6 @@ final class NimbusFeatureFlagLayer: Sendable {
         case .hntSponsoredShortcuts:
             return checkHNTSponsoredShortcutsFeature(from: nimbus)
 
-        case .homepageRedesign:
-            return checkHomepageRedesignFeature(from: nimbus)
-
         case .homepageSearchBar:
             return checkHomepageSearchBarFeature(from: nimbus)
 
@@ -239,10 +236,6 @@ final class NimbusFeatureFlagLayer: Sendable {
 
     private func checkHNTSponsoredShortcutsFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.hntSponsoredShortcutsFeature.value().enabled
-    }
-
-    private func checkHomepageRedesignFeature(from nimbus: FxNimbus) -> Bool {
-        return nimbus.features.homepageRedesignFeature.value().enabled
     }
 
     private func checkHomepageSearchBarFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
@@ -4,11 +4,6 @@ features:
     description: >
       This feature is for managing the roll out of the Homepage New Tab Redesign feature.
     variables:
-      enabled:
-        description: >
-          Enables the feature.
-        type: Boolean
-        default: false
       search-bar:
         description: >
           If true, enables the search bar feature on homepage for users.
@@ -45,7 +40,6 @@ features:
     defaults:
       - channel: beta
         value:
-          enabled: false
           search-bar: false
           shortcuts-library: false
           stories-redesign: true
@@ -57,7 +51,6 @@ features:
 
       - channel: developer
         value:
-          enabled: false
           search-bar: false
           shortcuts-library: false
           stories-redesign: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14647)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31672)

## :bulb: Description
- Removes the unused `enabled` variable from the `homepage-redesign-feature` flag

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

