### PR TITLE
Refactor FXIOS-14784 [Tab manager] Small improvements for configuration

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -521,6 +521,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     func createWebview(with restoreSessionData: Data? = nil, configuration: WKWebViewConfiguration) {
         self.configuration = configuration
         if webView == nil {
+            configuration.userContentController = WKUserContentController()
             let webView = TabWebView(frame: .zero, configuration: configuration, windowUUID: windowUUID)
             webView.configure(delegate: self, navigationDelegate: navigationDelegate)
             webView.accessibilityLabel = .WebViewAccessibilityLabel


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14784)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31908)

## :bulb: Description
We shoud be able to remove this code [since it's part](https://github.com/mozilla-mobile/firefox-ios/blob/cc2a153ede0251445b0217f1e2bad56f526bac97/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift#L69-L70) of the `DefaultWKEngineConfigurationProvider` that we use to create the configuration.
```
            configuration.userContentController = WKUserContentController()
            configuration.allowsInlineMediaPlayback = true
```

And then I am also creating a new method under `TabWebView` to `removeAllUserScripts`. Just so we don't have to access the `configuration.userContentController` from the `Tab` itself.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

