### PR TITLE
Refactor FXIOS-14749 DISCO-3680 [MozillaRustComponentsWrapper] Switch to the viaduct-hyper backend

### DIFF
--- a/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Viaduct/RustViaductFFI.h
+++ b/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Viaduct/RustViaductFFI.h
@@ -1,9 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-#pragma once
-#include <stdint.h>
-#include <Foundation/NSObjCRuntime.h>
-
-void viaduct_use_reqwest_backend();

--- a/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Viaduct/Viaduct.swift
+++ b/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Viaduct/Viaduct.swift
@@ -8,8 +8,6 @@ import Foundation
 #endif
 
 /// The public interface to viaduct.
-/// Right now it doesn't do any "true" viaduct things,
-/// it simply activated the reqwest backend.
 ///
 /// This is a singleton, and should be used via the
 /// `shared` static member.
@@ -19,9 +17,9 @@ public class Viaduct {
 
     private init() {}
 
-    public func useReqwestBackend() {
-        // Note: Doesn't need to synchronize since
-        // use_reqwest_backend is backend by a CallOnce.
-        viaduct_use_reqwest_backend()
+    public func initialize() {
+        // This method is a no-op that exists for historical reasons. Focus
+        // contains Nimbus code, which depends on viaduct but Nimbus is never
+        // actually used.
     }
 }

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Viaduct/RustViaductFFI.h
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Viaduct/RustViaductFFI.h
@@ -1,9 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-#pragma once
-#include <stdint.h>
-#include <Foundation/NSObjCRuntime.h>
-
-void viaduct_use_reqwest_backend();

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Viaduct/Viaduct.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Viaduct/Viaduct.swift
@@ -8,8 +8,6 @@ import Foundation
 #endif
 
 /// The public interface to viaduct.
-/// Right now it doesn't do any "true" viaduct things,
-/// it simply activated the reqwest backend.
 ///
 /// This is a singleton, and should be used via the
 /// `shared` static member.
@@ -20,9 +18,24 @@ public class Viaduct {
 
     private init() {}
 
-    public func useReqwestBackend() {
-        // Note: Doesn't need to synchronize since
-        // use_reqwest_backend is backend by a CallOnce.
-        viaduct_use_reqwest_backend()
+    public func initialize() {
+        // Note: This function doesn't need to synchronize since the Rust functions are thread-safe.
+
+        // This value comes from a very old workaround for FxA/Push.  We should probably get rid of
+        // this at some point and move to the value from `UserAgent.swift`.  However, make sure to
+        // first investigate that this old comment no longer applies:
+        //
+        // > The FxA servers rely on the UA agent to filter
+        // > some push messages directed to iOS devices.
+        // > This is obviously a terrible hack and we should
+        // > probably do https://github.com/mozilla/application-services/issues/1326
+        // > instead, but this will unblock us for now.
+        setGlobalDefaultUserAgent(userAgent: "Firefox-iOS-FxA/24")
+        do {
+            try viaductInitBackendHyper()
+        } catch {
+            // The last line will throw if we try to initialize more than once.
+            // Just ignore the error in this case.
+        }
     }
 }

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -66,7 +66,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
 
         // Set-up Rust network stack. Note that this has to be called
         // before any Application Services component gets used.
-        Viaduct.shared.useReqwestBackend()
+        Viaduct.shared.initialize()
 
         initializeRustErrors(logger: logger)
         logger.log("willFinishLaunchingWithOptions begin",

--- a/firefox-ios/Extensions/NotificationService/NotificationService.swift
+++ b/firefox-ios/Extensions/NotificationService/NotificationService.swift
@@ -24,7 +24,7 @@ class NotificationService: UNNotificationServiceExtension, @unchecked Sendable {
     ) {
         // Set-up Rust network stack. This is needed in addition to the call
         // from the AppDelegate due to the fact that this uses a separate process
-        Viaduct.shared.useReqwestBackend()
+        Viaduct.shared.initialize()
         MozillaAppServices.initialize()
 
         // FIXME: FXIOS-14273 Dictionaries are non-Sendable

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -111,7 +111,7 @@ class ShareViewController: UIViewController {
             showProgressIndicator()
 
             let profile = BrowserProfile(localName: "profile")
-            Viaduct.shared.useReqwestBackend()
+            Viaduct.shared.initialize()
             RustFirefoxAccounts.startup(prefs: profile.prefs) { [weak self] _ in
                 // Hide spinner and finish UI setup (Note: this completion
                 // block is currently guaranteed to arrive on main thread.)

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -56,7 +56,7 @@ public final class RustFirefoxSuggest: RustFirefoxSuggestProtocol, Sendable {
     public func ingest(emptyOnly: Bool) async throws {
         // Ensure that the Rust networking stack has been initialized before
         // downloading new suggestions. This is safe to call multiple times.
-        Viaduct.shared.useReqwestBackend()
+        Viaduct.shared.initialize()
 
         try await withCheckedThrowingContinuation { continuation in
             writerQueue.async(qos: .utility) {

--- a/focus-ios/Blockzilla/Nimbus/NimbusWrapper.swift
+++ b/focus-ios/Blockzilla/Nimbus/NimbusWrapper.swift
@@ -53,7 +53,7 @@ final class NimbusWrapper {
     }()
 
     func initializeRustComponents() {
-        Viaduct.shared.useReqwestBackend()
+        Viaduct.shared.initialize()
     }
 
     func initialize() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/DISCO-3680)
[iOS Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14749)

## :bulb: Description
Switching from the `viaduct-reqwest` backend to the `viaduct-hyper` backend.  This uses the newer backend API and making this change will help us move upgrade some of our older viaduct code.

This should mostly be transparent.  The main difference from the POV of firefox-ios is that `viaduct-reqwest` hardcodes a user-agent for iOS.  `viaduct-hyper` requires that consumers initialize their default user-agent.

This won't build until https://github.com/mozilla/application-services/pull/7169 is present in the app-services megazord, which should be tomorrow's nightly.  I haven't tested any of this myself since I don't have a working iOS setup.  The changes seem simple enough, but I'd love to get this double-checked by someone who has a mac machine.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

