### PR TITLE
Support .pkpasses wallet bundles alongside .pkpass

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -12,7 +12,7 @@ extension BrowserViewController: DownloadQueueDelegate {
         guard download.originWindow == uuid else { return }
 
         // Do not need toast message for Passbook Passes since we don't save the download
-        guard download.mimeType != MIMEType.Passbook else { return }
+        guard !MIMEType.isPassbook(download.mimeType) else { return }
 
         if let downloadProgressManager = self.downloadProgressManager {
             if tabManager.selectedTab?.isPrivate == true {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -626,7 +626,7 @@ extension BrowserViewController: WKNavigationDelegate {
             }
 
             // Blob URLs are downloaded via DownloadHelper.js where we check if we need to handle any special cases like:
-            // - If the blob response has a .pkpass MIME type (FXIOS-11684)
+            // - If the blob response has a .pkpass or .pkpasses MIME type (FXIOS-11684)
             // - The <a> tag pressed has a "download" attribute, indicating a file download (FXIOS-11125)
             // Once inspected, if there are no special cases to handle, we will then navigate to the blob URL's location
             // via JS since we are cancelling the navigation here

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
@@ -75,10 +75,7 @@ class Download: NSObject {
     // Determines if we want to save the download to the downloads panel
     fileprivate func shouldWriteToDisk() -> Bool {
         // If we downloaded a Passbook Pass, we want to open this immediately instead of saving it to downloads
-        if self.mimeType == MIMEType.Passbook {
-            return false
-        }
-        return true
+        return !MIMEType.isPassbook(self.mimeType)
     }
 
     // Used to avoid name spoofing using Unicode RTL char to change file extension

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/MIMEType.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/MIMEType.swift
@@ -15,6 +15,7 @@ struct MIMEType {
     static let HTML = "text/html"
     static let OctetStream = "application/octet-stream"
     static let Passbook = "application/vnd.apple.pkpass"
+    static let PassbookBundle = "application/vnd.apple.pkpasses"
     static let PDF = "application/pdf"
     static let PlainText = "text/plain"
     static let PNG = "image/png"
@@ -39,6 +40,10 @@ struct MIMEType {
 
     static func canShowInWebView(_ mimeType: String) -> Bool {
         return webViewViewableTypes.contains(mimeType.lowercased())
+    }
+
+    static func isPassbook(_ mimeType: String) -> Bool {
+        return [MIMEType.Passbook, MIMEType.PassbookBundle].contains(mimeType.lowercased())
     }
 
     static func mimeTypeFromFileExtension(_ fileExtension: String) -> String {

--- a/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
@@ -6,6 +6,7 @@ import PassKit
 import Shared
 import WebKit
 import Common
+import zlib
 
 final class OpenPassBookHelper: @unchecked Sendable {
     private enum InvalidPassError: Error {
@@ -40,7 +41,7 @@ final class OpenPassBookHelper: @unchecked Sendable {
 
     @MainActor
     static func shouldOpenWithPassBook(mimeType: String, forceDownload: Bool = false) -> Bool {
-        return mimeType == MIMEType.Passbook && PKAddPassesViewController.canAddPasses() && !forceDownload
+        return MIMEType.isPassbook(mimeType) && PKAddPassesViewController.canAddPasses() && !forceDownload
     }
 
     @MainActor
@@ -133,22 +134,62 @@ final class OpenPassBookHelper: @unchecked Sendable {
     @MainActor
     private func open(passData: Data) throws {
         do {
-            let pass = try PKPass(data: passData)
-            let passLibrary = PKPassLibrary()
-            if passLibrary.containsPass(pass) {
-                UIApplication.shared.open(pass.passURL!, options: [:])
-            } else {
-                guard let addController = PKAddPassesViewController(pass: pass) else {
-                    throw InvalidPassError.openError
-                }
-                Task { @MainActor in
-                    presenter.present(addController, animated: true, completion: nil)
-                }
-            }
+            try openSinglePass(passData: passData)
+            return
+        } catch {
+            // .pkpasses archives contain multiple .pkpass files and cannot be opened as a single PKPass.
+            // Fall through to bundle extraction and multi-pass handling.
+        }
+
+        do {
+            let bundledPassData = try PKPassBundleExtractor.extractPasses(from: passData)
+            let passes = try bundledPassData.map { try PKPass(data: $0) }
+            try open(passes: passes)
         } catch {
             sendLogError(with: error.localizedDescription)
             throw InvalidPassError.openError
         }
+    }
+
+    @MainActor
+    private func openSinglePass(passData: Data) throws {
+        do {
+            let pass = try PKPass(data: passData)
+            try open(passes: [pass])
+        } catch {
+            throw error
+        }
+    }
+
+    @MainActor
+    private func open(passes: [PKPass]) throws {
+        guard !passes.isEmpty else {
+            throw InvalidPassError.openError
+        }
+
+        let passLibrary = PKPassLibrary()
+        let passesToAdd = passes.filter { !passLibrary.containsPass($0) }
+
+        if passesToAdd.isEmpty {
+            // If all passes are already in Wallet, open the first pass.
+            if let passURL = passes.first?.passURL {
+                UIApplication.shared.open(passURL, options: [:])
+            }
+            return
+        }
+
+        let addController: PKAddPassesViewController?
+        if passesToAdd.count == 1 {
+            addController = PKAddPassesViewController(pass: passesToAdd[0])
+        } else {
+            addController = PKAddPassesViewController(passes: passesToAdd)
+        }
+
+        guard let addController else {
+            throw InvalidPassError.openError
+        }
+
+        presenter.present(addController, animated: true, completion: nil)
     }
 
     @MainActor
@@ -168,5 +209,195 @@ final class OpenPassBookHelper: @unchecked Sendable {
                    level: .warning,
                    category: .webview,
                    description: errorDescription)
+    }
+}
+
+enum PKPassBundleExtractor {
+    enum ExtractionError: Error {
+        case invalidArchive
+        case unsupportedCompressionMethod(UInt16)
+        case encryptedEntry
+        case invalidCompressedData
+    }
+
+    private struct CentralDirectoryEntry {
+        let filename: String
+        let compressionMethod: UInt16
+        let generalPurposeBitFlag: UInt16
+        let compressedSize: UInt32
+        let uncompressedSize: UInt32
+        let localHeaderOffset: UInt32
+    }
+
+    static func extractPasses(from archiveData: Data) throws -> [Data] {
+        let entries = try readCentralDirectoryEntries(from: archiveData)
+        let passEntries = entries.filter { $0.filename.lowercased().hasSuffix(".pkpass") }
+        guard !passEntries.isEmpty else {
+            throw ExtractionError.invalidArchive
+        }
+
+        return try passEntries.map { try extractEntryData(from: archiveData, entry: $0) }
+    }
+
+    private static func readCentralDirectoryEntries(from data: Data) throws -> [CentralDirectoryEntry] {
+        guard let eocdOffset = findEndOfCentralDirectory(in: data) else {
+            throw ExtractionError.invalidArchive
+        }
+
+        guard let totalEntries = data.readUInt16LE(at: eocdOffset + 10),
+              let centralDirectoryOffset = data.readUInt32LE(at: eocdOffset + 16) else {
+            throw ExtractionError.invalidArchive
+        }
+
+        var entries: [CentralDirectoryEntry] = []
+        var cursor = Int(centralDirectoryOffset)
+
+        for _ in 0..<Int(totalEntries) {
+            guard data.readUInt32LE(at: cursor) == 0x02014b50 else {
+                throw ExtractionError.invalidArchive
+            }
+
+            guard let generalPurposeBitFlag = data.readUInt16LE(at: cursor + 8),
+                  let compressionMethod = data.readUInt16LE(at: cursor + 10),
+                  let compressedSize = data.readUInt32LE(at: cursor + 20),
+                  let uncompressedSize = data.readUInt32LE(at: cursor + 24),
+                  let fileNameLength = data.readUInt16LE(at: cursor + 28),
+                  let extraFieldLength = data.readUInt16LE(at: cursor + 30),
+                  let fileCommentLength = data.readUInt16LE(at: cursor + 32),
+                  let localHeaderOffset = data.readUInt32LE(at: cursor + 42) else {
+                throw ExtractionError.invalidArchive
+            }
+
+            let filenameOffset = cursor + 46
+            let filenameLength = Int(fileNameLength)
+            guard let filenameData = data.readData(at: filenameOffset, length: filenameLength),
+                  let filename = String(data: filenameData, encoding: .utf8) else {
+                throw ExtractionError.invalidArchive
+            }
+
+            entries.append(CentralDirectoryEntry(
+                filename: filename,
+                compressionMethod: compressionMethod,
+                generalPurposeBitFlag: generalPurposeBitFlag,
+                compressedSize: compressedSize,
+                uncompressedSize: uncompressedSize,
+                localHeaderOffset: localHeaderOffset
+            ))
+
+            cursor += 46 + Int(fileNameLength) + Int(extraFieldLength) + Int(fileCommentLength)
+        }
+
+        return entries
+    }
+
+    private static func extractEntryData(from data: Data, entry: CentralDirectoryEntry) throws -> Data {
+        if (entry.generalPurposeBitFlag & 0x0001) != 0 {
+            throw ExtractionError.encryptedEntry
+        }
+
+        let localHeaderOffset = Int(entry.localHeaderOffset)
+        guard data.readUInt32LE(at: localHeaderOffset) == 0x04034b50,
+              let fileNameLength = data.readUInt16LE(at: localHeaderOffset + 26),
+              let extraFieldLength = data.readUInt16LE(at: localHeaderOffset + 28) else {
+            throw ExtractionError.invalidArchive
+        }
+
+        let compressedDataOffset = localHeaderOffset + 30 + Int(fileNameLength) + Int(extraFieldLength)
+        guard let compressedData = data.readData(at: compressedDataOffset, length: Int(entry.compressedSize)) else {
+            throw ExtractionError.invalidArchive
+        }
+
+        switch entry.compressionMethod {
+        case 0: // stored
+            return compressedData
+        case 8: // deflate
+            return try inflateRawDeflate(compressedData, expectedSize: Int(entry.uncompressedSize))
+        default:
+            throw ExtractionError.unsupportedCompressionMethod(entry.compressionMethod)
+        }
+    }
+
+    private static func inflateRawDeflate(_ data: Data, expectedSize: Int) throws -> Data {
+        guard expectedSize >= 0 else {
+            throw ExtractionError.invalidCompressedData
+        }
+
+        if expectedSize == 0 {
+            return Data()
+        }
+
+        var stream = z_stream()
+        let initStatus = inflateInit2_(&stream, -MAX_WBITS, ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size))
+        guard initStatus == Z_OK else {
+            throw ExtractionError.invalidCompressedData
+        }
+        defer { inflateEnd(&stream) }
+
+        var output = Data(count: expectedSize)
+        let status = output.withUnsafeMutableBytes { outputBytes in
+            data.withUnsafeBytes { inputBytes -> Int32 in
+                guard let outBase = outputBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                      let inBase = inputBytes.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                    return Z_BUF_ERROR
+                }
+
+                stream.next_in = UnsafeMutablePointer<Bytef>(mutating: inBase)
+                stream.avail_in = UInt32(data.count)
+                stream.next_out = outBase
+                stream.avail_out = UInt32(expectedSize)
+
+                return inflate(&stream, Z_FINISH)
+            }
+        }
+
+        guard status == Z_STREAM_END, Int(stream.total_out) == expectedSize else {
+            throw ExtractionError.invalidCompressedData
+        }
+
+        return output
+    }
+
+    private static func findEndOfCentralDirectory(in data: Data) -> Int? {
+        // EOCD record is at least 22 bytes and may have a variable length comment (up to UInt16.max).
+        let minimumEOCDLength = 22
+        guard data.count >= minimumEOCDLength else { return nil }
+
+        let maxCommentLength = Int(UInt16.max)
+        let scanStart = max(0, data.count - minimumEOCDLength - maxCommentLength)
+        var cursor = data.count - minimumEOCDLength
+
+        while cursor >= scanStart {
+            if data.readUInt32LE(at: cursor) == 0x06054b50 {
+                return cursor
+            }
+            cursor -= 1
+        }
+        return nil
+    }
+}
+
+private extension Data {
+    func readUInt16LE(at offset: Int) -> UInt16? {
+        guard offset >= 0, offset + 2 <= count else { return nil }
+        return withUnsafeBytes { bytes in
+            let base = bytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+            return UInt16(base[offset]) | (UInt16(base[offset + 1]) << 8)
+        }
+    }
+
+    func readUInt32LE(at offset: Int) -> UInt32? {
+        guard offset >= 0, offset + 4 <= count else { return nil }
+        return withUnsafeBytes { bytes in
+            let base = bytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+            return UInt32(base[offset])
+                | (UInt32(base[offset + 1]) << 8)
+                | (UInt32(base[offset + 2]) << 16)
+                | (UInt32(base[offset + 3]) << 24)
+        }
+    }
+
+    func readData(at offset: Int, length: Int) -> Data? {
+        guard offset >= 0, length >= 0, offset + length <= count else { return nil }
+        return subdata(in: offset..<(offset + length))
     }
 }

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
@@ -38,6 +38,15 @@ Object.defineProperty(window.__firefox__, "download", {
 
         var blob = this.response;
         
+        // Checking if the blob is a wallet pass or a pdf, if not, continue navigation
+        if (
+          blob.type != "application/vnd.apple.pkpass" &&
+          blob.type != "application/vnd.apple.pkpasses" &&
+          blob.type != "application/pdf"
+        ) {
+          window.location.href = url;
+          return
+        }
         const header = xhr.getResponseHeader("Content-Disposition");
         const fileName = header ? header.split("filename=")?.[1] : getLastPathComponent(url);
       

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Downloads/DownloadHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Downloads/DownloadHelperTests.swift
@@ -8,6 +8,36 @@ import WebKit
 @testable import Client
 
 class DownloadHelperTests: XCTestCase {
+    func test_isPassbook_whenPkpass_isTrue() {
+        XCTAssertTrue(MIMEType.isPassbook(MIMEType.Passbook))
+    }
+
+    func test_isPassbook_whenPkpasses_isTrue() {
+        XCTAssertTrue(MIMEType.isPassbook(MIMEType.PassbookBundle))
+    }
+
+    func test_isPassbook_whenOtherMimeType_isFalse() {
+        XCTAssertFalse(MIMEType.isPassbook(MIMEType.PDF))
+    }
+
+    func test_pkpassBundleExtractor_whenArchiveContainsPkpass_extractsPassData() throws {
+        let nestedPassData = Data([0x50, 0x4B, 0x50, 0x41, 0x53, 0x53]) // "PKPASS"
+        let archiveData = makeStoredZipArchive(entries: [
+            ("bundle/boarding.pkpass", nestedPassData),
+            ("bundle/readme.txt", Data("ignore".utf8))
+        ])
+
+        let extracted = try PKPassBundleExtractor.extractPasses(from: archiveData)
+
+        XCTAssertEqual(extracted, [nestedPassData])
+    }
+
+    func test_pkpassBundleExtractor_whenArchiveHasNoPkpass_throws() {
+        let archiveData = makeStoredZipArchive(entries: [("bundle/readme.txt", Data("ignore".utf8))])
+
+        XCTAssertThrowsError(try PKPassBundleExtractor.extractPasses(from: archiveData))
+    }
+
     @MainActor
     func test_init_whenMIMETypeIsNil_initializeCorrectly() {
         let response = anyResponse(mimeType: nil)
@@ -215,6 +245,73 @@ class DownloadHelperTests: XCTestCase {
     private func anyCachePolicy() -> URLRequest.CachePolicy {
         return .useProtocolCachePolicy
     }
+
+    private func makeStoredZipArchive(entries: [(String, Data)]) -> Data {
+        var archive = Data()
+        var centralDirectory = Data()
+        var localHeaderOffsets: [UInt32] = []
+
+        for (filename, fileData) in entries {
+            let fileNameData = Data(filename.utf8)
+            let localHeaderOffset = UInt32(archive.count)
+            localHeaderOffsets.append(localHeaderOffset)
+
+            // Local file header signature
+            archive.appendLE32(0x04034b50)
+            archive.appendLE16(20) // version needed
+            archive.appendLE16(0) // flags
+            archive.appendLE16(0) // compression: stored
+            archive.appendLE16(0) // mod time
+            archive.appendLE16(0) // mod date
+            archive.appendLE32(0) // crc32 not required by extractor tests
+            archive.appendLE32(UInt32(fileData.count))
+            archive.appendLE32(UInt32(fileData.count))
+            archive.appendLE16(UInt16(fileNameData.count))
+            archive.appendLE16(0) // extra length
+            archive.append(fileNameData)
+            archive.append(fileData)
+        }
+
+        let centralDirectoryOffset = UInt32(archive.count)
+        for (index, entry) in entries.enumerated() {
+            let fileNameData = Data(entry.0.utf8)
+            let fileData = entry.1
+
+            // Central directory file header signature
+            centralDirectory.appendLE32(0x02014b50)
+            centralDirectory.appendLE16(20) // version made by
+            centralDirectory.appendLE16(20) // version needed
+            centralDirectory.appendLE16(0) // flags
+            centralDirectory.appendLE16(0) // compression: stored
+            centralDirectory.appendLE16(0) // mod time
+            centralDirectory.appendLE16(0) // mod date
+            centralDirectory.appendLE32(0) // crc32 not required by extractor tests
+            centralDirectory.appendLE32(UInt32(fileData.count))
+            centralDirectory.appendLE32(UInt32(fileData.count))
+            centralDirectory.appendLE16(UInt16(fileNameData.count))
+            centralDirectory.appendLE16(0) // extra length
+            centralDirectory.appendLE16(0) // comment length
+            centralDirectory.appendLE16(0) // disk number start
+            centralDirectory.appendLE16(0) // internal attrs
+            centralDirectory.appendLE32(0) // external attrs
+            centralDirectory.appendLE32(localHeaderOffsets[index])
+            centralDirectory.append(fileNameData)
+        }
+
+        archive.append(centralDirectory)
+
+        // End of central directory record
+        archive.appendLE32(0x06054b50)
+        archive.appendLE16(0) // disk number
+        archive.appendLE16(0) // central dir start disk
+        archive.appendLE16(UInt16(entries.count))
+        archive.appendLE16(UInt16(entries.count))
+        archive.appendLE32(UInt32(centralDirectory.count))
+        archive.appendLE32(centralDirectoryOffset)
+        archive.appendLE16(0) // zip comment length
+
+        return archive
+    }
 }
 
 class MockHTTPURLResponse: HTTPURLResponse, @unchecked Sendable {
@@ -234,4 +331,18 @@ class MockHTTPURLResponse: HTTPURLResponse, @unchecked Sendable {
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     override var mimeType: String? { forcedMimeType }
+}
+
+private extension Data {
+    mutating func appendLE16(_ value: UInt16) {
+        append(UInt8(value & 0x00ff))
+        append(UInt8((value >> 8) & 0x00ff))
+    }
+
+    mutating func appendLE32(_ value: UInt32) {
+        append(UInt8(value & 0x000000ff))
+        append(UInt8((value >> 8) & 0x000000ff))
+        append(UInt8((value >> 16) & 0x000000ff))
+        append(UInt8((value >> 24) & 0x000000ff))
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #24655 by adding support for `application/vnd.apple.pkpasses` in the same flow as `.pkpass`.

## What changed
- Treat `.pkpasses` as passbook MIME across download/open decision points.
- For pass opening:
  - Try single-pass decode first (`PKPass(data:)`).
  - If that fails, parse `.pkpasses` archive, extract inner `.pkpass` entries, and present Wallet with `PKAddPassesViewController(passes:)`.
- Keep JS blob handling aligned for `.pkpasses`.
- Add unit tests for passbook MIME checks and bundle extraction.

## Why
`.pkpasses` is an archive containing one or more `.pkpass` files, so parsing it as a single pass fails (`pass.json` missing).

## Validation
- Built and ran in simulator.
- Manually tested `.pkpasses` flow.
- Existing `.pkpass` flow remains supported.