### PR TITLE
Bugfix FXIOS-15317 [Translations Phase 2] Settings sections display incorrect colors in Private Browsing

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationAddLanguageCell.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationAddLanguageCell.swift
@@ -20,6 +20,6 @@ final class TranslationAddLanguageCell: UICollectionViewListCell, ThemeApplicabl
         content.textProperties.color = theme.colors.actionPrimary
         contentConfiguration = content
         backgroundConfiguration = .listGroupedCell()
-        backgroundConfiguration?.backgroundColor = theme.colors.layer2
+        backgroundConfiguration?.backgroundColor = theme.colors.layer5
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguageCell.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguageCell.swift
@@ -24,6 +24,6 @@ final class TranslationLanguageCell: UICollectionViewListCell, ThemeApplicable {
         content.secondaryTextProperties.color = theme.colors.textSecondary
         contentConfiguration = content
         backgroundConfiguration = .listGroupedCell()
-        backgroundConfiguration?.backgroundColor = theme.colors.layer2
+        backgroundConfiguration?.backgroundColor = theme.colors.layer5
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerLanguageCell.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerLanguageCell.swift
@@ -20,6 +20,6 @@ final class TranslationPickerLanguageCell: UITableViewCell {
         content.textProperties.color = theme.colors.textPrimary
         content.secondaryTextProperties.color = theme.colors.textSecondary
         contentConfiguration = content
-        backgroundColor = theme.colors.layer2
+        backgroundColor = theme.colors.layer5
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationToggleCell.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationToggleCell.swift
@@ -25,6 +25,6 @@ final class TranslationToggleCell: UICollectionViewListCell, ThemeApplicable {
         contentConfiguration = content
         toggle.onTintColor = theme.colors.actionPrimary
         backgroundConfiguration = .listGroupedCell()
-        backgroundConfiguration?.backgroundColor = theme.colors.layer2
+        backgroundConfiguration?.backgroundColor = theme.colors.layer5
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15317)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32888)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Use layer5 instead of layer2 for translation settings cell backgrounds. In the private theme, layer2 equals layer1 (both Violet90), making cells indistinguishable from the background. layer5 (Ink20) matches the color used by other settings cells (ThemedTableViewCell) and provides the correct visual separation in private browsing.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<img height="600" alt="IMG_0351" src="https://github.com/user-attachments/assets/0df8d815-1e99-460b-ae85-b0ee91866aa2" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


