### PR TITLE
Update firefox-ios to avoid direct use of the session token

### DIFF
--- a/MozillaRustComponents/Package.swift
+++ b/MozillaRustComponents/Package.swift
@@ -1,13 +1,13 @@
 // swift-tools-version: 5.10
 import PackageDescription
 
-let checksum = "21e6a5ba86117ce988b82f3c4cee9cb89f7f5b698552e1e560a71ec1dbbfd03d"
-let version = "152.0.20260502050228"
-let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.152.20260502050228/artifacts/public/build/MozillaRustComponents.xcframework.zip"
+let checksum = "96f46c4d2cc022b99df55506f6700f47d3cb73c07ff1060d6dab156a80d35d78"
+let version = "152.0.20260506050225"
+let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.152.20260506050225/artifacts/public/build/MozillaRustComponents.xcframework.zip"
 
 // Focus xcframework
-let focusChecksum = "0966489d32fd0e4b21971054cadbd7a92331377b82562342a6af19489a22c250"
-let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.152.20260502050228/artifacts/public/build/FocusRustComponents.xcframework.zip"
+let focusChecksum = "e1735fcc0a10a3d3fc18274f8444ad007edd512d7f76f7b52be2c6f419f800a6"
+let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.152.20260506050225/artifacts/public/build/FocusRustComponents.xcframework.zip"
 
 let package = Package(
     name: "MozillaRustComponentsSwift",

--- a/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 2, hour: 5, minute: 24, second: 38))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 6, hour: 5, minute: 38, second: 2))
     }
 
     enum NimbusEvents {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
@@ -107,12 +107,15 @@ open class FxAccountManager: @unchecked Sendable {
         return state == .authIssues
     }
 
-    /// Set the user data before completing their authentication
-    public func setUserData(userData: UserData, completion: @Sendable @escaping () -> Void) {
+    public func handleWebChannelLogin(jsonPayload: String, completion: @Sendable @escaping () -> Void) {
         DispatchQueue.global().async {
-            self.account?.setUserData(userData: userData)
+            try? self.account?.handleWebChannelLogin(jsonPayload: jsonPayload)
             completion()
         }
+    }
+
+    public func getSignedInUserForWebChannel() -> String? {
+        return account?.getSignedInUserForWebChannel()
     }
 
     /// Begins a new authentication flow.
@@ -225,16 +228,6 @@ open class FxAccountManager: @unchecked Sendable {
         }
     }
 
-    /// Get the session token associated with this account.
-    /// Note that you should have requested the `.session` scope earlier to be able to get this token.
-    public func getSessionToken() -> Result<String, Error> {
-        do {
-            return try .success(requireAccount().getSessionToken())
-        } catch {
-            return .failure(error)
-        }
-    }
-
     /// Clear the access token cache for reauthentication.
     public func clearAccessTokenCache() {
         account?.clearAccessTokenCache()
@@ -249,14 +242,15 @@ open class FxAccountManager: @unchecked Sendable {
         }
     }
 
-    /// The account password has been changed locally and a new session token has been sent to us through WebChannel.
+    /// The account password has been changed locally; give the fxa component the data
+    /// we got so it can update the account state appopriately.
     public func handlePasswordChanged(
-        newSessionToken: String,
+        jsonPayload: String,
         completionHandler: @escaping @MainActor @Sendable () -> Void
     ) {
         fxaFsmQueue.async {
             do {
-                try self.requireAccount().handleSessionTokenChange(sessionToken: newSessionToken)
+                try self.requireAccount().handleWebChannelPasswordChange(jsonPayload: jsonPayload)
                 // handleSessionTokenChange invalidates the old refresh token so the device
                 // record on the server is stale. Re-register the device.
                 self.requireConstellation().initDevice(

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/PersistedFirefoxAccount.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/PersistedFirefoxAccount.swift
@@ -52,9 +52,20 @@ class PersistedFirefoxAccount {
         try inner.toJson()
     }
 
-    func setUserData(userData: UserData) {
+    func handleWebChannelLogin(jsonPayload: String) throws {
         defer { tryPersistState() }
-        inner.setUserData(userData: userData)
+        try inner.handleWebChannelLogin(jsonPayload: jsonPayload)
+    }
+
+    func getSignedInUserForWebChannel() -> String? {
+        return inner.getSignedInUserForWebChannel()
+    }
+
+    func handleWebChannelPasswordChange(jsonPayload: String) throws {
+        defer { tryPersistState() }
+        try notifyAuthErrors {
+            try self.inner.handleWebChannelPasswordChange(jsonPayload: jsonPayload)
+        }
     }
 
     func beginOAuthFlow(
@@ -220,20 +231,6 @@ class PersistedFirefoxAccount {
         defer { tryPersistState() }
         return try notifyAuthErrors {
             try self.inner.getAccessToken(scope: scope, useCache: useCache)
-        }
-    }
-
-    func getSessionToken() throws -> String {
-        defer { tryPersistState() }
-        return try notifyAuthErrors {
-            try self.inner.getSessionToken()
-        }
-    }
-
-    func handleSessionTokenChange(sessionToken: String) throws {
-        defer { tryPersistState() }
-        return try notifyAuthErrors {
-            try self.inner.handleSessionTokenChange(sessionToken: sessionToken)
         }
     }
 

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 2, hour: 5, minute: 24, second: 35))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 6, hour: 5, minute: 37, second: 59))
     }
 
     enum AdsClient {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/fxa_client.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/fxa_client.swift
@@ -914,24 +914,11 @@ public protocol FirefoxAccountProtocol: AnyObject, Sendable {
     func getProfile(ignoreCache: Bool) throws  -> Profile
     
     /**
-     * Get the session token for the user's account, if one is available.
-     *
-     * **💾 This method alters the persisted account state.**
-     *
-     * Applications that function as a web browser may need to hold on to a session token
-     * on behalf of Firefox Accounts web content. This method exists so that they can retrieve
-     * it an pass it back to said web content when required.
-     *
-     * # Notes
-     *
-     *    - Please do not attempt to use the resulting token to directly make calls to the
-     *      Firefox Accounts servers! All account management functionality should be performed
-     *      in web content.
-     *    - A session token is only available to applications that have requested the
-     *      `https:///identity.mozilla.com/tokens/session` scope.
-
+     * Returns a complete signedInUser JSON object for a WebChannel fxaccounts:fxa_status response,
+     * embedding the session token privately. Email and uid come from the cached profile in internal
+     * state. Returns null if no session token is set.
      */
-    func getSessionToken() throws  -> String
+    func getSignedInUserForWebChannel()  -> String?
     
     /**
      * Get the current state
@@ -964,21 +951,20 @@ public protocol FirefoxAccountProtocol: AnyObject, Sendable {
     func handlePushMessage(payload: String) throws  -> AccountEvent
     
     /**
-     * Update the stored session token for the user's account.
-     *
-     * **💾 This method alters the persisted account state.**
-     *
-     * Applications that function as a web browser may need to hold on to a session token
-     * on behalf of Firefox Accounts web content. This method exists so that said web content
-     * signals that it has generated a new session token, the stored value can be updated
-     * to match.
-     *
-     * # Arguments
-     *
-     *    - `session_token` - the new session token value provided from web content.
-
+     * Stores anything necessary from a WebChannel login JSON payload. This includes the session
+     * token, but that is abstracted because the consuming apps should not be aware of the
+     * specific payload format returned, nor should they get access to the session token
+     * directly if possible.
+     * The [json_payload] is the `data` object from the `fxaccounts:login` WebChannel command.
      */
-    func handleSessionTokenChange(sessionToken: String) throws 
+    func handleWebChannelLogin(jsonPayload: String) throws 
+    
+    /**
+     * Handle a WebChannel password-change notification by exchanging the new session token
+     * for a new refresh token via a network call.
+     * The [json_payload] is the `data` object from the `fxaccounts:change_password` WebChannel command.
+     */
+    func handleWebChannelPasswordChange(jsonPayload: String) throws 
     
     /**
      * Create a new device record for this application.
@@ -1109,14 +1095,6 @@ public protocol FirefoxAccountProtocol: AnyObject, Sendable {
 
      */
     func setPushSubscription(subscription: DevicePushSubscription) throws  -> LocalDevice
-    
-    /**
-     * Sets the users information based on the web content's login information
-     * This is intended to only be used by user agents (eg: Firefox) to set the users
-     * session token and tie it to the refresh token that will be issued at the end of the
-     * oauth flow.
-     */
-    func setUserData(userData: UserData) 
     
     /**
      * Used by the application to test auth token issues
@@ -1757,26 +1735,13 @@ open func getProfile(ignoreCache: Bool)throws  -> Profile  {
 }
     
     /**
-     * Get the session token for the user's account, if one is available.
-     *
-     * **💾 This method alters the persisted account state.**
-     *
-     * Applications that function as a web browser may need to hold on to a session token
-     * on behalf of Firefox Accounts web content. This method exists so that they can retrieve
-     * it an pass it back to said web content when required.
-     *
-     * # Notes
-     *
-     *    - Please do not attempt to use the resulting token to directly make calls to the
-     *      Firefox Accounts servers! All account management functionality should be performed
-     *      in web content.
-     *    - A session token is only available to applications that have requested the
-     *      `https:///identity.mozilla.com/tokens/session` scope.
-
+     * Returns a complete signedInUser JSON object for a WebChannel fxaccounts:fxa_status response,
+     * embedding the session token privately. Email and uid come from the cached profile in internal
+     * state. Returns null if no session token is set.
      */
-open func getSessionToken()throws  -> String  {
-    return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeFxaError_lift) {
-    uniffi_fxa_client_fn_method_firefoxaccount_get_session_token(
+open func getSignedInUserForWebChannel() -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+    uniffi_fxa_client_fn_method_firefoxaccount_get_signed_in_user_for_web_channel(
             self.uniffiCloneHandle(),$0
     )
 })
@@ -1832,24 +1797,29 @@ open func handlePushMessage(payload: String)throws  -> AccountEvent  {
 }
     
     /**
-     * Update the stored session token for the user's account.
-     *
-     * **💾 This method alters the persisted account state.**
-     *
-     * Applications that function as a web browser may need to hold on to a session token
-     * on behalf of Firefox Accounts web content. This method exists so that said web content
-     * signals that it has generated a new session token, the stored value can be updated
-     * to match.
-     *
-     * # Arguments
-     *
-     *    - `session_token` - the new session token value provided from web content.
-
+     * Stores anything necessary from a WebChannel login JSON payload. This includes the session
+     * token, but that is abstracted because the consuming apps should not be aware of the
+     * specific payload format returned, nor should they get access to the session token
+     * directly if possible.
+     * The [json_payload] is the `data` object from the `fxaccounts:login` WebChannel command.
      */
-open func handleSessionTokenChange(sessionToken: String)throws   {try rustCallWithError(FfiConverterTypeFxaError_lift) {
-    uniffi_fxa_client_fn_method_firefoxaccount_handle_session_token_change(
+open func handleWebChannelLogin(jsonPayload: String)throws   {try rustCallWithError(FfiConverterTypeFxaError_lift) {
+    uniffi_fxa_client_fn_method_firefoxaccount_handle_web_channel_login(
             self.uniffiCloneHandle(),
-        FfiConverterString.lower(sessionToken),$0
+        FfiConverterString.lower(jsonPayload),$0
+    )
+}
+}
+    
+    /**
+     * Handle a WebChannel password-change notification by exchanging the new session token
+     * for a new refresh token via a network call.
+     * The [json_payload] is the `data` object from the `fxaccounts:change_password` WebChannel command.
+     */
+open func handleWebChannelPasswordChange(jsonPayload: String)throws   {try rustCallWithError(FfiConverterTypeFxaError_lift) {
+    uniffi_fxa_client_fn_method_firefoxaccount_handle_web_channel_password_change(
+            self.uniffiCloneHandle(),
+        FfiConverterString.lower(jsonPayload),$0
     )
 }
 }
@@ -2032,20 +2002,6 @@ open func setPushSubscription(subscription: DevicePushSubscription)throws  -> Lo
         FfiConverterTypeDevicePushSubscription_lower(subscription),$0
     )
 })
-}
-    
-    /**
-     * Sets the users information based on the web content's login information
-     * This is intended to only be used by user agents (eg: Firefox) to set the users
-     * session token and tie it to the refresh token that will be issued at the end of the
-     * oauth flow.
-     */
-open func setUserData(userData: UserData)  {try! rustCall() {
-    uniffi_fxa_client_fn_method_firefoxaccount_set_user_data(
-            self.uniffiCloneHandle(),
-        FfiConverterTypeUserData_lower(userData),$0
-    )
-}
 }
     
     /**
@@ -3326,68 +3282,6 @@ public func FfiConverterTypeTabHistoryEntry_lift(_ buf: RustBuffer) throws -> Ta
 #endif
 public func FfiConverterTypeTabHistoryEntry_lower(_ value: TabHistoryEntry) -> RustBuffer {
     return FfiConverterTypeTabHistoryEntry.lower(value)
-}
-
-
-public struct UserData: Equatable, Hashable {
-    public var sessionToken: String
-    public var uid: String
-    public var email: String
-    public var verified: Bool
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(sessionToken: String, uid: String, email: String, verified: Bool) {
-        self.sessionToken = sessionToken
-        self.uid = uid
-        self.email = email
-        self.verified = verified
-    }
-
-    
-
-    
-}
-
-#if compiler(>=6)
-extension UserData: Sendable {}
-#endif
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public struct FfiConverterTypeUserData: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UserData {
-        return
-            try UserData(
-                sessionToken: FfiConverterString.read(from: &buf), 
-                uid: FfiConverterString.read(from: &buf), 
-                email: FfiConverterString.read(from: &buf), 
-                verified: FfiConverterBool.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: UserData, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.sessionToken, into: &buf)
-        FfiConverterString.write(value.uid, into: &buf)
-        FfiConverterString.write(value.email, into: &buf)
-        FfiConverterBool.write(value.verified, into: &buf)
-    }
-}
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeUserData_lift(_ buf: RustBuffer) throws -> UserData {
-    return try FfiConverterTypeUserData.lift(buf)
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeUserData_lower(_ value: UserData) -> RustBuffer {
-    return FfiConverterTypeUserData.lower(value)
 }
 
 // Note that we don't yet support `indirect` for enums.
@@ -4777,7 +4671,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_fxa_client_checksum_method_firefoxaccount_get_profile() != 18322) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_fxa_client_checksum_method_firefoxaccount_get_session_token() != 45605) {
+    if (uniffi_fxa_client_checksum_method_firefoxaccount_get_signed_in_user_for_web_channel() != 36302) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_fxa_client_checksum_method_firefoxaccount_get_state() != 11194) {
@@ -4789,7 +4683,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_fxa_client_checksum_method_firefoxaccount_handle_push_message() != 12910) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_fxa_client_checksum_method_firefoxaccount_handle_session_token_change() != 61407) {
+    if (uniffi_fxa_client_checksum_method_firefoxaccount_handle_web_channel_login() != 61652) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_fxa_client_checksum_method_firefoxaccount_handle_web_channel_password_change() != 5890) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_fxa_client_checksum_method_firefoxaccount_initialize_device() != 52372) {
@@ -4811,9 +4708,6 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_fxa_client_checksum_method_firefoxaccount_set_push_subscription() != 27852) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_fxa_client_checksum_method_firefoxaccount_set_user_data() != 31422) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_fxa_client_checksum_method_firefoxaccount_simulate_network_error() != 31630) {

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -11,7 +11,6 @@ import PDFKit
 
 import enum MozillaAppServices.OAuthScope
 import struct MozillaAppServices.FxaAuthData
-import struct MozillaAppServices.UserData
 
 enum FxAPageType: Equatable {
     case emailLoginFlow
@@ -278,18 +277,10 @@ extension FxAWebViewModel {
             )
         case .login:
             guard let data = data as? [String: Any],
-                let sessionToken = data["sessionToken"] as? String,
-                let email = data["email"] as? String,
-                let uid = data["uid"] as? String,
-                let verified = data["verified"] as? Bool
+                  let jsonData = try? JSONSerialization.data(withJSONObject: data),
+                  let jsonString = String(data: jsonData, encoding: .utf8)
             else { return }
-            let userData = UserData(
-                sessionToken: sessionToken,
-                uid: uid,
-                email: email,
-                verified: verified
-            )
-            profile.rustFxA.accountManager?.setUserData(userData: userData) {}
+            profile.rustFxA.accountManager?.handleWebChannelLogin(jsonPayload: jsonString) {}
         case .canLinkAccount:
             if let id = id {
                 onCanLinkAccount(msgId: id, webView: webView)
@@ -333,19 +324,11 @@ extension FxAWebViewModel {
         let data: String
         switch pageType {
         case .settingsPage:
-            // Both email and uid are required at this time to properly link the FxA settings session
-            let email = fxa.accountProfile()?.email ?? ""
-            let uid = fxa.accountProfile()?.uid ?? ""
-            let token = (try? fxa.getSessionToken().get()) ?? ""
+            let signedInUserJson = fxa.getSignedInUserForWebChannel() ?? "null"
             data = """
                 {
                     capabilities: {},
-                    signedInUser: {
-                        sessionToken: "\(token)",
-                        email: "\(email)",
-                        uid: "\(uid)",
-                        verified: true,
-                    }
+                    signedInUser: \(signedInUserJson),
                 }
                 """
         case .emailLoginFlow, .qrCode:
@@ -405,10 +388,11 @@ extension FxAWebViewModel {
 
     private func onPasswordChange(data: Any, webView: WKWebView) {
         guard let data = data as? [String: Any],
-              let sessionToken = data["sessionToken"] as? String
+              let jsonData = try? JSONSerialization.data(withJSONObject: data),
+              let jsonString = String(data: jsonData, encoding: .utf8)
         else { return }
 
-        profile.rustFxA.accountManager?.handlePasswordChanged(newSessionToken: sessionToken) { [weak self] in
+        profile.rustFxA.accountManager?.handlePasswordChanged(jsonPayload: jsonString) { [weak self] in
             NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
             self?.profile.syncManager?.syncEverything(why: .enabledChange)
         }


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Update firefox-ios to avoid direct use of the session token and use webchannel-specific methods instead.

This will fix the breaking change introduced in https://github.com/mozilla/application-services/pull/7317

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

