### PR TITLE
Bugfix FXIOS-14292 Investigate increased time in Bitrise and ClearCache

### DIFF
--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -225,8 +225,12 @@ class UITestAppDelegate: AppDelegate {
         willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         // If the app is running from a XCUITest reset all settings in the app
+        // removeAllCachedResponses() crashes on iOS 17 simulators from Xcode 26
+        // https://github.com/mozilla-mobile/firefox-ios/issues/30947
         if ProcessInfo.processInfo.arguments.contains(LaunchArguments.ClearProfile) {
-            resetApplication()
+            if !UIDevice.current.systemVersion.hasPrefix("17.") {
+                resetApplication()
+            }
         }
 
         Tab.ChangeUserAgent.clear()
@@ -243,7 +247,7 @@ class UITestAppDelegate: AppDelegate {
         // Clear the cookie/url cache
         // removeAllCachedResponses() crashes on iOS 17 simulators from Xcode 26
         // https://github.com/mozilla-mobile/firefox-ios/issues/30947
-        // URLCache.shared.removeAllCachedResponses()
+        URLCache.shared.removeAllCachedResponses()
         let storage = HTTPCookieStorage.shared
         if let cookies = storage.cookies {
             for cookie in cookies {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Let me disable resetApplication just for iOS 17 for now.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

