### PR TITLE
Remove FXIOS-15286 [Telemetry] Ad cookies parsing not used

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/Ads.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/Ads.js
@@ -5,15 +5,13 @@
 /**
  * Send
  * - current URL
- * - cookies of this page
  * - all links found in this page
  * to the native application.
  */
 function sendCurrentState() {
     let message = {
         'url': document.location.href,
-        'urls': getLinks(),
-        'cookies': getCookies()
+        'urls': getLinks()
     };
     
     webkit.messageHandlers.adsMessageHandler.postMessage(message);
@@ -36,56 +34,6 @@ function getLinks() {
     }
 
     return urls;
-}
-
-/**
- * Get all cookies for the current document.
- *
- * @return {Array<{name: string, value: string}>} containing all cookies.
- */
-function getCookies() {
-    let cookiesList = safeCookiesList();
-    let result = [];
-
-    cookiesList.forEach(cookie => {
-        var [name, ...value] = cookie.split('=');
-        // For that special cases where the value contains '='.
-        value = value.join("=")
-
-        result.push({
-            "name" : name,
-            "value" : value
-        });
-    });
-
-    return result;
-}
-
-// FXIOS-13891: WebKit process crashes on cross-origin cookie operation on about:blank tabs
-// Helper method to verify via SecurityError earlier than touching the document crashes it
-function safeCookiesList() {
-    let documentCookies = [];
-
-    const isNewTab = window.location.protocol == "about:";
-    const hasOpener = !!window.opener;
-    const hasParent = hasOpener && window.opener.parent != window.opener;
-
-    // Special-casing only different origins coming from different frames in new tabs
-    if (isNewTab && hasOpener && hasParent) {
-        const frameParent = window.opener.parent;
-        // Positively catch the SecurityError on the conditional as a way to not touch the cookie inside
-        try {
-            if (frameParent.location.origin == window.opener.location.origin) {
-                documentCookies = document.cookie.split("; ");
-            }
-        } catch {
-            documentCookies = [""];
-        }
-    } else {
-        documentCookies = document.cookie.split("; ");
-    }
-
-    return documentCookies;
 }
 
 // Whenever a page is first accessed or when loaded from cache

--- a/focus-ios/Blockzilla/Ads.js
+++ b/focus-ios/Blockzilla/Ads.js
@@ -8,15 +8,13 @@
 /**
  * Send
  * - current URL
- * - cookies of this page
  * - all links found in this page
  * to the native application.
  */
 function sendCurrentState() {
     let message = {
         'url': document.location.href,
-        'urls': getLinks(),
-        'cookies': getCookies()
+        'urls': getLinks()
     };
     
     webkit.messageHandlers.adsMessageHandler.postMessage(message);
@@ -39,29 +37,6 @@ function getLinks() {
     }
 
     return urls;
-}
-
-/**
- * Get all cookies for the current document.
- *
- * @return {Array<{name: string, value: string}>} containing all cookies.
- */
-function getCookies() {
-    let cookiesList = document.cookie.split("; ");
-    let result = [];
-
-    cookiesList.forEach(cookie => {
-        var [name, ...value] = cookie.split('=');
-        // For that special cases where the value contains '='.
-        value = value.join("=")
-
-        result.push({
-            "name" : name,
-            "value" : value
-        });
-    });
-
-    return result;
 }
 
 // Whenever a page is first accessed or when loaded from cache


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-15286
GitHub issue #32826

## :bulb: Description

The values collected JS–side are not utilized further by the native helpers. This has caused WebKit crashes so it would be better to remove completely if unused.

<!--
## :movie_camera: Demos
 -->

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code