### PR TITLE
  Bugfix FXIOS-15333 [Translations Phase 2] Show "Translate Page" option when page language matches preferred language

### DIFF
--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
@@ -29,16 +29,25 @@ final class TranslationsService: TranslationsServiceProtocol {
         self.logger = logger
     }
 
-    /// Determines whether translation should be offered by checking any of the given
-    /// preferred target languages against the detected page language.
-    /// Returns `true` if at least one preferred language has an available model pair.
+    /// Determines whether translation should be offered by checking the detected page language
+    /// against the given preferred target languages. Returns `true` if:
+    /// - The page language is already one of the user's preferred languages and there is at
+    ///   least one other preferred language to translate to (language-picker flow), OR
+    /// - The page language is not in the preferred list and at least one preferred language
+    ///   has an available model pair.
     /// NOTE: `fetchModels` inspects Remote Settings metadata and returns JSON data
     /// describing the pipeline, it does not fetch large model attachments.
     func shouldOfferTranslation(for windowUUID: WindowUUID, using preferredLanguages: [String]) async throws -> Bool {
         guard !preferredLanguages.isEmpty else { return false }
         let pageLanguage = try await detectPageLanguage(for: windowUUID)
+
+        // If the page is already in one of the user's preferred languages, offer the
+        // translation picker as long as there is at least one other language to translate to.
+        if preferredLanguages.contains(pageLanguage) {
+            return preferredLanguages.count > 1
+        }
+
         for language in preferredLanguages {
-            guard language != pageLanguage else { continue }
             if await modelsFetcher.fetchModels(from: pageLanguage, to: language) != nil {
                 return true
             }

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
@@ -47,10 +47,8 @@ final class TranslationsService: TranslationsServiceProtocol {
             return preferredLanguages.count > 1
         }
 
-        for language in preferredLanguages {
-            if await modelsFetcher.fetchModels(from: pageLanguage, to: language) != nil {
-                return true
-            }
+        for language in preferredLanguages where await modelsFetcher.fetchModels(from: pageLanguage, to: language) != nil {
+            return true
         }
         return false
     }

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceProtocol.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceProtocol.swift
@@ -7,9 +7,12 @@ import Common
 /// A service responsible for coordinating in-page translations.
 @MainActor
 protocol TranslationsServiceProtocol {
-    /// Determines whether translation should be offered by checking any of the given
-    /// preferred target languages against the detected page language.
-    /// Returns `true` if at least one preferred language has an available model pair.
+    /// Determines whether translation should be offered by checking the detected page language
+    /// against the given preferred target languages. Returns `true` if:
+    /// - The page language is already one of the user's preferred languages and there is at
+    ///   least one other preferred language to translate to (language-picker flow), OR
+    /// - The page language is not in the preferred list and at least one preferred language
+    ///   has an available model pair.
     func shouldOfferTranslation(for windowUUID: WindowUUID, using preferredLanguages: [String]) async throws -> Bool
     /// Performs translation and returns immediately.
     /// TODO(FXIOS-14213): We should implement a lifecycle for the service similar to `SummarizerServiceLifecycle`.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsServiceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsServiceTests.swift
@@ -127,7 +127,7 @@ final class TranslationsServiceTests: XCTestCase {
         let result = try await subject.shouldOfferTranslation(for: .XCTestDefaultUUID, using: ["en", "fr"])
         XCTAssertTrue(
             result,
-            "Expected shouldOfferTranslation to be true when the page is in a preferred language and other preferred languages exist."
+            "Expected shouldOfferTranslation to be true when the page is in a preferred language and others exist."
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsServiceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsServiceTests.swift
@@ -115,6 +115,22 @@ final class TranslationsServiceTests: XCTestCase {
         )
     }
 
+    func test_shouldOfferTranslation_returnsTrue_whenPageLanguageMatchesFirstPreferredLanguageAndOthersExist() async throws {
+        let subject = createSubject(
+            detectedLanguage: "en",
+            languageDetectorError: nil,
+            modelsAvailable: false
+        )
+
+        setupWebViewForTabManager()
+
+        let result = try await subject.shouldOfferTranslation(for: .XCTestDefaultUUID, using: ["en", "fr"])
+        XCTAssertTrue(
+            result,
+            "Expected shouldOfferTranslation to be true when the page is in a preferred language and other preferred languages exist."
+        )
+    }
+
     func test_shouldOfferTranslation_returnsTrue_whenFallbackPreferredLanguageHasModel() async throws {
         let subject = createSubject(
             detectedLanguage: "de",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15333)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32911)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added an early-return path to `shouldOfferTranslation`: if the page is already in one of the user's preferred languages and there is at least one other preferred language to translate to, return `true` immediately, the model-availability check is not needed here since the language picker surfaces the available target languages at selection time.

Single-language flow is unaffected: `targetLanguagesForEligibilityCheck` returns a single-item list in that path, so `count > 1` evaluates to false as before.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


