### PR TITLE
[MTE-5184] - skip multiwindow tests on ios 26

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
@@ -13,12 +13,21 @@ class MultiWindowTests: IpadOnlyTestCase {
     override func setUp() async throws {
         try await super.setUp()
         super.setUpLaunchArguments()
+        // Skip all tests in this class on iOS 26
+        if ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26 {
+            throw XCTSkip("Skipping MultiWindowTests on iOS 26")
+        }
         if dotMenuIdentifier.element(boundBy: 1).exists {
             closeSplitViewWindow(windowToClose: 1)
         }
     }
 
     override func tearDown() async throws {
+        // No-op on iOS 26 (matching setUp skip)
+        if ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26 {
+            try await super.tearDown()
+            return
+        }
         if dotMenuIdentifier.element(boundBy: 1).exists {
             closeSplitViewWindow(windowToClose: 1)
         }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5184

## :bulb: Description
Starting with iOS 26 on iPad apple removed the classic split view and slide over modes with a new multitasking system model.
Skipping multi window tests on iPad to run on iOS 26
