### PR TITLE
Convert TabCounterTests to new framework

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 
 @MainActor
 final class TabTrayScreen {
@@ -189,6 +190,16 @@ final class TabTrayScreen {
         let closeTabButton = app.collectionViews.buttons["Close Tab"]
         BaseTestCase().mozWaitForElementToExist(closeTabButton)
         closeTabButton.waitAndTap()
+    }
+
+    func closeFirstTab() {
+        if BaseTestCase().iPad() {
+            app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
+        } else {
+            app.otherElements[AccessibilityIdentifiers.TabTray.tabsTray]
+                .collectionViews.cells.element(boundBy: 0)
+                .buttons[AccessibilityIdentifiers.TabTray.closeButton].waitAndTap()
+        }
     }
 
     func assertNoWebViewLeakDetected(timeout: TimeInterval = TIMEOUT) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
@@ -2,56 +2,49 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Common
 import XCTest
 
 class TabCounterTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2359077
     func testTabIncrement() {
+        let toolbar = ToolbarScreen(app: app)
+
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
 
-        var tabsOpen = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value
-        XCTAssertEqual("1", tabsOpen as? String)
+        toolbar.assertTabsButtonValue(expectedCount: "1")
 
         navigator.createNewTab()
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
 
-        tabsOpen = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value
-        XCTAssertEqual("2", tabsOpen as? String)
+        toolbar.assertTabsButtonValue(expectedCount: "2")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2359078
     func testTabDecrement() {
+        let toolbar = ToolbarScreen(app: app)
+        let tabTray = TabTrayScreen(app: app)
+
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
 
-        var tabsOpen = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value
-        XCTAssertEqual("1", tabsOpen as? String)
+        toolbar.assertTabsButtonValue(expectedCount: "1")
 
         navigator.createNewTab()
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
 
-        tabsOpen = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value
-        XCTAssertEqual("2", tabsOpen as? String)
+        toolbar.assertTabsButtonValue(expectedCount: "2")
 
         navigator.goto(TabTray)
-        if iPad() {
-            app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
-        } else {
-            app.otherElements[tabsTray]
-                .collectionViews.cells.element(boundBy: 0)
-                .buttons[AccessibilityIdentifiers.TabTray.closeButton].waitAndTap()
-        }
+        tabTray.closeFirstTab()
 
         app.otherElements[tabsTray].cells.element(boundBy: 0).waitAndTap()
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
 
-        tabsOpen = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value
-        XCTAssertEqual("1", tabsOpen as? String)
+        toolbar.assertTabsButtonValue(expectedCount: "1")
 
         navigator.goto(TabTray)
         XCTAssertEqual(app.cells.count, 1, "There should be only one tab in the tab tray")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
@@ -4,7 +4,7 @@
 
 import XCTest
 
-class TabCounterTests: FeatureFlaggedTestBase {
+class TabCounterTests: BaseTestCase {
     private var toolbarScreen: ToolbarScreen!
     private var tabTrayScreen: TabTrayScreen!
 
@@ -16,7 +16,6 @@ class TabCounterTests: FeatureFlaggedTestBase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2359077
     func testTabIncrement() {
-        app.launch()
         toolbarScreen.assertTabsButtonExists()
         toolbarScreen.assertTabsButtonValue(expectedCount: "1")
 
@@ -27,7 +26,6 @@ class TabCounterTests: FeatureFlaggedTestBase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2359078
     func testTabDecrement() {
-        app.launch()
         toolbarScreen.assertTabsButtonExists()
         toolbarScreen.assertTabsButtonValue(expectedCount: "1")
 
@@ -38,11 +36,6 @@ class TabCounterTests: FeatureFlaggedTestBase {
         toolbarScreen.tapOnTabsButton()
         tabTrayScreen.closeFirstTab()
 
-        tabTrayScreen.tapTabAtIndex(index: 0)
-        toolbarScreen.assertTabsButtonExists()
-        toolbarScreen.assertTabsButtonValue(expectedCount: "1")
-
-        toolbarScreen.tapOnTabsButton()
         tabTrayScreen.assertTabCount(1)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
@@ -4,49 +4,45 @@
 
 import XCTest
 
-class TabCounterTests: BaseTestCase {
+class TabCounterTests: FeatureFlaggedTestBase {
+    private var toolbarScreen: ToolbarScreen!
+    private var tabTrayScreen: TabTrayScreen!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        toolbarScreen = ToolbarScreen(app: app)
+        tabTrayScreen = TabTrayScreen(app: app)
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2359077
     func testTabIncrement() {
-        let toolbar = ToolbarScreen(app: app)
+        app.launch()
+        toolbarScreen.assertTabsButtonExists()
+        toolbarScreen.assertTabsButtonValue(expectedCount: "1")
 
-        navigator.nowAt(NewTabScreen)
-        waitForTabsButton()
-
-        toolbar.assertTabsButtonValue(expectedCount: "1")
-
-        navigator.createNewTab()
-        navigator.nowAt(NewTabScreen)
-        waitForTabsButton()
-
-        toolbar.assertTabsButtonValue(expectedCount: "2")
+        toolbarScreen.openNewTabFromTabTray()
+        toolbarScreen.assertTabsButtonExists()
+        toolbarScreen.assertTabsButtonValue(expectedCount: "2")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2359078
     func testTabDecrement() {
-        let toolbar = ToolbarScreen(app: app)
-        let tabTray = TabTrayScreen(app: app)
+        app.launch()
+        toolbarScreen.assertTabsButtonExists()
+        toolbarScreen.assertTabsButtonValue(expectedCount: "1")
 
-        navigator.nowAt(NewTabScreen)
-        waitForTabsButton()
+        toolbarScreen.openNewTabFromTabTray()
+        toolbarScreen.assertTabsButtonExists()
+        toolbarScreen.assertTabsButtonValue(expectedCount: "2")
 
-        toolbar.assertTabsButtonValue(expectedCount: "1")
+        toolbarScreen.tapOnTabsButton()
+        tabTrayScreen.closeFirstTab()
 
-        navigator.createNewTab()
-        navigator.nowAt(NewTabScreen)
-        waitForTabsButton()
+        tabTrayScreen.tapTabAtIndex(index: 0)
+        toolbarScreen.assertTabsButtonExists()
+        toolbarScreen.assertTabsButtonValue(expectedCount: "1")
 
-        toolbar.assertTabsButtonValue(expectedCount: "2")
-
-        navigator.goto(TabTray)
-        tabTray.closeFirstTab()
-
-        app.otherElements[tabsTray].cells.element(boundBy: 0).waitAndTap()
-        navigator.nowAt(NewTabScreen)
-        waitForTabsButton()
-
-        toolbar.assertTabsButtonValue(expectedCount: "1")
-
-        navigator.goto(TabTray)
-        XCTAssertEqual(app.cells.count, 1, "There should be only one tab in the tab tray")
+        toolbarScreen.tapOnTabsButton()
+        tabTrayScreen.assertTabCount(1)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15427)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33095)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Migrated TabCounterTests to the new TAE framework:

- Replaced inline app.buttons tab-counter checks with ToolbarScreen.assertTabsButtonValue().
- Extracted raw iPhone/iPad tab-closing interactions into a new closeFirstTab() method in TabTrayScreen.swift.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

