### PR TITLE
Remove FXIOS-14456 #31308 ⁃ Fix test failing on XCode 26.2 to enable using this version on Bitrise clean up

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWebKit.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWebKit.swift
@@ -5,58 +5,6 @@
 import Foundation
 import WebKit
 
-// TODO: FXIOS-14534 - Merge all existing MockFrameInfo
-// MARK: MockWKFrameInfo
-class MockWKFrameInfo: WKFrameInfo {
-    let overridenSecurityOrigin: WKSecurityOrigin
-    let overridenWebView: WKWebView?
-    let overridenTargetFrame: Bool
-
-    init(webView: MockWKWebView? = nil, frameURL: URL? = nil, isMainFrame: Bool? = false) {
-        overridenSecurityOrigin = MockWKSecurityOrigin.new(frameURL)
-        overridenWebView = webView
-        overridenTargetFrame = isMainFrame ?? false
-    }
-
-    override var isMainFrame: Bool {
-        return overridenTargetFrame
-    }
-
-    override var securityOrigin: WKSecurityOrigin {
-        return overridenSecurityOrigin
-    }
-
-    override var webView: WKWebView? {
-        return overridenWebView
-    }
-}
-
-// MARK: MockWKSecurityOrigin
-class MockWKSecurityOrigin: WKSecurityOrigin {
-    var overridenProtocol: String!
-    var overridenHost: String!
-    var overridenPort: Int!
-
-    class func new(_ url: URL?) -> MockWKSecurityOrigin {
-        // Dynamically allocate a MockWKSecurityOrigin instance because
-        // the initializer for WKSecurityOrigin is unavailable
-        //  https://github.com/WebKit/WebKit/blob/52222cf447b7215dd9bcddee659884f704001827/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.h#L40
-        guard let instance = self.perform(NSSelectorFromString("alloc"))?.takeUnretainedValue()
-                as? MockWKSecurityOrigin
-        else {
-            fatalError("Could not allocate MockWKSecurityOrigin instance")
-        }
-        instance.overridenProtocol = url?.scheme ?? ""
-        instance.overridenHost = url?.host ?? ""
-        instance.overridenPort = url?.port ?? 0
-        return instance
-    }
-
-    override var `protocol`: String { overridenProtocol }
-    override var host: String { overridenHost }
-    override var port: Int { overridenPort }
-}
-
 // MARK: MockWKWebView
 class MockWKWebView: WKWebView {
     var overridenURL: URL


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14456)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31308)

## :bulb: Description
- Removed unused mocks also the usage of this mocks will cause crahes in unit test since Apple doesn't provide API to properly mock them.
- Clean up part of SPIKE https://mozilla-hub.atlassian.net/browse/FXIOS-14534

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

