### PR TITLE
Bugfix FXIOS-14841 - Fix force-dry-run not being propagated to treescript payload

### DIFF
--- a/taskcluster/ffios_taskgraph/transforms/version_bump.py
+++ b/taskcluster/ffios_taskgraph/transforms/version_bump.py
@@ -33,4 +33,8 @@ def version_bump_task(config, tasks):
 
         task["worker"]["next-version"] = str(version)
         task["worker"].update(branch=config.params["head_ref"])
+
+        if config.params.get("merge_config", {}).get("force-dry-run"):
+            task["worker"]["force-dry-run"] = True
+
         yield task

--- a/taskcluster/ffios_taskgraph/worker_types.py
+++ b/taskcluster/ffios_taskgraph/worker_types.py
@@ -12,6 +12,7 @@ from voluptuous import Optional, Required
         Required("bump"): bool,
         Optional("bump-files"): [str],
         Optional("push"): bool,
+        Optional("force-dry-run"): bool,
         Optional("branch"): str,
         Optional("next-version"): str,
         Optional("create-branch-info"): {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14841)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32013)

## :bulb: Description

The force-dry-run flag from merge automation was stored in `merge_config` params but never forwarded to the worker dict, so the payload builder never set dry_run in the task payload leading to it not working at all...

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

