### PR TITLE
Remove FXIOS-14604 [TabManager] Restore tabs force boolean unused

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -83,7 +83,7 @@ protocol TabManager: AnyObject {
 
     func notifyCurrentTabDidFinishLoading()
 
-    func restoreTabs(_ forced: Bool)
+    func restoreTabs()
 
     func expireLoginAlerts()
     @discardableResult
@@ -97,10 +97,6 @@ protocol TabManager: AnyObject {
 extension TabManager {
     func selectTab(_ tab: Tab?) {
         selectTab(tab, previous: nil)
-    }
-
-    func restoreTabs(_ forced: Bool = false) {
-        restoreTabs(forced)
     }
 
     @discardableResult

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -111,7 +111,7 @@ class MockTabManager: TabManager {
 
     func preserveTabs() {}
 
-    func restoreTabs(_ forced: Bool) {}
+    func restoreTabs() {}
 
     func getTabForUUID(uuid: String) -> Tab? {
         return nil

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -216,25 +216,6 @@ class TabManagerTests: XCTestCase {
     }
 
     @MainActor
-    func testRestoreTabsForced() {
-        let expectation = XCTestExpectation(description: "Tab restoration event should have been called")
-        let testUUID = UUID()
-        let subject = createSubject(tabs: generateTabs(count: 5), windowUUID: testUUID)
-
-        mockTabStore.fetchTabWindowData = WindowData(id: UUID(),
-                                                     activeTabId: UUID(),
-                                                     tabData: getMockTabData(count: 3))
-        subject.restoreTabs(true)
-
-        AppEventQueue.wait(for: .tabRestoration(testUUID)) { [tabs = subject.tabs, mockTabStore] in
-            XCTAssertEqual(tabs.count, 3)
-            XCTAssertEqual(mockTabStore?.fetchWindowDataCalledCount, 1)
-            expectation.fulfill()
-        }
-        wait(for: [expectation])
-    }
-
-    @MainActor
     func testRestoreTabs_whenDeeplinkTabPresent_withSameURLAsRestoredTab() throws {
         setIsDeeplinkOptimizationRefactorEnabled(true)
         let expectation = XCTestExpectation(description: "Tab restoration event should have been called")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14604)

## :bulb: Description
Remove an unused `forced` parameter. I think it was used at one point in the past when we had a "force restore" alert shown to the user. That alert was removed a while ago so we can clean this up.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

