### PR TITLE
Bugfix FXIOS-15314 [Onboarding] Fix landscape mode during onboarding flow

### DIFF
--- a/firefox-ios/Client/Coordinators/LaunchView/ModernLaunchScreenViewController.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/ModernLaunchScreenViewController.swift
@@ -72,6 +72,14 @@ class ModernLaunchScreenViewController: UIViewController, LaunchFinishedLoadingD
         return true
     }
 
+    override var shouldAutorotate: Bool {
+        return false
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
+
     required init?(coder: NSCoder) {
         fatalError()
     }

--- a/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
@@ -63,4 +63,8 @@ class RootNavigationController: UINavigationController {
     override var childForStatusBarHidden: UIViewController? {
         return topViewController
     }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return topViewController?.supportedInterfaceOrientations ?? .allButUpsideDown
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15314)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32885)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Lock ModernLaunchScreenViewController to portrait to prevent the logo animation from rendering in landscape when the device is already rotated
- Forward supportedInterfaceOrientations from RootNavigationController to its topViewController so the nav stack respects each VC's orientation declaration throughout the launch → onboarding → browser lifecycle

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

https://github.com/user-attachments/assets/9ee40cdb-8c1e-41b9-8a25-b71cba2434b5




| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


