### PR TITLE
Document FXIOS-14806 [Bootstrap] Remove Python requirement +add Node install options

### DIFF
--- a/firefox-ios/README.md
+++ b/firefox-ios/README.md
@@ -11,7 +11,7 @@ For information on how to contribute to this project, including communication ch
 ## Building the code
 
 1. Install the version of [Xcode](https://developer.apple.com/download/applications/) from Apple that matches what this project uses, as listed in the root [README](../README.md).
-1. Node.js is required, e.g. installed via [Brew](https://brew.sh), with [n](https://github.com/tj/n#readme), or just [n-install](https://github.com/mklement0/n-install#readme) depending whether you want to use a package manager.
+1. Node.js is required, e.g. installed via [Brew](https://brew.sh), with [n](https://github.com/tj/n#readme), or just [n-install](https://github.com/mklement0/n-install#readme) depending whether you want to use a package manager:
    ```shell
    brew install n  # or, skipping brew:  curl -L https://bit.ly/n-install | bash
    n lts


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-14806
GitHub issue #31949

## :bulb: Description

Python requirements have already been removed from setup instructions, this cleans up the corresponding readme text as well.

Given all other things to install are removed, and only Node.js is necessary, there might not be a need for installing brew just for that for folks that don't already have it, so providing alternative (better) avenues to just stand up (and manage) Node runtimes.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] If needed, I updated documentation and added comments to complex code