### PR TITLE
No Bug - Optimize longest UI test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -286,6 +286,11 @@ final class BrowserScreen {
         BaseTestCase().mozWaitForElementToExist(app.webViews.firstMatch, timeout: timeout)
     }
 
+    func assertWebViewHasContent(timeout: TimeInterval = TIMEOUT) {
+        let firstText = app.webViews.firstMatch.staticTexts.firstMatch
+        BaseTestCase().mozWaitForElementToExist(firstText, timeout: timeout)
+    }
+
     func tapWebViewButton(buttonText: String) {
         app.webViews.buttons[buttonText].waitAndTap()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
@@ -8,7 +8,6 @@ class URLValidationTests: BaseTestCase {
     let urlTypes = ["www.mozilla.org", "www.mozilla.org/", "https://www.mozilla.org", "www.mozilla.org/en", "www.mozilla.org/en-",
                     "www.mozilla.org/en-US", "https://www.mozilla.org/", "https://www.mozilla.org/en", "https://www.mozilla.org/en-US"]
     let urlHttpTypes = ["http://example.com", "http://example.com/"]
-    let urlField = XCUIApplication().textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
     var browserScreen: BrowserScreen!
 
     override func setUp() async throws {
@@ -29,23 +28,22 @@ class URLValidationTests: BaseTestCase {
     // Smoketest
     func testDifferentURLTypes() {
         for url in urlTypes {
-            navigator.openURL(url)
-            waitUntilPageLoad()
-            browserScreen.assertMozillaPageLoaded(urlField: urlField)
+            browserScreen.navigateToURL(url)
+            browserScreen.assertWebViewLoaded()
+            browserScreen.assertAddressBarContains(value: "mozilla.org")
             clearURL()
         }
 
         for url in urlHttpTypes {
-            navigator.openURL(url)
-            waitUntilPageLoad()
-            browserScreen.assertExampleDomainLoaded(urlField: urlField)
+            browserScreen.navigateToURL(url)
+            browserScreen.assertWebViewLoaded()
+            browserScreen.assertAddressBarContains(value: "example.com")
             clearURL()
         }
     }
 
     private func clearURL() {
-        navigator.nowAt(BrowserTab)
-        navigator.goto(URLBarOpen)
+        browserScreen.tapOnAddressBar()
         browserScreen.clearURL()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
@@ -29,14 +29,14 @@ class URLValidationTests: BaseTestCase {
     func testDifferentURLTypes() {
         for url in urlTypes {
             browserScreen.navigateToURL(url)
-            browserScreen.assertWebViewLoaded()
+            browserScreen.assertWebViewHasContent()
             browserScreen.assertAddressBarContains(value: "mozilla.org")
             clearURL()
         }
 
         for url in urlHttpTypes {
             browserScreen.navigateToURL(url)
-            browserScreen.assertWebViewLoaded()
+            browserScreen.assertWebViewHasContent()
             browserScreen.assertAddressBarContains(value: "example.com")
             clearURL()
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This UI Test takes longest than any other to run. Let's try to optimize it and use TAE completely.

  **testDifferentURLTypes** optimization (~2m → ~1m)
  - Replaced navigator.openURL + waitUntilPageLoad + assertMozillaPageLoaded/assertExampleDomainLoaded (full page content render wait) with `browserScreen.navigateToURL` + `assertWebViewHasContent` + `assertAddressBarContains`. 
  The URL normalization assertion (assertAddressBarContains) still catches the original bug (bare domains / /en- variants treated as search queries). assertWebViewHasContent fails on a blank page by requiring at least one staticText to appear in the webview.
  - Replaced navigator.nowAt + navigator.goto(URLBarOpen) in clearURL() with direct POM calls.
  - Removed unused urlField class property.

  New POM methods in BrowserScreen
  - navigateToURL(_ url: String) — encapsulates tap address bar + type + return.
  - assertWebViewHasContent() — waits for any static text in the webview; fails on blank/no-content pages.


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

