### PR TITLE
Remove FXIOS-14751 [iPad Tab Tray Design] toast from Tab Tray

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -91,7 +91,6 @@ enum TabPanelMiddlewareActionType: ActionType {
     case willAppearTabPanel
     case didChangeTabPanel
     case refreshTabs
-    case showToast
     case scrollToTab
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -517,8 +517,6 @@ final class TabManagerMiddleware: FeatureFlaggable,
         guard let tabsState = state.componentState(TabsPanelState.self, for: .tabsPanel, window: uuid) else { return }
 
         tabsPanelTelemetry.closeAllTabsSheetOptionSelected(option: .all, mode: tabsState.isPrivateMode ? .private : .normal)
-        let normalCount = tabManager.normalTabs.count
-        let privateCount = tabManager.privateTabs.count
         tabManager.removeAllTabs(isPrivateMode: tabsState.isPrivateMode)
 
         triggerRefresh(uuid: uuid, isPrivate: tabsState.isPrivateMode)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -449,30 +449,12 @@ final class TabManagerMiddleware: FeatureFlaggable,
                                                    windowUUID: uuid,
                                                    actionType: TabPanelViewActionType.tabPanelDidLoad)
             store.dispatch(didLoadAction)
-
-            if !isTabTrayUIExperimentsEnabled {
-                let toastAction = TabPanelMiddlewareAction(toastType: .closedSingleTab,
-                                                           windowUUID: uuid,
-                                                           actionType: TabPanelMiddlewareActionType.showToast)
-                store.dispatch(toastAction)
-            }
         } else if shouldDismiss {
             let dismissAction = TabTrayAction(windowUUID: uuid,
                                               actionType: TabTrayActionType.dismissTabTray)
             store.dispatch(dismissAction)
 
-            if !isTabTrayUIExperimentsEnabled {
-                let toastAction = GeneralBrowserAction(toastType: .closedSingleTab,
-                                                       windowUUID: uuid,
-                                                       actionType: GeneralBrowserActionType.showToast)
-                store.dispatch(toastAction)
-            }
             addNewTabIfPrivate(uuid: uuid)
-        } else if !isTabTrayUIExperimentsEnabled {
-            let toastAction = TabPanelMiddlewareAction(toastType: .closedSingleTab,
-                                                       windowUUID: uuid,
-                                                       actionType: TabPanelMiddlewareActionType.showToast)
-            store.dispatch(toastAction)
         }
     }
 
@@ -487,15 +469,6 @@ final class TabManagerMiddleware: FeatureFlaggable,
         QuickActionsImplementation().addDynamicApplicationShortcutItemOfType(.openLastBookmark,
                                                                              withUserData: userData,
                                                                              toApplication: .shared)
-
-        if !isTabTrayUIExperimentsEnabled {
-            // The Tab Tray uses a "PlainToast", so the urlString will go unused
-            let toastAction = TabPanelMiddlewareAction(toastType: .addBookmark(urlString: shareItem.url),
-                                                       windowUUID: uuid,
-                                                       actionType: TabPanelMiddlewareActionType.showToast)
-            store.dispatch(toastAction)
-        }
-
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .add,
                                      object: .bookmark,
@@ -550,18 +523,7 @@ final class TabManagerMiddleware: FeatureFlaggable,
 
         triggerRefresh(uuid: uuid, isPrivate: tabsState.isPrivateMode)
 
-        if tabsState.isPrivateMode && !isTabTrayUIExperimentsEnabled {
-            let action = TabPanelMiddlewareAction(toastType: .closedAllTabs(count: privateCount),
-                                                  windowUUID: uuid,
-                                                  actionType: TabPanelMiddlewareActionType.showToast)
-            store.dispatch(action)
-        } else {
-            if !isTabTrayUIExperimentsEnabled {
-                let toastAction = GeneralBrowserAction(toastType: .closedAllTabs(count: normalCount),
-                                                       windowUUID: uuid,
-                                                       actionType: GeneralBrowserActionType.showToast)
-                store.dispatch(toastAction)
-            }
+        if !tabsState.isPrivateMode {
             addNewTabIfPrivate(uuid: uuid)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -190,17 +190,6 @@ struct TabTrayState: ScreenState, Equatable {
                                 hasSyncableAccount: state.hasSyncableAccount,
                                 enableDeleteTabsButton: tabDisplayModel.enableDeleteTabsButton)
 
-        case TabPanelMiddlewareActionType.showToast:
-            guard let type = action.toastType else { return defaultState(from: state) }
-
-            return TabTrayState(windowUUID: state.windowUUID,
-                                isPrivateMode: state.isPrivateMode,
-                                selectedPanel: state.selectedPanel,
-                                normalTabsCount: state.normalTabsCount,
-                                privateTabsCount: state.privateTabsCount,
-                                hasSyncableAccount: state.hasSyncableAccount,
-                                toastType: type)
-
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Redux/TabTrayStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Redux/TabTrayStateTests.swift
@@ -270,21 +270,6 @@ final class TabTrayStateTests: XCTestCase {
         XCTAssertEqual(newState.privateTabsCount, "3")
     }
 
-    @MainActor
-    func test_reduceTabPanelMiddleware_ShowToastAction() {
-        let initialState = createSubject()
-        let reducer = tabTrayReducer()
-
-        XCTAssertNil(initialState.toastType)
-
-        let action = TabPanelMiddlewareAction(toastType: .closedSingleTab,
-                                              windowUUID: .XCTestDefaultUUID,
-                                              actionType: TabPanelMiddlewareActionType.showToast)
-        let newState = reducer(initialState, action)
-
-        XCTAssertEqual(newState.toastType, .closedSingleTab)
-    }
-
     // MARK: - TabPanelViewAction Tests
 
     @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14751)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31856)

## :bulb: Description
- Remove toast on Tab Tray for iPad to match iPhone behaviour, this toast were already behind a feature flag. This is the first step before removing undo close tabs flaky code 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

