### PR TITLE
[MTE-5178] - Fixes for login tests on 26.2

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -774,6 +774,7 @@ class LoginTest: BaseTestCase {
 
         app.buttons[passwordssQuery.AddLogin.saveButton].waitAndTap()
         mozWaitForElementToExist(app.tables[loginList].otherElements["SAVED PASSWORDS"])
+        loginSettingsScreen.tapSaveButtonIfExists()
     }
 
     func enterTextInField(typedText: String) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LoginSettingsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LoginSettingsScreen.swift
@@ -26,6 +26,10 @@ final class LoginSettingsScreen {
         XCTAssertEqual(count, expected, "Expected \(expected) rows in login list but found \(count)")
     }
 
+    func tapSaveButtonIfExists() {
+        sel.SAVE_BUTTON_CELL.element(in: app).tapIfExists()
+    }
+
     func assertDomainVisible(_ domain: String) {
         let domainText = sel.domainLabel(domain).element(in: app)
         BaseTestCase().mozWaitForElementToExist(domainText)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/LoginSettingSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/LoginSettingSelectors.swift
@@ -125,7 +125,7 @@ struct LoginSettingsSelectors: LoginSettingsSelectorsSet {
     )
 
     let SAVE_BUTTON_CELL = Selector.buttonIdOrLabel(
-        IDs.saveButton,
+        IDs.saveButtonCell,
         description: "Save button in Add Login screen",
         groups: ["settings", "logins"]
     )


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5178

## :bulb: Description
Handled save password pop up on iOS 26

