### PR TITLE
Remove FXIOS-14751 [iPad Tab Tray Design] Consistent design remove toast presentation from TabTrayViewController

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -42,10 +42,6 @@ final class TabTrayViewController: UIViewController,
             static let width: CGFloat = 343
         }
 
-        struct Toast {
-            static let undoDelay = DispatchTimeInterval.seconds(0)
-            static let undoDuration = DispatchTimeInterval.seconds(3)
-        }
         static let fixedSpaceWidth: CGFloat = 32
         static let segmentedControlHorizontalSpacing: CGFloat = 16
         static let titleFont: UIFont = FXFontStyles.Bold.caption2.systemFont()
@@ -111,7 +107,6 @@ final class TabTrayViewController: UIViewController,
         return childPanelControllers[index]
     }
 
-    var shownToast: Toast?
     var logger: Logger
 
     // MARK: - UI
@@ -398,18 +393,6 @@ final class TabTrayViewController: UIViewController,
         if tabTrayState.showCloseConfirmation {
             showCloseAllConfirmation()
             tabTrayState.showCloseConfirmation = false
-        }
-
-        if let toastType = tabTrayState.toastType {
-            presentToast(toastType: toastType) { [weak self] undoClose in
-                guard let self else { return }
-
-                // Undo the action described by the toast
-                if let action = (toastType.reduxAction(for: self.windowUUID) as? TabPanelViewAction), undoClose {
-                    store.dispatch(action)
-                }
-                self.shownToast = nil
-            }
         }
 
         if let enableDeleteTabsButton = tabTrayState.enableDeleteTabsButton {
@@ -720,53 +703,6 @@ final class TabTrayViewController: UIViewController,
             return themeManager.resolvedTheme(with: tabTrayState.isPrivateMode)
         } else {
             return themeManager.getCurrentTheme(for: windowUUID)
-        }
-    }
-
-    private func presentToast(toastType: ToastType, completion: @escaping @MainActor (Bool) -> Void) {
-        if let currentToast = shownToast {
-            currentToast.dismiss(false)
-        }
-
-        if toastType.reduxAction(for: windowUUID) is TabPanelViewAction {
-            let viewModel = ButtonToastViewModel(labelText: toastType.title, buttonText: toastType.buttonText)
-            let toast = ButtonToast(viewModel: viewModel,
-                                    theme: retrieveTheme(),
-                                    completion: { buttonPressed in
-                completion(buttonPressed)
-            })
-            showToast(toast)
-            shownToast = toast
-        } else {
-            let viewModel = PlainToastViewModel(labelText: toastType.title)
-            let toast = PlainToast(viewModel: viewModel, theme: retrieveTheme())
-            showToast(toast)
-        }
-    }
-
-    private func showToast(_ toast: Toast,
-                           afterWaiting delay: DispatchTimeInterval = Toast.UX.toastDelayBefore,
-                           duration: DispatchTimeInterval? = Toast.UX.toastDismissAfter) {
-        toast.showToast(viewController: self,
-                        delay: UX.Toast.undoDelay,
-                        duration: UX.Toast.undoDuration) { toast in
-            if self.tabTrayUtils.shouldDisplayExperimentUI(), !self.isRegularLayout {
-                [
-                    toast.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor,
-                                                   constant: Toast.UX.toastSidePadding),
-                    toast.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor,
-                                                    constant: -Toast.UX.toastSidePadding),
-                    toast.bottomAnchor.constraint(equalTo: self.segmentedControl.topAnchor)
-                ]
-            } else {
-                [
-                    toast.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor,
-                                                   constant: Toast.UX.toastSidePadding),
-                    toast.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor,
-                                                    constant: -Toast.UX.toastSidePadding),
-                    toast.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
-                ]
-            }
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14751)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31856)

## :bulb: Description
- Follow up from https://github.com/mozilla-mobile/firefox-ios/pull/33113 I miss to remove the toast presentation 


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

