### PR TITLE
Bugfix FXIOS-15174 [News Transition] Fix stories peek with large dynamic type

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -53,8 +53,8 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             static let storiesSpacing: CGFloat = 12
             static let verticalStoriesSpacing: CGFloat = 16
 
-            /// `storiesPeekOffset` is how much we want the stories section (section header) to peek in vertically
-            ///  from the bottom of the homepage viewport
+            /// `storiesPeekOffset` is how much we want the stories section (not including section header)
+            /// to peek in vertically from the bottom of the homepage viewport
             static let storiesPeekOffset: CGFloat = 14
 
             @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15174)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32659)

## :bulb: Description
- Persist stories peek offset even at large dynamic type

### 📝 Technical Notes
- Previously, we were only accounting for the news affordance header's hardcoded height (72px) instead of it's actual height which must be measured when dynamic type changes. 

## :movie_camera: Demos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/283bbeaf-fd03-46dc-8076-33bafd99fa34

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/d2ad3f43-842b-4904-8065-6c906b5251c5

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

