### PR TITLE
Add FXIOS-15189 [FeatureFlags] Add manager for user preferences

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1668,6 +1668,7 @@
 		C7FA9E1E2E4BD4D1004F2CA1 /* AddShortcutsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FA9E1D2E4BD4D1004F2CA1 /* AddShortcutsSetting.swift */; };
 		C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80685D026A0C93900DCD895 /* UserResearch.swift */; };
 		C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */; };
+		B2C3D4E5F67890123456789A /* NimbusFeatureFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6789012345678 /* NimbusFeatureFlagsTests.swift */; };
 		C80C11EE28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80C11ED28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift */; };
 		C80C11F028B3C9150062922A /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80C11EF28B3C9150062922A /* MockUserDefaults.swift */; };
 		C80C11F428B3CD580062922A /* MockUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80C11F328B3CD580062922A /* MockUserDefaultsTests.swift */; };
@@ -1685,6 +1686,8 @@
 		C825E9832832A425006CB811 /* NimbusSearchBarLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C825E9822832A425006CB811 /* NimbusSearchBarLayer.swift */; };
 		C82A94F2269F68ED00624AA7 /* LegacyFeatureFlagsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82A94E6269CB77F00624AA7 /* LegacyFeatureFlagsManager.swift */; };
 		C82A94F3269F68F300624AA7 /* CoreFlaggableFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82A94E4269CB77500624AA7 /* CoreFlaggableFeature.swift */; };
+		3F1E468E9C1D6C2B235CECDE /* CoreBuildFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D47B07BE70DD7C23C13187 /* CoreBuildFlags.swift */; };
+		5EBC19023A85C482AD197501 /* NimbusFeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3294BB4D24674A3EA5323E21 /* NimbusFeatureFlags.swift */; };
 		C82CDD47233E8996002E2743 /* Tab+ChangeUserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */; };
 		C82F4C2B29AE2DF1005BD116 /* NotificationsSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82F4C2A29AE2DF0005BD116 /* NotificationsSettingsViewController.swift */; };
 		C83432FE26BAD30D00ABAAA6 /* EnhancedTrackingProtectionDetailsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83432FD26BAD30D00ABAAA6 /* EnhancedTrackingProtectionDetailsVC.swift */; };
@@ -10291,6 +10294,7 @@
 		C7FA9E1D2E4BD4D1004F2CA1 /* AddShortcutsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddShortcutsSetting.swift; sourceTree = "<group>"; };
 		C80685D026A0C93900DCD895 /* UserResearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResearch.swift; sourceTree = "<group>"; };
 		C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagManagerTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6789012345678 /* NimbusFeatureFlagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusFeatureFlagsTests.swift; sourceTree = "<group>"; };
 		C80C11ED28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMetadataTrackerTests.swift; sourceTree = "<group>"; };
 		C80C11EF28B3C9150062922A /* MockUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserDefaults.swift; sourceTree = "<group>"; };
 		C80C11F328B3CD580062922A /* MockUserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserDefaultsTests.swift; sourceTree = "<group>"; };
@@ -10304,6 +10308,8 @@
 		C81C66C329F00D1000F6422F /* UserActivityRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserActivityRouteTests.swift; sourceTree = "<group>"; };
 		C825E9822832A425006CB811 /* NimbusSearchBarLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusSearchBarLayer.swift; sourceTree = "<group>"; };
 		C82A94E4269CB77500624AA7 /* CoreFlaggableFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreFlaggableFeature.swift; sourceTree = "<group>"; };
+		C2D47B07BE70DD7C23C13187 /* CoreBuildFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreBuildFlags.swift; sourceTree = "<group>"; };
+		3294BB4D24674A3EA5323E21 /* NimbusFeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusFeatureFlags.swift; sourceTree = "<group>"; };
 		C82A94E6269CB77F00624AA7 /* LegacyFeatureFlagsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyFeatureFlagsManager.swift; sourceTree = "<group>"; };
 		C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tab+ChangeUserAgent.swift"; sourceTree = "<group>"; };
 		C82F4C2A29AE2DF0005BD116 /* NotificationsSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSettingsViewController.swift; sourceTree = "<group>"; };
@@ -14930,10 +14936,12 @@
 		C82A94E3269CB74500624AA7 /* FeatureFlags */ = {
 			isa = PBXGroup;
 			children = (
+				C2D47B07BE70DD7C23C13187 /* CoreBuildFlags.swift */,
 				C82A94E4269CB77500624AA7 /* CoreFlaggableFeature.swift */,
 				C8656D74270F834600E199EA /* FlaggableFeatureOptions.swift */,
 				C82A94E6269CB77F00624AA7 /* LegacyFeatureFlagsManager.swift */,
 				C8B07A4028199500000AFCE7 /* NimbusFlaggableFeature.swift */,
+				3294BB4D24674A3EA5323E21 /* NimbusFeatureFlags.swift */,
 			);
 			path = FeatureFlags;
 			sourceTree = "<group>";
@@ -16547,6 +16555,7 @@
 				1D7B789E2AE088930011E9F2 /* EventQueueTests.swift */,
 				8A96C4B728F9DD0600B75884 /* Extensions */,
 				C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */,
+				A1B2C3D4E5F6789012345678 /* NimbusFeatureFlagsTests.swift */,
 				D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */,
 				C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */,
 				E1AEC16D286E0CF500062E29 /* Frontend */,
@@ -19266,6 +19275,8 @@
 				96F8DA49280452CA00E53239 /* GleanPlumbContextProvider.swift in Sources */,
 				0E6C1E232C909E04001A43BB /* PasswordGeneratorState.swift in Sources */,
 				C82A94F3269F68F300624AA7 /* CoreFlaggableFeature.swift in Sources */,
+				3F1E468E9C1D6C2B235CECDE /* CoreBuildFlags.swift in Sources */,
+				5EBC19023A85C482AD197501 /* NimbusFeatureFlags.swift in Sources */,
 				F84B22241A09122500AAB793 /* LibraryViewController.swift in Sources */,
 				E16941B82C5119A200FF5F4E /* Autocompletable.swift in Sources */,
 				39455F771FC83F430088A22C /* TabEventHandler.swift in Sources */,
@@ -20122,6 +20133,7 @@
 				0A8058272F694E2F004CB4A9 /* CreditCardBottomSheetViewControllerTests.swift in Sources */,
 				8A5604F629DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift in Sources */,
 				C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */,
+				B2C3D4E5F67890123456789A /* NimbusFeatureFlagsTests.swift in Sources */,
 				8A552AC72CB43AB400564C98 /* HomepageStateTests.swift in Sources */,
 				8AABBD032A001CBC0089941E /* MockApplicationHelper.swift in Sources */,
 				8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1669,6 +1669,7 @@
 		C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80685D026A0C93900DCD895 /* UserResearch.swift */; };
 		C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */; };
 		B2C3D4E5F67890123456789A /* NimbusFeatureFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6789012345678 /* NimbusFeatureFlagsTests.swift */; };
+		A7B8C9D0E12345678901234B /* UserFeaturePreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A7B8C9D0E1234567890123 /* UserFeaturePreferencesTests.swift */; };
 		C80C11EE28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80C11ED28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift */; };
 		C80C11F028B3C9150062922A /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80C11EF28B3C9150062922A /* MockUserDefaults.swift */; };
 		C80C11F428B3CD580062922A /* MockUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80C11F328B3CD580062922A /* MockUserDefaultsTests.swift */; };
@@ -1688,6 +1689,7 @@
 		C82A94F3269F68F300624AA7 /* CoreFlaggableFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82A94E4269CB77500624AA7 /* CoreFlaggableFeature.swift */; };
 		3F1E468E9C1D6C2B235CECDE /* CoreBuildFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D47B07BE70DD7C23C13187 /* CoreBuildFlags.swift */; };
 		5EBC19023A85C482AD197501 /* NimbusFeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3294BB4D24674A3EA5323E21 /* NimbusFeatureFlags.swift */; };
+		E5F6A7B8C90123456789012A /* UserFeaturePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C9012345678901 /* UserFeaturePreferences.swift */; };
 		C82CDD47233E8996002E2743 /* Tab+ChangeUserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */; };
 		C82F4C2B29AE2DF1005BD116 /* NotificationsSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82F4C2A29AE2DF0005BD116 /* NotificationsSettingsViewController.swift */; };
 		C83432FE26BAD30D00ABAAA6 /* EnhancedTrackingProtectionDetailsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83432FD26BAD30D00ABAAA6 /* EnhancedTrackingProtectionDetailsVC.swift */; };
@@ -10295,6 +10297,7 @@
 		C80685D026A0C93900DCD895 /* UserResearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResearch.swift; sourceTree = "<group>"; };
 		C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagManagerTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6789012345678 /* NimbusFeatureFlagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusFeatureFlagsTests.swift; sourceTree = "<group>"; };
+		F6A7B8C9D0E1234567890123 /* UserFeaturePreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeaturePreferencesTests.swift; sourceTree = "<group>"; };
 		C80C11ED28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMetadataTrackerTests.swift; sourceTree = "<group>"; };
 		C80C11EF28B3C9150062922A /* MockUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserDefaults.swift; sourceTree = "<group>"; };
 		C80C11F328B3CD580062922A /* MockUserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserDefaultsTests.swift; sourceTree = "<group>"; };
@@ -10310,6 +10313,7 @@
 		C82A94E4269CB77500624AA7 /* CoreFlaggableFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreFlaggableFeature.swift; sourceTree = "<group>"; };
 		C2D47B07BE70DD7C23C13187 /* CoreBuildFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreBuildFlags.swift; sourceTree = "<group>"; };
 		3294BB4D24674A3EA5323E21 /* NimbusFeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusFeatureFlags.swift; sourceTree = "<group>"; };
+		D4E5F6A7B8C9012345678901 /* UserFeaturePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeaturePreferences.swift; sourceTree = "<group>"; };
 		C82A94E6269CB77F00624AA7 /* LegacyFeatureFlagsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyFeatureFlagsManager.swift; sourceTree = "<group>"; };
 		C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tab+ChangeUserAgent.swift"; sourceTree = "<group>"; };
 		C82F4C2A29AE2DF0005BD116 /* NotificationsSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSettingsViewController.swift; sourceTree = "<group>"; };
@@ -14942,6 +14946,7 @@
 				C82A94E6269CB77F00624AA7 /* LegacyFeatureFlagsManager.swift */,
 				C8B07A4028199500000AFCE7 /* NimbusFlaggableFeature.swift */,
 				3294BB4D24674A3EA5323E21 /* NimbusFeatureFlags.swift */,
+				D4E5F6A7B8C9012345678901 /* UserFeaturePreferences.swift */,
 			);
 			path = FeatureFlags;
 			sourceTree = "<group>";
@@ -16556,6 +16561,7 @@
 				8A96C4B728F9DD0600B75884 /* Extensions */,
 				C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */,
 				A1B2C3D4E5F6789012345678 /* NimbusFeatureFlagsTests.swift */,
+				F6A7B8C9D0E1234567890123 /* UserFeaturePreferencesTests.swift */,
 				D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */,
 				C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */,
 				E1AEC16D286E0CF500062E29 /* Frontend */,
@@ -19277,6 +19283,7 @@
 				C82A94F3269F68F300624AA7 /* CoreFlaggableFeature.swift in Sources */,
 				3F1E468E9C1D6C2B235CECDE /* CoreBuildFlags.swift in Sources */,
 				5EBC19023A85C482AD197501 /* NimbusFeatureFlags.swift in Sources */,
+				E5F6A7B8C90123456789012A /* UserFeaturePreferences.swift in Sources */,
 				F84B22241A09122500AAB793 /* LibraryViewController.swift in Sources */,
 				E16941B82C5119A200FF5F4E /* Autocompletable.swift in Sources */,
 				39455F771FC83F430088A22C /* TabEventHandler.swift in Sources */,
@@ -20134,6 +20141,7 @@
 				8A5604F629DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift in Sources */,
 				C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */,
 				B2C3D4E5F67890123456789A /* NimbusFeatureFlagsTests.swift in Sources */,
+				A7B8C9D0E12345678901234B /* UserFeaturePreferencesTests.swift in Sources */,
 				8A552AC72CB43AB400564C98 /* HomepageStateTests.swift in Sources */,
 				8AABBD032A001CBC0089941E /* MockApplicationHelper.swift in Sources */,
 				8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */,

--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -54,6 +54,9 @@ class DependencyHelper {
         let nimbusFeatureFlags = NimbusFeatureFlags(prefs: profile.prefs)
         AppContainer.shared.register(service: nimbusFeatureFlags as NimbusFeatureFlagProviding)
 
+        let userPreferences = UserFeaturePreferences(prefs: profile.prefs)
+        AppContainer.shared.register(service: userPreferences as UserFeaturePreferring)
+
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }

--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -51,6 +51,9 @@ class DependencyHelper {
         appDelegate.gleanUsageReportingMetricsService
         AppContainer.shared.register(service: gleanUsageReportingMetricsService)
 
+        let nimbusFeatureFlags = NimbusFeatureFlags(prefs: profile.prefs)
+        AppContainer.shared.register(service: nimbusFeatureFlags as NimbusFeatureFlagProviding)
+
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }

--- a/firefox-ios/Client/FeatureFlags/CoreBuildFlags.swift
+++ b/firefox-ios/Client/FeatureFlags/CoreBuildFlags.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Compile-time build channel checks. No instance needed.
+///
+/// These are features that are used for developer purposes and are
+/// not directly user impacting, which is why these should be kept
+/// separate from other feature flags
+enum CoreBuildFlags {
+    static var isAdjustEnvironmentProd: Bool {
+        #if MOZ_CHANNEL_release || MOZ_CHANNEL_beta
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    static var isUsingMockData: Bool {
+        #if MOZ_CHANNEL_developer
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    static var isUsingStagingUnifiedAdsAPI: Bool {
+        #if MOZ_CHANNEL_developer
+        return true
+        #else
+        return false
+        #endif
+    }
+}

--- a/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
+++ b/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
@@ -34,7 +34,7 @@ enum FlaggableFeatureCheckOptions {
 }
 
 // FIXME: FXIOS-13986 Make truly thread safe
-class LegacyFeatureFlagsManager: HasNimbusFeatureFlags, @unchecked Sendable {
+class LegacyFeatureFlagsManager: HasNimbusFeatureFlagLayer, @unchecked Sendable {
     /// This Singleton should only be accessed directly in places where the
     /// `FeatureFlaggable` is not available. Otherwise, access to the feature
     /// flags system should be done through the protocol, giving access to the

--- a/firefox-ios/Client/FeatureFlags/NimbusFeatureFlags.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFeatureFlags.swift
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Shared
+
+/// Protocol for checking whether a feature is enabled via Nimbus remote config.
+protocol NimbusFeatureFlagProviding: Sendable {
+    func isEnabled(_ flag: NimbusFeatureFlagID) -> Bool
+}
+
+/// Wraps NimbusFeatureFlagLayer with debug override support for beta/dev builds.
+/// Registered in AppContainer; accessed via HasNimbusFeatureFlags protocol.
+final class NimbusFeatureFlags: NimbusFeatureFlagProviding, @unchecked Sendable {
+    private let layer: NimbusFeatureFlagLayer
+    private let prefs: Prefs
+
+    init(layer: NimbusFeatureFlagLayer = NimbusManager.shared.featureFlagLayer,
+         prefs: Prefs) {
+        self.layer = layer
+        self.prefs = prefs
+    }
+
+    func isEnabled(_ flag: NimbusFeatureFlagID) -> Bool {
+        #if MOZ_CHANNEL_beta || MOZ_CHANNEL_developer
+        if let debugKey = flag.debugKey,
+           let override = prefs.boolForKey(debugKey) {
+            return override
+        }
+        #endif
+        return layer.checkNimbusConfigFor(flag)
+    }
+}
+
+// MARK: - DI Access Protocol
+
+/// Adopt this protocol to access Nimbus feature flags via AppContainer.
+/// Replaces FeatureFlaggable for Nimbus checks.
+protocol HasNimbusFeatureFlags {
+    var nimbusFeatureFlags: NimbusFeatureFlagProviding { get }
+}
+
+extension HasNimbusFeatureFlags {
+    var nimbusFeatureFlags: NimbusFeatureFlagProviding {
+        AppContainer.shared.resolve()
+    }
+}

--- a/firefox-ios/Client/FeatureFlags/UserFeaturePreferences.swift
+++ b/firefox-ios/Client/FeatureFlags/UserFeaturePreferences.swift
@@ -1,0 +1,157 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Shared
+
+/// Protocol for reading/writing user feature preferences.
+/// Each property reads from Prefs, falling back to the Nimbus default.
+protocol UserFeaturePreferring: Sendable {
+    // Bool preferences (read)
+    var isAIKillSwitchEnabled: Bool { get }
+    var isFirefoxSuggestEnabled: Bool { get }
+    var isSentFromFirefoxEnabled: Bool { get }
+    var isSponsoredShortcutsEnabled: Bool { get }
+    var isHomepageBookmarksSectionEnabled: Bool { get }
+    var isHomepageJumpBackInSectionEnabled: Bool { get }
+
+    // Typed preferences (read)
+    var searchBarPosition: SearchBarPosition { get }
+    var startAtHomeSetting: StartAtHome { get }
+    var homepageStoriesScrollDirection: ScrollDirection { get }
+
+    // Setters
+    func setAIKillSwitchEnabled(_ enabled: Bool)
+    func setFirefoxSuggestEnabled(_ enabled: Bool)
+    func setSentFromFirefoxEnabled(_ enabled: Bool)
+    func setSponsoredShortcutsEnabled(_ enabled: Bool)
+    func setHomepageBookmarksSectionEnabled(_ enabled: Bool)
+    func setHomepageJumpBackInSectionEnabled(_ enabled: Bool)
+    func setSearchBarPosition(_ position: SearchBarPosition)
+    func setStartAtHomeSetting(_ setting: StartAtHome)
+    func setHomepageStoriesScrollDirection(_ direction: ScrollDirection)
+}
+
+final class UserFeaturePreferences: UserFeaturePreferring, @unchecked Sendable {
+    private let prefs: Prefs
+    private let nimbusLayer: NimbusFeatureFlagLayer
+    private let nimbusSearchBar: NimbusSearchBarLayer
+
+    init(
+        prefs: Prefs,
+        nimbusLayer: NimbusFeatureFlagLayer = NimbusManager.shared.featureFlagLayer,
+        nimbusSearchBar: NimbusSearchBarLayer = NimbusManager.shared.bottomSearchBarLayer
+    ) {
+        self.prefs = prefs
+        self.nimbusLayer = nimbusLayer
+        self.nimbusSearchBar = nimbusSearchBar
+    }
+
+    // MARK: - Bool preferences
+
+    var isAIKillSwitchEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.Settings.aiKillSwitchFeature)
+        ?? nimbusLayer.checkNimbusConfigFor(.aiKillSwitch)
+    }
+
+    var isFirefoxSuggestEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.FeatureFlags.FirefoxSuggest)
+        ?? nimbusLayer.checkNimbusConfigFor(.firefoxSuggestFeature)
+    }
+
+    var isSentFromFirefoxEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.FeatureFlags.SentFromFirefox)
+        ?? nimbusLayer.checkNimbusConfigFor(.sentFromFirefox)
+    }
+
+    var isSponsoredShortcutsEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.FeatureFlags.SponsoredShortcuts)
+        ?? nimbusLayer.checkNimbusConfigFor(.hntSponsoredShortcuts)
+    }
+
+    var isHomepageBookmarksSectionEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection)
+        ?? nimbusLayer.checkNimbusConfigFor(.homepageBookmarksSectionDefault)
+    }
+
+    var isHomepageJumpBackInSectionEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection)
+        ?? nimbusLayer.checkNimbusConfigFor(.homepageJumpBackinSectionDefault)
+    }
+
+    // MARK: - Typed preferences
+
+    var searchBarPosition: SearchBarPosition {
+        if let raw = prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition),
+           let position = SearchBarPosition(rawValue: raw) {
+            return position
+        }
+        return nimbusSearchBar.getDefaultPosition()
+    }
+
+    var startAtHomeSetting: StartAtHome {
+        if let raw = prefs.stringForKey(PrefsKeys.FeatureFlags.StartAtHome),
+           let setting = StartAtHome(rawValue: raw) {
+            return setting
+        }
+        return FxNimbus.shared.features.startAtHomeFeature.value().setting
+    }
+
+    var homepageStoriesScrollDirection: ScrollDirection {
+        // This flag currently has no user prefs key — it's Nimbus-only
+        return FxNimbus.shared.features.homepageRedesignFeature.value().storiesScrollDirection
+    }
+
+    // MARK: - Setters
+
+    func setAIKillSwitchEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.Settings.aiKillSwitchFeature)
+    }
+
+    func setFirefoxSuggestEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.FeatureFlags.FirefoxSuggest)
+    }
+
+    func setSentFromFirefoxEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.FeatureFlags.SentFromFirefox)
+    }
+
+    func setSponsoredShortcutsEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.FeatureFlags.SponsoredShortcuts)
+    }
+
+    func setHomepageBookmarksSectionEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.HomepageSettings.BookmarksSection)
+    }
+
+    func setHomepageJumpBackInSectionEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.HomepageSettings.JumpBackInSection)
+    }
+
+    func setSearchBarPosition(_ position: SearchBarPosition) {
+        prefs.setString(position.rawValue, forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+    }
+
+    func setStartAtHomeSetting(_ setting: StartAtHome) {
+        prefs.setString(setting.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
+    }
+
+    func setHomepageStoriesScrollDirection(_ direction: ScrollDirection) {
+        // Currently no user prefs key — this is a no-op until one is added
+    }
+}
+
+// MARK: - DI Access Protocol
+
+/// Adopt this protocol to access user feature preferences via AppContainer.
+/// Replaces FeatureFlaggable for user preference checks.
+protocol HasUserFeaturePreferences {
+    var userPreferences: UserFeaturePreferring { get }
+}
+
+extension HasUserFeaturePreferences {
+    var userPreferences: UserFeaturePreferring {
+        AppContainer.shared.resolve()
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/MozAdsClientFactory.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/MozAdsClientFactory.swift
@@ -12,7 +12,7 @@ protocol MozAdsClientFactory {
 
 final class DefaultMozAdsClientFactory: MozAdsClientFactory, FeatureFlaggable {
     func createClient() -> MozAdsClientProtocol {
-        if featureFlags.isCoreFeatureEnabled(.useStagingUnifiedAdsAPI) {
+        if CoreBuildFlags.isUsingStagingUnifiedAdsAPI {
             return RustAdsClient.staging
         }
         return RustAdsClient.production

--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
@@ -184,7 +184,7 @@ final class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, Feature
     }
 
     private var resourceEndpoint: URL? {
-        if featureFlags.isCoreFeatureEnabled(.useStagingUnifiedAdsAPI) {
+        if CoreBuildFlags.isUsingStagingUnifiedAdsAPI {
             return URL(string: UnifiedAdsProvider.stagingResourceEndpoint)
         }
         return URL(string: UnifiedAdsProvider.prodResourceEndpoint)

--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsUserDataRemover.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsUserDataRemover.swift
@@ -61,7 +61,7 @@ struct UnifiedAdsUserDataRemover: FeatureFlaggable {
     }
 
     private var resourceEndpoint: URL? {
-        if featureFlags.isCoreFeatureEnabled(.useStagingUnifiedAdsAPI) {
+        if  CoreBuildFlags.isUsingStagingUnifiedAdsAPI {
             return URL(string: UnifiedAdsUserDataRemover.stagingResourceEndpoint)
         }
         return URL(string: UnifiedAdsUserDataRemover.prodResourceEndpoint)

--- a/firefox-ios/Client/Nimbus/NimbusManager.swift
+++ b/firefox-ios/Client/Nimbus/NimbusManager.swift
@@ -4,9 +4,9 @@
 
 import Foundation
 
-protocol HasNimbusFeatureFlags { }
+protocol HasNimbusFeatureFlagLayer { }
 
-extension HasNimbusFeatureFlags {
+extension HasNimbusFeatureFlagLayer {
     var nimbusFlags: NimbusFeatureFlagLayer {
         return NimbusManager.shared.featureFlagLayer
     }

--- a/firefox-ios/Providers/Merino/MerinoProvider.swift
+++ b/firefox-ios/Providers/Merino/MerinoProvider.swift
@@ -109,7 +109,7 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
     }
 
     private var shouldUseMockData: Bool {
-        return featureFlags.isCoreFeatureEnabled(.useMockData) || prefs.boolForKey(PrefsKeys.useMerinoTestData) ?? false
+        return CoreBuildFlags.isUsingMockData || prefs.boolForKey(PrefsKeys.useMerinoTestData) ?? false
     }
 
     private func iOSToMerinoLocale(from locale: String) -> CuratedRecommendationLocale? {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -71,6 +71,9 @@ final class DependencyHelperMock {
         let nimbusFeatureFlags = NimbusFeatureFlags(prefs: profile.prefs)
         AppContainer.shared.register(service: nimbusFeatureFlags as NimbusFeatureFlagProviding)
 
+        let userPreferences = UserFeaturePreferences(prefs: profile.prefs)
+        AppContainer.shared.register(service: userPreferences as UserFeaturePreferring)
+
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -68,6 +68,9 @@ final class DependencyHelperMock {
         MockGleanUsageReportingMetricsService(profile: profile)
         AppContainer.shared.register(service: gleanUsageReportingMetricsService)
 
+        let nimbusFeatureFlags = NimbusFeatureFlags(prefs: profile.prefs)
+        AppContainer.shared.register(service: nimbusFeatureFlags as NimbusFeatureFlagProviding)
+
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FeatureFlagManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FeatureFlagManagerTests.swift
@@ -19,9 +19,9 @@ final class FeatureFlagManagerTests: XCTestCase, FeatureFlaggable {
 
     // MARK: - Tests
     func testExpectedCoreFeatures() {
-        let adjustSetting = featureFlags.isCoreFeatureEnabled(.adjustEnvironmentProd)
-        let mockDataSetting = featureFlags.isCoreFeatureEnabled(.useMockData)
-        let unifiedAdsAPISetting = featureFlags.isCoreFeatureEnabled(.useStagingUnifiedAdsAPI)
+        let adjustSetting = CoreBuildFlags.isAdjustEnvironmentProd
+        let mockDataSetting = CoreBuildFlags.isUsingMockData
+        let unifiedAdsAPISetting = CoreBuildFlags.isUsingStagingUnifiedAdsAPI
 
         XCTAssertFalse(adjustSetting)
         XCTAssertTrue(mockDataSetting)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NimbusFeatureFlagsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NimbusFeatureFlagsTests.swift
@@ -1,0 +1,109 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+import XCTest
+
+@testable import Client
+
+final class NimbusFeatureFlagsTests: XCTestCase {
+    private var prefs: MockProfilePrefs!
+    private var subject: NimbusFeatureFlags!
+
+    override func setUp() {
+        super.setUp()
+        prefs = MockProfilePrefs()
+        subject = NimbusFeatureFlags(prefs: prefs)
+    }
+
+    override func tearDown() {
+        prefs = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func testIsEnabled_delegatesToNimbusLayer() {
+        // The layer returns Nimbus defaults (from FxNimbus.shared).
+        // bottomSearchBar defaults to true in Nimbus config for developer builds.
+        let result = subject.isEnabled(.bottomSearchBar)
+        XCTAssertTrue(result)
+    }
+
+    func testIsEnabled_withDebugOverrideSet_returnsOverride() {
+        // On developer builds, debug overrides take precedence.
+        // .translation has a debugKey, so we can override it.
+        guard let debugKey = NimbusFeatureFlagID.translation.debugKey else {
+            XCTFail("translation should have a debugKey")
+            return
+        }
+
+        // Get the Nimbus default, then override to the opposite
+        let nimbusDefault = subject.isEnabled(.translation)
+        prefs.setBool(!nimbusDefault, forKey: debugKey)
+
+        #if MOZ_CHANNEL_beta || MOZ_CHANNEL_developer
+        XCTAssertEqual(subject.isEnabled(.translation), !nimbusDefault)
+        #else
+        // On release builds, debug overrides are ignored
+        XCTAssertEqual(subject.isEnabled(.translation), nimbusDefault)
+        #endif
+    }
+
+    func testIsEnabled_flagWithoutDebugKey_ignoresPrefs() {
+        // .addressAutofillEdit has no debugKey, so prefs won't affect it
+        XCTAssertNil(NimbusFeatureFlagID.addressAutofillEdit.debugKey)
+        let result = subject.isEnabled(.addressAutofillEdit)
+        // Should return the Nimbus default regardless of any prefs
+        XCTAssertNotNil(result)
+    }
+
+    // MARK: - Mock protocol conformance
+
+    func testMockConformance() {
+        let mock = MockNimbusFeatureFlags()
+        mock.enabledFlags = [.bottomSearchBar, .translation]
+
+        XCTAssertTrue(mock.isEnabled(.bottomSearchBar))
+        XCTAssertTrue(mock.isEnabled(.translation))
+        XCTAssertFalse(mock.isEnabled(.reportSiteIssue))
+    }
+}
+
+// MARK: - CoreBuildFlags Tests
+
+final class CoreBuildFlagsTests: XCTestCase {
+    func testBuildChannelFlags() {
+        // On developer builds (test environment), these should match expectations
+        #if MOZ_CHANNEL_developer
+        XCTAssertFalse(CoreBuildFlags.isAdjustEnvironmentProd)
+        XCTAssertTrue(CoreBuildFlags.isUsingMockData)
+        XCTAssertTrue(CoreBuildFlags.isUsingStagingUnifiedAdsAPI)
+        #elseif MOZ_CHANNEL_beta
+        XCTAssertTrue(CoreBuildFlags.isAdjustEnvironmentProd)
+        XCTAssertFalse(CoreBuildFlags.isUsingMockData)
+        XCTAssertFalse(CoreBuildFlags.isUsingStagingUnifiedAdsAPI)
+        #elseif MOZ_CHANNEL_release
+        XCTAssertTrue(CoreBuildFlags.isAdjustEnvironmentProd)
+        XCTAssertFalse(CoreBuildFlags.isUsingMockData)
+        XCTAssertFalse(CoreBuildFlags.isUsingStagingUnifiedAdsAPI)
+        #else
+        XCTAssertFalse(CoreBuildFlags.isAdjustEnvironmentProd)
+        XCTAssertFalse(CoreBuildFlags.isUsingMockData)
+        XCTAssertFalse(CoreBuildFlags.isUsingStagingUnifiedAdsAPI)
+        #endif
+    }
+}
+
+// MARK: - Test Helpers
+
+final class MockNimbusFeatureFlags: NimbusFeatureFlagProviding, @unchecked Sendable {
+    var enabledFlags: Set<NimbusFeatureFlagID> = []
+
+    func isEnabled(_ flag: NimbusFeatureFlagID) -> Bool {
+        enabledFlags.contains(flag)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/UserFeaturePreferencesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/UserFeaturePreferencesTests.swift
@@ -1,0 +1,232 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+import XCTest
+
+@testable import Client
+
+final class UserFeaturePreferencesTests: XCTestCase {
+    private var prefs: MockProfilePrefs!
+    private var subject: UserFeaturePreferences!
+
+    override func setUp() {
+        super.setUp()
+        prefs = MockProfilePrefs()
+        subject = UserFeaturePreferences(prefs: prefs)
+    }
+
+    override func tearDown() {
+        prefs = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    // MARK: - Bool preferences: defaults from Nimbus
+
+    func testBoolDefaults_returnNimbusValues_whenNoUserPrefSet() {
+        // With no prefs set, each property should return the Nimbus default.
+        // We just verify they return without crashing — the actual Nimbus defaults
+        // may vary by config, so we check the type is correct.
+        _ = subject.isAIKillSwitchEnabled
+        _ = subject.isFirefoxSuggestEnabled
+        _ = subject.isSentFromFirefoxEnabled
+        _ = subject.isSponsoredShortcutsEnabled
+        _ = subject.isHomepageBookmarksSectionEnabled
+        _ = subject.isHomepageJumpBackInSectionEnabled
+    }
+
+    // MARK: - Bool preferences: user overrides
+
+    func testFirefoxSuggest_readsUserPref() {
+        prefs.setBool(false, forKey: PrefsKeys.FeatureFlags.FirefoxSuggest)
+        XCTAssertFalse(subject.isFirefoxSuggestEnabled)
+
+        prefs.setBool(true, forKey: PrefsKeys.FeatureFlags.FirefoxSuggest)
+        XCTAssertTrue(subject.isFirefoxSuggestEnabled)
+    }
+
+    func testSentFromFirefox_readsUserPref() {
+        prefs.setBool(true, forKey: PrefsKeys.FeatureFlags.SentFromFirefox)
+        XCTAssertTrue(subject.isSentFromFirefoxEnabled)
+    }
+
+    func testSponsoredShortcuts_readsUserPref() {
+        prefs.setBool(false, forKey: PrefsKeys.FeatureFlags.SponsoredShortcuts)
+        XCTAssertFalse(subject.isSponsoredShortcutsEnabled)
+    }
+
+    func testHomepageBookmarksSection_readsUserPref() {
+        prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.BookmarksSection)
+        XCTAssertFalse(subject.isHomepageBookmarksSectionEnabled)
+    }
+
+    func testHomepageJumpBackInSection_readsUserPref() {
+        prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.JumpBackInSection)
+        XCTAssertFalse(subject.isHomepageJumpBackInSectionEnabled)
+    }
+
+    func testAIKillSwitch_readsUserPref() {
+        prefs.setBool(true, forKey: PrefsKeys.Settings.aiKillSwitchFeature)
+        XCTAssertTrue(subject.isAIKillSwitchEnabled)
+
+        prefs.setBool(false, forKey: PrefsKeys.Settings.aiKillSwitchFeature)
+        XCTAssertFalse(subject.isAIKillSwitchEnabled)
+    }
+
+    // MARK: - Typed preferences
+
+    func testSearchBarPosition_defaultsToNimbus() {
+        let position = subject.searchBarPosition
+        // Default from NimbusSearchBarLayer — just verify it's a valid value
+        XCTAssertTrue(position == .top || position == .bottom)
+    }
+
+    func testSearchBarPosition_readsUserPref() {
+        prefs.setString(SearchBarPosition.bottom.rawValue,
+                        forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        XCTAssertEqual(subject.searchBarPosition, .bottom)
+
+        prefs.setString(SearchBarPosition.top.rawValue,
+                        forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        XCTAssertEqual(subject.searchBarPosition, .top)
+    }
+
+    func testStartAtHomeSetting_defaultsToNimbus() {
+        let setting = subject.startAtHomeSetting
+        // Verify it's a valid StartAtHome value
+        XCTAssertTrue([.afterFourHours, .always, .disabled].contains(setting))
+    }
+
+    func testStartAtHomeSetting_readsUserPref() {
+        prefs.setString(StartAtHome.always.rawValue,
+                        forKey: PrefsKeys.FeatureFlags.StartAtHome)
+        XCTAssertEqual(subject.startAtHomeSetting, .always)
+
+        prefs.setString(StartAtHome.disabled.rawValue,
+                        forKey: PrefsKeys.FeatureFlags.StartAtHome)
+        XCTAssertEqual(subject.startAtHomeSetting, .disabled)
+    }
+
+    func testHomepageStoriesScrollDirection_returnsNimbusValue() {
+        let direction = subject.homepageStoriesScrollDirection
+        XCTAssertTrue([.baseline, .horizontal, .vertical].contains(direction))
+    }
+
+    // MARK: - Setters
+
+    func testSetFirefoxSuggestEnabled_writesPref() {
+        subject.setFirefoxSuggestEnabled(true)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.FirefoxSuggest), true)
+
+        subject.setFirefoxSuggestEnabled(false)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.FirefoxSuggest), false)
+    }
+
+    func testSetSentFromFirefoxEnabled_writesPref() {
+        subject.setSentFromFirefoxEnabled(true)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.SentFromFirefox), true)
+    }
+
+    func testSetSponsoredShortcutsEnabled_writesPref() {
+        subject.setSponsoredShortcutsEnabled(false)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.SponsoredShortcuts), false)
+    }
+
+    func testSetHomepageBookmarksSectionEnabled_writesPref() {
+        subject.setHomepageBookmarksSectionEnabled(true)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection), true)
+    }
+
+    func testSetHomepageJumpBackInSectionEnabled_writesPref() {
+        subject.setHomepageJumpBackInSectionEnabled(false)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection), false)
+    }
+
+    func testSetAIKillSwitchEnabled_writesPref() {
+        subject.setAIKillSwitchEnabled(true)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.Settings.aiKillSwitchFeature), true)
+    }
+
+    func testSetSearchBarPosition_writesPref() {
+        subject.setSearchBarPosition(.bottom)
+        XCTAssertEqual(prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition),
+                       SearchBarPosition.bottom.rawValue)
+
+        subject.setSearchBarPosition(.top)
+        XCTAssertEqual(prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition),
+                       SearchBarPosition.top.rawValue)
+    }
+
+    func testSetStartAtHomeSetting_writesPref() {
+        subject.setStartAtHomeSetting(.always)
+        XCTAssertEqual(prefs.stringForKey(PrefsKeys.FeatureFlags.StartAtHome),
+                       StartAtHome.always.rawValue)
+    }
+
+    // MARK: - Roundtrip: set then read
+
+    func testRoundtrip_boolPreferences() {
+        subject.setFirefoxSuggestEnabled(false)
+        XCTAssertFalse(subject.isFirefoxSuggestEnabled)
+
+        subject.setFirefoxSuggestEnabled(true)
+        XCTAssertTrue(subject.isFirefoxSuggestEnabled)
+    }
+
+    func testRoundtrip_searchBarPosition() {
+        subject.setSearchBarPosition(.bottom)
+        XCTAssertEqual(subject.searchBarPosition, .bottom)
+
+        subject.setSearchBarPosition(.top)
+        XCTAssertEqual(subject.searchBarPosition, .top)
+    }
+
+    func testRoundtrip_startAtHome() {
+        subject.setStartAtHomeSetting(.always)
+        XCTAssertEqual(subject.startAtHomeSetting, .always)
+
+        subject.setStartAtHomeSetting(.disabled)
+        XCTAssertEqual(subject.startAtHomeSetting, .disabled)
+    }
+
+    // MARK: - Mock protocol conformance
+
+    func testMockConformance() {
+        let mock = MockUserFeaturePreferences()
+        mock.isFirefoxSuggestEnabled = false
+        XCTAssertFalse(mock.isFirefoxSuggestEnabled)
+
+        mock.searchBarPosition = .bottom
+        XCTAssertEqual(mock.searchBarPosition, .bottom)
+
+        mock.setSearchBarPosition(.top)
+        XCTAssertEqual(mock.searchBarPosition, .top)
+    }
+}
+
+// MARK: - Test Helpers
+
+final class MockUserFeaturePreferences: UserFeaturePreferring, @unchecked Sendable {
+    var isAIKillSwitchEnabled = true
+    var isFirefoxSuggestEnabled = true
+    var isSentFromFirefoxEnabled = false
+    var isSponsoredShortcutsEnabled = true
+    var isHomepageBookmarksSectionEnabled = true
+    var isHomepageJumpBackInSectionEnabled = true
+    var searchBarPosition = SearchBarPosition.bottom
+    var startAtHomeSetting = StartAtHome.afterFourHours
+    var homepageStoriesScrollDirection = ScrollDirection.baseline
+
+    func setAIKillSwitchEnabled(_ enabled: Bool) { isAIKillSwitchEnabled = enabled }
+    func setFirefoxSuggestEnabled(_ enabled: Bool) { isFirefoxSuggestEnabled = enabled }
+    func setSentFromFirefoxEnabled(_ enabled: Bool) { isSentFromFirefoxEnabled = enabled }
+    func setSponsoredShortcutsEnabled(_ enabled: Bool) { isSponsoredShortcutsEnabled = enabled }
+    func setHomepageBookmarksSectionEnabled(_ enabled: Bool) { isHomepageBookmarksSectionEnabled = enabled }
+    func setHomepageJumpBackInSectionEnabled(_ enabled: Bool) { isHomepageJumpBackInSectionEnabled = enabled }
+    func setSearchBarPosition(_ position: SearchBarPosition) { searchBarPosition = position }
+    func setStartAtHomeSetting(_ setting: StartAtHome) { startAtHomeSetting = setting }
+    func setHomepageStoriesScrollDirection(_ direction: ScrollDirection) { homepageStoriesScrollDirection = direction }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15189)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32695)

## :bulb: Description
This PR adds a separate user preference manager that's very explicit about settable user preferences, given that these are significantly less than existing feature flags.

There's one weird thing I still have to figure out, the isHomepageStories thing. I just added it here for now, but it may be that that gets axed so it could easily be removed from here.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

