### PR TITLE
Add FXIOS-15302 #32858 [Translations Phase 2] Enable keys for export

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -3391,7 +3391,7 @@ extension String {
                 key: "Settings.Translation.ToggleFooter.v151",
                 tableName: "Settings",
                 value: "Turn this off to remove translation from the toolbar and menu.",
-                comment: "Footer text below the enable-translations toggle in the Translation settings screen."
+                comment: "Footer text below the enable toggle in the Translation settings screen."
             )
 
             public struct PreferredLanguages {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15302)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32858)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Assigns real v151 localization keys to 14 translation strings that were previously blocked from export with empty key values.


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

