### PR TITLE
BugFix [PDF refactor] FXIOS-11571 Handle BLOB pdf files

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
@@ -9,7 +9,7 @@ Object.defineProperty(window.__firefox__, "download", {
   enumerable: false,
   configurable: false,
   writable: false,
-  value: function(url, appIdToken, fileName = null) {
+  value: function(url, appIdToken) {
     if (appIdToken !== APP_ID_TOKEN) {
       return;
     }
@@ -38,18 +38,20 @@ Object.defineProperty(window.__firefox__, "download", {
 
         var blob = this.response;
         
-        // Checking if the blob is a pkpass (Passbook Pass) or download, if not, continue navigation
-        if (blob.type != "application/vnd.apple.pkpass" && !fileName) {
+        // Checking if the blob is a pkpass (Passbook Pass) or a pdf, if not, continue navigation
+        if (blob.type != "application/vnd.apple.pkpass" && blob.type != "application/pdf") {
           window.location.href = url;
           return
         }
+        const header = xhr.getResponseHeader("Content-Disposition");
+        const fileName = header ? header.split("filename=")?.[1] : getLastPathComponent(url);
       
         blobToBase64String(blob, function(base64String) {
           webkit.messageHandlers.downloadManager.postMessage({
-            url: url,
+            url,
             mimeType: blob.type,
             size: blob.size,
-            base64String: base64String,
+            base64String,
             fileName
           });
         });


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11571)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25195)

## :bulb: Description
Fix `DownloadHelper.js` to allow download of BLOB pdfs files.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

