### PR TITLE
Bugfix FXIOS-15004 [Homepage] Homepage stories layout stutter

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -551,9 +551,10 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         let homepageState = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID)
         let collectionViewHeight = environment.container.contentSize.height
 
-        // If something went wrong with our availableContentHeight calculation in BVC, fall back to just using the actual
-        // collection view height
-        let availableContentHeight = homepageState?.availableContentHeight ?? collectionViewHeight
+        // If something went wrong with our availableContentHeight calculation in BVC, or the value has not been
+        // initialized yet, fall back to the actual collection view height.
+        let availableContentHeight = homepageState?.availableContentHeight ?? 0
+        let height = availableContentHeight > 0 ? availableContentHeight : collectionViewHeight
 
         // Calculate each individual sections height
         // Note: If showing vertical stories, no need to calculate stories height, since that is handled by
@@ -567,7 +568,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         let searchBarHeight = getSearchBarSectionHeight(environment: environment)
 
         // Calculate the spacer height, which is determined by the total height available minus the height of each section
-        let rawSpacerHeight = availableContentHeight
+        let rawSpacerHeight = height
             - UX.topSpacing
             - headerLogoHeight
             - privacyNoticeHeight


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15004)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32316)

## :bulb: Description
- Fix a startup layout jitter on homepage where the stories section briefly appears directly under shortcuts, then jumps down.

### 📝 Technical Notes:
- This was caused by the spacer section being rendered before `availableContentHeight` was initialized in BVC, causing it to compute to 0 and collapsing for the first frame.
- Now we fallback to the height of the homepage collection view if `availableContentHeight` is `0` in `HomepageSectionLayoutProvider::createSpacerSectionLayout()`

## :movie_camera: Demos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/d7c7d1d6-9ce0-4391-86ab-8359c069f0b0

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/3778074d-0cb8-414e-8fbc-3cff6ac2609b

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

