### PR TITLE
Bugfix FXIOS-14810 [A11y] Fix clipping of keyboard accessory button labels

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
@@ -77,6 +77,7 @@ final class AutofillAccessoryViewButtonItem: UIBarButtonItem {
         self.useAccessoryTextLabel = .build { label in
             label.font = FXFontStyles.Bold.callout.scaledFont()
             label.adjustsFontSizeToFitWidth = true
+            label.minimumScaleFactor = 0.65
             label.text = labelText
             label.numberOfLines = 0
             label.accessibilityTraits = .button


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14810)

## :bulb: Description

Prevent clipping, don't allow Dynamic Type to size label big enough to truncate (per team AX feedback).

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="before2" src="https://github.com/user-attachments/assets/4865b8e3-0854-4795-a671-acff14d7cd64" /> | <img width="1206" height="2622" alt="after2" src="https://github.com/user-attachments/assets/6eb96917-4530-491e-b6ac-d488e0f67c5b" /> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

