### PR TITLE
Bugfix FXIOS-15332 [Translation Phase 2] Device Language label disappears after reordering preferred languages

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
@@ -148,7 +148,7 @@ final class TranslationSettingsMiddleware {
         return codes.map { code in
             let native = localeProvider.nativeLanguageName(for: code)
             let localized = localeProvider.localizedLanguageName(for: code)
-            let isDeviceLanguage = code == deviceCode && code == codes.first
+            let isDeviceLanguage = code == deviceCode
             let subtitle: String? = isDeviceLanguage
                 ? .Settings.Translation.PreferredLanguages.DeviceLanguage
                 : (native == localized ? nil : localized)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
@@ -125,6 +125,51 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.translationSettingsProvider = { _, _ in }
     }
 
+    func test_viewDidLoad_deviceLanguage_notFirst_stillHasDeviceLanguageSubtitle() throws {
+        mockModelsFetcher.supportedTargetLanguages = ["en", "fr"]
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationsFeature)
+        mockProfile.prefs.setString("fr,en", forKey: PrefsKeys.Settings.translationPreferredLanguages)
+
+        let subject = createSubject(localeCode: "en")
+        let action = TranslationSettingsViewAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TranslationSettingsViewActionType.viewDidLoad
+        )
+
+        let expectation = XCTestExpectation(description: "didLoadSettings dispatched")
+        expectation.expectedFulfillmentCount = 2
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationSettingsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.last as? TranslationSettingsMiddlewareAction)
+        let preferredLanguages = try XCTUnwrap(dispatchedAction.preferredLanguages)
+
+        XCTAssertEqual(preferredLanguages[1].code, "en")
+        XCTAssertEqual(preferredLanguages[1].subtitleText, .Settings.Translation.PreferredLanguages.DeviceLanguage)
+        subject.translationSettingsProvider = { _, _ in }
+    }
+
+    func test_saveLanguages_deviceLanguage_notFirst_stillHasDeviceLanguageSubtitle() throws {
+        let subject = createSubject(localeCode: "en")
+        let action = TranslationSettingsViewAction(
+            languages: ["fr", "en"],
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TranslationSettingsViewActionType.saveLanguages
+        )
+
+        subject.translationSettingsProvider(mockStore.state, action)
+
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationSettingsMiddlewareAction)
+        let preferredLanguages = try XCTUnwrap(dispatched.preferredLanguages)
+
+        XCTAssertEqual(preferredLanguages[1].code, "en")
+        XCTAssertEqual(preferredLanguages[1].subtitleText, .Settings.Translation.PreferredLanguages.DeviceLanguage)
+        subject.translationSettingsProvider = { _, _ in }
+    }
+
     func test_viewDidLoad_readsAutoTranslatePref_whenEnabled() throws {
         mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslate)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15332)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32910)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The "Device Language" subtitle was only assigned when the language was both the device locale and the first item in the list. After saving a reordered list where the device language is no longer first, buildLanguageDetails cleared the subtitle. Remove the position guard so the label is shown for the device language regardless of its position.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


