### PR TITLE
Bugfix FXIOS-15238 [Warnings] Fix warnings in TopTabsLayoutDelegate and TopTabsViewLayout

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsLayout.swift
@@ -15,14 +15,10 @@ class TopTabsLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
         @MainActor
         static let minTabWidth: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 130 : 76
         static let maxTabWidth: CGFloat = 220
-        static let faderPading: CGFloat = 8
-        static let separatorYOffset: CGFloat = 7
-        static let separatorHeight: CGFloat = 32
     }
 
     weak var tabSelectionDelegate: TabSelectionDelegate?
     weak var scrollViewDelegate: TopTabsScrollDelegate?
-    let headerFooterWidth = UX.separatorWidth + UX.faderPading
 
     @objc
     func collectionView(
@@ -95,8 +91,6 @@ extension TopTabsLayoutDelegate: UICollectionViewDelegate {
 
 class TopTabsViewLayout: UICollectionViewFlowLayout {
     var decorationAttributeArr: [Int: UICollectionViewLayoutAttributes?] = [:]
-    let separatorYOffset = TopTabsLayoutDelegate.UX.separatorYOffset
-    let separatorSize = TopTabsLayoutDelegate.UX.separatorHeight
     let SeparatorZIndex = -2 /// Prevent the header/footer from appearing above the Tabs
 
     override func prepare() {


### PR DESCRIPTION
## :scroll: Tickets
[JIRA ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15238)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32758)

## :bulb: Description

remove unused variable emitting warning during periphery check
  
## checked
- [x] Build the Periphery scheme and verify the above warnings are resolved
- [x] Build the Fennec scheme and verify no compilation errors
