### PR TITLE
[MTE-5170] - Fixes for homepage tests failures

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -261,6 +261,26 @@ class BaseTestCase: XCTestCase {
         navigator.performAction(Action.Bookmark)
     }
 
+    func enableBookmarksInSettings() {
+        navigator.goto(HomeSettings)
+        let homepageSettings = HomepageSettingsScreen(app: app)
+        homepageSettings.assertBookmarkToggleExists()
+        homepageSettings.enableBookmarkToggle()
+        navigator.nowAt(HomeSettings)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.nowAt(BrowserTab)
+    }
+
+    func enableJumpBackInInSettings() {
+        navigator.goto(HomeSettings)
+        let homepageSettings = HomepageSettingsScreen(app: app)
+        homepageSettings.assertJumpBackInToggleExists()
+        homepageSettings.enableJumpBackInToggle()
+        navigator.nowAt(HomeSettings)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.nowAt(BrowserTab)
+    }
+
     func unbookmark(url: String) {
         navigator.nowAt(BrowserTab)
         navigator.goto(LibraryPanel_Bookmarks)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -397,9 +397,12 @@ class BookmarksTests: FeatureFlaggedTestBase {
     func testLongTapRecentlySavedLink() {
         addLaunchArgument(jsonFileName: "homepageRedesignOff", featureName: "homepage-redesign-feature")
         app.launch()
+        enableBookmarksInSettings()
         validateLongTapOptionsFromBookmarkLink(isExperiment: true)
         forceRestartApp()
         app.launch()
+        navigator.nowAt(NewTabScreen)
+        enableBookmarksInSettings()
         if #available(iOS 18, *) {
             XCUIDevice.shared.orientation = .landscapeLeft
             navigator.nowAt(NewTabScreen)
@@ -517,7 +520,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
         // Tap to "Open in New Tab"
         contextMenuTable.cells.buttons[StandardImageIdentifiers.Large.plus].waitAndTap()
         // The webpage opens in a new tab
-        switchToTabAndValidate(nrOfTabs: "3")
+        switchToTabAndValidate(nrOfTabs: "4")
 
         // Tap to "Open in Private Tab"
         navigator.performAction(Action.GoToHomePage)
@@ -569,7 +572,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
             if isPrivate {
                 app.buttons[AccessibilityIdentifiers.Browser.TopTabs.privateModeButton].waitAndTap()
             } else {
-                app.collectionViews[AccessibilityIdentifiers.Browser.TopTabs.collectionView].cells.element(boundBy: 2)
+                app.collectionViews[AccessibilityIdentifiers.Browser.TopTabs.collectionView].cells.element(boundBy: 3)
                     .waitAndTap()
             }
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -213,6 +213,7 @@ class Action {
     static let TogglePocketInNewTab = "TogglePocketInNewTab"
     static let ToggleHistoryInNewTab = "ToggleHistoryInNewTab"
     static let ToggleRecentlySaved = "ToggleRecentlySaved"
+    static let ToggleJumpBackIn = "ToggleJumpBackIn"
 
     static let SelectNewTabAsBlankPage = "SelectNewTabAsBlankPage"
     static let SelectNewTabAsFirefoxHomePage = "SelectNewTabAsFirefoxHomePage"

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -195,6 +195,7 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
     func testJumpBackIn() {
         addLaunchArgument(jsonFileName: "homepageRedesignOff", featureName: "homepage-redesign-feature")
         app.launch()
+        enableJumpBackInInSettings()
         navigator.openURL(path(forTestPage: exampleUrl))
         waitUntilPageLoad()
         navigator.goto(TabTray)
@@ -230,7 +231,7 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
         app.launch()
         // Preconditons: Create 6 bookmarks & add 1 items to reading list
-        navigator.nowAt(BrowserTab)
+        enableBookmarksInSettings()
         bookmarkPages()
         // iOS 15 does not have the Reader View button available (when experiment Off)
         if #available(iOS 16, *) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -25,11 +25,7 @@ class JumpBackInTests: FeatureFlaggedTestBase {
         // "Jump Back In" is enabled by default. See Settings -> Homepage
         addLaunchArgument(jsonFileName: "homepageRedesignOff", featureName: "homepage-redesign-feature")
         app.launch()
-        navigator.goto(HomeSettings)
-        mozWaitForElementToExist(app.switches["Jump Back In"])
-        XCTAssertEqual(app.switches["Jump Back In"].value as? String, "1")
-
-        navigator.goto(NewTabScreen)
+        enableJumpBackInInSettings()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306922

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
@@ -422,7 +422,7 @@ class OnboardingTests: BaseTestCase {
         mozWaitForElementToExist(topSites)
     }
 
-    // Smoketest TAE
+    // Smoketest
     // https://mozilla.testrail.io/index.php?/cases/view/3193571
     func testValidateContinueButton() {
         let onboardingScreen = OnboardingScreen(app: app)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomepageSettingsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomepageSettingsScreen.swift
@@ -23,8 +23,18 @@ final class HomepageSettingsScreen {
         return settingTable.cells.switches[toggle]
     }
 
+    private var jumpBackInSwitch: XCUIElement {
+        let settingTable = sel.HOMEPAGE_SETTINGS_TABLE.element(in: app)
+        let toggle = sel.JUMP_BACK_IN_TOGGLE.value
+        return settingTable.cells.switches[toggle]
+    }
+
     func assertBookmarkToggleExists(timeout: TimeInterval = TIMEOUT) {
         BaseTestCase().mozWaitForElementToExist(bookmarkSwitch)
+    }
+
+    func assertJumpBackInToggleExists(timeout: TimeInterval = TIMEOUT) {
+        BaseTestCase().mozWaitForElementToExist(jumpBackInSwitch)
     }
 
     func disableBookmarkToggle() {
@@ -36,6 +46,20 @@ final class HomepageSettingsScreen {
 
     func enableBookmarkToggle() {
         let switchElement = bookmarkSwitch
+        if switchElement.value as? String == "0" {
+            switchElement.waitAndTap()
+        }
+    }
+
+    func disableJumpBackInToggle() {
+        let switchElement = jumpBackInSwitch
+        if switchElement.value as? String == "1" {
+            switchElement.waitAndTap()
+        }
+    }
+
+    func enableJumpBackInToggle() {
+        let switchElement = jumpBackInSwitch
         if switchElement.value as? String == "0" {
             switchElement.waitAndTap()
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/HomepageSettingsSelector.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/HomepageSettingsSelector.swift
@@ -6,6 +6,7 @@ import XCTest
 
 protocol HomepageSettingsSelectorSet {
     var BOOKMARK_TOGGLE: Selector { get }
+    var JUMP_BACK_IN_TOGGLE: Selector { get }
     var HOMEPAGE_SETTINGS_TABLE: Selector { get }
     var all: [Selector] { get }
 }
@@ -13,6 +14,7 @@ protocol HomepageSettingsSelectorSet {
 struct HomepageSettingsSelectors: HomepageSettingsSelectorSet {
     private enum IDs {
         static let bookmarkToogle = "Bookmarks"
+        static let jumpBackInToggle = "Jump Back In"
     }
 
     let HOMEPAGE_SETTINGS_TABLE = Selector.firstTable(
@@ -26,5 +28,11 @@ struct HomepageSettingsSelectors: HomepageSettingsSelectorSet {
         groups: ["homepage_settings"]
     )
 
-    var all: [Selector] { [BOOKMARK_TOGGLE, HOMEPAGE_SETTINGS_TABLE] }
+    let JUMP_BACK_IN_TOGGLE = Selector.staticTextByLabel(
+        IDs.jumpBackInToggle,
+        description: "Jump back in toggle in homepage settings",
+        groups: ["homepage_settings"]
+    )
+
+    var all: [Selector] { [BOOKMARK_TOGGLE, HOMEPAGE_SETTINGS_TABLE, JUMP_BACK_IN_TOGGLE] }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerHomePanelNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerHomePanelNavigation.swift
@@ -65,6 +65,10 @@ func registerHomePanelNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIAp
             app.tables.cells.switches["Bookmarks"].waitAndTap()
         }
 
+        screenState.gesture(forAction: Action.ToggleJumpBackIn) { userState in
+            app.tables.cells.switches["Jump Back In"].waitAndTap()
+        }
+
         screenState.gesture(forAction: Action.SelectShortcuts) { userState in
             let topSitesSetting = AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.settingsPage
             app.tables.cells[topSitesSetting].waitAndTap()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5170

## :bulb: Description
testJumpBackInSection, testPrivateTab, testLongTapOnJumpBackInLink, testLongTapRecentlySavedLink, testRecentlySaved
and testJumpBackIn tests started to fail after the homepage changes, where some settings were disabled by default.
The fix was to enable Bookmark and Jump Back In settings and making the options to be available in homepage.
