### PR TITLE
Refactor FXIOS-14674 [L10N] Focus import/export to use new L10NTools flags

### DIFF
--- a/focus-ios/focus-ios-tests/tools/export-strings.sh
+++ b/focus-ios/focus-ios-tests/tools/export-strings.sh
@@ -23,17 +23,13 @@ git clone https://github.com/mozilla-mobile/LocalizationTools.git focus-ios-test
 echo "[*] Building tools/Localizations"
 (cd focus-ios-tests/tools/Localizations && swift build)
 
-echo "[*] Replacing firefox with focus in swift task files"
-sed -i '' 's/firefox-ios.xliff/focus-ios.xliff/g' focus-ios-tests/tools/Localizations/Sources/LocalizationTools/tasks/*.swift
-
-echo "[*] Updating EXPORT_BASE_PATH with (getpid()) in swift export task"
-sed -ri '' 's/\/tmp\/ios-localization/\/tmp\/ios-localization-\\(getpid())/g' focus-ios-tests/tools/Localizations/Sources/LocalizationTools/tasks/ExportTask.swift
-
 echo "[*] Exporting Strings (output in export-strings.log)"
 (cd focus-ios-tests/tools/Localizations && swift run LocalizationTools \
   --export \
   --project-path "$PWD/../../../Blockzilla.xcodeproj" \
   --l10n-project-path "$PWD/../../../focusios-l10n" \
+  --xliff-name focus-ios.xliff \
+  --export-base-path /tmp/ios-localization-focus \
   --locale en-US) > export-strings.log 2>&1
 
 echo "[!] Hooray strings have been succesfully exported."

--- a/focus-ios/focus-ios-tests/tools/import-strings.sh
+++ b/focus-ios/focus-ios-tests/tools/import-strings.sh
@@ -42,23 +42,14 @@ git clone https://github.com/mozilla-mobile/LocalizationTools.git focus-ios-test
 echo "[*] Building tools/Localizations"
 (cd focus-ios-tests/tools/Localizations && swift build)
 
-echo "[*] Replacing firefox with focus in swift task files"
-sed -i '' 's/firefox-ios.xliff/focus-ios.xliff/g' focus-ios-tests/tools/Localizations/Sources/LocalizationTools/tasks/*.swift
-
-echo "[*] Removing es-ES locale mapping from swift import task"
-sed -i '' '/es-ES/d' focus-ios-tests/tools/Localizations/Sources/LocalizationTools/tasks/ImportTask.swift
-
-echo "[*] Use en instead of en-US as developmentRegion in swift import task"
-sed -i '' 's/"developmentRegion" : "en-US"/"developmentRegion" : "en"/' focus-ios-tests/tools/Localizations/Sources/LocalizationTools/tasks/ImportTask.swift
-
-echo "[*] Removing WidgetKit/en-US.lproj/WidgetIntents.strings from swift import task"
-# Match all text between a line containing 'ShortcutItemTitleQRCode' to ']' and delete them
-sed -ri '' '/ShortcutItemTitleQRCode/,/\]/{/ShortcutItemTitleQRCode/!{/\]/!d;};}' focus-ios-tests/tools/Localizations/Sources/LocalizationTools/tasks/ImportTask.swift
-
 echo "[*] Importing Strings - takes a minute. (output in import-strings.log)"
 (cd focus-ios-tests/tools/Localizations && swift run LocalizationTools \
   --import \
   --project-path "$PWD/../../../Blockzilla.xcodeproj" \
-  --l10n-project-path "$PWD/../../../focusios-l10n") > import-strings.log 2>&1
+  --l10n-project-path "$PWD/../../../focusios-l10n" \
+  --xliff-name focus-ios.xliff \
+  --development-region en \
+  --project-name Blockzilla.xcodeproj \
+  --skip-widget-kit) > import-strings.log 2>&1
 
 echo "[!] Strings have been imported. You can now create a PR."


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14674)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31721)

## :bulb: Description
Let's not have weird different behaviour in scripts. This change is related to [this PR](https://github.com/mozilla-mobile/LocalizationTools/pull/11) in L10NTools repo; that change must be merged first.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

