### PR TITLE
Add FXIOS-14794 [Danger] Add unit tests check for new files only

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -98,7 +98,7 @@ func checkCodeCoverage() {
 }
 
 class CodeCoverageGate {
-    private let coverageBypassLabel = "Ignore-code-coverage"
+    private let coverageBypassLabel = "ignore-code-coverage"
     private let jsonPath = "coverage.json"
     private let threshold: Double = 70
     private let minimumAddedLines = 5


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14794)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31924)

## :bulb: Description
Modify the existing check to have a code coverage gate of 70% on new files. People can use the bypass label whenever they need it to bypass the check, but they should comment and tag a member of [@fxios-unit-test-owners](https://github.com/orgs/mozilla-mobile/teams/fxios-unit-test-owners)

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

