### PR TITLE
Refactor MTE-5219 XCUITest performance improvements

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -69,7 +69,7 @@ class BaseTestCase: XCTestCase {
     func closeFromAppSwitcherAndRelaunch() {
         let swipeStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.999))
         let swipeEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.001))
-        sleep(2)
+        _ = app.wait(for: .runningForeground, timeout: TIMEOUT)
         swipeStart.press(forDuration: 0.1, thenDragTo: swipeEnd)
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         mozWaitForElementToExist(springboard.icons["XCUITests-Runner"])
@@ -485,8 +485,7 @@ class BaseTestCase: XCTestCase {
         app.buttons["Close"].tapIfExists()
         navigator.goto(SettingsScreen)
         navigator.goto(DisplaySettings)
-        sleep(3)
-        if !app.navigationBars["Appearance"].exists {
+        if !app.navigationBars["Appearance"].waitForExistence(timeout: TIMEOUT) {
             navigator.goto(DisplaySettings)
         }
         mozWaitForElementToExist(app.navigationBars["Appearance"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
@@ -426,17 +426,16 @@ class O_AddressesTests: BaseTestCase {
         settingsScreen.validateAutofillPasswordOptions()
         settingsScreen.rotateDevice(to: .portrait)
         // While in dark mode check for the options
-        sleep(1)
         exitAutofillSettingsToNewTab()
         // Adding sleep to avoid loading screen on bitrise
-        sleep(3)
+        toolbar.assertSettingsButtonExists()
         switchThemeToDarkOrLight(theme: "Dark")
         navigateToAutofillPasswordSettingsScreen()
         settingsScreen.validateAutofillPasswordOptions()
         // While in light mode check for the options
         exitAutofillSettingsToNewTab()
         // Adding sleep to avoid loading screen on bitrise
-        sleep(3)
+        toolbar.assertSettingsButtonExists()
         switchThemeToDarkOrLight(theme: "Light")
         navigateToAutofillPasswordSettingsScreen()
         settingsScreen.validateAutofillPasswordOptions()
@@ -592,20 +591,7 @@ class O_AddressesTests: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         navigator.goto(AddressesSettings)
-        let addresses = AccessibilityIdentifiers.Settings.Address.Addresses.self
-        sleep(4)
-        if !app.navigationBars[addresses.title].exists {
-            navigator.goto(AddressesSettings)
-        }
-        app.buttons[addresses.addAddress].waitAndTap()
-        mozWaitForElementToExist(app.navigationBars[addresses.addAddress])
-        var attempts = 3
-        while !app.staticTexts["Name"].exists && attempts > 0 {
-            app.buttons["Close"].tapIfExists()
-            app.buttons[addresses.addAddress].tapIfExists()
-            attempts -= 1
-        }
-        mozWaitForElementToExist(app.staticTexts["Name"])
+        addressScreen.reachAddNewAddressScreen()
     }
 
     private func addNewAddress() {
@@ -764,7 +750,7 @@ class O_AddressesTests: BaseTestCase {
 
     private func retryTypingText(element: XCUIElement, textField: String) {
         var nrOfTaps = 5
-        sleep(3)
+        mozWaitElementHittable(element: element, timeout: TIMEOUT)
         while !element.isVisible() && nrOfTaps > 0 {
             element.tapIfExists()
             nrOfTaps -= 1

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
@@ -103,7 +103,7 @@ final class CookiePersistenceTests: BaseTestCase {
         app.terminate()
 
         // Wait a moment if needed (optional but sometimes helpful)
-        sleep(1)
+        _ = app.wait(for: .notRunning, timeout: TIMEOUT)
 
         // Launch it again
         app.launch()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -192,12 +192,13 @@ private extension BaseTestCase {
             XCTFail("Neither Top Tabs nor Tab Tray collection view is present", file: file, line: line)
             return
         }
-        let firstTabCell = collectionView.cells.element(boundBy: 0).label
-        let secondTabCell = collectionView.cells.element(boundBy: 1).label
 
         if dragAndDropTab {
-            sleep(2)
+            tabTrayScreen.waitForTabCells()
         }
+
+        let firstTabCell = collectionView.cells.element(boundBy: 0).label
+        let secondTabCell = collectionView.cells.element(boundBy: 1).label
 
         let context = dragAndDropTab ? "after" : "before"
         XCTAssertEqual(firstTabCell, firstTab, "first tab \(context) is not correct", file: file, line: line)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
@@ -21,15 +21,12 @@ final class SettingScreen {
 
     func closeSettingsWithDoneButton() {
         let doneButton = sel.DONE_BUTTON.element(in: app)
+        BaseTestCase().mozWaitElementHittable(element: doneButton, timeout: TIMEOUT)
         doneButton.waitAndTap()
     }
 
     func rotateDevice(to orientation: UIDeviceOrientation) {
         XCUIDevice.shared.orientation = orientation
-    }
-
-    func switchTheme(to theme: String) {
-        BaseTestCase().switchThemeToDarkOrLight(theme: theme)
     }
 
     func validatePrivacyOptions(timeout: TimeInterval = TIMEOUT_LONG) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
@@ -157,9 +157,8 @@ final class TabTrayScreen {
             BaseTestCase().waitForElementsToExist(cells)
 
             if afterDragAndDrop {
-                sleep(2)
+                waitForTabCells()
             }
-
             let firstTabLabel = cells[0].label
             let secondTabLabel = cells[1].label
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -587,7 +587,7 @@ class TodayWidgetTests: BaseTestCase {
         UIPasteboard.general.string = copiedString
         app.terminate()
 
-        sleep(3)
+        _ = app.wait(for: .notRunning, timeout: TIMEOUT)
 
         goToTodayWidgetPage()
         // Remove Firefox Widget if it already exists
@@ -614,7 +614,6 @@ class TodayWidgetTests: BaseTestCase {
             format: "label CONTAINS[c] %@", "Copied Link")
         ).element.waitAndTap()
 
-        sleep(2)
         mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: TIMEOUT)
         springboard.alerts.buttons["Allow Paste"].waitAndTap()
         skipOnboardingIfNeeded(app: app)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -73,7 +73,10 @@ class TrackingProtectionTests: BaseTestCase {
     func checkTrackingProtectionOn() -> Bool {
         var trackingProtection = true
         if iPad() {
-            sleep(1)
+            mozWaitElementHittable(
+                element: app.buttons[AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon],
+                timeout: TIMEOUT
+            )
         }
         if app.buttons[AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon].label
             == secureTrackingProtectionOffLabel {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5219)

## :bulb: Description
- Replace hardcoded `sleep()` calls with state-based or element-based waits across XCUITests to reduce total test execution time and improve reliability on slow CI environments (Bitrise)
  - Fix misplaced waits where labels were read before the sleep had any effect
  - Remove dead code and no-op sleeps

  ## Changes

  **BaseTestCase**
  - `closeFromAppSwitcherAndRelaunch()`: replace `sleep(2)` with `app.wait(for: .runningForeground, timeout: TIMEOUT)`
  - `switchThemeToDarkOrLight()`: replace `sleep(3)` + immediate `.exists` check with `waitForExistence(timeout: TIMEOUT)` before retry

  **PageScreens/SettingScreen**
  - `closeSettingsWithDoneButton()`: add `mozWaitElementHittable` before tap to handle post-rotation state
  - Remove unused dead code `switchTheme(to:)`

  **PageScreens/AddressScreen**
  - `retryTypingText()`: replace `sleep(1)` with `mozWaitElementHittable`

  **C_AddressesTests**
  - `testAddressOptionIsAvailableInSettingsMenu()`: replace `sleep(1)` +
    `sleep(3)` x2 with `settingsScreen.closeSettingsWithDoneButton()` and `toolbar.assertSettingsButtonExists()`
  - `reachAddNewAddressScreen()`: eliminate `sleep(4)` by delegating fully to  `addressScreen.reachAddNewAddressScreen()` (POM)

  **CookiePersistenceTests**
  - `relaunchApp()`: replace `sleep(1)` with `app.wait(for: .notRunning, timeout: TIMEOUT)`

  **TodayWidgetTests**
  - `testFxShortcutGoToCopiedLinkWidget()`: replace `sleep(3)` after `app.terminate()` with `app.wait(for: .notRunning, timeout: TIMEOUT)`; remove redundant `sleep(2)` before `mozWaitElementHittable

**DragAndDropTests / TabTrayScreen**
  - `checkTabsOrder()`: fix misplaced sleep — move `waitForTabCells()` before reading cell labels instead of after

  **TrackingProtectionTests**
  - `checkTrackingProtectionOn()`: replace `sleep(1)` (iPad only) with
    `mozWaitElementHittable` on lock icon before reading its label

  **registerTabMenuNavigation**
  - Remove `sleep(1)` no-op executed during ScreenGraph setup, not at runtime

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

