### PR TITLE
Add FXIOS-14922 [Summarizer] Skip failing tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -146,7 +146,9 @@
     },
     {
       "skippedTests" : [
-        "SummarizeViewModelTests\/test_summarize_throwsSummarizeError()"
+        "SummarizeViewModelTests\/test_summarize_throwsSummarizeError()",
+        "SummarizeViewModelTests\/test_summarize_withNotEnoughStartingWords()",
+        "SummarizeViewModelTests\/test_summarizer_whenTosNotAcceppted_whenTriggerIsNotShake_startsSummarizer()"
       ],
       "target" : {
         "containerPath" : "container:..\/BrowserKit",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14922)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32158)

## :bulb: Description
This PR:
- Disables `test_summarize_withNotEnoughStartingWords()`
- Disables `SummarizeViewModelTests\/test_summarizer_whenTosNotAcceppted_whenTriggerIsNotShake_startsSummarizer()`
- Test fixes are tacked in [FXIOS-14916](https://mozilla-hub.atlassian.net/browse/FXIOS-14916)

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code



[FXIOS-14916]: https://mozilla-hub.atlassian.net/browse/FXIOS-14916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ