### PR TITLE
Fix breaking change for logins made in app-services.

### DIFF
--- a/MozillaRustComponents/Package.swift
+++ b/MozillaRustComponents/Package.swift
@@ -1,13 +1,13 @@
 // swift-tools-version: 5.10
 import PackageDescription
 
-let checksum = "bcef62cf6e4e41837dfc3272143eda00bedfe74c2e32a2eb106acf45fe8995a9"
-let version = "151.0.20260402050248"
-let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.151.20260402050248/artifacts/public/build/MozillaRustComponents.xcframework.zip"
+let checksum = "79e5f59918a5e16534df73af7e01c3bc3be253cdd9bb163eab81b28dbd1bd670"
+let version = "151.0.20260412050229"
+let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.151.20260412050229/artifacts/public/build/MozillaRustComponents.xcframework.zip"
 
 // Focus xcframework
-let focusChecksum = "c45c063bb420e588a1f63f472ca8ba387c245b8fd51627523685ef1194b18a5d"
-let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.151.20260402050248/artifacts/public/build/FocusRustComponents.xcframework.zip"
+let focusChecksum = "e4e84ec52e750d122defe15d92321d101a5001af0beb1f608a5855598c1d876c"
+let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.151.20260412050229/artifacts/public/build/FocusRustComponents.xcframework.zip"
 
 let package = Package(
     name: "MozillaRustComponentsSwift",

--- a/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 4, day: 2, hour: 5, minute: 23, second: 49))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 4, day: 12, hour: 5, minute: 28, second: 40))
     }
 
     enum NimbusEvents {

--- a/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/ads_client.swift
+++ b/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/ads_client.swift
@@ -538,7 +538,7 @@ public protocol MozAdsClientProtocol: AnyObject, Sendable {
     
     func recordImpression(impressionUrl: String) throws 
     
-    func reportAd(reportUrl: String) throws 
+    func reportAd(reportUrl: String, reason: MozAdsReportReason) throws 
     
     func requestImageAds(mozAdRequests: [MozAdsPlacementRequest], options: MozAdsRequestOptions?) throws  -> [String: MozAdsImage]
     
@@ -623,10 +623,11 @@ open func recordImpression(impressionUrl: String)throws   {try rustCallWithError
 }
 }
     
-open func reportAd(reportUrl: String)throws   {try rustCallWithError(FfiConverterTypeMozAdsClientApiError_lift) {
+open func reportAd(reportUrl: String, reason: MozAdsReportReason)throws   {try rustCallWithError(FfiConverterTypeMozAdsClientApiError_lift) {
     uniffi_ads_client_fn_method_mozadsclient_report_ad(
             self.uniffiCloneHandle(),
-        FfiConverterString.lower(reportUrl),$0
+        FfiConverterString.lower(reportUrl),
+        FfiConverterTypeMozAdsReportReason_lower(reason),$0
     )
 }
 }
@@ -1217,7 +1218,7 @@ public struct MozAdsCacheConfig: Equatable, Hashable {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(dbPath: String, defaultCacheTtlSeconds: UInt64?, maxSizeMib: UInt64?) {
+    public init(dbPath: String, defaultCacheTtlSeconds: UInt64? = nil, maxSizeMib: UInt64? = nil) {
         self.dbPath = dbPath
         self.defaultCacheTtlSeconds = defaultCacheTtlSeconds
         self.maxSizeMib = maxSizeMib
@@ -1265,6 +1266,60 @@ public func FfiConverterTypeMozAdsCacheConfig_lift(_ buf: RustBuffer) throws -> 
 #endif
 public func FfiConverterTypeMozAdsCacheConfig_lower(_ value: MozAdsCacheConfig) -> RustBuffer {
     return FfiConverterTypeMozAdsCacheConfig.lower(value)
+}
+
+
+public struct MozAdsCachePolicy: Equatable, Hashable {
+    public var mode: MozAdsCacheMode
+    public var ttlSeconds: UInt64?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(mode: MozAdsCacheMode, ttlSeconds: UInt64? = nil) {
+        self.mode = mode
+        self.ttlSeconds = ttlSeconds
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension MozAdsCachePolicy: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeMozAdsCachePolicy: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsCachePolicy {
+        return
+            try MozAdsCachePolicy(
+                mode: FfiConverterTypeMozAdsCacheMode.read(from: &buf), 
+                ttlSeconds: FfiConverterOptionUInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: MozAdsCachePolicy, into buf: inout [UInt8]) {
+        FfiConverterTypeMozAdsCacheMode.write(value.mode, into: &buf)
+        FfiConverterOptionUInt64.write(value.ttlSeconds, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMozAdsCachePolicy_lift(_ buf: RustBuffer) throws -> MozAdsCachePolicy {
+    return try FfiConverterTypeMozAdsCachePolicy.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMozAdsCachePolicy_lower(_ value: MozAdsCachePolicy) -> RustBuffer {
+    return FfiConverterTypeMozAdsCachePolicy.lower(value)
 }
 
 
@@ -1327,14 +1382,14 @@ public func FfiConverterTypeMozAdsCallbacks_lower(_ value: MozAdsCallbacks) -> R
 
 
 public struct MozAdsContentCategory: Equatable, Hashable {
-    public var taxonomy: MozAdsIabContentTaxonomy
     public var categories: [String]
+    public var taxonomy: MozAdsIabContentTaxonomy
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(taxonomy: MozAdsIabContentTaxonomy, categories: [String]) {
-        self.taxonomy = taxonomy
+    public init(categories: [String], taxonomy: MozAdsIabContentTaxonomy) {
         self.categories = categories
+        self.taxonomy = taxonomy
     }
 
     
@@ -1353,14 +1408,14 @@ public struct FfiConverterTypeMozAdsContentCategory: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsContentCategory {
         return
             try MozAdsContentCategory(
-                taxonomy: FfiConverterTypeMozAdsIABContentTaxonomy.read(from: &buf), 
-                categories: FfiConverterSequenceString.read(from: &buf)
+                categories: FfiConverterSequenceString.read(from: &buf), 
+                taxonomy: FfiConverterTypeMozAdsIABContentTaxonomy.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsContentCategory, into buf: inout [UInt8]) {
-        FfiConverterTypeMozAdsIABContentTaxonomy.write(value.taxonomy, into: &buf)
         FfiConverterSequenceString.write(value.categories, into: &buf)
+        FfiConverterTypeMozAdsIABContentTaxonomy.write(value.taxonomy, into: &buf)
     }
 }
 
@@ -1381,14 +1436,14 @@ public func FfiConverterTypeMozAdsContentCategory_lower(_ value: MozAdsContentCa
 
 
 public struct MozAdsIabContent: Equatable, Hashable {
-    public var taxonomy: MozAdsIabContentTaxonomy
     public var categoryIds: [String]
+    public var taxonomy: MozAdsIabContentTaxonomy
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(taxonomy: MozAdsIabContentTaxonomy, categoryIds: [String]) {
-        self.taxonomy = taxonomy
+    public init(categoryIds: [String], taxonomy: MozAdsIabContentTaxonomy) {
         self.categoryIds = categoryIds
+        self.taxonomy = taxonomy
     }
 
     
@@ -1407,14 +1462,14 @@ public struct FfiConverterTypeMozAdsIABContent: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsIabContent {
         return
             try MozAdsIabContent(
-                taxonomy: FfiConverterTypeMozAdsIABContentTaxonomy.read(from: &buf), 
-                categoryIds: FfiConverterSequenceString.read(from: &buf)
+                categoryIds: FfiConverterSequenceString.read(from: &buf), 
+                taxonomy: FfiConverterTypeMozAdsIABContentTaxonomy.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsIabContent, into buf: inout [UInt8]) {
-        FfiConverterTypeMozAdsIABContentTaxonomy.write(value.taxonomy, into: &buf)
         FfiConverterSequenceString.write(value.categoryIds, into: &buf)
+        FfiConverterTypeMozAdsIABContentTaxonomy.write(value.taxonomy, into: &buf)
     }
 }
 
@@ -1505,14 +1560,14 @@ public func FfiConverterTypeMozAdsImage_lower(_ value: MozAdsImage) -> RustBuffe
 
 
 public struct MozAdsPlacementRequest: Equatable, Hashable {
-    public var placementId: String
     public var iabContent: MozAdsIabContent?
+    public var placementId: String
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(placementId: String, iabContent: MozAdsIabContent?) {
-        self.placementId = placementId
+    public init(iabContent: MozAdsIabContent? = nil, placementId: String) {
         self.iabContent = iabContent
+        self.placementId = placementId
     }
 
     
@@ -1531,14 +1586,14 @@ public struct FfiConverterTypeMozAdsPlacementRequest: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsPlacementRequest {
         return
             try MozAdsPlacementRequest(
-                placementId: FfiConverterString.read(from: &buf), 
-                iabContent: FfiConverterOptionTypeMozAdsIABContent.read(from: &buf)
+                iabContent: FfiConverterOptionTypeMozAdsIABContent.read(from: &buf), 
+                placementId: FfiConverterString.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsPlacementRequest, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.placementId, into: &buf)
         FfiConverterOptionTypeMozAdsIABContent.write(value.iabContent, into: &buf)
+        FfiConverterString.write(value.placementId, into: &buf)
     }
 }
 
@@ -1560,15 +1615,15 @@ public func FfiConverterTypeMozAdsPlacementRequest_lower(_ value: MozAdsPlacemen
 
 public struct MozAdsPlacementRequestWithCount: Equatable, Hashable {
     public var count: UInt32
-    public var placementId: String
     public var iabContent: MozAdsIabContent?
+    public var placementId: String
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(count: UInt32, placementId: String, iabContent: MozAdsIabContent?) {
+    public init(count: UInt32, iabContent: MozAdsIabContent? = nil, placementId: String) {
         self.count = count
-        self.placementId = placementId
         self.iabContent = iabContent
+        self.placementId = placementId
     }
 
     
@@ -1588,15 +1643,15 @@ public struct FfiConverterTypeMozAdsPlacementRequestWithCount: FfiConverterRustB
         return
             try MozAdsPlacementRequestWithCount(
                 count: FfiConverterUInt32.read(from: &buf), 
-                placementId: FfiConverterString.read(from: &buf), 
-                iabContent: FfiConverterOptionTypeMozAdsIABContent.read(from: &buf)
+                iabContent: FfiConverterOptionTypeMozAdsIABContent.read(from: &buf), 
+                placementId: FfiConverterString.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsPlacementRequestWithCount, into buf: inout [UInt8]) {
         FfiConverterUInt32.write(value.count, into: &buf)
-        FfiConverterString.write(value.placementId, into: &buf)
         FfiConverterOptionTypeMozAdsIABContent.write(value.iabContent, into: &buf)
+        FfiConverterString.write(value.placementId, into: &buf)
     }
 }
 
@@ -1616,66 +1671,12 @@ public func FfiConverterTypeMozAdsPlacementRequestWithCount_lower(_ value: MozAd
 }
 
 
-public struct MozAdsRequestCachePolicy: Equatable, Hashable {
-    public var mode: MozAdsCacheMode
-    public var ttlSeconds: UInt64?
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(mode: MozAdsCacheMode, ttlSeconds: UInt64?) {
-        self.mode = mode
-        self.ttlSeconds = ttlSeconds
-    }
-
-    
-
-    
-}
-
-#if compiler(>=6)
-extension MozAdsRequestCachePolicy: Sendable {}
-#endif
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public struct FfiConverterTypeMozAdsRequestCachePolicy: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsRequestCachePolicy {
-        return
-            try MozAdsRequestCachePolicy(
-                mode: FfiConverterTypeMozAdsCacheMode.read(from: &buf), 
-                ttlSeconds: FfiConverterOptionUInt64.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: MozAdsRequestCachePolicy, into buf: inout [UInt8]) {
-        FfiConverterTypeMozAdsCacheMode.write(value.mode, into: &buf)
-        FfiConverterOptionUInt64.write(value.ttlSeconds, into: &buf)
-    }
-}
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeMozAdsRequestCachePolicy_lift(_ buf: RustBuffer) throws -> MozAdsRequestCachePolicy {
-    return try FfiConverterTypeMozAdsRequestCachePolicy.lift(buf)
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeMozAdsRequestCachePolicy_lower(_ value: MozAdsRequestCachePolicy) -> RustBuffer {
-    return FfiConverterTypeMozAdsRequestCachePolicy.lower(value)
-}
-
-
 public struct MozAdsRequestOptions: Equatable, Hashable {
-    public var cachePolicy: MozAdsRequestCachePolicy?
+    public var cachePolicy: MozAdsCachePolicy?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(cachePolicy: MozAdsRequestCachePolicy?) {
+    public init(cachePolicy: MozAdsCachePolicy?) {
         self.cachePolicy = cachePolicy
     }
 
@@ -1695,12 +1696,12 @@ public struct FfiConverterTypeMozAdsRequestOptions: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsRequestOptions {
         return
             try MozAdsRequestOptions(
-                cachePolicy: FfiConverterOptionTypeMozAdsRequestCachePolicy.read(from: &buf)
+                cachePolicy: FfiConverterOptionTypeMozAdsCachePolicy.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsRequestOptions, into buf: inout [UInt8]) {
-        FfiConverterOptionTypeMozAdsRequestCachePolicy.write(value.cachePolicy, into: &buf)
+        FfiConverterOptionTypeMozAdsCachePolicy.write(value.cachePolicy, into: &buf)
     }
 }
 
@@ -1869,16 +1870,16 @@ public func FfiConverterTypeMozAdsSpocFrequencyCaps_lower(_ value: MozAdsSpocFre
 
 
 public struct MozAdsSpocRanking: Equatable, Hashable {
-    public var priority: UInt32
-    public var personalizationModels: [String: UInt32]
     public var itemScore: Double
+    public var personalizationModels: [String: UInt32]
+    public var priority: UInt32
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(priority: UInt32, personalizationModels: [String: UInt32], itemScore: Double) {
-        self.priority = priority
-        self.personalizationModels = personalizationModels
+    public init(itemScore: Double, personalizationModels: [String: UInt32], priority: UInt32) {
         self.itemScore = itemScore
+        self.personalizationModels = personalizationModels
+        self.priority = priority
     }
 
     
@@ -1897,16 +1898,16 @@ public struct FfiConverterTypeMozAdsSpocRanking: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsSpocRanking {
         return
             try MozAdsSpocRanking(
-                priority: FfiConverterUInt32.read(from: &buf), 
+                itemScore: FfiConverterDouble.read(from: &buf), 
                 personalizationModels: FfiConverterDictionaryStringUInt32.read(from: &buf), 
-                itemScore: FfiConverterDouble.read(from: &buf)
+                priority: FfiConverterUInt32.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsSpocRanking, into buf: inout [UInt8]) {
-        FfiConverterUInt32.write(value.priority, into: &buf)
-        FfiConverterDictionaryStringUInt32.write(value.personalizationModels, into: &buf)
         FfiConverterDouble.write(value.itemScore, into: &buf)
+        FfiConverterDictionaryStringUInt32.write(value.personalizationModels, into: &buf)
+        FfiConverterUInt32.write(value.priority, into: &buf)
     }
 }
 
@@ -2291,6 +2292,80 @@ public func FfiConverterTypeMozAdsIABContentTaxonomy_lower(_ value: MozAdsIabCon
 }
 
 
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum MozAdsReportReason: Equatable, Hashable {
+    
+    case inappropriate
+    case notInterested
+    case seenTooManyTimes
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension MozAdsReportReason: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeMozAdsReportReason: FfiConverterRustBuffer {
+    typealias SwiftType = MozAdsReportReason
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsReportReason {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .inappropriate
+        
+        case 2: return .notInterested
+        
+        case 3: return .seenTooManyTimes
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: MozAdsReportReason, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .inappropriate:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .notInterested:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .seenTooManyTimes:
+            writeInt(&buf, Int32(3))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMozAdsReportReason_lift(_ buf: RustBuffer) throws -> MozAdsReportReason {
+    return try FfiConverterTypeMozAdsReportReason.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMozAdsReportReason_lower(_ value: MozAdsReportReason) -> RustBuffer {
+    return FfiConverterTypeMozAdsReportReason.lower(value)
+}
+
+
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
@@ -2342,6 +2417,30 @@ fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeMozAdsCachePolicy: FfiConverterRustBuffer {
+    typealias SwiftType = MozAdsCachePolicy?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeMozAdsCachePolicy.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeMozAdsCachePolicy.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeMozAdsIABContent: FfiConverterRustBuffer {
     typealias SwiftType = MozAdsIabContent?
 
@@ -2358,30 +2457,6 @@ fileprivate struct FfiConverterOptionTypeMozAdsIABContent: FfiConverterRustBuffe
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeMozAdsIABContent.read(from: &buf)
-        default: throw UniffiInternalError.unexpectedOptionalTag
-        }
-    }
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-fileprivate struct FfiConverterOptionTypeMozAdsRequestCachePolicy: FfiConverterRustBuffer {
-    typealias SwiftType = MozAdsRequestCachePolicy?
-
-    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
-        guard let value = value else {
-            writeInt(&buf, Int8(0))
-            return
-        }
-        writeInt(&buf, Int8(1))
-        FfiConverterTypeMozAdsRequestCachePolicy.write(value, into: &buf)
-    }
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
-        switch try readInt(&buf) as Int8 {
-        case 0: return nil
-        case 1: return try FfiConverterTypeMozAdsRequestCachePolicy.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -2707,7 +2782,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_ads_client_checksum_method_mozadsclient_record_impression() != 43275) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ads_client_checksum_method_mozadsclient_report_ad() != 6019) {
+    if (uniffi_ads_client_checksum_method_mozadsclient_report_ad() != 18252) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ads_client_checksum_method_mozadsclient_request_image_ads() != 2157) {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 4, day: 2, hour: 5, minute: 23, second: 47))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 4, day: 12, hour: 5, minute: 28, second: 37))
     }
 
     enum AdsClient {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/ads_client.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/ads_client.swift
@@ -538,7 +538,7 @@ public protocol MozAdsClientProtocol: AnyObject, Sendable {
     
     func recordImpression(impressionUrl: String) throws 
     
-    func reportAd(reportUrl: String) throws 
+    func reportAd(reportUrl: String, reason: MozAdsReportReason) throws 
     
     func requestImageAds(mozAdRequests: [MozAdsPlacementRequest], options: MozAdsRequestOptions?) throws  -> [String: MozAdsImage]
     
@@ -623,10 +623,11 @@ open func recordImpression(impressionUrl: String)throws   {try rustCallWithError
 }
 }
     
-open func reportAd(reportUrl: String)throws   {try rustCallWithError(FfiConverterTypeMozAdsClientApiError_lift) {
+open func reportAd(reportUrl: String, reason: MozAdsReportReason)throws   {try rustCallWithError(FfiConverterTypeMozAdsClientApiError_lift) {
     uniffi_ads_client_fn_method_mozadsclient_report_ad(
             self.uniffiCloneHandle(),
-        FfiConverterString.lower(reportUrl),$0
+        FfiConverterString.lower(reportUrl),
+        FfiConverterTypeMozAdsReportReason_lower(reason),$0
     )
 }
 }
@@ -1217,7 +1218,7 @@ public struct MozAdsCacheConfig: Equatable, Hashable {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(dbPath: String, defaultCacheTtlSeconds: UInt64?, maxSizeMib: UInt64?) {
+    public init(dbPath: String, defaultCacheTtlSeconds: UInt64? = nil, maxSizeMib: UInt64? = nil) {
         self.dbPath = dbPath
         self.defaultCacheTtlSeconds = defaultCacheTtlSeconds
         self.maxSizeMib = maxSizeMib
@@ -1265,6 +1266,60 @@ public func FfiConverterTypeMozAdsCacheConfig_lift(_ buf: RustBuffer) throws -> 
 #endif
 public func FfiConverterTypeMozAdsCacheConfig_lower(_ value: MozAdsCacheConfig) -> RustBuffer {
     return FfiConverterTypeMozAdsCacheConfig.lower(value)
+}
+
+
+public struct MozAdsCachePolicy: Equatable, Hashable {
+    public var mode: MozAdsCacheMode
+    public var ttlSeconds: UInt64?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(mode: MozAdsCacheMode, ttlSeconds: UInt64? = nil) {
+        self.mode = mode
+        self.ttlSeconds = ttlSeconds
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension MozAdsCachePolicy: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeMozAdsCachePolicy: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsCachePolicy {
+        return
+            try MozAdsCachePolicy(
+                mode: FfiConverterTypeMozAdsCacheMode.read(from: &buf), 
+                ttlSeconds: FfiConverterOptionUInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: MozAdsCachePolicy, into buf: inout [UInt8]) {
+        FfiConverterTypeMozAdsCacheMode.write(value.mode, into: &buf)
+        FfiConverterOptionUInt64.write(value.ttlSeconds, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMozAdsCachePolicy_lift(_ buf: RustBuffer) throws -> MozAdsCachePolicy {
+    return try FfiConverterTypeMozAdsCachePolicy.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMozAdsCachePolicy_lower(_ value: MozAdsCachePolicy) -> RustBuffer {
+    return FfiConverterTypeMozAdsCachePolicy.lower(value)
 }
 
 
@@ -1327,14 +1382,14 @@ public func FfiConverterTypeMozAdsCallbacks_lower(_ value: MozAdsCallbacks) -> R
 
 
 public struct MozAdsContentCategory: Equatable, Hashable {
-    public var taxonomy: MozAdsIabContentTaxonomy
     public var categories: [String]
+    public var taxonomy: MozAdsIabContentTaxonomy
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(taxonomy: MozAdsIabContentTaxonomy, categories: [String]) {
-        self.taxonomy = taxonomy
+    public init(categories: [String], taxonomy: MozAdsIabContentTaxonomy) {
         self.categories = categories
+        self.taxonomy = taxonomy
     }
 
     
@@ -1353,14 +1408,14 @@ public struct FfiConverterTypeMozAdsContentCategory: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsContentCategory {
         return
             try MozAdsContentCategory(
-                taxonomy: FfiConverterTypeMozAdsIABContentTaxonomy.read(from: &buf), 
-                categories: FfiConverterSequenceString.read(from: &buf)
+                categories: FfiConverterSequenceString.read(from: &buf), 
+                taxonomy: FfiConverterTypeMozAdsIABContentTaxonomy.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsContentCategory, into buf: inout [UInt8]) {
-        FfiConverterTypeMozAdsIABContentTaxonomy.write(value.taxonomy, into: &buf)
         FfiConverterSequenceString.write(value.categories, into: &buf)
+        FfiConverterTypeMozAdsIABContentTaxonomy.write(value.taxonomy, into: &buf)
     }
 }
 
@@ -1381,14 +1436,14 @@ public func FfiConverterTypeMozAdsContentCategory_lower(_ value: MozAdsContentCa
 
 
 public struct MozAdsIabContent: Equatable, Hashable {
-    public var taxonomy: MozAdsIabContentTaxonomy
     public var categoryIds: [String]
+    public var taxonomy: MozAdsIabContentTaxonomy
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(taxonomy: MozAdsIabContentTaxonomy, categoryIds: [String]) {
-        self.taxonomy = taxonomy
+    public init(categoryIds: [String], taxonomy: MozAdsIabContentTaxonomy) {
         self.categoryIds = categoryIds
+        self.taxonomy = taxonomy
     }
 
     
@@ -1407,14 +1462,14 @@ public struct FfiConverterTypeMozAdsIABContent: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsIabContent {
         return
             try MozAdsIabContent(
-                taxonomy: FfiConverterTypeMozAdsIABContentTaxonomy.read(from: &buf), 
-                categoryIds: FfiConverterSequenceString.read(from: &buf)
+                categoryIds: FfiConverterSequenceString.read(from: &buf), 
+                taxonomy: FfiConverterTypeMozAdsIABContentTaxonomy.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsIabContent, into buf: inout [UInt8]) {
-        FfiConverterTypeMozAdsIABContentTaxonomy.write(value.taxonomy, into: &buf)
         FfiConverterSequenceString.write(value.categoryIds, into: &buf)
+        FfiConverterTypeMozAdsIABContentTaxonomy.write(value.taxonomy, into: &buf)
     }
 }
 
@@ -1505,14 +1560,14 @@ public func FfiConverterTypeMozAdsImage_lower(_ value: MozAdsImage) -> RustBuffe
 
 
 public struct MozAdsPlacementRequest: Equatable, Hashable {
-    public var placementId: String
     public var iabContent: MozAdsIabContent?
+    public var placementId: String
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(placementId: String, iabContent: MozAdsIabContent?) {
-        self.placementId = placementId
+    public init(iabContent: MozAdsIabContent? = nil, placementId: String) {
         self.iabContent = iabContent
+        self.placementId = placementId
     }
 
     
@@ -1531,14 +1586,14 @@ public struct FfiConverterTypeMozAdsPlacementRequest: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsPlacementRequest {
         return
             try MozAdsPlacementRequest(
-                placementId: FfiConverterString.read(from: &buf), 
-                iabContent: FfiConverterOptionTypeMozAdsIABContent.read(from: &buf)
+                iabContent: FfiConverterOptionTypeMozAdsIABContent.read(from: &buf), 
+                placementId: FfiConverterString.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsPlacementRequest, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.placementId, into: &buf)
         FfiConverterOptionTypeMozAdsIABContent.write(value.iabContent, into: &buf)
+        FfiConverterString.write(value.placementId, into: &buf)
     }
 }
 
@@ -1560,15 +1615,15 @@ public func FfiConverterTypeMozAdsPlacementRequest_lower(_ value: MozAdsPlacemen
 
 public struct MozAdsPlacementRequestWithCount: Equatable, Hashable {
     public var count: UInt32
-    public var placementId: String
     public var iabContent: MozAdsIabContent?
+    public var placementId: String
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(count: UInt32, placementId: String, iabContent: MozAdsIabContent?) {
+    public init(count: UInt32, iabContent: MozAdsIabContent? = nil, placementId: String) {
         self.count = count
-        self.placementId = placementId
         self.iabContent = iabContent
+        self.placementId = placementId
     }
 
     
@@ -1588,15 +1643,15 @@ public struct FfiConverterTypeMozAdsPlacementRequestWithCount: FfiConverterRustB
         return
             try MozAdsPlacementRequestWithCount(
                 count: FfiConverterUInt32.read(from: &buf), 
-                placementId: FfiConverterString.read(from: &buf), 
-                iabContent: FfiConverterOptionTypeMozAdsIABContent.read(from: &buf)
+                iabContent: FfiConverterOptionTypeMozAdsIABContent.read(from: &buf), 
+                placementId: FfiConverterString.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsPlacementRequestWithCount, into buf: inout [UInt8]) {
         FfiConverterUInt32.write(value.count, into: &buf)
-        FfiConverterString.write(value.placementId, into: &buf)
         FfiConverterOptionTypeMozAdsIABContent.write(value.iabContent, into: &buf)
+        FfiConverterString.write(value.placementId, into: &buf)
     }
 }
 
@@ -1616,66 +1671,12 @@ public func FfiConverterTypeMozAdsPlacementRequestWithCount_lower(_ value: MozAd
 }
 
 
-public struct MozAdsRequestCachePolicy: Equatable, Hashable {
-    public var mode: MozAdsCacheMode
-    public var ttlSeconds: UInt64?
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(mode: MozAdsCacheMode, ttlSeconds: UInt64?) {
-        self.mode = mode
-        self.ttlSeconds = ttlSeconds
-    }
-
-    
-
-    
-}
-
-#if compiler(>=6)
-extension MozAdsRequestCachePolicy: Sendable {}
-#endif
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public struct FfiConverterTypeMozAdsRequestCachePolicy: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsRequestCachePolicy {
-        return
-            try MozAdsRequestCachePolicy(
-                mode: FfiConverterTypeMozAdsCacheMode.read(from: &buf), 
-                ttlSeconds: FfiConverterOptionUInt64.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: MozAdsRequestCachePolicy, into buf: inout [UInt8]) {
-        FfiConverterTypeMozAdsCacheMode.write(value.mode, into: &buf)
-        FfiConverterOptionUInt64.write(value.ttlSeconds, into: &buf)
-    }
-}
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeMozAdsRequestCachePolicy_lift(_ buf: RustBuffer) throws -> MozAdsRequestCachePolicy {
-    return try FfiConverterTypeMozAdsRequestCachePolicy.lift(buf)
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeMozAdsRequestCachePolicy_lower(_ value: MozAdsRequestCachePolicy) -> RustBuffer {
-    return FfiConverterTypeMozAdsRequestCachePolicy.lower(value)
-}
-
-
 public struct MozAdsRequestOptions: Equatable, Hashable {
-    public var cachePolicy: MozAdsRequestCachePolicy?
+    public var cachePolicy: MozAdsCachePolicy?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(cachePolicy: MozAdsRequestCachePolicy?) {
+    public init(cachePolicy: MozAdsCachePolicy?) {
         self.cachePolicy = cachePolicy
     }
 
@@ -1695,12 +1696,12 @@ public struct FfiConverterTypeMozAdsRequestOptions: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsRequestOptions {
         return
             try MozAdsRequestOptions(
-                cachePolicy: FfiConverterOptionTypeMozAdsRequestCachePolicy.read(from: &buf)
+                cachePolicy: FfiConverterOptionTypeMozAdsCachePolicy.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsRequestOptions, into buf: inout [UInt8]) {
-        FfiConverterOptionTypeMozAdsRequestCachePolicy.write(value.cachePolicy, into: &buf)
+        FfiConverterOptionTypeMozAdsCachePolicy.write(value.cachePolicy, into: &buf)
     }
 }
 
@@ -1869,16 +1870,16 @@ public func FfiConverterTypeMozAdsSpocFrequencyCaps_lower(_ value: MozAdsSpocFre
 
 
 public struct MozAdsSpocRanking: Equatable, Hashable {
-    public var priority: UInt32
-    public var personalizationModels: [String: UInt32]
     public var itemScore: Double
+    public var personalizationModels: [String: UInt32]
+    public var priority: UInt32
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(priority: UInt32, personalizationModels: [String: UInt32], itemScore: Double) {
-        self.priority = priority
-        self.personalizationModels = personalizationModels
+    public init(itemScore: Double, personalizationModels: [String: UInt32], priority: UInt32) {
         self.itemScore = itemScore
+        self.personalizationModels = personalizationModels
+        self.priority = priority
     }
 
     
@@ -1897,16 +1898,16 @@ public struct FfiConverterTypeMozAdsSpocRanking: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsSpocRanking {
         return
             try MozAdsSpocRanking(
-                priority: FfiConverterUInt32.read(from: &buf), 
+                itemScore: FfiConverterDouble.read(from: &buf), 
                 personalizationModels: FfiConverterDictionaryStringUInt32.read(from: &buf), 
-                itemScore: FfiConverterDouble.read(from: &buf)
+                priority: FfiConverterUInt32.read(from: &buf)
         )
     }
 
     public static func write(_ value: MozAdsSpocRanking, into buf: inout [UInt8]) {
-        FfiConverterUInt32.write(value.priority, into: &buf)
-        FfiConverterDictionaryStringUInt32.write(value.personalizationModels, into: &buf)
         FfiConverterDouble.write(value.itemScore, into: &buf)
+        FfiConverterDictionaryStringUInt32.write(value.personalizationModels, into: &buf)
+        FfiConverterUInt32.write(value.priority, into: &buf)
     }
 }
 
@@ -2291,6 +2292,80 @@ public func FfiConverterTypeMozAdsIABContentTaxonomy_lower(_ value: MozAdsIabCon
 }
 
 
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum MozAdsReportReason: Equatable, Hashable {
+    
+    case inappropriate
+    case notInterested
+    case seenTooManyTimes
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension MozAdsReportReason: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeMozAdsReportReason: FfiConverterRustBuffer {
+    typealias SwiftType = MozAdsReportReason
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MozAdsReportReason {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .inappropriate
+        
+        case 2: return .notInterested
+        
+        case 3: return .seenTooManyTimes
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: MozAdsReportReason, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .inappropriate:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .notInterested:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .seenTooManyTimes:
+            writeInt(&buf, Int32(3))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMozAdsReportReason_lift(_ buf: RustBuffer) throws -> MozAdsReportReason {
+    return try FfiConverterTypeMozAdsReportReason.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMozAdsReportReason_lower(_ value: MozAdsReportReason) -> RustBuffer {
+    return FfiConverterTypeMozAdsReportReason.lower(value)
+}
+
+
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
@@ -2342,6 +2417,30 @@ fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeMozAdsCachePolicy: FfiConverterRustBuffer {
+    typealias SwiftType = MozAdsCachePolicy?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeMozAdsCachePolicy.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeMozAdsCachePolicy.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeMozAdsIABContent: FfiConverterRustBuffer {
     typealias SwiftType = MozAdsIabContent?
 
@@ -2358,30 +2457,6 @@ fileprivate struct FfiConverterOptionTypeMozAdsIABContent: FfiConverterRustBuffe
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeMozAdsIABContent.read(from: &buf)
-        default: throw UniffiInternalError.unexpectedOptionalTag
-        }
-    }
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-fileprivate struct FfiConverterOptionTypeMozAdsRequestCachePolicy: FfiConverterRustBuffer {
-    typealias SwiftType = MozAdsRequestCachePolicy?
-
-    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
-        guard let value = value else {
-            writeInt(&buf, Int8(0))
-            return
-        }
-        writeInt(&buf, Int8(1))
-        FfiConverterTypeMozAdsRequestCachePolicy.write(value, into: &buf)
-    }
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
-        switch try readInt(&buf) as Int8 {
-        case 0: return nil
-        case 1: return try FfiConverterTypeMozAdsRequestCachePolicy.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -2707,7 +2782,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_ads_client_checksum_method_mozadsclient_record_impression() != 43275) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_ads_client_checksum_method_mozadsclient_report_ad() != 6019) {
+    if (uniffi_ads_client_checksum_method_mozadsclient_report_ad() != 18252) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ads_client_checksum_method_mozadsclient_request_image_ads() != 2157) {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/logins.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/logins.swift
@@ -2308,11 +2308,6 @@ public enum LoginsApiError: Swift.Error, Equatable, Hashable, Foundation.Localiz
     case Interrupted(reason: String
     )
     /**
-     * Sync reported that authentication failed and the user should re-enter their FxA password.
-     */
-    case SyncAuthInvalid(reason: String
-    )
-    /**
      * something internal went wrong which doesn't have a public error value
      * because the consuming app can not reasonably take any action to resolve it.
      * The underlying error will have been logged and reported.
@@ -2374,10 +2369,7 @@ public struct FfiConverterTypeLoginsApiError: FfiConverterRustBuffer {
         case 11: return .Interrupted(
             reason: try FfiConverterString.read(from: &buf)
             )
-        case 12: return .SyncAuthInvalid(
-            reason: try FfiConverterString.read(from: &buf)
-            )
-        case 13: return .UnexpectedLoginsApiError(
+        case 12: return .UnexpectedLoginsApiError(
             reason: try FfiConverterString.read(from: &buf)
             )
 
@@ -2443,13 +2435,8 @@ public struct FfiConverterTypeLoginsApiError: FfiConverterRustBuffer {
             FfiConverterString.write(reason, into: &buf)
             
         
-        case let .SyncAuthInvalid(reason):
-            writeInt(&buf, Int32(12))
-            FfiConverterString.write(reason, into: &buf)
-            
-        
         case let .UnexpectedLoginsApiError(reason):
-            writeInt(&buf, Int32(13))
+            writeInt(&buf, Int32(12))
             FfiConverterString.write(reason, into: &buf)
             
         }

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/places.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/places.swift
@@ -566,17 +566,9 @@ fileprivate struct FfiConverterString: FfiConverter {
 
 public protocol PlacesApiProtocol: AnyObject, Sendable {
     
-    func bookmarksReset() throws 
-    
-    func bookmarksSync(keyId: String, accessToken: String, syncKey: String, tokenserverUrl: Url) throws  -> String
-    
-    func historySync(keyId: String, accessToken: String, syncKey: String, tokenserverUrl: Url) throws  -> String
-    
     func newConnection(connType: ConnectionType) throws  -> PlacesConnection
     
     func registerWithSyncManager() 
-    
-    func resetHistory() throws 
     
 }
 open class PlacesApi: PlacesApiProtocol, @unchecked Sendable {
@@ -632,37 +624,6 @@ open class PlacesApi: PlacesApiProtocol, @unchecked Sendable {
     
 
     
-open func bookmarksReset()throws   {try rustCallWithError(FfiConverterTypePlacesApiError_lift) {
-    uniffi_places_fn_method_placesapi_bookmarks_reset(
-            self.uniffiCloneHandle(),$0
-    )
-}
-}
-    
-open func bookmarksSync(keyId: String, accessToken: String, syncKey: String, tokenserverUrl: Url)throws  -> String  {
-    return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypePlacesApiError_lift) {
-    uniffi_places_fn_method_placesapi_bookmarks_sync(
-            self.uniffiCloneHandle(),
-        FfiConverterString.lower(keyId),
-        FfiConverterString.lower(accessToken),
-        FfiConverterString.lower(syncKey),
-        FfiConverterTypeUrl_lower(tokenserverUrl),$0
-    )
-})
-}
-    
-open func historySync(keyId: String, accessToken: String, syncKey: String, tokenserverUrl: Url)throws  -> String  {
-    return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypePlacesApiError_lift) {
-    uniffi_places_fn_method_placesapi_history_sync(
-            self.uniffiCloneHandle(),
-        FfiConverterString.lower(keyId),
-        FfiConverterString.lower(accessToken),
-        FfiConverterString.lower(syncKey),
-        FfiConverterTypeUrl_lower(tokenserverUrl),$0
-    )
-})
-}
-    
 open func newConnection(connType: ConnectionType)throws  -> PlacesConnection  {
     return try  FfiConverterTypePlacesConnection_lift(try rustCallWithError(FfiConverterTypePlacesApiError_lift) {
     uniffi_places_fn_method_placesapi_new_connection(
@@ -674,13 +635,6 @@ open func newConnection(connType: ConnectionType)throws  -> PlacesConnection  {
     
 open func registerWithSyncManager()  {try! rustCall() {
     uniffi_places_fn_method_placesapi_register_with_sync_manager(
-            self.uniffiCloneHandle(),$0
-    )
-}
-}
-    
-open func resetHistory()throws   {try rustCallWithError(FfiConverterTypePlacesApiError_lift) {
-    uniffi_places_fn_method_placesapi_reset_history(
             self.uniffiCloneHandle(),$0
     )
 }
@@ -4481,22 +4435,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_places_checksum_func_places_api_new() != 61152) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_places_checksum_method_placesapi_bookmarks_reset() != 9496) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_places_checksum_method_placesapi_bookmarks_sync() != 10687) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_places_checksum_method_placesapi_history_sync() != 37447) {
-        return InitializationResult.apiChecksumMismatch
-    }
     if (uniffi_places_checksum_method_placesapi_new_connection() != 496) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_places_checksum_method_placesapi_register_with_sync_manager() != 34707) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_places_checksum_method_placesapi_reset_history() != 11417) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_places_checksum_method_placesconnection_accept_result() != 5027) {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/sync15.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/sync15.swift
@@ -462,10 +462,28 @@ fileprivate struct FfiConverterString: FfiConverter {
 /**
  * Enumeration for the different types of device.
  *
- * Firefox Accounts separates devices into broad categories for display purposes,
- * such as distinguishing a desktop PC from a mobile phone. Upon signin, the
- * application should inspect the device it is running on and select an appropriate
+ * Firefox Accounts and the broader Sync universe separates devices into broad categories for
+ * various purposes, such as distinguishing a desktop PC from a mobile phone.
+ * Upon signin, the application should inspect the device it is running on and select an appropriate
  * [`DeviceType`] to include in its device registration record.
+ *
+ * A special variant in this enum, [`DeviceType::Unknown`] is used to capture
+ * the string values we don't recognise. It also has a custom serde serializer and deserializer
+ * which implements the following semantics:
+ * * deserializing a `DeviceType` which uses a string value we don't recognise or null will return
+ * `DeviceType::Unknown` rather than returning an error.
+ * * serializing `DeviceType::Unknown` will serialize `null`.
+ *
+ * This has a few important implications:
+ * * In general, `Option<DeviceType>` should be avoided, and a plain `DeviceType` used instead,
+ * because in that case, `None` would be semantically identical to `DeviceType::Unknown` and
+ * as mentioned above, `null` already deserializes as `DeviceType::Unknown`.
+ * * Any unknown device types can not be round-tripped via this enum - eg, if you deserialize
+ * a struct holding a `DeviceType` string value we don't recognize, then re-serialize it, the
+ * original string value is lost. We don't consider this a problem because in practice, we only
+ * upload records with *this* device's type, not the type of other devices, and it's reasonable
+ * to assume that this module knows about all valid device types for the device type it is
+ * deployed on.
  */
 
 public enum DeviceType: Equatable, Hashable {

--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
@@ -145,8 +145,8 @@ final class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, Feature
     private func fetchTilesWithAdsClient(completion: @escaping (UnifiedTileResult) -> Void) {
         logger.log("Fetching tiles with ads client", level: .info, category: .homepage)
         let mozAdRequests = [
-            MozAdsPlacementRequest(placementId: TileOrder.position1.rawValue, iabContent: nil),
-            MozAdsPlacementRequest(placementId: TileOrder.position2.rawValue, iabContent: nil)
+            MozAdsPlacementRequest(iabContent: nil, placementId: TileOrder.position1.rawValue),
+            MozAdsPlacementRequest(iabContent: nil, placementId: TileOrder.position2.rawValue)
         ]
         do {
             let mozAdsTiles = try adsClient.requestTileAds(

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -24,7 +24,6 @@ public extension LoginsStoreError {
         case .NoSuchRecord: return "NoSuchRecord"
         case .InvalidKey: return "InvalidKey"
         case .Interrupted: return "Interrupted"
-        case .SyncAuthInvalid: return "SyncAuthInvalid"
         case .UnexpectedLoginsApiError: return "UnexpectedLoginsApiError"
         case .MissingKey: return "MissingKey"
         case .EncryptionFailed(reason: let reason): return "EncryptionFailed reason:\(reason)"

--- a/firefox-ios/Storage/RustKeychain.swift
+++ b/firefox-ios/Storage/RustKeychain.swift
@@ -367,7 +367,6 @@ public final class RustKeychain: KeychainProtocol {
             case .InvalidRecord(let message),
                     .NoSuchRecord(let message),
                     .Interrupted(let message),
-                    .SyncAuthInvalid(let message),
                     .UnexpectedLoginsApiError(let message):
                 return message
             case .InvalidKey:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsProviderTests.swift
@@ -32,7 +32,7 @@ class MockMozAdsClient: MozAdsClientProtocol, @unchecked Sendable {
         recordImpressionCalledWith = impressionUrl
     }
 
-    func reportAd(reportUrl: String) throws {}
+    func reportAd(reportUrl: String, reason: MozAdsReportReason) throws {}
 
     func requestImageAds(
         mozAdRequests: [MozAdsPlacementRequest],


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Introduced in https://github.com/mozilla/application-services/pull/7152

That landed 5 days ago, so I'm surprised it hasn't come up yet, but I found it building locally.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

