### PR TITLE
Bugfix FXIOS-14665 ⁃ Tab Graphical bug with Accessibility Settings on iPadOS 26

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
@@ -14,7 +14,6 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFl
         static let faviconCornerRadius: CGFloat = 2
         static let tabTitlePadding: CGFloat = 10
         static let tabTitlePaddingVersion: CGFloat = 14
-        static let tabNudge: CGFloat = 1 // Nudge the favicon and close button by 1px
 
         // MARK: - Tab Appearance Constants
         static let tabCornerRadius: CGFloat = 8
@@ -168,7 +167,7 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFl
                 cellBackground.centerXAnchor.constraint(equalTo: centerXAnchor),
                 cellBackground.centerYAnchor.constraint(equalTo: centerYAnchor),
 
-                favicon.centerYAnchor.constraint(equalTo: centerYAnchor, constant: UX.tabNudge),
+                favicon.centerYAnchor.constraint(equalTo: centerYAnchor),
                 favicon.widthAnchor.constraint(equalToConstant: UX.faviconSize),
                 favicon.heightAnchor.constraint(equalToConstant: UX.faviconSize),
                 favicon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.tabTitlePadding),
@@ -184,9 +183,9 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFl
                     constant: UX.tabTitlePadding
                 ),
 
-                closeButton.centerYAnchor.constraint(equalTo: centerYAnchor, constant: UX.tabNudge),
+                closeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
                 closeButton.widthAnchor.constraint(equalTo: heightAnchor, constant: -UX.tabTitlePadding),
-                closeButton.heightAnchor.constraint(equalTo: heightAnchor),
+                closeButton.heightAnchor.constraint(equalTo: heightAnchor, constant: -UX.tabTitlePadding),
                 closeButton.trailingAnchor.constraint(equalTo: trailingAnchor),
             ]
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14665)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31702)

## :bulb: Description
Changed close button margins

## :movie_camera: Demos
<img width="820" height="1180" alt="IMG_0084" src="https://github.com/user-attachments/assets/07ca630f-2128-4058-83f3-e568eab57a08" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

