### PR TITLE
Add FXIOS-14787 [Stories Scroll Direction Experiment] Large horizontally scrolling homepage stories

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -135,6 +135,10 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         return storiesScrollDirection == .vertical && UIDevice.current.userInterfaceIdiom == .phone
     }
 
+    private var isStoriesScrollDirectionHorizontal: Bool {
+        return storiesScrollDirection == .horizontal && UIDevice.current.userInterfaceIdiom == .phone
+    }
+
     init(windowUUID: WindowUUID, logger: Logger = DefaultLogger.shared) {
         self.windowUUID = windowUUID
         self.logger = logger
@@ -927,6 +931,12 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         }
 
         let storyCells: [UIView] = storiesState.merinoData.map { story in
+            if isStoriesScrollDirectionHorizontal {
+                let cell = StoriesFeedCell()
+                cell.configure(story: story, theme: LightTheme())
+                return cell
+            }
+
             let cell = StoryCell()
             cell.configure(story: story, theme: LightTheme())
             return cell


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14787)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31912)

## :bulb: Description
- Account for larger story cell size when calculating the size of stories section user to determine the height of the homepage spacer

### 📝 Notes
- Most of the foundational work was done in #31925, including
  - Use larger `StoriesFeedCell`
  - Show all fetched stories (currently 100) on the homepage
  - Hide access to the stories feed view
  - This feature is iPhone only

## :movie_camera: Demos
| Before | After |
| ------------- | ------------- |
| <img width="1206" height="2622" alt="simulator_screenshot_92CF839D-FA6C-41CA-AF52-D6A95166F05C" src="https://github.com/user-attachments/assets/3c2f62b7-0df9-4f2e-b004-90055be965f9" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-02-03 at 16 12 42" src="https://github.com/user-attachments/assets/f3060a83-a03f-4b45-8c4c-de21527ec058" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

