### PR TITLE
Remove FXIOS-15173 [Top 10 bugs] Toast shown incorrectly when adding a new search engine

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -28,7 +28,6 @@ class CustomSearchViewController: SettingsTableViewController {
     private let logger: Logger
     private var urlString: String?
     private var engineTitle = ""
-    var successCallback: (() -> Void)?
     private lazy var spinnerView: UIActivityIndicatorView = .build { [self] spinner in
         spinner.style = .medium
         spinner.color = themeManager.getCurrentTheme(for: windowUUID).colors.iconSpinner
@@ -76,11 +75,7 @@ class CustomSearchViewController: SettingsTableViewController {
                 let engine = try await createEngine(query: trimmedQuery, name: trimmedTitle)
                 spinnerView.stopAnimating()
                 searchEnginesManager.addSearchEngine(engine)
-
-                CATransaction.begin() // Use transaction to call callback after animation has been completed
-                CATransaction.setCompletionBlock(successCallback)
                 _ = navigationController?.popViewController(animated: true)
-                CATransaction.commit()
             } catch {
                 spinnerView.stopAnimating()
                 let alert: UIAlertController

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -514,9 +514,6 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
             guard isLastItem else { return nil }
             let customSearchEngineForm = CustomSearchViewController(windowUUID: windowUUID)
             customSearchEngineForm.profile = self.profile
-            customSearchEngineForm.successCallback = {
-                self.showPlainToast()
-            }
             navigationController?.pushViewController(customSearchEngineForm, animated: true)
         case .searchEnginesSuggestions, .preSearch:
             return nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15173)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32658)

## :bulb: Description
- Remove (redundant) confirmation toast after adding a new search engine, user already has confirmation when the new engine is shown in the settings screen.
- Remove the `successCallback` since it was only used to show the Toast and completion block wasn't working as expected since show Toast at the wrong time


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

