### PR TITLE
Refactor FXIOS-15140 [Danger] Code coverage gate scaling per length of file

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -100,7 +100,6 @@ func checkCodeCoverage() {
 class CodeCoverageGate {
     private let coverageBypassLabel = "ignore-code-coverage"
     private let jsonPath = "coverage.json"
-    private let threshold: Double = 70
     private let minimumAddedLines = 5
 
     func failOnNewFilesWithoutCoverage() {
@@ -166,6 +165,10 @@ class CodeCoverageGate {
                 return raw <= 1.000001 ? raw * 100.0 : raw
             }()
 
+            // Calculate threshold based on file length
+            let lineCount = countLines(in: file)
+            let threshold = scaledPercentage(for: Double(lineCount)) * 100.0
+
             if percent + 0.0001 < threshold { // epsilon for float stability
                 rows.append("| `\(file)` | \(formatPct(percent)) | \(formatPct(threshold)) |")
             }
@@ -174,14 +177,14 @@ class CodeCoverageGate {
         guard !rows.isEmpty else {
             markdown("""
             ### ✅ New file code coverage
-            All new files meet the threshold of **\(formatPct(threshold))**.
+            All new files meet their thresholds**.
             """)
             return
         }
 
         let header = """
         ### ❌ New file code coverage
-        The following new file(s) are below **\(formatPct(threshold))** coverage:
+        The following new file(s) are below their scaled coverage:
 
         | File | Coverage | Required |
         |---|---:|---:|
@@ -197,6 +200,37 @@ class CodeCoverageGate {
             let owners = "Please also tag a member of the \(team) if the bypass is used."
             fail("\(header)\n\n\(tip) \(owners)")
         }
+    }
+
+    /// Maps an input value to a percentage using logarithmic scaling.
+    /// - Parameter x: Input value (must be > 0)
+    /// - Returns: A value between 0.5 and 0.8 for inputs between 10 and 500
+    func scaledPercentage(for x: Double) -> Double {
+        precondition(x > 0, "Input must be greater than 0")
+
+        let minX = 10.0
+        let maxX = 500.0
+        let minY = 0.4
+        let maxY = 0.7
+
+        // Clamp to min/max bounds
+        if x <= minX { return minY }
+        if x >= maxX { return maxY }
+
+        let numerator = log(x / minX)
+        let denominator = log(maxX / minX)
+
+        return minY + (maxY - minY) * (numerator / denominator)
+    }
+
+    /// Counts the number of lines in a file
+    /// - Parameter filePath: Path to the file
+    /// - Returns: Number of lines in the file, or 0 if file cannot be read
+    private func countLines(in filePath: String) -> Int {
+        guard let content = try? String(contentsOfFile: filePath, encoding: .utf8) else {
+            return 0
+        }
+        return content.components(separatedBy: .newlines).count
     }
 
     // Small helper to format percentages


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15140)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32586)

## :bulb: Description
As we discussed in yesterday's meeting, we want to scale the code coverage depending on the length of the files. It's going to scale from 40% to 70%. Let me know if you think scaling should be applied differently. For the use case in [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/32480) that triggered this conversation, the output would now be:

```
### ❌ New file code coverage
The following new file(s) are below their scaled coverage:

| File | Coverage | Required |
|---|---:|---:|
| `firefox-ios/Client/Frontend/Settings/AIControls/AIControlsSettingsView.swift` | 0.0% | 41.4% |
| `firefox-ios/Client/Frontend/Settings/Main/General/AIControlsSetting.swift` | 0.0% | 50.0% |

*Bypass label `ignore-code-coverage` detected — reporting as warnings only for this PR.*
```

Aka, the code coverage would have passed for the `firefox-ios/Client/Frontend/Settings/Main/General/AIControlsSetting.swift` file (since it was 68.2%). 

Note: I think it's saying 0% code coverage in my comment since I didn't use the right code coverage file to run locally, but it should be good when ran in the CI!

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

