### PR TITLE
[MTE-5188] - add wait until hittable validation for tabs button

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomaPageScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomaPageScreen.swift
@@ -8,6 +8,7 @@ final class HomePageScreen {
     private let sel: HomePageSelectorsSet
 
     private var collection: XCUIElement { sel.COLLECTION_VIEW.element(in: app) }
+    private var tabsButton: XCUIElement { sel.TABS_BUTTON.element(in: app) }
 
     init(app: XCUIApplication, selectors: HomePageSelectorsSet = HomePageSelectors()) {
         self.app = app
@@ -23,7 +24,10 @@ final class HomePageScreen {
     }
 
     func assertTabsButtonExists() {
-        let tabsButton = sel.TABS_BUTTON.element(in: app)
         BaseTestCase().mozWaitForElementToExist(tabsButton)
+    }
+
+    func waitUntilTabsButtonHittable(timeout: TimeInterval = 2.0) {
+        BaseTestCase().mozWaitElementHittable(element: tabsButton, timeout: timeout)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -322,6 +322,7 @@ class PrivateBrowsingTest: BaseTestCase {
         restartInBackground()
         navigator.nowAt(NewTabScreen)
         homePageScreen.assertTabsButtonExists()
+        homePageScreen.waitUntilTabsButtonHittable()
         navigator.goto(TabTray)
         navigator.nowAt(TabTray)
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5188

## :bulb: Description
Adding extra validation for testMultipleTabsPrivateBrowsingCloseDisabled and testMultipleTabsPrivateBrowsingCloseEnabled smoke tests, making sure the tabs button is hittable after the app is restarted
