### PR TITLE
[MTE-5189] - fix login test on iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -32,6 +32,7 @@ class LoginTest: BaseTestCase {
     var settingsScreen: SettingScreen!
     var webFormScreen: WebFormScreen!
     var saveLoginAlertScreen: SaveLoginAlertScreen!
+    var browserScreen: BrowserScreen!
 
     override func setUp() async throws {
         // Fresh install the app
@@ -49,12 +50,14 @@ class LoginTest: BaseTestCase {
         settingsScreen = SettingScreen(app: app)
         webFormScreen = WebFormScreen(app: app)
         saveLoginAlertScreen = SaveLoginAlertScreen(app: app)
+        browserScreen = BrowserScreen(app: app)
     }
 
     let passwordssQuery = AccessibilityIdentifiers.Settings.Logins.Passwords.self
     private func saveLogin(givenUrl: String) {
         navigator.openURL(givenUrl)
         waitUntilPageLoad()
+        browserScreen.dismissMicrosurveyIfExists()
         app.buttons["submit"].waitAndTap()
         app.buttons[AccessibilityIdentifiers.SaveLoginAlert.saveButton].waitAndTap()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -268,4 +268,9 @@ final class BrowserScreen {
     func tapWebViewTextIfExists(text: String) {
         app.webViews.staticTexts[text].tapIfExists()
     }
+
+    func dismissMicrosurveyIfExists() {
+        let microsurveyCloseButton = sel.MICROSURVEY_CLOSE_BUTTON.element(in: app)
+        microsurveyCloseButton.tapIfExists()
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
@@ -19,6 +19,7 @@ protocol BrowserSelectorsSet {
     var BOOK_OF_MOZILLA_TEXT: Selector { get }
     var ADDRESSTOOLBAR_LOCKICON: Selector { get }
     var TOPTABS_COLLECTIONVIEW: Selector { get }
+    var MICROSURVEY_CLOSE_BUTTON: Selector { get }
     func linkElement(named name: String) -> Selector
     func linkPreview(named preview: String) -> Selector
     func webPageElement(with text: String) -> Selector
@@ -38,6 +39,7 @@ struct BrowserSelectors: BrowserSelectorsSet {
         static let rfc = "RFC 2606"
         static let AddressToolbar_LockIcon = AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon
         static let topTabsCollectionView = AccessibilityIdentifiers.Browser.TopTabs.collectionView
+        static let microsurveyCloseButton = AccessibilityIdentifiers.Microsurvey.Prompt.closeButton
     }
 
     let ADDRESS_BAR = Selector.textFieldId(
@@ -124,6 +126,12 @@ struct BrowserSelectors: BrowserSelectorsSet {
         groups: ["browser"]
     )
 
+    let MICROSURVEY_CLOSE_BUTTON = Selector.buttonId(
+        IDs.microsurveyCloseButton,
+        description: "Microsurvey close button",
+        groups: ["browser", "microsurvey"]
+    )
+
     func linkElement(named name: String) -> Selector {
         Selector.linkById(
             name,
@@ -151,6 +159,7 @@ struct BrowserSelectors: BrowserSelectorsSet {
     var all: [Selector] { [ADDRESS_BAR, DOWNLOADS_TOAST_BUTTON, BACK_BUTTON,
                            MENU_BUTTON, STATIC_TEXT_MOZILLA, STATIC_TEXT_EXAMPLE_DOMAIN,
                            CLEAR_TEXT_BUTTON, CANCEL_BUTTON_URL_BAR, PRIVATE_BROWSING, CANCEL_BUTTON,
-                           LINK_RFC_2606, BOOK_OF_MOZILLA_TEXT, ADDRESSTOOLBAR_LOCKICON, TOPTABS_COLLECTIONVIEW]
+                           LINK_RFC_2606, BOOK_OF_MOZILLA_TEXT, ADDRESSTOOLBAR_LOCKICON, TOPTABS_COLLECTIONVIEW,
+                           MICROSURVEY_CLOSE_BUTTON]
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5189

## :bulb: Description
Fix for testLoginsListFromBrowserTabMenu test on iPad by dismissing the microsurvey pop up if appears .
This was causing the login details to not be saved because the microsurvey pop up was over the login pop up.

