### PR TITLE
Bugfix FXIOS-15177 [News Transition] Update news affordance icon

### DIFF
--- a/BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift
+++ b/BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift
@@ -91,6 +91,7 @@ public struct StandardImageIdentifiers {
         public static let logoFirefox = "logoFirefoxLarge"
         public static let microphone = "microphoneLarge"
         public static let moreHorizontalRound = "moreHorizontalRoundLarge"
+        public static let newsfeed = "newsfeedLarge"
         public static let newFolder = "newFolderLarge"
         public static let nightMode = "nightModeLarge"
         public static let nightModeFill = "nightModeFillLarge"

--- a/firefox-ios/Client/Assets/Images.xcassets/newsfeedLarge.imageset/Contents.json
+++ b/firefox-ios/Client/Assets/Images.xcassets/newsfeedLarge.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "newsfeed-20.pdf",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/firefox-ios/Client/Assets/Images.xcassets/newsfeedLarge.imageset/newsfeed-20.pdf
+++ b/firefox-ios/Client/Assets/Images.xcassets/newsfeedLarge.imageset/newsfeed-20.pdf
@@ -1,0 +1,219 @@
+%PDF-1.7
+%€€€€
+1 0 obj
+  << /Length 2 0 R
+     /Subtype /XML
+     /Type /Metadata
+  >>
+stream
+<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""
+      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+      <dc:title>
+        <rdf:Alt>
+          <rdf:li xml:lang="x-default">(news \057 newsfeed\05520)</rdf:li>
+        </rdf:Alt>
+      </dc:title>
+      <dc:language>
+        <rdf:Bag>
+          <rdf:li>(en)</rdf:li>
+        </rdf:Bag>
+      </dc:language>
+    </rdf:Description>
+    <rdf:Description xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/">
+      <pdfuaid:part>1</pdfuaid:part>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>
+endstream
+endobj
+
+2 0 obj
+  744
+endobj
+
+3 0 obj
+  << /Nums [ 0
+             []
+           ]
+     /Type /ParentTree
+  >>
+endobj
+
+4 0 obj
+  << >>
+endobj
+
+5 0 obj
+  << /Length 6 0 R >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+/Artifact BMC
+q
+1.000000 0.000000 -0.000000 1.000000 1.250000 13.500000 cm
+0.000000 0.376471 0.874510 scn
+8.750000 1.750000 m
+3.500000 1.750000 l
+3.500000 -3.750000 l
+8.750000 -3.750000 l
+8.750000 1.750000 l
+h
+f
+n
+Q
+q
+1.000000 0.000000 -0.000000 1.000000 1.250000 17.250000 cm
+0.000000 0.376471 0.874510 scn
+14.500000 -9.500000 m
+3.500000 -9.500000 l
+3.500000 -11.250000 l
+14.500000 -11.250000 l
+14.500000 -9.500000 l
+h
+f
+n
+Q
+q
+1.000000 0.000000 -0.000000 1.000000 1.250000 17.250000 cm
+0.000000 0.376471 0.874510 scn
+10.250000 -2.000000 m
+14.500000 -2.000000 l
+14.500000 -3.750000 l
+10.250000 -3.750000 l
+10.250000 -2.000000 l
+h
+f
+n
+Q
+q
+1.000000 0.000000 -0.000000 1.000000 1.250000 17.250000 cm
+0.000000 0.376471 0.874510 scn
+14.500000 -5.750000 m
+10.250000 -5.750000 l
+10.250000 -7.500000 l
+14.500000 -7.500000 l
+14.500000 -5.750000 l
+h
+f
+n
+Q
+q
+1.000000 0.000000 -0.000000 1.000000 1.250000 2.250000 cm
+0.000000 0.376471 0.874510 scn
+0.000000 14.250000 m
+0.000000 15.630249 1.119751 16.750000 2.500000 16.750000 c
+15.500000 16.750000 l
+16.880249 16.750000 18.000000 15.630249 18.000000 14.250000 c
+18.000000 2.500000 l
+18.000000 1.119751 16.880249 0.000000 15.500000 0.000000 c
+2.500000 0.000000 l
+1.119751 0.000000 0.000000 1.119751 0.000000 2.500000 c
+0.000000 14.250000 l
+h
+2.500000 15.000000 m
+2.086249 15.000000 1.750000 14.663751 1.750000 14.250000 c
+1.750000 2.500000 l
+1.750000 2.086249 2.086249 1.750000 2.500000 1.750000 c
+15.500000 1.750000 l
+15.913751 1.750000 16.250000 2.086249 16.250000 2.500000 c
+16.250000 14.250000 l
+16.250000 14.663751 15.913751 15.000000 15.500000 15.000000 c
+2.500000 15.000000 l
+h
+f*
+n
+Q
+EMC
+
+endstream
+endobj
+
+6 0 obj
+  1662
+endobj
+
+7 0 obj
+  << /Kids [ 8 0 R ]
+     /Count 1
+     /Type /Pages
+  >>
+endobj
+
+8 0 obj
+  << /Annots []
+     /Parent 7 0 R
+     /Resources 4 0 R
+     /MediaBox [ 0.000000 0.000000 20.000000 20.000000 ]
+     /Type /Page
+     /Tabs /S
+     /StructParents 0
+     /Contents 5 0 R
+  >>
+endobj
+
+9 0 obj
+  << /P 10 0 R
+     /S /Part
+     /Pg 8 0 R
+     /Type /StructElem
+  >>
+endobj
+
+10 0 obj
+  << /K [ 9 0 R ]
+     /P 11 0 R
+     /S /Document
+     /Type /StructElem
+  >>
+endobj
+
+11 0 obj
+  << /ParentTreeNextKey 1
+     /ParentTree 3 0 R
+     /K [ 10 0 R ]
+     /Type /StructTreeRoot
+  >>
+endobj
+
+12 0 obj
+  << /MarkInfo << /Marked true >>
+     /Metadata 1 0 R
+     /ViewerPreferences << /DisplayDocTitle true >>
+     /Info << /Producer (Figma)
+              /Title (news \057 newsfeed\05520)
+           >>
+     /StructTreeRoot 11 0 R
+     /Lang (en)
+     /Pages 7 0 R
+     /Type /Catalog
+  >>
+endobj
+
+xref
+0 13
+0000000000 65535 f
+0000000015 00000 n
+0000000857 00000 n
+0000000879 00000 n
+0000000967 00000 n
+0000000991 00000 n
+0000002709 00000 n
+0000002732 00000 n
+0000002806 00000 n
+0000003015 00000 n
+0000003103 00000 n
+0000003199 00000 n
+0000003316 00000 n
+trailer
+<< /ID [ (15645\07215749) (15645\07215749) ]
+   /Root 12 0 R
+   /Size 13
+>>
+startxref
+3621
+%%EOF

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsAffordanceHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsAffordanceHeaderView.swift
@@ -13,7 +13,7 @@ final class NewsAffordanceHeaderView: UIView, ThemeApplicable {
         static let stackHorizontalInset: CGFloat = 20
         static let iconSpacing: CGFloat = 4
         static let chevronSize: CGFloat = 20
-        static let newsIconSize: CGFloat = 24
+        static let newsIconSize: CGFloat = 20
     }
 
     // MARK: - UI Elements
@@ -44,7 +44,7 @@ final class NewsAffordanceHeaderView: UIView, ThemeApplicable {
 
     private lazy var newsIconImageView: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
-        imageView.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.readingList)
+        imageView.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.newsfeed)
     }
 
     private lazy var newsLabel: UILabel = .build { label in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15177)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32673)

## :bulb: Description
- Update the news affordance header to use a unique newsfeed icon instead of the reading list icon

### 📝 Technical Notes:
- This icon is not yet in the [acorn-icons repo](https://github.com/FirefoxUX/acorn-icons), but is in the process of being added

## :movie_camera: Demos
| Before | After |
| ------------- | ------------- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-03-31 at 16 51 39" src="https://github.com/user-attachments/assets/8a66e4cb-8900-4797-bd08-919652d6d63a" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-03-31 at 16 48 34" src="https://github.com/user-attachments/assets/1ea32b3d-0d1c-4556-b77e-81fe3fdfd3d8" /> |

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

