### PR TITLE
Add FXIOS-15202 Large file debug utility

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/AppDataUsageReportSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/AppDataUsageReportSetting.swift
@@ -15,23 +15,48 @@ class AppDataUsageReportSetting: HiddenSetting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         let results = generateAppDataSummary()
-        UIPasteboard.general.string = results
+        UIPasteboard.general.string = results.report
 
-        // Hidden debug utility not localized for now.
-        showSimpleAlert("Summary generated. Text has been copied to the clipboard.")
+        // Hidden debug utility (strings not localized for now)
+        showReportAlert("Summary generated. Text has been copied to the clipboard.", largeFiles: results.largeFiles)
     }
 
     // MARK: - Internal Utilities
 
-    private func showSimpleAlert(_ message: String) {
+    private func showReportAlert(_ message: String, largeFiles: [String: UInt64]) {
         let alert = UIAlertController(title: "App Data Usage",
                                       message: message,
                                       preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+            self.promptForLargeFileCopy(largeFiles)
+        }))
         settings.present(alert, animated: true)
     }
 
-    private func generateAppDataSummary() -> String {
+    private func promptForLargeFileCopy(_ largeFiles: [String: UInt64]) {
+        guard !largeFiles.isEmpty else { return }
+        let message = "Copy large files to your Files app for debugging? This may use a significant amount of storage."
+        let alert = UIAlertController(title: "Copy Large Files?", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Copy Files", style: .default, handler: { _ in
+            self.copyLargeFiles(largeFiles)
+        }))
+        alert.addAction(UIAlertAction(title: "Don't Copy", style: .cancel))
+        settings.present(alert, animated: true)
+    }
+
+    private func copyLargeFiles(_ largeFiles: [String: UInt64]) {
+        let fileManager = FileManager.default
+        guard let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+        for file in largeFiles.keys {
+            let filePath = file as String
+            let sourceURL = URL(fileURLWithPath: filePath)
+            let destinationURL = documentsURL.appendingPathComponent(sourceURL.lastPathComponent)
+            guard !fileManager.fileExists(atPath: destinationURL.path) else { continue }
+            try? fileManager.copyItem(at: sourceURL, to: destinationURL)
+        }
+    }
+
+    private func generateAppDataSummary() -> (report: String, largeFiles: [String: UInt64]) {
         var directoriesAndSizes: [String: UInt64] = [:]
         var largeFileWarnings: [String: UInt64] = [:]
         let fileManager = FileManager.default
@@ -110,6 +135,6 @@ class AppDataUsageReportSetting: HiddenSetting {
         for (file, size) in largeFileWarnings {
             result += "\nSize: \(size / 1024) kb \t\tFile: \t\(file)"
         }
-        return result
+        return (result, largeFileWarnings)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)

## :bulb: Description

Updates our App Data Usage diagnostic utility in the hidden debug menu to include support for copying large files temporarily to the Files app. **This has no effect on general app usage in production**, and will only be used in cases where we direct users to this utility specifically to help investigate bugs.

## :movie_camera: Demos

<img width="391" height="252" alt="Screenshot 2026-03-26 at 11 13 05 AM" src="https://github.com/user-attachments/assets/383ca702-4d14-444d-84e7-91330099aa34" />

<img width="420" height="682" alt="Screenshot 2026-03-26 at 11 10 52 AM" src="https://github.com/user-attachments/assets/6611faa5-d2d5-46a1-832c-f0bc8156dba1" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

