### PR TITLE
Bugfix FXIOS-15418 [Homepage] Shortcuts aren't tappable if a custom new tab is set.

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -10,6 +10,7 @@ import Storage
 
 final class HomepageViewController: UIViewController,
                                     UICollectionViewDelegate,
+                                    UIGestureRecognizerDelegate,
                                     UIPopoverPresentationControllerDelegate,
                                     UIAdaptivePresentationControllerDelegate,
                                     FeatureFlaggable,
@@ -895,6 +896,7 @@ final class HomepageViewController: UIViewController,
         // We want any interaction with the homepage to dismiss the keyboard, including taps
         let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tap.cancelsTouchesInView = false
+        tap.delegate = self
         view.addGestureRecognizer(tap)
     }
 
@@ -1272,5 +1274,17 @@ final class HomepageViewController: UIViewController,
         traitCollection: UITraitCollection
     ) -> UIModalPresentationStyle {
         .none
+    }
+
+    // MARK: - UIGestureRecognizerDelegate
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        guard gestureRecognizer.view === view,
+              let collectionView else {
+            return true
+        }
+
+        let location = touch.location(in: collectionView)
+        return collectionView.indexPathForItem(at: location) == nil
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33064)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15418)

## :bulb: Description

Adding a gesture recognizer delegate to block "dismissKeyboard" gesture if shortcut is tapped.
This prevent later logic to override the tap.

## :movie_camera: Demos

| Before | After |
| - | - |
| <video src=https://github.com/user-attachments/assets/d3759489-d35e-4354-bf3c-f80fa904521c > | <video src=https://github.com/user-attachments/assets/a1fe69e5-575b-4ad9-9e33-c99554386f4e > |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

