### PR TITLE
Migrate DisplaySettingsTests to TAE framework

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DisplaySettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DisplaySettingsTests.swift
@@ -5,6 +5,8 @@
 import XCTest
 
 class DisplaySettingTests: BaseTestCase {
+    private var settingScreen: SettingScreen!
+
     override func setUp() async throws {
         // Fresh install the app
         // removeApp() does not work on iOS 15 and 16 intermittently
@@ -15,12 +17,13 @@ class DisplaySettingTests: BaseTestCase {
         }
         // The app is correctly installed
         try await super.setUp()
+        settingScreen = SettingScreen(app: app)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2337485
     func testCheckDisplaySettingsDefault() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(DisplaySettings)
+        navigator.goto(SettingsScreen)
+        settingScreen.navigateToDisplaySettings()
         waitForElementsToExist(
             [
                 app.navigationBars["Appearance"],
@@ -33,34 +36,26 @@ class DisplaySettingTests: BaseTestCase {
             waitForElementsToExist([app.buttons[AccessibilityIdentifiers.Settings.Appearance.darkModeToggle]])
         }
 
-        let automaticIsSelected = app.buttons[AccessibilityIdentifiers.Settings.Appearance.automaticThemeView].value
-        XCTAssertEqual(automaticIsSelected as? String, "1")
-
-        let lightThemeValue = app.buttons[AccessibilityIdentifiers.Settings.Appearance.lightThemeView].value
-        XCTAssertEqual(lightThemeValue as? String, "0")
-
-        let darkThemeValue = app.buttons[AccessibilityIdentifiers.Settings.Appearance.darkThemeView].value
-        XCTAssertEqual(darkThemeValue as? String, "0")
+        settingScreen.assertAutomaticThemeSelected()
+        settingScreen.assertLightThemeSelected(false)
+        settingScreen.assertDarkThemeSelected(false)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3298823
     func testCheckSystemThemeChanges() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(DisplaySettings)
+        navigator.goto(SettingsScreen)
+        settingScreen.navigateToDisplaySettings()
 
         // Select Light mode
-        navigator.performAction(Action.SelectLightTheme)
-        let lightIsSelected = app.buttons[AccessibilityIdentifiers.Settings.Appearance.lightThemeView].value
-        XCTAssertEqual(lightIsSelected as? String, "1")
+        settingScreen.selectLightTheme()
+        settingScreen.assertLightThemeSelected()
 
         // Select Dark mode
-        navigator.performAction(Action.SelectDarkTheme)
-        let darkIsSelected = app.buttons[AccessibilityIdentifiers.Settings.Appearance.darkThemeView].value
-        XCTAssertEqual(darkIsSelected as? String, "1")
+        settingScreen.selectDarkTheme()
+        settingScreen.assertDarkThemeSelected()
 
         // Select Automatic mode
-        navigator.performAction(Action.SelectAutomaticTheme)
-        let automaticIsSelected = app.buttons[AccessibilityIdentifiers.Settings.Appearance.automaticThemeView].value
-        XCTAssertEqual(automaticIsSelected as? String, "1")
+        settingScreen.selectAutomaticTheme()
+        settingScreen.assertAutomaticThemeSelected()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
@@ -162,6 +162,30 @@ final class SettingScreen {
         cell.waitAndTap()
     }
 
+    func assertAutomaticThemeSelected(_ selected: Bool = true) {
+        let button = sel.AUTOMATIC_THEME_BUTTON.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(button)
+        let value = button.value as? String
+        let expected = selected ? "1" : "0"
+        XCTAssertEqual(value, expected, "Expected 'Automatic Theme' button selected=\(selected), but got \(String(describing: value))")
+    }
+
+    func assertLightThemeSelected(_ selected: Bool = true) {
+        let button = sel.LIGHT_THEME_BUTTON.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(button)
+        let value = button.value as? String
+        let expected = selected ? "1" : "0"
+        XCTAssertEqual(value, expected, "Expected 'Light Theme' button selected=\(selected), but got \(String(describing: value))")
+    }
+
+    func assertDarkThemeSelected(_ selected: Bool = true) {
+        let button = sel.DARK_THEME_BUTTON.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(button)
+        let value = button.value as? String
+        let expected = selected ? "1" : "0"
+        XCTAssertEqual(value, expected, "Expected 'Dark Theme' button selected=\(selected), but got \(String(describing: value))")
+    }
+
     func selectDarkTheme() {
         let button = sel.DARK_THEME_BUTTON.element(in: app)
         BaseTestCase().mozWaitForElementToExist(button)
@@ -170,6 +194,12 @@ final class SettingScreen {
 
     func selectLightTheme() {
         let button = sel.LIGHT_THEME_BUTTON.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(button)
+        button.waitAndTap()
+    }
+
+    func selectAutomaticTheme() {
+        let button = sel.AUTOMATIC_THEME_BUTTON.element(in: app)
         BaseTestCase().mozWaitForElementToExist(button)
         button.waitAndTap()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SettingsSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SettingsSelectors.swift
@@ -26,6 +26,7 @@ protocol SettingsSelectorsSet {
 
     // Display / Theme
     var DISPLAY_THEME_CELL: Selector { get }
+    var AUTOMATIC_THEME_BUTTON: Selector { get }
     var DARK_THEME_BUTTON: Selector { get }
     var LIGHT_THEME_BUTTON: Selector { get }
 
@@ -175,6 +176,12 @@ struct SettingsSelectors: SettingsSelectorsSet {
     let DISPLAY_THEME_CELL = Selector.tableCellById(
         AccessibilityIdentifiers.Settings.Theme.title,
         description: "Display Theme settings cell",
+        groups: ["settings", "theme"]
+    )
+
+    let AUTOMATIC_THEME_BUTTON = Selector.buttonId(
+        AccessibilityIdentifiers.Settings.Appearance.automaticThemeView,
+        description: "Automatic theme selection button",
         groups: ["settings", "theme"]
     )
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15426)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33094)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Migrates `DisplaySettingsTests` to the TAE framework.                                                     
  - Replace `navigator.goto(DisplaySettings)` with
  `settingScreen.navigateToDisplaySettings()`                                   
  - Replace `navigator.performAction(Action.Select*Theme)` with
  `selectLightTheme()`, `selectDarkTheme()`, `selectAutomaticTheme()`           
  - Add 3 assertion methods to `SettingScreen` for theme selection checks       
  (`assertAutomaticThemeSelected`, `assertLightThemeSelected`,           
  `assertDarkThemeSelected`) with a `Bool` parameter to handle both             
  selected/not-selected cases                                      
  - Add `AUTOMATIC_THEME_BUTTON` selector to `SettingsSelectors`
  
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

