### PR TITLE
Bugfix FXIOS-14914 #32144 ⁃ [CC Autofill][iPad] - Card buttons are not visible after editing the card

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -39,21 +39,32 @@ struct CreditCardInputView: ThemeableView {
     }
 
     var body: some View {
-        NavigationView {
-            main
-                .blur(radius: isBlurred ? UX.blurRadius : 0)
-                .onReceive(NotificationCenter.default.publisher(
-                    for: UIApplication.willResignActiveNotification)
-                ) { _ in
-                    isBlurred = true
-                }
-                .onReceive(NotificationCenter.default.publisher(
-                    for: UIApplication.didBecomeActiveNotification)
-                ) { _ in
-                    isBlurred = false
-                }
+        if #available(iOS 16.0, *) {
+            NavigationStack {
+                bodyContent
+            }
+            .listenToThemeChanges(theme: $theme, manager: themeManager, windowUUID: windowUUID)
+        } else {
+            NavigationView {
+                bodyContent
+            }
+            .listenToThemeChanges(theme: $theme, manager: themeManager, windowUUID: windowUUID)
         }
-        .listenToThemeChanges(theme: $theme, manager: themeManager, windowUUID: windowUUID)
+    }
+
+    private var bodyContent: some View {
+        main
+            .blur(radius: isBlurred ? UX.blurRadius : 0)
+            .onReceive(NotificationCenter.default.publisher(
+                for: UIApplication.willResignActiveNotification)
+            ) { _ in
+                isBlurred = true
+            }
+            .onReceive(NotificationCenter.default.publisher(
+                for: UIApplication.didBecomeActiveNotification)
+            ) { _ in
+                isBlurred = false
+            }
     }
 
     private var main: some View {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14914)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32144)

## :bulb: Description
Using NavigationStack for iOS 16 or above

## :movie_camera: Demos
<img width="820" height="1180" alt="IMG_0086" src="https://github.com/user-attachments/assets/ce57f993-a688-4ce0-9bc6-cfebe20e287e" />
<img width="820" height="1180" alt="IMG_0085" src="https://github.com/user-attachments/assets/f1ac9786-2d9c-4167-96e0-20b9d46b2785" />
<img width="603" height="1311" alt="IMG_8588" src="https://github.com/user-attachments/assets/c548b4f3-85df-4868-93b8-d9cfce5c75cd" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

