### PR TITLE
Refactor FXIOS-14726 [StateForTab] Unset URL for empty responses

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2503,10 +2503,10 @@ class BrowserViewController: UIViewController,
     }
 
     private func handleURL(url: URL?, tab: Tab, webView: WKWebView) {
-        // Special case: if the webView.url is nil, set the tab url as "about:blank"
+        // Special case: if the webView.url is nil, set the tab url also nil
         // This also handles cases where the url has been set to a previous url but the request has been canceled
         if webView.url == nil {
-            tab.url = URL(string: "about:blank")
+            tab.url = nil
             // Update UI to reflect the URL we have set the tab to
             if tab === tabManager.selectedTab {
                 updateUIForReaderHomeStateForTab(tab)
@@ -2542,10 +2542,6 @@ class BrowserViewController: UIViewController,
             if let urlOrigin = url.origin,
                let newTabURL = URL(string: urlOrigin) {
                 tab.url = newTabURL
-                // Update UI to reflect the URL we have set the tab to
-                if tab === tabManager.selectedTab {
-                    updateUIForReaderHomeStateForTab(tab)
-                }
             }
             return
         }


### PR DESCRIPTION
## :scroll: Tickets
FXIOS-14726
FXIOS-14728
FXIOS-14731

## :bulb: Description

Following up from #31814 and #31843

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation and added comments to complex code