### PR TITLE
Add MTE-5254 TestRail links missed from file renames

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -225,6 +225,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         browser.assertAddressBarContains(value: "wikipedia.org")
     }
 
+    // https://mozilla.testrail.io/index.php?/cases/view/2273338
     // Smoketest
     func testTopSitesOpenInNewPrivateTabDefaultTopSite() {
         app.launch()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ModernOrangeAndBlueOnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ModernOrangeAndBlueOnboardingTests.swift
@@ -43,6 +43,7 @@ class ModernOrangeAndBlueOnboardingTests: FeatureFlaggedTestSuite {
 
     // MARK: - Full Flow Tests
 
+    // https://mozilla.testrail.io/index.php?/cases/view/2575178
     // Smoketest
     func testModernOnboardingFullFlowWithToS() throws {
         launchApp()
@@ -54,6 +55,7 @@ class ModernOrangeAndBlueOnboardingTests: FeatureFlaggedTestSuite {
         firefoxHomePageScreen.assertTopSitesItemCellExist()
     }
 
+    // https://mozilla.testrail.io/index.php?/cases/view/2575178
     // Smoketest
     func testModernOnboardingFullFlowToSAlreadyAccepted() throws {
         launchApp()
@@ -81,6 +83,7 @@ class ModernOrangeAndBlueOnboardingTests: FeatureFlaggedTestSuite {
         onboardingScreen.assertModernWelcomeScreen()
     }
 
+    // https://mozilla.testrail.io/index.php?/cases/view/2575175
     func testModernOnboardingToolbarPlacementTop() throws {
         if iPad() {
             throw XCTSkip("Toolbar customization is not available on iPad")
@@ -117,6 +120,7 @@ class ModernOrangeAndBlueOnboardingTests: FeatureFlaggedTestSuite {
         XCTAssertTrue(toolbar.frame.origin.y < screenHeight / 2, "Toolbar is not near the top")
     }
 
+    // https://mozilla.testrail.io/index.php?/cases/view/2575176
     func testModernOnboardingToolbarPlacementBottom() throws {
         if iPad() {
             throw XCTSkip("Toolbar customization is not available on iPad")
@@ -183,6 +187,7 @@ class ModernOrangeAndBlueOnboardingTests: FeatureFlaggedTestSuite {
 
     // MARK: - Sync Flow Tests
 
+    // https://mozilla.testrail.io/index.php?/cases/view/2306814
     func testModernOnboardingSyncFlow() throws {
         launchApp()
 
@@ -217,6 +222,7 @@ class ModernOrangeAndBlueOnboardingTests: FeatureFlaggedTestSuite {
         onboardingScreen.exitSignInFlow()
     }
 
+    // https://mozilla.testrail.io/index.php?/cases/view/2306816
     func testModernOnboardingSkipSync() throws {
         launchApp()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5254)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR retrieves and adds the TestRail links back to the tests. Some files have been renamed and tests have been moved around. In the process, some links were not migrated over to the new files.

I have also updated the corresponding TestRail entry if there are any name changes.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

