### PR TITLE
[MTE-5239] - add homepage header test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -61,6 +61,7 @@
         "ActivityStreamTest\/testContextMenuInLandscape()",
         "ActivityStreamTest\/testDefaultSitesTAE()",
         "ActivityStreamTest\/testDefaultSites_TAE()",
+        "ActivityStreamTest\/testHomepageHeader()",
         "ActivityStreamTest\/testLongTapOnTopSiteOptions()",
         "ActivityStreamTest\/testShortcutsToggle()",
         "ActivityStreamTest\/testSiteCanBeAddedToShortcuts()",

--- a/firefox-ios/firefox-ios-tests/Tests/TAESmokeTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/TAESmokeTestPlan.xctestplan
@@ -60,6 +60,7 @@
         "ActivityStreamTest\/testContextMenuInLandscape()",
         "ActivityStreamTest\/testDefaultSites()",
         "ActivityStreamTest\/testDefaultSites_TAE()",
+        "ActivityStreamTest\/testHomepageHeader()",
         "ActivityStreamTest\/testLongTapOnTopSiteOptions()",
         "ActivityStreamTest\/testShortcutsToggle()",
         "ActivityStreamTest\/testSiteCanBeAddedToShortcuts()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -21,6 +21,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
     private var tabTray: TabTrayScreen!
     private var browser: BrowserScreen!
     private var toolbar: ToolbarScreen!
+    private var homePage: HomePageScreen!
 
     typealias TopSites = AccessibilityIdentifiers.FirefoxHomepage.TopSites
     let TopSiteCellgroup = XCUIApplication().links[TopSites.itemCell]
@@ -48,6 +49,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         tabTray = TabTrayScreen(app: app)
         browser = BrowserScreen(app: app)
         toolbar = ToolbarScreen(app: app)
+        homePage = HomePageScreen(app: app)
     }
 
     override func tearDown() async throws {
@@ -350,6 +352,28 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         mozWaitForElementToNotExist(itemCell)
         mozWaitForElementToNotExist(firstWebsite)
         mozWaitForElementToNotExist(secondWebsite)
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/2861432
+    func testHomepageHeader() {
+        app.launch()
+        XCTExpectFailure("The app was not launched", strict: false) {
+            topSites.assertVisible()
+        }
+        // "Firefox" text is displayed in the header
+        homePage.validateHomePageLogo(isPrivate: false)
+        // Validate step 1 in private browsing
+        // "Firefox" text is displayed in the header of the homepage.
+        navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        homePage.validateHomePageLogo(isPrivate: true)
+        // Validate steps 1 and 2 in landscape orientation
+        XCUIDevice.shared.orientation = .landscapeLeft
+        homePage.assertPrivateHomeTitleExists()
+        homePage.validateHomePageLogo(isPrivate: true)
+        navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleExperimentRegularMode)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        homePage.validateHomePageLogo(isPrivate: false)
     }
 
     private func addWebsiteToShortcut(website: String) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomaPageScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomaPageScreen.swift
@@ -1,18 +1,27 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+import XCTest
 
 @MainActor
 final class HomePageScreen {
     private let app: XCUIApplication
     private let sel: HomePageSelectorsSet
+    private let topSitesSel: TopSitesSelectorsSet
 
     private var collection: XCUIElement { sel.COLLECTION_VIEW.element(in: app) }
     private var tabsButton: XCUIElement { sel.TABS_BUTTON.element(in: app) }
+    private var homeLogo: XCUIElement { sel.HOME_LOGO.element(in: app) }
+    private var privHomepageTitle: XCUIElement { sel.PRIVATE_HOME_TITLE.element(in: app) }
 
-    init(app: XCUIApplication, selectors: HomePageSelectorsSet = HomePageSelectors()) {
+    init(
+        app: XCUIApplication,
+        selectors: HomePageSelectorsSet = HomePageSelectors(),
+        topSitesSelectors: TopSitesSelectorsSet = TopSitesSelectors()
+    ) {
         self.app = app
         self.sel = selectors
+        self.topSitesSel = topSitesSelectors
     }
 
     func swipeToCustomizeHomeOption() {
@@ -29,5 +38,30 @@ final class HomePageScreen {
 
     func waitUntilTabsButtonHittable(timeout: TimeInterval = 2.0) {
         BaseTestCase().mozWaitElementHittable(element: tabsButton, timeout: timeout)
+    }
+
+    func assertHomeLogoExists() {
+        BaseTestCase().mozWaitForElementToExist(homeLogo)
+    }
+
+    func assertPrivateHomeTitleExists() {
+        BaseTestCase().mozWaitForElementToExist(privHomepageTitle)
+    }
+
+    func validateHomeLogoPosition(isPrivate: Bool = false) {
+        if !isPrivate {
+            XCTAssertTrue(homeLogo.isAbove(
+                element: topSitesSel.TOP_SITE_ITEM_CELL.element(in: app).firstMatch),
+                          "Firefox Home logo should be above the top sites section")
+        } else {
+            XCTAssertTrue(homeLogo.isAbove(
+                element: privHomepageTitle),
+                          "Firefox Home logo should be above the home page title in private mode")
+        }
+    }
+
+    func validateHomePageLogo(isPrivate: Bool) {
+        assertHomeLogoExists()
+        validateHomeLogoPosition(isPrivate: isPrivate)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/HomePageSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/HomePageSelectors.swift
@@ -5,6 +5,8 @@
 protocol HomePageSelectorsSet {
     var COLLECTION_VIEW: Selector { get }
     var TABS_BUTTON: Selector { get }
+    var HOME_LOGO: Selector { get }
+    var PRIVATE_HOME_TITLE: Selector { get }
     var all: [Selector] { get }
 }
 
@@ -12,6 +14,8 @@ struct HomePageSelectors: HomePageSelectorsSet {
     private enum IDs {
         static let collectionView = "FxCollectionView"
         static let tabsButton = AccessibilityIdentifiers.Toolbar.tabsButton
+        static let homeLogo = AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.logoID
+        static let privateHomepageTitle = AccessibilityIdentifiers.PrivateMode.Homepage.title
     }
 
     let COLLECTION_VIEW = Selector.collectionViewIdOrLabel(
@@ -26,5 +30,17 @@ struct HomePageSelectors: HomePageSelectorsSet {
         groups: ["homepage", "toolbar"]
     )
 
-    var all: [Selector] { [COLLECTION_VIEW, TABS_BUTTON] }
+    let HOME_LOGO = Selector.imageId(
+        IDs.homeLogo,
+        description: "Firefox Home logo image",
+        groups: ["homepage"]
+    )
+
+    let PRIVATE_HOME_TITLE = Selector.staticTextId(
+        IDs.privateHomepageTitle,
+        description: "Title of the private browsing homepage",
+        groups: ["homepage", "private_browsing"]
+    )
+
+    var all: [Selector] { [COLLECTION_VIEW, TABS_BUTTON, HOME_LOGO, PRIVATE_HOME_TITLE] }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -170,7 +170,6 @@ class ToolbarTests: FeatureFlaggedTestBase {
             mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
             mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
             if !isPrivate {
-                mozWaitForElementToExist(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.topSites])
                 mozWaitForElementToExist(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.merino])
             }
             navigator.nowAt(BrowserTab)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5239

## :bulb: Description
Add test for homepage header: https://mozilla.testrail.io/index.php?/cases/view/2861432
Small fix for  testOpenNewTabButtonOnToolbar, by removing the validation for the old top sites title that has been replaced with the firefox logo, validated on the new test.
