### PR TITLE
Refactor FXIOS-15327 [Technical Debt] [Redux] Swift CopyWithUpdates macro fails to compile when properties have trailing comments

### DIFF
--- a/CopyWithUpdatesMacro/Sources/CopyWithUpdatesClient/main.swift
+++ b/CopyWithUpdatesMacro/Sources/CopyWithUpdatesClient/main.swift
@@ -9,9 +9,10 @@ import CopyWithUpdates
 @CopyWithUpdates
 struct Report {
     let venue: String
-    let sponsor: String?
-    let drinks: [String]
-    let complexStructure: [Date: [(String, Int)]]
+    let sponsor: String? // Test a trailing comment
+    let drinks: [String] /* Test a docstring trailing comments */
+    /// Test markup documentation
+    let complexStructure: [Date: [(String, Int)]/* test middle docstring comment*/] /// Test some trailing doc comments
     let characters: [String]?
     let budget: Double
 }

--- a/CopyWithUpdatesMacro/Sources/CopyWithUpdatesMacros/CopyWithUpdates.swift
+++ b/CopyWithUpdatesMacro/Sources/CopyWithUpdatesMacros/CopyWithUpdates.swift
@@ -56,15 +56,18 @@ public struct CopyWithUpdatesMacro: MemberMacro {
                 continue
             }
 
+            // Strip comments after the property definition
+            let propertyTypeString = stripCommentsFromTypeDefinition(ofProperty: propertyType.description)
+
             if propertyType.is(OptionalTypeSyntax.self) {
                 /// Optionals are treated as double optionals (`??`)
-                arguments.append("\(propertyName): \(propertyType)? = .some(nil)")
+                arguments.append("\(propertyName): \(propertyTypeString)? = .some(nil)")
 
                 /// We treat a top-level `nil` argument semantically as setting the property to `nil`, instead of passing
                 /// `.some(nil)`, which would feel odd at call sites.
                 assignments.append("\(propertyName): \(propertyName).map { $0 ?? self.\(propertyName) } ?? nil")
             } else {
-                arguments.append("\(propertyName): \(propertyType)? = nil")
+                arguments.append("\(propertyName): \(propertyTypeString)? = nil")
                 assignments.append("\(propertyName): \(propertyName) ?? self.\(propertyName)")
             }
         }
@@ -107,6 +110,40 @@ public struct CopyWithUpdatesMacro: MemberMacro {
             MessageID(domain: "CopyWithUpdatesMacros", id: String(describing: self))
         }
     }
+}
+
+// MARK: - Helpers
+public func stripCommentsFromTypeDefinition(ofProperty property: String) -> String {
+    var stringToClean = property
+
+    // Remove `// ...` or `/// ...` trailing comments
+    if let commentType1Position = stringToClean.range(of: "//")?.lowerBound {
+        stringToClean = String(stringToClean.prefix(upTo: commentType1Position))
+
+        // Recursively repeat in case there are other comment types on this line
+        return stripCommentsFromTypeDefinition(ofProperty: stringToClean)
+    }
+
+    // Remove `/* ... */` comments
+    if let commentType2PositionLower = stringToClean.range(of: "/*")?.lowerBound,
+       let commentType2PositionUpper = stringToClean.range(of: "*/")?.upperBound {
+        // Remove the `/* ... */` comment as if it's in the middle of the definition
+        let firstPart = stringToClean.prefix(upTo: commentType2PositionLower)
+        let secondPart = stringToClean.suffix(from: commentType2PositionUpper)
+        stringToClean = String(firstPart + secondPart)
+
+        // Recursively repeat this in case there are other `/* ... */` on the line
+        return stripCommentsFromTypeDefinition(ofProperty: stringToClean)
+    } else if let commentType2PositionLower = stringToClean.range(of: "/*")?.lowerBound {
+        // Remove the `/* ... ` which starts on this line and terminates on another line
+        stringToClean = String(stringToClean.prefix(upTo: commentType2PositionLower))
+
+        // Recursively repeat in case there are other comment types on this line
+        return stripCommentsFromTypeDefinition(ofProperty: stringToClean)
+    }
+
+    // Trim any lingering whitespace at the end of the property definition
+    return stringToClean.trimmingCharacters(in: .whitespaces)
 }
 
 @main

--- a/CopyWithUpdatesMacro/Tests/CopyWithUpdatesTests/CopyWithUpdatesTests.swift
+++ b/CopyWithUpdatesMacro/Tests/CopyWithUpdatesTests/CopyWithUpdatesTests.swift
@@ -76,11 +76,15 @@ final class CopyWithUpdatesTests: XCTestCase {
 
                 public func copyWithUpdates(venue: String? = nil, sponsor: String?? = .some(nil), drinks: [String]? = nil, complexStructure: [Date: [(String, Int)]]? = nil, characters: [String]?? = .some(nil), budget: Double? = nil) -> Self {
                     return Self (
-                        venue: venue ?? self.venue,
-                        sponsor: sponsor == .none ? nil : self.sponsor,
+                    venue: venue ?? self.venue,
+                        sponsor: sponsor.map {
+                            $0 ?? self.sponsor
+                        } ?? nil,
                         drinks: drinks ?? self.drinks,
                         complexStructure: complexStructure ?? self.complexStructure,
-                        characters: characters == .none ? nil : self.characters,
+                        characters: characters.map {
+                            $0 ?? self.characters
+                        } ?? nil,
                         budget: budget ?? self.budget
                     )
                 }
@@ -119,7 +123,7 @@ final class CopyWithUpdatesTests: XCTestCase {
 
                 public func copyWithUpdates(prop1: UUID? = nil, prop2: String? = nil) -> Self {
                     return Self (
-                        prop1: prop1 ?? self.prop1,
+                    prop1: prop1 ?? self.prop1,
                         prop2: prop2 ?? self.prop2
                     )
                 }
@@ -130,6 +134,178 @@ final class CopyWithUpdatesTests: XCTestCase {
         #else
         throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
+    }
+
+    func testMacro_withPropertyAndTrailingLineComment() throws {
+        #if canImport(CopyWithUpdatesMacros)
+        assertMacroExpansion(
+            """
+            @CopyWithUpdates
+            struct TestType {
+                let prop1: String? // A trailing comment should not affect function argument list
+            }
+            """,
+            expandedSource: """
+            struct TestType {
+                let prop1: String? // A trailing comment should not affect function argument list
+
+                public func copyWithUpdates(prop1: String?? = .some(nil)) -> Self {
+                    return Self (
+                    prop1: prop1.map {
+                            $0 ?? self.prop1
+                        } ?? nil
+                    )
+                }
+            }
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testMacro_withMultipleCommentTypes_forNonOptionals() throws {
+        #if canImport(CopyWithUpdatesMacros)
+        assertMacroExpansion(
+            """
+            @CopyWithUpdates
+            struct TestType {
+                let prop1: [String: Value/* middle comment should not affect function argument list */]
+                /// Markup comment for prop2 should not affect function argument list
+                let prop2: String
+                let prop3: Int // A trailing comment should not affect function argument list
+            }
+            """,
+            expandedSource: """
+            struct TestType {
+                let prop1: [String: Value/* middle comment should not affect function argument list */]
+                /// Markup comment for prop2 should not affect function argument list
+                let prop2: String
+                let prop3: Int // A trailing comment should not affect function argument list
+
+                public func copyWithUpdates(prop1: [String: Value]? = nil, prop2: String? = nil, prop3: Int? = nil) -> Self {
+                    return Self (
+                    prop1: prop1 ?? self.prop1,
+                        prop2: prop2 ?? self.prop2,
+                        prop3: prop3 ?? self.prop3
+                    )
+                }
+            }
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testMacro_withMultipleCommentTypes_forOptionals() throws {
+        #if canImport(CopyWithUpdatesMacros)
+        // swiftlint:disable line_length
+        assertMacroExpansion(
+            """
+            @CopyWithUpdates
+            struct TestType {
+                let prop1: [String: Value/* middle comment should not affect function argument list */]?
+                /// Markup comment for prop2 should not affect function argument list
+                let prop2: String?
+                let prop3: Int? // A trailing comment should not affect function argument list
+            }
+            """,
+            expandedSource: """
+            struct TestType {
+                let prop1: [String: Value/* middle comment should not affect function argument list */]?
+                /// Markup comment for prop2 should not affect function argument list
+                let prop2: String?
+                let prop3: Int? // A trailing comment should not affect function argument list
+
+                public func copyWithUpdates(prop1: [String: Value]?? = .some(nil), prop2: String?? = .some(nil), prop3: Int?? = .some(nil)) -> Self {
+                    return Self (
+                    prop1: prop1.map {
+                            $0 ?? self.prop1
+                        } ?? nil,
+                        prop2: prop2.map {
+                            $0 ?? self.prop2
+                        } ?? nil,
+                        prop3: prop3.map {
+                            $0 ?? self.prop3
+                        } ?? nil
+                    )
+                }
+            }
+            """,
+            macros: testMacros
+        )
+        // swiftlint:enable line_length
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testStrippingCommentsFromProperty() {
+        let propertyDescription = "let prop1: [String: SomeType] // Simple trailing comment"
+
+        let result = stripCommentsFromTypeDefinition(ofProperty: propertyDescription)
+
+        XCTAssertEqual(result, "let prop1: [String: SomeType]")
+    }
+
+    func testStrippingMarkupFromProperty() {
+        let propertyDescription = "let prop1: [String: SomeType] /// Simple markup comment"
+
+        let result = stripCommentsFromTypeDefinition(ofProperty: propertyDescription)
+
+        XCTAssertEqual(result, "let prop1: [String: SomeType]")
+    }
+
+    func testStrippingDocstringFromProperty_opensOnLine() {
+        let propertyDescription = "let prop1: [String: SomeType] /* Opening comment..."
+
+        let result = stripCommentsFromTypeDefinition(ofProperty: propertyDescription)
+
+        XCTAssertEqual(result, "let prop1: [String: SomeType]")
+    }
+
+    func testStrippingDocstringFromProperty_opensAndClosesOnLine_start() {
+        let propertyDescription = " /* start comment */ let prop1: [String: SomeType]"
+
+        let result = stripCommentsFromTypeDefinition(ofProperty: propertyDescription)
+
+        XCTAssertEqual(result, "let prop1: [String: SomeType]")
+    }
+
+    func testStrippingDocstringFromProperty_opensAndClosesOnLine_middle() {
+        let propertyDescription = "let prop1: [String: SomeType/* middle comment */]"
+
+        let result = stripCommentsFromTypeDefinition(ofProperty: propertyDescription)
+
+        XCTAssertEqual(result, "let prop1: [String: SomeType]")
+    }
+
+    func testStrippingDocstringFromProperty_opensAndClosesOnLine_end() {
+        let propertyDescription = "let prop1: [String: SomeType] /* end comment */"
+
+        let result = stripCommentsFromTypeDefinition(ofProperty: propertyDescription)
+
+        XCTAssertEqual(result, "let prop1: [String: SomeType]")
+    }
+
+    func testStrippingMultipleCommentsFromProperty() {
+        let propertyDescription
+        = "/* start comment */let prop1: [String: SomeType/* middle comment */]/* end comment */ // Trailing comment"
+
+        let result = stripCommentsFromTypeDefinition(ofProperty: propertyDescription)
+
+        XCTAssertEqual(result, "let prop1: [String: SomeType]")
+    }
+
+    func testStrippingTrailingWhitespaceFromProperty() {
+        let propertyDescription = "let prop1: [String: SomeType]    "
+
+        let result = stripCommentsFromTypeDefinition(ofProperty: propertyDescription)
+
+        XCTAssertEqual(result, "let prop1: [String: SomeType]")
     }
 
     func testIntegration_withOptionalSet() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15327)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32902)

## :bulb: Description

Previously, the macro was adding documentation from the property into the copyWithUpdates function's argument list. This caused compile errors if you added a trailing comment to one of your properties.

- Fixes macro by using string manipulation to strip documentation from property definitions
  - Trailing comments `// ...`
  - Docstrings beginning and ending on the same line `/* ... */`
  - Docstrings beginning on the same line and terminating on a different line `/* ...`
  - Markup `/// ...` above the line or on the same line
- Adds a bunch of unit tests to check these edge cases and the helper method for stripping documentation

The helper method recursively strips comments from the string until no comments remain (in case a property definition line were to have multiple comments).

P.S. You can test this code by opening the CopyWithUpdates macro folder directly with Xcode, and then running the unit tests.

<img height="400" alt="Screenshot 2026-04-02 at 1 07 44 PM" src="https://github.com/user-attachments/assets/aa5152e7-a7ad-40ae-98a7-ad63f07c0581" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

