### PR TITLE
Bugfix FXIOS-15203 [Bookmarks Panel Search] Add bottom overlay to bookmarks search bar

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -111,10 +111,10 @@ class SiteTableViewController: UIViewController,
         view.addSubview(tableView)
 
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15203)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32717)

## :bulb: Description
This PR adds a bottom overlay to the bookmarks search bar, matching the existing behavior in the history search panel.

Previously, when the bookmarks search bar was activated, the `bottomStackView` was not made visible when the keyboard spacer was added, and there was no animation when the keyboard dismissed. This resulted in a missing overlay especially noticeable on iPads.

### Changes made in `BookmarksViewController.swift`:
1. **`setupView()`**: Updated constraints: Using `view.safeAreaLayoutGuide` instead of only `view` to apply layout constraints.

## :movie_camera: Demos

| Before | After |
| - | - |
| No bottom overlay on bookmarks search bar (search bar floats without background on iPad) | Bottom overlay appears behind bookmarks search bar, consistent with history search panel |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
