### PR TITLE
Add FXIOS-14943 [Shortcuts] Conditionally show shortcuts section header

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -656,7 +656,7 @@ final class HomepageViewController: UIViewController,
         with sectionLabelCell: LabelButtonHeaderView
     ) -> LabelButtonHeaderView? {
         switch section {
-        case .topSites(let textColor, _):
+        case .topSites(let textColor, _, _):
             sectionLabelCell.configure(
                 state: homepageState.topSitesState.sectionHeaderState,
                 moreButtonAction: { [weak self] _ in

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -170,10 +170,11 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
                 itemHeight: UX.MessageCardConstants.height,
                 bottomInsets: UX.spacingBetweenSections
             )
-        case .topSites(_, let numberOfTilesPerRow):
+        case .topSites(_, let numberOfTilesPerRow, let shouldShowSectionHeader):
             return createTopSitesSectionLayout(
                 for: traitCollection,
-                numberOfTilesPerRow: numberOfTilesPerRow
+                numberOfTilesPerRow: numberOfTilesPerRow,
+                shouldShowSectionHeader: shouldShowSectionHeader
             )
         case .jumpBackIn(_, let configuration):
             return createJumpBackInSectionLayout(
@@ -349,21 +350,24 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
     private func createTopSitesSectionLayout(
         for traitCollection: UITraitCollection,
-        numberOfTilesPerRow: Int
+        numberOfTilesPerRow: Int,
+        shouldShowSectionHeader: Bool
     ) -> NSCollectionLayoutSection {
         let section = TopSitesSectionLayoutProvider.createTopSitesSectionLayout(for: traitCollection,
                                                                                 numberOfTilesPerRow: numberOfTilesPerRow)
 
-        let headerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1),
-            heightDimension: .estimated(UX.sectionHeaderHeight)
-        )
-        let header = NSCollectionLayoutBoundarySupplementaryItem(
-            layoutSize: headerSize,
-            elementKind: UICollectionView.elementKindSectionHeader,
-            alignment: .top
-        )
-        section.boundarySupplementaryItems = [header]
+        if shouldShowSectionHeader {
+            let headerSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .estimated(UX.sectionHeaderHeight)
+            )
+            let header = NSCollectionLayoutBoundarySupplementaryItem(
+                layoutSize: headerSize,
+                elementKind: UICollectionView.elementKindSectionHeader,
+                alignment: .top
+            )
+            section.boundarySupplementaryItems = [header]
+        }
 
         let bottomInset = UX.spacingBetweenSections
         section.contentInsets.top = 0
@@ -675,7 +679,9 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         }
 
         // Add header height
-        totalHeight += getHeaderHeight(headerState: topSitesState.sectionHeaderState, environment: environment)
+        if topSitesState.shouldShowSectionHeader {
+            totalHeight += getHeaderHeight(headerState: topSitesState.sectionHeaderState, environment: environment)
+        }
 
         // Build array of configured cells for the data being displayed on the homepage
         let allCells = cellsData.map { data in

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesSectionState.swift
@@ -16,6 +16,7 @@ struct TopSitesSectionState: StateType, Equatable {
     let numberOfRows: Int
     let numberOfTilesPerRow: Int
     let shouldShowSection: Bool
+    let shouldShowSectionHeader: Bool
 
     let sectionHeaderState = SectionHeaderConfiguration(
         title: .FirefoxHomepage.Shortcuts.SectionTitle,
@@ -36,7 +37,8 @@ struct TopSitesSectionState: StateType, Equatable {
             topSitesData: [],
             numberOfRows: numberOfRows,
             numberOfTilesPerRow: TopSitesSectionLayoutProvider.UX.minCards,
-            shouldShowSection: shouldShowSection
+            shouldShowSection: shouldShowSection,
+            shouldShowSectionHeader: false
         )
     }
 
@@ -45,13 +47,15 @@ struct TopSitesSectionState: StateType, Equatable {
         topSitesData: [TopSiteConfiguration],
         numberOfRows: Int,
         numberOfTilesPerRow: Int,
-        shouldShowSection: Bool
+        shouldShowSection: Bool,
+        shouldShowSectionHeader: Bool,
     ) {
         self.windowUUID = windowUUID
         self.topSitesData = topSitesData
         self.numberOfRows = numberOfRows
         self.numberOfTilesPerRow = numberOfTilesPerRow
         self.shouldShowSection = shouldShowSection
+        self.shouldShowSectionHeader = shouldShowSectionHeader
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -81,12 +85,15 @@ struct TopSitesSectionState: StateType, Equatable {
             return defaultState(from: state)
         }
 
+        let shouldShowSectionHeader = sites.count > state.numberOfRows * state.numberOfTilesPerRow
+
         return TopSitesSectionState(
             windowUUID: state.windowUUID,
             topSitesData: sites,
             numberOfRows: state.numberOfRows,
             numberOfTilesPerRow: state.numberOfTilesPerRow,
-            shouldShowSection: state.shouldShowSection
+            shouldShowSection: state.shouldShowSection,
+            shouldShowSectionHeader: shouldShowSectionHeader
         )
     }
 
@@ -97,12 +104,15 @@ struct TopSitesSectionState: StateType, Equatable {
             return defaultState(from: state)
         }
 
+        let shouldShowSectionHeader = state.topSitesData.count > numberOfRows * state.numberOfTilesPerRow
+
         return TopSitesSectionState(
             windowUUID: state.windowUUID,
             topSitesData: state.topSitesData,
             numberOfRows: numberOfRows,
             numberOfTilesPerRow: state.numberOfTilesPerRow,
-            shouldShowSection: state.shouldShowSection
+            shouldShowSection: state.shouldShowSection,
+            shouldShowSectionHeader: shouldShowSectionHeader
         )
     }
 
@@ -113,12 +123,15 @@ struct TopSitesSectionState: StateType, Equatable {
             return defaultState(from: state)
         }
 
+        let shouldShowSectionHeader = state.topSitesData.count > state.numberOfRows * numberOfTilesPerRow
+
         return TopSitesSectionState(
             windowUUID: state.windowUUID,
             topSitesData: state.topSitesData,
             numberOfRows: state.numberOfRows,
             numberOfTilesPerRow: numberOfTilesPerRow,
-            shouldShowSection: state.shouldShowSection
+            shouldShowSection: state.shouldShowSection,
+            shouldShowSectionHeader: shouldShowSectionHeader
         )
     }
 
@@ -134,7 +147,8 @@ struct TopSitesSectionState: StateType, Equatable {
             topSitesData: state.topSitesData,
             numberOfRows: state.numberOfRows,
             numberOfTilesPerRow: state.numberOfTilesPerRow,
-            shouldShowSection: isEnabled
+            shouldShowSection: isEnabled,
+            shouldShowSectionHeader: state.shouldShowSectionHeader
         )
     }
 
@@ -144,7 +158,8 @@ struct TopSitesSectionState: StateType, Equatable {
             topSitesData: state.topSitesData,
             numberOfRows: state.numberOfRows,
             numberOfTilesPerRow: state.numberOfTilesPerRow,
-            shouldShowSection: state.shouldShowSection
+            shouldShowSection: state.shouldShowSection,
+            shouldShowSectionHeader: state.shouldShowSectionHeader
         )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14943)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32192)

## :bulb: Description
- Conditionally show the shortcuts section header only if the total number of shortcuts exceeds the amount allowed to show on the homepage

### 📝 Technical Notes:
- Previously, we always showed the `Shortcuts` section header and corresponding `Show All` header button that would take users to the Shortcuts Library, however, the Shortcuts Library is currently a superfluous screen* if all of the shortcuts are already being shown on the homepage
- The total number of shortcuts shown on the homepage is a product of the number of rows of shortcuts the user has set to show on the homepage and the number of shortcuts shown per row (determined by homepage width)

*We may want to revisit this in the future when we introduce drag-and-drop-to-rearrange to the Shortcuts Library, as that would mean there is value in that screen, even when the total number of shortcuts does not exceed the amount allowed to show on the homepage

## :movie_camera: Demos
| Before | After |
| ------------- | ------------- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-02-25 at 18 12 09" src="https://github.com/user-attachments/assets/4c864139-1a1b-4d87-8e01-76ff5b0cad5a" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-02-25 at 18 12 16" src="https://github.com/user-attachments/assets/6152a3cc-317f-44ad-ae60-c424e8a10579" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

