### PR TITLE
Bugfix FXIOS-15230 [Translations Phase 2] Long-press active translate button to change language 

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2936,21 +2936,7 @@ class BrowserViewController: UIViewController,
         if data.isTranslated, let langCode = data.translatedToLanguage {
             configureShowOriginalHeader(for: alert, languageCode: langCode)
         } else {
-            let title: String = .Translations.LanguagePicker.Title
-            let attributedTitleKey = "attributedTitle"
-            alert.title = title
-            alert.setValue(
-                NSAttributedString(
-                    string: title,
-                    attributes: [
-                        .font: DefaultDynamicFontHelper.preferredBoldFont(
-                            withTextStyle: .headline,
-                            size: UIFont.labelFontSize
-                        )
-                    ]
-                ),
-                forKey: attributedTitleKey
-            )
+            alert.title = .Translations.LanguagePicker.Title
         }
 
         data.languages.forEach { code in
@@ -2984,6 +2970,22 @@ class BrowserViewController: UIViewController,
             alert.addAction(UIAlertAction(title: .CancelString, style: .cancel))
         }
 
+        if let title = alert.title {
+            let attributedTitleKey = "attributedTitle"
+            alert.setValue(
+                NSAttributedString(
+                    string: title,
+                    attributes: [
+                        .font: DefaultDynamicFontHelper.preferredBoldFont(
+                            withTextStyle: .headline,
+                            size: UIFont.labelFontSize
+                        )
+                    ]
+                ),
+                forKey: attributedTitleKey
+            )
+        }
+
         if let popover = alert.popoverPresentationController {
             if let sourceButton {
                 popover.sourceView = sourceButton
@@ -3004,9 +3006,7 @@ class BrowserViewController: UIViewController,
         languageCode: String
     ) {
         let langName = Locale.current.localizedString(forLanguageCode: languageCode) ?? languageCode
-        let title = String(format: .Translations.LanguagePicker.PageTranslatedTitle, langName)
-        let attributedTitleKey = "attributedTitle"
-        alert.title = title
+        alert.title = String(format: .Translations.LanguagePicker.PageTranslatedTitle, langName)
         let showOriginalAction = UIAlertAction(
             title: .Translations.LanguagePicker.ShowOriginal,
             style: .default
@@ -3021,18 +3021,6 @@ class BrowserViewController: UIViewController,
         }
         alert.addAction(showOriginalAction)
         alert.preferredAction = showOriginalAction
-        alert.setValue(
-            NSAttributedString(
-                string: title,
-                attributes: [
-                    .font: DefaultDynamicFontHelper.preferredBoldFont(
-                        withTextStyle: .headline,
-                        size: UIFont.labelFontSize
-                    )
-                ]
-            ),
-            forKey: attributedTitleKey
-        )
     }
 
     func didTapOnHome() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3004,7 +3004,9 @@ class BrowserViewController: UIViewController,
         languageCode: String
     ) {
         let langName = Locale.current.localizedString(forLanguageCode: languageCode) ?? languageCode
-        alert.title = String(format: .Translations.LanguagePicker.PageTranslatedTitle, langName)
+        let title = String(format: .Translations.LanguagePicker.PageTranslatedTitle, langName)
+        let attributedTitleKey = "attributedTitle"
+        alert.title = title
         let showOriginalAction = UIAlertAction(
             title: .Translations.LanguagePicker.ShowOriginal,
             style: .default
@@ -3019,6 +3021,18 @@ class BrowserViewController: UIViewController,
         }
         alert.addAction(showOriginalAction)
         alert.preferredAction = showOriginalAction
+        alert.setValue(
+            NSAttributedString(
+                string: title,
+                attributes: [
+                    .font: DefaultDynamicFontHelper.preferredBoldFont(
+                        withTextStyle: .headline,
+                        size: UIFont.labelFontSize
+                    )
+                ]
+            ),
+            forKey: attributedTitleKey
+        )
     }
 
     func didTapOnHome() {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -178,7 +178,9 @@ class MainMenuCoordinator: BaseCoordinator, LegacyFeatureFlaggable {
                 let manager = PreferredTranslationLanguagesManager(prefs: prefs)
                 let supported = await ASTranslationModelsFetcher.shared.fetchSupportedTargetLanguages()
                 let languages = manager.preferredLanguages(supportedTargetLanguages: supported)
-                let pageLanguage = try? await TranslationsService().detectPageLanguage(for: windowUUID)
+                let pageLanguage = isTranslated
+                    ? translationConfig?.sourceLanguage
+                    : (try? await TranslationsService().detectPageLanguage(for: windowUUID))
                 let filteredLanguages = languages.filter { $0 != pageLanguage }
                 if isSingleLanguageFlow, let language = filteredLanguages.first, !isTranslated {
                     store.dispatch(TranslationLanguageSelectedAction(

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -181,7 +181,7 @@ class MainMenuCoordinator: BaseCoordinator, LegacyFeatureFlaggable {
                 let pageLanguage = isTranslated
                     ? translationConfig?.sourceLanguage
                     : (try? await TranslationsService().detectPageLanguage(for: windowUUID))
-                let filteredLanguages = languages.filter { $0 != pageLanguage }
+                let filteredLanguages = languages.filter { $0 != pageLanguage && $0 != translatedLanguage }
                 if isSingleLanguageFlow, let language = filteredLanguages.first, !isTranslated {
                     store.dispatch(TranslationLanguageSelectedAction(
                         windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionConfiguration.swift
@@ -58,7 +58,7 @@ struct ToolbarActionConfiguration: Equatable, LegacyFeatureFlaggable {
                actionType == .readerMode ||
                actionType == .readerModeWithSummarizer ||
                actionType == .summarizer ||
-               actionType == .translate ||
+               (actionType == .translate && isSelected) ||
                (actionType == .tabs && isShowingTopTabs == false)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionConfiguration.swift
@@ -58,6 +58,7 @@ struct ToolbarActionConfiguration: Equatable, LegacyFeatureFlaggable {
                actionType == .readerMode ||
                actionType == .readerModeWithSummarizer ||
                actionType == .summarizer ||
+               actionType == .translate ||
                (actionType == .tabs && isShowingTopTabs == false)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -369,6 +369,9 @@ final class ToolbarMiddleware: LegacyFeatureFlaggable {
                                                   actionType: GeneralBrowserActionType.showSummarizer)
                 store.dispatch(action)
             }
+        case .translate:
+            // Long-press on translate is handled in TranslationsMiddleware.
+            break
         default:
             break
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
@@ -55,14 +55,17 @@ struct TranslationConfiguration: Equatable, LegacyFeatureFlaggable {
     let state: IconState?
     /// The language code the page was translated to, if in the active state (e.g. "en", "fr").
     let translatedToLanguage: String?
+    /// The original language of the page before translation (e.g. "de", "fr").
+    let sourceLanguage: String?
 
     // We initially set icon state as nil until we can detect the
     // web page and determine if we should show the translation icon
     // and set the icon to .inactive state.
-    init(prefs: Prefs, state: IconState? = nil, translatedToLanguage: String? = nil) {
+    init(prefs: Prefs, state: IconState? = nil, translatedToLanguage: String? = nil, sourceLanguage: String? = nil) {
         self.prefs = prefs
         self.state = state
         self.translatedToLanguage = translatedToLanguage
+        self.sourceLanguage = sourceLanguage
     }
 
     var isMultiLanguageFlow: Bool {
@@ -85,5 +88,6 @@ struct TranslationConfiguration: Equatable, LegacyFeatureFlaggable {
         return lhs.isTranslationFeatureEnabled == rhs.isTranslationFeatureEnabled
             && lhs.state == rhs.state
             && lhs.translatedToLanguage == rhs.translatedToLanguage
+            && lhs.sourceLanguage == rhs.sourceLanguage
     }
 }

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -91,7 +91,6 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
     private func handleTappingOnTranslateButton(for action: ToolbarMiddlewareAction, and state: AppState) {
         guard let gestureType = action.gestureType,
               let type = action.buttonType,
-              gestureType == .tap,
               type == .translate
         else { return }
 
@@ -111,6 +110,20 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
             )
             return
         }
+
+        if gestureType == .longPress {
+            guard translationConfiguration.state == .active,
+                  featureFlags.isFeatureEnabled(.translationLanguagePicker, checking: .buildOnly)
+            else { return }
+            showLanguagePickerForActiveTranslation(
+                for: action,
+                translatedToLanguage: translationConfiguration.translatedToLanguage,
+                sourceLanguage: translationConfiguration.sourceLanguage
+            )
+            return
+        }
+
+        guard gestureType == .tap else { return }
 
         if translationConfiguration.state == .inactive,
            featureFlags.isFeatureEnabled(.translationLanguagePicker, checking: .buildOnly) {
@@ -157,6 +170,28 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
             self.handleUpdatingTranslationIcon(for: action, with: .inactive)
             restoringWindows.insert(action.windowUUID)
             self.reloadPage(for: action)
+        }
+    }
+
+    private func showLanguagePickerForActiveTranslation(
+        for action: ToolbarMiddlewareAction,
+        translatedToLanguage: String?,
+        sourceLanguage: String?
+    ) {
+        let capturedButton = action.buttonTapped
+        Task {
+            let manager = PreferredTranslationLanguagesManager(prefs: profile.prefs)
+            let supported = await translationsService.fetchSupportedTargetLanguages()
+            let languages = manager.preferredLanguages(supportedTargetLanguages: supported)
+            let filteredLanguages = languages.filter { $0 != sourceLanguage }
+            store.dispatch(GeneralBrowserAction(
+                buttonTapped: capturedButton,
+                translationLanguages: filteredLanguages,
+                isPageTranslated: true,
+                translatedToLanguage: translatedToLanguage,
+                windowUUID: action.windowUUID,
+                actionType: GeneralBrowserActionType.showTranslationLanguagePicker
+            ))
         }
     }
 
@@ -318,10 +353,12 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
 
     private func performTranslation(for action: Action, targetLanguage: String, isPrivate: Bool, autoTranslate: Bool) async {
         do {
+            var detectedSourceLanguage: String?
             try await translationsService.translateCurrentPage(
                 for: action.windowUUID,
                 to: targetLanguage,
                 onLanguageIdentified: { identifiedLanguage, deviceLanguage in
+                    detectedSourceLanguage = identifiedLanguage
                     self.translationsTelemetry.pageLanguageIdentified(
                         identifiedLanguage: identifiedLanguage,
                         deviceLanguage: deviceLanguage
@@ -340,6 +377,7 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
                 for: ToolbarActionType.translationCompleted,
                 with: .active,
                 translatedToLanguage: targetLanguage,
+                sourceLanguage: detectedSourceLanguage,
                 and: action.windowUUID
             )
             maybeShowAutoTranslatePrompt(windowUUID: action.windowUUID)
@@ -386,13 +424,15 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
         for actionType: ToolbarActionType,
         with state: TranslationConfiguration.IconState,
         translatedToLanguage: String? = nil,
+        sourceLanguage: String? = nil,
         and windowUUID: WindowUUID
     ) {
         let toolbarAction = ToolbarAction(
             translationConfiguration: TranslationConfiguration(
                 prefs: profile.prefs,
                 state: state,
-                translatedToLanguage: translatedToLanguage
+                translatedToLanguage: translatedToLanguage,
+                sourceLanguage: sourceLanguage
             ),
             windowUUID: windowUUID,
             actionType: actionType

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -183,7 +183,7 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
             let manager = PreferredTranslationLanguagesManager(prefs: profile.prefs)
             let supported = await translationsService.fetchSupportedTargetLanguages()
             let languages = manager.preferredLanguages(supportedTargetLanguages: supported)
-            let filteredLanguages = languages.filter { $0 != sourceLanguage }
+            let filteredLanguages = languages.filter { $0 != sourceLanguage && $0 != translatedToLanguage }
             store.dispatch(GeneralBrowserAction(
                 buttonTapped: capturedButton,
                 translationLanguages: filteredLanguages,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32750)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Adds long-press support on the translate toolbar button when a page is already translated, allowing the user to change the target language without restoring the original first.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


