### PR TITLE
Refactor FXIOS-15001 [Homepage] Decouple homepage tab UI state and Tab

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1076,6 +1076,7 @@
 		8A7AF0C72C9A119A009691B5 /* TabPeekStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7AF0C52C9A1167009691B5 /* TabPeekStateTests.swift */; };
 		8A7C12612E01DB0F00F2D7FA /* SearchBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7C12602E01DB0C00F2D7FA /* SearchBarCell.swift */; };
 		8A7D08E32CAAF7C30035999C /* HomepageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7D08E22CAAF7C30035999C /* HomepageViewController.swift */; };
+		8A7D08E52FBE2EBC0035999C /* HomepageTabStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7D08E42FBE2EBC0035999C /* HomepageTabStateStore.swift */; };
 		8A7D1AC52BA3542600162F4B /* splashScreen.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A7D1AC42BA3542600162F4B /* splashScreen.json */; };
 		8A8158CB2C2C77B000281F72 /* MicrosurveyTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8158CA2C2C77B000281F72 /* MicrosurveyTelemetry.swift */; };
 		8A827E302C20C7F5008D5E3C /* MicrosurveyMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A827E2E2C20C55E008D5E3C /* MicrosurveyMiddlewareTests.swift */; };
@@ -9376,6 +9377,7 @@
 		8A7AF0C52C9A1167009691B5 /* TabPeekStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabPeekStateTests.swift; sourceTree = "<group>"; };
 		8A7C12602E01DB0C00F2D7FA /* SearchBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarCell.swift; sourceTree = "<group>"; };
 		8A7D08E22CAAF7C30035999C /* HomepageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageViewController.swift; sourceTree = "<group>"; };
+		8A7D08E42FBE2EBC0035999C /* HomepageTabStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageTabStateStore.swift; sourceTree = "<group>"; };
 		8A7D1AC42BA3542600162F4B /* splashScreen.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = splashScreen.json; sourceTree = "<group>"; };
 		8A8158CA2C2C77B000281F72 /* MicrosurveyTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyTelemetry.swift; sourceTree = "<group>"; };
 		8A827E2E2C20C55E008D5E3C /* MicrosurveyMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyMiddlewareTests.swift; sourceTree = "<group>"; };
@@ -13941,6 +13943,7 @@
 				8A454D2A2CB7079A009436D9 /* Header */,
 				8ABDBAA42CB6BF3A00B51F63 /* Merino */,
 				8A7D08E22CAAF7C30035999C /* HomepageViewController.swift */,
+				8A7D08E42FBE2EBC0035999C /* HomepageTabStateStore.swift */,
 				8AA0A6622CAC40AA00AC7EB3 /* HomepageDiffableDataSource.swift */,
 				8AD3AFC22D143EF000CFC887 /* HomepageDimensionImplementation.swift */,
 				8AF347DC2CADD0E100624036 /* Redux */,
@@ -18962,6 +18965,7 @@
 				A093CD292F35408E0017774C /* MozAdsClientFactory.swift in Sources */,
 				DFACBF7F277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift in Sources */,
 				8A7D08E32CAAF7C30035999C /* HomepageViewController.swift in Sources */,
+				8A7D08E52FBE2EBC0035999C /* HomepageTabStateStore.swift in Sources */,
 				D01017F5219CB6BD009CBB5A /* DownloadContentScript.swift in Sources */,
 				39E186DF2F7D991700FD3FFA /* MerinoCategory.swift in Sources */,
 				8A093D832A4B68940099ABA5 /* PrivacySettingsDelegate.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -52,6 +52,7 @@ final class BrowserCoordinator: BaseCoordinator,
     private let applicationHelper: ApplicationHelper
     private let summarizerNimbusUtils: SummarizerNimbusUtils
     private let touExperimentsTracking: ToUExperimentsTracking
+    private let homepageTabStateStore: HomepageTabStateStore
     private var browserIsReady = false
     private var windowUUID: WindowUUID { return tabManager.windowUUID }
     private var isDeeplinkOptimiziationRefactorEnabled: Bool {
@@ -66,6 +67,7 @@ final class BrowserCoordinator: BaseCoordinator,
     init(router: Router,
          screenshotService: ScreenshotService,
          tabManager: TabManager,
+         homepageTabStateStore: HomepageTabStateStore = HomepageTabStateStore(),
          profile: Profile = AppContainer.shared.resolve(),
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          windowManager: WindowManager = AppContainer.shared.resolve(),
@@ -79,6 +81,7 @@ final class BrowserCoordinator: BaseCoordinator,
         self.themeManager = themeManager
         self.windowManager = windowManager
         self.touExperimentsTracking = ToUExperimentsTracking(prefs: profile.prefs)
+        self.homepageTabStateStore = homepageTabStateStore
         self.browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
         self.applicationHelper = applicationHelper
         self.glean = glean
@@ -143,6 +146,7 @@ final class BrowserCoordinator: BaseCoordinator,
         let homepageController = self.homepageViewController ?? HomepageViewController(
             windowUUID: windowUUID,
             tabManager: tabManager,
+            homepageTabStateStore: homepageTabStateStore,
             overlayManager: overlayManager,
             statusBarScrollDelegate: statusBarScrollDelegate,
             toastContainer: toastContainer
@@ -1247,6 +1251,10 @@ final class BrowserCoordinator: BaseCoordinator,
                        category: .coordinator)
             findAndHandle(route: savedRoute)
         }
+    }
+
+    func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
+        homepageTabStateStore.removeState(for: tab.tabUUID)
     }
 
     // MARK: - TabTrayCoordinatorDelegate

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageTabStateStore.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageTabStateStore.swift
@@ -14,6 +14,8 @@ protocol HomepageTabStateStoring: AnyObject {
     func removeState(for tabUUID: TabUUID)
 }
 
+/// Stores homepage UI state keyed by `TabUUID` so it can be restored while
+/// the shared homepage controller is reused across tabs.
 final class HomepageTabStateStore: HomepageTabStateStoring {
     private var states: [TabUUID: HomepageTabState] = [:]
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageTabStateStore.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageTabStateStore.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct HomepageTabState: Equatable {
+    var scrollOffsetY: CGFloat?
+}
+
+protocol HomepageTabStateStoring: AnyObject {
+    func state(for tabUUID: TabUUID) -> HomepageTabState
+    func updateState(for tabUUID: TabUUID, _ update: (inout HomepageTabState) -> Void)
+    func removeState(for tabUUID: TabUUID)
+}
+
+final class HomepageTabStateStore: HomepageTabStateStoring {
+    private var states: [TabUUID: HomepageTabState] = [:]
+
+    func state(for tabUUID: TabUUID) -> HomepageTabState {
+        return states[tabUUID] ?? HomepageTabState()
+    }
+
+    func updateState(for tabUUID: TabUUID, _ update: (inout HomepageTabState) -> Void) {
+        var state = states[tabUUID] ?? HomepageTabState()
+        update(&state)
+        states[tabUUID] = state
+    }
+
+    func removeState(for tabUUID: TabUUID) {
+        states.removeValue(forKey: tabUUID)
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -69,6 +69,7 @@ final class HomepageViewController: UIViewController,
 
     // MARK: - Private constants
     private let tabManager: TabManager
+    private let homepageTabStateStore: HomepageTabStateStoring
     private let overlayManager: OverlayModeManager
     private let logger: Logger
     private let toastContainer: UIView
@@ -83,6 +84,7 @@ final class HomepageViewController: UIViewController,
          profile: Profile = AppContainer.shared.resolve(),
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          tabManager: TabManager,
+         homepageTabStateStore: HomepageTabStateStoring = HomepageTabStateStore(),
          overlayManager: OverlayModeManager,
          statusBarScrollDelegate: StatusBarScrollDelegate? = nil,
          toastContainer: UIView,
@@ -94,6 +96,7 @@ final class HomepageViewController: UIViewController,
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
         self.tabManager = tabManager
+        self.homepageTabStateStore = homepageTabStateStore
         self.overlayManager = overlayManager
         self.statusBarScrollDelegate = statusBarScrollDelegate
         self.toastContainer = toastContainer
@@ -247,7 +250,7 @@ final class HomepageViewController: UIViewController,
     func restoreVerticalScrollOffset() {
         activeTabUUID = tabManager.selectedTab?.tabUUID
         guard let activeTabUUID,
-              let homepageScrollOffset = tabManager.getTabForUUID(uuid: activeTabUUID)?.homepageScrollOffset
+              let homepageScrollOffset = homepageTabStateStore.state(for: activeTabUUID).scrollOffsetY
         else {
             scrollToTop()
             return
@@ -283,8 +286,10 @@ final class HomepageViewController: UIViewController,
     }
 
     private func saveVerticalScrollOffset() {
-        guard let activeTabUUID, let tab = tabManager.getTabForUUID(uuid: activeTabUUID) else { return }
-        tab.homepageScrollOffset = collectionView?.contentOffset.y
+        guard let activeTabUUID else { return }
+        homepageTabStateStore.updateState(for: activeTabUUID) { state in
+            state.scrollOffsetY = collectionView?.contentOffset.y
+        }
     }
 
     private func handleScroll(_ scrollView: UIScrollView, isUserInteraction: Bool) {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -159,8 +159,6 @@ class Tab: NSObject,
     var hasHomeScreenshot = false
     var shouldScrollToTop = false
     var isFindInPageMode = false
-    // Stores the vertical homepage offset for this tab when reusing the shared HomepageViewController.
-    var homepageScrollOffset: CGFloat?
 
     // To check if current URL is the starting page i.e. either blank page or internal page like topsites
     var isURLStartingPage: Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -26,6 +26,7 @@ final class BrowserCoordinatorTests: XCTestCase, LegacyFeatureFlaggable, StoreTe
     private var scrollDelegate: MockStatusBarScrollDelegate!
     private var browserViewController: MockBrowserViewController!
     private var mockStore: MockStoreForMiddleware<AppState>!
+    private var homepageTabStateStore: HomepageTabStateStore!
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
     override func setUp() async throws {
@@ -44,6 +45,7 @@ final class BrowserCoordinatorTests: XCTestCase, LegacyFeatureFlaggable, StoreTe
         glean = MockGleanWrapper()
         scrollDelegate = MockStatusBarScrollDelegate()
         browserViewController = MockBrowserViewController(profile: profile, tabManager: tabManager)
+        homepageTabStateStore = HomepageTabStateStore()
         setupStore()
     }
 
@@ -58,6 +60,7 @@ final class BrowserCoordinatorTests: XCTestCase, LegacyFeatureFlaggable, StoreTe
         glean = nil
         scrollDelegate = nil
         browserViewController = nil
+        homepageTabStateStore = nil
         resetStore()
         DependencyHelperMock().reset()
         try await super.tearDown()
@@ -670,6 +673,31 @@ final class BrowserCoordinatorTests: XCTestCase, LegacyFeatureFlaggable, StoreTe
         subject.didFinish(from: childCoordinator)
 
         XCTAssertEqual(subject.childCoordinators.count, 0)
+    }
+
+    // MARK: - TabManagerDelegate
+
+    func testDidRemoveTab_removesHomepageTabStateForTab() throws {
+        let subject = createSubject()
+        let tab = MockTab(profile: profile, windowUUID: windowUUID)
+        homepageTabStateStore.updateState(for: tab.tabUUID) { $0.scrollOffsetY = 180 }
+
+        subject.tabManager(tabManager, didRemoveTab: tab, isRestoring: false)
+
+        XCTAssertNil(homepageTabStateStore.state(for: tab.tabUUID).scrollOffsetY)
+    }
+
+    func testDidRemoveTab_keepsHomepageTabStateForOtherTabs() throws {
+        let subject = createSubject()
+        let removedTab = MockTab(profile: profile, windowUUID: windowUUID)
+        let otherTab = MockTab(profile: profile, windowUUID: windowUUID)
+        homepageTabStateStore.updateState(for: removedTab.tabUUID) { $0.scrollOffsetY = 120 }
+        homepageTabStateStore.updateState(for: otherTab.tabUUID) { $0.scrollOffsetY = 240 }
+
+        subject.tabManager(tabManager, didRemoveTab: removedTab, isRestoring: false)
+
+        XCTAssertNil(homepageTabStateStore.state(for: removedTab.tabUUID).scrollOffsetY)
+        XCTAssertEqual(homepageTabStateStore.state(for: otherTab.tabUUID).scrollOffsetY, 240)
     }
 
     // MARK: - Search route
@@ -1346,6 +1374,7 @@ final class BrowserCoordinatorTests: XCTestCase, LegacyFeatureFlaggable, StoreTe
         let subject = BrowserCoordinator(router: mockRouter,
                                          screenshotService: screenshotService,
                                          tabManager: tabManager,
+                                         homepageTabStateStore: homepageTabStateStore,
                                          profile: profile,
                                          glean: glean,
                                          applicationHelper: applicationHelper)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
@@ -13,15 +13,18 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
     var mockThemeManager: MockThemeManager?
     var mockStore: MockStoreForMiddleware<AppState>!
     var mockThrottler: MockThrottler!
+    var homepageTabStateStore: HomepageTabStateStore!
 
     override func setUp() async throws {
         try await super.setUp()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
         DependencyHelperMock().bootstrapDependencies()
+        homepageTabStateStore = HomepageTabStateStore()
         setupStore()
     }
 
     override func tearDown() async throws {
+        homepageTabStateStore = nil
         mockThrottler = nil
         mockNotificationCenter = nil
         mockThemeManager = nil
@@ -335,9 +338,9 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
     func test_restoreContentOffset_withStoredOffset_setsCollectionViewOffset() {
         let tabManager = HomepageRestoreContentOffsetTabManager()
         let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
-        tab.homepageScrollOffset = 180
         tabManager.tabs = [tab]
         tabManager.selectedTab = tab
+        homepageTabStateStore.updateState(for: tab.tabUUID) { $0.scrollOffsetY = 180 }
         let subject = createSubject(tabManager: tabManager)
 
         subject.loadViewIfNeeded()
@@ -400,7 +403,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
 
         subject.viewWillDisappear(false)
 
-        XCTAssertEqual(tab.homepageScrollOffset, 140)
+        XCTAssertEqual(homepageTabStateStore.state(for: tab.tabUUID).scrollOffsetY, 140)
     }
 
     func test_scrollViewDidEndDragging_savesVerticalScrollOffset() {
@@ -424,7 +427,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
 
         subject.scrollViewDidEndDragging(UIScrollView(), willDecelerate: false)
 
-        XCTAssertEqual(tab.homepageScrollOffset, 140)
+        XCTAssertEqual(homepageTabStateStore.state(for: tab.tabUUID).scrollOffsetY, 140)
     }
 
     func test_scrollViewDidEndDecelerating_savesVerticalScrollOffset() {
@@ -448,7 +451,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
 
         subject.scrollViewDidEndDecelerating(UIScrollView())
 
-        XCTAssertEqual(tab.homepageScrollOffset, 140)
+        XCTAssertEqual(homepageTabStateStore.state(for: tab.tabUUID).scrollOffsetY, 140)
     }
 
     func test_newState_updatesWallpaperHeightConstraint_withAvailableWallpaperHeight() throws {
@@ -491,6 +494,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
             windowUUID: .XCTestDefaultUUID,
             themeManager: themeManager,
             tabManager: tabManager,
+            homepageTabStateStore: homepageTabStateStore,
             overlayManager: mockOverlayManager,
             statusBarScrollDelegate: statusBarScrollDelegate,
             toastContainer: UIView(),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15001)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32309)

## :bulb: Description
- Move homepage scroll offset state out of `Tab` and into a dedicated `HomepageTabStateStore` keyed by `TabUUID` that `HomepageViewController` reads and writes to.

### 📝 Notes
- This is also the foundation for how we will implement other per-tab homepage state such as [selected newsfeed category](https://mozilla-hub.atlassian.net/browse/FXIOS-15452)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

