### PR TITLE
NoBug - Update Bitrise steps

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -152,7 +152,7 @@ workflows:
     steps:
     - activate-ssh-key@4.1.1:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - restore-spm-cache@2.1.1:
+    - restore-spm-cache@3:
         is_always_run: true
     - activate-build-cache-for-xcode@0: {}
     - xcode-build-for-test@3:
@@ -216,7 +216,7 @@ workflows:
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.2-arm64.xctestrun
         - maximum_test_repetitions: 2
-    - xcode-test-shard-calculation@0:
+    - xcode-test-shard-calculation@0.2:
         run_if: '{{enveq "BITRISE_TEST_BUNDLE_PATH" "" | not}}'
         inputs:
         - product_path: $BITRISE_XCTESTRUN_SMOKE_TEST_FILE_PATH
@@ -253,7 +253,7 @@ workflows:
 
             echo "Removing .bcsymbolmap files from test bundle"
             find "$BITRISE_TEST_BUNDLE_PATH" -name "*.bcsymbolmap" -delete 2>/dev/null || true
-    - deploy-to-bitrise-io@2.10.0:
+    - deploy-to-bitrise-io@2.23:
         run_if: '{{enveq "BITRISE_TEST_BUNDLE_PATH" "" | not}}'
         inputs:
         - pipeline_intermediate_files: |-

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -354,10 +354,10 @@ class BaseTestCase: XCTestCase {
             navigator.goto(URLBarOpen)
         }
         navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
-        waitUntilPageLoad()
+        mozWaitForElementToExist(app.buttons["Reader View"])
 
         app.buttons["Reader View"].waitAndTap()
-        waitUntilPageLoad()
+        mozWaitForElementToExist(app.buttons["Add to Reading List"])
         app.buttons["Add to Reading List"].waitAndTap()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
@@ -442,7 +442,7 @@ class O_AddressesTests: BaseTestCase {
         navigateFromAutofillPasswordSettingsToNewTabScreen()
         // Go to a webpage, and select night mode on and off, check options
         navigator.openURL(path(forTestPage: "test-example.html"))
-        mozWaitForElementToExist(app.webViews.firstMatch)
+        waitUntilPageLoad()
         toggleThemeViaDisplaySettings()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
@@ -442,7 +442,7 @@ class O_AddressesTests: BaseTestCase {
         navigateFromAutofillPasswordSettingsToNewTabScreen()
         // Go to a webpage, and select night mode on and off, check options
         navigator.openURL(path(forTestPage: "test-example.html"))
-        waitUntilPageLoad()
+        mozWaitForElementToExist(app.webViews.firstMatch)
         toggleThemeViaDisplaySettings()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -23,7 +23,7 @@ class PhotonActionSheetTests: BaseTestCase {
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)
         navigator.openURL("example.com")
-        waitUntilPageLoad()
+        mozWaitForElementToExist(app.webViews.firstMatch)
         browserScreen.waitForClipboardToastToDisappear()
         toolBarScreen.tapShareButton()
         photonActionSheetScreen.assertPhotonActionSheetExists()
@@ -37,7 +37,7 @@ class PhotonActionSheetTests: BaseTestCase {
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)
         navigator.openURL(path(forTestPage: "test-example.html"))
-        waitUntilPageLoad()
+        mozWaitForElementToExist(app.webViews.firstMatch)
 
         // Open Page Action Menu Sheet and Pin the site
         navigator.nowAt(BrowserTab)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -312,7 +312,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.nowAt(BrowserTab)
         navigator.openURL(URL)
-        waitUntilPageLoad()
+        mozWaitForElementToExist(app.webViews.firstMatch)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -207,7 +207,6 @@ class SearchTests: FeatureFlaggedTestBase {
 
         searchSettingsScreen.waitForSearchEngineSelectionComplete()
 
-        navigator.goto(HomePanelsScreen)
         navigator.goto(URLBarOpen)
         navigator.openURL("foo bar")
         mozWaitForElementToExist(app.webViews.firstMatch)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -209,7 +209,6 @@ class SearchTests: FeatureFlaggedTestBase {
 
         navigator.goto(URLBarOpen)
         navigator.openURL("foo bar")
-        mozWaitForElementToExist(app.webViews.firstMatch)
         browserScreen.addressToolbarContainValue(value: searchEngine.lowercased())
     }
 


### PR DESCRIPTION
## :scroll: Tickets

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
There is one shard running the UI Tests that is taking longer than the rest by ~4mins, we should try to find a way to split this time across all shards so there is not one limiting and for which the whole test run is waiting to finish

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

