### PR TITLE
Remove FXIOS-15131 [Tab manager] Reload page clean up

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4942,7 +4942,7 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
         if needsReload {
-            selectedTab.reloadPage()
+            selectedTab.reload()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
+++ b/firefox-ios/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
@@ -117,7 +117,7 @@ final class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
     override func notifiedTabSetupRequired() {
         guard let tab = self.tab as? Tab else { return }
         self.logger.log("Notified tab setup required", level: .info, category: .adblock)
-        self.setupForTab(completion: { tab.reloadPage() })
+        self.setupForTab(completion: { tab.reload() })
         TabEvent.post(.didChangeContentBlocking, for: tab)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -530,7 +530,7 @@ private extension LegacyTabScrollController {
     @objc
     func reload() {
         guard let tab = tab else { return }
-        tab.reloadPage()
+        tab.reload()
         TelemetryWrapper.recordEvent(category: .action, method: .pull, object: .reload)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabProviderAdapter.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabProviderAdapter.swift
@@ -43,6 +43,6 @@ final class TabProviderAdapter: TabProviderProtocol {
     }
 
     func reloadPage() {
-        tab.reloadPage()
+        tab.reload()
     }
 }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -739,10 +739,6 @@ class Tab: NSObject,
         }
     }
 
-    func reloadPage() {
-        reload()
-    }
-
     // MARK: - Content script
 
     func addContentScript(_ helper: TabContentScript, name: String) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15131)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32566)

## :bulb: Description
The `reloadPage` function was only calling `reload` behind the scenes. `Tab.reload` is also public, so there's no need to have those two methods. I think this `reloadPage` was behaving differently before, and it made sense at the time. Nowadays, it's pretty useless, so I am removing it.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

