### PR TITLE
Bugfix FXIOS-14975 [Homepage] Fix Show All button border extending past text width

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/LabelButtonHeaderView.swift
@@ -30,6 +30,8 @@ class LabelButtonHeaderView: UIView, ThemeApplicable, Notifiable {
 
     private(set) lazy var moreButton: ActionButton = .build { button in
         button.isHidden = true
+        button.setContentHuggingPriority(.required, for: .horizontal)
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
 
     // MARK: - Variables


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14975)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32259)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Set `contentHuggingPriority` and `contentCompressionResistancePriority` 
to `.required` on the `moreButton` in `LabelButtonHeaderView` so that 
the button's tappable width shrinks to fit its text content, preventing 
the border from extending past the label when Show Borders is enabled.


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <img width="456" height="972" alt="image" src="https://github.com/user-attachments/assets/996875f4-4549-474c-9fe0-c02f9447e30b" /> | <img width="456" height="972" alt="image" src="https://github.com/user-attachments/assets/00a7e008-0374-406b-b580-9a70ef6c5e5b" /> |


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

