### PR TITLE
EXP-6417 Fix remote-improvements support URL to use firefox path

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -249,7 +249,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
             titleText: .RolloutsSettingTitle,
             subtitleText: String(format: .RolloutsSettingMessage, AppName.shortName.rawValue),
             learnMoreText: .RolloutsSettingLink,
-            learnMoreURL: SupportUtils.URLForTopic("remote-improvements"),
+            learnMoreURL: SupportUtils.URLForTopic("remote-improvements", useMobilePath: false),
             a11yId: AccessibilityIdentifiers.Settings.SendData.rolloutsTitle,
             learnMoreA11yId: AccessibilityIdentifiers.Settings.SendData.rolloutsLearnMoreButton,
             settingsDelegate: parentCoordinator

--- a/focus-ios/Blockzilla/Utilities/SupportUtils.swift
+++ b/focus-ios/Blockzilla/Utilities/SupportUtils.swift
@@ -54,6 +54,7 @@ extension URL {
             self.init(string: SupportTopic.fallbackURL)!
             return
         }
-        self.init(string: "https://support.mozilla.org/1/mobile/\(AppInfo.shortVersion)/iOS/\(languageIdentifier)/\(escapedTopic)")!
+        let productPath = topic == .rollouts ? "firefox" : "mobile"
+        self.init(string: "https://support.mozilla.org/1/\(productPath)/\(AppInfo.shortVersion)/iOS/\(languageIdentifier)/\(escapedTopic)")!
     }
 }


### PR DESCRIPTION
Use /firefox/ instead of /mobile/ in the support URL for the rollouts setting to match the correct SUMO article path.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-6417)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

