### PR TITLE
Bugfix FXIOS-15071 [Tracking protection] Blocked trackers view is not reacting to theme change

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersHelpers/BlockedTrackerCell.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersHelpers/BlockedTrackerCell.swift
@@ -6,7 +6,8 @@ import Foundation
 import Common
 
 class BlockedTrackerCell: UITableViewCell,
-                          ReusableCell {
+                          ReusableCell,
+                          ThemeApplicable {
     private struct UX {
         static let imageMargins: CGFloat = 10
         static let textVerticalDistance: CGFloat = 11

--- a/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersHelpers/BlockedTrackersHeaderView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersHelpers/BlockedTrackersHeaderView.swift
@@ -6,7 +6,8 @@ import Foundation
 import Common
 
 class BlockedTrackersHeaderView: UITableViewHeaderFooterView,
-                                 ReusableCell {
+                                 ReusableCell,
+                                 ThemeApplicable {
     let totalTrackersBlockedLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .left

--- a/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersTableController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersTableController.swift
@@ -259,15 +259,5 @@ class BlockedTrackersTableViewController: UIViewController,
         navigationView.applyTheme(theme: theme)
         trackersTable.applyTheme(theme: theme)
         view.backgroundColor = theme.colors.layer3
-
-        if let headerView = trackersTable.headerView(forSection: 0) as? BlockedTrackersHeaderView {
-            headerView.applyTheme(theme: theme)
-        }
-
-        for cell in trackersTable.visibleCells {
-            if let blockedTrackerCell = cell as? BlockedTrackerCell {
-                blockedTrackerCell.applyTheme(theme: theme)
-            }
-        }
     }
 }


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15071)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32446)

## :bulb: Description
This PR solves the bug related to blocked trackers view not reacting to theme change and now the view theme is updated instantly when the theme is changed.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

