### PR TITLE
Fix #32719: Use displayedBookmarkNodes instead of bookmarkNodes for U…

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -71,6 +71,9 @@ final class BookmarksViewController: SiteTableViewController,
             if #available(iOS 26.0, *) {
                 bottomRightButton.tintColor = currentTheme().colors.textPrimary
             }
+            // Hide search button when there are no bookmarks
+            guard !viewModel.bookmarkNodes.isEmpty else { return [flexibleSpace, bottomRightButton] }
+            // Show search and edit buttons when bookmarks are available
             return searchItems + [flexibleSpace, bottomRightButton]
         case .bookmarks(state: .search):
             return searchItems + [flexibleSpace]
@@ -278,11 +281,11 @@ final class BookmarksViewController: SiteTableViewController,
             return middleIndexPath.row
         }
 
-        return viewModel.bookmarkNodes.count
+        return viewModel.displayedBookmarkNodes.count
     }
 
     private func deleteBookmarkNodeAtIndexPath(_ indexPath: IndexPath) {
-        guard let bookmarkNode = viewModel.bookmarkNodes[safe: indexPath.row]else {
+        guard let bookmarkNode = viewModel.displayedBookmarkNodes[safe: indexPath.row] else {
             return
         }
 
@@ -369,7 +372,7 @@ final class BookmarksViewController: SiteTableViewController,
             }
 
         tableView.beginUpdates()
-        viewModel.bookmarkNodes.remove(at: indexPath.row)
+        viewModel.removeDisplayedBookmarkNode(at: indexPath.row)
         tableView.deleteRows(at: [indexPath], with: .left)
         tableView.endUpdates()
         updateEmptyState(animated: false)
@@ -442,7 +445,7 @@ final class BookmarksViewController: SiteTableViewController,
     }
 
     private func updateEmptyState(animated: Bool) {
-        let showEmptyState = viewModel.bookmarkNodes.isEmpty && !tableView.isEditing
+        let showEmptyState = viewModel.displayedBookmarkNodes.isEmpty && !tableView.isEditing
 
         if animated {
             a11yEmptyStateScrollView.isHidden = false
@@ -654,7 +657,7 @@ final class BookmarksViewController: SiteTableViewController,
 
     /// Root folders and local desktop folder cannot be moved or edited
     private func isCurrentFolderEditable(at indexPath: IndexPath) -> Bool {
-        guard let currentRowData = viewModel.bookmarkNodes[safe: indexPath.row] else {
+        guard let currentRowData = viewModel.displayedBookmarkNodes[safe: indexPath.row] else {
             return false
         }
 
@@ -785,7 +788,7 @@ extension BookmarksViewController: LibraryPanelContextMenu {
                     self.presentContextMenu(for: site, with: indexPath, completionHandler: {
                         return self.contextMenu(for: site, with: indexPath)
                     })
-                } else if let bookmarkNode = self.viewModel.bookmarkNodes[safe: indexPath.row],
+                } else if let bookmarkNode = self.viewModel.displayedBookmarkNodes[safe: indexPath.row],
                           bookmarkNode.type == .folder,
                           self.isCurrentFolderEditable(at: indexPath) {
                     self.presentContextMenu(for: bookmarkNode, indexPath: indexPath)
@@ -843,7 +846,7 @@ extension BookmarksViewController: LibraryPanelContextMenu {
         let editBookmark = SingleActionViewModel(title: .Bookmarks.Menu.EditBookmark,
                                                  iconString: StandardImageIdentifiers.Large.edit,
                                                  tapHandler: { _ in
-            guard let bookmarkNode = self.viewModel.bookmarkNodes[safe: indexPath.row],
+            guard let bookmarkNode = self.viewModel.displayedBookmarkNodes[safe: indexPath.row],
                   let bookmarkFolder = self.viewModel.bookmarkFolder else {
                 return
             }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
@@ -107,7 +107,7 @@ final class BookmarksPanelViewModel: @unchecked Sendable {
     }
 
     func getSiteDetails(for indexPath: IndexPath, completion: @escaping @Sendable (Site?) -> Void) {
-        guard let bookmarkNode = bookmarkNodes[safe: indexPath.row],
+        guard let bookmarkNode = displayedBookmarkNodes[safe: indexPath.row],
               let bookmarkItem = bookmarkNode as? BookmarkItemData
         else {
             logger.log("Could not get site details for indexPath \(indexPath)",
@@ -152,6 +152,24 @@ final class BookmarksPanelViewModel: @unchecked Sendable {
                 }
             }
         ).items
+    }
+
+    // MARK: - Displayed Data Source Mutations
+
+    /// Removes a bookmark node from the displayed data source at the given index.
+    /// When searching, this removes from `filteredBookmarkNodes` and also from the
+    /// backing `bookmarkNodes` array so both stay in sync.
+    /// When not searching, this removes directly from `bookmarkNodes`.
+    func removeDisplayedBookmarkNode(at index: Int) {
+        if isSearching {
+            let node = filteredBookmarkNodes[index]
+            filteredBookmarkNodes.remove(at: index)
+            if let backingIndex = bookmarkNodes.firstIndex(where: { $0.guid == node.guid }) {
+                bookmarkNodes.remove(at: backingIndex)
+            }
+        } else {
+            bookmarkNodes.remove(at: index)
+        }
     }
 
     // MARK: - Search


### PR DESCRIPTION
# Fix #32719: Bookmarks panel search — sync internal data arrays with UI

Closes [issue#32719](https://github.com/mozilla-mobile/firefox-ios/issues/32719)

## Summary

When bookmarks panel search is enabled (via `bookmarksSearchFeature.yaml`), several methods in `BookmarksViewController` and `BookmarksPanelViewModel` were accessing `viewModel.bookmarkNodes` directly to resolve UI index paths. Because `bookmarkNodes` is the full backing store while the table view displays `displayedBookmarkNodes` (which returns search-filtered results when searching), the indices were mismatched. This caused out-of-sync data and crashes — for example, deleting a bookmark from filtered search results would use the wrong index into the backing array.

## Changes

### `BookmarksPanelViewModel.swift`

- **`getSiteDetails(for:completion:)`** — Changed to look up the node from `displayedBookmarkNodes` instead of `bookmarkNodes`, since the `indexPath` originates from the UI table view which uses the displayed (possibly filtered) data source.
- **Added `removeDisplayedBookmarkNode(at:)`** — New helper method that correctly removes a node from the active data source. When searching, it removes from `filteredBookmarkNodes` *and* the backing `bookmarkNodes` (matched by GUID) so both stay in sync. When not searching, it removes directly from `bookmarkNodes`.

### `BookmarksViewController.swift`

| Method | Change |
|---|---|
| `centerVisibleRow()` | Use `displayedBookmarkNodes.count` as fallback instead of `bookmarkNodes.count` |
| `deleteBookmarkNodeAtIndexPath(_:)` | Look up the node from `displayedBookmarkNodes` instead of `bookmarkNodes` |
| `deleteBookmarkNode(_:bookmarkNode:)` | Use `viewModel.removeDisplayedBookmarkNode(at:)` instead of `viewModel.bookmarkNodes.remove(at:)` |
| `updateEmptyState(animated:)` | Check `displayedBookmarkNodes.isEmpty` instead of `bookmarkNodes.isEmpty` |
| `isCurrentFolderEditable(at:)` | Look up row data from `displayedBookmarkNodes` instead of `bookmarkNodes` |
| `presentContextMenu(for:)` | Use `displayedBookmarkNodes` for the folder-type fallback lookup |
| `getContextMenuActions(for:with:)` | Use `displayedBookmarkNodes` for the edit-bookmark action lookup |
| `toolbarButtonItems` | Added guard to hide search and edit buttons when bookmarks list is empty |

### Unchanged (intentionally still using `bookmarkNodes`)

- **`addBookmarkNodeToTable`** — Inserts into the backing store; not called during search.
- **`flashRow()`** — Flashes the last added row; not called during search.
- **Drag & drop methods** (`dropSessionDidUpdate`, `performDropWith`) — Already protected by `canEditRowAt` / `canMoveRowAt` returning `false` when `isSearching`.
- **`moveRow(at:to:)`** in the view model — Only reachable when editing, which is disabled during search.

## Testing

1. Enable `bookmarksSearchFeature` in the feature YAML.
2. Navigate to the Bookmarks panel with several bookmarks.
3. Tap the search button and enter a query that filters to a subset.
4. Long-press or tap the context menu on a filtered result → verify the correct bookmark's context menu appears.
5. Delete a bookmark from the filtered results → verify no crash and the row is removed.
6. Cancel search → verify the deleted bookmark is also gone from the full list.
7. Verify empty state shows correctly when all displayed bookmarks are deleted.
