### PR TITLE
Refactor FXIOS-14582 Verify toolbar exists for iOS 26

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
@@ -173,11 +173,15 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
     private func validateMarkupTool() {
         // The Markup tool opens
         if #available(iOS 26, *) {
-            if iPad() {
+            if !iPad() {
                 app.navigationBars.buttons["More"].waitAndTap()
+                mozWaitForElementToExist(app.buttons["Markup"])
+                mozWaitForElementToExist(app.buttons["Close"])
+                mozWaitForElementToExist(app.otherElements["Drawing-Palette"])
+            } else {
+                mozWaitForElementToExist(app.switches["Markup"])
+                mozWaitForElementToExist(app.buttons["close"])
             }
-            // iOS 26: The markup isn't shown in debug description
-            // https://github.com/mozilla-mobile/firefox-ios/issues/31552
         } else {
             mozWaitForElementToExist(app.switches["Markup"])
             mozWaitForElementToExist(app.buttons["Done"])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14582)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31552)


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I have confirmed that the markup tool is shown on iOS 26 (both iPhone and iPad) via test automation.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<img width="200" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-26 at 10 02 18" src="https://github.com/user-attachments/assets/1d016b6e-e562-4ba9-9f62-0ee5d449eab7" />

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

