### PR TITLE
Add FXIOS-14940 [News Transition] feature flag

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -26,6 +26,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case hntSponsoredShortcuts
     case homepageBookmarksSectionDefault
     case homepageJumpBackinSectionDefault
+    case homepageNewsTransition
     case homepageSearchBar
     case homepageStoriesScrollDirection
     case homepageStoryCategories
@@ -89,6 +90,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .deeplinkOptimizationRefactor,
                 .defaultZoomFeature,
                 .downloadLiveActivities,
+                .homepageNewsTransition,
                 .homepageSearchBar,
                 .homepageStoryCategories,
                 .hostedSummarizer,
@@ -168,6 +170,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .feltPrivacyFeltDeletion,
                 .feltPrivacySimplifiedUI,
                 .firefoxJpGuideDefaultSite,
+                .homepageNewsTransition,
                 .homepageSearchBar,
                 .homepageStoriesScrollDirection,
                 .homepageStoryCategories,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -87,6 +87,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .homepageNewsTransition,
+                titleText: format(string: "Homepage News Transition"),
+                statusText: format(string: "Toggle to enable the homepage news transition")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .homepageSearchBar,
                 titleText: format(string: "Homepage Search Bar"),
                 statusText: format(string: "Toggle to enable homepage search bar for redesign")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -55,17 +55,20 @@ final class NimbusFeatureFlagLayer: Sendable {
         case .homepageBookmarksSectionDefault:
             return checkHomepageBookmarksSectionDefault(from: nimbus)
 
-        case .homepageStoryCategories:
-            return checkHomepageStoriesCaterogiesFeature(from: nimbus)
-
         case .homepageJumpBackinSectionDefault:
             return checkHomepageJumpBackInSectionDefault(from: nimbus)
+
+        case .homepageNewsTransition:
+            return checkHomepageNewsTransitionFeature(from: nimbus)
 
         case .homepageSearchBar:
             return checkHomepageSearchBarFeature(from: nimbus)
 
         case .homepageStoriesScrollDirection:
             return checkHomepageStoriesScrollDirectionFeature(from: nimbus) != .baseline
+
+        case .homepageStoryCategories:
+            return checkHomepageStoriesCaterogiesFeature(from: nimbus)
 
         case .needsReloadRefactor:
             return checkNeedsReloadRefactorFeature(from: nimbus)
@@ -254,16 +257,20 @@ final class NimbusFeatureFlagLayer: Sendable {
         return nimbus.features.homepageRedesignFeature.value().bookmarksSectionDefault
     }
 
-    private func checkHomepageStoriesCaterogiesFeature(from nimbus: FxNimbus) -> Bool {
-        return nimbus.features.homepageRedesignFeature.value().categoriesEnabled
-    }
-
     private func checkHomepageJumpBackInSectionDefault(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.homepageRedesignFeature.value().jbiSectionDefault
     }
 
+    private func checkHomepageNewsTransitionFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.homepageRedesignFeature.value().newsTransition
+    }
+
     private func checkHomepageSearchBarFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.homepageRedesignFeature.value().searchBar
+    }
+
+    private func checkHomepageStoriesCaterogiesFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.homepageRedesignFeature.value().categoriesEnabled
     }
 
     private func checkHomepageStoriesScrollDirectionFeature(from nimbus: FxNimbus) -> ScrollDirection {

--- a/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
@@ -29,6 +29,11 @@ features:
           If true, enables the categories flow in the stories
         type: Boolean
         default: false
+      news-transition:
+        description: >
+          If true, enables the news transition for stories on the homepage
+        type: Boolean
+        default: false
 
     defaults:
       - channel: beta
@@ -38,6 +43,7 @@ features:
           bookmarks-section-default: false
           jbi-section-default: false
           categories-enabled: false
+          news-transition: false
 
       - channel: developer
         value:
@@ -46,6 +52,7 @@ features:
           bookmarks-section-default: false
           jbi-section-default: false
           categories-enabled: false
+          news-transition: false
 
 enums:
   ScrollDirection:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14940)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32188)

## :bulb: Description
- Add the `news-transition` variable to the `homepage-redesign-feature` nimbus feature flag

### 📝 Technical Notes:
- This feature contains strings that were introduced in v149, so it should not be enabled in nimbus until that version is released

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code