### PR TITLE
Add FXIOS-15033 [Performance] Cache normal/private tabs to avoid redundant O(n) filters on every access

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -36,11 +36,11 @@ class TabManagerImplementation: NSObject,
     private(set) var tabs: [Tab] {
         didSet {
             // Invalidate cache on every mutation to keep it always updated.
-            _tabSplitCache = nil
+            tabsInternalCache = nil
         }
     }
 
-    private var _tabSplitCache: (normal: [Tab], private: [Tab])?
+    private var tabsInternalCache: (normal: [Tab], private: [Tab])?
 
     var isDeeplinkOptimizationRefactorEnabled: Bool {
         return featureFlags.isFeatureEnabled(.deeplinkOptimizationRefactor, checking: .buildOnly)
@@ -169,13 +169,19 @@ class TabManagerImplementation: NSObject,
     /// Single O(n) pass that splits `tabs` into normal and private lists.
     /// Result is cached until the next `tabs` mutation.
     private func tabSplit() -> (normal: [Tab], private: [Tab]) {
-        if let cached = _tabSplitCache { return cached }
+        if let cached = tabsInternalCache { return cached }
         var normalTabs = [Tab]()
         var privateTabs = [Tab]()
         normalTabs.reserveCapacity(tabs.count)
-        for tab in tabs { if tab.isPrivate { privateTabs.append(tab) } else { normalTabs.append(tab) } }
+        for tab in tabs {
+            if tab.isPrivate {
+                privateTabs.append(tab)
+            } else {
+                normalTabs.append(tab)
+            }
+        }
         let result = (normal: normalTabs, private: privateTabs)
-        _tabSplitCache = result
+        tabsInternalCache = result
         return result
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -1515,9 +1515,9 @@ final class TabManagerTests: XCTestCase {
          let subject = createSubject(tabs: tabs)
 
          _ = subject.normalTabs
-         _ = subject.privateTabs // should hit same cache, not recompute
+         _ = subject.privateTabs // Should hit the same cache, does not recompute.
 
-         subject.removeTab(tabs[0].tabUUID)  // invalidate
+         subject.removeTab(tabs[0].tabUUID) // Invalidates the internal cache.
 
          let normalTabs = subject.normalTabs
          let privateTabs = subject.privateTabs


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15033)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32376)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- `normalTabs` and `privateTabs` are accessed frequently across many classes.
- Previously every call to `normalTabs` or `privateTabs` triggered a separate `O(n)` filter. Now both are computed in a single `O(n)` pass and cached until `tabs` changes.
- Wrote unit tests.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

