### PR TITLE
[MTE-5273]-fixes for navigation tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -618,7 +618,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
         springBoardScreen.longPressFennecIcon(at: 0, duration: 1.5)
         springBoardScreen.tapNewPrivateButton()
         onboardingScreen.handleTermsOfService()
-        onboardingScreen.waitForCurrentScreenElements()
+        onboardingScreen.waitForCurrentScreenElements(waitForImage: false)
         onboardingScreen.closeTourIfNeeded()
         browserScreen.assertPrivateModeMessageCardExists()
         navigator.openURL(website_1["url"]!)
@@ -657,7 +657,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
 
         // Close onboarding if it appears
         onboardingScreen.handleTermsOfService()
-        onboardingScreen.waitForCurrentScreenElements()
+        onboardingScreen.waitForCurrentScreenElements(waitForImage: false)
         onboardingScreen.closeTourIfNeeded()
 
         // Verify the bookmarked page opens

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/OnboardingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/OnboardingScreen.swift
@@ -104,7 +104,7 @@ final class OnboardingScreen {
     /// Handles the initial ToS screen based on app channel (Firefox Beta, Firefox, Fennec). ToS must be accepted before the
     /// onboarding flow begins.
     func handleTermsOfService() {
-        BaseTestCase().mozWaitForElementToExist(tosContinueButton)
+        BaseTestCase().mozWaitForElementToExist(tosContinueButton, timeout: TIMEOUT_LONG)
         tosContinueButton.tap()
     }
 
@@ -208,14 +208,15 @@ final class OnboardingScreen {
     func waitForCurrentScreenElements(checkCloseButton: Bool = false,
                                       checkPageControl: Bool = false,
                                       waitForImage: Bool = true) {
-        let img = app.images["\(rootA11yId)ImageView"]
+        var img: XCUIElement
         let title = sel.titleLabel(rootId: rootA11yId).element(in: app)
         let desc = sel.descriptionLabel(rootId: rootA11yId).element(in: app)
 
         if waitForImage {
-            let img = app.images["\(rootA11yId)ImageView"]
+            img = app.images["\(rootA11yId)ImageView"]
             BaseTestCase().waitForElementsToExist([img, title, desc, primaryButton])
         } else {
+            img = app.images["firefoxLoader"]
             BaseTestCase().waitForElementsToExist([title, desc, primaryButton])
         }
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5273

## :bulb: Description
Small fixes for testLongTapFirefoxIconNewPrivateTab and testLongTapFirefoxIconOpenLastBookmark 
