### PR TITLE
Add FXIOS-15106 [New Error Pages] Debug toggle for other error pages feature flag (follow-up)

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -159,8 +159,8 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
             },
             FeatureFlagsBoolSetting(
                 with: .otherErrorPages,
-                titleText: format(string: "Other Error Pages"),
-                statusText: format(string: "Toggle to display natively created error pages for certificate and other errors")
+                titleText: format(string: "Wrong Host Certificate Native Error Page"),
+                statusText: format(string: "Toggle to display the natively created wrong host error page")
             ) { [weak self] _ in
                 self?.reloadView()
             },


### PR DESCRIPTION
📜 Tickets

Github issue: #32526

💡 Description

This PR adds a debug toggle in the Feature Flags menu to manually enable/disable the `other_error_pages` feature flag for testing purposes.

<img width="349" height="106" alt="image" src="https://github.com/user-attachments/assets/3a27d1e9-d458-417f-bfbe-9f7f43054e7b" />


This issue was previously opened (#31424) but was accidentally overwritten in [#32010]. This PR directs to the same toggle button.
**Note:** This PR is part of Outreachy.

**Implementation details**

- Added `FeatureFlagsBoolSetting` for `.otherErrorPages` in `FeatureFlagsDebugViewController.swift`
- Follows the same pattern as other feature flag toggles in the debug menu

📝 Checklist

- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [ ] I ensured unit tests pass and wrote tests for new code 
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) 
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review 
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n 
- [ ] If needed, I updated documentation and added comments to complex code 

## Related

- Part of certificate error page implementation
