### PR TITLE
Bugfix FXIOS-15183 #32687 Fix stuck translation spinner with timeout, error propagation, and engine crash recovery

### DIFF
--- a/firefox-ios/Client/Assets/CC_Script/translations-engine.sys.mjs
+++ b/firefox-ios/Client/Assets/CC_Script/translations-engine.sys.mjs
@@ -650,29 +650,41 @@ function listenForPortMessages(languagePair, innerWindowId, port) {
       case "TranslationsPort:TranslationRequest": {
         const { sourceText, isHTML, translationId } = data;
 
-        const engine = await TranslationsEngine.getOrCreate(
-          languagePair,
-          innerWindowId
-        );
+        try {
+          const engine = await TranslationsEngine.getOrCreate(
+            languagePair,
+            innerWindowId
+          );
 
-        TE_addProfilerMarker({
-          innerWindowId,
-          type: "Request",
-          message: `Handled translation request of ${sourceText.length} code units`,
-        });
+          TE_addProfilerMarker({
+            innerWindowId,
+            type: "Request",
+            message: `Handled translation request of ${sourceText.length} code units`,
+          });
 
-        const targetText = await engine.translate(
-          sourceText,
-          isHTML,
-          innerWindowId,
-          translationId
-        );
+          const targetText = await engine.translate(
+            sourceText,
+            isHTML,
+            innerWindowId,
+            translationId
+          );
 
-        port.postMessage({
-          type: "TranslationsPort:TranslationResponse",
-          translationId,
-          targetText,
-        });
+          port.postMessage({
+            type: "TranslationsPort:TranslationResponse",
+            translationId,
+            targetText,
+          });
+        } catch (error) {
+          TE_logError(
+            `Translation request failed for translationId ${translationId}`,
+            error
+          );
+          port.postMessage({
+            type: "TranslationsPort:TranslationError",
+            translationId,
+            error: error?.message ?? "Unknown translation error",
+          });
+        }
 
         break;
       }

--- a/firefox-ios/Client/Frontend/Translations/Engine/TranslationsEngine.swift
+++ b/firefox-ios/Client/Frontend/Translations/Engine/TranslationsEngine.swift
@@ -5,7 +5,7 @@
 import WebKit
 
 @MainActor
-final class TranslationsEngine {
+final class TranslationsEngine: NSObject, WKNavigationDelegate {
     /// A single WKWebView managed by the engine.
     private let webView: WKWebView
     /// Keep bridges alive as long as their webviews exist.
@@ -38,6 +38,9 @@ final class TranslationsEngine {
 
         self.webView = WKWebView(frame: .zero, configuration: config)
         self.webView.isHidden = true
+
+        super.init()
+        self.webView.navigationDelegate = self
 
         #if targetEnvironment(simulator)
         /// Allow Safari Web Inspector only when running in simulator.
@@ -92,5 +95,16 @@ final class TranslationsEngine {
     private func loadEntrypointHTML() {
         let appURL = URL(string: "translations://app/TranslationsEngine.html")!
         webView.load(URLRequest(url: appURL))
+    }
+
+    // MARK: - WKNavigationDelegate
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        let enumerator = bridges.objectEnumerator()
+        while let bridge = enumerator?.nextObject() as? Bridge {
+            bridge.teardown()
+        }
+        bridges.removeAllObjects()
+        loadEntrypointHTML()
     }
 }

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
@@ -135,7 +135,7 @@ final class TranslationsService: TranslationsServiceProtocol {
         do {
             _ = try await webView.callAsyncJavaScript(js, contentWorld: .defaultClient)
         } catch {
-            /// NOTE: It would be safe to pass in the js string directly here, but it would just add too much noise
+            /// NOTE: It would be safe to pass in the js string directly here, but it would just add too much noise 
             /// since from and to could be any language code. We only care that discardTranslationsJS failed.
             throw TranslationsServiceError.jsEvaluationFailed(reason: "JS evaluation failed: discardTranslationsJS")
         }

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceError.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceError.swift
@@ -8,6 +8,7 @@ enum TranslationsServiceError: Error, Equatable {
     case deviceLanguageUnavailable
     case jsEvaluationFailed(reason: String)
     case pageLanguageDetectionFailed(description: String)
+    case translationTimedOut
     case unknown(domain: String, code: Int)
     /// Converts an unknown error into a `TranslationsServiceError`.
     /// This intentionally loses information about the original error type.
@@ -33,6 +34,8 @@ enum TranslationsServiceError: Error, Equatable {
             return "js_evaluation_failed(\(reason))"
         case .pageLanguageDetectionFailed(let description):
             return "page_language_detection_failed(\(description))"
+        case .translationTimedOut:
+            return "translation_timed_out"
         case .unknown(let domain, let code):
             return "unknown(domain:\(domain),code:\(code))"
         }

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
@@ -9,11 +9,13 @@ import "Assets/CC_Script/translations-engine.sys.mjs";
 /// In Gecko, we mark translations done when the engine is ready.
 /// In iOS, we will go a step further and wait for the first translation response to be received.
 let isDoneResolve;
+let isDoneReject;
 let isDonePromise;
 
 const resetIsDone = () => {
-    isDonePromise = new Promise(resolve => {
+    isDonePromise = new Promise((resolve, reject) => {
         isDoneResolve = resolve;
+        isDoneReject = reject;
     });
 };
 
@@ -33,6 +35,21 @@ window.receive = (message) => {
     if (message.type === "TranslationsPort:TranslationResponse" && isDoneResolve) {
         isDoneResolve(true);
         isDoneResolve = null;
+        isDoneReject = null;
+    }
+
+    if (message.type === "TranslationsPort:TranslationError" && isDoneReject) {
+        isDoneReject(new Error(message.error || "Translation engine error"));
+        isDoneResolve = null;
+        isDoneReject = null;
+    }
+
+    if (message.type === "TranslationsPort:EngineTerminated"
+        && message.innerWindowId === innerWindowId
+        && isDoneReject) {
+        isDoneReject(new Error("Translation engine terminated"));
+        isDoneResolve = null;
+        isDoneReject = null;
     }
 
     if(message.type !== "TranslationsPort:EngineTerminated") {
@@ -82,7 +99,13 @@ const discardTranslations = ({from, to}) => {
 /// NOTE: This returns a promise that resolves when the translation process is "done".
 /// This is used mainly to turn the translations button to the active state in the UI.
 /// This should be called from swift.
-const isDone = async () => isDonePromise;
+/// Races against a 15-second timeout so the spinner never hangs indefinitely.
+const isDone = async () => {
+    const timeout = new Promise((_, reject) => {
+        setTimeout(() => reject(new Error("Translation timed out")), 15000);
+    });
+    return Promise.race([isDonePromise, timeout]);
+};
 
 /// NOTE: Expose the Translations API to the privileged context.
 /// Anything not exposed here will not be accessible outside this user script.


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Add 15-second timeout to isDone() in TranslationsEntrypoint.js so the spinner never hangs indefinitely when the WASM engine fails silently.
- Add isDoneReject path for TranslationError and EngineTerminated (scoped to current session via innerWindowId check to ignore stale messages).
- Wrap TranslationRequest handler in translations-engine.sys.mjs with try/catch that sends TranslationError response instead of silently dropping failed requests.
- Add translationTimedOut case to TranslationsServiceError for telemetry.
- Add webViewWebContentProcessDidTerminate to TranslationsEngine to recover from engine WebProcess crashes by reloading the entrypoint.


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

