### PR TITLE
Bugfix FXIOS-14971 [Deeplinks] Blank tab bugfix

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4797,9 +4797,9 @@ extension BrowserViewController: TabManagerDelegate {
             navigationHandler?.removeDocumentLoading()
         }
 
-        // Remove the old accessibilityLabel. Since this webview shouldn't be visible, it doesn't need it
-        // and having multiple views with the same label confuses tests.
-        if let previousWebView = previousTab?.webView {
+        // Remove the old accessibilityLabel only when the selected tab isn't the previous tab.
+        // When the previous webview isn't visible anymore we ensure proper clean up for tests.
+        if let previousWebView = previousTab?.webView, selectedTab != previousTab {
             previousWebView.endEditing(true)
             previousWebView.accessibilityLabel = nil
             previousWebView.accessibilityElementsHidden = true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14971)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32254)

## :bulb: Description

### Context
This is the best bug fix I've opened in the past couple months. Period. Pretty sure this is our deeplink blank tab issue from a previous incident 2 years ago. The original issue was happening when a user was opening a deeplink, it would intermittently open to a blank tab.

Previous tickets/work related to this problem were tracked with:
- [Ticket number 1](https://mozilla-hub.atlassian.net/browse/FXIOS-8461)
- [Ticket number 2](https://mozilla-hub.atlassian.net/browse/FXIOS-8558)
- [Ticket number 3](https://mozilla-hub.atlassian.net/browse/FXIOS-8581)

We were not able to reproduce the issue easily, so we were left with shots in the dark. WELL UNTIL NOW. 

### The fix
This change is really simple. The previous webview is the current webview in many occasions ([and it's safe to do so](https://github.com/mozilla-mobile/firefox-ios/blob/e96285e4e5d9bdc92a8741fcf4b5d543b8a6bfc6/firefox-ios/Client/TabManagement/TabManagerImplementation.swift#L806)), so we were removing it with the line `previousWebView.removeFromSuperview()`, hence why the webview was a blank page. There was simply no webview shown, even if it was kept in memory in all the right places. [A reload fixed the problem](https://github.com/mozilla-mobile/firefox-ios/pull/19099/changes), as it shows the webview again in the view hierarchy. Now I am pretty hopeful we can remove this whole bugfix with [this PR/ungoing work](https://github.com/mozilla-mobile/firefox-ios/pull/32288) that I am currently testing.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

