### PR TITLE
Add FXIOS-14848 [Brand Refresh] Revert accent colors for onboarding brand refresh variant

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/DarkTheme.swift
@@ -67,8 +67,6 @@ private struct DarkColourPalette: ThemeColourPalette {
     var actionPrimary: UIColor = FXColors.Blue30
     var actionPrimaryHover: UIColor = FXColors.Blue20
     var actionPrimaryDisabled: UIColor = FXColors.Blue30.withAlphaComponent(0.5)
-    // TODO: FXIOS-14760 Update brand refresh primary action color to match design system
-    var actionPrimaryBrandRefresh = UIColor(colorString: "B9A6FF")
     var actionSecondary: UIColor = FXColors.DarkGrey05
     var actionSecondaryDisabled: UIColor = FXColors.DarkGrey05.withAlphaComponent(0.5)
     var actionSecondaryHover: UIColor = FXColors.LightGrey90

--- a/BrowserKit/Sources/Common/Theming/LightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/LightTheme.swift
@@ -56,8 +56,6 @@ private struct LightColourPalette: ThemeColourPalette {
     var actionPrimary: UIColor = FXColors.Blue50
     var actionPrimaryHover: UIColor = FXColors.Blue60
     var actionPrimaryDisabled: UIColor = FXColors.Blue50.withAlphaComponent(0.5)
-    // TODO: FXIOS-14760 Update brand refresh primary action color to match design system
-    var actionPrimaryBrandRefresh = UIColor(colorString: "7543E3")
     var actionSecondary: UIColor = FXColors.LightGrey30
     var actionSecondaryDisabled: UIColor = FXColors.LightGrey30.withAlphaComponent(0.5)
     var actionSecondaryHover: UIColor = FXColors.LightGrey40

--- a/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
@@ -58,8 +58,6 @@ private struct PrivateModeColorPalette: ThemeColourPalette {
     var actionPrimary: UIColor = FXColors.Blue30
     var actionPrimaryHover: UIColor = FXColors.Blue20
     var actionPrimaryDisabled: UIColor = FXColors.Blue30.withAlphaComponent(0.5)
-    // TODO: FXIOS-14760 Update brand refresh primary action color to match design system
-    var actionPrimaryBrandRefresh = UIColor(colorString: "B9A6FF")
     var actionSecondary: UIColor = FXColors.DarkGrey05
     var actionSecondaryDisabled: UIColor = FXColors.DarkGrey05.withAlphaComponent(0.5)
     var actionSecondaryHover: UIColor = FXColors.LightGrey90

--- a/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
@@ -41,7 +41,6 @@ public protocol ThemeColourPalette {
     var actionPrimary: UIColor { get }
     var actionPrimaryHover: UIColor { get }
     var actionPrimaryDisabled: UIColor { get }
-    var actionPrimaryBrandRefresh: UIColor { get }
     var actionSecondary: UIColor { get }
     var actionSecondaryDisabled: UIColor { get }
     var actionSecondaryHover: UIColor { get }

--- a/BrowserKit/Sources/OnboardingKit/Views/OnboardingFlow/OnboardingButton.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/OnboardingFlow/OnboardingButton.swift
@@ -25,12 +25,7 @@ extension View {
     }
 
     private func primaryButtonColor(theme: Theme, variant: OnboardingVariant) -> UIColor {
-        switch variant {
-        case .brandRefresh:
-            return theme.colors.actionPrimaryBrandRefresh
-        default:
-            return theme.colors.actionPrimary
-        }
+        return theme.colors.actionPrimary
     }
 
     @ViewBuilder

--- a/BrowserKit/Sources/OnboardingKit/Views/OnboardingFlow/OnboardingSegmentedButton.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/OnboardingFlow/OnboardingSegmentedButton.swift
@@ -88,11 +88,6 @@ struct OnboardingSegmentedButton<Action: Equatable & Hashable & Sendable>: View 
             return Color(theme.colors.iconSecondary)
         }
 
-        switch variant {
-        case .brandRefresh:
-            return Color(theme.colors.actionPrimaryBrandRefresh)
-        default:
-            return Color(theme.colors.actionPrimary)
-        }
+        return Color(theme.colors.actionPrimary)
     }
 }

--- a/BrowserKit/Sources/OnboardingKit/Views/TermsOfUse/TermsOfUseView.swift
+++ b/BrowserKit/Sources/OnboardingKit/Views/TermsOfUse/TermsOfUseView.swift
@@ -171,12 +171,7 @@ public struct TermsOfUseView<ViewModel: OnboardingCardInfoModelProtocol>: Themea
     }
 
     private var linkColor: UIColor {
-        switch viewModel.variant {
-        case .brandRefresh:
-            return theme.colors.actionPrimaryBrandRefresh
-        default:
-            return theme.colors.actionPrimary
-        }
+        return theme.colors.actionPrimary
     }
 
     @ViewBuilder

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
@@ -105,7 +105,6 @@ struct TabTrayPanelSwipePalette: ThemeColourPalette {
     var actionPrimary: UIColor { base.actionPrimary }
     var actionPrimaryHover: UIColor { base.actionPrimaryHover }
     var actionPrimaryDisabled: UIColor { base.actionPrimaryDisabled }
-    var actionPrimaryBrandRefresh: UIColor { base.actionPrimaryBrandRefresh }
     var actionSecondaryDisabled: UIColor { base.actionSecondaryDisabled }
     var actionSecondaryHover: UIColor { base.actionSecondaryHover }
     var formSurfaceOff: UIColor { base.formSurfaceOff }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14848)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Remove actionPrimaryBrandRefresh property from ThemeColourPalette protocol
- Remove brand refresh color definitions from DarkTheme, LightTheme, and PrivateModeTheme
- Update OnboardingButton, OnboardingSegmentedButton, and TermsOfUseView to use standard actionPrimary color
- Remove brand refresh color reference from TabTrayPanelSwipePalette

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| dark | light |
| - | - |
| <img width="267" height="504" alt="Screenshot 2026-02-10 at 14 51 22" src="https://github.com/user-attachments/assets/a5bd9627-6e4d-4b7b-8dd2-d1e4cb893cdf" /> | <img width="251" height="512" alt="Screenshot 2026-02-10 at 14 51 29" src="https://github.com/user-attachments/assets/06289b5d-8f82-456d-bd41-458e8304150b" /> |
| <img width="263" height="506" alt="Screenshot 2026-02-10 at 14 51 36" src="https://github.com/user-attachments/assets/7486a2ff-b9d1-4181-8cba-5f85518c0283" /> | <img width="257" height="510" alt="Screenshot 2026-02-10 at 14 51 40" src="https://github.com/user-attachments/assets/8859e61f-e084-4209-b2d1-2a23c6e64307" /> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

