### PR TITLE
Bugfix FXIOS-11828 ⁃ [iPad] Weird behavior when closing tabs while Voice-Over is ON

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
@@ -53,7 +53,6 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFl
         label.lineBreakMode = .byCharWrapping
         label.font = FXFontStyles.Regular.caption1.scaledFont()
         label.semanticContentAttribute = .forceLeftToRight
-        label.isAccessibilityElement = false
     }
 
     let favicon: FaviconImageView = .build { _ in }
@@ -84,7 +83,6 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFl
         accessibilityLabel = getA11yTitleLabel(tab: tab)
         showsLargeContentViewer = true
         largeContentTitle = tab.getTabTrayTitle()
-        isAccessibilityElement = true
 
         closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel,
                                                 self.titleText.text ?? "")

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -376,6 +376,17 @@ extension TopTabsViewController: TopTabCellDelegate {
         delegate?.topTabsShowCloseTabsToast()
         NotificationCenter.default.post(name: .TopTabsTabClosed, object: nil, userInfo: windowUUID.userInfo)
         store.dispatch(TopTabsAction(windowUUID: windowUUID, actionType: TopTabsActionType.didTapCloseTab))
+
+        // Focus voice-over on the selected tab after current tab is closed
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            guard let self,
+                  let selected = self.tabManager.selectedTab,
+                  let index = self.topTabDisplayManager.dataStore.index(of: selected) else { return }
+
+            let indexPath = IndexPath(item: index, section: 0)
+            guard let selectedCell = self.collectionView.cellForItem(at: indexPath) else { return }
+            UIAccessibility.post(notification: .layoutChanged, argument: selectedCell)
+        }
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11828)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25785)

## :bulb: Description
Move voice-over to the selectedTab after tab is closed

## :movie_camera: Demos

https://github.com/user-attachments/assets/5faf53e6-b233-493d-9147-87d7950b1371



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

