### PR TITLE
Bugfix FXIOS-14646 [UI] [Performance] Don't enforce static container height at `required`

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -232,6 +232,7 @@ public class BrowserAddressToolbar: UIView,
         trailingBrowserActionStackConstraint?.isActive = true
 
         locationContainerHeightConstraint = locationContainer.heightAnchor.constraint(equalToConstant: UX.locationHeight)
+        locationContainerHeightConstraint?.priority = .defaultHigh
         locationContainerHeightConstraint?.isActive = true
 
         toolbarBottomConstraint = toolbarContainerView.bottomAnchor.constraint(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14646)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31671)

## :bulb: Description

Allows a more permissive layout height for location container. In practice it appears this only impacts layout during app launch, but allows the layout engine to avoid several constraint errors and related engine overhead as a result of resolving those.

More context/info here: https://mozilla.slack.com/archives/C0A1FEWR06P/p1768508058474599

## :movie_camera: Demos

Screenshots from regression testing:

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-01-15 at 13 30 50" src="https://github.com/user-attachments/assets/87818188-da77-488f-b10e-59b530d02e36" />

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-01-15 at 13 30 34" src="https://github.com/user-attachments/assets/dd088a56-6bd0-4016-ba7c-0c198c722299" />

<img width="2868" height="1320" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-01-15 at 13 27 46" src="https://github.com/user-attachments/assets/6c925b4f-5baf-477d-ab90-ce3244d28157" />

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-01-15 at 13 27 34" src="https://github.com/user-attachments/assets/ee6f44bf-442e-4c07-a5ef-47ebec912546" />

<img width="1640" height="2360" alt="Simulator Screenshot - iPad (10th generation) - 2026-01-15 at 13 25 27" src="https://github.com/user-attachments/assets/4da64c59-67f8-4def-8710-f22656f5ba39" />


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

