### PR TITLE
Remove FXIOS-15237 [FindInPage] Fix FindInPage Periphery warnings

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
@@ -112,11 +112,11 @@ extension BrowserViewController: FindInPageBarDelegate, FindInPageHelperDelegate
         webView.evaluateJavascriptInDefaultContentWorld("__firefox__.\(function)(\"\(escaped)\")")
     }
 
-    func findInPageHelper(_ findInPageHelper: FindInPageHelper, didUpdateCurrentResult currentResult: Int) {
+    func findInPageHelper(didUpdateCurrentResult currentResult: Int) {
         findInPageBar?.currentResult = currentResult
     }
 
-    func findInPageHelper(_ findInPageHelper: FindInPageHelper, didUpdateTotalResults totalResults: Int) {
+    func findInPageHelper(didUpdateTotalResults totalResults: Int) {
         findInPageBar?.totalResults = totalResults
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
@@ -88,21 +88,21 @@ extension BrowserViewController {
 }
 
 extension BrowserViewController: FindInPageBarDelegate, FindInPageHelperDelegate {
-    func findInPage(_ findInPage: FindInPageBar, didTextChange text: String) {
+    func findInPage(didTextChange text: String) {
         find(text, function: "find")
     }
 
-    func findInPage(_ findInPage: FindInPageBar, didFindNextWithText text: String) {
+    func findInPage(didFindNextWithText text: String) {
         findInPageBar?.endEditing(true)
         find(text, function: "findNext")
     }
 
-    func findInPage(_ findInPage: FindInPageBar, didFindPreviousWithText text: String) {
+    func findInPage(didFindPreviousWithText text: String) {
         findInPageBar?.endEditing(true)
         find(text, function: "findPrevious")
     }
 
-    func findInPageDidPressClose(_ findInPage: FindInPageBar) {
+    func findInPageDidPressClose() {
         updateFindInPageVisibility(isVisible: false)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/FindInPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/FindInPageBar.swift
@@ -7,16 +7,16 @@ import UIKit
 
 protocol FindInPageBarDelegate: AnyObject {
     @MainActor
-    func findInPage(_ findInPage: FindInPageBar, didTextChange text: String)
+    func findInPage(didTextChange text: String)
 
     @MainActor
-    func findInPage(_ findInPage: FindInPageBar, didFindPreviousWithText text: String)
+    func findInPage(didFindPreviousWithText text: String)
 
     @MainActor
-    func findInPage(_ findInPage: FindInPageBar, didFindNextWithText text: String)
+    func findInPage(didFindNextWithText text: String)
 
     @MainActor
-    func findInPageDidPressClose(_ findInPage: FindInPageBar)
+    func findInPageDidPressClose()
 }
 
 class FindInPageBar: UIView, ThemeApplicable {
@@ -105,7 +105,7 @@ class FindInPageBar: UIView, ThemeApplicable {
 
         set {
             searchText.text = newValue
-            didTextChange(searchText)
+            didTextChange()
         }
     }
 
@@ -158,25 +158,25 @@ class FindInPageBar: UIView, ThemeApplicable {
     }
 
     @objc
-    private func didFindPrevious(_ sender: UIButton) {
-        delegate?.findInPage(self, didFindPreviousWithText: searchText.text ?? "")
+    private func didFindPrevious() {
+        delegate?.findInPage(didFindPreviousWithText: searchText.text ?? "")
     }
 
     @objc
-    private func didFindNext(_ sender: UIButton) {
-        delegate?.findInPage(self, didFindNextWithText: searchText.text ?? "")
+    private func didFindNext() {
+        delegate?.findInPage(didFindNextWithText: searchText.text ?? "")
     }
 
     @objc
-    private func didTextChange(_ sender: UITextField) {
+    private func didTextChange() {
         matchCountView.isHidden = searchText.text?.trimmingCharacters(in: .whitespaces).isEmpty ?? true
         saveSearchText(searchText.text)
-        delegate?.findInPage(self, didTextChange: searchText.text ?? "")
+        delegate?.findInPage(didTextChange: searchText.text ?? "")
     }
 
     @objc
-    private func didPressClose(_ sender: UIButton) {
-        delegate?.findInPageDidPressClose(self)
+    private func didPressClose() {
+        delegate?.findInPageDidPressClose()
     }
 
     private func saveSearchText(_ searchText: String?) {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
@@ -8,10 +8,10 @@ import WebKit
 
 protocol FindInPageHelperDelegate: AnyObject {
     @MainActor
-    func findInPageHelper(_ findInPageHelper: FindInPageHelper, didUpdateCurrentResult currentResult: Int)
+    func findInPageHelper(didUpdateCurrentResult currentResult: Int)
 
     @MainActor
-    func findInPageHelper(_ findInPageHelper: FindInPageHelper, didUpdateTotalResults totalResults: Int)
+    func findInPageHelper(didUpdateTotalResults totalResults: Int)
 }
 
 class FindInPageHelper: TabContentScript {
@@ -45,11 +45,11 @@ class FindInPageHelper: TabContentScript {
         }
 
         if let currentResult = data["currentResult"] {
-            delegate?.findInPageHelper(self, didUpdateCurrentResult: currentResult)
+            delegate?.findInPageHelper(didUpdateCurrentResult: currentResult)
         }
 
         if let totalResults = data["totalResults"] {
-            delegate?.findInPageHelper(self, didUpdateTotalResults: totalResults)
+            delegate?.findInPageHelper(didUpdateTotalResults: totalResults)
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15237)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32757)

## :bulb: Description
- Summary
  - remove unused parameters from `FindInPageBarDelegate`
  - remove unused parameters from `FindInPageHelperDelegate`
  - update `FindInPageBar` action handlers to use zero-argument selectors, matching current usage

- Notes
  - while reproducing the warnings from this issue, I found the same unused-parameter pattern in `FindInPageHelper`, so I included that related cleanup in the same Find in Page
area

## :movie_camera: Demos
<img width="363" height="807" alt="スクリーンショット 2026-04-14 8 03 25" src="https://github.com/user-attachments/assets/9620dc6d-72e9-4033-978a-024752c11eb6" />

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x]  Build the Periphery scheme and verify the above warnings are resolved
- [x]  Build the Fennec scheme and verify no compilation errors

