### PR TITLE
Bugfix FXIOS-15195 Replace homepage header text with MCP

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Header/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Header/HomepageHeaderCell.swift
@@ -14,6 +14,7 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
         static let firefoxLogoImageSize = CGSize(width: 40, height: 40)
         static let firefoxTextImageSize = CGSize(width: 90, height: 40)
         static let interImageSpacing: CGFloat = 10
+        static let headerLabelColor = UIColor(rgb: 0x785ced)
 
         static func contentWidth() -> CGFloat {
             return UX.firefoxLogoImageSize.width + UX.interImageSpacing + UX.firefoxTextImageSize.width
@@ -46,8 +47,12 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
         imageView.contentMode = .scaleAspectFit
     }
 
-    private lazy var logoTextImage: UIImageView = .build { imageView in
-        imageView.contentMode = .scaleAspectFit
+    private lazy var logoTextLabel: UILabel = .build { label in
+        label.text = "MCP"
+        label.font = FXFontStyles.Regular.title1.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 1
+        label.textAlignment = .left
     }
 
     // MARK: - Initializers
@@ -65,7 +70,7 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
         if !hasConfiguredView {
             contentView.backgroundColor = .clear
             logoStackView.addArrangedSubview(logoImage)
-            logoStackView.addArrangedSubview(logoTextImage)
+            logoStackView.addArrangedSubview(logoTextLabel)
 
             logoContainerView.addSubview(logoStackView)
             stackContainer.addArrangedSubview(logoContainerView)
@@ -104,8 +109,8 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
         logoConstraints = [
             logoImage.widthAnchor.constraint(equalToConstant: UX.firefoxLogoImageSize.width),
             logoImage.heightAnchor.constraint(equalToConstant: UX.firefoxLogoImageSize.height),
-            logoTextImage.widthAnchor.constraint(equalToConstant: UX.firefoxTextImageSize.width),
-            logoTextImage.heightAnchor.constraint(equalToConstant: UX.firefoxTextImageSize.height)
+            logoTextLabel.widthAnchor.constraint(equalToConstant: UX.firefoxTextImageSize.width),
+            logoTextLabel.heightAnchor.constraint(equalToConstant: UX.firefoxTextImageSize.height)
         ]
 
         NSLayoutConstraint.activate(logoConstraints)
@@ -118,22 +123,6 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
 
     // MARK: - ThemeApplicable
     func applyTheme(theme: Theme) {
-        // TODO: FXIOS-10851 This can be moved to the new homescreen wallpaper fetching redux
-        let wallpaperManager = WallpaperManager()
-        let browserViewType = store.state.componentState(
-            BrowserViewControllerState.self,
-            for: .browserViewController,
-            window: currentWindowUUID
-        )?.browserViewType
-
-        if let logoTextColor = wallpaperManager.currentWallpaper.logoTextColor, browserViewType != .privateHomepage {
-            logoTextImage.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoText)
-                .withRenderingMode(.alwaysTemplate)
-            logoTextImage.tintColor = logoTextColor
-        } else {
-            logoTextImage.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoText)
-                .withRenderingMode(.alwaysTemplate)
-            logoTextImage.tintColor = theme.colors.textPrimary
-        }
+        logoTextLabel.textColor = UX.headerLabelColor
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15195)
[Github issue](N/A)

## :bulb: Description
- Replace the homepage header Firefox wordmark image with a simple `MCP` text label.
- Keep the existing Firefox logo mark, spacing, and centered header width intact.
- Match the Figma spec on the requested `iPhone 17` / `iOS 26` simulator build.

## :movie_camera: Demos
| Before | After |
| - | - |
| Local screenshot: `/Users/mlichtenstein/firefox-ios/.codex-artifacts/fxios-15195-before.png` | Local screenshot: `/Users/mlichtenstein/firefox-ios/.codex-artifacts/fxios-15195-after.png` |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
