### PR TITLE
Bugfix FXIOS-14954  [Memory leaks] Fix EnhancedTrackingProtection leak on present completion

### DIFF
--- a/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
@@ -95,9 +95,9 @@ class EnhancedTrackingProtectionCoordinator: BaseCoordinator,
                 enhancedTrackingProtectionMenuVC.asPopover = true
                 guard let trackingProtectionNavController = trackingProtectionNavController else { return }
                 trackingProtectionNavController.sheetPresentationController?.prefersEdgeAttachedInCompactHeight = true
-                router.present(trackingProtectionNavController, animated: true) {
+                router.present(trackingProtectionNavController, animated: true) { [weak self] in
                     // Ensures the VC gets deinit when we dismiss through `UIAdaptivePresentationControllerDelegate`
-                    self.didFinish()
+                    self?.didFinish()
                 }
             } else {
                 guard let trackingProtectionNavController = trackingProtectionNavController else { return }
@@ -105,9 +105,9 @@ class EnhancedTrackingProtectionCoordinator: BaseCoordinator,
                 trackingProtectionNavController.modalPresentationStyle = .popover
                 trackingProtectionNavController.popoverPresentationController?.sourceView = sourceView
                 trackingProtectionNavController.popoverPresentationController?.permittedArrowDirections = .up
-                router.present(trackingProtectionNavController, animated: true) {
+                router.present(trackingProtectionNavController, animated: true) { [weak self] in
                     // Ensures the VC gets deinit when we dismiss through `UIAdaptivePresentationControllerDelegate`
-                    self.didFinish()
+                    self?.didFinish()
                 }
             }
         } else if let legacyEnhancedTrackingProtectionMenuVC {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14954)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32219)

## :bulb: Description
To fix the retain cycle here while still calling the didFinish function on coordinator I have added weak to the self reference. Let me know I can give more thought if you want to fix this in some other way.

Verified that we don't get this leak in the test after this. 

## :movie_camera: Demos
N/A

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

