### PR TITLE
Bugfix FXIOS-32843 [Bookmarks Panel Search] Add debug toggle for bookmarks search feature

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -52,6 +52,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .bookmarksSearchFeature,
+                titleText: format(string: "Bookmarks Search"),
+                statusText: format(string: "Toggle to enable bookmarks panel search feature")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .deeplinkOptimizationRefactor,
                 titleText: format(string: "Deeplink Optimization Refactor"),
                 statusText: format(string: "Toggle to enable deeplink optimization refactor")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15294)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32843)

## :bulb: Description
Adds a debug toggle for the `bookmarksSearchFeature` feature flag in the `FeatureFlagsDebugViewController`.

This allows QA to enable or disable the bookmarks panel search feature from the hidden debug settings screen (Settings → tap Firefox version 5 times → Feature Flags) for testing purposes when verifying bugfixes.

The new `FeatureFlagsBoolSetting` entry is placed in alphabetical order (by title) alongside the existing feature flag toggles, following the same pattern used by the other debug settings.

**Changes:**
- Added a `FeatureFlagsBoolSetting` entry for `.bookmarksSearchFeature` with the title "Bookmarks Search" in `FeatureFlagsDebugViewController.swift`

## :movie_camera: Demos

| Before | After |
| - | - |
| No "Bookmarks Search" toggle in Feature Flags debug settings | "Bookmarks Search" toggle appears in the Feature Flags debug settings list |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
