### PR TITLE
Bugfix FXIOS-14272 ⁃ [Top 10 Bugs] Private browsing mode's toolbar buttons intermittently have no icon symbols when Reduced Transparency is enabled

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -263,6 +263,10 @@ final class TabTrayViewController: UIViewController,
         }
     }
 
+    public var isReduceTransparencyEnabled: Bool {
+        UIAccessibility.isReduceTransparencyEnabled
+    }
+
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
 
@@ -482,7 +486,9 @@ final class TabTrayViewController: UIViewController,
     private func setupToolBarAppearance(theme: Theme) {
         guard tabTrayUtils.isTabTrayUIExperimentsEnabled else { return }
 
-        if #available(iOS 26, *) { return }
+        // When Reduce Transparency is on, fall through to set a solid
+        // appearance so button backgrounds use the correct theme color.
+        if #available(iOS 26, *), !isReduceTransparencyEnabled { return }
 
         let backgroundAlpha = tabTrayUtils.backgroundAlpha()
         let color = theme.colors.layer1.withAlphaComponent(backgroundAlpha)
@@ -533,6 +539,7 @@ final class TabTrayViewController: UIViewController,
         navigationItem.titleView = nil
         updateTitle()
         view.addSubviews(containerView)
+
         if tabTrayUtils.shouldDisplayExperimentUI() {
             containerView.addSubview(panelContainer)
             containerView.addSubview(segmentedControl)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14272)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30896)

## :bulb: Description
- Fix bug forcing to `setupToolBarAppearance` when Reduce transparency  is enabled 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

https://github.com/user-attachments/assets/fe53c337-ab17-434c-a2e5-131e4fc66e79


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

