### PR TITLE
Bugfix FXIOS-15171 [News Transition] Fix constraint warnings

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/LabelButtonHeaderView.swift
@@ -68,7 +68,10 @@ class LabelButtonHeaderView: UICollectionReusableView,
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: UX.topSpacing),
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.leadingInset),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.bottomSpace),
+            // Collection view sizing can temporarily collapse supplementary views to zero height.
+            // Keep the inset in normal layouts, but let auto layout relax it during that pass.
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.bottomSpace)
+                .priority(UILayoutPriority(999)),
         ])
 
         // Setting custom values to resolve horizontal ambiguity

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderView.swift
@@ -16,7 +16,12 @@ final class NewsTransitionHeaderView: UICollectionReusableView,
     }
 
     private lazy var newsAffordanceContentView: NewsAffordanceHeaderView = .build()
-    private lazy var sectionTitleHeaderView: LabelButtonHeaderView = .build()
+    private lazy var sectionTitleHeaderView: LabelButtonHeaderView = {
+        // This reusable view is embedded inside another supplementary view, so keep it frame-based instead of auto layout
+        let view = LabelButtonHeaderView(frame: .zero)
+        view.autoresizingMask = [.flexibleWidth, .flexibleTopMargin]
+        return view
+    }()
 
     private var progress: CGFloat = 0
     private var transitionEnabled = true
@@ -40,11 +45,26 @@ final class NewsTransitionHeaderView: UICollectionReusableView,
         updateViewState(forHeight: bounds.height)
     }
 
+    override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+        super.apply(layoutAttributes)
+
+        // Supplementary view sizing can change before `layoutSubviews` runs during rotation.
+        // Sync the active affordance constraints from the incoming layout height immediately.
+        updateViewState(forHeight: layoutAttributes.size.height)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateViewState(forHeight: bounds.height)
+        updateSectionTitleHeaderFrame()
+    }
+
     func configure(state: SectionHeaderConfiguration, textColor: UIColor?, theme: Theme, transitionEnabled: Bool = true) {
         self.transitionEnabled = transitionEnabled
         newsAffordanceContentView.applyTheme(theme: theme)
         sectionTitleHeaderView.configure(state: state, moreButtonAction: nil, textColor: textColor, theme: theme)
         sectionTitleHeaderView.moreButton.isHidden = true
+        updateSectionTitleHeaderFrame()
         updateViewState(forHeight: bounds.height)
     }
 
@@ -82,6 +102,7 @@ final class NewsTransitionHeaderView: UICollectionReusableView,
 
         addSubview(newsAffordanceContentView)
         addSubview(sectionTitleHeaderView)
+        updateSectionTitleHeaderFrame()
 
         newsAffordanceExpandedConstraints = [
             newsAffordanceContentView.topAnchor.constraint(equalTo: topAnchor),
@@ -91,11 +112,6 @@ final class NewsTransitionHeaderView: UICollectionReusableView,
             newsAffordanceContentView.leadingAnchor.constraint(equalTo: leadingAnchor),
             newsAffordanceContentView.trailingAnchor.constraint(equalTo: trailingAnchor),
             newsAffordanceContentView.bottomAnchor.constraint(equalTo: bottomAnchor),
-
-            sectionTitleHeaderView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
-            sectionTitleHeaderView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            sectionTitleHeaderView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            sectionTitleHeaderView.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
     }
 
@@ -124,5 +140,28 @@ final class NewsTransitionHeaderView: UICollectionReusableView,
         } else {
             NSLayoutConstraint.deactivate(newsAffordanceExpandedConstraints)
         }
+    }
+
+    private func updateSectionTitleHeaderFrame() {
+        guard bounds.width > 0, bounds.height > 0 else {
+            sectionTitleHeaderView.frame = bounds
+            return
+        }
+
+        // Measure the label header at its natural height, then pin that measured frame to the
+        // bottom of the transition container so the crossfade matches the final resting position.
+        let measuredHeight = sectionTitleHeaderView.systemLayoutSizeFitting(
+            CGSize(width: bounds.width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+
+        let headerHeight = min(bounds.height, measuredHeight)
+        sectionTitleHeaderView.frame = CGRect(
+            x: 0,
+            y: bounds.height - headerHeight,
+            width: bounds.width,
+            height: headerHeight
+        )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15171)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32653)

## :bulb: Description
- Fixes some constraint warnings that you would see on launch and orientation switch with the `NewsTransitionHeaderView`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

