### PR TITLE
[MTE-5278]-small fix for private tabs test on iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -257,13 +257,10 @@ class PrivateBrowsingTest: BaseTestCase {
         )
         numTab = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(0, numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
-        mozWaitForElementToExist(app.staticTexts["Private Browsing"])
 
         app.buttons["Undo"].waitAndTap()
 
         // All the private tabs are restored
-        waitForTabsButton()
-        navigator.goto(TabTray)
         numTab = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(4, numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
     }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5278

## :bulb: Description
Small fix for testAllPrivateTabsRestore on iPad