### PR TITLE
Bugfix FXIOS-15386  [Translations Phase 2] Auto-translate prompt Enable button not visible at large dynamic text sizes

### DIFF
--- a/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
+++ b/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
@@ -115,7 +115,6 @@ final class AutoTranslatePromptView: UIView, ThemeApplicable, Notifiable {
             messageEnableStack.alignment = .center
             contentRow.alignment = .center
         }
-        setNeedsLayout()
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
+++ b/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
@@ -8,7 +8,7 @@ import Redux
 import Shared
 import UIKit
 
-final class AutoTranslatePromptView: UIView, ThemeApplicable {
+final class AutoTranslatePromptView: UIView, ThemeApplicable, Notifiable {
     private struct UX {
         static let borderThickness: CGFloat = 1.0
         static let contentPadding = NSDirectionalEdgeInsets(
@@ -19,6 +19,8 @@ final class AutoTranslatePromptView: UIView, ThemeApplicable {
         )
         static let contentSpacing: CGFloat = 8
     }
+
+    var notificationCenter: NotificationProtocol = NotificationCenter.default
 
     private let windowUUID: WindowUUID
 
@@ -50,6 +52,12 @@ final class AutoTranslatePromptView: UIView, ThemeApplicable {
         button.addTarget(self, action: #selector(self.didTapDismiss), for: .touchUpInside)
     }
 
+    private lazy var messageEnableStack: UIStackView = .build { stack in
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = UX.contentSpacing
+    }
+
     private lazy var contentRow: UIStackView = .build { stack in
         stack.axis = .horizontal
         stack.alignment = .center
@@ -60,6 +68,11 @@ final class AutoTranslatePromptView: UIView, ThemeApplicable {
         self.windowUUID = windowUUID
         super.init(frame: .zero)
         setupView()
+        startObservingNotifications(
+            withNotificationCenter: notificationCenter,
+            forObserver: self,
+            observing: [UIContentSizeCategory.didChangeNotification]
+        )
     }
 
     required init?(coder: NSCoder) {
@@ -67,8 +80,10 @@ final class AutoTranslatePromptView: UIView, ThemeApplicable {
     }
 
     private func setupView() {
-        contentRow.addArrangedSubview(messageLabel)
-        contentRow.addArrangedSubview(enableButton)
+        messageEnableStack.addArrangedSubview(messageLabel)
+        messageEnableStack.addArrangedSubview(enableButton)
+
+        contentRow.addArrangedSubview(messageEnableStack)
         contentRow.addArrangedSubview(closeButton)
 
         addSubview(topBorderView)
@@ -85,6 +100,22 @@ final class AutoTranslatePromptView: UIView, ThemeApplicable {
             contentRow.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.contentPadding.leading),
             contentRow.trailingAnchor.constraint(equalTo: trailingAnchor, constant: UX.contentPadding.trailing),
         ])
+
+        adjustLayout()
+    }
+
+    private func adjustLayout() {
+        let isAccessibility = UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory
+        if isAccessibility {
+            messageEnableStack.axis = .vertical
+            messageEnableStack.alignment = .leading
+            contentRow.alignment = .top
+        } else {
+            messageEnableStack.axis = .horizontal
+            messageEnableStack.alignment = .center
+            contentRow.alignment = .center
+        }
+        setNeedsLayout()
     }
 
     @objc
@@ -101,6 +132,16 @@ final class AutoTranslatePromptView: UIView, ThemeApplicable {
             windowUUID: windowUUID,
             actionType: TranslationsActionType.didDismissAutoTranslatePrompt
         ))
+    }
+
+    // MARK: - Notifiable
+
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case UIContentSizeCategory.didChangeNotification:
+            ensureMainThread { self.adjustLayout() }
+        default: break
+        }
     }
 
     // MARK: - ThemeApplicable


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15386)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32985)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Wrapped messageLabel and enableButton in a nested messageEnableStack. At accessibility content size categories, this inner stack switches to a vertical axis so the button drops below the message text. The close button stays top-right at all sizes. Layout updates live via UIContentSizeCategory.didChangeNotification.   

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<img height="600" alt="IMG_0359" src="https://github.com/user-attachments/assets/710f05bd-ceaa-402e-9192-378175548fe0" />


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


