### PR TITLE
Bugfix  FXIOS-14985 Status bar overlay is strangely animated when we start a search

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5059,7 +5059,14 @@ extension BrowserViewController: KeyboardHelperDelegate {
             // When animation duration is zero the keyboard is already showing and we don't need
             // to update the toolbar again. This is the case when we are moving between fields in a form.
             if state.animationDuration > 0 {
-                updateToolbarDisplay()
+                // Use performWithoutAnimation to prevent the keyboard's animation context
+                // from leaking into updateToolbarDisplay. Without this, the keyboard's
+                // animation curve captures property changes on the status bar overlay and
+                // blur views, causing a visible left-to-right fill artifact with UIGlassEffect
+                // on iOS 26+. (See: https://github.com/nickmilo/firefox-ios/issues/32283)
+                UIView.performWithoutAnimation {
+                    self.updateToolbarDisplay()
+                }
             }
         } else {
             updateToolbarDisplay()
@@ -5094,8 +5101,11 @@ extension BrowserViewController: KeyboardHelperDelegate {
 
         cancelEditingMode()
         if isToolbarTranslucencyRefactorEnabled {
-            updateBlurViews()
-            addOrUpdateMaskViewIfNeeded()
+            // Prevent keyboard animation context leak (same as keyboardWillShow fix)
+            UIView.performWithoutAnimation {
+                self.updateBlurViews()
+                self.addOrUpdateMaskViewIfNeeded()
+            }
         } else {
             updateToolbarDisplay()
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14985)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32283)

## :bulb: Description
Fixes the status bar overlay animation artifact that appears when starting a search on iOS 26+.

**Root cause:** In `keyboardWillShowWithState`, after the `UIView.animate` block runs with the keyboard's animation curve (curve 7), subsequent calls to `updateToolbarDisplay()` get captured by the keyboard's per-thread `CATransaction`. This causes property changes on the status bar overlay and blur views (`UIGlassEffect`) to animate with the keyboard's timing, producing a visible left-to-right fill artifact in the status bar area.

**Fix:** Wrap `updateToolbarDisplay()` in `UIView.performWithoutAnimation` within `keyboardWillShowWithState`, and similarly wrap `updateBlurViews()`/`addOrUpdateMaskViewIfNeeded()` in `keyboardWillHideWithState`. This breaks the leaked animation context so toolbar display updates happen instantly.

**Affected code paths:**
- `BrowserViewController.keyboardHelper(_:keyboardWillShowWithState:)` — wraps `updateToolbarDisplay()` 
- `BrowserViewController.keyboardHelper(_:keyboardWillHideWithState:)` — wraps `updateBlurViews()` + `addOrUpdateMaskViewIfNeeded()`

## :movie_camera: Demos
<!-- Unable to demo — requires physical iOS 26 device with UIGlassEffect. The bug is only visible with: wallpaper set + bottom search bar + homepage + tap address bar to start search. -->

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code