### PR TITLE
Refactor FXIOS-14693 [App icons] Enable fun icons by default

### DIFF
--- a/firefox-ios/nimbus-features/appIconSelectionFeature.yaml
+++ b/firefox-ios/nimbus-features/appIconSelectionFeature.yaml
@@ -9,11 +9,11 @@ features:
         description: >
           Controls whether users see the fun icons in the app icon settings.
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:
-          funIconsEnabled: false
+          funIconsEnabled: true
       - channel: developer
         value:
           funIconsEnabled: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14693)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31757)

## :bulb: Description
Enables the feature flag for fun icons by default.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

