### PR TITLE
Bugfix FXIOS-11754 Focus RTL Incorrect rendering of the URLbar elements

### DIFF
--- a/focus-ios/Blockzilla/UIComponents/URLBar/URLBar.swift
+++ b/focus-ios/Blockzilla/UIComponents/URLBar/URLBar.swift
@@ -19,7 +19,7 @@ final class URLBar: UIView {
         let button = UIButton()
         button.isHidden = true
         button.alpha = 0
-        button.setImage(.cancel, for: .normal)
+        button.setImage(.cancel.imageFlippedForRightToLeftLayoutDirection(), for: .normal)
         button.setContentCompressionResistancePriority(UILayoutPriority(rawValue: UIConstants.layout.urlBarLayoutPriorityRawValue), for: .horizontal)
         button.addTarget(self, action: #selector(cancelPressed), for: .touchUpInside)
         button.accessibilityIdentifier = "URLBar.cancelButton"
@@ -130,7 +130,7 @@ final class URLBar: UIView {
     private lazy var backButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setImage(.backActive.imageFlippedForRightToLeftLayoutDirection(), for: .normal)
+        button.setImage(.backActive, for: .normal)
         button.accessibilityLabel = UIConstants.strings.browserBack
         button.isEnabled = false
         button.isPointerInteractionEnabled = true
@@ -1261,8 +1261,15 @@ private final class URLTextField: AutocompleteTextField {
     }
 
     override fileprivate func rightViewRect(forBounds bounds: CGRect) -> CGRect {
-        let direction: CGFloat = effectiveUserInterfaceLayoutDirection == .rightToLeft ? 1 : -1
-        return super.rightViewRect(forBounds: bounds).offsetBy(dx: direction * UIConstants.layout.urlBarWidthInset, dy: 0)
+        return super.rightViewRect(forBounds: bounds).offsetBy(dx: -UIConstants.layout.urlBarWidthInset, dy: 0)
+    }
+
+    override fileprivate func leftViewRect(forBounds bounds: CGRect) -> CGRect {
+        if effectiveUserInterfaceLayoutDirection == .rightToLeft, let rv = rightView {
+            let size = rv.bounds.size
+            return CGRect(x: UIConstants.layout.urlBarWidthInset, y: (bounds.height - size.height) / 2, width: size.width, height: size.height)
+        }
+        return super.leftViewRect(forBounds: bounds)
     }
 
     private func textFieldDidEndEditing(_ textField: UITextField) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11754)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25645)

## :bulb: Description
This PR solves incorrect rendering of the URLbar elements for RTL  in Focus App - URLbar text has now correct layout, clear button position, no text/clear overlap, chevron direction.
There was a previous [PR](https://github.com/mozilla-mobile/firefox-ios/pull/31851) related to this bug but the fix was not concluded with all the adjustments for all UI elements.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-03-20 at 23 54 54" src="https://github.com/user-attachments/assets/77fd920d-fffc-4a85-a4b9-f5d78efc1086" />

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

