### PR TITLE
Bugfix MTE-5253 Tap "View More" instead of "More" on iOS 26.3

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
@@ -196,7 +196,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
         app.buttons["Reader View"].waitAndTap()
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
         if #available(iOS 26, *), !app.collectionViews.cells[option].exists {
-            app.cells["actionGroupCell"].staticTexts["More"].waitAndTap(timeout: 10)
+            app.scrollViews.cells["View More"].waitAndTap(timeout: 10)
         }
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.collectionViews.cells[option])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5253)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
After the upgrade to Xcode and iOS 26.3, the options from the "Share" menu requires "View More" button instead of "More" to expand. Multiple tests from `ShareToolbarTests` failed because of this change.
<img width="300" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-12 at 16 59 04" src="https://github.com/user-attachments/assets/19d184ce-4ae4-44ad-933d-e38f518f21a6" />

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

