### PR TITLE
[MTE-5188] - Improve restartInBackground function

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -57,6 +57,13 @@ class BaseTestCase: XCTestCase {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         mozWaitForElementToExist(springboard.icons["XCUITests-Runner"])
         app.activate()
+        // Wait until the app is fully opened (running in foreground) before continuing
+        let predicate = NSPredicate(format: "state == %d", XCUIApplication.State.runningForeground.rawValue)
+        let exp = XCTNSPredicateExpectation(predicate: predicate, object: app)
+        let waitResult = XCTWaiter.wait(for: [exp], timeout: 30)
+        if waitResult != .completed {
+            XCTFail("App did not reach runningForeground state after restart")
+        }
     }
 
     func closeFromAppSwitcherAndRelaunch() {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5188

## :bulb: Description
Tests like testMultipleTabsPrivateBrowsingCloseDisabled or testMultipleTabsPrivateBrowsingCloseEnabled are failing because after returning from restart in background the app doesn't fully wait to be visible in foreground making the select actions to take place on different places on the app than the element requested. 
This implementation makes the app to fully wait to be visible in foreground.
Locally this works, monitoring results in jenkins will be required after merge.

