### PR TITLE
[MTE-5250]-Fix testLongTapFirefoxIconOpenLastBookmark test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -629,7 +629,7 @@ class NavigationTest: BaseTestCase {
         // Open and bookmark a page
         navigator.openURL(website_1["url"]!)
         waitUntilPageLoad()
-        bookmark()
+        bookmark(isLockIconOff: false)
 
         // Terminate app and go to springboard
         app.terminate()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5250

## :bulb: Description
Small fix for navigation test that started to fail due to the recent changes on the lock icon accessibility identifiers.
