### PR TITLE
Bugfix FXIOS-14890 [Top 10 Bugs] Reader view mode shifts domain name in the address bar shifts to the right

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -195,6 +195,11 @@ final class LocationView: UIView,
         configureLockIconButton(config)
         configureURLTextField(config)
         configureA11y(config)
+
+        // Must be called before updateIconContainer. The overflow check inside updateIconContainer measures
+        // urlTextField.text to determine layout; without this call the text still holds the raw URL instead
+        // of the normalized host, causing overflow to trigger incorrectly in reader mode
+        // and producing a visible shift when the lock icon is hidden.
         formatAndTruncateURLTextField()
         updateIconContainer(isURLTextFieldCentered: isURLTextFieldCentered,
                             locationTextFieldTrailingPadding: uxConfig.locationTextFieldTrailingPadding)
@@ -548,6 +553,11 @@ final class LocationView: UIView,
         urlAbsolutePath = config.url?.absoluteString
     }
 
+    /// Updates the URL text field (when not editing) by:
+    /// - Extracting the subdomain and normalized host.
+    /// - Applying primary color to the host and secondary color to the subdomain.
+    /// - Truncating from the head if the text is too long.
+    /// - Setting the styled result as the text field's attributed text.
     private func formatAndTruncateURLTextField() {
         guard !isEditing else { return }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14890)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32094)

## :bulb: Description
Adds back `formatAndTruncateURLTextField` to avoid url text change, the call was removed in [31664](https://github.com/mozilla-mobile/firefox-ios/pull/31664).

This call is needed because `formatAndTruncateURLTextField` normalizes the URL to just the host (_wikipedia.org_) instead of the full URL (_https://en.m.wikipedia.org/wiki/Article_Name_). A subsequent call calculates the overflow of the text and adjusts the leading constraint of the textfield based on the URL. For reader mode URLs  this returns truemost of the time, triggering constraint changes that visibly shifted the textfield position.

Note: There is still a small shift due to the removal of the shield icon but I compare with previous builds and the shift was also visible. I also tested that there is no regression concerning [31664](https://github.com/mozilla-mobile/firefox-ios/pull/31664)


## :movie_camera: Demos

https://github.com/user-attachments/assets/ae3c1246-1412-4f66-b2d8-d6fc53923bac


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

