### PR TITLE
[MTE-5277] - fixes for failing smoke tests on iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -309,7 +309,6 @@
         "TabsTests\/testCloseAllTabsPrivateModeUndo_TAE()",
         "TabsTests\/testCloseAllTabsPrivateModeUndo_tabTrayExperimentOff()",
         "TabsTests\/testCloseAllTabsPrivateModeUndo_tabTrayExperimentOn()",
-        "TabsTests\/testCloseAllTabsUndo()",
         "TabsTests\/testCloseAllTabsUndo_TAE()",
         "TabsTests\/testCloseAllTabsUndo_tabTrayExperimentOff()",
         "TabsTests\/testCloseTabFromPageOptionsMenu()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -586,6 +586,7 @@
         "TabsTests\/testCloseAllTabsPrivateModeUndo_TAE()",
         "TabsTests\/testCloseAllTabsPrivateMode_tabTrayExperimentOff()",
         "TabsTests\/testCloseAllTabsPrivateMode_tabTrayExperimentOn()",
+        "TabsTests\/testCloseAllTabsUndo()",
         "TabsTests\/testCloseAllTabsUndo_TAE()",
         "TabsTests\/testCloseAllTabs_tabTrayExperimentOff()",
         "TabsTests\/testCloseOneTab()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -245,10 +245,6 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         BaseTestCase().waitForTabsButton()
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
         tabTray.assertCellExists(named: siteName)
-        if iPad() {
-            waitForTabsButton()
-            navigator.goto(TabTray)
-        }
         tabTray.assertFirstCellVisible()
         tabTray.assertTabCount(1)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -371,7 +371,9 @@ class BookmarksTests: FeatureFlaggedTestBase {
         homepageSettingsScreen.disableBookmarkToggle()
         homepageSettingsScreen.assertBookmarkToggleIsDisabled()
         navigator.nowAt(HomeSettings)
-        waitForTabsButton()
+        if !iPad() {
+            waitForTabsButton()
+        }
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         browserScreen.tapCancelButtonIfExist()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -272,7 +272,9 @@ class LoginTest: BaseTestCase {
         navigator.goto(SettingsScreen)
         navigator.performAction(Action.AcceptClearPrivateData)
 
-        waitForTabsButton()
+        if !iPad() {
+            waitForTabsButton()
+        }
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.openURL(urlLogin)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -129,16 +129,12 @@ class TabsTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         toolBarScreen.tapOnTabsButton()
         tabTrayScreen.tapOnNewTabButton()
-        waitForTabsButton()
-        navigator.goto(TabTray)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         // Close all tabs, undo it and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
         tabTrayScreen.undoRemovingAllTabs()
         firefoxHomePageScreen.assertTopSitesItemCellExist()
         navigator.nowAt(BrowserTab)
-        waitForTabsButton()
-        navigator.goto(TabTray)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         tabTrayScreen.waitForTabWithLabel(urlLabel)
     }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5277

## :bulb: Description
This PR https://github.com/mozilla-mobile/firefox-ios/pull/32838 introduced new failures for iPad smoke tests.
I am expecting to see new failures also for the full functional run on iPad.
Adjusted the test to pass on both platforms.
Also removed test testCloseAllTabsUndo from the smoke test plan and add it to the full functional one.
