### PR TITLE
Refactor FXIOS-15365: [Redux] Use @CopyWithUpdates macro for TrackingProtectionState

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -2,10 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
+import CopyWithUpdates
 import Foundation
 import Redux
-import Common
 
+@CopyWithUpdates
 struct TrackingProtectionState: ScreenState {
     enum NavType {
         case home
@@ -120,10 +122,8 @@ struct TrackingProtectionState: ScreenState {
     }
 
     private static func handleClearCookiesAction(from state: TrackingProtectionState) -> TrackingProtectionState {
-        return TrackingProtectionState(
-            windowUUID: state.windowUUID,
+        return state.copyWithUpdates(
             trackingProtectionEnabled: !state.trackingProtectionEnabled,
-            connectionSecure: state.connectionSecure,
             shouldClearCookies: true,
             shouldUpdateBlockedTrackerStats: false,
             shouldUpdateConnectionStatus: false,
@@ -133,10 +133,7 @@ struct TrackingProtectionState: ScreenState {
     }
 
     private static func handleNavigateToSettingsAction(from state: TrackingProtectionState) -> TrackingProtectionState {
-        return TrackingProtectionState(
-            windowUUID: state.windowUUID,
-            trackingProtectionEnabled: state.trackingProtectionEnabled,
-            connectionSecure: state.connectionSecure,
+        return state.copyWithUpdates(
             shouldClearCookies: false,
             shouldUpdateBlockedTrackerStats: false,
             shouldUpdateConnectionStatus: false,
@@ -148,10 +145,7 @@ struct TrackingProtectionState: ScreenState {
     private static func handleShowTrackingProtectionDetailsAction(
         from state: TrackingProtectionState
     ) -> TrackingProtectionState {
-        return TrackingProtectionState(
-            windowUUID: state.windowUUID,
-            trackingProtectionEnabled: state.trackingProtectionEnabled,
-            connectionSecure: state.connectionSecure,
+        return state.copyWithUpdates(
             shouldClearCookies: false,
             shouldUpdateBlockedTrackerStats: false,
             shouldUpdateConnectionStatus: false,
@@ -163,10 +157,7 @@ struct TrackingProtectionState: ScreenState {
     private static func handleShowBlockedTrackersDetailsAction(
         from state: TrackingProtectionState
     ) -> TrackingProtectionState {
-        return TrackingProtectionState(
-            windowUUID: state.windowUUID,
-            trackingProtectionEnabled: state.trackingProtectionEnabled,
-            connectionSecure: state.connectionSecure,
+        return state.copyWithUpdates(
             shouldClearCookies: false,
             shouldUpdateBlockedTrackerStats: false,
             shouldUpdateConnectionStatus: false,
@@ -176,10 +167,7 @@ struct TrackingProtectionState: ScreenState {
     }
 
     private static func handleGoBackAction(from state: TrackingProtectionState) -> TrackingProtectionState {
-        return TrackingProtectionState(
-            windowUUID: state.windowUUID,
-            trackingProtectionEnabled: state.trackingProtectionEnabled,
-            connectionSecure: state.connectionSecure,
+        return state.copyWithUpdates(
             shouldClearCookies: false,
             shouldUpdateBlockedTrackerStats: false,
             shouldUpdateConnectionStatus: false,
@@ -191,11 +179,7 @@ struct TrackingProtectionState: ScreenState {
     private static func handleUpdateBlockedTrackerStatsAction(
         from state: TrackingProtectionState
     ) -> TrackingProtectionState {
-        return TrackingProtectionState(
-            windowUUID: state.windowUUID,
-            trackingProtectionEnabled: state.trackingProtectionEnabled,
-            connectionSecure: state.connectionSecure,
-            shouldClearCookies: state.shouldClearCookies,
+        return state.copyWithUpdates(
             shouldUpdateBlockedTrackerStats: true,
             shouldUpdateConnectionStatus: false,
             navigateTo: nil,
@@ -204,10 +188,7 @@ struct TrackingProtectionState: ScreenState {
     }
 
     private static func handleUpdateConnectionStatusAction(from state: TrackingProtectionState) -> TrackingProtectionState {
-        return TrackingProtectionState(
-            windowUUID: state.windowUUID,
-            trackingProtectionEnabled: state.trackingProtectionEnabled,
-            connectionSecure: state.connectionSecure,
+        return state.copyWithUpdates(
             shouldClearCookies: false,
             shouldUpdateBlockedTrackerStats: false,
             shouldUpdateConnectionStatus: true,
@@ -217,10 +198,7 @@ struct TrackingProtectionState: ScreenState {
     }
 
     private static func handleShowAlertAction(from state: TrackingProtectionState) -> TrackingProtectionState {
-        return TrackingProtectionState(
-            windowUUID: state.windowUUID,
-            trackingProtectionEnabled: state.trackingProtectionEnabled,
-            connectionSecure: state.connectionSecure,
+        return state.copyWithUpdates(
             shouldClearCookies: false,
             shouldUpdateBlockedTrackerStats: false,
             shouldUpdateConnectionStatus: false,
@@ -232,10 +210,8 @@ struct TrackingProtectionState: ScreenState {
     private static func handleToggleTrackingProtectionStatusAction(
         from state: TrackingProtectionState
     ) -> TrackingProtectionState {
-        return TrackingProtectionState(
-            windowUUID: state.windowUUID,
+        return state.copyWithUpdates(
             trackingProtectionEnabled: !state.trackingProtectionEnabled,
-            connectionSecure: state.connectionSecure,
             shouldClearCookies: false,
             shouldUpdateBlockedTrackerStats: false,
             shouldUpdateConnectionStatus: false,
@@ -247,10 +223,7 @@ struct TrackingProtectionState: ScreenState {
     private static func handleDismissTrackingProtectionAction(
         from state: TrackingProtectionState
     ) -> TrackingProtectionState {
-        return TrackingProtectionState(
-            windowUUID: state.windowUUID,
-            trackingProtectionEnabled: state.trackingProtectionEnabled,
-            connectionSecure: state.connectionSecure,
+        return state.copyWithUpdates(
             shouldClearCookies: false,
             shouldUpdateBlockedTrackerStats: false,
             shouldUpdateConnectionStatus: false,
@@ -260,10 +233,7 @@ struct TrackingProtectionState: ScreenState {
     }
 
     static func defaultState(from state: TrackingProtectionState) -> TrackingProtectionState {
-        return TrackingProtectionState(
-            windowUUID: state.windowUUID,
-            trackingProtectionEnabled: state.trackingProtectionEnabled,
-            connectionSecure: state.connectionSecure,
+        return state.copyWithUpdates(
             shouldClearCookies: false,
             shouldUpdateBlockedTrackerStats: false,
             shouldUpdateConnectionStatus: false,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15365)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32952)

## :bulb: Description
Applies the `@CopyWithUpdates` Swift macro to `TrackingProtectionState`, replacing manual state construction in every reducer handler with `state.copyWithUpdates(...)` calls.

Only properties that change need to be passed, reducing boilerplate. For reference, see [#32214](https://github.com/mozilla-mobile/firefox-ios/pull/32214) which applied the same pattern to `HomepageState`.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code