### PR TITLE
Add FXIOS-15189 [FeatureFlags] Add UserPreferencesManager

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -469,6 +469,7 @@
 		391B4FFF1F9767F50094F841 /* FxScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */; };
 		39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */; };
 		392D791A2F8FCE1A00B10BDC /* FeatureFlagID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392D79192F8FCE0E00B10BDC /* FeatureFlagID.swift */; };
+		392D80542F901D2600B10BDC /* UserFeaturePreferenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392D80532F901D1500B10BDC /* UserFeaturePreferenceManager.swift */; };
 		392ED7E41D0AEF56009D9B62 /* NewTabAccessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392ED7E31D0AEF56009D9B62 /* NewTabAccessors.swift */; };
 		392ED7E61D0AEFEF009D9B62 /* HomePageAccessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392ED7E51D0AEFEF009D9B62 /* HomePageAccessors.swift */; };
 		3933D4F42EF3358300C0C4E3 /* DefaultBrowserUtilityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3933D4F32EF3357D00C0C4E3 /* DefaultBrowserUtilityTelemetry.swift */; };
@@ -483,6 +484,7 @@
 		396E38F21EE0C8ED00CC180F /* FxAPushMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3905B4D41E8E7A6B0027D953 /* FxAPushMessageHandler.swift */; };
 		397848DE1ED86605004C0C0B /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397848DD1ED86605004C0C0B /* NotificationService.swift */; };
 		397848E21ED86605004C0C0B /* NotificationService.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 397848DB1ED86605004C0C0B /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		399BA8002F901D9200CCC502 /* UserFeaturePreferenceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399BA7FF2F901D8600CCC502 /* UserFeaturePreferenceManagerTests.swift */; };
 		39A359E41BFCCE94006B9E87 /* UserActivityHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A359E31BFCCE94006B9E87 /* UserActivityHandler.swift */; };
 		39A35AED1C0662A3006B9E87 /* SpotlightHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */; };
 		39AF317429DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AF317329DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift */; };
@@ -3398,6 +3400,7 @@
 		39104C4F9A5CFDE66911D82B /* hy-AM */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hy-AM"; path = "hy-AM.lproj/Search.strings"; sourceTree = "<group>"; };
 		39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabEventHandlerTests.swift; sourceTree = "<group>"; };
 		392D79192F8FCE0E00B10BDC /* FeatureFlagID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagID.swift; sourceTree = "<group>"; };
+		392D80532F901D1500B10BDC /* UserFeaturePreferenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeaturePreferenceManager.swift; sourceTree = "<group>"; };
 		392ED7E31D0AEF56009D9B62 /* NewTabAccessors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NewTabAccessors.swift; path = Accessors/NewTabAccessors.swift; sourceTree = "<group>"; };
 		392ED7E51D0AEFEF009D9B62 /* HomePageAccessors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HomePageAccessors.swift; path = Accessors/HomePageAccessors.swift; sourceTree = "<group>"; };
 		3933D4F32EF3357D00C0C4E3 /* DefaultBrowserUtilityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserUtilityTelemetry.swift; sourceTree = "<group>"; };
@@ -3412,6 +3415,7 @@
 		397848DB1ED86605004C0C0B /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		397848DD1ED86605004C0C0B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		397848DF1ED86605004C0C0B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		399BA7FF2F901D8600CCC502 /* UserFeaturePreferenceManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeaturePreferenceManagerTests.swift; sourceTree = "<group>"; };
 		39A359E31BFCCE94006B9E87 /* UserActivityHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserActivityHandler.swift; path = Helpers/UserActivityHandler.swift; sourceTree = "<group>"; };
 		39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = SpotlightHelper.js; sourceTree = "<group>"; };
 		39AD454C88A908D41BA13329 /* te */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = te; path = te.lproj/Today.strings; sourceTree = "<group>"; };
@@ -14943,6 +14947,7 @@
 			children = (
 				C2D47B07BE70DD7C23C13187 /* CoreBuildFlags.swift */,
 				C82A94E4269CB77500624AA7 /* CoreFlaggableFeature.swift */,
+				392D80532F901D1500B10BDC /* UserFeaturePreferenceManager.swift */,
 				C8656D74270F834600E199EA /* FlaggableFeatureOptions.swift */,
 				C82A94E6269CB77F00624AA7 /* LegacyFeatureFlagsManager.swift */,
 				C8B07A4028199500000AFCE7 /* NimbusFlaggableFeature.swift */,
@@ -16561,6 +16566,7 @@
 				1D7B789E2AE088930011E9F2 /* EventQueueTests.swift */,
 				8A96C4B728F9DD0600B75884 /* Extensions */,
 				C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */,
+				399BA7FF2F901D8600CCC502 /* UserFeaturePreferenceManagerTests.swift */,
 				A1B2C3D4E5F6789012345678 /* NimbusFeatureFlagsTests.swift */,
 				D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */,
 				C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */,
@@ -19121,6 +19127,7 @@
 				8A5D1CB22A30D756005AD35C /* SiriPageSetting.swift in Sources */,
 				39A359E41BFCCE94006B9E87 /* UserActivityHandler.swift in Sources */,
 				4331A9BD271D267E005E8080 /* ContextualHintViewProvider.swift in Sources */,
+				392D80542F901D2600B10BDC /* UserFeaturePreferenceManager.swift in Sources */,
 				8A093D7F2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift in Sources */,
 				0B0ED7292D5B46B6001515CB /* TemporaryDocumentLoadingView.swift in Sources */,
 				D88FDAAF1F4E2BA000FD9709 /* PhotonActionSheetAnimator.swift in Sources */,
@@ -19968,6 +19975,7 @@
 				C2B808B12A77FA3F00A65487 /* DownloadsCoordinatorTests.swift in Sources */,
 				C2DFB1452ECE62EE004E20AB /* MockTranslationsService.swift in Sources */,
 				354F8FAB2E0985B9007DFFEB /* SearchBarStateTests.swift in Sources */,
+				399BA8002F901D9200CCC502 /* UserFeaturePreferenceManagerTests.swift in Sources */,
 				5A475E9129DB8AA7009C13FD /* MockDiskImageStore.swift in Sources */,
 				AAD9D64B2EB25B3500BFECAF /* TranslationsMiddlewareTests.swift in Sources */,
 				C2506C952A6A8D2600F2B76E /* HistoryCoordinatorTests.swift in Sources */,

--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -54,6 +54,9 @@ class DependencyHelper {
         let featureFlagsProvider = FeatureFlagsProvider(prefs: profile.prefs)
         AppContainer.shared.register(service: featureFlagsProvider as FeatureFlagProviding)
 
+        let userFeaturePreferenceManager = UserFeaturePreferenceManager(prefs: profile.prefs)
+        AppContainer.shared.register(service: userFeaturePreferenceManager as UserFeaturePreferring)
+
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }

--- a/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
+++ b/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
@@ -1,0 +1,146 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Shared
+
+/// Protocol for reading/writing user feature preferences.
+/// Each property reads from Prefs, falling back to the Nimbus default.
+protocol UserFeaturePreferring: Sendable {
+    // Bool preferences (read)
+    var isAIKillSwitchEnabled: Bool { get }
+    var isFirefoxSuggestEnabled: Bool { get }
+    var isSentFromFirefoxEnabled: Bool { get }
+    var isSponsoredShortcutsEnabled: Bool { get }
+    var isHomepageBookmarksSectionEnabled: Bool { get }
+    var isHomepageJumpBackInSectionEnabled: Bool { get }
+
+    // Typed preferences (read)
+    var searchBarPosition: SearchBarPosition { get }
+    var startAtHomeSetting: StartAtHome { get }
+
+    // Setters
+    func setAIKillSwitchEnabled(_ enabled: Bool)
+    func setFirefoxSuggestEnabled(_ enabled: Bool)
+    func setSentFromFirefoxEnabled(_ enabled: Bool)
+    func setSponsoredShortcutsEnabled(_ enabled: Bool)
+    func setHomepageBookmarksSectionEnabled(_ enabled: Bool)
+    func setHomepageJumpBackInSectionEnabled(_ enabled: Bool)
+    func setSearchBarPosition(_ position: SearchBarPosition)
+    func setStartAtHomeSetting(_ setting: StartAtHome)
+}
+
+final class UserFeaturePreferenceManager: UserFeaturePreferring, @unchecked Sendable {
+    private let prefs: Prefs
+    private let nimbusLayer: NimbusFeatureFlagLayer
+    private let nimbusSearchBar: NimbusSearchBarLayer
+
+    init(
+        prefs: Prefs,
+        nimbusLayer: NimbusFeatureFlagLayer = NimbusManager.shared.featureFlagLayer,
+        nimbusSearchBar: NimbusSearchBarLayer = NimbusManager.shared.bottomSearchBarLayer
+    ) {
+        self.prefs = prefs
+        self.nimbusLayer = nimbusLayer
+        self.nimbusSearchBar = nimbusSearchBar
+    }
+
+    // MARK: - Bool preferences
+
+    var isAIKillSwitchEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.Settings.aiKillSwitchFeature)
+        ?? nimbusLayer.checkNimbusConfigFor(.aiKillSwitch)
+    }
+
+    var isFirefoxSuggestEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.FeatureFlags.FirefoxSuggest)
+        ?? nimbusLayer.checkNimbusConfigFor(.firefoxSuggestFeature)
+    }
+
+    var isSentFromFirefoxEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.FeatureFlags.SentFromFirefox)
+        ?? nimbusLayer.checkNimbusConfigFor(.sentFromFirefox)
+    }
+
+    var isSponsoredShortcutsEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.FeatureFlags.SponsoredShortcuts)
+        ?? nimbusLayer.checkNimbusConfigFor(.hntSponsoredShortcuts)
+    }
+
+    var isHomepageBookmarksSectionEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection)
+        ?? nimbusLayer.checkNimbusConfigFor(.homepageBookmarksSectionDefault)
+    }
+
+    var isHomepageJumpBackInSectionEnabled: Bool {
+        prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection)
+        ?? nimbusLayer.checkNimbusConfigFor(.homepageJumpBackinSectionDefault)
+    }
+
+    // MARK: - Typed preferences
+
+    var searchBarPosition: SearchBarPosition {
+        if let raw = prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition),
+           let position = SearchBarPosition(rawValue: raw) {
+            return position
+        }
+        return nimbusSearchBar.getDefaultPosition()
+    }
+
+    var startAtHomeSetting: StartAtHome {
+        if let raw = prefs.stringForKey(PrefsKeys.FeatureFlags.StartAtHome),
+           let setting = StartAtHome(rawValue: raw) {
+            return setting
+        }
+        return FxNimbus.shared.features.startAtHomeFeature.value().setting
+    }
+
+    // MARK: - Setters
+
+    func setAIKillSwitchEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.Settings.aiKillSwitchFeature)
+    }
+
+    func setFirefoxSuggestEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.FeatureFlags.FirefoxSuggest)
+    }
+
+    func setSentFromFirefoxEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.FeatureFlags.SentFromFirefox)
+    }
+
+    func setSponsoredShortcutsEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.FeatureFlags.SponsoredShortcuts)
+    }
+
+    func setHomepageBookmarksSectionEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.HomepageSettings.BookmarksSection)
+    }
+
+    func setHomepageJumpBackInSectionEnabled(_ enabled: Bool) {
+        prefs.setBool(enabled, forKey: PrefsKeys.HomepageSettings.JumpBackInSection)
+    }
+
+    func setSearchBarPosition(_ position: SearchBarPosition) {
+        prefs.setString(position.rawValue, forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+    }
+
+    func setStartAtHomeSetting(_ setting: StartAtHome) {
+        prefs.setString(setting.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
+    }
+}
+
+// MARK: - DI Access Protocol
+
+/// Adopt this protocol to access user feature preferences via AppContainer.
+/// Replaces FeatureFlaggable for user preference checks.
+protocol HasUserFeaturePreferences {
+    var userPreferences: UserFeaturePreferring { get }
+}
+
+extension HasUserFeaturePreferences {
+    var userPreferences: UserFeaturePreferring {
+        AppContainer.shared.resolve()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -71,6 +71,9 @@ final class DependencyHelperMock {
         let nimbusFeatureFlags = FeatureFlagsProvider(prefs: profile.prefs)
         AppContainer.shared.register(service: nimbusFeatureFlags as FeatureFlagProviding)
 
+        let userFeaturePreferenceManager = UserFeaturePreferenceManager(prefs: profile.prefs)
+        AppContainer.shared.register(service: userFeaturePreferenceManager as UserFeaturePreferring)
+
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/UserFeaturePreferenceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/UserFeaturePreferenceManagerTests.swift
@@ -1,0 +1,225 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+import XCTest
+
+@testable import Client
+
+final class UserFeaturePreferenceManagerTests: XCTestCase {
+    private var prefs: MockProfilePrefs!
+    private var subject: UserFeaturePreferenceManager!
+
+    override func setUp() {
+        super.setUp()
+        prefs = MockProfilePrefs()
+        subject = UserFeaturePreferenceManager(prefs: prefs)
+    }
+
+    override func tearDown() {
+        prefs = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    // MARK: - Bool preferences: defaults from Nimbus
+
+    func testBoolDefaults_returnNimbusValues_whenNoUserPrefSet() {
+        // With no prefs set, each property should return the Nimbus default.
+        // We just verify they return without crashing — the actual Nimbus defaults
+        // may vary by config, so we check the type is correct.
+        _ = subject.isAIKillSwitchEnabled
+        _ = subject.isFirefoxSuggestEnabled
+        _ = subject.isSentFromFirefoxEnabled
+        _ = subject.isSponsoredShortcutsEnabled
+        _ = subject.isHomepageBookmarksSectionEnabled
+        _ = subject.isHomepageJumpBackInSectionEnabled
+    }
+
+    // MARK: - Bool preferences: user overrides
+
+    func testFirefoxSuggest_readsUserPref() {
+        prefs.setBool(false, forKey: PrefsKeys.FeatureFlags.FirefoxSuggest)
+        XCTAssertFalse(subject.isFirefoxSuggestEnabled)
+
+        prefs.setBool(true, forKey: PrefsKeys.FeatureFlags.FirefoxSuggest)
+        XCTAssertTrue(subject.isFirefoxSuggestEnabled)
+    }
+
+    func testSentFromFirefox_readsUserPref() {
+        prefs.setBool(true, forKey: PrefsKeys.FeatureFlags.SentFromFirefox)
+        XCTAssertTrue(subject.isSentFromFirefoxEnabled)
+    }
+
+    func testSponsoredShortcuts_readsUserPref() {
+        prefs.setBool(false, forKey: PrefsKeys.FeatureFlags.SponsoredShortcuts)
+        XCTAssertFalse(subject.isSponsoredShortcutsEnabled)
+    }
+
+    func testHomepageBookmarksSection_readsUserPref() {
+        prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.BookmarksSection)
+        XCTAssertFalse(subject.isHomepageBookmarksSectionEnabled)
+    }
+
+    func testHomepageJumpBackInSection_readsUserPref() {
+        prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.JumpBackInSection)
+        XCTAssertFalse(subject.isHomepageJumpBackInSectionEnabled)
+    }
+
+    func testAIKillSwitch_readsUserPref() {
+        prefs.setBool(true, forKey: PrefsKeys.Settings.aiKillSwitchFeature)
+        XCTAssertTrue(subject.isAIKillSwitchEnabled)
+
+        prefs.setBool(false, forKey: PrefsKeys.Settings.aiKillSwitchFeature)
+        XCTAssertFalse(subject.isAIKillSwitchEnabled)
+    }
+
+    // MARK: - Typed preferences
+
+    func testSearchBarPosition_defaultsToNimbus() {
+        let position = subject.searchBarPosition
+        // Default from NimbusSearchBarLayer — just verify it's a valid value
+        XCTAssertTrue(position == .top || position == .bottom)
+    }
+
+    func testSearchBarPosition_readsUserPref() {
+        prefs.setString(SearchBarPosition.bottom.rawValue,
+                        forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        XCTAssertEqual(subject.searchBarPosition, .bottom)
+
+        prefs.setString(SearchBarPosition.top.rawValue,
+                        forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        XCTAssertEqual(subject.searchBarPosition, .top)
+    }
+
+    func testStartAtHomeSetting_defaultsToNimbus() {
+        let setting = subject.startAtHomeSetting
+        // Verify it's a valid StartAtHome value
+        XCTAssertTrue([.afterFourHours, .always, .disabled].contains(setting))
+    }
+
+    func testStartAtHomeSetting_readsUserPref() {
+        prefs.setString(StartAtHome.always.rawValue,
+                        forKey: PrefsKeys.FeatureFlags.StartAtHome)
+        XCTAssertEqual(subject.startAtHomeSetting, .always)
+
+        prefs.setString(StartAtHome.disabled.rawValue,
+                        forKey: PrefsKeys.FeatureFlags.StartAtHome)
+        XCTAssertEqual(subject.startAtHomeSetting, .disabled)
+    }
+
+    // MARK: - Setters
+
+    func testSetFirefoxSuggestEnabled_writesPref() {
+        subject.setFirefoxSuggestEnabled(true)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.FirefoxSuggest), true)
+
+        subject.setFirefoxSuggestEnabled(false)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.FirefoxSuggest), false)
+    }
+
+    func testSetSentFromFirefoxEnabled_writesPref() {
+        subject.setSentFromFirefoxEnabled(true)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.SentFromFirefox), true)
+    }
+
+    func testSetSponsoredShortcutsEnabled_writesPref() {
+        subject.setSponsoredShortcutsEnabled(false)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.SponsoredShortcuts), false)
+    }
+
+    func testSetHomepageBookmarksSectionEnabled_writesPref() {
+        subject.setHomepageBookmarksSectionEnabled(true)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection), true)
+    }
+
+    func testSetHomepageJumpBackInSectionEnabled_writesPref() {
+        subject.setHomepageJumpBackInSectionEnabled(false)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection), false)
+    }
+
+    func testSetAIKillSwitchEnabled_writesPref() {
+        subject.setAIKillSwitchEnabled(true)
+        XCTAssertEqual(prefs.boolForKey(PrefsKeys.Settings.aiKillSwitchFeature), true)
+    }
+
+    func testSetSearchBarPosition_writesPref() {
+        subject.setSearchBarPosition(.bottom)
+        XCTAssertEqual(prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition),
+                       SearchBarPosition.bottom.rawValue)
+
+        subject.setSearchBarPosition(.top)
+        XCTAssertEqual(prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition),
+                       SearchBarPosition.top.rawValue)
+    }
+
+    func testSetStartAtHomeSetting_writesPref() {
+        subject.setStartAtHomeSetting(.always)
+        XCTAssertEqual(prefs.stringForKey(PrefsKeys.FeatureFlags.StartAtHome),
+                       StartAtHome.always.rawValue)
+    }
+
+    // MARK: - Roundtrip: set then read
+
+    func testRoundtrip_boolPreferences() {
+        subject.setFirefoxSuggestEnabled(false)
+        XCTAssertFalse(subject.isFirefoxSuggestEnabled)
+
+        subject.setFirefoxSuggestEnabled(true)
+        XCTAssertTrue(subject.isFirefoxSuggestEnabled)
+    }
+
+    func testRoundtrip_searchBarPosition() {
+        subject.setSearchBarPosition(.bottom)
+        XCTAssertEqual(subject.searchBarPosition, .bottom)
+
+        subject.setSearchBarPosition(.top)
+        XCTAssertEqual(subject.searchBarPosition, .top)
+    }
+
+    func testRoundtrip_startAtHome() {
+        subject.setStartAtHomeSetting(.always)
+        XCTAssertEqual(subject.startAtHomeSetting, .always)
+
+        subject.setStartAtHomeSetting(.disabled)
+        XCTAssertEqual(subject.startAtHomeSetting, .disabled)
+    }
+
+    // MARK: - Mock protocol conformance
+
+    func testMockConformance() {
+        let mock = MockUserFeaturePreferences()
+        mock.isFirefoxSuggestEnabled = false
+        XCTAssertFalse(mock.isFirefoxSuggestEnabled)
+
+        mock.searchBarPosition = .bottom
+        XCTAssertEqual(mock.searchBarPosition, .bottom)
+
+        mock.setSearchBarPosition(.top)
+        XCTAssertEqual(mock.searchBarPosition, .top)
+    }
+}
+
+// MARK: - Test Helpers
+
+final class MockUserFeaturePreferences: UserFeaturePreferring, @unchecked Sendable {
+    var isAIKillSwitchEnabled = true
+    var isFirefoxSuggestEnabled = true
+    var isSentFromFirefoxEnabled = false
+    var isSponsoredShortcutsEnabled = true
+    var isHomepageBookmarksSectionEnabled = true
+    var isHomepageJumpBackInSectionEnabled = true
+    var searchBarPosition = SearchBarPosition.bottom
+    var startAtHomeSetting = StartAtHome.afterFourHours
+
+    func setAIKillSwitchEnabled(_ enabled: Bool) { isAIKillSwitchEnabled = enabled }
+    func setFirefoxSuggestEnabled(_ enabled: Bool) { isFirefoxSuggestEnabled = enabled }
+    func setSentFromFirefoxEnabled(_ enabled: Bool) { isSentFromFirefoxEnabled = enabled }
+    func setSponsoredShortcutsEnabled(_ enabled: Bool) { isSponsoredShortcutsEnabled = enabled }
+    func setHomepageBookmarksSectionEnabled(_ enabled: Bool) { isHomepageBookmarksSectionEnabled = enabled }
+    func setHomepageJumpBackInSectionEnabled(_ enabled: Bool) { isHomepageJumpBackInSectionEnabled = enabled }
+    func setSearchBarPosition(_ position: SearchBarPosition) { searchBarPosition = position }
+    func setStartAtHomeSetting(_ setting: StartAtHome) { startAtHomeSetting = setting }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15189)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32695)

## :bulb: Description
This PR adds a separate user preference manager that's very explicit about settable user preferences, given that these are significantly less than existing feature flags.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

