### PR TITLE
Bugfix FXIOS-14288 [Relay] Fix edge case race in Autofill for email fields

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
@@ -483,7 +483,7 @@ window.__firefox__.includeOnce("LoginsHelper", function() {
       LoginManagerContent.fromFill = true
       this.yieldFocusBackToField();
       // Only fill if the pending field is still focused
-      if (pendingRelayEmailField && pendingRelayEmailField === LoginManagerContent.activeField) {
+      if (pendingRelayEmailField?.isConnected && pendingRelayEmailField === LoginManagerContent.activeField) {
           pendingRelayEmailField.setUserInput(email);
       }
       LoginManagerContent.fromFill = false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14288)

## :bulb: Description

Basic fix for scenario where the user attempts to auto-fill Email, the network requests are slow, and the user taps into a different field before the requests complete. In that scenario previously, we would incorrectly populate the focused field with an email value even though they are no longer focused on the email field.

This fix is basic and prevents the autofill, there are some additional edge cases which may still be problematic. In the above scenario with this fix in place, the user will still see the related toast messages once the network requests return successfully (which happened before also), but we should now prevent the form from being populated incorrectly which is the most critical issue.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

