### PR TITLE
Add FXIOS-14841 - Add a `mark-as-merged` task to merge automation

### DIFF
--- a/taskcluster/ffios_taskgraph/target_tasks.py
+++ b/taskcluster/ffios_taskgraph/target_tasks.py
@@ -76,7 +76,7 @@ def target_tasks_ship(full_task_graph, parameters, graph_config):
 
 @register_target_task("merge_automation")
 def target_tasks_merge_automation(full_task_graph, parameters, graph_config):
-    return [l for l, t in full_task_graph.tasks.items() if t.kind == "branch-version-bump"]
+    return [l for l, t in full_task_graph.tasks.items() if t.kind in ("branch-version-bump", "mark-as-merged")]
 
 @register_target_task("promote_focus")
 def target_tasks_promote_focus(full_task_graph, parameters, graph_config):

--- a/taskcluster/ffios_taskgraph/transforms/mark_as_merged.py
+++ b/taskcluster/ffios_taskgraph/transforms/mark_as_merged.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def make_task_description(config, tasks):
+    merge_config = config.params.get("merge_config", {})
+    merge_automation_id = merge_config.get("merge-automation-id")
+
+    if not merge_automation_id:
+        return
+
+    for task in tasks:
+        resolve_keyed_by(
+            task,
+            "scopes",
+            item_name=task["name"],
+            level=config.params["level"],
+        )
+
+        task["worker"]["merge-automation-id"] = merge_automation_id
+
+        yield task
+

--- a/taskcluster/ffios_taskgraph/worker_types.py
+++ b/taskcluster/ffios_taskgraph/worker_types.py
@@ -116,3 +116,14 @@ def build_shipit_release_payload(config, task, task_def):
         "version": task["worker"]["version"],
         "cron_revision": task["worker"]["revision"],
     }
+
+@payload_builder(
+    "scriptworker-shipit-merge",
+    schema={
+        Required("merge-automation-id"): int,
+    }
+)
+def build_shipit_release_payload(config, task, task_def):
+    task_def["payload"] = {
+        "automation_id": task["worker"]["merge-automation-id"],
+    }

--- a/taskcluster/kinds/mark-as-merged/kind.yml
+++ b/taskcluster/kinds/mark-as-merged/kind.yml
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - ffios_taskgraph.transforms.mark_as_merged:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - branch-version-bump
+
+tasks:
+    mark-as-merged:
+        name: mark-as-merged
+        description: mark merge automation as completed in shipit
+        dependencies:
+            branch-version-bump: branch-version-bump-task
+        run-on-tasks-for: []
+        worker-type: ship-it
+        worker:
+            implementation: scriptworker-shipit-merge
+        scopes:
+            by-level:
+                '3':
+                    - project:mobile:releng:ship-it:server:production
+                    - project:mobile:releng:ship-it:action:mark-as-merged
+                default:
+                    - project:mobile:releng:ship-it:server:staging
+                    - project:mobile:releng:ship-it:action:mark-as-merged


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14841)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32013)

## :bulb: Description
This task runs when merge automation is ran from shipit to convey back that the automation has completed

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

