### PR TITLE
Add FXIOS-14849 [Unit Tests] fix failing summarizer settings tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
@@ -25,9 +25,13 @@ final class SummarizeSettingsViewControllerTests: XCTestCase {
     }
 
     func test_generateSettings_withShakeFeature_hasExpectedSections() {
-        setupNimbusHostedSummarizerTesting(isEnabled: true)
-        let subject = createSubject()
+        let mockSummarizeNimbusUtils = MockSummarizerNimbusUtils()
+        mockSummarizeNimbusUtils.shakeGestureFeatureFlagEnabled = true
+
+        let subject = createSubject(with: mockSummarizeNimbusUtils)
         let sections = subject.generateSettings()
+
+        XCTAssertEqual(mockSummarizeNimbusUtils.isShakeGestureFeatureFlagEnabledCallCount, 1)
         XCTAssertEqual(sections.count, 2)
         XCTAssertNil(sections.first?.title)
         XCTAssertEqual(sections.first?.children.count, 1)
@@ -36,9 +40,13 @@ final class SummarizeSettingsViewControllerTests: XCTestCase {
     }
 
     func test_generateSettings_withoutShakeFeature_hasExpectedSections() {
-        setupNimbusHostedSummarizerTesting(isEnabled: false)
-        let subject = createSubject()
+        let mockSummarizeNimbusUtils = MockSummarizerNimbusUtils()
+        mockSummarizeNimbusUtils.shakeGestureFeatureFlagEnabled = false
+
+        let subject = createSubject(with: mockSummarizeNimbusUtils)
         let sections = subject.generateSettings()
+
+        XCTAssertEqual(mockSummarizeNimbusUtils.isShakeGestureFeatureFlagEnabledCallCount, 1)
         XCTAssertEqual(sections.count, 1)
         XCTAssertNil(sections.first?.title)
         XCTAssertEqual(sections.first?.children.count, 1)
@@ -47,15 +55,43 @@ final class SummarizeSettingsViewControllerTests: XCTestCase {
     }
 
     // MARK: - Helper
-    private func createSubject() -> SummarizeSettingsViewController {
-        let subject = SummarizeSettingsViewController(prefs: profile.prefs, windowUUID: .XCTestDefaultUUID)
+    private func createSubject(with summarizeNimbusUtils: MockSummarizerNimbusUtils) -> SummarizeSettingsViewController {
+        let subject = SummarizeSettingsViewController(
+            prefs: profile.prefs,
+            summarizeNimbusUtils: summarizeNimbusUtils,
+            windowUUID: .XCTestDefaultUUID
+        )
         trackForMemoryLeaks(subject)
         return subject
     }
+}
 
-    private func setupNimbusHostedSummarizerTesting(isEnabled: Bool) {
-        FxNimbus.shared.features.hostedSummarizerFeature.with { _, _ in
-            return HostedSummarizerFeature(enabled: isEnabled, shakeGesture: isEnabled)
-        }
+final class MockSummarizerNimbusUtils: SummarizerNimbusUtils {
+    var isSummarizeFeatureToggledOn = false
+    var isSummarizeFeatureEnabled = false
+    var isShakeGestureEnabled = false
+    var isToolbarButtonEnabled = false
+
+    var appleSummarizerEnabled = false
+    var hostedSummarizerEnabled = false
+    var shakeGestureFeatureFlagEnabled = false
+
+    private(set) var isAppleSummarizerEnabledCallCount = 0
+    private(set) var isHostedSummarizerEnabledCallCount = 0
+    private(set) var isShakeGestureFeatureFlagEnabledCallCount = 0
+
+    func isAppleSummarizerEnabled() -> Bool {
+        isAppleSummarizerEnabledCallCount += 1
+        return appleSummarizerEnabled
+    }
+
+    func isHostedSummarizerEnabled() -> Bool {
+        isHostedSummarizerEnabledCallCount += 1
+        return hostedSummarizerEnabled
+    }
+
+    func isShakeGestureFeatureFlagEnabled() -> Bool {
+        isShakeGestureFeatureFlagEnabledCallCount += 1
+        return shakeGestureFeatureFlagEnabled
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14849)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32033)

## :bulb: Description
It seems in 26.3, apple intelligence is now enabled by default in testing. We were observing whether apple intelligence was actually available or not. The proper way is to inject a mock that determines whether we should show the shake gesture section instead. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

