### PR TITLE
Add [Summarizer] FXIOS-15069 required strings for s2s UI components

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -7419,7 +7419,7 @@ extension String {
         public static let ReaderModeWithSummarizerButtonAccessibilityLabel = MZLocalizedString(
             key: "Toolbar.ReaderModeWithSummarizer.Button.v150",
             tableName: "Toolbar",
-            value: "Reader View. Page summarization available.",
+            value: "Reader View. Page summary available.",
             comment: "Accessibility label for the reader view button with a bottom badge that indicates that the summary is available for the page. The button is displayed in the address bar.")
 
         public struct Translation {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15069)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32442)

## :bulb: Description
Added required strings for s2s UI components.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

