### PR TITLE
Bugfix FXIOS-15055 Link share prompt is displaced on iPad

### DIFF
--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -120,7 +120,11 @@ class LibraryCoordinator: BaseCoordinator,
         add(child: coordinator)
 
         // Note: Called from History, Bookmarks, and Reading List long presses > Share from the context menu
-        coordinator.start(shareType: .site(url: url), shareMessage: nil, sourceView: sourceView, popoverArrowDirection: .any)
+        let arrowDirection: UIPopoverArrowDirection = UIDevice.current.userInterfaceIdiom == .pad ? .any : .up
+        coordinator.start(shareType: .site(url: url),
+                          shareMessage: nil,
+                          sourceView: sourceView,
+                          popoverArrowDirection: arrowDirection)
     }
 
     private func makeBookmarksCoordinator(navigationController: UINavigationController) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15055)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32416)

## :bulb: Description
This PR solves the issue with the popover for share link that previously did not fit completely on the screen. This bug was happening on history links, bookmarks and reading list on iPad and now this fix solves all the cases and the prompt is displayed corectly.

<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->


<img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2026-04-02 at 11 07 35" src="https://github.com/user-attachments/assets/2b0fe95b-f18f-4526-8f52-059e239f29b0" />



## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

