### PR TITLE
Bugfix FXIOS-13895 [iOS 26] [New first run onboarding] "Continue" button voice over is not read when selected on double tap

### DIFF
--- a/BrowserKit/Sources/OnboardingKit/Views/Common/OnboardingButton.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/Common/OnboardingButton.swift
@@ -90,12 +90,14 @@ struct OnboardingPrimaryButton: View {
     var body: some View {
         Button(action: {
             action()
+            UIAccessibility.post(notification: .announcement, argument: title)
         }, label: {
             Text(title)
                 .frame(maxWidth: .infinity)
                 .paddedVersion(.vertical, old: UX.Button.verticalPadding, new: UX.Button.verticalGlassPadding)
                 .padding(.horizontal, UX.Button.horizontalPadding)
         })
+        .accessibilityLabel(title)
         .accessibility(identifier: accessibilityIdentifier)
         .primaryButtonStyle(theme: theme)
         .backgroundClipShape()
@@ -111,12 +113,14 @@ struct OnboardingSecondaryButton: View {
     var body: some View {
         Button(action: {
             action()
+            UIAccessibility.post(notification: .announcement, argument: title)
         }, label: {
             Text(title)
                 .frame(maxWidth: .infinity)
                 .paddedVersion(.vertical, old: UX.Button.verticalPadding, new: UX.Button.verticalGlassPadding)
                 .padding(.horizontal, UX.Button.horizontalPadding)
         })
+        .accessibilityLabel(title)
         .accessibility(identifier: accessibilityIdentifier)
         .secondaryButtonStyle(theme: theme)
         .backgroundClipShape()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13895)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30107)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Add VoiceOver announcement on button tap to provide immediate audible confirmation when users activate primary/secondary buttons. This matches standard iOS accessibility behavior and improves VoiceOver UX.

Changes:
- Post UIAccessibility.announcement notification after button action
- Add explicit accessibilityLabel modifier to both button types
- Follows same pattern as ToolbarButton implementation

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

