### PR TITLE
Bugfix FXIOS-14650 [Relay] Icon tint color

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/RelayMaskSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/RelayMaskSettingsViewController.swift
@@ -91,8 +91,12 @@ final class ManageRelayMasksSetting: Setting {
     private let parentNav: UINavigationController?
 
     override var accessoryView: UIImageView? {
-        let image = UIImage(named: StandardImageIdentifiers.Small.externalLink)
-        return UIImageView(image: image)
+        let image = UIImage(named: StandardImageIdentifiers.Small.externalLink)?.withRenderingMode(.alwaysTemplate)
+        let imageView = UIImageView(image: image)
+        if let theme {
+            imageView.tintColor = theme.colors.iconPrimary
+        }
+        return imageView
     }
 
     override var accessibilityIdentifier: String? {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14650)

## :bulb: Description

Icon tint fix.

## :movie_camera: Demos

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-28 at 16 14 11" src="https://github.com/user-attachments/assets/6255fcf5-9895-4fad-b168-f0bb1cbe83a8" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-28 at 16 13 54" src="https://github.com/user-attachments/assets/624349a5-3f3a-4a1d-b5e7-ad861c4d534e" />

**Figma reference:**
<img width="379" height="119" alt="Screenshot 2026-01-28 at 4 16 22 PM" src="https://github.com/user-attachments/assets/ca73470b-2be2-4996-bde5-902254cf5af4" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

