### PR TITLE
Bugfix FXIOS-14791 [Settings] Fix Send Technical Data toggle animation

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -271,12 +271,10 @@ class AppSettingsTableViewController: SettingsTableViewController,
             settingsDelegate: parentCoordinator
         )
 
-        sendTechnicalDataSettings.settingDidChange = { [weak self] value in
-            guard let self else { return }
+        sendTechnicalDataSettings.settingDidChange = { value in
             DefaultGleanWrapper().setUpload(isEnabled: value)
             Experiments.setTelemetrySetting(value)
             studiesSetting.updateSetting(for: value)
-            self.tableView.reloadData()
         }
         sendTechnicalDataSetting = sendTechnicalDataSettings
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SendDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SendDataSetting.swift
@@ -85,9 +85,7 @@ final class SendDataSetting: BoolSetting {
         cell.accessoryView = control
         cell.selectionStyle = .none
 
-        if !enabled {
-            cell.subviews.forEach { $0.alpha = 0.5 }
-        }
+        cell.contentView.alpha = enabled ? 1.0 : 0.5
 
         cell.learnMoreDidTap = { [weak self] in
             guard let self else { return }
@@ -101,6 +99,7 @@ final class SendDataSetting: BoolSetting {
         // in which case, we would to make sure that users are opted out of experiments
         // Note: Switch should be enabled only when telemetry usage is enabled
         updateControlState(isEnabled: isUsageEnabled)
+        updateCellAppearance(isEnabled: isUsageEnabled)
 
         // Set experiments study setting based on usage enabled state
         // Special Case (EXP-4780, FXIOS-10534) disable Studies if usage data is disabled
@@ -113,5 +112,14 @@ final class SendDataSetting: BoolSetting {
         control.setSwitchTappable(to: isEnabled)
         control.toggleSwitch(to: isEnabled)
         writeBool(control.switchView)
+    }
+
+    private func updateCellAppearance(isEnabled: Bool) {
+        var view: UIView? = control.superview
+        while let current = view, !(current is UITableViewCell) {
+            view = current.superview
+        }
+        guard let cell = view as? UITableViewCell else { return }
+        cell.contentView.alpha = isEnabled ? 1.0 : 0.5
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SendDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SendDataSetting.swift
@@ -15,6 +15,7 @@ final class SendDataSetting: BoolSetting {
     private let featureFlagName: NimbusFeatureFlagID?
 
     private weak var settingsDelegate: SupportSettingsDelegate?
+    private weak var cell: UITableViewCell?
 
     override var url: URL? { return learnMoreURL }
     override var accessibilityIdentifier: String? { return a11yId }
@@ -62,6 +63,7 @@ final class SendDataSetting: BoolSetting {
     override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
         guard let cell = cell as? ThemedLearnMoreTableViewCell else { return }
         guard let title = title?.string, let subtitle = status?.string else { return }
+        self.cell = cell
 
         cell.configure(
             title: title,
@@ -99,7 +101,7 @@ final class SendDataSetting: BoolSetting {
         // in which case, we would to make sure that users are opted out of experiments
         // Note: Switch should be enabled only when telemetry usage is enabled
         updateControlState(isEnabled: isUsageEnabled)
-        updateCellAppearance(isEnabled: isUsageEnabled)
+        cell?.contentView.alpha = isUsageEnabled ? 1.0 : 0.5
 
         // Set experiments study setting based on usage enabled state
         // Special Case (EXP-4780, FXIOS-10534) disable Studies if usage data is disabled
@@ -112,14 +114,5 @@ final class SendDataSetting: BoolSetting {
         control.setSwitchTappable(to: isEnabled)
         control.toggleSwitch(to: isEnabled)
         writeBool(control.switchView)
-    }
-
-    private func updateCellAppearance(isEnabled: Bool) {
-        var view: UIView? = control.superview
-        while let current = view, !(current is UITableViewCell) {
-            view = current.superview
-        }
-        guard let cell = view as? UITableViewCell else { return }
-        cell.contentView.alpha = isEnabled ? 1.0 : 0.5
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14791)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31919)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The "Send Technical and Interaction Data" toggle animation in Settings was interrupted by `tableView.reloadData()` called in its `settingDidChange` callback.

Changes:
  - Removed `tableView.reloadData()` from the callback to avoid interrupting the switch animation
  - Added `updateCellAppearance(isEnabled:)` to `SendDataSetting` to directly update the Studies cell's `contentView.alpha` without a full table reload
  - Changed disabled cell dimming from `cell.subviews` to `cell.contentView` to avoid double-dimming with the switch's built-in disabled appearance
  - Ensured alpha is always set (both `1.0` and `0.5`) so re-enabling correctly restores cell appearance

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->
https://github.com/user-attachments/assets/9eb1b04e-dc87-40cc-928f-c7787fa9bafd

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

