### PR TITLE
Bugfix MTE-5169 Settings heading may not be visible after swipe

### DIFF
--- a/focus-ios/focus-ios-tests/XCUITest/SettingTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/SettingTest.swift
@@ -263,8 +263,8 @@ class SettingTest: BaseTestCase {
         app.tables.cells["settingsViewController.themeCell"].swipeUp()
 
         // Check that Safari toggle is off, swipe to get to Safari Integration menu
-        waitForExistence(app.otherElements["SIRI SHORTCUTS"])
-        app.otherElements["SIRI SHORTCUTS"].swipeUp()
+        waitForExistence(app.otherElements["SEARCH"])
+        app.otherElements["SEARCH"].swipeUp()
         XCTAssertEqual(app.switches["BlockerToggle.Safari"].value! as! String, "0")
 
         iOS_Settings.activate()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5169)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
`testSafariIntegration()` fails intermittently because the heading "Siri Shortcuts" may not be visible after swipe:
https://mozilla.slack.com/archives/CAFC45W5A/p1768904811577939
<img width="200" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-01-20 at 10 34 28" src="https://github.com/user-attachments/assets/b2945285-e197-4425-8b92-a47a0b409b2c" />
<img width="200" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-20 at 11 02 05" src="https://github.com/user-attachments/assets/dac5d6bc-f867-4a96-883c-e5ad02fa39e2" />

This PR is to use an earlier heading to swipe up the page.

I have tested the change on iPhone 17 and iPad (A16) simulators running iOS 26.2.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

