### PR TITLE
Bugfix FXIOS-14723 [Privacy Notice] Add bottom insets to privacy notice

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -41,7 +41,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         }
 
         struct PrivacyNoticeConstants {
-            static let topInsets: CGFloat = 12
+            static let bottomInsets: CGFloat = 24
         }
 
         struct MessageCardConstants {
@@ -132,8 +132,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         case .privacyNotice:
             return createSingleItemSectionLayout(
                 for: traitCollection,
-                itemHeight: UX.MessageCardConstants.height,
-                topInsets: UX.PrivacyNoticeConstants.topInsets
+                bottomInsets: UX.PrivacyNoticeConstants.bottomInsets
             )
         case .messageCard:
             return createSingleItemSectionLayout(
@@ -493,7 +492,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         let privacyNoticeCell = PrivacyNoticeCell()
         totalHeight += HomepageDimensionCalculator.fittingHeight(for: privacyNoticeCell, width: containerWidth)
-        totalHeight += UX.PrivacyNoticeConstants.topInsets
+        totalHeight += UX.PrivacyNoticeConstants.bottomInsets
         return totalHeight
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14723)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31803)

## :bulb: Description
- Add bottom insets to the Privacy Notice section of the homepage since [the top padding of the LabelButtonHeaderView](https://github.com/mozilla-mobile/firefox-ios/pull/31545/files#diff-ec9454cab957968e5ac906e244395ae772fffcd0728a126e4441755ce3e29e1aR16) was removed

## :movie_camera: Demos
| Before | After |
| ------------- | ------------- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-01-23 at 11 05 12" src="https://github.com/user-attachments/assets/dc2e478e-5e29-4b63-bf26-09d91bb7124c" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-01-23 at 11 21 21" src="https://github.com/user-attachments/assets/8e8eb9fb-1a19-4e80-b5c7-4313880fa89a" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

