### PR TITLE
Add SPM_Nightly_Beta_Mac_Only workflow for iPad Mac TestFlight upload

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1538,11 +1538,11 @@ workflows:
     - slack@4.2.1:
         is_always_run: true
         run_if: ".IsBuildFailed"
-        title: 'Nightly FirefoxBeta Mac build & deploy failed'
+        title: 'Nightly FirefoxBeta build & deploy failed'
         inputs:
         - title: ''
         - author_name: ''
-        - pretext_on_error: "*Firefox-iOS* :firefox: *SPM_Nightly_Beta_Mac_Only* :x:"
+        - pretext_on_error: "*Firefox-iOS* :firefox: *SPM_Nightly_Beta_Only* :x:"
         - buttons: ""
         - fields: |
             Log | ${BITRISE_BUILD_URL}
@@ -1551,7 +1551,7 @@ workflows:
     - opts:
         is_expand: false
       BITRISE_SCHEME: Firefox
-    description: Build, archive and upload Firefox Beta Nightly for Mac (Designed for iPad)
+    description: This step is to build, archive and upload Firefox Release and Beta
 
   SPM_Common_Steps:
     steps:


### PR DESCRIPTION
## :scroll: Tickets
N/A

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Separate workflow for Mac Only. This time added 
platform: macos
pkg_path: "$BITRISE_PKG_PATH"


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

