### PR TITLE
[MTE-5215]-fix for swiping tabs test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -304,12 +304,50 @@ final class BrowserScreen {
         saveButton.tapIfExists()
     }
 
-    func swipeToAndValidateAddressBarValue(swipeRight: Bool, _ value: String) {
-        if swipeRight {
-            addressBar.swipeRight()
-        } else {
-            addressBar.swipeLeft()
+    func swipeToAndValidateAddressBarValue(swipeRight: Bool,
+                                           _ value: String,
+                                           durations: [TimeInterval] = [0.06, 0.02],
+                                           maxAttempts: Int = 2,
+                                           checkTimeout: TimeInterval = 2.0) {
+        // Ensure address bar exists and is hittable
+        BaseTestCase().mozWaitForElementToExist(addressBar)
+        let waitUntil = Date().addingTimeInterval(2)
+        while !addressBar.isHittable && Date() < waitUntil {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
         }
-        assertAddressBarContains(value: value)
+        guard addressBar.isHittable else {
+            XCTFail("Address bar not hittable, cannot perform swipe")
+            return
+        }
+
+        // Coordinates with margins to avoid edge gestures
+        let leftPoint = addressBar.coordinate(withNormalizedOffset: CGVector(dx: 0.12, dy: 0.5))
+        let rightPoint = addressBar.coordinate(withNormalizedOffset: CGVector(dx: 0.88, dy: 0.5))
+        let startPoint = swipeRight ? leftPoint : rightPoint
+        let endPoint = swipeRight ? rightPoint : leftPoint
+
+        for attempt in 0..<maxAttempts {
+            let duration = durations[min(attempt, durations.count - 1)]
+            // Press-and-drag; varying `duration` changes the feel/velocity of the gesture
+            startPoint.press(forDuration: duration, thenDragTo: endPoint)
+
+            // Let UI settle briefly
+            RunLoop.current.run(until: Date().addingTimeInterval(0.35))
+
+            // Poll address bar value for the expected substring
+            let deadline = Date().addingTimeInterval(checkTimeout)
+            var success = false
+            while Date() < deadline {
+                if let val = (addressBar.value as? String), val.contains(value) {
+                    success = true
+                    break
+                }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+            }
+            assertAddressBarContains(value: value)
+            if success { return }
+        }
+
+        XCTFail("Failed to achieve expected address bar value '\(value)' after \(maxAttempts) attempts")
     }
  }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5215

## :bulb: Description
Replace flaky `addressBar.swipe` with a reliable coordinate-based press-and-drag gesture.

- Replaced simple `swipe` with a press-and-drag using normalized coordinates and safe margins.
- Waits for the address bar to be hittable, uses configurable durations to approximate velocity, retries on failure, and polls the address bar value for deterministic verification.
- Supports both directions via a `swipeRight: Bool` parameter (covers `swipeLeft`).