### PR TITLE
Add [Nimbus] Enable is_ready and cache_not_ready_for_feature telemetry events

### DIFF
--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusBuilder.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusBuilder.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Glean
 
 /**
  * A builder for [Nimbus] singleton objects, parameterized in a declarative class.
@@ -240,6 +241,7 @@ public class NimbusBuilder {
             // * we gave a 200ms timeout to the loading of a file from res/raw
             // * on completion or cancellation, applyPendingExperiments or initialize was
             //   called, and this thread waited for that to complete.
+            GleanMetrics.NimbusEvents.isReady.record()
             featureManifest?.initialize { nimbus }
             onCreateCallback?(nimbus)
 

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -83,6 +83,11 @@ final class AppLaunchUtil: Sendable {
         /// and backfill accept date/version if needed - after telemetry set up
         TermsOfUseMigration(prefs: profile.prefs).migrateTermsOfService()
 
+        // Enable cache_not_ready_for_feature metric (disabled by default in application-services)
+        Glean.shared.applyServerKnobsConfig(
+            "{\"metrics_enabled\":{\"nimbus_health.cache_not_ready_for_feature\":true}}"
+        )
+
         // Start initializing the Nimbus SDK. This should be done after Glean
         // has been started.
         initializeExperiments()


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32103)

## :bulb: Description
Two Nimbus SDK telemetry events are available on Desktop and Android but not firing on iOS:

1. **`nimbus_events.is_ready`** — Fires when Nimbus finishes launching. The metric is enabled in the SDK but the recording call was never made on iOS.
2. **`nimbus_health.cache_not_ready_for_feature`** — Fires when a feature configuration is requested before the in-memory cache is populated. The recording code already exists in `Nimbus.swift` but the metric is `disabled: true` at the SDK level, so Glean silently drops it.

### Changes

- Record `NimbusEvents.isReady` in the `NimbusBuilder` `onCreate` callback in `Experiments.swift`
- Call `Glean.shared.applyServerKnobsConfig()` with a hardcoded config to enable `cache_not_ready_for_feature` before Nimbus initialization in `AppLaunchUtil.swift`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code

Fixes https://github.com/mozilla-mobile/firefox-ios/issues/32103