### PR TITLE
Add FXIOS-15450 [Quick Answers] setting to configure environment endpoints for MLPA

### DIFF
--- a/BrowserKit/Sources/LLMKit/LiteLLMCreator.swift
+++ b/BrowserKit/Sources/LLMKit/LiteLLMCreator.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import Shared
+import MLPAKit
+
+public struct LiteLLMCreator {
+    public static func createAppAttestLiteLLM(using prefs: Prefs) -> LiteLLMClient? {
+        let mlpaEnvironmentKey = prefs.stringForKey(PrefsKeys.MLPASettings.mlpaEndpointEnvironment) ?? ""
+        let mlpaEnvironment = MLPAEnvironment(rawValue: mlpaEnvironmentKey) ?? .prod
+        guard let endPoint = MLPAConstants.completionsEndpoint(with: mlpaEnvironment),
+              let client = try? AppAttestClient(remoteServer: MLPAAppAttestServer(with: mlpaEnvironment)) else {
+            return nil
+        }
+        let authenticator = AppAttestRequestAuth(appAttestClient: client)
+        return LiteLLMClient(authenticator: authenticator, baseURL: endPoint)
+    }
+}

--- a/BrowserKit/Sources/MLPAKit/MLPAAppAttestServer.swift
+++ b/BrowserKit/Sources/MLPAKit/MLPAAppAttestServer.swift
@@ -11,10 +11,16 @@ public struct MLPAAppAttestServer: AppAttestRemoteServerProtocol {
         let challenge: String
     }
 
+    private let environmentType: MLPAEnvironment
     private let bundleIdentifier: String
     private let urlSession: URLSessionProtocol
 
-    public init(urlSession: URLSessionProtocol = URLSession.shared, bundleIdentifier: String = AppInfo.bundleIdentifier) {
+    public init(
+        with type: MLPAEnvironment = .prod,
+        urlSession: URLSessionProtocol = URLSession.shared,
+        bundleIdentifier: String = AppInfo.bundleIdentifier
+    ) {
+        self.environmentType = type
         self.urlSession = urlSession
         self.bundleIdentifier = bundleIdentifier
     }
@@ -26,7 +32,7 @@ public struct MLPAAppAttestServer: AppAttestRemoteServerProtocol {
     /// because Base64 values can contain `+`, `/`, and `=` characters that
     /// would otherwise break the URL.
     public func fetchChallenge(for keyId: String) async throws -> String {
-        guard let challengeEndpoint = MLPAConstants.challengeEndpoint else {
+        guard let challengeEndpoint = MLPAConstants.challengeEndpoint(with: environmentType) else {
             throw AppAttestServiceError.invalidURL(description: "challengeEndpoint")
         }
 
@@ -53,7 +59,7 @@ public struct MLPAAppAttestServer: AppAttestRemoteServerProtocol {
         attestationObject: Data,
         challenge: String
     ) async throws {
-        guard let attestEndpoint = MLPAConstants.attestEndpoint else {
+        guard let attestEndpoint = MLPAConstants.attestEndpoint(with: environmentType) else {
             throw AppAttestServiceError.invalidURL(description: "attestEndpoint")
         }
 

--- a/BrowserKit/Sources/MLPAKit/MLPAJWTPayload.swift
+++ b/BrowserKit/Sources/MLPAKit/MLPAJWTPayload.swift
@@ -26,11 +26,34 @@ public enum MLPAConstants {
     static let contentTypeJSON = "application/json"
     static let POST = "POST"
 
-    static let baseURL = URL(string: "https://mlpa-prod-prod-mozilla.global.ssl.fastly.net")
+    public static func completionsEndpoint(with env: MLPAEnvironment) -> URL? {
+        env.baseURL?.appendingPathComponent("v1")
+    }
 
-    public static var completionsEndpoint: URL? { baseURL?.appendingPathComponent("v1") }
-    static var challengeEndpoint: URL? { baseURL?.appendingPathComponent("verify/challenge") }
-    static var attestEndpoint: URL? { baseURL?.appendingPathComponent("verify/attest") }
+    static func challengeEndpoint(with env: MLPAEnvironment) -> URL? {
+        env.baseURL?.appendingPathComponent("verify/challenge")
+    }
+
+    static func attestEndpoint(with env: MLPAEnvironment) -> URL? {
+        env.baseURL?.appendingPathComponent("verify/attest")
+    }
+}
+
+public enum MLPAEnvironment: String, Sendable {
+    case dev
+    case stage
+    case prod
+
+    var baseURL: URL? {
+        switch self {
+        case .dev:
+            return URL(string: "https://mlpa-nonprod-dev-mozilla.global.ssl.fastly.net")
+        case .stage:
+            return URL(string: "https://mlpa-nonprod-stage-mozilla.global.ssl.fastly.net")
+        case .prod:
+            return URL(string: "https://mlpa-prod-prod-mozilla.global.ssl.fastly.net")
+        }
+    }
 }
 
 /// The shared fields that every MLPA JWT envelope carries.

--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -139,6 +139,10 @@ public struct PrefsKeys {
         public static let signedInFxaAccount = "signedInFxaAccountKey"
     }
 
+    public struct MLPASettings {
+        public static let mlpaEndpointEnvironment = "mlpaEndpointEnvironment"
+    }
+
     public struct UserFeatureFlagPrefs {
         public static let ASPocketStories = "ASPocketStoriesUserPrefsKey"
         public static let StartAtHome = "StartAtHomeUserPrefsKey"

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerServiceFactory.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerServiceFactory.swift
@@ -5,6 +5,7 @@
 import Foundation
 import LLMKit
 import MLPAKit
+import Shared
 
 public protocol SummarizerServiceFactory {
     /// An object which responds to Summarize activities.
@@ -14,6 +15,7 @@ public protocol SummarizerServiceFactory {
               isHostedSummarizerEnabled: Bool,
               isAppAttestAuthEnabled: Bool,
               usesPermissiveGuardrails: Bool,
+              prefs: Prefs,
               config: SummarizerConfig?) -> SummarizerService?
 
     /// Returns the max words that the summarizer Service can handle.
@@ -29,6 +31,7 @@ public struct DefaultSummarizerServiceFactory: SummarizerServiceFactory {
                      isHostedSummarizerEnabled: Bool,
                      isAppAttestAuthEnabled: Bool,
                      usesPermissiveGuardrails: Bool = false,
+                     prefs: Prefs,
                      config: SummarizerConfig?) -> SummarizerService? {
         let maxWords = maxWords(isAppleSummarizerEnabled: isAppleSummarizerEnabled,
                                 isHostedSummarizerEnabled: isHostedSummarizerEnabled)
@@ -46,7 +49,11 @@ public struct DefaultSummarizerServiceFactory: SummarizerServiceFactory {
             )
         } else {
             guard isHostedSummarizerEnabled,
-                  let llmClient = makeLiteLLMClient(config: config, isAppAttestAuthEnabled: isAppAttestAuthEnabled) else {
+                  let llmClient = makeLiteLLMClient(
+                    config: config,
+                    prefs: prefs,
+                    isAppAttestAuthEnabled: isAppAttestAuthEnabled
+                  ) else {
                 return nil
             }
 
@@ -59,7 +66,11 @@ public struct DefaultSummarizerServiceFactory: SummarizerServiceFactory {
         }
         #else
         guard isHostedSummarizerEnabled,
-              let llmClient = makeLiteLLMClient(config: config, isAppAttestAuthEnabled: isAppAttestAuthEnabled) else {
+              let llmClient = makeLiteLLMClient(
+                config: config,
+                prefs: prefs,
+                isAppAttestAuthEnabled: isAppAttestAuthEnabled
+              ) else {
             return nil
         }
         let llmSummarizer = LiteLLMSummarizer(client: llmClient, config: config)
@@ -84,6 +95,7 @@ public struct DefaultSummarizerServiceFactory: SummarizerServiceFactory {
     // TODO: FXIOS-15146 - Add this to LLMKit and make creation more generic
     private func makeLiteLLMClient(
         config: SummarizerConfig,
+        prefs: Prefs,
         isAppAttestAuthEnabled: Bool
     ) -> LiteLLMClient? {
         guard let model = config.options["model"] as? String, !model.isEmpty else {
@@ -91,12 +103,7 @@ public struct DefaultSummarizerServiceFactory: SummarizerServiceFactory {
         }
 
         if isAppAttestAuthEnabled {
-            guard let endPoint = MLPAConstants.completionsEndpoint,
-                  let client = try? AppAttestClient(remoteServer: MLPAAppAttestServer()) else {
-                return nil
-            }
-            let authenticator = AppAttestRequestAuth(appAttestClient: client)
-            return LiteLLMClient(authenticator: authenticator, baseURL: endPoint)
+            return LiteLLMCreator.createAppAttestLiteLLM(using: prefs)
         } else {
             guard let endPoint = URL(string: LiteLLMConfig.apiEndpoint ?? ""),
                   let key = LiteLLMConfig.apiKey else {

--- a/BrowserKit/Tests/MLPAKitTests/MLPAAppAttestServerTests.swift
+++ b/BrowserKit/Tests/MLPAKitTests/MLPAAppAttestServerTests.swift
@@ -108,7 +108,7 @@ final class MLPAAppAttestServerTests: XCTestCase {
         urlSession: MockURLSession = MockURLSession(),
         bundleIdentifier: String = AppAttestTestData.bundleID
     ) -> MLPAAppAttestServer {
-        return MLPAAppAttestServer(urlSession: urlSession, bundleIdentifier: bundleIdentifier)
+        return MLPAAppAttestServer(with: .dev, urlSession: urlSession, bundleIdentifier: bundleIdentifier)
     }
 
     private func httpResponse(statusCode: Int) -> HTTPURLResponse {

--- a/BrowserKit/Tests/SummarizeKitTests/SummarizeServiceFactoryTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/SummarizeServiceFactoryTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Shared
 @testable import SummarizeKit
 
 final class MockSummarizerServiceLifecycle: SummarizerServiceLifecycle, @unchecked Sendable {
@@ -47,6 +48,7 @@ final class SummarizeServiceFactoryTests: XCTestCase {
             isAppleSummarizerEnabled: true,
             isHostedSummarizerEnabled: false,
             isAppAttestAuthEnabled: false,
+            prefs: MockProfilePrefs(),
             config: nil
         )
         let service = try XCTUnwrap(result as? DefaultSummarizerService)
@@ -62,6 +64,7 @@ final class SummarizeServiceFactoryTests: XCTestCase {
             isAppleSummarizerEnabled: false,
             isHostedSummarizerEnabled: true,
             isAppAttestAuthEnabled: false,
+            prefs: MockProfilePrefs(),
             config: nil
         )
 
@@ -75,6 +78,7 @@ final class SummarizeServiceFactoryTests: XCTestCase {
             isAppleSummarizerEnabled: false,
             isHostedSummarizerEnabled: true,
             isAppAttestAuthEnabled: true,
+            prefs: MockProfilePrefs(),
             config: nil
         )
 
@@ -88,6 +92,7 @@ final class SummarizeServiceFactoryTests: XCTestCase {
             isAppleSummarizerEnabled: false,
             isHostedSummarizerEnabled: false,
             isAppAttestAuthEnabled: false,
+            prefs: MockProfilePrefs(),
             config: nil
         )
 

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1408,6 +1408,7 @@
 		AA3CEBAD2ECB853400DDEFEF /* SearchTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CEBAC2ECB853400DDEFEF /* SearchTelemetryTests.swift */; };
 		AA459F872F630F3500D05D04 /* QuickAnswersKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA459F862F630F3500D05D04 /* QuickAnswersKit */; };
 		AA4D99432E857AF300BB039D /* MockRecentSearchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4D99422E857AEE00BB039D /* MockRecentSearchProvider.swift */; };
+		AA5001492F912F610065A279 /* ChangeMLPAEndpointSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5001482F912F530065A279 /* ChangeMLPAEndpointSetting.swift */; };
 		AA5E81472EB12BDC00919E60 /* TranslationsMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5E81462EB12BD800919E60 /* TranslationsMiddleware.swift */; };
 		AA5E81482EF5000000000001 /* PreferredTranslationLanguagesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5E81492EF5000000000001 /* PreferredTranslationLanguagesManager.swift */; };
 		AA62FA6A2EF2F49A009785D9 /* LocaleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3B67B2CF65DE300AFA1FE /* LocaleProvider.swift */; };
@@ -9940,6 +9941,7 @@
 		AA24AD332E7C3ACC008659A3 /* MockTrendingSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTrendingSearchEngine.swift; sourceTree = "<group>"; };
 		AA3CEBAC2ECB853400DDEFEF /* SearchTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTelemetryTests.swift; sourceTree = "<group>"; };
 		AA4D99422E857AEE00BB039D /* MockRecentSearchProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRecentSearchProvider.swift; sourceTree = "<group>"; };
+		AA5001482F912F530065A279 /* ChangeMLPAEndpointSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeMLPAEndpointSetting.swift; sourceTree = "<group>"; };
 		AA5E81462EB12BD800919E60 /* TranslationsMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsMiddleware.swift; sourceTree = "<group>"; };
 		AA5E81492EF5000000000001 /* PreferredTranslationLanguagesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferredTranslationLanguagesManager.swift; sourceTree = "<group>"; };
 		AA6A6F372EF57EB800D1912D /* SystemLocaleProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemLocaleProviderTests.swift; sourceTree = "<group>"; };
@@ -13635,6 +13637,7 @@
 				8A3EF7FC2A2FCFAC00796E3A /* AppReviewPromptSetting.swift */,
 				1DA710062AE7106B00677F6B /* AppDataUsageReportSetting.swift */,
 				1D1418772DC92DFC004BBFAD /* ChangeRSServerSetting.swift */,
+				AA5001482F912F530065A279 /* ChangeMLPAEndpointSetting.swift */,
 				8A3EF7FE2A2FCFBB00796E3A /* ChangeToChinaSetting.swift */,
 				8A093D7C2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift */,
 				8A3EF7F12A2FCF4000796E3A /* DeleteExportedDataSetting.swift */,
@@ -18904,6 +18907,7 @@
 				B2FEA68D2B460D390058E616 /* AddressAutofillSettingsViewController.swift in Sources */,
 				21618A8A2A4389F700A5189E /* PresentedComponentsState.swift in Sources */,
 				8CC617092C35463B001C7688 /* AddressModifiedStatus.swift in Sources */,
+				AA5001492F912F610065A279 /* ChangeMLPAEndpointSetting.swift in Sources */,
 				EB1C84BF212EFFBF001489DF /* BrowserViewController+ReaderMode.swift in Sources */,
 				81020C922BB5AFA2007B8481 /* OnboardingMultipleChoiceButtonView.swift in Sources */,
 				96D95016270238500079D39D /* MainThreadThrottler.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
@@ -73,6 +73,7 @@ final class SummarizeCoordinator: BaseCoordinator,
             isHostedSummarizerEnabled: isHostedSummarizerEnabled,
             isAppAttestAuthEnabled: isAppAttestAuthEnabled,
             usesPermissiveGuardrails: usesPermissiveGuardrails,
+            prefs: prefs,
             config: config) else {
             parentCoordinatorDelegate?.didFinish(from: self)
             return

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -533,6 +533,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
             DeleteLoginsKeysSetting(settings: self),
             DeleteAutofillKeysSetting(settings: self),
             ChangeRSServerSetting(settings: self),
+            ChangeMLPAEndpointSetting(settings: self),
             PopupHTMLSetting(settings: self),
             AddShortcutsSetting(settings: self, settingsDelegate: self),
             MerinoTestDataSetting(settings: self, settingsDelegate: self)

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -533,13 +533,13 @@ class AppSettingsTableViewController: SettingsTableViewController,
             DeleteLoginsKeysSetting(settings: self),
             DeleteAutofillKeysSetting(settings: self),
             ChangeRSServerSetting(settings: self),
-            ChangeMLPAEndpointSetting(settings: self),
             PopupHTMLSetting(settings: self),
             AddShortcutsSetting(settings: self, settingsDelegate: self),
             MerinoTestDataSetting(settings: self, settingsDelegate: self)
         ]
 
         #if MOZ_CHANNEL_beta || MOZ_CHANNEL_developer
+        hiddenDebugOptions.append(ChangeMLPAEndpointSetting(settings: self))
         hiddenDebugOptions.append(DeleteAppAttestKeySetting(settings: self))
         hiddenDebugOptions.append(PrivacyNoticeUpdate(settings: self))
         hiddenDebugOptions.append(FeatureFlagsSettings(settings: self, settingsDelegate: self))

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeMLPAEndpointSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeMLPAEndpointSetting.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+import Shared
+import MLPAKit
+
+final class ChangeMLPAEndpointSetting: HiddenSetting {
+    private let prefsKey = PrefsKeys.MLPASettings.mlpaEndpointEnvironment
+    private let prefs: Prefs = { return (AppContainer.shared.resolve() as Profile).prefs }()
+
+    override var title: NSAttributedString? {
+        guard let theme else { return nil }
+
+        return NSAttributedString(string: "MLPA Endpoint",
+                                  attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        let currentEnvRaw = prefs.stringForKey(prefsKey) ?? MLPAEnvironment.prod.rawValue
+        let message = """
+        Current: \(currentEnvRaw.capitalized)
+        """
+        let alert = UIAlertController(title: "MLPA Endpoint",
+                                      message: message,
+                                      preferredStyle: .alert)
+
+        alert.addAction(UIAlertAction(title: "Production", style: .default, handler: { [weak self] _ in
+            guard let self else { return }
+            self.prefs.removeObjectForKey(self.prefsKey)
+        }))
+        alert.addAction(UIAlertAction(title: "Staging", style: .default, handler: { [weak self] _ in
+            guard let self else { return }
+            self.prefs.setString(MLPAEnvironment.stage.rawValue, forKey: self.prefsKey)
+        }))
+        alert.addAction(UIAlertAction(title: "Dev", style: .default, handler: { [weak self] _ in
+            guard let self else { return }
+            self.prefs.setString(MLPAEnvironment.dev.rawValue, forKey: self.prefsKey)
+        }))
+        settings.present(alert, animated: true)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SummarizeCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SummarizeCoordinatorTests.swift
@@ -28,6 +28,7 @@ class MockSummarizerServiceFactory: SummarizerServiceFactory {
               isHostedSummarizerEnabled: Bool,
               isAppAttestAuthEnabled: Bool,
               usesPermissiveGuardrails: Bool,
+              prefs: Prefs,
               config: SummarizerConfig?) -> SummarizerService? {
         return DefaultSummarizerService(summarizer: MockSummarizer(), lifecycleDelegate: lifecycleDelegate, maxWords: 10)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15450)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33138)

## :bulb: Description
Add debug settings for changing the MLPA environment endpoints. Followed similar to how we implement Remote Settings configuration. 

<img width="400" height="900" alt="simulator_screenshot_C7E465A7-2F11-4317-B08D-D5019BC9A612" src="https://github.com/user-attachments/assets/8ae92bcc-eec9-4f62-b4c0-0644b1385c01" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

