### PR TITLE
Refactor FXIOS-11720 download any blob mime type in DownloadHelper.js

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
@@ -38,11 +38,6 @@ Object.defineProperty(window.__firefox__, "download", {
 
         var blob = this.response;
         
-        // Checking if the blob is a pkpass (Passbook Pass) or a pdf, if not, continue navigation
-        if (blob.type != "application/vnd.apple.pkpass" && blob.type != "application/pdf") {
-          window.location.href = url;
-          return
-        }
         const header = xhr.getResponseHeader("Content-Disposition");
         const fileName = header ? header.split("filename=")?.[1] : getLastPathComponent(url);
       


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11720)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25557)

## :bulb: Description
Refactor `DownloadHelper.js` to not check for mimeType when downloading a Blob file. This allows to download any Blob file.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

