### PR TITLE
Add FXIOS-14570 [Dependabot] Configure quarterly grouped JS updates (+GHA bumps)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: quarterly
+    groups:
+      frontend:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "npm"
+      include: scope
+    labels:
+      - Dependencies
+      - javascript
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: quarterly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "actions(gha)"


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-14570
GitHub issue #31525

## :bulb: Description

This adds explicit dependabot schedule to submit lumped dependency bumps, grouped by dev or prod type, once in a while, as a reminder to keep the versions up to date over time, without having a large backlog of versions to verify when a sec bump is triggered by dependabot outside of the scheduled updates.

## :movie_camera: Demos

This is how it looked for another project, with the same prefixes as proposed here:

> <img width="1438" height="336" alt="Screenshot 2026-02-22 at 1 18 20" src="https://github.com/user-attachments/assets/8dc9407c-d48f-47f0-b2b0-1a847a62f523" />

<details><summary>Details how a grouped update looks like [+]</summary>
<p>

> <img width="1114" height="1150" alt="Screenshot 2026-02-22 at 1 18 51" src="https://github.com/user-attachments/assets/c8c59ff2-fa7b-469f-9b42-1f56487551f1" />

</p>
</details> 


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If needed, I updated documentation and added comments to complex code