### PR TITLE
Refactor FXIOS-15363: [Redux] Use @CopyWithUpdates macro for TranslationSettingsState

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsState.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import CopyWithUpdates
 import Redux
 
 struct PreferredLanguageDetails: Equatable, Hashable {
@@ -19,7 +20,9 @@ struct PreferredLanguageDetails: Equatable, Hashable {
     }
 }
 
+@CopyWithUpdates
 struct TranslationSettingsState: ScreenState, Equatable {
+    var windowUUID: WindowUUID
     var isTranslationsEnabled: Bool
     var isAutoTranslateEnabled: Bool
     var isEditing: Bool
@@ -27,7 +30,6 @@ struct TranslationSettingsState: ScreenState, Equatable {
     var preferredLanguages: [PreferredLanguageDetails]
     var supportedLanguages: [String]
     var availableLanguages: [String]
-    var windowUUID: WindowUUID
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let state = appState.componentState(
@@ -101,8 +103,7 @@ struct TranslationSettingsState: ScreenState, Equatable {
         switch action.actionType {
         case TranslationSettingsMiddlewareActionType.didLoadSettings,
              TranslationSettingsMiddlewareActionType.didUpdateSettings:
-            return TranslationSettingsState(
-                windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                 isTranslationsEnabled: action.isTranslationsEnabled ?? state.isTranslationsEnabled,
                 isAutoTranslateEnabled: action.isAutoTranslateEnabled ?? state.isAutoTranslateEnabled,
                 preferredLanguages: action.preferredLanguages ?? state.preferredLanguages,
@@ -120,8 +121,7 @@ struct TranslationSettingsState: ScreenState, Equatable {
     ) -> TranslationSettingsState {
         switch action.actionType {
         case TranslationSettingsViewActionType.enterEditMode:
-            return TranslationSettingsState(
-                windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                 isTranslationsEnabled: state.isTranslationsEnabled,
                 isAutoTranslateEnabled: state.isAutoTranslateEnabled,
                 isEditing: true,
@@ -131,8 +131,7 @@ struct TranslationSettingsState: ScreenState, Equatable {
                 availableLanguages: state.availableLanguages
             )
         case TranslationSettingsViewActionType.cancelEditMode:
-            return TranslationSettingsState(
-                windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                 isTranslationsEnabled: state.isTranslationsEnabled,
                 isAutoTranslateEnabled: state.isAutoTranslateEnabled,
                 isEditing: false,
@@ -142,12 +141,11 @@ struct TranslationSettingsState: ScreenState, Equatable {
                 availableLanguages: state.availableLanguages
             )
         case TranslationSettingsViewActionType.reorderLanguages:
-            return TranslationSettingsState(
-                windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                 isTranslationsEnabled: state.isTranslationsEnabled,
                 isAutoTranslateEnabled: state.isAutoTranslateEnabled,
                 isEditing: state.isEditing,
-                pendingLanguages: action.pendingLanguages ?? state.pendingLanguages,
+                pendingLanguages: action.pendingLanguages,
                 preferredLanguages: state.preferredLanguages,
                 supportedLanguages: state.supportedLanguages,
                 availableLanguages: state.availableLanguages
@@ -156,8 +154,7 @@ struct TranslationSettingsState: ScreenState, Equatable {
             guard let code = action.languageCode else { return defaultState(from: state) }
             var pending = state.pendingLanguages ?? state.preferredLanguages
             pending.removeAll { $0.code == code }
-            return TranslationSettingsState(
-                windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                 isTranslationsEnabled: state.isTranslationsEnabled,
                 isAutoTranslateEnabled: state.isAutoTranslateEnabled,
                 isEditing: state.isEditing,
@@ -172,8 +169,7 @@ struct TranslationSettingsState: ScreenState, Equatable {
     }
 
     static func defaultState(from state: TranslationSettingsState) -> TranslationSettingsState {
-        return TranslationSettingsState(
-            windowUUID: state.windowUUID,
+        return state.copyWithUpdates(
             isTranslationsEnabled: state.isTranslationsEnabled,
             isAutoTranslateEnabled: state.isAutoTranslateEnabled,
             isEditing: state.isEditing,

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsState.swift
@@ -122,46 +122,23 @@ struct TranslationSettingsState: ScreenState, Equatable {
         switch action.actionType {
         case TranslationSettingsViewActionType.enterEditMode:
             return state.copyWithUpdates(
-                isTranslationsEnabled: state.isTranslationsEnabled,
-                isAutoTranslateEnabled: state.isAutoTranslateEnabled,
-                isEditing: true,
-                pendingLanguages: state.preferredLanguages,
-                preferredLanguages: state.preferredLanguages,
-                supportedLanguages: state.supportedLanguages,
-                availableLanguages: state.availableLanguages
+                isEditing: true
             )
         case TranslationSettingsViewActionType.cancelEditMode:
             return state.copyWithUpdates(
-                isTranslationsEnabled: state.isTranslationsEnabled,
-                isAutoTranslateEnabled: state.isAutoTranslateEnabled,
                 isEditing: false,
                 pendingLanguages: nil,
-                preferredLanguages: state.preferredLanguages,
-                supportedLanguages: state.supportedLanguages,
-                availableLanguages: state.availableLanguages
             )
         case TranslationSettingsViewActionType.reorderLanguages:
             return state.copyWithUpdates(
-                isTranslationsEnabled: state.isTranslationsEnabled,
-                isAutoTranslateEnabled: state.isAutoTranslateEnabled,
-                isEditing: state.isEditing,
                 pendingLanguages: action.pendingLanguages,
-                preferredLanguages: state.preferredLanguages,
-                supportedLanguages: state.supportedLanguages,
-                availableLanguages: state.availableLanguages
             )
         case TranslationSettingsViewActionType.removeLanguage:
             guard let code = action.languageCode else { return defaultState(from: state) }
             var pending = state.pendingLanguages ?? state.preferredLanguages
             pending.removeAll { $0.code == code }
             return state.copyWithUpdates(
-                isTranslationsEnabled: state.isTranslationsEnabled,
-                isAutoTranslateEnabled: state.isAutoTranslateEnabled,
-                isEditing: state.isEditing,
                 pendingLanguages: pending,
-                preferredLanguages: state.preferredLanguages,
-                supportedLanguages: state.supportedLanguages,
-                availableLanguages: state.availableLanguages
             )
         default:
             return defaultState(from: state)
@@ -169,15 +146,7 @@ struct TranslationSettingsState: ScreenState, Equatable {
     }
 
     static func defaultState(from state: TranslationSettingsState) -> TranslationSettingsState {
-        return state.copyWithUpdates(
-            isTranslationsEnabled: state.isTranslationsEnabled,
-            isAutoTranslateEnabled: state.isAutoTranslateEnabled,
-            isEditing: state.isEditing,
-            pendingLanguages: state.pendingLanguages,
-            preferredLanguages: state.preferredLanguages,
-            supportedLanguages: state.supportedLanguages,
-            availableLanguages: state.availableLanguages
-        )
+        return state.copyWithUpdates()
     }
 
     static func == (lhs: TranslationSettingsState, rhs: TranslationSettingsState) -> Bool {

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsState.swift
@@ -122,7 +122,8 @@ struct TranslationSettingsState: ScreenState, Equatable {
         switch action.actionType {
         case TranslationSettingsViewActionType.enterEditMode:
             return state.copyWithUpdates(
-                isEditing: true
+                isEditing: true,
+                pendingLanguages: state.preferredLanguages
             )
         case TranslationSettingsViewActionType.cancelEditMode:
             return state.copyWithUpdates(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15363)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32950)

## :bulb: Description

- Made usage of `@CopyWithUpdates` in TranslationSettingsState
- Moved `windowUUID` on top of the variable declaration so `@CopyWithUpdates` macro could generate code in the same order than the other initializer declaration
- Replaced manual state construction in every reducer handler with `state.copyWithUpdates`
- kept only the needed changes, reducing the boilerplate

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

