### PR TITLE
Bugfix FXIOS-14923 - [Crash Fixes] - Crash in addPrintFormatter during print preview

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabPrintPageRenderer.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabPrintPageRenderer.swift
@@ -14,7 +14,7 @@ final class TabPrintPageRenderer: UIPrintPageRenderer {
 
     private let tabDisplayTitle: String
     private let tabURL: URL?
-    private var printFormatter: UIViewPrintFormatter?
+    private var formatter: UIViewPrintFormatter?
 
     let textAttributes = [NSAttributedString.Key.font: UX.textFont]
     let dateString: String
@@ -22,7 +22,7 @@ final class TabPrintPageRenderer: UIPrintPageRenderer {
     required init(tabDisplayTitle: String, tabURL: URL?, viewPrintFormatter: UIViewPrintFormatter?) {
         self.tabDisplayTitle = tabDisplayTitle
         self.tabURL = tabURL
-        self.printFormatter = viewPrintFormatter
+        self.formatter = viewPrintFormatter
 
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .short
@@ -34,7 +34,7 @@ final class TabPrintPageRenderer: UIPrintPageRenderer {
         self.footerHeight = UX.marginScale * UX.insets
         self.headerHeight = UX.marginScale * UX.insets
 
-        if let formatter = printFormatter {
+        if let formatter {
             formatter.perPageContentInsets = UIEdgeInsets(equalInset: UX.insets)
             addPrintFormatter(formatter, startingAtPageAt: 0)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14923)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32160)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Fixes [crash](https://mozilla.sentry.io/issues/7271042897/?query=is%3Aunresolved%20release.version%3A147.4&referrer=issue-stream&sort=new). 
- `UIViewPrintFormatter` was deallocated before background rendering completed because `UIPrintPageRenderer` doesn't retain formatters added via `addPrintFormatter(_:startingAtPageAt:)`, causing access to freed memory.
- Fix: Added a strong reference to `UIViewPrintFormatter` as a stored property to keep it alive during the entire print operation lifecycle.
## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

