### PR TITLE
Revert "Bugfix FXIOS-14988 [Top 10 Bugs] Status bar overlaps with top address toolbar after rotation Snapkit removal enabled"

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/BrowserViewControllerLayoutManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/BrowserViewControllerLayoutManager.swift
@@ -57,7 +57,8 @@ final class BrowserViewControllerLayoutManager {
             headerView.leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
             headerView.trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
         ])
-        headerTopConstraint = headerView.topAnchor.constraint(equalTo: parentView.topAnchor)
+        let topAnchor = getHeaderTopAnchor(isBottomSearchBar: isBottomSearchBar)
+        headerTopConstraint = headerView.topAnchor.constraint(equalTo: topAnchor)
         headerTopConstraint?.isActive = true
 
         if isBottomSearchBar {
@@ -69,7 +70,19 @@ final class BrowserViewControllerLayoutManager {
 
     func updateHeaderConstraints(isBottomSearchBar: Bool) {
         updateHeaderHeightConstraint(isBottomSearchBar: isBottomSearchBar)
-        headerTopConstraint?.constant = getHeaderTopConstant(isBottomSearchBar: isBottomSearchBar)
+
+        let targetAnchor = getHeaderTopAnchor(isBottomSearchBar: isBottomSearchBar)
+
+        // Preserve current offset
+        let currentConstant = headerTopConstraint?.constant ?? 0
+        headerTopConstraint?.isActive = false
+
+        // Create constraint with new correct anchor
+        headerTopConstraint = headerView.topAnchor.constraint(equalTo: targetAnchor)
+        headerTopConstraint?.constant = currentConstant
+        headerTopConstraint?.isActive = true
+
+        updateScrollControllerHeaderConstraint()
     }
 
     func addReaderModeBarHeight(_ readerModeBar: ReaderModeBarView) {
@@ -210,27 +223,27 @@ final class BrowserViewControllerLayoutManager {
         headerHeightConstraint?.isActive = true
     }
 
-    /// Returns the correct top constraint constant for the header based on search bar position and trait collection
+    /// Returns the correct top anchor for the header based on search bar position and trait collection
     /// - Parameter isBottomSearchBar: Whether the search bar is positioned at the bottom
-    /// - Returns: The appropriate constant value to constrain the header to
-    private func getHeaderTopConstant(isBottomSearchBar: Bool) -> CGFloat {
-        guard !isBottomSearchBar else { return 0 }
+    /// - Returns: The appropriate NSLayoutYAxisAnchor to constrain the header to
+    private func getHeaderTopAnchor(isBottomSearchBar: Bool) -> NSLayoutYAxisAnchor {
+        // Bottom toolbar always uses safeArea
+        guard !isBottomSearchBar else {
+            return parentView.safeAreaLayoutGuide.topAnchor
+        }
 
+        // Top toolbar depends on nav toolbar visibility
         let isNavToolbar = toolbarHelper.shouldShowNavigationToolbar(for: parentView.traitCollection)
         let shouldShowTopTabs = toolbarHelper.shouldShowTopTabs(for: parentView.traitCollection)
 
-        // Landscape case where status bar is hidden, header sits at the top without padding
-        guard isNavToolbar || shouldShowTopTabs else { return 0 }
-
         // TODO: [iOS 26 Bug] - Remove this workaround when Apple fixes safe area inset updates.
-        // Bug: Safe area top inset doesn't update correctly on rotation on iOS 26.0.
-        // On landscape rotation it remains 20pt (should be 0pt for devices without a notch).
-        // On portrait return it becomes 0pt (should be the status bar height).
-        // Workaround: Use statusBarManager.statusBarFrame.height which returns the correct
-        // value regardless of the safeAreaLayoutGuide bug.
+        // Bug: Safe area top inset doesn't update correctly on landscape rotation (remains 20pt)
+        // on iOS 26. Prior to iOS 26, safe area inset was updating correctly on rotation.
+        // Impact: Header remains partially visible when scrolling.
+        // Workaround: Manually adjust constraints based on orientation.
         // Related Bug: https://mozilla-hub.atlassian.net/browse/FXIOS-13756
         // Apple Developer Forums: https://developer.apple.com/forums/thread/798014
-        return parentView.window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+        return (isNavToolbar || shouldShowTopTabs) ? parentView.safeAreaLayoutGuide.topAnchor : parentView.topAnchor
     }
 
     private func updateScrollControllerHeaderConstraint() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1546,19 +1546,6 @@ class BrowserViewController: UIViewController,
         logCurrentNimbusExperimentsState()
     }
 
-    // TODO: [iOS 26 Bug] - Remove this workaround when Apple fixes safe area inset updates.
-    // On initial display, the view is not yet in the window hierarchy at setup time, so
-    // statusBarManager is unavailable and the header top constraint starts with constant = 0.
-    // viewSafeAreaInsetsDidChange fires once the view enters the hierarchy, at which point
-    // statusBarManager returns the correct value and the constant is updated.
-    // Related Bug: https://mozilla-hub.atlassian.net/browse/FXIOS-13756
-    // Apple Developer Forums: https://developer.apple.com/forums/thread/798014
-    override func viewSafeAreaInsetsDidChange() {
-        super.viewSafeAreaInsetsDidChange()
-        guard isSnapKitRemovalEnabled else { return }
-        browserLayoutManager.updateHeaderConstraints(isBottomSearchBar: isBottomSearchBar)
-    }
-
     /// Logging current Nimbus state
     private func logCurrentNimbusExperimentsState() {
         var currentExperimentsDictionary = [String: String]()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerLayoutManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerLayoutManagerTests.swift
@@ -129,7 +129,7 @@ final class BrowserViewControllerLayoutManagerTests: XCTestCase {
 
     // MARK: - Anchor Selection
 
-    func test_setupHeaderConstraints_topToolbarWithNavToolbar_usesParentView() {
+    func test_setupHeaderConstraints_topToolbarWithNavToolbar_usesSafeArea() {
         let subject = createSubject()
         toolbarHelper.shouldShowNavigationToolbar = true
         subject.setupHeaderConstraints(isBottomSearchBar: false)
@@ -139,7 +139,7 @@ final class BrowserViewControllerLayoutManagerTests: XCTestCase {
         }
 
         // If using safe area, the secondItem should be a UILayoutGuide
-        XCTAssertTrue(topConstraint?.secondItem === parentView)
+        XCTAssertTrue(topConstraint?.secondItem is UILayoutGuide)
     }
 
     func test_setupHeaderConstraints_topToolbarWithoutNavToolbar_usesViewTop() {
@@ -156,7 +156,7 @@ final class BrowserViewControllerLayoutManagerTests: XCTestCase {
         XCTAssertTrue(topConstraint?.secondItem === parentView)
     }
 
-    func test_setupHeaderConstraints_bottomSearchBar_usesParentView() {
+    func test_setupHeaderConstraints_bottomSearchBar_alwaysUsesSafeArea() {
         let subject = createSubject()
         toolbarHelper.shouldShowNavigationToolbar = false
         toolbarHelper.shouldShowTopTabs = false
@@ -166,8 +166,8 @@ final class BrowserViewControllerLayoutManagerTests: XCTestCase {
             ($0.firstItem === headerView && $0.firstAttribute == .top)
         }
 
-        // Bottom search bar should should be the parentView
-        XCTAssertTrue(topConstraint?.secondItem === parentView)
+        // Bottom search bar should always use safe area
+        XCTAssertTrue(topConstraint?.secondItem is UILayoutGuide)
     }
 
     func test_updateHeaderConstraints_withoutScrollController_doesNotCrash() {
@@ -414,7 +414,7 @@ final class BrowserViewControllerLayoutManagerTests: XCTestCase {
 
     private func countRelevantConstraints(for view: UIView) -> Int {
         let relevantConstraints = view.constraints.filter {
-            [.leading, .trailing, .bottom, .top, .height].contains($0.firstAttribute)
+            [.leading, .trailing, .bottom, .height].contains($0.firstAttribute)
         }
         return relevantConstraints.count
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14988)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32286)

## :bulb: Description
Reverts mozilla-mobile/firefox-ios#32562 because causes bugs when address toolbar is in bottom position, we will add back behind feature flag and covering top and bottom address bar
 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

