### PR TITLE
Bugfix FXIOS-15304 [Translations Phase 2] Re-evaluate translation eligibility after settings toggle   

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
@@ -61,7 +61,7 @@ final class TranslationSettingsMiddleware {
                 from: "\(current)"
             )
             store.dispatch(ToolbarAction(
-                translationConfiguration: TranslationConfiguration(prefs: prefs, state: .inactive),
+                translationConfiguration: TranslationConfiguration(prefs: prefs),
                 windowUUID: action.windowUUID,
                 actionType: ToolbarActionType.didTranslationSettingsChange
             ))

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -75,6 +75,8 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
 
         case ToolbarActionType.didTranslationSettingsChange:
             guard let action = (action as? ToolbarAction) else { return }
+            // Clear stale per-window state so eligibility is re-evaluated from scratch
+            // rather than acting on cached flow data from before the settings change.
             self.selectedTargetLanguages[windowUUID] = nil
             self.translationFlowIds[windowUUID] = nil
             self.restoringWindows.remove(windowUUID)

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -73,6 +73,14 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
         case TranslationsActionType.didTapEnableAutoTranslate:
             self.profile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslate)
 
+        case ToolbarActionType.didTranslationSettingsChange:
+            guard let action = (action as? ToolbarAction) else { return }
+            self.selectedTargetLanguages[windowUUID] = nil
+            self.translationFlowIds[windowUUID] = nil
+            self.restoringWindows.remove(windowUUID)
+            guard action.translationConfiguration?.isTranslationFeatureEnabled == true else { return }
+            self.checkTranslationsAreEligible(for: action)
+
         default:
            break
         }
@@ -210,7 +218,9 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
         let manager = PreferredTranslationLanguagesManager(prefs: profile.prefs)
         let supported = await translationsService.fetchSupportedTargetLanguages()
         let preferred = manager.preferredLanguages(supportedTargetLanguages: supported)
-        guard let targetLanguage = preferred.first else { return false }
+        let pageLanguage = try? await translationsService.detectPageLanguage(for: action.windowUUID)
+        let filteredPreferred = preferred.filter { $0 != pageLanguage }
+        guard let targetLanguage = filteredPreferred.first else { return false }
         let isPrivate = store.state.componentState(
             ToolbarState.self,
             for: .toolbar,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
@@ -211,6 +211,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         let toolbarAction = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let toolbarActionType = try XCTUnwrap(toolbarAction.actionType as? ToolbarActionType)
         XCTAssertEqual(toolbarActionType, ToolbarActionType.didTranslationSettingsChange)
+        XCTAssertNil(toolbarAction.translationConfiguration?.state)
 
         let settingsAction = try XCTUnwrap(mockStore.dispatchedActions.last as? TranslationSettingsMiddlewareAction)
         let settingsActionType = try XCTUnwrap(settingsAction.actionType as? TranslationSettingsMiddlewareActionType)
@@ -237,6 +238,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         let toolbarAction = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let toolbarActionType = try XCTUnwrap(toolbarAction.actionType as? ToolbarActionType)
         XCTAssertEqual(toolbarActionType, ToolbarActionType.didTranslationSettingsChange)
+        XCTAssertNil(toolbarAction.translationConfiguration?.state)
 
         let settingsAction = try XCTUnwrap(mockStore.dispatchedActions.last as? TranslationSettingsMiddlewareAction)
         XCTAssertEqual(settingsAction.isTranslationsEnabled, true)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -455,7 +455,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
 
     // MARK: - didTranslationSettingsChange tests
 
-    func test_didTranslationSettingsChange_withFeatureEnabled_andEligiblePage_dispatchesReceivedTranslationLanguage() throws {
+    func test_didTranslationSettingsChange_featureEnabled_eligiblePage_dispatchesReceivedTranslationLanguage() throws {
         setTranslationsFeatureEnabled(enabled: true)
         let mockTranslationService = MockTranslationsService(shouldOfferTranslationResult: .success(true))
         let subject = createSubject(translationsService: mockTranslationService)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -453,6 +453,82 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(mockTranslationsTelemetry.webpageRestoredCalledCount, 1)
     }
 
+    // MARK: - didTranslationSettingsChange tests
+
+    func test_didTranslationSettingsChange_withFeatureEnabled_andEligiblePage_dispatchesReceivedTranslationLanguage() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let mockTranslationService = MockTranslationsService(shouldOfferTranslationResult: .success(true))
+        let subject = createSubject(translationsService: mockTranslationService)
+        let action = ToolbarAction(
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.didTranslationSettingsChange
+        )
+
+        let expectation = XCTestExpectation(description: "receivedTranslationLanguage dispatched after feature enabled")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
+        XCTAssertEqual(actionType, ToolbarActionType.receivedTranslationLanguage)
+        XCTAssertEqual(actionCalled.translationConfiguration?.state, .inactive)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+    }
+
+    func test_didTranslationSettingsChange_withFeatureDisabled_doesNotDispatchAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.Settings.translationsFeature)
+        let mockTranslationService = MockTranslationsService(shouldOfferTranslationResult: .success(true))
+        let subject = createSubject(translationsService: mockTranslationService)
+        let action = ToolbarAction(
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.didTranslationSettingsChange
+        )
+
+        let expectation = XCTestExpectation(description: "no action dispatched when feature disabled")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+    }
+
+    func test_didTranslationSettingsChange_clearsStoredTargetLanguageForRetry() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.Settings.translationsFeature)
+        let subject = createSubject()
+
+        seedTargetLanguage(in: subject, successDispatchCount: 2)
+
+        let toggleAction = ToolbarAction(
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.didTranslationSettingsChange
+        )
+        subject.translationsProvider(mockStore.state, toggleAction)
+
+        let retryAction = TranslationsAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TranslationsActionType.didTapRetryFailedTranslation
+        )
+
+        let expectation = XCTestExpectation(description: "no retry dispatch after settings change cleared state")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(mockStore.state, retryAction)
+
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+    }
+
     // MARK: - Auto-translate tests
 
     func test_urlDidChangeAction_withAutoTranslateEnabled_andPreferredLanguages_translatesAutomatically() throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15304)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32862)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
When the Enable Translations toggle is turned off then back on, the translation icon incorrectly reappears. This happens because the middleware never resets its cached state or re-checks eligibility when the setting changes.   

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


