### PR TITLE
 Refactor FXIOS-14751 [iPad Tab Tray Design] Consistent design with new design feature flag handling

### DIFF
--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -23,19 +23,17 @@ class TabTrayCoordinator: BaseCoordinator,
     weak var parentCoordinator: TabTrayCoordinatorDelegate?
     private let profile: Profile
     private let tabManager: TabManager
-
-    private var isTabTrayUIExperimentsEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
-        && UIDevice.current.userInterfaceIdiom != .pad
-    }
+    private let tabTrayUtils: TabTrayUtils
 
     init(router: Router,
          tabTraySection: TabTrayPanelType,
          profile: Profile,
-         tabManager: TabManager
+         tabManager: TabManager,
+         tabTrayUtils: TabTrayUtils = DefaultTabTrayUtils()
     ) {
         self.profile = profile
         self.tabManager = tabManager
+        self.tabTrayUtils = tabTrayUtils
         super.init(router: router)
         initializeTabTrayViewController(panelType: tabTraySection)
     }
@@ -72,7 +70,7 @@ class TabTrayCoordinator: BaseCoordinator,
 
         let panels: [UIViewController]
         // Panels order is different for the experiment
-        if isTabTrayUIExperimentsEnabled {
+        if tabTrayUtils.shouldDisplayExperimentUI() {
             panels = [privateTabsPanel, regularTabsPanel, syncTabs]
         } else {
             panels = [regularTabsPanel, privateTabsPanel, syncTabs]

--- a/firefox-ios/Client/Frontend/Browser/Tabs/TabTrayUtils.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/TabTrayUtils.swift
@@ -8,6 +8,8 @@ protocol TabTrayUtils {
     @MainActor
     var isTabTrayUIExperimentsEnabled: Bool { get }
     @MainActor
+    var isTabTrayIpadUIExperimentsEnabled: Bool { get }
+    @MainActor
     var isTabTrayTranslucencyEnabled: Bool { get }
     @MainActor
     var isReduceTransparencyEnabled: Bool { get }
@@ -34,6 +36,10 @@ struct DefaultTabTrayUtils: LegacyFeatureFlaggable, TabTrayUtils {
         return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
     }
 
+    var isTabTrayIpadUIExperimentsEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.tabTrayiPadUIExperiments, checking: .buildOnly)
+    }
+
     var isTabTrayTranslucencyEnabled: Bool {
         return featureFlags.isFeatureEnabled(.tabTrayTranslucency, checking: .buildOnly)
     }
@@ -51,11 +57,13 @@ struct DefaultTabTrayUtils: LegacyFeatureFlaggable, TabTrayUtils {
     }
 
     func shouldDisplayExperimentUI() -> Bool {
-        return isTabTrayUIExperimentsEnabled && UIDevice.current.userInterfaceIdiom != .pad
+        return isTabTrayUIExperimentsEnabled && UIDevice.current.userInterfaceIdiom != .pad ||
+            isTabTrayIpadUIExperimentsEnabled && UIDevice.current.userInterfaceIdiom == .pad
     }
 
     func shouldBlur() -> Bool {
-        return isTabTrayUIExperimentsEnabled && isTabTrayTranslucencyEnabled && !isReduceTransparencyEnabled
+        return shouldDisplayExperimentUI() &&
+            isTabTrayTranslucencyEnabled && !isReduceTransparencyEnabled
     }
 
     func backgroundAlpha() -> CGFloat {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -29,11 +29,7 @@ final class TabDisplayPanelViewController: UIViewController,
     private let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
     private var viewHasAppeared = false
-
-    private var isTabTrayUIExperimentsEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
-        && UIDevice.current.userInterfaceIdiom != .pad
-    }
+    private var tabTrayUtils: TabTrayUtils
 
     private lazy var layout: TabTrayLayoutType = {
         return shouldUseiPadSetup() ? .regular : .compact
@@ -41,6 +37,10 @@ final class TabDisplayPanelViewController: UIViewController,
 
     var isCompactLayout: Bool {
         return layout == .compact
+    }
+
+    var isTabTrayUIExperimentsEnabled: Bool {
+        return tabTrayUtils.shouldDisplayExperimentUI()
     }
 
     // MARK: UI elements
@@ -75,12 +75,14 @@ final class TabDisplayPanelViewController: UIViewController,
          windowUUID: WindowUUID,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
-         dragAndDropDelegate: TabDisplayViewDragAndDropInteraction) {
+         dragAndDropDelegate: TabDisplayViewDragAndDropInteraction,
+         tabTrayUtils: TabTrayUtils = DefaultTabTrayUtils()) {
         self.panelType = isPrivateMode ? .privateTabs : .tabs
         self.tabsState = TabsPanelState(windowUUID: windowUUID, isPrivateMode: isPrivateMode)
         self.notificationCenter = notificationCenter
         self.themeManager = themeManager
         self.windowUUID = windowUUID
+        self.tabTrayUtils = tabTrayUtils
         super.init(nibName: nil, bundle: nil)
         tabDisplayView.dragAndDropDelegate = dragAndDropDelegate
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -42,6 +42,7 @@ final class TabDisplayView: UIView,
     private let windowUUID: WindowUUID
     var theme: Theme?
     weak var dragAndDropDelegate: TabDisplayViewDragAndDropInteraction?
+    private var tabTrayUtils: TabTrayUtils
 
     lazy var dataSource =
     TabDisplayDiffableDataSource(
@@ -76,8 +77,7 @@ final class TabDisplayView: UIView,
         })
 
     private var isTabTrayUIExperimentsEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
-        && UIDevice.current.userInterfaceIdiom != .pad
+        return tabTrayUtils.shouldDisplayExperimentUI()
     }
 
     // Dragging on the collection view is either an 'active drag' where the item is moved, or
@@ -126,11 +126,13 @@ final class TabDisplayView: UIView,
 
     public init(panelType: TabTrayPanelType,
                 state: TabsPanelState,
-                windowUUID: WindowUUID) {
+                windowUUID: WindowUUID,
+                tabTrayUtils: TabTrayUtils = DefaultTabTrayUtils()) {
         self.panelType = panelType
         self.tabsState = state
         self.tabsSectionManager = TabsSectionManager()
         self.windowUUID = windowUUID
+        self.tabTrayUtils = tabTrayUtils
         super.init(frame: .zero)
         setupLayout()
         configureDataSource()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -484,7 +484,7 @@ final class TabTrayViewController: UIViewController,
     }
 
     private func setupToolBarAppearance(theme: Theme) {
-        guard tabTrayUtils.isTabTrayUIExperimentsEnabled else { return }
+        guard tabTrayUtils.shouldDisplayExperimentUI() else { return }
 
         // When Reduce Transparency is on, fall through to set a solid
         // appearance so button backgrounds use the correct theme color.
@@ -506,7 +506,7 @@ final class TabTrayViewController: UIViewController,
     }
 
     private func setupNavigationBarAppearance(theme: Theme) {
-        guard tabTrayUtils.isTabTrayUIExperimentsEnabled else { return }
+        guard tabTrayUtils.shouldDisplayExperimentUI() else { return }
 
         let backgroundAlpha = tabTrayUtils.backgroundAlpha()
         let color = theme.colors.layer1.withAlphaComponent(backgroundAlpha)
@@ -595,7 +595,7 @@ final class TabTrayViewController: UIViewController,
     }
 
     private func setupBlurView() {
-        guard tabTrayUtils.isTabTrayUIExperimentsEnabled, tabTrayUtils.isTabTrayTranslucencyEnabled else { return }
+        guard tabTrayUtils.shouldDisplayExperimentUI(), tabTrayUtils.isTabTrayTranslucencyEnabled else { return }
 
         if #available(iOS 26, *) { return }
 
@@ -646,7 +646,7 @@ final class TabTrayViewController: UIViewController,
             titleWidthConstraint?.isActive = true
         }
 
-        let isTabTrayEnabled = tabTrayUtils.isTabTrayUIExperimentsEnabled && tabTrayUtils.isTabTrayTranslucencyEnabled
+        let isTabTrayEnabled = tabTrayUtils.shouldDisplayExperimentUI() && tabTrayUtils.isTabTrayTranslucencyEnabled
         let topConstraintTo = isTabTrayEnabled ? view.topAnchor : view.safeAreaLayoutGuide.topAnchor
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14751)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31856)

## :bulb: Description
- Small refactor to use TabTrayUtils instead of directly checking `tabTrayUIExperiment` feature flag.
- Add iPad feature flag and update `shouldDisplayExperimentUI` to check both iPhone and iPad experiments.
-  No changes in functionality tabTrayiPadUIExperiment is still disabled so no regressions for iPhone


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

