### PR TITLE
Add FXIOS-14956 [Address Bar] Disabled Smart Quotes & Smart Dashes

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -51,6 +51,8 @@ final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable
         keyboardType = .webSearch
         autocorrectionType = .no
         autocapitalizationType = .none
+        smartQuotesType = .no
+        smartDashesType = .no
         returnKeyType = .go
         tintAdjustmentMode = .normal
 


### PR DESCRIPTION
## :scroll: Tickets
* [Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14956)
* GitHub issue: #32224

## :bulb: Description
This change introduces new `LocationTextField` configuration options that disable smart substitution of quotes (single and double) and dashes to prevent the unexpected behavior explained in #32224.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] (*PENDING*) I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
