### PR TITLE
Add FXIOS-15422 [Newsfeed Categories] Story category picker

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1105,6 +1105,7 @@
 		8A8DDEBF276259A900E7B97A /* RatingPromptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8DDEBE276259A900E7B97A /* RatingPromptManager.swift */; };
 		8A8F54202E5CB95B00C0207F /* GleanPingUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8F541F2E5CB8AF00C0207F /* GleanPingUploader.swift */; };
 		8A91D4112F7D6C7800A1B2C3 /* NewsTransitionHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A91D4102F7D6C7800A1B2C3 /* NewsTransitionHeaderCell.swift */; };
+		8A91D4132F7D6C7900A1B2C3 /* StoryCategoryPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A91D4122F7D6C7900A1B2C3 /* StoryCategoryPickerView.swift */; };
 		8A927D4B2E2ED5D600E676CC /* LegacyClipboardBarDisplayHandlerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A927D4A2E2ED5D600E676CC /* LegacyClipboardBarDisplayHandlerDelegate.swift */; };
 		8A93080927BFE88F0052167D /* PhotonActionSheetContainerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93080827BFE88F0052167D /* PhotonActionSheetContainerCell.swift */; };
 		8A93080B27C01AD60052167D /* SingleActionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93080A27C01AD60052167D /* SingleActionViewModel.swift */; };
@@ -9307,6 +9308,7 @@
 		8A8DDEBE276259A900E7B97A /* RatingPromptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManager.swift; sourceTree = "<group>"; };
 		8A8F541F2E5CB8AF00C0207F /* GleanPingUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPingUploader.swift; sourceTree = "<group>"; };
 		8A91D4102F7D6C7800A1B2C3 /* NewsTransitionHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsTransitionHeaderCell.swift; sourceTree = "<group>"; };
+		8A91D4122F7D6C7900A1B2C3 /* StoryCategoryPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryCategoryPickerView.swift; sourceTree = "<group>"; };
 		8A927D4A2E2ED5D600E676CC /* LegacyClipboardBarDisplayHandlerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyClipboardBarDisplayHandlerDelegate.swift; sourceTree = "<group>"; };
 		8A93080827BFE88F0052167D /* PhotonActionSheetContainerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetContainerCell.swift; sourceTree = "<group>"; };
 		8A93080A27C01AD60052167D /* SingleActionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleActionViewModel.swift; sourceTree = "<group>"; };
@@ -13794,6 +13796,7 @@
 				8A2DAD4C2CC02AA10067ECD0 /* LabelButtonHeaderCell.swift */,
 				8A9B7A892F1A120100ABCDEF /* NewsAffordanceHeaderView.swift */,
 				8A91D4102F7D6C7800A1B2C3 /* NewsTransitionHeaderCell.swift */,
+				8A91D4122F7D6C7900A1B2C3 /* StoryCategoryPickerView.swift */,
 				8A6E63CE2D4A7FB70040D355 /* SectionHeaderConfiguration.swift */,
 			);
 			path = SectionHeader;
@@ -18744,6 +18747,7 @@
 				8A2DAD4D2CC02AA10067ECD0 /* LabelButtonHeaderCell.swift in Sources */,
 				8A9B7A8A2F1A120100ABCDEF /* NewsAffordanceHeaderView.swift in Sources */,
 				8A91D4112F7D6C7800A1B2C3 /* NewsTransitionHeaderCell.swift in Sources */,
+				8A91D4132F7D6C7900A1B2C3 /* StoryCategoryPickerView.swift in Sources */,
 				C825E9832832A425006CB811 /* NimbusSearchBarLayer.swift in Sources */,
 				8AF347DE2CADD1B200624036 /* HomepageState.swift in Sources */,
 				8A75AF9C2DE8A1CF00B2C592 /* StartAtHomeMiddleware.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -768,6 +768,7 @@
 		61DD72D12F5936C4002BFEA6 /* AIControlsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DD72D02F5936AF002BFEA6 /* AIControlsSetting.swift */; };
 		61DD72D52F5937A6002BFEA6 /* AIControlsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DD72D42F5937A0002BFEA6 /* AIControlsSettingsView.swift */; };
 		61E637852D03615D00E95B63 /* LabelButtonHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E637842D03615D00E95B63 /* LabelButtonHeaderViewTests.swift */; };
+		61E637872D03615D00E95B63 /* StoryCategoryPickerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E637862D03615D00E95B63 /* StoryCategoryPickerViewTests.swift */; };
 		61F7A4332D136C3A00F7317B /* RouteBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F7A4322D136C3A00F7317B /* RouteBuilderTests.swift */; };
 		630FE1352C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1322C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift */; };
 		631A369F2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */; };
@@ -8710,6 +8711,7 @@
 		61DD72D02F5936AF002BFEA6 /* AIControlsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIControlsSetting.swift; sourceTree = "<group>"; };
 		61DD72D42F5937A0002BFEA6 /* AIControlsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIControlsSettingsView.swift; sourceTree = "<group>"; };
 		61E637842D03615D00E95B63 /* LabelButtonHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelButtonHeaderViewTests.swift; sourceTree = "<group>"; };
+		61E637862D03615D00E95B63 /* StoryCategoryPickerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryCategoryPickerViewTests.swift; sourceTree = "<group>"; };
 		61F7A4322D136C3A00F7317B /* RouteBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteBuilderTests.swift; sourceTree = "<group>"; };
 		623648C2A7D09ECA31155208 /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ka; path = ka.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		625D4575B4794C49451D6990 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
@@ -13325,6 +13327,7 @@
 				8AD3AFC42D143F0D00CFC887 /* HomepageDimensionCalculatorTests.swift */,
 				8A00BD862CAB3FE500680AF9 /* HomepageViewControllerTests.swift */,
 				61E637842D03615D00E95B63 /* LabelButtonHeaderViewTests.swift */,
+				61E637862D03615D00E95B63 /* StoryCategoryPickerViewTests.swift */,
 				A1F0D0002F70000100ABC001 /* NewsTransitionHeaderCellTests.swift */,
 				8A87B4352CC1A8FD003A9239 /* Mock */,
 				8A6E8DE92B275B49000C4301 /* PrivateHomepageViewControllerTests.swift */,
@@ -20001,6 +20004,7 @@
 				967EDABD29D705300089208D /* CreditCardValidatorTests.swift in Sources */,
 				967EDABF29D769A10089208D /* CreditCardInputFieldTests.swift in Sources */,
 				61E637852D03615D00E95B63 /* LabelButtonHeaderViewTests.swift in Sources */,
+				61E637872D03615D00E95B63 /* StoryCategoryPickerViewTests.swift in Sources */,
 				A1F0D0012F70000100ABC001 /* NewsTransitionHeaderCellTests.swift in Sources */,
 				21F2A2D42B0D194A00626AEC /* TabsPanelStateTests.swift in Sources */,
 				8ACA8F7629198D6400D3075D /* MainThreadThrottlerTests.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -270,6 +270,8 @@ struct AccessibilityIdentifiers {
         }
 
         struct Pocket {
+            static let allCategory = "Category.All"
+            static let category = "Category"
             static let itemCell = "PocketCell"
             static let footerLearnMoreLabel = "Pocket.footerLearnMoreLabel"
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/StoryCategoryPickerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/StoryCategoryPickerView.swift
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import Foundation
+import UIKit
+
+final class StoryCategoryPickerView: UIView, ThemeApplicable {
+    struct UX {
+        static let topSpacing: CGFloat = 16
+    }
+
+    static let allCategoryID = "__all__"
+
+    private lazy var chipPickerView: ChipPickerView = .build()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(
+        categories: [MerinoCategoryConfiguration],
+        selectedCategoryID: String?,
+        onSelection: (@MainActor (String?) -> Void)?
+    ) {
+        let items = pickerItems(from: categories)
+        let selectedPickerID = selectedCategoryID ?? Self.allCategoryID
+
+        chipPickerView.configure(
+            items: items,
+            selectedID: selectedPickerID,
+            onSelection: { selectedID in
+                onSelection?(selectedID == Self.allCategoryID ? nil : selectedID)
+            }
+        )
+        isHidden = items.isEmpty
+    }
+
+    func applyTheme(theme: Theme) {
+        chipPickerView.applyTheme(theme: theme)
+    }
+
+    private func setupLayout() {
+        addSubview(chipPickerView)
+
+        NSLayoutConstraint.activate([
+            chipPickerView.topAnchor.constraint(equalTo: topAnchor, constant: UX.topSpacing),
+            chipPickerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            chipPickerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            chipPickerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    private func pickerItems(from categories: [MerinoCategoryConfiguration]) -> [ChipPickerItem] {
+        guard !categories.isEmpty else { return [] }
+
+        let allItems = ChipPickerItem(
+            id: Self.allCategoryID,
+            title: .FirefoxHomepage.Pocket.AllStoryCategories,
+            a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory
+        )
+        let categoryItems: [ChipPickerItem] = categories.map { category in
+            return ChipPickerItem(
+                id: category.feedID,
+                title: category.title,
+                a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + "." + category.feedID
+            )
+        }
+
+        return [allItems] + categoryItems
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/StoryCategoryPickerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/StoryCategoryPickerView.swift
@@ -61,7 +61,7 @@ final class StoryCategoryPickerView: UIView, ThemeApplicable {
     private func pickerItems(from categories: [MerinoCategoryConfiguration]) -> [ChipPickerItem] {
         guard !categories.isEmpty else { return [] }
 
-        let allItems = ChipPickerItem(
+        let allItem = ChipPickerItem(
             id: Self.allCategoryID,
             title: .FirefoxHomepage.Pocket.AllStoryCategories,
             a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory
@@ -74,6 +74,6 @@ final class StoryCategoryPickerView: UIView, ThemeApplicable {
             )
         }
 
-        return [allItems] + categoryItems
+        return [allItem] + categoryItems
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/StoryCategoryPickerViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/StoryCategoryPickerViewTests.swift
@@ -27,7 +27,7 @@ final class StoryCategoryPickerViewTests: XCTestCase {
 
         XCTAssertFalse(view.isHidden)
         XCTAssertEqual(buttons.count, 3)
-        XCTAssertEqual(buttons.map(\.currentTitle), [
+        XCTAssertEqual(buttons.map { $0.configuration?.title }, [
             .FirefoxHomepage.Pocket.AllStoryCategories,
             "Technology",
             "Science",
@@ -41,7 +41,7 @@ final class StoryCategoryPickerViewTests: XCTestCase {
 
         XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory,
                              in: view)?.isSelected == true)
-        XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + "technology",
+        XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + ".technology",
                              in: view)?.isSelected == false)
     }
 
@@ -52,7 +52,7 @@ final class StoryCategoryPickerViewTests: XCTestCase {
 
         XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory,
                              in: view)?.isSelected == false)
-        XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + "technology",
+        XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + ".technology",
                              in: view)?.isSelected == true)
     }
 
@@ -78,7 +78,7 @@ final class StoryCategoryPickerViewTests: XCTestCase {
             selectedCategoryID = newSelection
         }
 
-        button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + "science", in: view)?
+        button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + ".science", in: view)?
             .sendActions(for: .touchUpInside)
 
         XCTAssertEqual(selectedCategoryID, "science")
@@ -112,13 +112,13 @@ final class StoryCategoryPickerViewTests: XCTestCase {
     }
 
     private func createSubject() -> StoryCategoryPickerView {
-        let view = StoryCategoryPickerView(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
+        let view = StoryCategoryPickerView()
         trackForMemoryLeaks(view)
         return view
     }
 
     private func chipButtons(in view: UIView) -> [UIButton] {
-        allSubviews(in: view).compactMap { $0 as? UIButton }.filter { $0.currentTitle != nil }
+        allSubviews(in: view).compactMap { $0 as? UIButton }.filter { $0.configuration?.title != nil }
     }
 
     private func button(withA11yID a11yID: String, in view: UIView) -> UIButton? {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/StoryCategoryPickerViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/StoryCategoryPickerViewTests.swift
@@ -1,0 +1,131 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import UIKit
+
+@testable import Client
+
+@MainActor
+final class StoryCategoryPickerViewTests: XCTestCase {
+    func test_configure_withEmptyCategories_hidesView() {
+        let view = createSubject()
+
+        view.configure(categories: [], selectedCategoryID: nil, onSelection: nil)
+
+        XCTAssertTrue(view.isHidden)
+        XCTAssertTrue(chipButtons(in: view).isEmpty)
+    }
+
+    func test_configure_withCategories_showsViewAndPrependsAllCategory() {
+        let view = createSubject()
+
+        view.configure(categories: testCategories, selectedCategoryID: nil, onSelection: nil)
+
+        let buttons = chipButtons(in: view)
+
+        XCTAssertFalse(view.isHidden)
+        XCTAssertEqual(buttons.count, 3)
+        XCTAssertEqual(buttons.map(\.currentTitle), [
+            .FirefoxHomepage.Pocket.AllStoryCategories,
+            "Technology",
+            "Science",
+        ])
+    }
+
+    func test_configure_withNilSelectedCategory_selectsAllCategory() {
+        let view = createSubject()
+
+        view.configure(categories: testCategories, selectedCategoryID: nil, onSelection: nil)
+
+        XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory,
+                             in: view)?.isSelected == true)
+        XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + "technology",
+                             in: view)?.isSelected == false)
+    }
+
+    func test_configure_withSelectedFeedID_selectsMatchingCategory() {
+        let view = createSubject()
+
+        view.configure(categories: testCategories, selectedCategoryID: "technology", onSelection: nil)
+
+        XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory,
+                             in: view)?.isSelected == false)
+        XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + "technology",
+                             in: view)?.isSelected == true)
+    }
+
+    func test_selectingAllCategory_callsOnSelectionWithNil() {
+        let view = createSubject()
+        var selectedCategoryID: String? = "technology"
+
+        view.configure(categories: testCategories, selectedCategoryID: "technology") { newSelection in
+            selectedCategoryID = newSelection
+        }
+
+        button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory, in: view)?
+            .sendActions(for: .touchUpInside)
+
+        XCTAssertNil(selectedCategoryID)
+    }
+
+    func test_selectingSpecificCategory_callsOnSelectionWithFeedID() {
+        let view = createSubject()
+        var selectedCategoryID: String?
+
+        view.configure(categories: testCategories, selectedCategoryID: nil) { newSelection in
+            selectedCategoryID = newSelection
+        }
+
+        button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + "science", in: view)?
+            .sendActions(for: .touchUpInside)
+
+        XCTAssertEqual(selectedCategoryID, "science")
+    }
+
+    private var testCategories: [MerinoCategoryConfiguration] {
+        [
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "technology",
+                    recommendations: [],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Technology",
+                    subtitle: nil,
+                    receivedFeedRank: 2
+                )
+            ),
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "science",
+                    recommendations: [],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Science",
+                    subtitle: nil,
+                    receivedFeedRank: 1
+                )
+            ),
+        ]
+    }
+
+    private func createSubject() -> StoryCategoryPickerView {
+        let view = StoryCategoryPickerView(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
+        trackForMemoryLeaks(view)
+        return view
+    }
+
+    private func chipButtons(in view: UIView) -> [UIButton] {
+        allSubviews(in: view).compactMap { $0 as? UIButton }.filter { $0.currentTitle != nil }
+    }
+
+    private func button(withA11yID a11yID: String, in view: UIView) -> UIButton? {
+        chipButtons(in: view).first(where: { $0.accessibilityIdentifier == a11yID })
+    }
+
+    private func allSubviews(in view: UIView) -> [UIView] {
+        view.subviews + view.subviews.flatMap { allSubviews(in: $0) }
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15422)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33080)

## :bulb: Description
- Create a thin stories-specific wrapper around `ChipPickerView` that:
  - Converts `[MerinoCategoryConfiguration]` into `[ChipPickerItem]`
  - Injects the client-side "All" option, which does not exist in the server response
  - Sets homepage-specific accessibility identifiers
  - Sets some small layout wrapper around the chip picker, like the top spacing

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

