### PR TITLE
Remove FXIOS-15458 [Toolbar] Clean up feature flags - Part 2

### DIFF
--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -58,7 +58,6 @@ enum FeatureFlagID: String, CaseIterable {
     case toolbarSwipingTabs
     case toolbarTranslucency
     case toolbarTranslucencyRefactor
-    case toolbarMinimalAddressBar
     case toolbarMiddleButtonCustomization
     case tosFeature
     case touFeature

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -77,7 +77,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .toolbarSwipingTabs,
                 .toolbarTranslucency,
                 .toolbarTranslucencyRefactor,
-                .toolbarMinimalAddressBar,
                 .toolbarMiddleButtonCustomization,
                 .tosFeature,
                 .touFeature,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabScrollHandlerDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabScrollHandlerDelegate.swift
@@ -78,7 +78,7 @@ extension BrowserViewController: TabScrollHandler.Delegate,
         // Minimal address bar: keep a small strip visible so the domain remains readable
         // while scrolled. Applies only when the nav toolbar (iPhone portrait) or iPad layout is visible
         let isNavToolbarVisible = ToolbarHelper().shouldShowNavigationToolbar(for: view.traitCollection)
-        if isMinimalAddressBarEnabled && (isiPad || isNavToolbarVisible) {
+        if isiPad || isNavToolbarVisible {
             return -headerHeight + UX.minimalHeaderOffset
         }
 
@@ -91,7 +91,7 @@ extension BrowserViewController: TabScrollHandler.Delegate,
         guard let tab = tabManager.selectedTab,
               let tabURL = tab.url else { return false }
 
-        return isMinimalAddressBarEnabled && !tab.isFindInPageMode && !tabURL.isReaderModeURL
+        return !tab.isFindInPageMode && !tabURL.isReaderModeURL
     }
 
     /// Helper method for testing overKeyboardScrollHeight behavior.
@@ -103,8 +103,7 @@ extension BrowserViewController: TabScrollHandler.Delegate,
         let isReaderModeActive = tabManager.selectedTab?.url?.isReaderModeURL == true
 
         // Return full height if conditions aren't met for adjustment.
-        let shouldAdjustHeight = isMinimalAddressBarEnabled
-                                  && isBottomSearchBar
+        let shouldAdjustHeight = isBottomSearchBar
                                   && zoomPageBar == nil
                                   && !isReaderModeActive
         guard shouldAdjustHeight else { return containerHeight }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -138,8 +138,7 @@ class BrowserViewController: UIViewController,
         view.accessibilityIdentifier = AccessibilityIdentifiers.Browser.statusBarOverlay
     }
     private(set) lazy var addressToolbarContainer: AddressToolbarContainer = .build(nil, {
-        AddressToolbarContainer(isMinimalAddressBarEnabled: self.isMinimalAddressBarEnabled,
-                                toolbarHelper: self.toolbarHelper)
+        AddressToolbarContainer(toolbarHelper: self.toolbarHelper)
     })
     private(set) lazy var readerModeCache: ReaderModeCache = DiskReaderModeCache.shared
     private(set) lazy var overlayManager: OverlayModeManager = DefaultOverlayModeManager()
@@ -309,11 +308,6 @@ class BrowserViewController: UIViewController,
 
     var isSwipingTabsEnabled: Bool {
         return toolbarHelper.isSwipingTabsEnabled
-    }
-
-    var isMinimalAddressBarEnabled: Bool {
-        let flagToCheck = FeatureFlagID.toolbarMinimalAddressBar
-        return featureFlags.isFeatureEnabled(flagToCheck, checking: .buildOnly)
     }
 
     var isToolbarNavigationHintEnabled: Bool {

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -42,10 +42,6 @@ final class LegacyTabScrollController: NSObject,
         func toolbarDisplayStateDidChange()
     }
 
-    private var isMinimalAddressBarEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.toolbarMinimalAddressBar, checking: .buildOnly)
-    }
-
     enum ScrollDirection {
         case up
         case down
@@ -139,7 +135,7 @@ final class LegacyTabScrollController: NSObject,
             ToolbarHelper().shouldShowNavigationToolbar(for: scrollView.traitCollection)
         } else { false }
 
-        guard isMinimalAddressBarEnabled && (isiPad || isNavToolbarVisible) else {
+        guard isiPad || isNavToolbarVisible else {
             return baseOffset
         }
 
@@ -164,17 +160,14 @@ final class LegacyTabScrollController: NSObject,
     /// Helper method for testing overKeyboardScrollHeight behavior.
     /// - Parameters:
     ///   - safeAreaInsets: The safe area insets to use (nil treated as .zero).
-    ///   - isMinimalAddressBarEnabled: Whether minimal address bar feature is enabled.
     ///   - isBottomSearchBar: Whether search bar is set to the bottom.
     /// - Returns: The calculated scroll height.
     func calculateOverKeyboardScrollHeight(with safeAreaInsets: UIEdgeInsets?,
-                                           isMinimalAddressBarEnabled: Bool,
                                            isBottomSearchBar: Bool) -> CGFloat {
         guard let containerHeight = overKeyboardContainer?.frame.height else { return .zero }
         let isReaderModeActive = tab?.url?.isReaderModeURL == true
         // Return full height if conditions aren't met for adjustment.
-        let shouldAdjustHeight = isMinimalAddressBarEnabled
-                                  && isBottomSearchBar
+        let shouldAdjustHeight = isBottomSearchBar
                                   && zoomPageBar == nil
                                   && !isReaderModeActive
         guard shouldAdjustHeight else { return containerHeight }
@@ -192,7 +185,6 @@ final class LegacyTabScrollController: NSObject,
     private var overKeyboardScrollHeight: CGFloat {
         return calculateOverKeyboardScrollHeight(
             with: UIWindow.keyWindow?.safeAreaInsets,
-            isMinimalAddressBarEnabled: isMinimalAddressBarEnabled,
             isBottomSearchBar: isBottomSearchBar
         )
     }
@@ -295,7 +287,7 @@ final class LegacyTabScrollController: NSObject,
 
     func createToolbarTapHandler() -> (() -> Void) {
         return { [unowned self] in
-            guard isMinimalAddressBarEnabled && toolbarState == .collapsed else { return }
+            guard toolbarState == .collapsed else { return }
             showToolbars(animated: true)
         }
     }
@@ -337,7 +329,6 @@ final class LegacyTabScrollController: NSObject,
 
             lastPanTranslation = translation.y
             if checkRubberbanding() && shouldUpdateUIWhenScrolling {
-                scrollWithDelta(delta)
                 updateToolbarState()
             }
         }
@@ -494,9 +485,7 @@ private extension LegacyTabScrollController {
     var showDurationRatio: CGFloat {
         var durationRatio: CGFloat
         if isBottomSearchBar {
-            durationRatio = if isMinimalAddressBarEnabled { UX.minimalAddressBarAnimationDuration } else {
-                abs(overKeyboardContainerOffset / overKeyboardScrollHeight)
-            }
+            durationRatio = UX.minimalAddressBarAnimationDuration
         } else {
             durationRatio = abs(headerTopOffset / headerHeight)
         }
@@ -613,41 +602,6 @@ private extension LegacyTabScrollController {
         toolbarState = state
     }
 
-    /// Handles synchronized scrolling of the header, bottom container, and over-keyboard container
-    /// in response to a vertical scroll delta.
-    /// Updates all containers offset based in scrolling delta
-    ///
-    /// This function performs the following actions:
-    /// 1. Verifies that scrolling is necessary (i.e., content height exceeds the scroll view height).
-    /// 2. Updates the `headerTopOffset` by applying the delta and clamps it within the allowed range.
-    /// 3. If the header should be displayed at the new offset, updates the scroll view's content offset accordingly.
-    /// 4. Updates the `bottomContainerOffset` and `overKeyboardContainerOffset` with the delta,
-    ///    clamping each within their respective bounds.
-    /// 5. Updates the alpha (transparency) of subviews in `header` and `zoomPageBar` based on scroll position.
-    ///
-    /// - Parameter delta: The amount by which to scroll, where a positive delta scrolls down and
-    ///   a negative delta scrolls up.
-    func scrollWithDelta(_ delta: CGFloat) {
-        guard !isMinimalAddressBarEnabled, hasScrollableContent else { return }
-
-        let updatedOffset = headerTopOffset - delta
-        headerTopOffset = clamp(offset: updatedOffset, min: headerOffset, max: 0)
-        if isHeaderDisplayedForGivenOffset(headerTopOffset) {
-            scrollView?.contentOffset = CGPoint(x: contentOffset.x, y: contentOffset.y - delta)
-        }
-
-        let bottomUpdatedOffset = bottomContainerOffset + delta
-        bottomContainerOffset = clamp(offset: bottomUpdatedOffset, min: 0, max: bottomContainerScrollHeight)
-
-        if !isMinimalAddressBarEnabled {
-            let overKeyboardUpdatedOffset = overKeyboardContainerOffset + delta
-            overKeyboardContainerOffset = clamp(offset: overKeyboardUpdatedOffset, min: 0, max: overKeyboardScrollHeight)
-        }
-
-        headerContainer?.updateAlphaForSubviews(scrollAlpha)
-        zoomPageBar?.updateAlphaForSubviews(scrollAlpha)
-    }
-
     func isHeaderDisplayedForGivenOffset(_ offset: CGFloat) -> Bool {
         return offset > -headerHeight && offset < 0
     }
@@ -706,7 +660,7 @@ private extension LegacyTabScrollController {
             self.headerTopOffset = headerOffset
             self.bottomContainerOffset = bottomContainerOffset
 
-            if isMinimalAddressBarEnabled && tab?.isFindInPageMode == false && tab?.url?.isReaderModeURL == false {
+            if tab?.isFindInPageMode == false && tab?.url?.isReaderModeURL == false {
                 store.dispatch(
                     ToolbarAction(
                         scrollAlpha: Float(alpha),

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -40,10 +40,6 @@ final class TabScrollHandler: NSObject,
         static let minimumScrollThreshold: CGFloat = 20
     }
 
-    private var isMinimalAddressBarEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.toolbarMinimalAddressBar, checking: .buildAndUser)
-    }
-
     enum ScrollDirection {
         case up
         case down
@@ -295,7 +291,7 @@ final class TabScrollHandler: NSObject,
 
     func createToolbarTapHandler() -> (() -> Void) {
         return { [unowned self] in
-            guard isMinimalAddressBarEnabled && toolbarDisplayState.isCollapsed  else { return }
+            guard toolbarDisplayState.isCollapsed  else { return }
             showToolbars(animated: true)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -72,7 +72,6 @@ final class AddressToolbarContainer: UIView,
 
     typealias SubscriberStateType = ToolbarState
 
-    private let isMinimalAddressBarEnabled: Bool
     private let toolbarHelper: ToolbarHelperInterface
     private var windowUUID: WindowUUID?
     private var profile: Profile?
@@ -151,8 +150,7 @@ final class AddressToolbarContainer: UIView,
     /// and the Cancel button is visible (allowing the user to leave overlay mode).
     var inOverlayMode = false
 
-    init(isMinimalAddressBarEnabled: Bool, toolbarHelper: ToolbarHelperInterface = ToolbarHelper()) {
-        self.isMinimalAddressBarEnabled = isMinimalAddressBarEnabled
+    init(toolbarHelper: ToolbarHelperInterface = ToolbarHelper()) {
         self.toolbarHelper = toolbarHelper
         super.init(frame: .zero)
     }
@@ -322,7 +320,7 @@ final class AddressToolbarContainer: UIView,
     // MARK: - AlphaDimmable
     func updateAlphaForSubviews(_ alpha: CGFloat) {
         let isReaderModeActive = state?.addressToolbar.readerModeState == .active
-        if !isMinimalAddressBarEnabled || isReaderModeActive {
+        if isReaderModeActive {
             // when the user scrolls the webpage the address toolbar gets hidden by changing its alpha
             regularToolbar.alpha = alpha
         }

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -163,9 +163,6 @@ final class NimbusFeatureFlagLayer: Sendable {
         case .toolbarTranslucencyRefactor:
             return checkToolbarTranslucencyRefactorFeature(from: nimbus)
 
-        case .toolbarMinimalAddressBar:
-            return checkToolbarMinimalAddressBarFeature(from: nimbus)
-
         case .toolbarMiddleButtonCustomization:
             return checkToolbarMiddleButtonCustomizationFeature(from: nimbus)
 
@@ -306,11 +303,6 @@ final class NimbusFeatureFlagLayer: Sendable {
     private func checkToolbarTranslucencyRefactorFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.toolbarRefactorFeature.value()
         return config.translucencyRefactor
-    }
-
-    private func checkToolbarMinimalAddressBarFeature(from nimbus: FxNimbus) -> Bool {
-        let config = nimbus.features.toolbarRefactorFeature.value()
-        return config.minimalAddressBar
     }
 
     private func checkToolbarMiddleButtonCustomizationFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
@@ -137,23 +137,6 @@ final class LegacyTabScrollControllerTests: XCTestCase {
     }
 
     // MARK: - overKeyboardScrollHeight Helper Method Tests
-    func testOverKeyboardScrollHeight_whenMinimalAddressBarDisabled_returnsContainerHeight() {
-        let subject = createSubject()
-        setupTabScroll(with: subject)
-
-        let containerHeight: CGFloat = 100
-        overKeyboardContainer.frame = CGRect(x: 0, y: 0, width: 200, height: containerHeight)
-
-        let safeAreaInsets = UIEdgeInsets(top: 44, left: 0, bottom: 34, right: 0)
-        let result = subject.calculateOverKeyboardScrollHeight(
-            with: safeAreaInsets,
-            isMinimalAddressBarEnabled: false,
-            isBottomSearchBar: true
-        )
-
-        XCTAssertEqual(result, containerHeight)
-    }
-
     func testOverKeyboardScrollHeight_minimalEnabledWithHomeIndicator_returnsZero() {
         let subject = createSubject()
         setupTabScroll(with: subject)
@@ -161,7 +144,6 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         let safeAreaInsets = UIEdgeInsets(top: 44, left: 0, bottom: 34, right: 0)
         let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
-            isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
         )
 
@@ -178,7 +160,6 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         let safeAreaInsets = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
         let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
-            isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
         )
 
@@ -194,7 +175,6 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         let safeAreaInsets = UIEdgeInsets(top: 44, left: 0, bottom: 0, right: 0)
         let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
-            isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
         )
 
@@ -209,7 +189,6 @@ final class LegacyTabScrollControllerTests: XCTestCase {
 
         let result = subject.calculateOverKeyboardScrollHeight(
             with: nil,
-            isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
         )
 
@@ -224,7 +203,6 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         let containerHeight: CGFloat = 100
         let result = subject.calculateOverKeyboardScrollHeight(
             with: UIEdgeInsets.zero,
-            isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
         )
 
@@ -242,7 +220,6 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         let safeAreaInsets = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
         let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
-            isMinimalAddressBarEnabled: true,
             isBottomSearchBar: false
         )
 
@@ -263,7 +240,6 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         let safeAreaInsets = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
         let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
-            isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
         )
 
@@ -280,7 +256,6 @@ final class LegacyTabScrollControllerTests: XCTestCase {
 
         let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
-            isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
         )
 
@@ -295,7 +270,6 @@ final class LegacyTabScrollControllerTests: XCTestCase {
 
         let result = subject.calculateOverKeyboardScrollHeight(
             with: safeAreaInsets,
-            isMinimalAddressBarEnabled: true,
             isBottomSearchBar: true
         )
 

--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -44,11 +44,6 @@ features:
           Enables translucency refactor for toolbars.
         type: Boolean
         default: true
-      minimal_address_bar:
-        description: >
-          Enables minimal address bar mode on scroll to ensure the url is always visible.
-        type: Boolean
-        default: true
       middle_button_customization:
         description: >
           Enables the middle button customization for navigation toolbar.
@@ -76,7 +71,6 @@ features:
           swiping_tabs: true
           translucency: true
           translucency-refactor: true
-          minimal_address_bar: true
           middle_button_customization: true
           layout: version1
           tab_tray_button_type: number
@@ -90,7 +84,6 @@ features:
           swiping_tabs: true
           translucency: true
           translucency-refactor: true
-          minimal_address_bar: true
           middle_button_customization: true
           layout: version1
           tab_tray_button_type: number


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15458)
~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~

## :bulb: Description
Removes the toolbar refactor feature flag`minimal_address_bar`. Additional feature flags will be removed in the following PRs.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code