### PR TITLE
Refactor FXIOS-15402 [Sentry] Update to 0.9.10 & disable network breadcrumbs

### DIFF
--- a/BrowserKit/Package.resolved
+++ b/BrowserKit/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "296a236f920c1e9d03078eb62076c82dbe012a6626942c71b98dfa691f0b8f3a",
+  "originHash" : "7652867bf935281c038ad52d72ad40eec39f02d67b07ecfa159f26830b9f3f3f",
   "pins" : [
     {
       "identity" : "dip",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "5575af93efb776414f243e93d6af9f6258dc539a",
-        "version" : "8.36.0"
+        "revision" : "3a22ecd00ad1398747bfd587e44df82716908dd3",
+        "version" : "9.10.0"
       }
     },
     {

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -81,7 +81,7 @@ let package = Package(
             exact: "2.1.1"),
         .package(
             url: "https://github.com/getsentry/sentry-cocoa.git",
-            exact: "8.36.0"),
+            exact: "9.10.0"),
         .package(
             url: "https://github.com/nbhasin2/GCDWebServer.git",
             branch: "master"),

--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -121,7 +121,10 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
             options.dsn = dsn
             if self.shouldEnableTraceProfiling {
                 options.tracesSampleRate = 0.2
-                options.profilesSampleRate = 0.2
+                options.configureProfiling = {
+                    $0.sessionSampleRate = 0.2
+                    $0.lifecycle = .trace
+                }
             }
             options.environment = self.environment.rawValue
             options.releaseName = self.releaseName

--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -130,6 +130,7 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
             options.enableAppHangTracking = self.shouldEnableAppHangTracking
             options.enableMetricKit = self.shouldEnableMetricKit
             options.enableCaptureFailedRequests = false
+            options.enableNetworkBreadcrumbs = false
             options.enableSwizzling = false
             options.beforeBreadcrumb = { crumb in
                 if crumb.type == "http" || crumb.category == "http" {

--- a/BrowserKit/Sources/Common/Logger/Wrapper/SentryWrapper.swift
+++ b/BrowserKit/Sources/Common/Logger/Wrapper/SentryWrapper.swift
@@ -21,7 +21,7 @@ public final class DefaultSentry: SentryWrapper {
     public init() {}
 
     public var crashedInLastRun: Bool {
-        return SentrySDK.crashedLastRun
+        return SentrySDK.lastRunStatus == .didCrash
     }
 
     public var dsn: String? {

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -32242,7 +32242,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 8.36.0;
+				version = 9.10.0;
 			};
 		};
 		5A984D322C8A31A0007938C9 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9f9784b380c352cfb7bcf173fa8d01920283027e898d030fd8078b8cfca2ca0f",
+  "originHash" : "e7d8931d67761f37e7664664586e08ff85dd2fa89878e390b6c48f85c6b6e85c",
   "pins" : [
     {
       "identity" : "a-star",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "5575af93efb776414f243e93d6af9f6258dc539a",
-        "version" : "8.36.0"
+        "revision" : "3a22ecd00ad1398747bfd587e44df82716908dd3",
+        "version" : "9.10.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "ae33e5941bb88d88538d0a6b19ca0b01e6c76dcf",
-        "version" : "1.3.1"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "21f7878f2b39d46fd8ba2b06459ccb431cdf876c",
-        "version" : "3.8.1"
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {

--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -7317,7 +7317,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
 			requirement = {
 				kind = exactVersion;
-				version = 8.36.0;
+				version = 9.10.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/nbhasin2/GCDWebServer.git",
         "state": {
           "branch": "master",
-          "revision": "7674c93e79ee5aac17681acace324761325e7346",
+          "revision": "0039b4d377874784258154c2c551d146320a8985",
           "version": null
         }
       },
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "5575af93efb776414f243e93d6af9f6258dc539a",
-          "version": "8.36.0"
+          "revision": "3a22ecd00ad1398747bfd587e44df82716908dd3",
+          "version": "9.10.0"
         }
       },
       {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15402)
[Github ticket](https://github.com/mozilla-mobile/firefox-ios/issues/33019)

## :bulb: Description

Still investigating but wanted to get a PR up so we have a place to discuss & document. This PR updates Sentry to 0.9.10 and disables breadcrumb logging. We're already disabling `enableCaptureFailedRequests` 🤔 , the only other culprit I could find was `enableNetworkBreadcrumbs`. However the documentation states that since network breadcrumbs requires swizzling, the fact that we set `enableSwizzling` to false should've meant we're not sending breadcrumbs.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

