### PR TITLE
Add FXIOS-14997 [News Transition] Multi-column support for stories section

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDimensionImplementation.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDimensionImplementation.swift
@@ -131,19 +131,20 @@ struct HomepageDimensionCalculator {
     }
 
     // Calculates the number of cells that fit given a container's width, including spacing between items
-    static func numberOfCellsThatFit(in containerWidth: CGFloat, traitCollection: UITraitCollection) -> Int {
+    static func numberOfCellsThatFit(in containerWidth: CGFloat, horizontalInset: CGFloat) -> Int {
+        let minimumCellWidth = HomepageSectionLayoutProvider.UX.PocketConstants.minimumCellWidth
         // Portion of the container not occupied by insets
-        let sectionHorizontalInsets = (HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: traitCollection) * 2)
+        let sectionHorizontalInsets = horizontalInset * 2
         let availableContainerWidth = containerWidth - sectionHorizontalInsets
         // # of cells that would fit in container
-        let cellsPerRow = floor(availableContainerWidth / HomepageSectionLayoutProvider.UX.PocketConstants.minimumCellWidth)
+        let cellsPerRow = floor(availableContainerWidth / minimumCellWidth)
         // Amount of space used by inter-item spacing
         let spacingAdjustment = (cellsPerRow > 1 ?
                                  (cellsPerRow - 1) * HomepageSectionLayoutProvider.UX.PocketConstants.interItemSpacing : 0)
         // Available container width for cells
         let adjustedContainerWidth = availableContainerWidth - spacingAdjustment
         // Number of cells that will fit in a row, considering inter-item spacing
-        let adjustedCellsPerRow = Int(adjustedContainerWidth / HomepageSectionLayoutProvider.UX.PocketConstants.minimumCellWidth)
+        let adjustedCellsPerRow = Int(adjustedContainerWidth / minimumCellWidth)
         return max(HomepageSectionLayoutProvider.UX.PocketConstants.minimumCellsPerRow, adjustedCellsPerRow)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -320,8 +320,9 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         ?? SectionHeaderConfiguration(title: "", a11yIdentifier: "")
 
         let containerWidth = environment.container.effectiveContentSize.width
+        let horizontalInset = UX.leadingInset(traitCollection: traitCollection)
         let cellCount = HomepageDimensionCalculator.numberOfCellsThatFit(in: containerWidth,
-                                                                         traitCollection: traitCollection)
+                                                                         horizontalInset: horizontalInset)
 
         // For iOS 17+ we use uniform height across cells in the same group (row) which is the height of the tallest cell
         // in the group.
@@ -366,7 +367,6 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         )
         section.boundarySupplementaryItems = [header]
 
-        let horizontalInset = UX.leadingInset(traitCollection: traitCollection)
         section.contentInsets = NSDirectionalEdgeInsets(
             top: 0,
             leading: horizontalInset,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDimensionCalculatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDimensionCalculatorTests.swift
@@ -8,12 +8,24 @@ import XCTest
 
 @MainActor
 class HomepageDimensionCalculatorTests: XCTestCase {
-    struct UX {
-        struct DeviceSize {
-            static let iPhone14 = CGSize(width: 390, height: 844)
-            static let iPadAir = CGSize(width: 820, height: 1180)
-            static let iPadAirCompactSplit = CGSize(width: 320, height: 375)
-        }
+    struct DeviceSize {
+        static let iPhone14 = CGSize(width: 390, height: 844)
+        static let iPadAir = CGSize(width: 820, height: 1180)
+        static let iPadAirCompactSplit = CGSize(width: 320, height: 375)
+
+        static let iPhone17PortraitWidth: CGFloat = 402
+        static let iPhone17LandscapeSafeAreaWidth: CGFloat = 750
+        static let iPhone17ProMaxPortraitWidth: CGFloat = 440
+        static let iPhone17ProMaxLandscapeSafeAreaWidth: CGFloat = 832
+        static let iPhoneSEPortraitWidth: CGFloat = 320
+        static let iPhoneSELandscapeWidth: CGFloat = 568
+        static let iPadPro13InPortrait: CGFloat = 1032
+        static let iPadPro13InLandscape: CGFloat = 1376
+    }
+
+    struct Insets {
+        static let iPhoneInset = HomepageSectionLayoutProvider.UX.standardInset
+        static let ipadInset = HomepageSectionLayoutProvider.UX.iPadInset
     }
 
     // MARK: - maxJumpBackInItemsToDisplay
@@ -78,7 +90,7 @@ class HomepageDimensionCalculatorTests: XCTestCase {
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .phone)
 
         let numberOfTilesPerRow = HomepageDimensionCalculator.numberOfTopSitesPerRow(
-            availableWidth: UX.DeviceSize.iPhone14.width,
+            availableWidth: DeviceSize.iPhone14.width,
             leadingInset: leadingInset
         )
 
@@ -90,7 +102,7 @@ class HomepageDimensionCalculatorTests: XCTestCase {
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .phone)
 
         let numberOfTilesPerRow = HomepageDimensionCalculator.numberOfTopSitesPerRow(
-            availableWidth: UX.DeviceSize.iPhone14.height,
+            availableWidth: DeviceSize.iPhone14.height,
             leadingInset: leadingInset
         )
 
@@ -102,7 +114,7 @@ class HomepageDimensionCalculatorTests: XCTestCase {
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
 
         let numberOfTilesPerRow = HomepageDimensionCalculator.numberOfTopSitesPerRow(
-            availableWidth: UX.DeviceSize.iPadAir.width,
+            availableWidth: DeviceSize.iPadAir.width,
             leadingInset: leadingInset
         )
 
@@ -114,7 +126,7 @@ class HomepageDimensionCalculatorTests: XCTestCase {
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
 
         let numberOfTilesPerRow = HomepageDimensionCalculator.numberOfTopSitesPerRow(
-            availableWidth: UX.DeviceSize.iPadAir.height,
+            availableWidth: DeviceSize.iPadAir.height,
             leadingInset: leadingInset
         )
 
@@ -126,7 +138,7 @@ class HomepageDimensionCalculatorTests: XCTestCase {
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
 
         let numberOfTilesPerRow = HomepageDimensionCalculator.numberOfTopSitesPerRow(
-            availableWidth: UX.DeviceSize.iPadAirCompactSplit.width,
+            availableWidth: DeviceSize.iPadAirCompactSplit.width,
             leadingInset: leadingInset
         )
 
@@ -138,7 +150,7 @@ class HomepageDimensionCalculatorTests: XCTestCase {
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
 
         let numberOfTilesPerRow = HomepageDimensionCalculator.numberOfTopSitesPerRow(
-            availableWidth: UX.DeviceSize.iPadAirCompactSplit.height,
+            availableWidth: DeviceSize.iPadAirCompactSplit.height,
             leadingInset: leadingInset
         )
 
@@ -161,5 +173,59 @@ class HomepageDimensionCalculatorTests: XCTestCase {
         let result = HomepageDimensionCalculator.getTallestViewHeight(views: views, viewWidth: testWidth)
 
         XCTAssertEqual(result, 80, accuracy: 0.1)
+    }
+
+    func test_numberOfCellsThatFit_withIphone17Portrait_returnsExpectedCellCount() {
+        let deviceSize = DeviceSize.iPhone17PortraitWidth
+        let cellCount = HomepageDimensionCalculator.numberOfCellsThatFit(in: deviceSize,
+                                                                         horizontalInset: Insets.iPhoneInset)
+        XCTAssertEqual(cellCount, 1)
+    }
+
+    func test_numberOfCellsThatFit_withIphone17Landscape_returnsExpectedCellCount() {
+        let deviceSize = DeviceSize.iPhone17LandscapeSafeAreaWidth
+        let cellCount = HomepageDimensionCalculator.numberOfCellsThatFit(in: deviceSize,
+                                                                         horizontalInset: Insets.iPhoneInset)
+        XCTAssertEqual(cellCount, 2)
+    }
+
+    func test_numberOfCellsThatFit_withIphone17ProMaxPortrait_returnsExpectedCellCount() {
+        let deviceSize = DeviceSize.iPhone17ProMaxPortraitWidth
+        let cellCount = HomepageDimensionCalculator.numberOfCellsThatFit(in: deviceSize,
+                                                                         horizontalInset: Insets.iPhoneInset)
+        XCTAssertEqual(cellCount, 1)
+    }
+
+    func test_numberOfCellsThatFit_withIphone17ProMaxLandscape_returnsExpectedCellCount() {
+        let deviceSize = DeviceSize.iPhone17ProMaxLandscapeSafeAreaWidth
+        let cellCount = HomepageDimensionCalculator.numberOfCellsThatFit(in: deviceSize,
+                                                                         horizontalInset: Insets.iPhoneInset)
+        XCTAssertEqual(cellCount, 2)
+    }
+
+    func test_numberOfCellsThatFit_withIphoneSePortrait_returnsExpectedCellCount() {
+        let deviceSize = DeviceSize.iPhoneSEPortraitWidth
+        let cellCount = HomepageDimensionCalculator.numberOfCellsThatFit(in: deviceSize,
+                                                                         horizontalInset: Insets.iPhoneInset)
+        XCTAssertEqual(cellCount, 1)
+    }
+
+    func test_numberOfCellsThatFit_witIhphoneSeLandscape_returnsExpectedCellCount() {
+        let deviceSize = DeviceSize.iPhoneSELandscapeWidth
+        let cellCount = HomepageDimensionCalculator.numberOfCellsThatFit(in: deviceSize,
+                                                                         horizontalInset: Insets.iPhoneInset)
+        XCTAssertEqual(cellCount, 1)
+    }
+
+    func test_numberOfCellsThatFit_withIpad13InPortrait_returnsExpectedCellCount() {
+        let deviceSize = DeviceSize.iPadPro13InPortrait
+        let cellCount = HomepageDimensionCalculator.numberOfCellsThatFit(in: deviceSize, horizontalInset: Insets.ipadInset)
+        XCTAssertEqual(cellCount, 2)
+    }
+
+    func test_numberOfCellsThatFit_withIpad13InLandscape_returnsExpectedCellCount() {
+        let deviceSize = DeviceSize.iPadPro13InLandscape
+        let cellCount = HomepageDimensionCalculator.numberOfCellsThatFit(in: deviceSize, horizontalInset: Insets.ipadInset)
+        XCTAssertEqual(cellCount, 3)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14997)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32303)

## :bulb: Description
- Add multi-column support to the stories homepage section

### 📝 Technical Notes:
- Uses similar methodologies as #30066 
- Story cards have a minimum width of 320px
- In terms of handling dynamic type
  - On devices on iOS 17+, all story cells in the same row are a uniform size, which is that of the largest cell
  - On devices on versions earlier than iOS 17, cells are sized based on their content, meaning cells in the same row can be varying heights

## :movie_camera: Demos
| Before | After |
| ------------- | ------------- |
| <img width="2622" height="1206" alt="Simulator Screenshot - iPhone 17 - 2026-03-27 at 17 46 47" src="https://github.com/user-attachments/assets/1d87bcc0-fea9-4e3d-8206-1e5c69114f20" /> | <img width="2622" height="1206" alt="Simulator Screenshot - iPhone 17 - 2026-03-27 at 17 39 11" src="https://github.com/user-attachments/assets/e6580625-ffad-416f-b368-5ca8610f5a29" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

