### PR TITLE
Refactor NO_TICKET [Bookmarks Panel] Disable bookmarks search feature in release

### DIFF
--- a/firefox-ios/nimbus-features/bookmarksSearchFeature.yaml
+++ b/firefox-ios/nimbus-features/bookmarksSearchFeature.yaml
@@ -8,11 +8,11 @@ features:
         description: >
           Whether or not this feature is enabled
         type: Boolean
-        default: true
+        default: false
     defaults:
       - channel: beta
         value:
-          enabled: true
+          enabled: false
       - channel: developer
         value:
-          enabled: true
+          enabled: false


### PR DESCRIPTION
## :scroll: Tickets
No ticket.

## :bulb: Description
QA found issues in bookmarks panel search (#32651) added in PR #32469, so we will temporarily disable the feature in the release and beta channels.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

