### PR TITLE
Bugfix FXIOS-15440 [Tab manager] Intermittent blank page when opening inactive tabs from tab tray

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4680,12 +4680,13 @@ extension BrowserViewController: TabManagerDelegate {
                     // [https://mozilla-hub.atlassian.net/browse/FXIOS-10335]
                     needsReload = true
                 }
+            }
 
-                if webView.url == nil {
-                    // The webView can go gray if it was zombified due to memory pressure.
-                    // When this happens, the URL is nil, so try restoring the page upon selection.
-                    needsReload = true
-                }
+            if webView.url == nil {
+                logger.log("Webview was zombified, reloading tab upon selection", level: .debug, category: .lifecycle)
+                // The webView can go gray if it was zombified due to memory pressure.
+                // When this happens, the URL is nil, so try restoring the page upon selection.
+                needsReload = true
             }
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4682,7 +4682,8 @@ extension BrowserViewController: TabManagerDelegate {
                 }
             }
 
-            if webView.url == nil {
+            // Do not reload if it's an about:blank page [FXIOS-14782]
+            if webView.url == nil && selectedTab.url?.absoluteString != "about:blank" {
                 logger.log("Webview was zombified, reloading tab upon selection", level: .debug, category: .lifecycle)
                 // The webView can go gray if it was zombified due to memory pressure.
                 // When this happens, the URL is nil, so try restoring the page upon selection.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15440)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33116)

## :bulb: Description
I was too overly positive with the refactor, and some part of the needs reload is still needed (see comment below). The needs reload refactor is enabled in developer and beta builds only, the experiment was paused/canceled for now until we can confirm this bugfix actually works with QA approval.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

