### PR TITLE
Fix FXIOS-14978 - Set branch suffix on major version bumps

### DIFF
--- a/taskcluster/ffios_taskgraph/transforms/version_bump.py
+++ b/taskcluster/ffios_taskgraph/transforms/version_bump.py
@@ -22,7 +22,7 @@ def version_bump_task(config, tasks):
             # We need to default to major here so taskgraph full can produce a valid task
             behavior = config.params.get("merge_config", {}).get("behavior", "major")
             if behavior == "major":
-                version_string = f"release/v{version.major_number}"
+                version_string = f"release/v{version.major_number}.0"
                 version = version.bump("major_number")
             elif behavior == "minor":
                 version_string = f"release/v{version.major_number}.{version.minor_number}"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14978)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32261)

## :bulb: Description
Major version bump branches should have a `.0` suffix.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

