### PR TITLE
Refactor FXIOS-15359 [Technical Debt] [Redux] Use @CopyWithUpdates macro for NativeErrorPageState

### DIFF
--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import CopyWithUpdates
 import Redux
 import Common
 
+@CopyWithUpdates
 struct NativeErrorPageState: ScreenState {
     var windowUUID: WindowUUID
     var title: String
@@ -63,8 +65,7 @@ struct NativeErrorPageState: ScreenState {
             guard let action = action as? NativeErrorPageAction, let model = action.nativePageErrorModel else {
                 return defaultState(from: state)
             }
-            return NativeErrorPageState(
-                windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                 title: model.errorTitle,
                 description: model.errorDescription,
                 foxImage: model.foxImageName,
@@ -78,14 +79,6 @@ struct NativeErrorPageState: ScreenState {
     }
 
     static func defaultState(from state: NativeErrorPageState) -> NativeErrorPageState {
-        return NativeErrorPageState(
-            windowUUID: state.windowUUID,
-            title: state.title,
-            description: state.description,
-            foxImage: state.foxImage,
-            url: state.url,
-            advancedSection: state.advancedSection,
-            showGoBackButton: state.showGoBackButton
-        )
+        return state.copyWithUpdates()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15359)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32946)

## :bulb: Description
Applies the `@CopyWithUpdates` Swift macro to `NativeErrorPageState`, replacing manual state construction in the reducer and `defaultState` with `state.copyWithUpdates(...)` calls.

Only properties that change need to be passed, reducing boilerplate. For reference, see [#32214](https://github.com/mozilla-mobile/firefox-ios/pull/32214) which applied the same pattern to `HomepageState`.

No UI, telemetry, or string changes are included in this PR.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code