### PR TITLE
Bugfix FXIOS-15052 - [Widgets] Incorrect behavior when using Website Shortcut Widget

### DIFF
--- a/firefox-ios/WidgetKit/TopSites/TopSitesWidget.swift
+++ b/firefox-ios/WidgetKit/TopSites/TopSitesWidget.swift
@@ -97,7 +97,6 @@ struct TopSitesView: View {
         .clipShape(RoundedRectangle(cornerRadius: UX.itemCornerRadius))
     }
 
-
     private func calculateIconSize(provider: GeometryProxy, rowSize: CGFloat) -> CGFloat {
         let dynamicIconScale = UIFontMetrics.default.scaledValue(for: UX.iconScale)
         // since the widget has 2 rows and the height of each row is half of the widget size.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15052)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32409)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- This seems to be an iOS bug: `widgetAccentedRenderingMode` inside a `Link` breaks the link destination. https://developer.apple.com/forums/thread/795408.
- To fix the issue I used an `overlay` and added the `Link` inside.
- I've also tested https://mozilla-hub.atlassian.net/browse/FXIOS-13534 to make sure no regressions are now introduced.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

https://github.com/user-attachments/assets/19d9d28b-a021-4b05-a209-c3ebdd76369f


</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

