### PR TITLE
Bugfix FXIOS-15417 [Favicon] SiteImageView fix LetterImageGenerator unreachable last palette color

### DIFF
--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/LetterImageGenerator.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/LetterImageGenerator.swift
@@ -63,7 +63,7 @@ final class DefaultLetterImageGenerator: LetterImageGenerator {
     }
 
     internal func generateBackgroundColor(forSite siteString: String) -> UIColor {
-        let index = abs(stableHash(siteString)) % (defaultBackgroundColors.count - 1)
+        let index = abs(stableHash(siteString)) % defaultBackgroundColors.count
         let colorHex = defaultBackgroundColors[index]
         return UIColor(colorString: colorHex)
     }

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/LetterImageGeneratorTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/LetterImageGeneratorTests.swift
@@ -68,7 +68,7 @@ final class LetterImageGeneratorTests: XCTestCase {
     func testGenerateLetterImage_returnsImageWithCorrectBackgroundColor_forM() async throws {
         let subject = DefaultLetterImageGenerator()
         let siteString = "mozilla.com"
-        let expectedBackgroundColor = UIColor(red: 0.223, green: 0.576, blue: 0.125, alpha: 1.0)
+        let expectedBackgroundColor = UIColor(red: 0.584, green: 0.803, blue: 1.0, alpha: 1.0)
         let pixelSamplePoint = CGPoint(x: 5, y: 5)
 
         let image = try await subject.generateLetterImage(siteString: siteString)
@@ -80,7 +80,7 @@ final class LetterImageGeneratorTests: XCTestCase {
     func testGenerateLetterImage_returnsImageWithCorrectBackgroundColor_forF() async throws {
         let subject = DefaultLetterImageGenerator()
         let siteString = "firefox.com"
-        let expectedBackgroundColor = UIColor(red: 0.584, green: 0.803, blue: 1.0, alpha: 1.0)
+        let expectedBackgroundColor = UIColor(red: 0.035, green: 0.588, blue: 0.973, alpha: 1.0)
         let pixelSamplePoint = CGPoint(x: 5, y: 5)
 
         let image = try await subject.generateLetterImage(siteString: siteString)
@@ -89,10 +89,21 @@ final class LetterImageGeneratorTests: XCTestCase {
         testColor(capturedColor: capturedColor, expectedColor: expectedBackgroundColor)
     }
 
+    // "," is chosen because it hashes to index 41 — the last palette bucket,
+    // which was previously unreachable due to an off-by-one in the color index.
+    func testGenerateBackgroundColor_lastPaletteColorIsReachable() {
+        let subject = DefaultLetterImageGenerator()
+        let expectedLastPaletteColor = UIColor(red: 1.0, green: 0.655, blue: 0.702, alpha: 1.0)
+
+        let color = subject.generateBackgroundColor(forSite: ",")
+
+        testColor(capturedColor: color, expectedColor: expectedLastPaletteColor)
+    }
+
     func testGenerateLetterImage_returnsImageWithCorrectBackgroundColor_forNonAlphaCharacter() async throws {
         let subject = DefaultLetterImageGenerator()
         let siteString = "?$%^"
-        let expectedBackgroundColor = UIColor(red: 0.003, green: 0.639, blue: 0.615, alpha: 1.0)
+        let expectedBackgroundColor = UIColor(red: 1.0, green: 0.655, blue: 0.573, alpha: 1.0)
         let pixelSamplePoint = CGPoint(x: 5, y: 5)
 
         let image = try await subject.generateLetterImage(siteString: siteString)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15417)
[Github issue #33059](https://github.com/mozilla-mobile/firefox-ios/issues/33059)

## :bulb: Description

### The bug
`DefaultLetterImageGenerator.generateBackgroundColor(forSite:)` in `BrowserKit/Sources/SiteImageView/ImageProcessing/LetterImageGenerator.swift` selected a background color with:

```swift
let index = abs(stableHash(siteString)) % (defaultBackgroundColors.count - 1)
```

`defaultBackgroundColors` has **42 entries**, so `% 41` produces indices `0…40` — the final entry `ffa7b3` (a soft pink at the end of the red→pink ramp) was **never** selected for any site. Only 41 of the 42 palette colors were ever used.

This is a classic "max-valid-index vs modulo divisor" off-by-one. With the fix (`% defaultBackgroundColors.count`), every color in the palette is now reachable.

### History
- Introduced in **2016** via [`d4df584a9b`](https://github.com/mozilla-mobile/firefox-ios/commit/d4df584a9b) — "Bug 1302904 - Fix a few UI related issues in AS cells." — in the original `UIConstants.DefaultColorStrings` helper.
- Carried forward verbatim in the 2022 BrowserKit rewrite [`12e68e7030`](https://github.com/mozilla-mobile/firefox-ios/commit/12e68e7030) — "Add FXIOS-5262 [v109] Add letter image generator" — as `DefaultLetterImageGenerator`.
- Latent for ~10 years. No comment or docstring anywhere marks the last color as intentionally reserved, and the palette is a smooth color ramp (the excluded entry is the final step of the red→pink ramp), so the exclusion has no design justification.

### Where and when the function is used
`LetterImageGenerator` is the **letter-favicon fallback** used by `SiteImageView` whenever a site has no real favicon available. `ImageHandler.fallbackToLetterFavicon(imageModel:)` calls it from the favicon fetch path, so the colored letter tile is rendered across the app wherever `SiteImageView` / `FaviconImageView` appear, including:

- Top Sites / pinned shortcuts on the homepage
- History panel and search
- Bookmarks panel
- Tab tray previews
- Jump Back In / recently-visited rows
- Internal pages such as `internal://local/about/home` (rendered as an "H" tile)

### Consequence
- User-visible impact is small per site (one of 42 pastel colors missing) but affects **every install**, **every letter**, and **every site without a real favicon** across the entire app for ~10 years.
- The hash-to-color mapping also shifts for existing sites because the divisor changes, so an "M" letter for `mozilla.com` now picks a different palette entry than before. This has no user-facing consequence beyond a color change on fallback favicons — these are not cached to disk with the color baked into any persistent identifier that I could find (the cache key is the site's `cacheKey`, and the regenerated image just replaces the old one).

### The fix
One-character change:

```diff
-        let index = abs(stableHash(siteString)) % (defaultBackgroundColors.count - 1)
+        let index = abs(stableHash(siteString)) % defaultBackgroundColors.count
```

### Tests
- Added `testGenerateBackgroundColor_lastPaletteColorIsReachable` as a focused regression test. Under djb2, the single-character site string `","` (unicode scalar 44) hashes to `5381 * 33 + 44 = 177617`, and `177617 % 42 == 41` — precisely the previously-unreachable last bucket, which holds `ffa7b3`. Under the old buggy formula (`% 41`) the same input landed on index 5 (`90e07f`), so this assertion would fail if the bug ever comes back.
- Updated the three existing hardcoded-expected-color tests (`_forM` / `_forF` / `_forNonAlphaCharacter`) with their new expected palette colors, because the change in divisor shifts which bucket each hash lands in. These tests pinned the old mapping, not the bug itself.
- All 10 tests in `LetterImageGeneratorTests` pass locally on iPhone 17 Pro (iOS 26.1).

## :movie_camera: Demos
No UI screenshots — the visible difference is that a single pastel pink (`#ffa7b3`) can now appear as a letter-favicon background tile, where before it never did. Not practically screenshotable as a before/after.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — N/A, no UI changes
- [ ] If adding telemetry, I read the data stewardship requirements — N/A
- [ ] If adding or modifying strings, I read the guidelines — N/A
- [x] If needed, I updated documentation and added comments to complex code
