### PR TITLE
BugFix [NO TICKET] indentation of contributors guardrails

### DIFF
--- a/.github/workflows/contribution-guardrails.yml
+++ b/.github/workflows/contribution-guardrails.yml
@@ -59,7 +59,6 @@ jobs:
           retry() { n=0; until "$@"; do n=$((n+1)); [ $n -ge 3 ] && break; sleep 2; done; }
           retry gh pr comment "$NUMBER" -R "$GH_REPO" -b "$BODY" || true
           retry gh pr close "$NUMBER" -R "$GH_REPO" || true
-          gh pr lock "$NUMBER" -R "$GH_REPO" -r "spam" || true
 
       - name: Handle outside-approved-scope label
         if: github.event.action == 'labeled' && github.event.label.name == 'outside-approved-scope'


### PR DESCRIPTION
## :scroll: Tickets
~~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~~
~~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~~

## :bulb: Description
Bug fix contributors guardrails failing due to missing indentation in the `BODY` var.
See reported issue in the workflow [here](https://github.com/mozilla-mobile/firefox-ios/actions/runs/23445978070/workflow)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

