### PR TITLE
Bugfix FXIOS-15208 #32723 [Translations - Phase 2] Toggle state out of sync with saved preference on screen load

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
@@ -88,6 +88,10 @@ final class TranslationPickerSettingsViewController: UIViewController,
         subscribeToRedux()
         store.dispatch(TranslationSettingsViewAction(
             windowUUID: windowUUID,
+            actionType: TranslationSettingsViewActionType.initialize
+        ))
+        store.dispatch(TranslationSettingsViewAction(
+            windowUUID: windowUUID,
             actionType: TranslationSettingsViewActionType.viewDidLoad
         ))
     }

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsAction.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsAction.swift
@@ -49,6 +49,7 @@ struct TranslationSettingsMiddlewareAction: Action {
 }
 
 enum TranslationSettingsViewActionType: ActionType {
+    case initialize
     case viewDidLoad
     case toggleTranslationsEnabled
     case addLanguage

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
@@ -36,6 +36,14 @@ final class TranslationSettingsMiddleware {
         )
 
         switch action.actionType {
+        case TranslationSettingsViewActionType.initialize:
+            let isEnabled = prefs.boolForKey(PrefsKeys.Settings.translationsFeature) ?? true
+            store.dispatch(TranslationSettingsMiddlewareAction(
+                isTranslationsEnabled: isEnabled,
+                windowUUID: action.windowUUID,
+                actionType: TranslationSettingsMiddlewareActionType.didLoadSettings
+            ))
+
         case TranslationSettingsViewActionType.viewDidLoad:
             Task { await self.loadSettings(windowUUID: action.windowUUID) }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15208)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32723)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The toggle briefly appeared ON even when translations was disabled, because the initial state defaulted to true and the correct value only arrived after the async language fetch completed. A new `initialize` action reads the pref synchronously before the async fetch so the toggle renders correctly from the start.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

