### PR TITLE
Refactor FXIOS-12976 #28301 Remove Snapkit and replace to use NSLayoutConstraint

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -469,6 +469,10 @@ class BrowserViewController: UIViewController,
         return featureFlagStatus
     }
 
+    private var isSnapKitRemovalEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.snapkitRemovalRefactor, checking: .buildOnly)
+    }
+
     // MARK: Computed vars
 
     lazy var isBottomSearchBar: Bool = {
@@ -1779,6 +1783,7 @@ class BrowserViewController: UIViewController,
             backgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
     }
+    // MARK: - Snapkit related
 
     private func updateHeaderConstraints() {
         let isNavToolbar = toolbarHelper.shouldShowNavigationToolbar(for: traitCollection)
@@ -1853,7 +1858,7 @@ class BrowserViewController: UIViewController,
         super.updateViewConstraints()
     }
 
-    func adjustBottomContentStackView(_ remake: ConstraintMaker) {
+    private func adjustBottomContentStackView(_ remake: ConstraintMaker) {
         remake.left.equalTo(view.safeArea.left)
         remake.right.equalTo(view.safeArea.right)
         remake.centerX.equalTo(view)
@@ -2220,8 +2225,12 @@ class BrowserViewController: UIViewController,
             keyboardBackdrop = UIView()
             keyboardBackdrop?.backgroundColor = currentTheme().colors.layer1
             view.insertSubview(keyboardBackdrop!, belowSubview: overKeyboardContainer)
-            keyboardBackdrop?.snp.makeConstraints { make in
-                make.edges.equalTo(view)
+            if isSnapKitRemovalEnabled {
+                setupKeyboardBackdropConstraints(for: keyboardBackdrop)
+            } else {
+                keyboardBackdrop?.snp.makeConstraints { make in
+                    make.edges.equalTo(view)
+                }
             }
             view.bringSubviewToFront(bottomContainer)
         }
@@ -2245,6 +2254,17 @@ class BrowserViewController: UIViewController,
         // be read by VoiceOver when reading in the
         // Search Controller
         contentContainer.accessibilityElementsHidden = true
+    }
+
+    private func setupKeyboardBackdropConstraints(for backdrop: UIView?) {
+        guard let backdrop else { return }
+        backdrop.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            backdrop.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backdrop.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            backdrop.topAnchor.constraint(equalTo: view.topAnchor),
+            backdrop.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
     }
 
     func hideSearchController() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12976)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28301)

## :bulb: Description
- Migrate `keyboardBackdrop` to use NSLayoutConstraints.
- `keyboardBackdrop` is setup during `showSearchController` and the constraints are never updated.
- The changes are behind `snapkitRemovalRefactor` feature flag

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

