### PR TITLE
Fix shortcut row count not updating after dismissing settings sheet

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -22,6 +22,11 @@ class TopSitesRowCountSettingsController: SettingsTableViewController, FeatureFl
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
+    }
 
     override func generateSettings() -> [SettingSection] {
         updateNumberofRows()
@@ -62,4 +67,5 @@ class TopSitesRowCountSettingsController: SettingsTableViewController, FeatureFl
             numberOfRows = self.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? defaultValue
         }
     }
+    
 }

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -23,11 +23,6 @@ class TopSitesRowCountSettingsController: SettingsTableViewController, FeatureFl
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
-    }
-
     override func generateSettings() -> [SettingSection] {
         updateNumberofRows()
         let createSetting: (Int32) -> CheckmarkSetting = { num in
@@ -37,10 +32,18 @@ class TopSitesRowCountSettingsController: SettingsTableViewController, FeatureFl
                 return num == self.numberOfRows
             },
                                     onChecked: {
+                guard self.numberOfRows != num else { return }
                 self.numberOfRows = num
                 self.prefs.setInt(Int32(num), forKey: PrefsKeys.NumberOfTopSiteRows)
                 self.tableView.reloadData()
-                NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
+
+                store.dispatch(
+                    TopSitesAction(
+                        numberOfRows: Int(num),
+                        windowUUID: self.windowUUID,
+                        actionType: TopSitesActionType.updatedNumberOfRows
+                    )
+                )
             })
         }
 

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -22,7 +22,7 @@ class TopSitesRowCountSettingsController: SettingsTableViewController, FeatureFl
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
@@ -67,5 +67,4 @@ class TopSitesRowCountSettingsController: SettingsTableViewController, FeatureFl
             numberOfRows = self.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? defaultValue
         }
     }
-    
 }


### PR DESCRIPTION
##  Tickets
Fixes #32292

##  Description
The homepage shortcut row count was not updating when the settings sheet was dismissed by swiping down.

This change ensures the update is triggered on dismissal, keeping the homepage in sync with user preferences.

## Demos
N/A

##  Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements
- [ ] If adding or modifying strings, I read the guidelines
- [ ] If needed, I updated documentation and added comments to complex code