### PR TITLE
[MTE-5141] - several fixes on iPad 26.2

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
@@ -11,6 +11,7 @@ class AuthenticationTest: BaseTestCase {
     let password = "Password"
     // https://mozilla.testrail.io/index.php?/cases/view/2360560
     func testBasicHTTPAuthenticationPromptVisibleAndLogin() {
+        let browserScreen = BrowserScreen(app: app)
         navigator.openURL(testBasicHTTPAuthURL)
         waitUntilPageLoad()
 
@@ -29,6 +30,8 @@ class AuthenticationTest: BaseTestCase {
             app.buttons["TabLocationView.reloadButton"].waitAndTap()
             waitUntilPageLoad()
         }
+        browserScreen.tapWebViewTextIfExists(text: "Verify you are human")
+        waitUntilPageLoad()
         mozWaitForElementToExist(app.staticTexts[
             "A username and password are being requested by jigsaw.w3.org. The site says: test"
         ])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -719,7 +719,8 @@ class LoginTest: BaseTestCase {
         // Tap on the cancel button
         if #available(iOS 26, *) {
             if iPad() {
-                app.buttons["Clear text"].waitAndTap()
+                // Tapping on app on iPad to dimiss the keyboard
+                app.waitAndTap()
             } else {
                 app.buttons["close"].waitAndTap()
             }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -264,4 +264,8 @@ final class BrowserScreen {
         let text = sel.webPageElement(with: text).element(in: app)
         BaseTestCase().mozWaitForElementToExist(text)
     }
+
+    func tapWebViewTextIfExists(text: String) {
+        app.webViews.staticTexts[text].tapIfExists()
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -261,7 +261,7 @@ class PrivateBrowsingTest: BaseTestCase {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.deleteCloseAllButton])
 
         // Tap on "Close All Tabs"
-        app.buttons[AccessibilityIdentifiers.TabTray.deleteCloseAllButton].waitAndTap()
+        app.buttons[AccessibilityIdentifiers.TabTray.deleteCloseAllButton].firstMatch.waitAndTap()
         if #unavailable(iOS 16) {
             // Wait for the screen to refresh first.
             mozWaitForElementToExist(


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5186

## :bulb: Description
Fixes for:
testAllPrivateTabsRestore
testSearchSavedLoginsByURL
testSearchSavedLoginsByUsername
testBasicHTTPAuthenticationPromptVisibleAndLogin
