### PR TITLE
Refactor FXIOS-14979 [Sync] telemetry for unsupported engines updated

### DIFF
--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/SyncManager/SyncManagerTelemetry.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/SyncManager/SyncManagerTelemetry.swift
@@ -75,8 +75,13 @@ func processSyncTelemetry(syncTelemetry: RustSyncTelemetryPing,
                                        engineInfo: engineInfo)
                 submitTabsPing(nil)
             default:
-                let message = "Ignoring telemetry for engine \(engineInfo.name)"
-                throw TelemetryReportingError.UnsupportedEngine(message: message)
+                // Previously when we encountered an unsupported engine we threw an error.
+                // This was problematic because it prevented other engines queued after the
+                // unsupported engine from reporting metrics. For now we will do nothing.
+                // See FXIOS-14438
+                assertionFailure(
+                    "Error: attempting to process telemetry for unsupported sync engine")
+                break
             }
         }
         submitGlobalPing(nil)

--- a/MozillaRustComponents/Tests/MozillaRustComponentsTests/EventStoreTests.swift
+++ b/MozillaRustComponents/Tests/MozillaRustComponentsTests/EventStoreTests.swift
@@ -31,7 +31,7 @@ final class EventStoreTests: XCTestCase {
 
     func createNimbus() throws -> NimbusInterface {
         let appSettings = NimbusAppSettings(appName: "EventStoreTest", channel: "nightly")
-        let nimbusEnabled = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath())
+        let nimbusEnabled = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath())
         XCTAssert(nimbusEnabled is Nimbus)
         if let nimbus = nimbusEnabled as? Nimbus {
             try nimbus.initializeOnThisThread()

--- a/MozillaRustComponents/Tests/MozillaRustComponentsTests/NimbusMessagingTests.swift
+++ b/MozillaRustComponents/Tests/MozillaRustComponentsTests/NimbusMessagingTests.swift
@@ -18,7 +18,7 @@ class NimbusMessagingTests: XCTestCase {
 
     func createNimbus() throws -> NimbusMessagingProtocol {
         let appSettings = NimbusAppSettings(appName: "NimbusMessagingTests", channel: "nightly")
-        let nimbusEnabled = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath())
+        let nimbusEnabled = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath())
         XCTAssert(nimbusEnabled is Nimbus)
         if let nimbus = nimbusEnabled as? Nimbus {
             try nimbus.initializeOnThisThread()

--- a/MozillaRustComponents/Tests/MozillaRustComponentsTests/NimbusTests.swift
+++ b/MozillaRustComponents/Tests/MozillaRustComponentsTests/NimbusTests.swift
@@ -100,16 +100,16 @@ class NimbusTests: XCTestCase {
 
     func testNimbusCreate() throws {
         let appSettings = NimbusAppSettings(appName: "test", channel: "nightly")
-        let nimbusEnabled = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath())
+        let nimbusEnabled = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath())
         XCTAssert(nimbusEnabled is Nimbus)
 
-        let nimbusDisabled = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath(), enabled: false)
+        let nimbusDisabled = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath(), enabled: false)
         XCTAssert(nimbusDisabled is NimbusDisabled, "Nimbus is disabled if a feature flag disables it")
     }
 
     func testSmokeTest() throws {
         let appSettings = NimbusAppSettings(appName: "test", channel: "nightly")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         try nimbus.setExperimentsLocallyOnThisThread(minimalExperimentJSON())
         try nimbus.applyPendingExperimentsOnThisThread()
@@ -137,7 +137,7 @@ class NimbusTests: XCTestCase {
 
     func testSmokeTestAsync() throws {
         let appSettings = NimbusAppSettings(appName: "test", channel: "nightly")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         // We do the same tests as `testSmokeTest` but with the actual calls that
         // the client app will make.
@@ -166,7 +166,7 @@ class NimbusTests: XCTestCase {
 
     func testApplyLocalExperimentsTimedOut() throws {
         let appSettings = NimbusAppSettings(appName: "test", channel: "nightly")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         let job = nimbus.applyLocalExperiments {
             Thread.sleep(forTimeInterval: 5.0)
@@ -182,7 +182,7 @@ class NimbusTests: XCTestCase {
 
     func testApplyLocalExperiments() throws {
         let appSettings = NimbusAppSettings(appName: "test", channel: "nightly")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         let job = nimbus.applyLocalExperiments {
             Thread.sleep(forTimeInterval: 0.1)
@@ -211,7 +211,7 @@ class NimbusTests: XCTestCase {
 
     func testRecordExperimentTelemetry() throws {
         let appSettings = NimbusAppSettings(appName: "NimbusUnitTest", channel: "test")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         let enrolledExperiments = [EnrolledExperiment(
             featureIds: [],
@@ -235,7 +235,7 @@ class NimbusTests: XCTestCase {
 
     func testRecordExperimentEvents() throws {
         let appSettings = NimbusAppSettings(appName: "NimbusUnitTest", channel: "test")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         // Create a list of events to record, one of each type, all associated with the same
         // experiment
@@ -292,7 +292,7 @@ class NimbusTests: XCTestCase {
 
     func testRecordFeatureActivation() throws {
         let appSettings = NimbusAppSettings(appName: "NimbusUnitTest", channel: "test")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         // Load an experiment in nimbus that we will record an event in. The experiment bucket configuration
         // is set so that it will be guaranteed to be active. This is necessary because the SDK checks for
@@ -321,7 +321,7 @@ class NimbusTests: XCTestCase {
 
     func testRecordExposureFromFeature() throws {
         let appSettings = NimbusAppSettings(appName: "NimbusUnitTest", channel: "test")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         // Load an experiment in nimbus that we will record an event in. The experiment bucket configuration
         // is set so that it will be guaranteed to be active. This is necessary because the SDK checks for
@@ -364,7 +364,7 @@ class NimbusTests: XCTestCase {
 
     func testRecordExposureFromExperiment() throws {
         let appSettings = NimbusAppSettings(appName: "NimbusUnitTest", channel: "test")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         // Load an experiment in nimbus that we will record an event in. The experiment bucket configuration
         // is set so that it will be guaranteed to be active. This is necessary because the SDK checks for
@@ -407,7 +407,7 @@ class NimbusTests: XCTestCase {
 
     func testRecordMalformedConfiguration() throws {
         let appSettings = NimbusAppSettings(appName: "NimbusUnitTest", channel: "test")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         // Load an experiment in nimbus that we will record an event in. The experiment bucket configuration
         // is set so that it will be guaranteed to be active. This is necessary because the SDK checks for
@@ -434,7 +434,7 @@ class NimbusTests: XCTestCase {
 
     func testRecordDisqualificationOnOptOut() throws {
         let appSettings = NimbusAppSettings(appName: "NimbusUnitTest", channel: "test")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         // Load an experiment in nimbus that we will record an event in. The experiment bucket configuration
         // is set so that it will be guaranteed to be active. This is necessary because the SDK checks for
@@ -462,7 +462,7 @@ class NimbusTests: XCTestCase {
 
     func testRecordDisqualificationOnGlobalOptOut() throws {
         let appSettings = NimbusAppSettings(appName: "NimbusUnitTest", channel: "test")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
 
         // Load an experiment in nimbus that we will record an event in. The experiment bucket configuration
         // is set so that it will be guaranteed to be active. This is necessary because the SDK checks for
@@ -491,7 +491,7 @@ class NimbusTests: XCTestCase {
 
     func testNimbusCreateWithJson() throws {
         let appSettings = NimbusAppSettings(appName: "test", channel: "nightly", customTargetingAttributes: ["is_first_run": false, "is_test": true])
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath())
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath())
         let helper = try nimbus.createMessageHelper()
 
         XCTAssertTrue(try helper.evalJexl(expression: "is_test"))
@@ -541,7 +541,7 @@ class NimbusTests: XCTestCase {
     func testNimbusRecordsRecordedContextObject() throws {
         let recordedContext = TestRecordedContext()
         let appSettings = NimbusAppSettings(appName: "test", channel: "nightly")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath(), recordedContext: recordedContext) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath(), recordedContext: recordedContext) as! Nimbus
 
         try nimbus.setExperimentsLocallyOnThisThread(minimalExperimentJSON())
         try nimbus.applyPendingExperimentsOnThisThread()
@@ -554,7 +554,7 @@ class NimbusTests: XCTestCase {
     func testNimbusRecordedContextEventQueriesAreRunAndTheValueIsWrittenBackIntoTheObject() throws {
         let recordedContext = TestRecordedContext(eventQueries: ["TEST_QUERY": "'event'|eventSum('Days', 1, 0)"])
         let appSettings = NimbusAppSettings(appName: "test", channel: "nightly")
-        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath(), recordedContext: recordedContext) as! Nimbus
+        let nimbus = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: createDatabasePath(), recordedContext: recordedContext) as! Nimbus
 
         try nimbus.setExperimentsLocallyOnThisThread(minimalExperimentJSON())
         try nimbus.applyPendingExperimentsOnThisThread()
@@ -573,7 +573,7 @@ class NimbusTests: XCTestCase {
     func testNimbusCanObtainCalculatedAttributes() throws {
         let appSettings = NimbusAppSettings(appName: "test", channel: "nightly")
         let databasePath = createDatabasePath()
-        _ = try Nimbus.create(nil, appSettings: appSettings, dbPath: databasePath) as! Nimbus
+        _ = try Nimbus.create(server: nil, appSettings: appSettings, dbPath: databasePath) as! Nimbus
 
         let calculatedAttributes = try getCalculatedAttributes(installationDate: Int64(Date().timeIntervalSince1970 * 1000) - (86_400_000 * 5), dbPath: databasePath, locale: getLocaleTag())
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14979)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32265)

## :bulb: Description
As a partial remedy to #31256 we're removing the throw statement when the sync telemetry logic encounters and unsupported engine to allow subsequent engines to be processed successfully.

Also fixing broken Nimbus tests caused by [this change](https://github.com/mozilla-mobile/firefox-ios/pull/31678/changes#diff-6e49c65ee2b36d6e64869ac4aa4de8ae0e6397c3d0fdf29b1d2e25abd945db9cL274).

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

