### PR TITLE
Bugfix FXIOS-15023 [Tab tray] Cannot use the toolbar on iOS 17.5 after opening a website

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -167,6 +167,10 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         context.containerView.addSubview(backgroundView)
         context.containerView.addSubview(bvcSnapshot)
 
+        // this masks the timing issue with the redux state update to TabDisplayView
+        // otherwise the selected tab won't be found in the diffable data source
+        destinationController.view.frame = finalFrame
+        destinationController.view.layoutIfNeeded()
 
         // Don't block the UI rendering with the animation to make the snapshotting code more performant
         DispatchQueue.main.async {
@@ -199,8 +203,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             collectionView.transform = CGAffineTransform(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
             collectionView.alpha = UX.halfAlpha
 
-            destinationController.view.frame = finalFrame
-            destinationController.view.layoutIfNeeded()
             self.performPresentationAnimation(
                 cellFrame: cellFrame,
                 tabCell: tabCell,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15023)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32355)

## :bulb: Description
Updates the tab tray animation to fail more gracefully. This is a quick fix - a [ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15027) to investigate a better solution was created.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

