### PR TITLE
Refactor MTE-4504 [Previews] Revert removing wait in validateBrowsingUI test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -424,18 +424,19 @@ class SettingsTests: FeatureFlaggedTestBase {
             [
                 table.cells[settingsQuery.OpenWithMail.title],
                 app.switches[settingsQuery.OfferToOpen.title],
+                app.switches[settingsQuery.ShowLink.title],
                 table.cells[settingsQuery.Browsing.autoPlay],
                 table.cells[settingsQuery.BlockPopUp.title],
                 table.cells[settingsQuery.NoImageMode.title],
                 app.switches[settingsQuery.BlockExternal.title]
             ]
         )
-        XCTAssertEqual(app.switches[settingsQuery.ShowLink.title].value as? String,
-                       "1",
-                       "Show links previews - toggle is not enabled by default")
         XCTAssertEqual(app.switches[settingsQuery.OfferToOpen.title].value as? String,
                        "0",
                        "Offer to Open Copied Links - toggle is not disabled by default")
+        XCTAssertEqual(app.switches[settingsQuery.ShowLink.title].value as? String,
+                       "1",
+                       "Show links previews - toggle is not enabled by default")
         XCTAssertEqual(app.switches[settingsQuery.Browsing.blockPopUps].value as? String,
                        "1",
                        "Block Pop-up  Windows - toggle is not enabled by default")


### PR DESCRIPTION
## :scroll: Tickets
FXIOS-11882
https://github.com/mozilla-mobile/firefox-ios/issues/25897#issuecomment-2818738590

## :bulb: Description

This reverts #26026 for a pref removal later reverted too. — Some bits were added recently independently, but this reverts that cleanly, by
a) adding the toggle to waitForElementsToExist too
b) ordering the toggles in the order of the menu screen

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If needed, I updated documentation and added comments to complex code