### PR TITLE
Bugfix FXIOS-14670 ⁃ [Intermittent] long URL spill out of the search/address bar when copied and applied with "Paste and go"

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -664,8 +664,8 @@ final class LocationView: UIView,
     func menuHelperPasteAndGo() {
         ensureMainThread {
             guard let pasteboardContents = UIPasteboard.general.string else { return }
-            self.delegate?.locationViewDidSubmitText(pasteboardContents)
             self.urlTextField.text = pasteboardContents
+            self.delegate?.locationViewDidSubmitText(pasteboardContents)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14670)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31711)

## :bulb: Description
Set urlTextField earlier 

## :movie_camera: Demos

https://github.com/user-attachments/assets/1759a5ab-d61f-44f1-8747-13a23236a965



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

