### PR TITLE
Refactor FXiOS-14532 [Performance] Delay keyboard work to the next run loop to improve performance

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5188,38 +5188,35 @@ extension BrowserViewController {
 
 extension BrowserViewController: KeyboardHelperDelegate {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
-        // Defer observer work to the next run loop to not compete with keyboard showing
-        DispatchQueue.main.async { [self] in
-            keyboardState = state
+        keyboardState = state
 
-            if !isSnapKitRemovalEnabled {
-                updateViewConstraints()
-            } else {
-                updateOverKeyboardContainerConstraints()
-                updateConstraintsForKeyboard()
-            }
+        if !isSnapKitRemovalEnabled {
+            updateViewConstraints()
+        } else {
+            updateOverKeyboardContainerConstraints()
+            updateConstraintsForKeyboard()
+        }
 
-            if isSwipingTabsEnabled {
-                addressToolbarContainer.hideSkeletonBars()
-            }
+        if isSwipingTabsEnabled {
+            addressToolbarContainer.hideSkeletonBars()
+        }
 
-            UIView.animate(
-                withDuration: state.animationDuration,
-                delay: 0,
-                options: [UIView.AnimationOptions(rawValue: UInt(state.animationCurve.rawValue << 16))],
-                animations: {
-                    self.bottomContentStackView.layoutIfNeeded()
-                })
+        UIView.animate(
+            withDuration: state.animationDuration,
+            delay: 0,
+            options: [UIView.AnimationOptions(rawValue: UInt(state.animationCurve.rawValue << 16))],
+            animations: {
+                self.bottomContentStackView.layoutIfNeeded()
+            })
 
-            if isToolbarTranslucencyRefactorEnabled {
-                // When animation duration is zero the keyboard is already showing and we don't need
-                // to update the toolbar again. This is the case when we are moving between fields in a form.
-                if state.animationDuration > 0 {
-                    updateToolbarDisplay()
-                }
-            } else {
+        if isToolbarTranslucencyRefactorEnabled {
+            // When animation duration is zero the keyboard is already showing and we don't need
+            // to update the toolbar again. This is the case when we are moving between fields in a form.
+            if state.animationDuration > 0 {
                 updateToolbarDisplay()
             }
+        } else {
+            updateToolbarDisplay()
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14532)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31439)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Move some work to the next run loop to not interfere with the expensive call of `locationView.becomeFirstResponder`

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->
Before:
<img width="1662" height="625" alt="Screenshot 2026-03-02 at 3 18 05 PM" src="https://github.com/user-attachments/assets/3fb9223e-d3cd-4801-88dc-9bb5cf20b9bf" />

After:
<img width="507" height="506" alt="Screenshot 2026-03-02 at 2 55 27 PM" src="https://github.com/user-attachments/assets/79109b27-f358-451e-aee5-9fde3f2422f0" />

UI still work as expected: 
https://github.com/user-attachments/assets/0567905a-53cc-4e4b-82ff-e37a9ed0b5a6

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

