### PR TITLE
Refactor FXIOS-15240 [Bookmarks Panel] Move methods from view controller to view model for MVVM

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -30,7 +30,6 @@ final class BookmarksViewController: SiteTableViewController,
     var state: LibraryPanelMainState
     var isTransitioning = false
     let viewModel: BookmarksPanelViewModelProtocol
-    var bookmarksSaver: BookmarksSaver?
     private var logger: Logger
     private let bookmarksTelemetry = BookmarksTelemetry()
 
@@ -156,8 +155,6 @@ final class BookmarksViewController: SiteTableViewController,
         self.state = isMobileFolder ? .bookmarks(state: .mainView) : .bookmarks(state: .inFolder)
         self.bookmarksHandler = viewModel.profile.places
         super.init(profile: viewModel.profile, windowUUID: windowUUID)
-
-        bookmarksSaver = DefaultBookmarksSaver(profile: profile)
 
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
@@ -327,26 +324,8 @@ final class BookmarksViewController: SiteTableViewController,
     /// Performs the delete asynchronously even though we update the
     /// table view data source immediately for responsiveness.
     private func deleteBookmarkNode(_ indexPath: IndexPath, bookmarkNode: FxBookmarkNode) {
-        profile.places.deleteBookmarkNode(guid: bookmarkNode.guid)
-            .uponQueue(.main) { _ in
-                // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
-                MainActor.assumeIsolated {
-                    if let recentBookmarkFolderGuid = self.profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder) {
-                        self.profile.places.getBookmark(guid: recentBookmarkFolderGuid)
-                            .uponQueue(.main) { node in
-                                // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
-                                MainActor.assumeIsolated {
-                                    guard let nodeValue = node.successValue, nodeValue == nil else { return }
-                                    self.profile.prefs.removeObjectForKey(PrefsKeys.RecentBookmarkFolder)
-                                }
-                            }
-                    }
-                    self.removeBookmarkShortcut()
-                }
-            }
-
         tableView.beginUpdates()
-        viewModel.removeBookmark(atPosition: indexPath.row)
+        viewModel.remove(bookmark: bookmarkNode)
         tableView.deleteRows(at: [indexPath], with: .left)
         tableView.endUpdates()
         updateEmptyState(animated: false)
@@ -433,6 +412,7 @@ final class BookmarksViewController: SiteTableViewController,
 
         emptyStateView.configure(isRoot: viewModel.isRootNode,
                                  isSignedIn: profile.hasAccount())
+
         // Depending on empty state, show/hide the search bar in the library panel's toolbar
         sendPanelChangeNotification()
     }
@@ -697,8 +677,8 @@ final class BookmarksViewController: SiteTableViewController,
                    withDestinationIndexPath destinationIndexPath: IndexPath?) -> UITableViewDropProposal {
         guard let destinationIndex = destinationIndexPath?.row,
               let sourceIndex = (session.localDragSession?.items[safe: 0]?.localObject as? IndexPath)?.row,
-              let destinationFolder = viewModel.bookmarkNodes[safe: destinationIndex],
-              let sourceNode = viewModel.bookmarkNodes[safe: sourceIndex],
+              let destinationFolder = viewModel.displayedBookmarkNodes[safe: destinationIndex],
+              let sourceNode = viewModel.displayedBookmarkNodes[safe: sourceIndex],
               destinationFolder.type == .folder,
               sourceNode.type == .bookmark || sourceNode.type == .folder,
               sourceNode.guid != destinationFolder.guid else {
@@ -713,28 +693,18 @@ final class BookmarksViewController: SiteTableViewController,
         guard let destinationIndexPath = coordinator.destinationIndexPath,
               let item = coordinator.items[safe: 0],
               let sourceIndexPath = item.dragItem.localObject as? IndexPath,
-              let sourceItem = viewModel.bookmarkNodes[safe: sourceIndexPath.row],
-              let destinationItem = viewModel.bookmarkNodes [safe: destinationIndexPath.row],
+              let sourceItem = viewModel.displayedBookmarkNodes[safe: sourceIndexPath.row],
+              let destinationItem = viewModel.displayedBookmarkNodes[safe: destinationIndexPath.row],
               coordinator.proposal.intent == .insertIntoDestinationIndexPath
         else { return }
 
-        Task {
-            let result = await bookmarksSaver?.save(bookmark: sourceItem,
-                                                    parentFolderGUID: destinationItem.guid)
-            switch result {
-            case .success:
-                Task { @MainActor in
-                    tableView.beginUpdates()
-                    viewModel.removeBookmark(atPosition: sourceIndexPath.row)
-                    tableView.deleteRows(at: [sourceIndexPath], with: .left)
-                    tableView.endUpdates()
-                    updateEmptyState(animated: false)
-                    profile.prefs.setString(destinationItem.guid, forKey: PrefsKeys.RecentBookmarkFolder)
-                }
-            default:
-                return
-            }
-        }
+        tableView.beginUpdates()
+        viewModel.moveBookmarkToFolder(bookmark: sourceItem, withGUID: destinationItem.guid)
+        tableView.deleteRows(at: [sourceIndexPath], with: .left)
+        tableView.endUpdates()
+
+        updateEmptyState(animated: false)
+        profile.prefs.setString(destinationItem.guid, forKey: PrefsKeys.RecentBookmarkFolder)
     }
 
     func tableView(_ tableView: UITableView, didEndEditingRowAt indexPath: IndexPath?) {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
@@ -12,7 +12,7 @@ import class MozillaAppServices.BookmarkItemData
 import enum MozillaAppServices.BookmarkRoots
 
 @MainActor
-protocol BookmarksPanelViewModelProtocol: Sendable {
+protocol BookmarksPanelViewModelProtocol: Sendable, CanRemoveQuickActionBookmark {
     var profile: Profile { get }
     var bookmarkNodes: [FxBookmarkNode] { get }
     var bookmarkFolder: FxBookmarkNode? { get }
@@ -25,8 +25,8 @@ protocol BookmarksPanelViewModelProtocol: Sendable {
     func resetSearch()
     func searchBookmarks(query: String, completion: @escaping @MainActor @Sendable () -> Void)
     func reloadData(completion: @escaping @MainActor () -> Void)
-    func addBookmark(bookmarkNode: FxBookmarkNode, atPosition position: Int)
-    func removeBookmark(atPosition position: Int)
+    func moveBookmarkToFolder(bookmark: FxBookmarkNode, withGUID parentFolderGUID: String)
+    func remove(bookmark: FxBookmarkNode)
     func getSiteDetails(for indexPath: IndexPath, completion: @escaping @MainActor (Site?) -> Void)
     func moveRow(at sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath)
     func createPinUnpinAction(
@@ -66,8 +66,9 @@ final class BookmarksPanelViewModel: BookmarksPanelViewModelProtocol {
         return isSearching ? filteredBookmarkNodes : bookmarkNodes
     }
 
+    var bookmarksHandler: BookmarksHandler
+    private var bookmarksSaver: BookmarksSaver
     private var hasDesktopFolders = false
-    private var bookmarksHandler: BookmarksHandler
     private var flashLastRowOnNextReload = false
     private let logger: Logger
 
@@ -75,10 +76,12 @@ final class BookmarksPanelViewModel: BookmarksPanelViewModelProtocol {
     init(profile: Profile,
          bookmarksHandler: BookmarksHandler,
          bookmarkFolderGUID: GUID = BookmarkRoots.MobileFolderGUID,
+         bookmarksSaver: BookmarksSaver? = nil,
          logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.bookmarksHandler = bookmarksHandler
         self.bookmarkFolderGUID = bookmarkFolderGUID
+        self.bookmarksSaver = bookmarksSaver ?? DefaultBookmarksSaver(profile: profile)
         self.logger = logger
     }
 
@@ -382,11 +385,50 @@ final class BookmarksPanelViewModel: BookmarksPanelViewModelProtocol {
         filteredBookmarkNodes.removeAll()
     }
 
-    func addBookmark(bookmarkNode: FxBookmarkNode, atPosition position: Int) {
-        bookmarkNodes.insert(bookmarkNode, at: position)
+    func removeBookmarkLocally(bookmark: FxBookmarkNode) {
+        // Immediately remove the bookmark from backing arrays and search matches, if needed (for UI responsiveness)
+        bookmarkNodes.removeAll(where: { $0.guid == bookmark.guid })
+        filteredBookmarkNodes.removeAll(where: { $0.guid == bookmark.guid })
     }
 
-    func removeBookmark(atPosition position: Int) {
-        bookmarkNodes.remove(at: position)
+    /// Deletes the bookmark. Deletion of the bookmark in places happens asynchronously, but tableView source arrays are
+    /// updated immediately for UI responsiveness.
+    func remove(bookmark: FxBookmarkNode) {
+        // Remove the bookmark from places (async background work)
+        profile.places.deleteBookmarkNode(guid: bookmark.guid).uponQueue(.main) { _ in
+            // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+            MainActor.assumeIsolated {
+                // Remove this bookmark out of recent places
+                if let recentBookmarkFolderGuid = self.profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder) {
+                    self.profile.places.getBookmark(guid: recentBookmarkFolderGuid).uponQueue(.main) { node in
+                        // FXIOS-13228 It should be safe to assumeIsolated here because of `.main` queue above
+                        MainActor.assumeIsolated {
+                            guard let nodeValue = node.successValue, nodeValue == nil else { return }
+
+                            self.profile.prefs.removeObjectForKey(PrefsKeys.RecentBookmarkFolder)
+                        }
+                    }
+                }
+
+                // Remove this bookmark from quick actions
+                self.removeBookmarkShortcut()
+            }
+        }
+
+        // Immediately remove the bookmark from backing arrays and search matches, if needed (for UI responsiveness)
+        removeBookmarkLocally(bookmark: bookmark)
+    }
+
+    /// Updates the bookmark with a new parent GUID. Update of bookmark in places happens asynchronously, but tableView
+    /// source arrays are updated immediately for UI responsiveness.
+    func moveBookmarkToFolder(bookmark: FxBookmarkNode, withGUID parentFolderGUID: String) {
+        // Save the bookmark updates (async)
+        Task {
+            _ = await bookmarksSaver.save(bookmark: bookmark, parentFolderGUID: parentFolderGUID)
+        }
+
+        // When a bookmark is dragged and dropped into another folder, we should remove it from the current view of bookmarks
+        // Immediately update the UI for responsiveness.
+        removeBookmarkLocally(bookmark: bookmark)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15240)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32761)

## :bulb: Description
Part 4 of some quick refactors to this area of the code.

This PR moves the methods for adding/removing bookmarks from the viewController into the viewModel.

Minor functionality change in the drag to drop (bookmarks edit mode) when you put a bookmark into a folder. It seems to me that if we were optimistically updating the UI for removing a bookmark we should also do the same thing for moving them. That also can reduce some of the async-await complexity in that method.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

