### PR TITLE
Refactor FXIOS-15399 [Native Error Pages] NativeErrorPageHelper review nits

### DIFF
--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -24,7 +24,7 @@ let CertErrors: [Int] = [
 ]
 
 class NativeErrorPageHelper {
-    enum Constants {
+    private enum Constants {
         static let certErrorQueryParam = "certerror"
         static let badCertQueryParam = "badcert"
         static let codeQueryParam = "code"
@@ -32,6 +32,10 @@ class NativeErrorPageHelper {
         static let peerCertificateChainKey = "NSErrorPeerCertificateChainKey"
         static let defaultBadCertDomainError = "SSL_ERROR_BAD_CERT_DOMAIN"
         static let sslErrorBadCertDomainCode = -9843
+        static let wrongHostMarker = "wrong.host"
+        static let badSSLHostMarker = "badssl"
+        static let domainDescriptionMarker = "domain"
+        static let hostnameDescriptionMarker = "hostname"
     }
 
     /// Holds the parsed certificate details extracted from an NSError.
@@ -189,8 +193,9 @@ class NativeErrorPageHelper {
             let desc = error.localizedDescription.lowercased()
             if let failingURL = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL,
                let host = failingURL.host,
-               host.contains("wrong.host") || host.contains("badssl")
-               || desc.contains("domain") || desc.contains("hostname") {
+               host.contains(Constants.wrongHostMarker) || host.contains(Constants.badSSLHostMarker)
+               || desc.contains(Constants.domainDescriptionMarker)
+               || desc.contains(Constants.hostnameDescriptionMarker) {
                 queryItems.append(URLQueryItem(
                     name: Constants.certErrorQueryParam,
                     value: Constants.defaultBadCertDomainError
@@ -227,7 +232,7 @@ class NativeErrorPageHelper {
             )
         }
 
-        // TODO: FXIOS-14569
+        // TODO: FXIOS-14569 — Investigate using SecTrustEvaluateWithError to evaluate TLS trust errors instead of private APIs.
         if let underlyingError = error.userInfo[NSUnderlyingErrorKey] as? NSError,
            let certErrorCode = underlyingError.userInfo[Constants.cfStreamErrorCodeKey] as? Int,
            certErrorCode == Constants.sslErrorBadCertDomainCode {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -232,7 +232,8 @@ class NativeErrorPageHelper {
             )
         }
 
-        // TODO: FXIOS-14569 — Investigate using SecTrustEvaluateWithError to evaluate TLS trust errors instead of private APIs.
+        // TODO: FXIOS-14569 — Investigate using SecTrustEvaluateWithError to evaluate TLS trust
+        // errors instead of private APIs.
         if let underlyingError = error.userInfo[NSUnderlyingErrorKey] as? NSError,
            let certErrorCode = underlyingError.userInfo[Constants.cfStreamErrorCodeKey] as? Int,
            certErrorCode == Constants.sslErrorBadCertDomainCode {


### PR DESCRIPTION
### 📜 Tickets
JIRA: FXIOS-15399 (follow-up to certificate exception UI work, code-only nits)
GitHub: Related to #33011

### 💡 Description
Addresses post-merge review nits on `NativeErrorPageHelper` after #31933:
- Expand FXIOS-14569 TODO with the Jira ticket title for context.
- Mark nested `Constants` as `private`.
- Move host/description heuristic substrings into `Constants`.

_**Note: This PR is a part of Outreachy**_

### 🧩 Implementation
- `firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift`

### 📝 Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our PR naming guidelines
- [ ] I ensured unit tests pass and considered adding tests for new code
- [ ] If working on UI, I checked and implemented accessibility
- [ ] If adding telemetry, I read the data stewardship requirements and requested a data review
- [ ] If adding or modifying strings, I read the guidelines and requested a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

🔗 Related
Follow-up to #31933