### PR TITLE
[NoBug] Allow running FullFuncional tests on release builds

### DIFF
--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
@@ -60,6 +60,9 @@
          <TestPlanReference
             reference = "container:firefox-ios-tests/Tests/Smoketest.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/FirefoxBeta.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/FirefoxBeta.xcscheme
@@ -60,6 +60,9 @@
          <TestPlanReference
             reference = "container:firefox-ios-tests/Tests/Smoketest.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference


### PR DESCRIPTION

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
On a similar [PR](https://github.com/mozilla-mobile/firefox-ios/pull/31852/changes) we enabled running Smoketest on release builds, in this one, we are enabling the FullFunctional test plan

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

