### PR TITLE
Bugfix SYNC-4976 Fix TPS testing configs to reflect oauth

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/conftest.py
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/conftest.py
@@ -57,9 +57,13 @@ def tps_addon(pytestconfig, tmpdir_factory):
 
 @pytest.fixture
 def tps_config(fxa_account):
-    yield {'fx_account': {
-        'username': fxa_account.email,
-        'password': fxa_account.password}}
+    yield {
+        'fx_account': {
+            'username': fxa_account.email,
+            'password': fxa_account.password,
+        },
+        'fxaStaging': True,
+    }
 
 
 @pytest.fixture
@@ -73,7 +77,9 @@ def tps_log(pytestconfig, tmpdir):
 def tps_profile(pytestconfig, tps_addon, tps_config, tps_log, fxa_urls):
     preferences = {
         'app.update.enabled': False,
+        'security.turn_off_all_security_so_that_viruses_can_take_over_this_computer': True,
         'browser.dom.window.dump.enabled': True,
+        'devtools.console.stdout.chrome': True,
         'browser.onboarding.enabled': False,
         'browser.sessionstore.resume_from_crash': False,
         'browser.shell.checkDefaultBrowser': False,
@@ -90,8 +96,6 @@ def tps_profile(pytestconfig, tps_addon, tps_config, tps_log, fxa_urls):
         'extensions.update.enabled': False,
         'extensions.update.notifyUser': False,
         'identity.fxaccounts.autoconfig.uri': fxa_urls['content'],
-        'identity.fxaccounts.contextParam': 'fx_desktop_v3',
-        'identity.fxaccounts.oauth.enabled': False,
         'testing.tps.skipPingValidation': True,
         'services.sync.firstSync': 'notReady',
         'services.sync.lastversion': '1.0',


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/SYNC-4976

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

With the OAuth flow being the only auth on desktop, TPS has been updated on desktop (https://mozilla-hub.atlassian.net/browse/SYNC-5199). We need to update the config to match the new flow. Also some automation updates with FxA's new auth pages. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

ickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

