### PR TITLE
Bugfix FXIOS-15420 [Toolbar] Private mask remains visible over the tab tray icon in normal browsing mode after switching from private browsing

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -129,14 +129,11 @@ class ToolbarButton: UIButton,
         largeContentImage = image
 
         configuration = config
+        removeBadgeAndMaskFromSuperview()
+
         if let buttonBadgeImage = element.bottomBadgeImage {
             addBottomBadgeImage(buttonBadgeImage)
-        } else {
-            bottomBadgeImageView?.removeFromSuperview()
-            bottomBadgeImageView = nil
-        }
-
-        if let badgeName = element.badgeImageName {
+        } else if let badgeName = element.badgeImageName {
             addBadgeIcon(imageName: badgeName)
             if let maskImageName = element.maskImageName {
                 addMaskIcon(maskImageName: maskImageName)
@@ -144,8 +141,6 @@ class ToolbarButton: UIButton,
                 maskImageView?.removeFromSuperview()
                 maskImageView = nil
             }
-        } else {
-            removeBadgeAndMaskFromSuperview()
         }
 
         layoutIfNeeded()
@@ -280,9 +275,11 @@ class ToolbarButton: UIButton,
     }
 
     private func removeBadgeAndMaskFromSuperview() {
+        bottomBadgeImageView?.removeFromSuperview()
         badgeImageView?.removeFromSuperview()
         maskImageView?.removeFromSuperview()
         badgeImageView = nil
+        bottomBadgeImageView = nil
         maskImageView = nil
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15420)
~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~

## :bulb: Description
Resets the toolbar button badges and mask.

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="800" alt="Screenshot Before" src="https://github.com/user-attachments/assets/3140e66c-63bb-41b0-970b-bc6378cc90d6" /> | <img width="800" alt="Screenshot After" src="https://github.com/user-attachments/assets/78a9bb59-fbc7-4bfa-bdd2-ad166467c0cb" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

