### PR TITLE
Bugfix FXIOS-14492 [Relay] Remove `clearAccessTokenCache`

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/RelayController.swift
+++ b/firefox-ios/Client/Frontend/Browser/RelayController.swift
@@ -7,6 +7,9 @@ import MozillaAppServices
 import Account
 import Shared
 
+// NOTE: This is a WIP as part of the Relay Phase 1 MVP. This code will be restructured
+// soon; unit tests are also forthcoming. For now, tracking that here: FXIOS-14222. -MR
+
 typealias RelayPopulateCompletion = @MainActor  (RelayMaskGenerationResult) -> Void
 
 /// Describes public protocol for Relay component to track state and facilitate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14492)

## :bulb: Description

Minor Relay updates:
- Remove the use of `clearAccessTokenCache`, replace with `useCache: false`
- Some additional logging
- Adds a safety check to prevent concurrent mask requests

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

