### PR TITLE
Refactor FXIOS-14663 [Previews] Show full URL when link preview is disabled

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -221,7 +221,7 @@ extension BrowserViewController: WKUIDelegate {
 
             let isPrivate = currentTab.isPrivate
 
-            let showPreview = self.profile.prefs.boolForKey(PrefsKeys.ContextMenuShowLinkPreviews) ?? true
+            let showPreview = profile.prefs.boolForKey(PrefsKeys.ContextMenuShowLinkPreviews) ?? true
             let urlTitle = !showPreview ? url.absoluteString : (url.normalizedHost ?? url.absoluteString)
 
             let actions = createActions(isPrivate: isPrivate,


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-14663
GitHub issue #31698

## :bulb: Description

To offer previewing the actual destination URL query instead of loading the URL itself, to match some other browsers the tradeoffs in the real estate can be tied to the preference to show the page preview render or not — to have at least some idea about the target links when previews are disabled, or for users who want to verify the URL first before loading it. (This would also resolve #27090 and close #27719)

The default is not impacted, this only changes the link context menu title for users who deliberately disable loading the previews in settings.

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="682" height="579" alt="Image" src="https://github.com/user-attachments/assets/ddd1657d-0024-4996-9e03-cf0bd2a9fb7b" /> | <img width="677" height="754" alt="Image" src="https://github.com/user-attachments/assets/b131cc40-64d6-4ae6-95e6-ff69418517f0" /> |

This would only show full URL when preview is disabled; by default with preview enabled it's still the short version:

| Previews enabled (default) | Previews disabled (preference) |
| - | - |
| <img width="471" height="698" alt="Image" src="https://github.com/user-attachments/assets/a0463636-fa82-4881-8402-00c5944d1e75" /> | <img width="468" height="698" alt="Image" src="https://github.com/user-attachments/assets/0926f85d-fa75-4ce6-bfc2-2c7fcc0bf127" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation and added comments to complex code