### PR TITLE
Bugfix FXIOS-15006 - [Focus iOS] - Crash when opening app from external URL

### DIFF
--- a/focus-ios/Blockzilla/BrowserViewController.swift
+++ b/focus-ios/Blockzilla/BrowserViewController.swift
@@ -1713,8 +1713,11 @@ extension BrowserViewController: LegacyWebControllerDelegate {
     }
 
     func webControllerDidStartNavigation(_ controller: LegacyWebController) {
-        if !SearchHistoryUtils.isFromURLBar && !SearchHistoryUtils.isNavigating && !SearchHistoryUtils.isReload {
-            SearchHistoryUtils.pushSearchToStack(with: (urlBar.url?.absoluteString)!)
+        if !SearchHistoryUtils.isFromURLBar &&
+            !SearchHistoryUtils.isNavigating &&
+            !SearchHistoryUtils.isReload,
+           let urlString = urlBar.url?.absoluteString {
+            SearchHistoryUtils.pushSearchToStack(with: urlString)
         }
         SearchHistoryUtils.isReload = false
         SearchHistoryUtils.isNavigating = false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15006)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32318)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

- Focus was crashing due to force unwrapping the `urlBar.url` in `webControllerDidStartNavigation`.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

