### PR TITLE
Bugfix FXIOS-15064 [Top 10 Bugs] Pull to refresh icon is visible after webpage finish loading

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
@@ -119,13 +119,13 @@ class PullRefreshView: UIView,
             updateElementAlpha()
         }
 
-        if refreshIconHasFocus {
-            refreshIconHasFocus = false
-            easterEggGif?.removeFromSuperview()
-            easterEggGif = nil
-            scrollObserver?.invalidate()
-            triggerReloadAnimation()
-        }
+        guard refreshIconHasFocus else { return }
+
+        refreshIconHasFocus = false
+        easterEggGif?.removeFromSuperview()
+        easterEggGif = nil
+        scrollObserver?.invalidate()
+        triggerReloadAnimation()
     }
 
     private func handleScrollViewDragging() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15064)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32432)

## :bulb: Description
- Fix pull-to-refresh progressView alpha initial value.
- Refactor `startObservingContentScroll` function for readability


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

