### PR TITLE
Add FXIOS-13721 Add progress bar for ToU webview

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseLinkViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseLinkViewController.swift
@@ -160,14 +160,12 @@ final class TermsOfUseLinkViewController: UIViewController,
         let displayedProgress = min(max(0.0, progress), maximumProgress)
         guard displayedProgress >= Double(progressBar.progress) else { return }
 
-        progressBar.alpha = 1
         progressBar.isHidden = false
         progressBar.setProgress(Float(displayedProgress), animated: true)
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation?) {
         isLoading = true
-        progressBar.alpha = 1
         progressBar.isHidden = false
         progressBar.setProgress(0, animated: false)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13721)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29767)

## :bulb: Description
This PR adds the page load progress bar UI component also for ToU links webview.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

