### PR TITLE
Bugfix FXIOS-15423 [Newsfeed Categories] Homepage scroll offset jumps on category switch

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -53,7 +53,11 @@ final class HomepageDiffableDataSource:
         case jumpBackIn(JumpBackInTabConfiguration)
         case jumpBackInSyncedTab(JumpBackInSyncedTabConfiguration)
         case bookmark(BookmarkConfiguration)
-        case merino(MerinoStoryConfiguration)
+        /// FXIOS-15423: Include the selected category in the item's identity so category transitions are treated as
+        /// a presentation-context change. Without the category context, diffable treats the same story in
+        /// a filtered feed and in the full "All" feed as one continuous item, which causes it to preserve
+        /// that story's on-screen position as stories are inserted above it.
+        case merino(MerinoStoryConfiguration, String?)
         case spacer
 
         static var cellTypes: [ReusableCell.Type] {
@@ -203,7 +207,9 @@ final class HomepageDiffableDataSource:
     }
 
     private func getMerinoStories(with merinoState: MerinoState) -> [HomepageDiffableDataSource.HomeItem]? {
-        let stories: [HomeItem] = merinoState.visibleStories.map( { .merino($0) })
+        let stories: [HomeItem] = merinoState.visibleStories.map {
+            .merino($0, merinoState.selectedCategoryID)
+        }
         guard merinoState.shouldShowSection, !stories.isEmpty else { return nil }
         return stories
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -591,7 +591,7 @@ final class HomepageViewController: UIViewController,
             return configuredCell(cellType: BookmarksCell.self, at: indexPath) { cell in
                 cell.configure(config: item, theme: currentTheme)
             }
-        case .merino(let story):
+        case .merino(let story, _):
             return configureMerinoCell(story, at: indexPath)
         case .spacer:
             return configuredCell(cellType: HomepageSpacerCell.self, at: indexPath) { _ in }
@@ -1063,7 +1063,7 @@ final class HomepageViewController: UIViewController,
             return Site.createBasicSite(url: config.url.absoluteString, title: config.titleText)
         case .bookmark(let state):
             return Site.createBasicSite(url: state.site.url, title: state.site.title)
-        case .merino(let state):
+        case .merino(let state, _):
             return Site.createBasicSite(url: state.url?.absoluteString ?? "", title: state.title)
         default:
             return nil
@@ -1116,7 +1116,7 @@ final class HomepageViewController: UIViewController,
                 visitType: .bookmark
             )
             dispatchNavigationBrowserAction(with: destination, actionType: NavigationBrowserActionType.tapOnCell)
-        case .merino(let story):
+        case .merino(let story, _):
             let destination = NavigationDestination(
                 .link,
                 url: story.url,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/ContextMenu/ContextMenuConfigurationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/ContextMenu/ContextMenuConfigurationTests.swift
@@ -27,9 +27,10 @@ final class ContextMenuConfigurationTests: XCTestCase {
                     tileId: 0,
                     receivedRank: 0
                 )
-            )
+            ),
+            nil
         )
-        guard case let .merino(state) = merinoItem else { return }
+        guard case let .merino(state, _) = merinoItem else { return }
         let subject = ContextMenuConfiguration(
             site: Site.createBasicSite(url: state.url?.absoluteString ?? "", title: state.title),
             menuType: MenuType(homepageItem: merinoItem),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
@@ -454,7 +454,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
     private func merinoTitles(from items: [HomepageItem]) -> [String] {
         items.compactMap {
-            guard case .merino(let story) = $0 else { return nil }
+            guard case .merino(let story, _) = $0 else { return nil }
             return story.title
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoMiddlewareTests.swift
@@ -167,7 +167,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = createSubject(merinoManager: merinoManager)
 
         let merinoItem = createMerinoItem()
-        guard case let .merino(state) = merinoItem else { return }
+        guard case let .merino(state, _) = merinoItem else { return }
         let action = ContextMenuAction(
             menuType: MenuType(homepageItem: merinoItem),
             site: Site.createBasicSite(url: state.url?.absoluteString ?? "", title: state.title),
@@ -230,7 +230,8 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
                     tileId: 0,
                     receivedRank: 0
                 )
-            )
+            ),
+            nil
         )
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15423)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33082)

## :bulb: Description
- Resolve homepage scroll offset jump when stories are added to the newsfeed when selecting the "All" category

### 📝 Technical Notes:
- This issue was caused by enabling animations on diffable data source snapshot applications in #33084, which was used to add a nicer transition when stories change upon category selection. Even with this fix, we still get a nice fade animation when switching categories (as opposed to the sudden change without it).
- The issue would occur when switching the selected category (not `All` or the second category in the picker) to the `All` category when the newsfeed took up a significant portion of the homepage, and would result in stories being prepended to the newsfeed, while keeping the scroll position at wherever the currently viewed item was at (see "Before" video for better depiction). This is because we are using the same data structure for story objects, and just filtering what is being displayed based on selected category.
- The fix includes changing the Merino story item identity to include the selected category when building the homepage diffable data source. This resolves the issue by making the diffable data source treat a story in a filtered category and the same story in the `All` feed as different item identities, so it no longer preserves that story’s on-screen position while earlier stories are inserted above it.
- This should not have meaningful performance impact because the extra diffable churn is limited to the small, user-triggered Merino section during category switches.


## :movie_camera: Demos

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/865b7296-b4d4-4eb5-b1da-63b3f109eb7d

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/68d21816-242e-401a-93c5-3310bb7a5e68

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

