### PR TITLE
Refactor FXIOS-15257 [Translations Phase 2] Split language edit mode into a dedicated screen

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
@@ -237,7 +237,7 @@ final class TranslationPickerSettingsViewController: UIViewController,
         }
 
         dataSource.reorderingHandlers.canReorderItem = { [weak self] item in
-            guard let self, state.isEditing else { return false }
+            guard let self, state.isTranslationsEnabled else { return false }
             if case .language = item { return true }
             return false
         }
@@ -249,11 +249,19 @@ final class TranslationPickerSettingsViewController: UIViewController,
                 if case .language(let details) = item { return details }
                 return nil
             }
-            store.dispatch(TranslationSettingsViewAction(
-                pendingLanguages: reorderedLanguages,
-                windowUUID: windowUUID,
-                actionType: TranslationSettingsViewActionType.reorderLanguages
-            ))
+            if state.isEditing {
+                store.dispatch(TranslationSettingsViewAction(
+                    pendingLanguages: reorderedLanguages,
+                    windowUUID: windowUUID,
+                    actionType: TranslationSettingsViewActionType.reorderLanguages
+                ))
+            } else {
+                store.dispatch(TranslationSettingsViewAction(
+                    languages: reorderedLanguages.map { $0.code },
+                    windowUUID: windowUUID,
+                    actionType: TranslationSettingsViewActionType.saveLanguages
+                ))
+            }
         }
 
         return dataSource
@@ -265,7 +273,7 @@ final class TranslationPickerSettingsViewController: UIViewController,
             guard let self, case let .language(details) = item else { return }
             cell.configure(with: details, theme: themeManager.getCurrentTheme(for: windowUUID))
             if details.isDeviceLanguage {
-                cell.accessories = [.reorder(displayed: .whenEditing)]
+                cell.accessories = [.reorder(displayed: .always)]
             } else {
                 let deleteActionHandler = { [weak self] in
                     guard let self else { return }
@@ -277,7 +285,7 @@ final class TranslationPickerSettingsViewController: UIViewController,
                 }
                 cell.accessories = [
                     .delete(displayed: .whenEditing, actionHandler: deleteActionHandler),
-                    .reorder(displayed: .whenEditing)
+                    .reorder(displayed: .always)
                 ]
                 cell.accessibilityCustomActions = [
                     UIAccessibilityCustomAction(
@@ -366,6 +374,18 @@ final class TranslationPickerSettingsViewController: UIViewController,
     }
 
     // MARK: - UICollectionViewDelegate
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        targetIndexPathForMoveFromItemAt originalIndexPath: IndexPath,
+        toProposedIndexPath proposedIndexPath: IndexPath
+    ) -> IndexPath {
+        guard proposedIndexPath.section == originalIndexPath.section,
+              dataSource.itemIdentifier(for: proposedIndexPath) != .addLanguage else {
+            return originalIndexPath
+        }
+        return proposedIndexPath
+    }
 
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         return dataSource.itemIdentifier(for: indexPath) == .addLanguage

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsDiffableDataSource.swift
@@ -88,16 +88,24 @@ final class TranslationSettingsDiffableDataSource:
         currentState = state
 
         var snapshot = NSDiffableDataSourceSnapshot<TranslationSettingsSection, TranslationSettingsItem>()
-        snapshot.appendSections([.enableToggle])
-        snapshot.appendItems([.enableToggle], toSection: .enableToggle)
 
-        if state.isTranslationsEnabled {
+        if state.isEditing {
             snapshot.appendSections([.preferredLanguages])
             let displayLanguages = state.pendingLanguages ?? state.preferredLanguages
             let langItems = displayLanguages.map { TranslationSettingsItem.language($0) }
-            snapshot.appendItems(langItems + [.addLanguage], toSection: .preferredLanguages)
-            snapshot.appendSections([.autoTranslate])
-            snapshot.appendItems([.autoTranslate], toSection: .autoTranslate)
+            snapshot.appendItems(langItems, toSection: .preferredLanguages)
+        } else {
+            snapshot.appendSections([.enableToggle])
+            snapshot.appendItems([.enableToggle], toSection: .enableToggle)
+
+            if state.isTranslationsEnabled {
+                snapshot.appendSections([.preferredLanguages])
+                let displayLanguages = state.pendingLanguages ?? state.preferredLanguages
+                let langItems = displayLanguages.map { TranslationSettingsItem.language($0) }
+                snapshot.appendItems(langItems + [.addLanguage], toSection: .preferredLanguages)
+                snapshot.appendSections([.autoTranslate])
+                snapshot.appendItems([.autoTranslate], toSection: .autoTranslate)
+            }
         }
 
         if let previousState {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15257)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32791)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Move language reordering and deletion out of the inline edit mode on the Translation Settings screen and into a new TranslationLanguageEditViewController pushed onto the navigation stack. Edit state is now fully local to the edit screen; Redux state is updated only when the user taps Done. Also adds an unsupported-device-language disabled row for devices whose language has no translation model available.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
<img  height="600" alt="IMG_0368" src="https://github.com/user-attachments/assets/e28e8bfc-58a5-4771-8284-ffea3fbe2201" />
<img  height="600" alt="IMG_0367" src="https://github.com/user-attachments/assets/ea1e9602-a9c8-49e9-b36c-16710253cd80" />
<img height="600" alt="IMG_0366" src="https://github.com/user-attachments/assets/5addc489-6e20-4ab3-b5a4-8154fc428766" />



<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


