### PR TITLE
[MTE-5247] fix for testHomepageHeader test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -369,6 +369,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         homePage.validateHomePageLogo(isPrivate: true)
         // Validate steps 1 and 2 in landscape orientation
         XCUIDevice.shared.orientation = .landscapeLeft
+        waitForRotation(to: .landscapeLeft)
         homePage.assertPrivateHomeTitleExists()
         homePage.validateHomePageLogo(isPrivate: true)
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleExperimentRegularMode)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -541,6 +541,62 @@ class BaseTestCase: XCTestCase {
             mozWaitForElementToExist(dragElement)
         }
     }
+
+    /// Wait until the app has fully rotated to the requested orientation.
+     /// - Parameters:
+     ///   - orientation: desired `UIDeviceOrientation`
+     ///   - timeout: max time to wait.
+     ///   - pollInterval: how often to re-check.
+    func waitForRotation(
+        to orientation: UIDeviceOrientation,
+        timeout: TimeInterval = 5.0,
+        pollInterval: TimeInterval = 0.1
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        var stableCount = 0
+        let requiredStable = 2
+
+        // Helper to check frame matches expected orientation
+        func frameMatchesOrientation(_ frame: CGRect, for orientation: UIDeviceOrientation) -> Bool {
+            switch orientation {
+            case .landscapeLeft, .landscapeRight:
+                return frame.width > frame.height
+            case .portrait, .portraitUpsideDown:
+                return frame.height > frame.width
+            default:
+                return false
+            }
+        }
+
+        while Date() < deadline {
+            let deviceOrientation = XCUIDevice.shared.orientation
+            let window = app.windows.firstMatch
+
+            if window.exists {
+                let frame = window.frame
+                // Check both device reported orientation and window frame alignment.
+                if deviceOrientation == orientation || (
+                    (orientation.isLandscape && deviceOrientation.isLandscape) ||
+                    (orientation.isPortrait && deviceOrientation.isPortrait)
+                ) {
+                    if frameMatchesOrientation(frame, for: orientation) {
+                        stableCount += 1
+                        if stableCount >= requiredStable { return } // rotation finished and stable
+                    } else {
+                        stableCount = 0
+                    }
+                } else {
+                    stableCount = 0
+                }
+            } else {
+                stableCount = 0
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(pollInterval))
+        }
+
+        XCTFail("Timed out waiting for app to rotate to \(orientation)")
+    }
 }
 
 class IpadOnlyTestCase: BaseTestCase {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5247

## :bulb: Description
Adding support to fully wait when the device rotates in landscape or portrait.
testHomepageHeader test was flaky because the app didn't wait for this rotation to fully happen and started to validate elements that were not positioned in the right place yet.

