### PR TITLE
Refactor RMST-296 [Remote-Settings] Renaming RemoteSettingsConfig2 to match updated application-services code

### DIFF
--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -28,7 +28,7 @@ import struct MozillaAppServices.SyncParams
 import struct MozillaAppServices.SyncResult
 import struct MozillaAppServices.VisitObservation
 import struct MozillaAppServices.PendingCommand
-import struct MozillaAppServices.RemoteSettingsConfig2
+import struct MozillaAppServices.RemoteSettingsConfig
 
 // TODO: FXIOS-14225 - SyncManager shouldn't be Sendable
 public protocol SyncManager: Sendable {
@@ -659,7 +659,7 @@ open class BrowserProfile: Profile,
         let remoteSettingsEnvironment = RemoteSettingsEnvironment(rawValue: remoteSettingsEnvironmentKey) ?? .prod
         let remoteSettingsServer = remoteSettingsEnvironment.toRemoteSettingsServer()
         let bucketName = (remoteSettingsServer == .prod ? "main" : "main-preview")
-        let config = RemoteSettingsConfig2(server: remoteSettingsServer,
+        let config = RemoteSettingsConfig(server: remoteSettingsServer,
                                            bucketName: bucketName,
                                            appContext: remoteSettingsAppContext())
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/RMST-296)
[Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=2011859)

## :bulb: Description
Application-Services [PR 7186](https://github.com/mozilla/application-services/pull/7186) is removing the legacy remote-settings rust client. In the process, this is renaming the `RemoteSettingsConfig2` struct to `RemoteSettingsConfig`.

Once this PR is landed, we will break builds. This PR will need to be landed and the generated wrappers under `MozillaRustComponents/Sources/` will need to be regenerated.


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
  - This PR, along with regenerating the swift wrappers, will fix broken builds once [7186](https://github.com/mozilla/application-services/pull/7186) lands

