### PR TITLE
[FXIOS-15029, 15036] Fix Autofill JS email focus callback for some website regsitration forms

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
@@ -546,7 +546,7 @@ window.__firefox__.includeOnce("LoginsHelper", function() {
       webkit.messageHandlers.loginsManagerMessageHandler.postMessage({
         type: "generatePassword",
       });
-    } else if (!isEmail && !formHasNewPassword && (password || updatedPasswordManagerEnabled)) {
+    } else if (isLoginField && !formHasNewPassword && (password || updatedPasswordManagerEnabled)) {
       webkit.messageHandlers.loginsManagerMessageHandler.postMessage({
         type: "fieldType",
         fieldType:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15029)

## :bulb: Description

@issammani I am not well-versed with our Autofill JS, but the issue seems to be that we have some login-specific checks that are interfering on some email registration forms.

The changes here:
- Skip the early return for `isLoginField` if the focused field appears to be email
- Avoids dropping into the username/password conditional if we can see the field looks like an email field

These changes fix the bug in the problematic sites I've tested so far, but I'd love some extra eyes on this, since I'm not a Javascript expert and I don't have much context on some of the logic for our Autofill code. I want to make sure that there isn't a risk of regressing or causing issues with other Autofill behaviors for e.g. standard login forms.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

