### PR TITLE
Add FXIOS-15408 [Newsfeed Categories] Homepage newsfeed categories integration

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -145,18 +145,7 @@ final class HomepageDiffableDataSource:
             snapshot.appendItems(stories, toSection: .pocket(textColor))
         }
 
-        apply(snapshot, animatingDifferences: false, completion: completion)
-    }
-
-    private func getMerinoStories(
-        with merinoState: MerinoState
-    ) -> [HomepageDiffableDataSource.HomeItem]? {
-        guard merinoState.shouldShowSection,
-              let stories: [HomeItem] = merinoState.merinoData.stories?.compactMap({ .merino($0) }),
-              !stories.isEmpty
-        else { return nil }
-
-        return stories
+        apply(snapshot, animatingDifferences: true, completion: completion)
     }
 
     /// Gets the proper amount of top sites based on layout configuration
@@ -211,6 +200,12 @@ final class HomepageDiffableDataSource:
     ) -> [HomepageDiffableDataSource.HomeItem]? {
         guard state.shouldShowSection, !state.bookmarks.isEmpty else { return nil }
         return state.bookmarks.compactMap { .bookmark($0) }
+    }
+
+    private func getMerinoStories(with merinoState: MerinoState) -> [HomepageDiffableDataSource.HomeItem]? {
+        let stories: [HomeItem] = merinoState.visibleStories.map( { .merino($0) })
+        guard merinoState.shouldShowSection, !stories.isEmpty else { return nil }
+        return stories
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -1043,7 +1043,6 @@ final class HomepageViewController: UIViewController,
         )
     }
 
-
     private func dispatchCategorySelectedAction(selectedCategoryID: String?) {
         store.dispatch(
             MerinoAction(

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -373,6 +373,8 @@ final class HomepageViewController: UIViewController,
         // TODO: - FXIOS-13346 / FXIOS-13343 - fix collection view being reloaded all the time also when data don't change
         // this is a quick workaround to avoid blocking the main thread by calling apply snapshot many times.
         if homepageState != state {
+            self.homepageState = state
+
             dataSource?.updateSnapshot(
                 state: state,
                 jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
@@ -390,7 +392,6 @@ final class HomepageViewController: UIViewController,
             resetTrackedObjects()
             trackVisibleItemImpressions()
         }
-        self.homepageState = state
     }
 
     func unsubscribeFromRedux() {
@@ -711,7 +712,10 @@ final class HomepageViewController: UIViewController,
             sectionHeaderConfiguration: MerinoState.Constants.sectionHeaderConfiguration,
             textColor: homepageState.wallpaperState.wallpaperConfiguration.textColor,
             theme: currentTheme,
-            transitionEnabled: transitionEnabled
+            transitionEnabled: transitionEnabled,
+            categories: homepageState.merinoState.availableCategories,
+            selectedCategoryID: homepageState.merinoState.selectedCategoryID,
+            onSelection: dispatchCategorySelectedAction
         )
         newsTransitionHeaderCell.setTransitionProgress(newsTransitionProgress())
         return newsTransitionHeaderCell
@@ -765,10 +769,7 @@ final class HomepageViewController: UIViewController,
         }
     }
 
-    /// Reapplies scroll-based fade progress to the visible pocket header after scrolling or relayout.
-    /// This is a no-op unless the pocket section is present and the `newsTransitionHeaderCell` is able to transition
-    /// (the section label fallback header used when there is no room for the header to transition does not participate
-    /// in the transition)
+    /// Updates the `NewsTransitionHeaderCell`s transition progress
     private func updateNewsTransitionHeaderProgress() {
         guard MerinoState.Constants.sectionHeaderConfiguration.style == .newsAffordance,
               let collectionView,
@@ -778,21 +779,24 @@ final class HomepageViewController: UIViewController,
                   }
                   return false
               }),
-              let headerAttributes = collectionView.layoutAttributesForSupplementaryElement(
-                  ofKind: UICollectionView.elementKindSectionHeader,
-                  at: IndexPath(item: 0, section: pocketSectionIndex)
-              ),
-              let headerView = collectionView.supplementaryView(
-                  forElementKind: UICollectionView.elementKindSectionHeader,
-                  at: IndexPath(item: 0, section: pocketSectionIndex)
+              let spacerSectionIndex = dataSource?.snapshot().sectionIdentifiers.firstIndex(where: {
+                  if case .spacer = $0 {
+                      return true
+                  }
+                  return false
+              }),
+              let spacerAttributes = collectionView.layoutAttributesForItem(at: IndexPath(item: 0,
+                                                                                          section: spacerSectionIndex)),
+              let headerView = collectionView.supplementaryView(forElementKind: UICollectionView.elementKindSectionHeader,
+                                                                at: IndexPath(item: 0, section: pocketSectionIndex)
               ) as? NewsTransitionHeaderCell
         else {
             return
         }
 
-        let expectedHeaderHeight = HomepageDimensionCalculator.fittingHeight(for: NewsTransitionHeaderCell(),
-                                                                             width: collectionView.bounds.width)
-        let transitionEnabled = headerAttributes.size.height >= expectedHeaderHeight
+        // We only want the stories header to transition if there is enough empty space on the homepage,
+        // which is denoted by the existence of the spacer
+        let transitionEnabled = spacerAttributes.size.height > 0.1
         headerView.setTransitionEnabled(transitionEnabled)
         headerView.setTransitionProgress(newsTransitionProgress())
     }
@@ -1035,6 +1039,17 @@ final class HomepageViewController: UIViewController,
                 navigationDestination: NavigationDestination(.privacyNoticeLink(url)),
                 windowUUID: windowUUID,
                 actionType: NavigationBrowserActionType.tapOnPrivacyNoticeLink
+            )
+        )
+    }
+
+
+    private func dispatchCategorySelectedAction(selectedCategoryID: String?) {
+        store.dispatch(
+            MerinoAction(
+                selectedCategoryID: selectedCategoryID,
+                windowUUID: windowUUID,
+                actionType: MerinoActionType.categorySelected
             )
         )
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -6,6 +6,7 @@ import Foundation
 import Common
 import Storage
 import UIKit
+
 /// Holds section layout logic for the new homepage as part of the rebuild project
 @MainActor
 final class HomepageSectionLayoutProvider: FeatureFlaggable {
@@ -47,8 +48,6 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         struct PocketConstants {
             static let preferredCellSize = CGSize(width: 361, height: 282)
             static let minimumCellWidth: CGFloat = 320
-            static let verticalStoriesCellEstimatedHeight: CGFloat = 282
-            static let verticalStoriesSpacing: CGFloat = 16
             static let minimumCellsPerRow = 1
             static let interItemSpacing: CGFloat = 16
             static let interGroupSpacing: CGFloat = 16
@@ -286,7 +285,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             bottom: UX.standardInset,
             trailing: horizontalInset
         )
-        section.interGroupSpacing = UX.interGroupSpacing
+        section.interGroupSpacing = UX.PocketConstants.interGroupSpacing
 
         return section
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -103,16 +103,6 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         }
     }
 
-    private enum StoriesHeaderHeightMode: Equatable {
-        case sectionTitle
-        case newsAffordance
-    }
-
-    private struct StoriesHeaderLayoutState: Equatable {
-        let headerHeightMode: StoriesHeaderHeightMode
-        let appliedPeekOffset: CGFloat
-    }
-
     private var logger: Logger
     private var windowUUID: WindowUUID
 
@@ -279,11 +269,8 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         let headerFooterSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
-            heightDimension: .absolute(
-                getHeaderHeight(
-                    sectionHeaderConfiguration: sectionHeaderConfiguration,
-                    environment: environment
-                )
+            heightDimension: .absolute(getHeaderHeight(sectionHeaderConfiguration: sectionHeaderConfiguration,
+                                                       environment: environment)
             )
         )
         let header = NSCollectionLayoutBoundarySupplementaryItem(
@@ -504,23 +491,30 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
     // result in it having a different height (eg changes to top/bottom insets).
     private func createSpacerSectionLayout(for environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
         let rawSpacerHeight = getRawSpacerHeight(environment: environment)
-        let storiesHeaderLayoutState = getStoriesHeaderLayoutState(environment: environment)
+
+        let merinoHeaderConfiguration = MerinoState.Constants.sectionHeaderConfiguration
+        let headerHeight = getHeaderHeight(sectionHeaderConfiguration: merinoHeaderConfiguration,
+                                           environment: environment)
 
         // Dimensions of <= 0.0 cause runtime warnings, so use a minimum height of 0.1
         var spacerHeight = max(0.1, rawSpacerHeight)
 
-        // For vertically scrolling stories, apply the appropriate peek treatment only when there is spare vertical space.
-        // If there isn’t enough room, stories flow naturally after the preceding content with no peeking.
+        // Resolves how the vertical stories header should be presented from the amount of free space available at the
+        // bottom of the unscrolled homepage.
+        //
+        // When there is enough space for the full news affordance + stories peek, we show that.
+        // Otherwise, if there is at least enough space to show the news affordance itself,
+        // we show that and as much of the stories peek as we can.
+        // Otherwise, if there is less space than the news affordance height, we fall back to the section-title header
+        // + categories picker and remove the peek entirely.
         if rawSpacerHeight > 0 {
-            if storiesHeaderLayoutState.headerHeightMode == .sectionTitle {
-                spacerHeight = 0.1
-            } else {
-                let headerHeight = HomepageDimensionCalculator.fittingHeight(for: NewsTransitionHeaderCell(),
-                                                                             width: environment.container.contentSize.width)
+            if merinoHeaderConfiguration.style == .newsAffordance && rawSpacerHeight >= headerHeight {
                 let headerWithSectionSpacing = headerHeight + UX.headerSectionSpacing
                 /// `totalPeek` is how much of the stories section (header + spacing + stories) we want above the fold
                 let totalPeek = headerWithSectionSpacing + UX.PocketConstants.getStoriesPeekOffset()
                 spacerHeight = max(0.1, rawSpacerHeight - totalPeek)
+            } else {
+                spacerHeight = 0.1
             }
         }
 
@@ -796,13 +790,15 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         let headerHeight: CGFloat
 
         switch sectionHeaderConfiguration.style {
-        case .newsAffordance
-            where getStoriesHeaderLayoutState(environment: environment).headerHeightMode == .newsAffordance:
+        case .newsAffordance:
+            guard let state = store.state.componentState(HomepageState.self, for: .homepage, window: windowUUID)
+            else { fallthrough }
             let header = NewsTransitionHeaderCell(frame: CGRect(width: 200, height: 200))
             header.configure(sectionHeaderConfiguration: sectionHeaderConfiguration,
-                             textColor: .black,
+                             textColor: nil,
                              theme: LightTheme(),
-                             transitionEnabled: true)
+                             transitionEnabled: true,
+                             categories: state.merinoState.availableCategories)
             headerHeight = HomepageDimensionCalculator.fittingHeight(for: header, width: containerWidth)
 
         default:
@@ -814,46 +810,11 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         return headerHeight
     }
 
-    /// Resolves how the vertical stories header should be presented from the amount of free
-    /// space available at the bottom of the unscrolled homepage.
-    ///
-    /// When there is enough space for the full news affordance peek, we use the affordance-height
-    /// header and the full affordance peek offset. If there is only enough space to show the
-    /// affordance itself, we still use the affordance-height header but only peek by the available
-    /// space. If there is less space than the affordance needs, we fall back to the section-title
-    /// header and remove the spacer peek entirely.
-    private func getStoriesHeaderLayoutState(
-        environment: NSCollectionLayoutEnvironment
-    ) -> StoriesHeaderLayoutState {
-        let rawSpacerHeight = getRawSpacerHeight(environment: environment)
-
-        let newsAffordanceHeaderHeight = HomepageDimensionCalculator
-            .fittingHeight(for: NewsTransitionHeaderCell(), width: environment.container.contentSize.width)
-        let fullPeekOffset = newsAffordanceHeaderHeight + UX.PocketConstants.getStoriesPeekOffset()
-
-        if rawSpacerHeight >= fullPeekOffset {
-            // Enough free space to show the full affordance header and the full peek offset.
-            return StoriesHeaderLayoutState(
-                headerHeightMode: .newsAffordance,
-                appliedPeekOffset: fullPeekOffset
-            )
-        }
-
-        if rawSpacerHeight >= newsAffordanceHeaderHeight {
-            // Enough space to show the affordance itself, but not enough for the full peek offset.
-            return StoriesHeaderLayoutState(
-                headerHeightMode: .newsAffordance,
-                appliedPeekOffset: rawSpacerHeight
-            )
-        }
-
-        // Not enough space for the affordance, so fall back to the section-title header with no peek.
-        return StoriesHeaderLayoutState(
-            headerHeightMode: .sectionTitle,
-            appliedPeekOffset: 0
-        )
-    }
-
+    /// Returns the height that the spacer should be, before accounting for vertical stories peeking above the fold.
+    /// Baseline stories: gets the height available for the spacer to take up to force the stories section to be
+    /// right above the fold
+    /// Vertical stories: gets the height of the distance between the bottom of the last non-stories section, and the bottom
+    /// of the viewport
     private func getRawSpacerHeight(environment: NSCollectionLayoutEnvironment) -> CGFloat {
         let homepageState = store.state.componentState(HomepageState.self, for: .homepage, window: windowUUID)
         let collectionViewHeight = environment.container.contentSize.height

--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoAction.swift
@@ -17,11 +17,13 @@ struct MerinoAction: Action {
     let merinoResponse: MerinoStoryResponse?
     let isEnabled: Bool?
     let telemetryConfig: OpenPocketTelemetryConfig?
+    let selectedCategoryID: String?
 
     init(
         merinoStoryResponse: MerinoStoryResponse? = nil,
         isEnabled: Bool? = nil,
         telemetryConfig: OpenPocketTelemetryConfig? = nil,
+        selectedCategoryID: String? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
@@ -30,6 +32,7 @@ struct MerinoAction: Action {
         self.merinoResponse = merinoStoryResponse
         self.isEnabled = isEnabled
         self.telemetryConfig = telemetryConfig
+        self.selectedCategoryID = selectedCategoryID
     }
 }
 
@@ -37,6 +40,7 @@ enum MerinoActionType: ActionType {
     case toggleShowSectionSetting
     case tapOnHomepageMerinoCell
     case viewedSection
+    case categorySelected
 }
 
 enum MerinoMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
@@ -14,6 +14,7 @@ struct MerinoState: StateType, Equatable {
     var windowUUID: WindowUUID
     let merinoData: MerinoStoryResponse
     let hasMerinoResponseContent: Bool
+    let selectedCategoryID: String? // nil = All stories
     let shouldShowSection: Bool
 
     struct Constants {
@@ -33,6 +34,7 @@ struct MerinoState: StateType, Equatable {
             windowUUID: windowUUID,
             merinoData: MerinoStoryResponse(),
             hasMerinoResponseContent: false,
+            selectedCategoryID: nil,
             shouldShowSection: shouldShowSection
         )
     }
@@ -41,11 +43,13 @@ struct MerinoState: StateType, Equatable {
         windowUUID: WindowUUID,
         merinoData: MerinoStoryResponse,
         hasMerinoResponseContent: Bool,
+        selectedCategoryID: String?,
         shouldShowSection: Bool
     ) {
         self.windowUUID = windowUUID
         self.merinoData = merinoData
         self.hasMerinoResponseContent = hasMerinoResponseContent
+        self.selectedCategoryID = selectedCategoryID
         self.shouldShowSection = shouldShowSection
     }
 
@@ -60,6 +64,8 @@ struct MerinoState: StateType, Equatable {
             return handleMerinoStoriesAction(action, state: state)
         case MerinoActionType.toggleShowSectionSetting:
             return handleSettingsToggleAction(action, state: state)
+        case MerinoActionType.categorySelected:
+            return handleCategorySelectedAction(action, state: state)
         default:
             return defaultState(from: state)
         }
@@ -72,18 +78,14 @@ struct MerinoState: StateType, Equatable {
             return defaultState(from: state)
         }
 
-        let merinoContentExists = if let stories = merinoResponse.stories {
-            !stories.isEmpty
-        } else if let categories = merinoResponse.categories {
-            !categories.isEmpty
-        } else {
-            false
-        }
+        let merinoContentExists = !(merinoResponse.stories?.isEmpty ?? true) ||
+                                  !(merinoResponse.categories?.isEmpty ?? true)
 
         return MerinoState(
             windowUUID: state.windowUUID,
             merinoData: merinoResponse,
             hasMerinoResponseContent: merinoContentExists,
+            selectedCategoryID: state.selectedCategoryID,
             shouldShowSection: merinoContentExists && state.shouldShowSection
         )
     }
@@ -100,6 +102,25 @@ struct MerinoState: StateType, Equatable {
         )
     }
 
+    private static func handleCategorySelectedAction(_ action: Action, state: MerinoState) -> MerinoState {
+        guard let merinoAction = action as? MerinoAction
+        else {
+            return defaultState(from: state)
+        }
+
+        /// `copyWithUpdates` uses a double-optional for optional fields:
+        /// - `.some(.some(value))` sets a concrete value
+        /// - `.some(nil)` leaves the existing value unchanged
+        /// - `nil` clears the property
+        /// We need to pass the outer optional explicitly here so tapping the client-side  "All" category can clear
+        /// `selectedCategoryID` back to `nil`.
+        return state.copyWithUpdates(
+            selectedCategoryID: merinoAction.selectedCategoryID == nil
+                ? (nil as String??)
+                : .some(merinoAction.selectedCategoryID)
+        )
+    }
+
     static func defaultState(from state: MerinoState) -> MerinoState {
         return state.copyWithUpdates()
     }
@@ -110,5 +131,24 @@ struct MerinoState: StateType, Equatable {
             a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.merino,
             style: .newsAffordance
         )
+    }
+}
+
+/// `@CopyWithUpdates` currently treats computed properties declared inside the struct as
+/// initializer/copy fields, which breaks generation with "extra arguments" errors.
+/// Keep derived accessors in this extension as a workaround.
+extension MerinoState {
+    var availableCategories: [MerinoCategoryConfiguration] {
+        (merinoData.categories ?? []).sorted { $0.rank < $1.rank }
+    }
+
+    var visibleStories: [MerinoStoryConfiguration] {
+        if !availableCategories.isEmpty {
+            if let selectedCategoryID {
+                return availableCategories.first(where: { $0.feedID == selectedCategoryID })?.recommendations ?? []
+            }
+            return availableCategories.flatMap(\.recommendations)
+        }
+        return merinoData.stories ?? []
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoStoryConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoStoryConfiguration.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// Converts the Merino story model to be presentable for the `MerinoStandardCell` view
+/// Converts the Merino story model to be presentable for the `StoryCellLarge` view
 final class MerinoStoryConfiguration: Sendable, Equatable, Hashable {
     private let story: MerinoStory
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoStoryResponse.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoStoryResponse.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// Converts the Merino story model to be presentable for the `MerinoStandardCell` view
+/// Converts the Merino story model to be presentable for the `StoryCellLarge` view
 final class MerinoStoryResponse: Sendable, Equatable, Hashable {
     let stories: [MerinoStoryConfiguration]?
     let categories: [MerinoCategoryConfiguration]?

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
@@ -17,6 +17,12 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
 
     private lazy var newsAffordanceContentView: NewsAffordanceHeaderView = .build()
     private lazy var sectionTitleHeaderView: LabelButtonHeaderView = .build()
+    private lazy var storyCategoryPickerView: StoryCategoryPickerView = .build()
+    private lazy var sectionTitleStackView: UIStackView = .build { stackView in
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+    }
 
     private var progress: CGFloat = 0
     private var transitionEnabled = true
@@ -46,11 +52,24 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
         verticalFittingPriority: UILayoutPriority
     ) -> CGSize {
-        let measuredView: UIView = transitionEnabled ? newsAffordanceContentView : sectionTitleHeaderView
-        return measuredView.systemLayoutSizeFitting(
+        let affordanceSize = newsAffordanceContentView.systemLayoutSizeFitting(
             targetSize,
             withHorizontalFittingPriority: horizontalFittingPriority,
             verticalFittingPriority: verticalFittingPriority
+        )
+        let headerSize = sectionTitleHeaderView.systemLayoutSizeFitting(
+            targetSize,
+            withHorizontalFittingPriority: horizontalFittingPriority,
+            verticalFittingPriority: verticalFittingPriority
+        )
+        let pickerSize = storyCategoryPickerView.systemLayoutSizeFitting(
+            targetSize,
+            withHorizontalFittingPriority: horizontalFittingPriority,
+            verticalFittingPriority: verticalFittingPriority
+        )
+        return CGSize(
+            width: affordanceSize.width,
+            height: max(affordanceSize.height, headerSize.height + pickerSize.height)
         )
     }
 
@@ -58,7 +77,10 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         sectionHeaderConfiguration: SectionHeaderConfiguration,
         textColor: UIColor?,
         theme: Theme,
-        transitionEnabled: Bool = true
+        transitionEnabled: Bool = true,
+        categories: [MerinoCategoryConfiguration] = [],
+        selectedCategoryID: String? = nil,
+        onSelection: (@MainActor @Sendable (String?) -> Void)? = nil
     ) {
         self.transitionEnabled = transitionEnabled
         newsAffordanceContentView.applyTheme(theme: theme)
@@ -69,6 +91,13 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
             theme: theme
         )
         sectionTitleHeaderView.moreButton.isHidden = true
+        storyCategoryPickerView.configure(
+            categories: categories,
+            selectedCategoryID: selectedCategoryID,
+            onSelection: onSelection
+        )
+        storyCategoryPickerView.applyTheme(theme: theme)
+
         updateViewState()
     }
 
@@ -86,35 +115,39 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
     func applyTheme(theme: Theme) {
         newsAffordanceContentView.applyTheme(theme: theme)
         sectionTitleHeaderView.applyTheme(theme: theme)
+        storyCategoryPickerView.applyTheme(theme: theme)
     }
 
     private func setupLayout() {
         clipsToBounds = true
 
+        sectionTitleStackView.addArrangedSubview(sectionTitleHeaderView)
+        sectionTitleStackView.addArrangedSubview(storyCategoryPickerView)
+
         addSubview(newsAffordanceContentView)
-        addSubview(sectionTitleHeaderView)
+        addSubview(sectionTitleStackView)
 
         NSLayoutConstraint.activate([
             newsAffordanceContentView.leadingAnchor.constraint(equalTo: leadingAnchor),
             newsAffordanceContentView.trailingAnchor.constraint(equalTo: trailingAnchor),
             newsAffordanceContentView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
-            sectionTitleHeaderView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            sectionTitleHeaderView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            sectionTitleHeaderView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            sectionTitleStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            sectionTitleStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            sectionTitleStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
     }
 
     private func updateViewState() {
         if transitionEnabled {
             newsAffordanceContentView.alpha = 1 - progress
-            sectionTitleHeaderView.alpha = progress
+            sectionTitleStackView.alpha = progress
             accessibilityLabel = progress < 0.5
                 ? newsAffordanceContentView.accessibilityLabel
                 : sectionTitleHeaderView.title
         } else {
             newsAffordanceContentView.alpha = 0
-            sectionTitleHeaderView.alpha = 1
+            sectionTitleStackView.alpha = 1
             accessibilityLabel = sectionTitleHeaderView.title
         }
     }

--- a/firefox-ios/Providers/Merino/MerinoProvider.swift
+++ b/firefox-ios/Providers/Merino/MerinoProvider.swift
@@ -56,7 +56,8 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
         else { throw Error.failure }
 
         if let cachedResponse = cache.loadResponse(),
-           cacheUpdateThresholdHasNotPassed() {
+           cacheUpdateThresholdHasNotPassed(),
+           cachedResponseMatchesCurrentHomepageStoriesMode(cachedResponse) {
             return cachedResponse
         }
 
@@ -122,5 +123,19 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
         let thresholdInSeconds: TimeInterval = thresholdInHours * 60 * 60
         guard let lastUpdate = cache.lastUpdatedDate() else { return false }
         return Date() < lastUpdate.addingTimeInterval(thresholdInSeconds)
+    }
+
+    /// Returns whether the cached response shape matches the current homepage stories mode.
+    /// When categories are enabled we require non-empty `feeds`, otherwise we require
+    /// non-empty top-level story `data`. If the shapes do not match, we bypass the cache
+    /// and fetch again so a mode switch is reflected immediately.
+    private func cachedResponseMatchesCurrentHomepageStoriesMode(_ response: CuratedRecommendationsResponse) -> Bool {
+        let categoriesEnabled = featureFlags.isFeatureEnabled(.homepageStoryCategories, checking: .buildOnly)
+
+        if categoriesEnabled {
+            return !(response.feeds?.isEmpty ?? true)
+        }
+
+        return !response.data.isEmpty
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
@@ -192,6 +192,86 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
     }
 
     @MainActor
+    func test_updateSnapshot_withCategorizedStoriesAndNoSelection_returnsFlattenedStories() throws {
+        let dataSource = try XCTUnwrap(diffableDataSource)
+
+        let state = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            MerinoAction(
+                merinoStoryResponse: MerinoStoryResponse(categories: createCategories()),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
+            )
+        )
+
+        dataSource.updateSnapshot(state: state, jumpBackInDisplayConfig: mockSectionConfig)
+
+        let snapshot = dataSource.snapshot()
+        let items = snapshot.itemIdentifiers(inSection: .pocket(nil))
+
+        XCTAssertEqual(items.count, 3)
+        XCTAssertEqual(merinoTitles(from: items), ["science 1", "science 2", "technology 1"])
+    }
+
+    @MainActor
+    func test_updateSnapshot_withCategorizedStoriesAndSelectedCategory_returnsSelectedCategoryStories() throws {
+        let dataSource = try XCTUnwrap(diffableDataSource)
+
+        let categorizedState = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            MerinoAction(
+                merinoStoryResponse: MerinoStoryResponse(categories: createCategories()),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
+            )
+        )
+        let selectedState = HomepageState.reducer(
+            categorizedState,
+            MerinoAction(
+                selectedCategoryID: "technology",
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoActionType.categorySelected
+            )
+        )
+
+        dataSource.updateSnapshot(state: selectedState, jumpBackInDisplayConfig: mockSectionConfig)
+
+        let snapshot = dataSource.snapshot()
+        let items = snapshot.itemIdentifiers(inSection: .pocket(nil))
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(merinoTitles(from: items), ["technology 1"])
+    }
+
+    @MainActor
+    func test_updateSnapshot_withCategorizedStoriesAndMissingSelectedCategory_omitsPocketSection() throws {
+        let dataSource = try XCTUnwrap(diffableDataSource)
+
+        let categorizedState = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            MerinoAction(
+                merinoStoryResponse: MerinoStoryResponse(categories: createCategories()),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
+            )
+        )
+        let selectedState = HomepageState.reducer(
+            categorizedState,
+            MerinoAction(
+                selectedCategoryID: "missing-category",
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoActionType.categorySelected
+            )
+        )
+
+        dataSource.updateSnapshot(state: selectedState, jumpBackInDisplayConfig: mockSectionConfig)
+
+        let snapshot = dataSource.snapshot()
+
+        XCTAssertFalse(snapshot.sectionIdentifiers.contains(.pocket(nil)))
+    }
+
+    @MainActor
     func test_updateSnapshot_withValidState_returnMessageCard() throws {
         let dataSource = try XCTUnwrap(diffableDataSource)
         let configuration = MessageCardConfiguration(
@@ -339,6 +419,44 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             MerinoStoryConfiguration(story: MerinoStory(from: $0))
         }
         return stories
+    }
+
+    private func createCategories() -> [MerinoCategoryConfiguration] {
+        [
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "technology",
+                    recommendations: [createStory(title: "technology 1")],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Technology",
+                    subtitle: nil,
+                    receivedFeedRank: 2
+                )
+            ),
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "science",
+                    recommendations: [createStory(title: "science 1"), createStory(title: "science 2")],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Science",
+                    subtitle: nil,
+                    receivedFeedRank: 1
+                )
+            ),
+        ]
+    }
+
+    private func createStory(title: String) -> MerinoStoryConfiguration {
+        return MerinoStoryConfiguration(story: MerinoStory(from: .makeItem(title)))
+    }
+
+    private func merinoTitles(from items: [HomepageItem]) -> [String] {
+        items.compactMap {
+            guard case .merino(let story) = $0 else { return nil }
+            return story.title
+        }
     }
 
     private var mockSectionConfig: JumpBackInSectionLayoutConfiguration {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
@@ -71,7 +71,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         homepageVC.newState(state: newState)
         let scrollView = UIScrollView()
 
-        XCTAssertNil(mockStatusBarScrollDelegate.savedScrollView)
+        mockStatusBarScrollDelegate.savedScrollView = nil
 
         homepageVC.scrollViewDidScroll(scrollView)
 
@@ -474,31 +474,6 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
             wallpaperView.constraints.first(where: { $0.firstAttribute == .height && $0.firstItem === wallpaperView })
         )
         XCTAssertEqual(wallpaperHeightConstraint.constant, 300)
-    }
-
-    func test_configureSupplementaryHeader_withNewsAffordanceStyle_usesNewsTransitionHeaderCell() async throws {
-        guard UIDevice.current.userInterfaceIdiom == .phone else {
-            throw XCTSkip("News affordance is phone-only.")
-        }
-        let subject = createSubject()
-        subject.loadViewIfNeeded()
-        let populatedState = await getPopulatedCollectionViewState(from: HomepageState(windowUUID: .XCTestDefaultUUID))
-        subject.newState(state: populatedState)
-        subject.view.layoutIfNeeded()
-
-        let collectionView = try getCollectionView(from: subject)
-        let pocketSectionIndex = try getPocketSectionIndex(from: collectionView)
-        let headerIndexPath = IndexPath(item: 0, section: pocketSectionIndex)
-
-        let header = try XCTUnwrap(
-            collectionView.dataSource?.collectionView?(
-                collectionView,
-                viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionHeader,
-                at: headerIndexPath
-            )
-        )
-
-        XCTAssertTrue(header is NewsTransitionHeaderCell)
     }
 
     private func createSubject(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/NewsTransitionHeaderCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/NewsTransitionHeaderCellTests.swift
@@ -23,7 +23,8 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
             sectionHeaderConfiguration: sectionHeaderConfiguration,
             textColor: nil,
             theme: theme,
-            transitionEnabled: true
+            transitionEnabled: true,
+            categories: []
         )
         view.setTransitionProgress(0)
         view.layoutIfNeeded()
@@ -39,7 +40,8 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
             sectionHeaderConfiguration: sectionHeaderConfiguration,
             textColor: nil,
             theme: theme,
-            transitionEnabled: true
+            transitionEnabled: true,
+            categories: []
         )
         view.setTransitionProgress(1)
         view.layoutIfNeeded()
@@ -55,7 +57,8 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
             sectionHeaderConfiguration: sectionHeaderConfiguration,
             textColor: nil,
             theme: theme,
-            transitionEnabled: false
+            transitionEnabled: false,
+            categories: []
         )
         view.setTransitionProgress(0)
         view.layoutIfNeeded()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/NewsTransitionHeaderCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/NewsTransitionHeaderCellTests.swift
@@ -30,7 +30,7 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
         view.layoutIfNeeded()
 
         XCTAssertEqual(affordanceView(in: view)?.alpha, 1)
-        XCTAssertEqual(labelHeaderView(in: view)?.alpha, 0)
+        XCTAssertEqual(sectionTitleStackView(in: view)?.alpha, 0)
     }
 
     func test_configure_withTransitionEnabledAndFullProgress_showsSectionTitle() {
@@ -47,7 +47,7 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
         view.layoutIfNeeded()
 
         XCTAssertEqual(affordanceView(in: view)?.alpha, 0)
-        XCTAssertEqual(labelHeaderView(in: view)?.alpha, 1)
+        XCTAssertEqual(sectionTitleStackView(in: view)?.alpha, 1)
     }
 
     func test_configure_withTransitionDisabled_showsSectionTitleOnly() {
@@ -64,7 +64,7 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
         view.layoutIfNeeded()
 
         XCTAssertEqual(affordanceView(in: view)?.alpha, 0)
-        XCTAssertEqual(labelHeaderView(in: view)?.alpha, 1)
+        XCTAssertEqual(sectionTitleStackView(in: view)?.alpha, 1)
     }
 
     private func createSubject() -> NewsTransitionHeaderCell {
@@ -79,6 +79,10 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
 
     private func labelHeaderView(in view: UIView) -> LabelButtonHeaderView? {
         return allSubviews(in: view).compactMap { $0 as? LabelButtonHeaderView }.first
+    }
+
+    private func sectionTitleStackView(in view: UIView) -> UIStackView? {
+        return allSubviews(in: view).compactMap { $0 as? UIStackView }.first
     }
 
     private func allSubviews(in view: UIView) -> [UIView] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
@@ -94,6 +94,136 @@ final class MerinoStateTests: XCTestCase {
         XCTAssertFalse(newState.shouldShowSection)
     }
 
+    @MainActor
+    func test_categorySelected_withSpecificCategory_updatesSelectedCategoryID() {
+        let initialState = createSubject()
+        let reducer = pocketReducer()
+
+        let newState = reducer(
+            initialState,
+            MerinoAction(
+                selectedCategoryID: "technology",
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoActionType.categorySelected
+            )
+        )
+
+        XCTAssertEqual(newState.selectedCategoryID, "technology")
+    }
+
+    @MainActor
+    func test_categorySelected_withNilCategory_clearsSelectedCategoryID() {
+        let initialState = pocketReducer()(
+            createSubject(),
+            MerinoAction(
+                selectedCategoryID: "technology",
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoActionType.categorySelected
+            )
+        )
+
+        let newState = pocketReducer()(
+            initialState,
+            MerinoAction(
+                selectedCategoryID: nil,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoActionType.categorySelected
+            )
+        )
+
+        XCTAssertNil(newState.selectedCategoryID)
+    }
+
+    @MainActor
+    func test_availableCategories_returnsCategoriesSortedByRank() {
+        let categories = [
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "technology",
+                    recommendations: [],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Technology",
+                    subtitle: nil,
+                    receivedFeedRank: 2
+                )
+            ),
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "science",
+                    recommendations: [],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Science",
+                    subtitle: nil,
+                    receivedFeedRank: 1
+                )
+            ),
+        ]
+        let state = pocketReducer()(
+            createSubject(),
+            MerinoAction(
+                merinoStoryResponse: MerinoStoryResponse(categories: categories),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
+            )
+        )
+
+        XCTAssertEqual(state.availableCategories.map(\.feedID), ["science", "technology"])
+    }
+
+    @MainActor
+    func test_visibleStories_withNoSelectedCategory_flattensAllCategoryRecommendations() {
+        let state = pocketReducer()(
+            createSubject(),
+            MerinoAction(
+                merinoStoryResponse: MerinoStoryResponse(categories: createTestCategories()),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
+            )
+        )
+
+        XCTAssertEqual(state.visibleStories.map(\.title), ["science1", "science2", "technology1"])
+    }
+
+    @MainActor
+    func test_visibleStories_withSelectedCategory_returnsOnlySelectedCategoryStories() {
+        let reducer = pocketReducer()
+        let categorizedState = reducer(
+            createSubject(),
+            MerinoAction(
+                merinoStoryResponse: MerinoStoryResponse(categories: createTestCategories()),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
+            )
+        )
+        let selectedState = reducer(
+            categorizedState,
+            MerinoAction(
+                selectedCategoryID: "technology",
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoActionType.categorySelected
+            )
+        )
+
+        XCTAssertEqual(selectedState.visibleStories.map(\.title), ["technology1"])
+    }
+
+    @MainActor
+    func test_handleMerinoStoriesAction_withCategories_setsHasMerinoResponseContentTrue() {
+        let state = pocketReducer()(
+            createSubject(),
+            MerinoAction(
+                merinoStoryResponse: MerinoStoryResponse(categories: createTestCategories()),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
+            )
+        )
+
+        XCTAssertTrue(state.hasMerinoResponseContent)
+        XCTAssertTrue(state.shouldShowSection)
+    }
+
     func test_initialState_returnsExpectedSectionHeaderConfiguration() {
         XCTAssertEqual(MerinoState.Constants.sectionHeaderConfiguration.style, .newsAffordance)
         XCTAssertEqual(MerinoState.Constants.sectionHeaderConfiguration.isButtonHidden, true)
@@ -106,5 +236,47 @@ final class MerinoStateTests: XCTestCase {
 
     private func pocketReducer() -> Reducer<MerinoState> {
         return MerinoState.reducer
+    }
+
+    private func createTestCategories() -> [MerinoCategoryConfiguration] {
+        [
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "technology",
+                    recommendations: [
+                        createStoryConfiguration(title: "technology1"),
+                    ],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Technology",
+                    subtitle: nil,
+                    receivedFeedRank: 2
+                )
+            ),
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "science",
+                    recommendations: [
+                        createStoryConfiguration(title: "science1"),
+                        createStoryConfiguration(title: "science2"),
+                    ],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Science",
+                    subtitle: nil,
+                    receivedFeedRank: 1
+                )
+            ),
+        ]
+    }
+
+    private func createStoryConfiguration(title: String) -> MerinoStoryConfiguration {
+        MerinoStoryConfiguration(story: MerinoStory(from: .makeItem(title)))
+    }
+
+    private func setupHomepageRedesignFeature(scrollDirection: ScrollDirection) {
+        FxNimbus.shared.features.homepageRedesignFeature.with { _, _ in
+            return HomepageRedesignFeature(storiesScrollDirection: scrollDirection)
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
@@ -273,10 +273,4 @@ final class MerinoStateTests: XCTestCase {
     private func createStoryConfiguration(title: String) -> MerinoStoryConfiguration {
         MerinoStoryConfiguration(story: MerinoStory(from: .makeItem(title)))
     }
-
-    private func setupHomepageRedesignFeature(scrollDirection: ScrollDirection) {
-        FxNimbus.shared.features.homepageRedesignFeature.with { _, _ in
-            return HomepageRedesignFeature(storiesScrollDirection: scrollDirection)
-        }
-    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Merino/MerinoProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Merino/MerinoProviderTests.swift
@@ -72,6 +72,14 @@ private final class MockCache: CuratedRecommendationsCacheProtocol {
 final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
     private let storiesFlag = PrefsKeys.UserFeatureFlagPrefs.ASPocketStories
 
+    override func setUp() {
+        super.setUp()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
+        FxNimbus.shared.features.homepageRedesignFeature.with { _, _ in
+            HomepageRedesignFeature(categoriesEnabled: false)
+        }
+    }
+
     func testIncorrectLocalesAreNotSupported() {
         XCTAssertFalse(MerinoProvider.isLocaleSupported("en_BD"))
         XCTAssertFalse(MerinoProvider.isLocaleSupported("enCA"))
@@ -193,6 +201,78 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
 
         XCTAssertEqual(result.data.map(\.title), ["cached"])
         XCTAssertEqual(control.fetcher.callCount, 0)
+    }
+
+    func test_fetchContent_fetchesFromNetwork_whenCategoriesEnabledAndCachedResponseHasNoFeeds() async throws {
+        FxNimbus.shared.features.homepageRedesignFeature.with { _, _ in
+            HomepageRedesignFeature(categoriesEnabled: true)
+        }
+
+        let control = await createSubject(thresholdHours: 1)
+        let cachedResponse = CuratedRecommendationsResponse.makeResponse(
+            items: [.makeItem("cached-story")],
+            feeds: nil
+        )
+        let networkFeeds = [FeedSection.makeSection(feedId: "technology", recommendations: [.makeItem("tech-story")])]
+        control.cache.seed(response: cachedResponse, lastUpdated: Date())
+        control.fetcher.stubbedResponse = CuratedRecommendationsResponse.makeResponse(
+            items: [.makeItem("network-story")],
+            feeds: networkFeeds
+        )
+
+        let result = try await control.subject.fetchContent()
+
+        XCTAssertEqual(control.fetcher.callCount, 1)
+        XCTAssertEqual(result.feeds?.first?.feedId, "technology")
+        XCTAssertTrue(control.cache.didClear)
+    }
+
+    func test_fetchContent_returnsCached_whenCategoriesEnabledAndCachedResponseHasFeeds() async throws {
+        FxNimbus.shared.features.homepageRedesignFeature.with { _, _ in
+            HomepageRedesignFeature(categoriesEnabled: true)
+        }
+
+        let control = await createSubject(thresholdHours: 1)
+        let cachedFeeds = [FeedSection.makeSection(feedId: "technology", recommendations: [.makeItem("tech-story")])]
+        let cachedResponse = CuratedRecommendationsResponse.makeResponse(
+            items: [.makeItem("cached-story")],
+            feeds: cachedFeeds
+        )
+        control.cache.seed(response: cachedResponse, lastUpdated: Date())
+        control.fetcher.stubbedResponse = CuratedRecommendationsResponse.makeResponse(
+            items: [.makeItem("network-story")],
+            feeds: [FeedSection.makeSection(feedId: "science", recommendations: [.makeItem("science-story")])]
+        )
+
+        let result = try await control.subject.fetchContent()
+
+        XCTAssertEqual(control.fetcher.callCount, 0)
+        XCTAssertEqual(result.feeds?.first?.feedId, "technology")
+        XCTAssertFalse(control.cache.didClear)
+    }
+
+    func test_fetchContent_fetchesFromNetwork_whenCategoriesDisabledAndCachedResponseHasNoStories() async throws {
+        FxNimbus.shared.features.homepageRedesignFeature.with { _, _ in
+            HomepageRedesignFeature(categoriesEnabled: false)
+        }
+
+        let control = await createSubject(thresholdHours: 1)
+        let cachedFeeds = [FeedSection.makeSection(feedId: "technology", recommendations: [.makeItem("tech-story")])]
+        let cachedResponse = CuratedRecommendationsResponse.makeResponse(
+            items: [],
+            feeds: cachedFeeds
+        )
+        control.cache.seed(response: cachedResponse, lastUpdated: Date())
+        control.fetcher.stubbedResponse = CuratedRecommendationsResponse.makeResponse(
+            items: [.makeItem("network-story")],
+            feeds: nil
+        )
+
+        let result = try await control.subject.fetchContent()
+
+        XCTAssertEqual(control.fetcher.callCount, 1)
+        XCTAssertEqual(result.data.map(\.title), ["network-story"])
+        XCTAssertTrue(control.cache.didClear)
     }
 
     func test_fetchContent_coalescesConcurrentRequests_whenCacheIsStale() async throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15408)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33029)

## :bulb: Description
- Newsfeed categories appear in the homepage newsfeed section when the newsfeed section header transitions to the expanded view
  - Newsfeed categories will not show alongside the blue news affordance header, only once the header transitions.
The category list always contains the “All” category in the first position
  - The “All” category shows a list of all items from each of the other categories, in order
  - The “All” category is always pre-selected on startup
- Tapping on a story category filters the list of displayed stories to only stories related to the selected category
- When switching the Homepage Story Categories feature flag’s state, we re-request the Merino API for updated content (such that we can show categories immediately once it’s enabled instead of waiting 1 hour for the cache to invalidate)
- Homepage section and item additions/removals are now animated
  - e.g. when stories category is changed, items are animated/transition

### Known Issues:
- [Switching to the "All" category appends stories above scroll offset](https://mozilla-hub.atlassian.net/browse/FXIOS-14756)
- [Newsfeed category picker is inaccessible from voiceover](https://mozilla-hub.atlassian.net/browse/FXIOS-15424)

## :movie_camera: Demos
<details>
<summary>Demo</summary>

https://github.com/user-attachments/assets/13fc6b3a-ef9c-441c-941c-2930f24cdd16

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

