### PR TITLE
Bugfix #32419 ⁃ [Unit tests] Flaky testUseSystemAppearance_WithRedux

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
@@ -26,16 +26,19 @@ class ThemeSettingsControllerTests: XCTestCase, StoreTestUtility {
     }
 
     @MainActor
-    func testUseSystemAppearance_WithRedux() async throws {
+    func testUseSystemAppearance_WithRedux() {
         let subject = createSubject()
         let themeSwitch = createUseSystemThemeSwitch(isOn: true)
         subject.systemThemeSwitchValueChanged(control: themeSwitch)
 
         // Needed to wait for Redux action handled async in main thread
-        try await Task.sleep(nanoseconds: 200)
-
-        XCTAssertTrue(subject.isSystemThemeOn)
-        XCTAssertEqual(subject.tableView.numberOfSections, 1)
+        let expectation = self.expectation(description: "Redux Middleware")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            expectation.fulfill()
+            XCTAssertTrue(subject.isSystemThemeOn)
+            XCTAssertEqual(subject.tableView.numberOfSections, 1)
+        }
+        waitForExpectations(timeout: 1)
     }
 
     func testUseCustomAppearance_WithRedux() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15056)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32419)

## :bulb: Description
The test was failing because the expectation was not met, and `trackForMemoryLeaks` failed. 
The assumption is that because `setUp` and `tearDown` are now async throws, there might be cases where the test is triggered in a Swift concurrency context that is NOT guaranteed to be on the main thread. 

When `waitForExpectations` is called off the main thread, it doesn't pump the main run loop, so `DispatchQueue.main.asyncAfter` blocks never fire, and the expectation times out. Adding @MainActor to the synchronous test method ensures it always runs on the main thread, allowing waitForExpectations to correctly drain the main run loop.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

