### PR TITLE
Bugfix FXIOS-15429 Allow zoom shortcuts on webpages

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
@@ -308,12 +308,16 @@ extension BrowserViewController {
 
     @objc
     func zoomIn() {
+        guard !contentContainer.hasAnyHomepage else { return }
+
         let zoomValue = zoomManager.zoomIn()
         zoomPageBar?.updateZoomLabel(zoomValue: zoomValue)
     }
 
     @objc
     func zoomOut() {
+        guard !contentContainer.hasAnyHomepage else { return }
+
         let zoomValue = zoomManager.zoomOut()
         zoomPageBar?.updateZoomLabel(zoomValue: zoomValue)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
@@ -308,16 +308,12 @@ extension BrowserViewController {
 
     @objc
     func zoomIn() {
-        guard contentContainer.hasAnyHomepage else { return }
-
         let zoomValue = zoomManager.zoomIn()
         zoomPageBar?.updateZoomLabel(zoomValue: zoomValue)
     }
 
     @objc
     func zoomOut() {
-        guard contentContainer.hasAnyHomepage else { return }
-
         let zoomValue = zoomManager.zoomOut()
         zoomPageBar?.updateZoomLabel(zoomValue: zoomValue)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15429)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33097)

## :bulb: Description

It appears in [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/26373/) a guard statement was added to the zoom in/out functions to limit zooming to homepages only. I don't have full context but that guard statement causes the zoom shortcuts to not work on webpages.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

