### PR TITLE
Refactor FXIOS-15416 [A11y] Bugfix Toasts respond to live Dynamic Type changes

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toasts/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/ButtonToast.swift
@@ -41,11 +41,13 @@ class ButtonToast: Toast {
 
     private var titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.subheadline.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 
     private var descriptionLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.footnote.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 
@@ -53,6 +55,7 @@ class ButtonToast: Toast {
         button.layer.cornerRadius = UX.buttonBorderRadius
         button.layer.borderWidth = UX.buttonBorderWidth
         button.titleLabel?.font = FXFontStyles.Regular.subheadline.scaledFont()
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.numberOfLines = 1
         button.titleLabel?.lineBreakMode = .byClipping
         button.titleLabel?.adjustsFontSizeToFitWidth = true

--- a/firefox-ios/Client/Frontend/Browser/Toasts/DownloadToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/DownloadToast.swift
@@ -34,11 +34,13 @@ class DownloadToast: Toast, DownloadProgressDelegate {
 
     private var titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.subheadline.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 
     private var descriptionLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.footnote.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toasts/PlainToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/PlainToast.swift
@@ -36,11 +36,13 @@ class PlainToast: Toast {
 
     private var titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.subheadline.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 
     private var descriptionLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.footnote.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15416)
[Github issue #33058](https://github.com/mozilla-mobile/firefox-ios/issues/33058)

## :bulb: Description

### The bug
The three `Toast` subclasses in `firefox-ios/Client/Frontend/Browser/Toasts/` use `.scaledFont()` on their labels (and on `ButtonToast`'s rounded-button title label) but never set `adjustsFontForContentSizeCategory = true`. Without that property, `.scaledFont()` is evaluated **once** at label construction and never re-evaluated, so a Dynamic Type change mid-run does not update the text.

This is especially visible because the base `Toast` class already observes `UIContentSizeCategory.didChangeNotification` (`Toast.swift`, init) and on change calls `adjustLayoutForA11ySizeCategory()`, which flips the stack-view axis between horizontal and vertical for accessibility sizes. So when a user changes Dynamic Type while a toast is visible (or while the app is running and a future toast is created from the same instance), the **layout reflows** but the **text stays at the old size** — the most "obviously broken" combination.

### User-visible consequence
Every VoiceOver / large-text user who adjusts Dynamic Type in Settings → Display & Brightness → Text Size (or Settings → Accessibility → Display & Text Size → Larger Text) while Firefox is running sees toasts with stale, too-small or too-large text until the toast class is re-instantiated. Toasts are a core notification surface:
- "Tab closed · Undo"
- "Bookmark added"
- "Downloading… / Download complete"
- "Link copied"
- "Added to Reading List"
- "Shortcut pinned"

### Proof this is an oversight, not project style
`adjustsFontForContentSizeCategory = true` is used **95 times** elsewhere in `firefox-ios/Client/Frontend/` — it is the established, canonical pattern for every other `UILabel` in the app that uses `.scaledFont()`. The three Toast files in this PR are the ones that missed it.

### Reference
Apple, [*Scaling fonts automatically*](https://developer.apple.com/documentation/uikit/scaling-fonts-automatically) and [`adjustsFontForContentSizeCategory`](https://developer.apple.com/documentation/uikit/uicontentsizecategoryadjusting/adjustsfontforcontentsizecategory), plus WWDC24 [*Get started with Dynamic Type*](https://developer.apple.com/videos/play/wwdc2024/10074/):

> *"As long as you are scaling the font with `UIFontMetrics`, the `adjustsFontForContentSizeCategory` property still works, so you do not need to worry about updating when the user changes the size."*

In other words, `UIFontMetrics.scaledFont(for:)` (which is what `FXFontStyles.Regular.*.scaledFont()` wraps) computes a font for the **current** content size at the moment of the call. The label only re-runs that computation on a size-category change if `adjustsFontForContentSizeCategory` is `true`. Without it, the font is frozen at whatever Dynamic Type size was active when the toast was built.

### The fix
Seven one-line additions across three files: set `adjustsFontForContentSizeCategory = true` immediately after `label.font = FXFontStyles.Regular.X.scaledFont()` in each `.build { … }` closure.

```diff
 private var titleLabel: UILabel = .build { label in
     label.font = FXFontStyles.Regular.subheadline.scaledFont()
+    label.adjustsFontForContentSizeCategory = true
     label.numberOfLines = 0
 }
```

Files touched:
- `PlainToast.swift` — `titleLabel`, `descriptionLabel`
- `ButtonToast.swift` — `titleLabel`, `descriptionLabel`, `roundedButton.titleLabel`
- `DownloadToast.swift` — `titleLabel`, `descriptionLabel`

No behavior change for users who don't alter Dynamic Type at runtime. For users who do, the toasts will now rescale live in lock-step with the rest of the app.

### Tests
No dedicated unit tests exist for Toast label font scaling (these are UIKit rendering-driven properties that aren't covered by the existing Toast test harness). The change is a small, diff-inspected correction that mirrors the established project pattern used 95 times in the same target.

## :movie_camera: Demos
N/A — the visible difference is "text re-scales when Dynamic Type changes", best verified on device by opening a toast, switching to Settings → Accessibility → Larger Text, returning to Firefox, and observing the toast text is now the correct size.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code — no existing tests broken; no new tests warranted for a UIKit property toggle
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements — N/A
- [ ] If adding or modifying strings, I read the guidelines — N/A
- [ ] If needed, I updated documentation and added comments to complex code — N/A, fix is self-documenting
