### PR TITLE
Fix FXIOS-14935 - Rename duplicated function name in worker_types.py

### DIFF
--- a/taskcluster/ffios_taskgraph/worker_types.py
+++ b/taskcluster/ffios_taskgraph/worker_types.py
@@ -124,7 +124,7 @@ def build_shipit_release_payload(config, task, task_def):
         Required("merge-automation-id"): int,
     }
 )
-def build_shipit_release_payload(config, task, task_def):
+def build_shipit_merge_payload(config, task, task_def):
     task_def["payload"] = {
         "automation_id": task["worker"]["merge-automation-id"],
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14935)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32185)

## :bulb: Description
Renames a duplicate function name added in #32133

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

