### PR TITLE
[FXIOS-14815] [Relay] Improve availability immediately after launch

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/RelayController.swift
+++ b/firefox-ios/Client/Frontend/Browser/RelayController.swift
@@ -318,7 +318,6 @@ final class RelayController: RelayControllerProtocol, Notifiable {
             withNotificationCenter: notificationCenter,
             forObserver: self,
             observing: [Notification.Name.ProfileDidStartSyncing,
-                        Notification.Name.ProfileDidFinishSyncing,
                         Notification.Name.FirefoxAccountChanged]
         )
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14815)

## :bulb: Description

Initially, per discussions with Services, the decision was to have the Profile sync notifications drive Relay state updates. In practice however this is not reliable, and since we should always be able to get the Relay status (as long as we have a signed-in account), this PR adds an explicit post-launch update for Relay to ensure the state is updated even if the profile sync is delayed for some reason.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

