### PR TITLE
Enable running UI tests in Firefox and FirefoxBeta

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,6 +41,18 @@ pipelines:
         depends_on:
         - focus_configure_build
         parallel: 1
+  pipeline_build_and_test_release:
+    workflows:
+      firefox_scheme_build_for_test: {}
+      firefox_beta_scheme_build_for_test: {}
+      run_firefox_scheme_ui_tests:
+        depends_on:
+        - firefox_scheme_build_for_test
+        parallel: 5
+      run_firefox_beta_scheme_ui_tests:
+        depends_on:
+        - firefox_beta_scheme_build_for_test
+        parallel: 5
 
 workflows:
   firefox_accessibility_test:
@@ -309,6 +321,194 @@ workflows:
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO"'
         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_Smoketest_iphonesimulator26.2-arm64.xctestrun
     - deploy-to-bitrise-io@2.10.0: {}
+  firefox_scheme_build_for_test:
+    description: Build Firefox scheme and shard XCUITests for parallel execution
+    steps:
+    - activate-ssh-key@4:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@6.2: {}
+    - certificate-and-profile-installer@1: {}
+    - restore-spm-cache@1:
+        is_always_run: true
+    - script@1.2.1:
+        title: Run bootstrap
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            set -x
+            ./bootstrap.sh
+    - xcode-build-for-test@3:
+        inputs:
+        - scheme: Firefox
+        - configuration: Firefox
+        - project_path: /Users/vagrant/git/firefox-ios/Client.xcodeproj
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.2
+    - script@1.2.1:
+        title: Find Smoketest xctestrun file
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -euxo pipefail
+
+            echo "Listing all .xctestrun files in $BITRISE_TEST_BUNDLE_PATH"
+            ls -la "$BITRISE_TEST_BUNDLE_PATH"
+
+            # Find the Smoketest xctestrun file (handles any architecture suffix)
+            SMOKE_UI_XCTESTRUN=$(find "$BITRISE_TEST_BUNDLE_PATH" -name "Firefox_Smoketest_*.xctestrun" | head -n 1)
+
+            if [ -z "$SMOKE_UI_XCTESTRUN" ] || [ ! -f "$SMOKE_UI_XCTESTRUN" ]; then
+              echo "ERROR: Smoketest .xctestrun file not found"
+              exit 1
+            fi
+
+            echo "Found Smoketest .xctestrun: $SMOKE_UI_XCTESTRUN"
+            envman add --key BITRISE_XCTESTRUN_SMOKE_TEST_FILE_PATH --value "$SMOKE_UI_XCTESTRUN"
+    - xcode-test-shard-calculation@0:
+        run_if: '{{enveq "BITRISE_TEST_BUNDLE_PATH" "" | not}}'
+        inputs:
+        - product_path: $BITRISE_XCTESTRUN_SMOKE_TEST_FILE_PATH
+        - shard_count: 5
+        - destination: $BITRISE_DESTINATION
+        outputs:
+        - BITRISE_TEST_SHARDS_PATH: BITRISE_TEST_SHARDS_PATH_FIREFOX_SCHEME
+        is_always_run: true
+    - deploy-to-bitrise-io@2.10.0:
+        run_if: '{{enveq "BITRISE_TEST_BUNDLE_PATH" "" | not}}'
+        inputs:
+        - pipeline_intermediate_files: |-
+            BITRISE_TEST_SHARDS_PATH_FIREFOX_SCHEME
+            BITRISE_TEST_BUNDLE_PATH
+            BITRISE_XCTESTRUN_SMOKE_TEST_FILE_PATH
+        is_always_run: true
+  run_firefox_scheme_ui_tests:
+    description: Run Firefox scheme XCUITests in parallel
+    before_run:
+    - 1_git_clone_and_post_clone
+    - 2_certificate_and_profile
+    steps:
+    - pull-intermediate-files@1: {}
+    - xcode-test-without-building@0.5.1:
+        inputs:
+        - only_testing: $BITRISE_TEST_SHARDS_PATH_FIREFOX_SCHEME/$BITRISE_IO_PARALLEL_INDEX
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.2
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO"'
+        - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Firefox_Smoketest_iphonesimulator26.2-arm64-x86_64.xctestrun
+    - deploy-to-bitrise-io@2.10.0: {}
+  firefox_scheme_smoke_tests:
+    description: Run XCUITests on Firefox scheme (non-parallelized, for standalone use)
+    before_run:
+    - firefox_scheme_build_for_test
+    steps:
+    - pull-intermediate-files@1: {}
+    - xcode-test-without-building@0.5.1:
+        inputs:
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.2
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+        - xctestrun: $BITRISE_XCTESTRUN_SMOKE_TEST_FILE_PATH
+        - maximum_test_repetitions: 2
+    - deploy-to-bitrise-io@2.10.0: {}
+    - slack@4.2.1:
+        run_if: ".IsBuildFailed"
+        inputs:
+        - channel: "#mobile-alerts-ios"
+        - message: "Firefox scheme XCUITests failed on build $BITRISE_BUILD_NUMBER"
+        - webhook_url: "$SLACK_WEBHOOK"
+  firefox_beta_scheme_build_for_test:
+    description: Build FirefoxBeta scheme and shard XCUITests for parallel execution
+    steps:
+    - activate-ssh-key@4:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@6.2: {}
+    - certificate-and-profile-installer@1: {}
+    - restore-spm-cache@1:
+        is_always_run: true
+    - script@1.2.1:
+        title: Run bootstrap
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            set -x
+            ./bootstrap.sh
+    - xcode-build-for-test@3:
+        inputs:
+        - scheme: FirefoxBeta
+        - configuration: FirefoxBeta
+        - project_path: /Users/vagrant/git/firefox-ios/Client.xcodeproj
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.2
+    - script@1.2.1:
+        title: Find Smoketest xctestrun file
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -euxo pipefail
+
+            echo "Listing all .xctestrun files in $BITRISE_TEST_BUNDLE_PATH"
+            ls -la "$BITRISE_TEST_BUNDLE_PATH"
+
+            # Find the Smoketest xctestrun file (handles any architecture suffix)
+            SMOKE_UI_XCTESTRUN=$(find "$BITRISE_TEST_BUNDLE_PATH" -name "FirefoxBeta_Smoketest_*.xctestrun" | head -n 1)
+
+            if [ -z "$SMOKE_UI_XCTESTRUN" ] || [ ! -f "$SMOKE_UI_XCTESTRUN" ]; then
+              echo "ERROR: Smoketest .xctestrun file not found"
+              exit 1
+            fi
+
+            echo "Found Smoketest .xctestrun: $SMOKE_UI_XCTESTRUN"
+            envman add --key BITRISE_XCTESTRUN_SMOKE_TEST_FILE_PATH --value "$SMOKE_UI_XCTESTRUN"
+    - xcode-test-shard-calculation@0:
+        run_if: '{{enveq "BITRISE_TEST_BUNDLE_PATH" "" | not}}'
+        inputs:
+        - product_path: $BITRISE_XCTESTRUN_SMOKE_TEST_FILE_PATH
+        - shard_count: 5
+        - destination: $BITRISE_DESTINATION
+        outputs:
+        - BITRISE_TEST_SHARDS_PATH: BITRISE_TEST_SHARDS_PATH_FIREFOX_BETA_SCHEME
+        is_always_run: true
+    - deploy-to-bitrise-io@2.10.0:
+        run_if: '{{enveq "BITRISE_TEST_BUNDLE_PATH" "" | not}}'
+        inputs:
+        - pipeline_intermediate_files: |-
+            BITRISE_TEST_SHARDS_PATH_FIREFOX_BETA_SCHEME
+            BITRISE_TEST_BUNDLE_PATH
+            BITRISE_XCTESTRUN_SMOKE_TEST_FILE_PATH
+        is_always_run: true
+  run_firefox_beta_scheme_ui_tests:
+    description: Run FirefoxBeta scheme XCUITests in parallel
+    before_run:
+    - 1_git_clone_and_post_clone
+    - 2_certificate_and_profile
+    steps:
+    - pull-intermediate-files@1: {}
+    - xcode-test-without-building@0.5.1:
+        inputs:
+        - only_testing: $BITRISE_TEST_SHARDS_PATH_FIREFOX_BETA_SCHEME/$BITRISE_IO_PARALLEL_INDEX
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.2
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO"'
+        - xctestrun: $BITRISE_TEST_BUNDLE_PATH/FirefoxBeta_Smoketest_iphonesimulator26.2-arm64-x86_64.xctestrun
+    - deploy-to-bitrise-io@2.10.0: {}
+  firefox_beta_scheme_smoke_tests:
+    description: Run XCUITests on FirefoxBeta scheme (non-parallelized, for standalone use)
+    before_run:
+    - firefox_beta_scheme_build_for_test
+    steps:
+    - pull-intermediate-files@1: {}
+    - xcode-test-without-building@0.5.1:
+        inputs:
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.2
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+        - xctestrun: $BITRISE_XCTESTRUN_SMOKE_TEST_FILE_PATH
+        - maximum_test_repetitions: 2
+    - deploy-to-bitrise-io@2.10.0: {}
+    - slack@4.2.1:
+        run_if: ".IsBuildFailed"
+        inputs:
+        - channel: "#mobile-alerts-ios"
+        - message: "FirefoxBeta scheme XCUITests failed on build $BITRISE_BUILD_NUMBER"
+        - webhook_url: "$SLACK_WEBHOOK"
   determine_apps_affected:
     steps:
     - git-clone@6.2: {}

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -17908,7 +17908,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Skip copying test-fixtures for any Firefox build configuration\nif [[ \"$CONFIGURATION\" == Firefox* ]]; then\n  echo \"Populate test-fixtures: skipping for $CONFIGURATION\"\n  exit 0\nfi\n\nfixtures=\"${SRCROOT}/../test-fixtures\"\n[[ -e $fixtures ]] || exit 1\n\noutpath=\"${TARGET_BUILD_DIR}/Client.app\"\nrsync -zvrt --update \"$fixtures\" \"$outpath\"\n";
+			shellScript = "fixtures=\"${SRCROOT}/../test-fixtures\"\n[[ -e $fixtures ]] || exit 1\n\noutpath=\"${TARGET_BUILD_DIR}/Client.app\"\nrsync -zvrt --update \"$fixtures\" \"$outpath\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E6639F191BF11E3A002D0853 /* Conditionally Add Optional Resources */ = {
@@ -27755,6 +27755,7 @@
 				INFOPLIST_FILE = "firefox-ios-tests/Tests/XCUITests/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(MOZ_BUNDLE_ID)";
 				PROVISIONING_PROFILE_SPECIFIER = "bitrise org.mozilla.ios.XCUITests";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/firefox-ios-tests/Tests/XCUITests/XCUITests-Bridging-Header.h";
 				SWIFT_VERSION = 6.0;
 				TEST_TARGET_NAME = Client;
 			};
@@ -27771,6 +27772,7 @@
 				INFOPLIST_FILE = "firefox-ios-tests/Tests/XCUITests/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(MOZ_BUNDLE_ID)";
 				PROVISIONING_PROFILE_SPECIFIER = "bitrise org.mozilla.ios.XCUITests";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/firefox-ios-tests/Tests/XCUITests/XCUITests-Bridging-Header.h";
 				SWIFT_VERSION = 6.0;
 				TEST_TARGET_NAME = Client;
 			};

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -17,6 +17,20 @@
                BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
                BuildableName = "Client.app"
                BlueprintName = "Client"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3BFE4B061D342FB800DDF53F"
+               BuildableName = "XCUITests.xctest"
+               BlueprintName = "XCUITests"
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -38,7 +52,26 @@
             ReferencedContainer = "container:Client.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:firefox-ios-tests/Tests/UnitTest.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:firefox-ios-tests/Tests/Smoketest.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3BFE4B061D342FB800DDF53F"
+               BuildableName = "XCUITests.xctest"
+               BlueprintName = "XCUITests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
          <TestableReference
             skipped = "NO">
             <BuildableReference

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/FirefoxBeta.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/FirefoxBeta.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -17,6 +17,20 @@
                BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
                BuildableName = "Client.app"
                BlueprintName = "Client"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3BFE4B061D342FB800DDF53F"
+               BuildableName = "XCUITests.xctest"
+               BlueprintName = "XCUITests"
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -38,7 +52,26 @@
             ReferencedContainer = "container:Client.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:firefox-ios-tests/Tests/UnitTest.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:firefox-ios-tests/Tests/Smoketest.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3BFE4B061D342FB800DDF53F"
+               BuildableName = "XCUITests.xctest"
+               BlueprintName = "XCUITests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
          <TestableReference
             skipped = "NO">
             <BuildableReference

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -165,7 +165,11 @@ class PhotonActionSheetTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306841
     // Smoketest
-    func testSharePageWithShareSheetOptions() {
+    func testSharePageWithShareSheetOptions() throws {
+        try XCTSkipIf(
+            isFirefoxBeta || isFirefox,
+            "Skipping test because Firefox and FirefoxBeta are not yet supported"
+        )
         openNewShareSheet()
         waitForElementsToExist(
             [

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
@@ -28,7 +28,7 @@ class ReadingListTests: FeatureFlaggedTestBase {
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])
-        app.buttons["Reader View"].waitAndTap()
+        enterReaderMode()
         // The settings of reader view are shown as well as the content of the web site
         waitForElementsToExist(
             [
@@ -63,7 +63,7 @@ class ReadingListTests: FeatureFlaggedTestBase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306991
     // Smoketest
-    func testAddToReadingList() {
+    func testAddToReadingList() throws {
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
         app.launch()
@@ -77,6 +77,7 @@ class ReadingListTests: FeatureFlaggedTestBase {
         app.buttons["Done"].waitAndTap()
         // Add item to reading list and check that it appears
         addContentToReaderView()
+
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_ReadingList)
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/OnboardingSelectorSet.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/OnboardingSelectorSet.swift
@@ -9,7 +9,10 @@ protocol OnboardingSelectorsSet {
     func descriptionLabel(rootId: String) -> Selector
     func primaryButton(rootId: String) -> Selector
     func secondaryButton(rootId: String) -> Selector
+    func betaPrimaryButton(screenIndex: Int) -> Selector
+    func betaSecondaryButton(screenIndex: Int) -> Selector
     var AGREE_AND_CONTINUE_BUTTON: Selector { get }
+    var CONTINUE_BUTTON: Selector { get }
     var MANAGE_TEXT_BUTTON: Selector { get }
     var QR_SIGN_IN_BUTTON: Selector { get }
     var EMAIL_SIGN_IN_BUTTON: Selector { get }
@@ -23,6 +26,7 @@ protocol OnboardingSelectorsSet {
 struct OnboardingSelectors: OnboardingSelectorsSet {
     private enum IDs {
         static let termsAndService_AgreeAndContinueButton = "TermsOfService.AgreeAndContinueButton"
+        static let continueButton = "Continue"
         static let manage_Text = "TermsOfService.ManageDataCollectionAgreement"
         static let QRCode_SignIn = "QRCodeSignIn.button"
         static let emailSignIn = "EmailSignIn.button"
@@ -35,6 +39,12 @@ struct OnboardingSelectors: OnboardingSelectorsSet {
     let AGREE_AND_CONTINUE_BUTTON = Selector.buttonId(
         IDs.termsAndService_AgreeAndContinueButton,
         description: "Agree & Continue button on first onboarding screen",
+        groups: ["onboarding"]
+    )
+
+    let CONTINUE_BUTTON = Selector.buttonByLabel(
+        IDs.continueButton,
+        description: "Continue button on first screen for Firefox/Firefox Beta",
         groups: ["onboarding"]
     )
 
@@ -76,6 +86,22 @@ struct OnboardingSelectors: OnboardingSelectorsSet {
         )
     }
 
+    func betaPrimaryButton(screenIndex: Int) -> Selector {
+        Selector.buttonId(
+            "onboarding.\(screenIndex)PrimaryButton",
+            description: "Beta-specific primary button for screen \(screenIndex)",
+            groups: ["onboarding", "beta"]
+        )
+    }
+
+    func betaSecondaryButton(screenIndex: Int) -> Selector {
+        Selector.buttonId(
+            "onboarding.\(screenIndex)SecondaryButton",
+            description: "Beta-specific secondary button for screen \(screenIndex)",
+            groups: ["onboarding", "beta"]
+        )
+    }
+
     let QR_SIGN_IN_BUTTON = Selector.buttonId(
         IDs.QRCode_SignIn,
         description: "QR Code Sign-In button",
@@ -113,7 +139,7 @@ struct OnboardingSelectors: OnboardingSelectorsSet {
     )
 
     var all: [Selector] {
-        [AGREE_AND_CONTINUE_BUTTON, QR_SIGN_IN_BUTTON, EMAIL_SIGN_IN_BUTTON,
+        [AGREE_AND_CONTINUE_BUTTON, CONTINUE_BUTTON, QR_SIGN_IN_BUTTON, EMAIL_SIGN_IN_BUTTON,
          DONE_BUTTON, CLOSE_BUTTON, NAVBAR_SYNC_AND_SAVE, CLOSE_TOUR_BUTTON]
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
@@ -16,8 +16,11 @@ class URLValidationTests: BaseTestCase {
         continueAfterFailure = true
         navigator.goto(SearchSettings)
         app.tables.switches["Show Search Suggestions"].waitAndTap()
-        scrollToElement(app.tables.switches["FirefoxSuggestShowNonSponsoredSuggestions"])
-        app.tables.switches["FirefoxSuggestShowNonSponsoredSuggestions"].waitAndTap()
+        // Skip FirefoxSuggest setting for FirefoxBeta and Firefox
+        if isFennec {
+            scrollToElement(app.tables.switches["FirefoxSuggestShowNonSponsoredSuggestions"])
+            app.tables.switches["FirefoxSuggestShowNonSponsoredSuggestions"].waitAndTap()
+        }
         navigator.goto(NewTabScreen)
         browserScreen = BrowserScreen(app: app)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This a draft PR to try to add UI Tests check for Firefox and Firefox Beta schemes. Let's start by adding only the Smoketest in a workflow that can be scheduled and that could also be run before the Nightly build is created.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

