### PR TITLE
BugFix [Summarizer] FXIOS-13524 stuttering on the summarizer view

### DIFF
--- a/BrowserKit/Sources/SummarizeKit/UI/SummarizeViewModel.swift
+++ b/BrowserKit/Sources/SummarizeKit/UI/SummarizeViewModel.swift
@@ -143,7 +143,7 @@ public final class DefaultSummarizeViewModel: SummarizeViewModel {
                 await waitForUnblockSummarization()
                 revealed = true
                 try Task.checkCancellation()
-            
+
                 let now = dateProvider.currentDate()
                 // debounce updates of new chunks to avoid calling onNewData too frequently.
                 if now.timeIntervalSince(lastUpdateTime) >= Constants.showSummaryChunksDelay {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13524)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29382)

## :bulb: Description
Added a delay when showing the data from the summarizer to prevent polluting the main thread with many repeated update calls.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

