### PR TITLE
Refactor FXIOS-14784 [Tab Manager] Ensure configuration doesn't get overriden

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -449,7 +449,7 @@ class Tab: NSObject,
     private var contentScriptManager = TabContentScriptManager()
 
     /// WebKit-provided configuration for popup tabs. Takes precedence over standard configuration when set.
-    var requiredConfiguration: WKWebViewConfiguration?
+    var requiredPopupConfiguration: WKWebViewConfiguration?
     private var configuration: WKWebViewConfiguration?
 
     /// Any time a tab tries to make requests to display a Javascript Alert and we are not the active
@@ -541,7 +541,8 @@ class Tab: NSObject,
     func createWebview(with restoreSessionData: Data? = nil, configuration: WKWebViewConfiguration) {
         guard webView == nil else { return }
 
-        let requiredConfiguration = requiredConfiguration ?? configuration
+        let requiredConfiguration = requiredPopupConfiguration ?? configuration
+        // Ensures we inject scripts into a new content controller
         requiredConfiguration.userContentController = .init()
         self.configuration = requiredConfiguration
         let webView = TabWebView(frame: .zero, configuration: requiredConfiguration, windowUUID: windowUUID)

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1097,7 +1097,7 @@ final class TabManagerImplementation: NSObject,
         // Configure the tab for the child popup webview. In this scenario we need to be sure to pass along
         // the specific `configuration` that we are given by the WKUIDelegate callback, since if we do not
         // use this configuration WebKit will throw an exception.
-        popup.requiredConfiguration = configuration
+        popup.requiredPopupConfiguration = configuration
         configureTab(popup,
                      request: nil,
                      afterTab: parentTab,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14784)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31908)

## :bulb: Description
- Ensure configuration doesn't get overridden whenever we have a required configuration from pop-ups. I added a `requiredPopupConfiguration` variable on the tab to achieve this.
- Add documentation/comments where needed


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

