### PR TITLE
Bugfix FXIOS-13927 ⁃ [RTL] Some toggles' text in the Settings page is aligned to the left

### DIFF
--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedLearnMoreTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedLearnMoreTableViewCell.swift
@@ -25,13 +25,11 @@ class ThemedLearnMoreTableViewCell: ThemedTableViewCell {
 
     private lazy var titleLabel: UILabel = .build { label in
         label.numberOfLines = 0
-        label.textAlignment = .left
         label.font = FXFontStyles.Regular.body.scaledFont()
     }
 
     private lazy var subtitleLabel: UILabel = .build { label in
         label.numberOfLines = 0
-        label.textAlignment = .left
         label.font = FXFontStyles.Regular.caption1.scaledFont()
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13927)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30174)

## :bulb: Description
Removed left alignment for labels

## :movie_camera: Demos
![IMG_7465](https://github.com/user-attachments/assets/2bbd17a4-6a34-4099-8941-fd7393d4a776)


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

