### PR TITLE
Refactor FXIOS-14784 [Tab manager] Creating TabContentScriptManager & TabWebView files

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -865,6 +865,8 @@
 		8A09BCC32D22F1BE00CFDF60 /* ContextMenuCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A09BCC22D22F1BE00CFDF60 /* ContextMenuCoordinatorTests.swift */; };
 		8A0A1BA02B2200FD00E8706F /* PrivateHomepageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0A1B9F2B2200FD00E8706F /* PrivateHomepageViewController.swift */; };
 		8A0A1BA32B22030100E8706F /* PrivateMessageCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0A1BA22B22030100E8706F /* PrivateMessageCardCell.swift */; };
+		8A0A7C2D2F61E3E600D00820 /* TabContentScriptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0A7C2C2F61E3E400D00820 /* TabContentScriptManager.swift */; };
+		8A0A7C402F61F03500D00820 /* TabWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0A7C3F2F61F03200D00820 /* TabWebView.swift */; };
 		8A0D32842A61E1CC007D976D /* StatusBarOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */; };
 		8A0DF2C22D6D1C670066EC00 /* AutoplaySettingTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0DF2C12D6D1C670066EC00 /* AutoplaySettingTelemetry.swift */; };
 		8A106D632D416F82009AD7E4 /* MessageCardMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A106D622D416F82009AD7E4 /* MessageCardMiddlewareTests.swift */; };
@@ -8977,6 +8979,8 @@
 		8A09BCC22D22F1BE00CFDF60 /* ContextMenuCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A0A1B9F2B2200FD00E8706F /* PrivateHomepageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateHomepageViewController.swift; sourceTree = "<group>"; };
 		8A0A1BA22B22030100E8706F /* PrivateMessageCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateMessageCardCell.swift; sourceTree = "<group>"; };
+		8A0A7C2C2F61E3E400D00820 /* TabContentScriptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabContentScriptManager.swift; sourceTree = "<group>"; };
+		8A0A7C3F2F61F03200D00820 /* TabWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabWebView.swift; sourceTree = "<group>"; };
 		8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarOverlay.swift; sourceTree = "<group>"; };
 		8A0DF2C12D6D1C670066EC00 /* AutoplaySettingTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoplaySettingTelemetry.swift; sourceTree = "<group>"; };
 		8A0E5F3D2BFBA49400DE052B /* MicrosurveyCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -13518,19 +13522,21 @@
 		8A590C6228C13E1D0032F1AA /* TabManagement */ = {
 			isa = PBXGroup;
 			children = (
-				61C92A002DEF39F9004ACF49 /* TabConfigurationProvider.swift */,
 				0B1278DF2DDB1D6E00406656 /* BackForwardList.swift */,
-				D3A994961A3686BD008AD1AC /* Tab.swift */,
-				5A64225029CB506500EEC3E5 /* TabManagerDelegate.swift */,
-				C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */,
-				39455F761FC83F430088A22C /* TabEventHandler.swift */,
+				0B7B957B2DCA305D007DC749 /* Document */,
 				39F819C51FD70F5D009E31E4 /* GlobalTabEventHandlers.swift */,
+				D3A994961A3686BD008AD1AC /* Tab.swift */,
+				C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */,
+				61C92A002DEF39F9004ACF49 /* TabConfigurationProvider.swift */,
+				8A0A7C2C2F61E3E400D00820 /* TabContentScriptManager.swift */,
+				39455F761FC83F430088A22C /* TabEventHandler.swift */,
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
+				5A64225029CB506500EEC3E5 /* TabManagerDelegate.swift */,
 				5A8017DF29CE15D90047120D /* TabManagerImplementation.swift */,
-				1D558A592BEE7D07001EF527 /* WindowSimpleTabsCoordinator.swift */,
+				8A0A7C3F2F61F03200D00820 /* TabWebView.swift */,
 				BD0D40792D83124E00C38511 /* TabWebViewPreview.swift */,
 				BDE2DB322DB1024E002FAE26 /* TabWebViewPreviewAppearanceConfiguration.swift */,
-				0B7B957B2DCA305D007DC749 /* Document */,
+				1D558A592BEE7D07001EF527 /* WindowSimpleTabsCoordinator.swift */,
 			);
 			path = TabManagement;
 			sourceTree = "<group>";
@@ -18864,6 +18870,7 @@
 				D0E89A2920910917001CE5C7 /* DownloadsPanel.swift in Sources */,
 				D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */,
 				8AC0B1C02D1D935C004237FD /* ContextMenuConfiguration.swift in Sources */,
+				8A0A7C2D2F61E3E600D00820 /* TabContentScriptManager.swift in Sources */,
 				BCB769192E4F80650046AA37 /* StylingViewModifiers.swift in Sources */,
 				BD011FB82D89B0D400FE1A32 /* AddressBarPanGestureHandler.swift in Sources */,
 				E19B38B328A42D5E00D8C541 /* WallpaperCollectionViewCell.swift in Sources */,
@@ -19310,6 +19317,7 @@
 				5A2918CB2B522338002B197E /* GeneralBrowserAction.swift in Sources */,
 				8A5D1CC12A30DCA4005AD35C /* SettingDisclosureUtility.swift in Sources */,
 				8ADED55C2D6679D500345293 /* BrowsingSettingsViewController.swift in Sources */,
+				8A0A7C402F61F03500D00820 /* TabWebView.swift in Sources */,
 				BCBE058C2E3A8720004B6039 /* SummarizeSetting.swift in Sources */,
 				E1442FD5294782D9003680B0 /* UIView+SnapKit.swift in Sources */,
 				2816F0001B33E05400522243 /* UIConstants.swift in Sources */,

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -84,7 +84,13 @@ enum TabUrlType: String {
 typealias TabUUID = String
 
 @MainActor
-class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
+class Tab: NSObject,
+           ThemeApplicable,
+           FeatureFlaggable,
+           ShareTab,
+           ContentBlockerTab,
+           TabWebViewDelegate,
+           UIGestureRecognizerDelegate {
     private var _isPrivate = false
     private(set) var isPrivate: Bool {
         get {
@@ -973,9 +979,9 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     func restoreTemporaryDocumentSession(_ session: TemporaryDocumentSession) {
         temporaryDocumentsSession = session
     }
-}
 
-extension Tab: UIGestureRecognizerDelegate {
+    // MARK: - UIGestureRecognizerDelegate
+
     // This prevents the recognition of one gesture recognizer from blocking another
     func gestureRecognizer(
         _ gestureRecognizer: UIGestureRecognizer,
@@ -1007,9 +1013,9 @@ extension Tab: UIGestureRecognizerDelegate {
             )
         }
     }
-}
 
-extension Tab: TabWebViewDelegate {
+    // MARK: - TabWebViewDelegate
+
     func tabWebView(_ tabWebView: TabWebView, didSelectFindInPageForSelection selection: String) {
         tabDelegate?.tab(self, didSelectFindInPageForSelection: selection)
     }
@@ -1025,9 +1031,9 @@ extension Tab: TabWebViewDelegate {
         // Hide the default WKWebView accessory view panel for PDF documents.
         return mimeType != MIMEType.PDF
     }
-}
 
-extension Tab: ContentBlockerTab {
+    // MARK: - ContentBlockerTab
+
     func currentURL() -> URL? {
         return url
     }
@@ -1038,258 +1044,5 @@ extension Tab: ContentBlockerTab {
 
     func imageContentBlockingEnabled() -> Bool {
         return noImageMode
-    }
-}
-
-private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
-    private var helpers = [String: TabContentScript]()
-
-    // Without calling this, the TabContentScriptManager will leak.
-    func uninstall(tab: Tab) {
-        helpers.forEach { helper in
-            helper.value.scriptMessageHandlerNames()?.forEach { name in
-                tab.webView?.configuration.userContentController.removeScriptMessageHandler(forName: name)
-            }
-            helper.value.prepareForDeinit()
-        }
-    }
-
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        for helper in helpers.values {
-            if let scriptMessageHandlerNames = helper.scriptMessageHandlerNames(),
-               scriptMessageHandlerNames.contains(message.name) {
-                helper.userContentController(userContentController, didReceiveScriptMessage: message)
-                return
-            }
-        }
-    }
-
-    func addContentScript(_ helper: TabContentScript, name: String, forTab tab: Tab) {
-        // If a helper script already exists on a tab, skip adding this duplicate.
-        guard helpers[name] == nil else { return }
-
-        helpers[name] = helper
-
-        // If this helper handles script messages, then get the handlers names and register them. The Browser
-        // receives all messages and then dispatches them to the right TabHelper.
-        helper.scriptMessageHandlerNames()?.forEach { scriptMessageHandlerName in
-            tab.webView?.configuration.userContentController.addInDefaultContentWorld(
-                scriptMessageHandler: self,
-                name: scriptMessageHandlerName
-            )
-        }
-    }
-
-    func addContentScriptToPage(_ helper: TabContentScript, name: String, forTab tab: Tab) {
-        // If a helper script already exists on the page, skip adding this duplicate.
-        guard helpers[name] == nil else { return }
-
-        helpers[name] = helper
-
-        // If this helper handles script messages, then get the handlers names and register them. The Browser
-        // receives all messages and then dispatches them to the right TabHelper.
-        helper.scriptMessageHandlerNames()?.forEach { scriptMessageHandlerName in
-            tab.webView?.configuration.userContentController.addInPageContentWorld(
-                scriptMessageHandler: self,
-                name: scriptMessageHandlerName
-            )
-        }
-    }
-
-    func addContentScriptToCustomWorld(_ helper: TabContentScript, name: String, forTab tab: Tab) {
-        // If a helper script already exists on the page, skip adding this duplicate.
-        guard helpers[name] == nil else { return }
-
-        helpers[name] = helper
-
-        // If this helper handles script messages, then get the handlers names and register them. The Browser
-        // receives all messages and then dispatches them to the right TabHelper.
-        helper.scriptMessageHandlerNames()?.forEach { scriptMessageHandlerName in
-            tab.webView?.configuration.userContentController.addInCustomContentWorld(
-                scriptMessageHandler: self,
-                name: scriptMessageHandlerName
-            )
-        }
-    }
-
-    func getContentScript(_ name: String) -> TabContentScript? {
-        return helpers[name]
-    }
-}
-
-protocol TabWebViewDelegate: AnyObject {
-    @MainActor
-    func tabWebView(_ tabWebView: TabWebView, didSelectFindInPageForSelection selection: String)
-    @MainActor
-    func tabWebViewSearchWithFirefox(
-        _ tabWebViewSearchWithFirefox: TabWebView,
-        didSelectSearchWithFirefoxForSelection selection: String
-    )
-    @MainActor
-    func tabWebViewShouldShowAccessoryView(_ tabWebView: TabWebView) -> Bool
-}
-
-class TabWebView: WKWebView, MenuHelperWebViewInterface, ThemeApplicable, FeatureFlaggable {
-    lazy var accessoryView: AccessoryViewProvider = .build(nil, {
-        AccessoryViewProvider(windowUUID: self.windowUUID)
-    })
-    private var logger: Logger = DefaultLogger.shared
-    private weak var delegate: TabWebViewDelegate?
-    let windowUUID: WindowUUID
-    private var pullRefresh: PullRefreshView?
-    private var theme: Theme?
-
-    override var hasOnlySecureContent: Bool {
-        // TODO: - FXIOS-11721 Understand how it should be showed the lock icon for a local PDF
-        // When PDF is shown we display the online URL for a local PDF so secure content should be true
-        if let url, url.isFileURL, url.lastPathComponent.hasSuffix(".pdf") {
-            return true
-        }
-        return super.hasOnlySecureContent
-    }
-
-    override var inputAccessoryView: UIView? {
-        guard delegate?.tabWebViewShouldShowAccessoryView(self) ?? true else { return nil }
-
-        return accessoryView
-    }
-
-    func configure(delegate: TabWebViewDelegate,
-                   navigationDelegate: WKNavigationDelegate?) {
-        self.delegate = delegate
-        self.navigationDelegate = navigationDelegate
-
-        accessoryView.previousClosure = { [weak self] in
-            guard let self else { return }
-            FormAutofillHelper.focusPreviousInputField(tabWebView: self,
-                                                       logger: self.logger)
-        }
-
-        accessoryView.nextClosure = { [weak self] in
-            guard let self else { return }
-            FormAutofillHelper.focusNextInputField(tabWebView: self,
-                                                   logger: self.logger)
-        }
-
-        accessoryView.doneClosure = { [weak self] in
-            guard let self else { return }
-            FormAutofillHelper.blurActiveElement(tabWebView: self, logger: self.logger)
-            self.endEditing(true)
-        }
-    }
-
-    init(frame: CGRect, configuration: WKWebViewConfiguration, windowUUID: WindowUUID) {
-        self.windowUUID = windowUUID
-        super.init(frame: frame, configuration: configuration)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func removeAllUserScripts() {
-        configuration.userContentController.removeAllUserScripts()
-        configuration.userContentController.removeAllScriptMessageHandlers()
-    }
-
-    func menuHelperFindInPage() {
-        ensureMainThread {
-            self.evaluateJavascriptInDefaultContentWorld("getSelection().toString()") { result, _ in
-                let selection = result as? String ?? ""
-                self.delegate?.tabWebView(self, didSelectFindInPageForSelection: selection)
-            }
-        }
-    }
-
-    func menuHelperSearchWith() {
-        ensureMainThread {
-            self.evaluateJavascriptInDefaultContentWorld("getSelection().toString()") { result, _ in
-                let selection = result as? String ?? ""
-                self.delegate?.tabWebViewSearchWithFirefox(self, didSelectSearchWithFirefoxForSelection: selection)
-            }
-        }
-    }
-
-    override internal func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        // The find-in-page selection menu only appears if the webview is the first responder.
-        // Do not becomeFirstResponder on a mouse event.
-        if let event = event, event.allTouches?.contains(where: { $0.type != .indirectPointer }) ?? false {
-            becomeFirstResponder()
-        }
-        return super.hitTest(point, with: event)
-    }
-
-    // swiftlint:disable unneeded_override
-#if compiler(>=6)
-    override func evaluateJavaScript(
-        _ javaScriptString: String,
-        completionHandler: (
-            @MainActor (Any?, (any Error)?) -> Void
-        )? = nil
-    ) {
-        super.evaluateJavaScript(javaScriptString, completionHandler: completionHandler)
-    }
-#else
-    /// Override evaluateJavascript - should not be called directly on TabWebViews any longer
-    /// We should only be calling evaluateJavascriptInDefaultContentWorld in the future
-    @available(*,
-                unavailable,
-                message: "Do not call evaluateJavaScript directly on TabWebViews, should only be called on super class")
-    override func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, Error?) -> Void)? = nil) {
-        super.evaluateJavaScript(javaScriptString, completionHandler: completionHandler)
-    }
-#endif
-    // swiftlint:enable unneeded_override
-
-    // MARK: - PullRefresh
-
-    func addPullRefresh(onReload: @escaping () -> Void) {
-        guard !scrollView.isZooming else { return }
-        guard pullRefresh == nil else {
-            pullRefresh?.startObservingContentScroll()
-            return
-        }
-        let refresh = PullRefreshView(parentScrollView: scrollView,
-                                      isPortraitOrientation: UIWindow.isPortrait) {
-            onReload()
-        }
-        scrollView.addSubview(refresh)
-        refresh.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            refresh.leadingAnchor.constraint(equalTo: leadingAnchor),
-            refresh.trailingAnchor.constraint(equalTo: trailingAnchor),
-            refresh.bottomAnchor.constraint(equalTo: scrollView.topAnchor),
-            refresh.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
-            refresh.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
-        ])
-
-        refresh.startObservingContentScroll()
-        pullRefresh = refresh
-        guard let theme else { return }
-        refresh.applyTheme(theme: theme)
-    }
-
-    func removePullRefresh() {
-        pullRefresh?.stopObservingContentScroll()
-        pullRefresh?.removeFromSuperview()
-        pullRefresh = nil
-    }
-
-    func setPullRefreshVisibility(isVisible: Bool) {
-        pullRefresh?.isHidden = !isVisible
-    }
-
-    // MARK: - ThemeApplicable
-
-    /// Updates the `background-color` of the webview to match
-    /// the theme if the webview is showing "about:blank" (nil).
-    func applyTheme(theme: Theme) {
-        self.theme = theme
-        backgroundColor = theme.colors.layer1
-        pullRefresh?.applyTheme(theme: theme)
-        if url == nil {
-            let backgroundColor = theme.colors.layer1.hexString
-            evaluateJavascriptInDefaultContentWorld("document.documentElement.style.backgroundColor = '\(backgroundColor)';")
-        }
     }
 }

--- a/firefox-ios/Client/TabManagement/TabContentScriptManager.swift
+++ b/firefox-ios/Client/TabManagement/TabContentScriptManager.swift
@@ -1,0 +1,81 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import WebKit
+
+final class TabContentScriptManager: NSObject, WKScriptMessageHandler {
+    private var helpers = [String: TabContentScript]()
+
+    // Without calling this, the TabContentScriptManager will leak.
+    func uninstall(tab: Tab) {
+        helpers.forEach { helper in
+            helper.value.scriptMessageHandlerNames()?.forEach { name in
+                tab.webView?.configuration.userContentController.removeScriptMessageHandler(forName: name)
+            }
+            helper.value.prepareForDeinit()
+        }
+    }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        for helper in helpers.values {
+            if let scriptMessageHandlerNames = helper.scriptMessageHandlerNames(),
+               scriptMessageHandlerNames.contains(message.name) {
+                helper.userContentController(userContentController, didReceiveScriptMessage: message)
+                return
+            }
+        }
+    }
+
+    func addContentScript(_ helper: TabContentScript, name: String, forTab tab: Tab) {
+        // If a helper script already exists on a tab, skip adding this duplicate.
+        guard helpers[name] == nil else { return }
+
+        helpers[name] = helper
+
+        // If this helper handles script messages, then get the handlers names and register them. The Browser
+        // receives all messages and then dispatches them to the right TabHelper.
+        helper.scriptMessageHandlerNames()?.forEach { scriptMessageHandlerName in
+            tab.webView?.configuration.userContentController.addInDefaultContentWorld(
+                scriptMessageHandler: self,
+                name: scriptMessageHandlerName
+            )
+        }
+    }
+
+    func addContentScriptToPage(_ helper: TabContentScript, name: String, forTab tab: Tab) {
+        // If a helper script already exists on the page, skip adding this duplicate.
+        guard helpers[name] == nil else { return }
+
+        helpers[name] = helper
+
+        // If this helper handles script messages, then get the handlers names and register them. The Browser
+        // receives all messages and then dispatches them to the right TabHelper.
+        helper.scriptMessageHandlerNames()?.forEach { scriptMessageHandlerName in
+            tab.webView?.configuration.userContentController.addInPageContentWorld(
+                scriptMessageHandler: self,
+                name: scriptMessageHandlerName
+            )
+        }
+    }
+
+    func addContentScriptToCustomWorld(_ helper: TabContentScript, name: String, forTab tab: Tab) {
+        // If a helper script already exists on the page, skip adding this duplicate.
+        guard helpers[name] == nil else { return }
+
+        helpers[name] = helper
+
+        // If this helper handles script messages, then get the handlers names and register them. The Browser
+        // receives all messages and then dispatches them to the right TabHelper.
+        helper.scriptMessageHandlerNames()?.forEach { scriptMessageHandlerName in
+            tab.webView?.configuration.userContentController.addInCustomContentWorld(
+                scriptMessageHandler: self,
+                name: scriptMessageHandlerName
+            )
+        }
+    }
+
+    func getContentScript(_ name: String) -> TabContentScript? {
+        return helpers[name]
+    }
+}

--- a/firefox-ios/Client/TabManagement/TabWebView.swift
+++ b/firefox-ios/Client/TabManagement/TabWebView.swift
@@ -1,0 +1,183 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import WebKit
+
+protocol TabWebViewDelegate: AnyObject {
+    @MainActor
+    func tabWebView(_ tabWebView: TabWebView, didSelectFindInPageForSelection selection: String)
+    @MainActor
+    func tabWebViewSearchWithFirefox(
+        _ tabWebViewSearchWithFirefox: TabWebView,
+        didSelectSearchWithFirefoxForSelection selection: String
+    )
+    @MainActor
+    func tabWebViewShouldShowAccessoryView(_ tabWebView: TabWebView) -> Bool
+}
+
+class TabWebView: WKWebView, MenuHelperWebViewInterface, ThemeApplicable, FeatureFlaggable {
+    lazy var accessoryView: AccessoryViewProvider = .build(nil, {
+        AccessoryViewProvider(windowUUID: self.windowUUID)
+    })
+    private var logger: Logger = DefaultLogger.shared
+    private weak var delegate: TabWebViewDelegate?
+    let windowUUID: WindowUUID
+    private var pullRefresh: PullRefreshView?
+    private var theme: Theme?
+
+    override var hasOnlySecureContent: Bool {
+        // TODO: - FXIOS-11721 Understand how it should be showed the lock icon for a local PDF
+        // When PDF is shown we display the online URL for a local PDF so secure content should be true
+        if let url, url.isFileURL, url.lastPathComponent.hasSuffix(".pdf") {
+            return true
+        }
+        return super.hasOnlySecureContent
+    }
+
+    override var inputAccessoryView: UIView? {
+        guard delegate?.tabWebViewShouldShowAccessoryView(self) ?? true else { return nil }
+
+        return accessoryView
+    }
+
+    func configure(delegate: TabWebViewDelegate,
+                   navigationDelegate: WKNavigationDelegate?) {
+        self.delegate = delegate
+        self.navigationDelegate = navigationDelegate
+
+        accessoryView.previousClosure = { [weak self] in
+            guard let self else { return }
+            FormAutofillHelper.focusPreviousInputField(tabWebView: self,
+                                                       logger: self.logger)
+        }
+
+        accessoryView.nextClosure = { [weak self] in
+            guard let self else { return }
+            FormAutofillHelper.focusNextInputField(tabWebView: self,
+                                                   logger: self.logger)
+        }
+
+        accessoryView.doneClosure = { [weak self] in
+            guard let self else { return }
+            FormAutofillHelper.blurActiveElement(tabWebView: self, logger: self.logger)
+            self.endEditing(true)
+        }
+    }
+
+    init(frame: CGRect, configuration: WKWebViewConfiguration, windowUUID: WindowUUID) {
+        self.windowUUID = windowUUID
+        super.init(frame: frame, configuration: configuration)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func removeAllUserScripts() {
+        configuration.userContentController.removeAllUserScripts()
+        configuration.userContentController.removeAllScriptMessageHandlers()
+    }
+
+    func menuHelperFindInPage() {
+        ensureMainThread {
+            self.evaluateJavascriptInDefaultContentWorld("getSelection().toString()") { result, _ in
+                let selection = result as? String ?? ""
+                self.delegate?.tabWebView(self, didSelectFindInPageForSelection: selection)
+            }
+        }
+    }
+
+    func menuHelperSearchWith() {
+        ensureMainThread {
+            self.evaluateJavascriptInDefaultContentWorld("getSelection().toString()") { result, _ in
+                let selection = result as? String ?? ""
+                self.delegate?.tabWebViewSearchWithFirefox(self, didSelectSearchWithFirefoxForSelection: selection)
+            }
+        }
+    }
+
+    override internal func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        // The find-in-page selection menu only appears if the webview is the first responder.
+        // Do not becomeFirstResponder on a mouse event.
+        if let event = event, event.allTouches?.contains(where: { $0.type != .indirectPointer }) ?? false {
+            becomeFirstResponder()
+        }
+        return super.hitTest(point, with: event)
+    }
+
+    // swiftlint:disable unneeded_override
+#if compiler(>=6)
+    override func evaluateJavaScript(
+        _ javaScriptString: String,
+        completionHandler: (
+            @MainActor (Any?, (any Error)?) -> Void
+        )? = nil
+    ) {
+        super.evaluateJavaScript(javaScriptString, completionHandler: completionHandler)
+    }
+#else
+    /// Override evaluateJavascript - should not be called directly on TabWebViews any longer
+    /// We should only be calling evaluateJavascriptInDefaultContentWorld in the future
+    @available(*,
+                unavailable,
+                message: "Do not call evaluateJavaScript directly on TabWebViews, should only be called on super class")
+    override func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, Error?) -> Void)? = nil) {
+        super.evaluateJavaScript(javaScriptString, completionHandler: completionHandler)
+    }
+#endif
+    // swiftlint:enable unneeded_override
+
+    // MARK: - PullRefresh
+
+    func addPullRefresh(onReload: @escaping () -> Void) {
+        guard !scrollView.isZooming else { return }
+        guard pullRefresh == nil else {
+            pullRefresh?.startObservingContentScroll()
+            return
+        }
+        let refresh = PullRefreshView(parentScrollView: scrollView,
+                                      isPortraitOrientation: UIWindow.isPortrait) {
+            onReload()
+        }
+        scrollView.addSubview(refresh)
+        refresh.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            refresh.leadingAnchor.constraint(equalTo: leadingAnchor),
+            refresh.trailingAnchor.constraint(equalTo: trailingAnchor),
+            refresh.bottomAnchor.constraint(equalTo: scrollView.topAnchor),
+            refresh.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
+            refresh.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+        ])
+
+        refresh.startObservingContentScroll()
+        pullRefresh = refresh
+        guard let theme else { return }
+        refresh.applyTheme(theme: theme)
+    }
+
+    func removePullRefresh() {
+        pullRefresh?.stopObservingContentScroll()
+        pullRefresh?.removeFromSuperview()
+        pullRefresh = nil
+    }
+
+    func setPullRefreshVisibility(isVisible: Bool) {
+        pullRefresh?.isHidden = !isVisible
+    }
+
+    // MARK: - ThemeApplicable
+
+    /// Updates the `background-color` of the webview to match
+    /// the theme if the webview is showing "about:blank" (nil).
+    func applyTheme(theme: Theme) {
+        self.theme = theme
+        backgroundColor = theme.colors.layer1
+        pullRefresh?.applyTheme(theme: theme)
+        if url == nil {
+            let backgroundColor = theme.colors.layer1.hexString
+            evaluateJavascriptInDefaultContentWorld("document.documentElement.style.backgroundColor = '\(backgroundColor)';")
+        }
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14784)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31908)

## :bulb: Description
- Creating `TabContentScriptManager` & `TabWebView` files so they are not living under the `Tab` one. Adding `ignore-code-coverage` label since the unit tests threshold fails, but I am not creating those files so just want to ignore the threshold for now. No changes to that code, just moving it.
- Organizing `extensions` under the `Tab.swift` file

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

