### PR TITLE
Refactor FXIOS-15364 [Technical Debt] [Redux] Apply copyWithUpdates to ShortcutsLibraryState

### DIFF
--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryState.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryState.swift
@@ -3,8 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import CopyWithUpdates
 import Redux
 
+@CopyWithUpdates
 struct ShortcutsLibraryState: ScreenState, Equatable {
     var windowUUID: WindowUUID
     let shortcuts: [TopSiteConfiguration]
@@ -20,11 +22,7 @@ struct ShortcutsLibraryState: ScreenState, Equatable {
             return
         }
 
-        self.init(
-            windowUUID: shortcutsLibraryState.windowUUID,
-            shortcuts: shortcutsLibraryState.shortcuts,
-            shouldRecordImpressionTelemetry: shortcutsLibraryState.shouldRecordImpressionTelemetry
-        )
+        self = shortcutsLibraryState.copyWithUpdates()
     }
 
     init(windowUUID: WindowUUID) {
@@ -64,17 +62,13 @@ struct ShortcutsLibraryState: ScreenState, Equatable {
     }
 
     private static func handleInitializeAction(state: Self) -> ShortcutsLibraryState {
-        return ShortcutsLibraryState(
-            windowUUID: state.windowUUID,
-            shortcuts: state.shortcuts,
+        return state.copyWithUpdates(
             shouldRecordImpressionTelemetry: true
         )
     }
 
     private static func handleImpressionTelemetryRecordedAction(state: Self) -> ShortcutsLibraryState {
-        return ShortcutsLibraryState(
-            windowUUID: state.windowUUID,
-            shortcuts: state.shortcuts,
+        return state.copyWithUpdates(
             shouldRecordImpressionTelemetry: false
         )
     }
@@ -86,18 +80,12 @@ struct ShortcutsLibraryState: ScreenState, Equatable {
             return defaultState(from: state)
         }
 
-        return ShortcutsLibraryState(
-            windowUUID: state.windowUUID,
-            shortcuts: sites,
-            shouldRecordImpressionTelemetry: state.shouldRecordImpressionTelemetry
+        return state.copyWithUpdates(
+            shortcuts: sites
         )
     }
 
     static func defaultState(from state: ShortcutsLibraryState) -> ShortcutsLibraryState {
-        return ShortcutsLibraryState(
-            windowUUID: state.windowUUID,
-            shortcuts: state.shortcuts,
-            shouldRecordImpressionTelemetry: state.shouldRecordImpressionTelemetry
-        )
+        return state.copyWithUpdates()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15364)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32951)

## :bulb: Description
This PR applies the `@CopyWithUpdates` Swift macro to the Redux `ShortcutsLibraryState` struct.

This macro auto-generates a `copyWithUpdates` method that easily copies a previous state and outputs a new state. Only properties that change need to be passed into the method, improving the readability of our reducer returns.

For more information see #31717 where the macro was added, and #32214 for the prior application to `HomepageState`.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code