### PR TITLE
Bugfix FXIOS-14797 #31932 [Brand refresh onboarding] - Incomplete text in the first card's header

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1900,7 +1900,7 @@ extension String {
                         value: "Open your links with built-in privacy",
                         comment: "Title for the welcome card in the v148 brand refresh onboarding flow.")
                     public static let TitleV3 = MZLocalizedString(
-                        key: "Onboarding.Modern.BrandRefresh.Welcome.Title.v149",
+                        key: "Onboarding.Modern.BrandRefresh.Welcome.TitleV3.v149",
                         tableName: "Onboarding",
                         value: "Open all your links with built-in privacy",
                         comment: "Title for the welcome card in the v148 brand refresh onboarding flow.")

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1894,16 +1894,15 @@ extension String {
                 }
 
                 public struct Welcome {
-                    @available(*, deprecated, message: "Use TitleV2 instead")
-                    public static let Title = MZLocalizedString(
-                        key: "Onboarding.Modern.BrandRefresh.Welcome.Title.v148",
-                        tableName: "Onboarding",
-                        value: "Say goodbye to creepy trackers",
-                        comment: "Title for the welcome card in the v148 brand refresh onboarding flow.")
                     public static let TitleV2 = MZLocalizedString(
                         key: "Onboarding.Modern.BrandRefresh.Welcome.Title.v148.v2",
                         tableName: "Onboarding",
                         value: "Open your links with built-in privacy",
+                        comment: "Title for the welcome card in the v148 brand refresh onboarding flow.")
+                    public static let TitleV3 = MZLocalizedString(
+                        key: "Onboarding.Modern.BrandRefresh.Welcome.Title.v149",
+                        tableName: "Onboarding",
+                        value: "Open all your links with built-in privacy",
                         comment: "Title for the welcome card in the v148 brand refresh onboarding flow.")
                     public static let Description = MZLocalizedString(
                         key: "Onboarding.Modern.BrandRefresh.Welcome.Description.v148",
@@ -8822,6 +8821,11 @@ extension String {
                 tableName: "FirefoxHomepage",
                 value: "Stories",
                 comment: "This is the title of the Stories section on Firefox Homepage.")
+            public static let WelcomeTitle = MZLocalizedString(
+                key: "Onboarding.Modern.BrandRefresh.Welcome.Title.v148",
+                tableName: "Onboarding",
+                value: "Say goodbye to creepy trackers",
+                comment: "Title for the welcome card in the v148 brand refresh onboarding flow.")
         }
     }
 }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -8821,7 +8821,7 @@ extension String {
                 tableName: "FirefoxHomepage",
                 value: "Stories",
                 comment: "This is the title of the Stories section on Firefox Homepage.")
-            public static let WelcomeTitle = MZLocalizedString(
+            public static let Title = MZLocalizedString(
                 key: "Onboarding.Modern.BrandRefresh.Welcome.Title.v148",
                 tableName: "Onboarding",
                 value: "Say goodbye to creepy trackers",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1903,7 +1903,7 @@ extension String {
                         key: "Onboarding.Modern.BrandRefresh.Welcome.TitleV3.v149",
                         tableName: "Onboarding",
                         value: "Open all your links with built-in privacy",
-                        comment: "Title for the welcome card in the v148 brand refresh onboarding flow.")
+                        comment: "Title for the welcome card in the v149 brand refresh onboarding flow.")
                     public static let Description = MZLocalizedString(
                         key: "Onboarding.Modern.BrandRefresh.Welcome.Description.v148",
                         tableName: "Onboarding",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31932)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Add new TitleV3 string for v149 onboarding welcome card
- Remove deprecated Title string from Welcome struct
- Move original Title string to FirefoxHomepage.Pocket.WelcomeTitle for backward compatibility

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


