### PR TITLE
Remove FXIOS-15239 [PhotonActionSheet] Remove unused code to fix Periphery warnings

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -331,39 +331,6 @@ class PhotonActionSheet: UIViewController,
         tableViewHeightConstraint?.constant = height
     }
 
-    private func getViewsHeightSum(views: [UIView]) -> CGFloat {
-        return views.map { $0.frame.height }.reduce(0, +)
-    }
-
-    private var visibleTableViewHeaders: [UITableViewHeaderFooterView] {
-        var visibleHeaders = [UITableViewHeaderFooterView]()
-        for sectionIndex in indexesOfVisibleHeaderSections {
-            guard let sectionHeader = tableView.headerView(forSection: sectionIndex) else { continue }
-            visibleHeaders.append(sectionHeader)
-        }
-
-        return visibleHeaders
-    }
-
-    private var indexesOfVisibleHeaderSections: [Int] {
-        var visibleSectionIndexes = [Int]()
-
-        (0..<tableView.numberOfSections).forEach { index in
-            let headerRect = tableView.rect(forSection: index)
-
-            // The "visible part" of the tableView is based on the content offset and the tableView's size.
-            let visiblePartOfTableView = CGRect(x: tableView.contentOffset.x,
-                                                y: tableView.contentOffset.y,
-                                                width: tableView.bounds.size.width,
-                                                height: tableView.bounds.size.height)
-
-            if visiblePartOfTableView.intersects(headerRect) {
-                visibleSectionIndexes.append(index)
-            }
-        }
-        return visibleSectionIndexes
-    }
-
     // MARK: Notifiable
 
     func handleNotifications(_ notification: Notification) {
@@ -395,10 +362,6 @@ class PhotonActionSheet: UIViewController,
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.actions[section].count
-    }
-
-    func tableView(_ tableView: UITableView, hasFullWidthSeparatorForRowAtIndexPath indexPath: IndexPath) -> Bool {
-        return false
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
@@ -9,7 +9,6 @@ import SiteImageView
 
 class PhotonActionSheetSiteHeaderView: UITableViewHeaderFooterView, ReusableCell, ThemeApplicable {
     struct UX {
-        static let borderWidth: CGFloat = 0.5
         static let padding: CGFloat = 12
         static let verticalPadding: CGFloat = 2
         static let siteImageViewSize: CGFloat = 52

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
@@ -80,23 +80,10 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
         icon.adjustsImageSizeForAccessibilityContentSizeCategory = true
     }
 
-    private lazy var disclosureLabel: UILabel = {
-        let label = UILabel()
-        return label
-    }()
-
     private lazy var selectedOverlay: UIView = .build { selectedOverlay in
         selectedOverlay.backgroundColor = UX.SelectedOverlayColor
         selectedOverlay.isHidden = true
     }
-
-    private lazy var disclosureIndicator: UIImageView = {
-        let disclosureIndicator = createIconImageView()
-        disclosureIndicator.image = UIImage(
-            named: StandardImageIdentifiers.Large.chevronRight
-        )?.withRenderingMode(.alwaysTemplate)
-        return disclosureIndicator
-    }()
 
     private lazy var stackView: UIStackView = .build { stackView in
         stackView.spacing = UX.InBetweenPadding
@@ -249,8 +236,6 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
 
         verticalBorder.backgroundColor = colors.layer4
         bottomBorder.backgroundColor = colors.layer4
-
-        disclosureIndicator.tintColor = colors.iconSecondary
 
         let iconTint: UIColor? = item?.needsIconActionableTint ?? false ? colors.iconAccentYellow : tintColor
         statusIcon.tintColor = iconTint


### PR DESCRIPTION
## Summary

Remove dead code detected by Periphery in PhotonActionSheet-related files:

- **PhotonActionSheet.swift**: Remove unused private function `getViewsHeightSum(views:)`, unused private computed properties `visibleTableViewHeaders` and `indexesOfVisibleHeaderSections`, and unused custom method `tableView(_:hasFullWidthSeparatorForRowAtIndexPath:)`
- **PhotonActionSheetSiteHeaderView.swift**: Remove unused `UX.borderWidth`
- **PhotonActionSheetView.swift**: Remove unused `disclosureLabel` and `disclosureIndicator` (never added to view hierarchy), and its reference in `applyTheme(theme:)`

Closes #32759

Thank you for the great talk at try! Swift Tokyo.

## Test plan

- [ ] Build the `Periphery` scheme and verify the above warnings are resolved
- [ ] Build the `Fennec` scheme and verify no compilation errors