### PR TITLE
Add FXIOS-14841 - Task for iOS release automation

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -59,6 +59,8 @@ release-promotion:
             target-tasks-method: push
         ship:
             target-tasks-method: ship
+        merge_automation:
+            target-tasks-method: merge_automation
         promote_focus:
             target-tasks-method: promote_focus
         push_focus:

--- a/taskcluster/ffios_taskgraph/__init__.py
+++ b/taskcluster/ffios_taskgraph/__init__.py
@@ -22,7 +22,7 @@ def register(graph_config):
     # Setup mozilla-taskgraph
     register_mozilla_taskgraph(graph_config)
 
-    _import_modules(["job", "parameters", "routes", "target_tasks", "release_promotion", "worker_types"])
+    _import_modules(["job", "parameters", "routes", "target_tasks", "release_promotion", "worker_types", "actions.merge_automation"])
 
 
 def _import_modules(modules):

--- a/taskcluster/ffios_taskgraph/actions/merge_automation.py
+++ b/taskcluster/ffios_taskgraph/actions/merge_automation.py
@@ -1,0 +1,64 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskgraph.parameters import Parameters
+
+from taskgraph.actions.registry import register_callback_action
+from taskgraph.decision import taskgraph_decision
+
+@register_callback_action(
+    name="merge-automation",
+    title="Merge Day Automation",
+    symbol="${input.behavior}",
+    description="Merge repository branches.",
+    permission="merge-automation",
+    order=500,
+    context=[],
+    schema=lambda graph_config: {
+        "type": "object",
+        "properties": {
+            "force-dry-run": {
+                "type": "boolean",
+                "description": "Override other options and do not push changes",
+                "default": True,
+            },
+            "behavior": {
+                "type": "string",
+                "description": "The type of release promotion to perform.",
+                # this enum should be kept in sync with the merge-automation kind
+                "enum": [
+                    "major",
+                    "minor",
+                ],
+                "default": "major",
+            },
+            "merge-automation-id": {
+                "type": "integer",
+                "description": "Shipit merge automation ID for marking as merged.",
+            },
+        },
+        "required": ["behavior"],
+    },
+)
+def merge_automation_action(parameters, graph_config, input, task_group_id, task_id):
+    # make parameters read-write
+    parameters = dict(parameters)
+
+    parameters["target_tasks_method"] = "merge_automation"
+    parameters["merge_config"] = {
+        "force-dry-run": input.get("force-dry-run", False),
+        "behavior": input.get("behavior", "major"),
+    }
+
+    for field in [
+        "merge-automation-id",
+    ]:
+        if input.get(field):
+            parameters["merge_config"][field] = input[field]
+
+    parameters["tasks_for"] = "action"
+    # make parameters read-only
+    parameters = Parameters(**parameters)
+
+    taskgraph_decision({"root": graph_config.root_dir}, parameters=parameters)

--- a/taskcluster/ffios_taskgraph/target_tasks.py
+++ b/taskcluster/ffios_taskgraph/target_tasks.py
@@ -74,6 +74,10 @@ def target_tasks_ship(full_task_graph, parameters, graph_config):
         product_type="firefox",
     )
 
+@register_target_task("merge_automation")
+def target_tasks_merge_automation(full_task_graph, parameters, graph_config):
+    return [l for l, t in full_task_graph.tasks.items() if t.kind == "branch-version-bump"]
+
 @register_target_task("promote_focus")
 def target_tasks_promote_focus(full_task_graph, parameters, graph_config):
     return _filter_release_promotion(

--- a/taskcluster/ffios_taskgraph/transforms/version_bump.py
+++ b/taskcluster/ffios_taskgraph/transforms/version_bump.py
@@ -5,12 +5,32 @@
 Add the right git branch configuration to the worker definition
 """
 
+from pathlib import Path
 from taskgraph.transforms.base import TransformSequence
+from mozilla_version.ios import MobileIosVersion
 
 transforms = TransformSequence()
 
 @transforms.add
-def add_branch_to_worker_config(config, tasks):
+def version_bump_task(config, tasks):
     for task in tasks:
+        versionfile = Path(__file__).parent.parent.parent.parent / "version.txt"
+        with open(versionfile) as fd:
+            version = MobileIosVersion.parse(fd.readline())
+
+        if "create-branch-info" in task["worker"]:
+            # We need to default to major here so taskgraph full can produce a valid task
+            behavior = config.params.get("merge_config", {}).get("behavior", "major")
+            if behavior == "major":
+                version_string = f"release/v{version.major_number}"
+                version = version.bump("major_number")
+            elif behavior == "minor":
+                version_string = f"release/v{version.major_number}.{version.minor_number}"
+                version = version.bump("minor_number")
+            else:
+                raise Exception(f"Unknown merge-automation behavior: {behavior}")
+            task["worker"]["create-branch-info"]["branch-name"] = version_string
+
+        task["worker"]["next-version"] = str(version)
         task["worker"].update(branch=config.params["head_ref"])
         yield task

--- a/taskcluster/kinds/branch-version-bump/kind.yml
+++ b/taskcluster/kinds/branch-version-bump/kind.yml
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - ffios_taskgraph.transforms.version_bump
+    - taskgraph.transforms.task
+
+tasks:
+  task:
+    description: Firefox iOS release branch and version bump
+    run-on-tasks-for: []
+    worker-type: tree
+    worker:
+      bump: true
+      bump-files:
+        - version.txt
+        - focus-ios/version.xcconfig
+        - firefox-ios/Client/Configuration/version.xcconfig
+      push: true
+      create-branch-info: {}
+
+    treeherder:
+      symbol: bvb
+      tier: 1
+      kind: build
+      platform: ios/opt


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14841)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32013)

## :bulb: Description
Adds a branch-version-bump task for release automation.
This task will be triggered by shipit action, and will create a release branch and bump version on required files.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

