### PR TITLE
Add FXIOS-15452 [Newsfeed Categories] Per-tab selected newsfeed category

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -30,7 +30,7 @@ final class HomepageDiffableDataSource:
         case searchBar
         case jumpBackIn(TextColor?, JumpBackInSectionLayoutConfiguration)
         case bookmarks(TextColor?)
-        case pocket(TextColor?)
+        case pocket(TextColor?, String?)
         case spacer
 
         var canHandleLongPress: Bool {
@@ -96,6 +96,7 @@ final class HomepageDiffableDataSource:
 
     func updateSnapshot(
         state: HomepageState,
+        selectedNewsfeedCategoryID: String? = nil,
         jumpBackInDisplayConfig: JumpBackInSectionLayoutConfiguration,
         completion: (() -> Void)? = nil
     ) {
@@ -144,9 +145,10 @@ final class HomepageDiffableDataSource:
             snapshot.appendItems([.searchBar], toSection: .searchBar)
         }
 
-        if let stories = getMerinoStories(with: state.merinoState) {
-            snapshot.appendSections([.pocket(textColor)])
-            snapshot.appendItems(stories, toSection: .pocket(textColor))
+        if let stories = getMerinoStories(with: state.merinoState, selectedNewsfeedCategoryID: selectedNewsfeedCategoryID) {
+            let pocketSection = HomeSection.pocket(textColor, selectedNewsfeedCategoryID)
+            snapshot.appendSections([pocketSection])
+            snapshot.appendItems(stories, toSection: pocketSection)
         }
 
         apply(snapshot, animatingDifferences: true, completion: completion)
@@ -206,9 +208,12 @@ final class HomepageDiffableDataSource:
         return state.bookmarks.compactMap { .bookmark($0) }
     }
 
-    private func getMerinoStories(with merinoState: MerinoState) -> [HomepageDiffableDataSource.HomeItem]? {
-        let stories: [HomeItem] = merinoState.visibleStories.map {
-            .merino($0, merinoState.selectedCategoryID)
+    private func getMerinoStories(
+        with merinoState: MerinoState,
+        selectedNewsfeedCategoryID: String?
+    ) -> [HomepageDiffableDataSource.HomeItem]? {
+        let stories: [HomeItem] = merinoState.visibleStories(selectedNewsfeedCategoryID: selectedNewsfeedCategoryID).map {
+            .merino($0, selectedNewsfeedCategoryID)
         }
         guard merinoState.shouldShowSection, !stories.isEmpty else { return nil }
         return stories

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageTabStateStore.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageTabStateStore.swift
@@ -6,6 +6,7 @@ import Foundation
 
 struct HomepageTabState: Equatable {
     var scrollOffsetY: CGFloat?
+    var selectedNewsfeedCategoryID: String?
 }
 
 protocol HomepageTabStateStoring: AnyObject {

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -59,7 +59,6 @@ final class HomepageViewController: UIViewController,
     private var wallpaperTopConstraint: NSLayoutConstraint?
     private var wallpaperHeightConstraint: NSLayoutConstraint?
 
-
     private var currentHomepageTabState: HomepageTabState {
         guard let activeTabUUID else { return HomepageTabState() }
         return homepageTabStateStore.state(for: activeTabUUID)

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -59,6 +59,12 @@ final class HomepageViewController: UIViewController,
     private var wallpaperTopConstraint: NSLayoutConstraint?
     private var wallpaperHeightConstraint: NSLayoutConstraint?
 
+
+    private var currentHomepageTabState: HomepageTabState {
+        guard let activeTabUUID else { return HomepageTabState() }
+        return homepageTabStateStore.state(for: activeTabUUID)
+    }
+
     private var currentTheme: Theme {
         themeManager.getCurrentTheme(for: windowUUID)
     }
@@ -167,6 +173,8 @@ final class HomepageViewController: UIViewController,
         super.viewWillAppear(animated)
 
         activeTabUUID = tabManager.selectedTab?.tabUUID
+        refreshHomepageDataSourceSnapshot()
+
         /// Used as a trigger for showing a microsurvey based on viewing the homepage
         Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
         store.dispatch(
@@ -382,6 +390,7 @@ final class HomepageViewController: UIViewController,
 
             dataSource?.updateSnapshot(
                 state: state,
+                selectedNewsfeedCategoryID: currentHomepageTabState.selectedNewsfeedCategoryID,
                 jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
             ) { [weak self] in
                 // Force the collection view to finish applying the latest layout before re-syncing the
@@ -653,7 +662,7 @@ final class HomepageViewController: UIViewController,
         at indexPath: IndexPath
     ) -> UICollectionViewCell {
         let position = indexPath.item + 1
-        let currentSection = dataSource?.snapshot().sectionIdentifiers[indexPath.section] ?? .pocket(.clear)
+        let currentSection = dataSource?.snapshot().sectionIdentifiers[indexPath.section] ?? .pocket(.clear, nil)
         let totalCount = dataSource?.snapshot().numberOfItems(inSection: currentSection)
 
         return configuredCell(cellType: StoryCell.self, at: indexPath) { cell in
@@ -719,8 +728,8 @@ final class HomepageViewController: UIViewController,
             theme: currentTheme,
             transitionEnabled: transitionEnabled,
             categories: homepageState.merinoState.availableCategories,
-            selectedCategoryID: homepageState.merinoState.selectedCategoryID,
-            onSelection: dispatchCategorySelectedAction
+            selectedNewsfeedCategoryID: currentHomepageTabState.selectedNewsfeedCategoryID,
+            onSelection: updatedSelectedNewsfeedCategory
         )
         newsTransitionHeaderCell.setTransitionProgress(newsTransitionProgress())
         return newsTransitionHeaderCell
@@ -762,7 +771,7 @@ final class HomepageViewController: UIViewController,
                 theme: currentTheme
             )
             return sectionLabelCell
-        case .pocket(let textColor):
+        case .pocket(let textColor, _):
             sectionLabelCell.configure(
                 sectionHeaderConfiguration: MerinoState.Constants.sectionHeaderConfiguration,
                 textColor: textColor,
@@ -1048,13 +1057,19 @@ final class HomepageViewController: UIViewController,
         )
     }
 
-    private func dispatchCategorySelectedAction(selectedCategoryID: String?) {
-        store.dispatch(
-            MerinoAction(
-                selectedCategoryID: selectedCategoryID,
-                windowUUID: windowUUID,
-                actionType: MerinoActionType.categorySelected
-            )
+    private func updatedSelectedNewsfeedCategory(selectedNewsfeedCategoryID: String?) {
+        guard let activeTabUUID else { return }
+        homepageTabStateStore.updateState(for: activeTabUUID) { state in
+            state.selectedNewsfeedCategoryID = selectedNewsfeedCategoryID
+        }
+        refreshHomepageDataSourceSnapshot()
+    }
+
+    private func refreshHomepageDataSourceSnapshot() {
+        dataSource?.updateSnapshot(
+            state: homepageState,
+            selectedNewsfeedCategoryID: currentHomepageTabState.selectedNewsfeedCategoryID,
+            jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
         )
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoAction.swift
@@ -17,13 +17,11 @@ struct MerinoAction: Action {
     let merinoResponse: MerinoStoryResponse?
     let isEnabled: Bool?
     let telemetryConfig: OpenPocketTelemetryConfig?
-    let selectedCategoryID: String?
 
     init(
         merinoStoryResponse: MerinoStoryResponse? = nil,
         isEnabled: Bool? = nil,
         telemetryConfig: OpenPocketTelemetryConfig? = nil,
-        selectedCategoryID: String? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
@@ -32,7 +30,6 @@ struct MerinoAction: Action {
         self.merinoResponse = merinoStoryResponse
         self.isEnabled = isEnabled
         self.telemetryConfig = telemetryConfig
-        self.selectedCategoryID = selectedCategoryID
     }
 }
 
@@ -40,7 +37,6 @@ enum MerinoActionType: ActionType {
     case toggleShowSectionSetting
     case tapOnHomepageMerinoCell
     case viewedSection
-    case categorySelected
 }
 
 enum MerinoMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
@@ -14,7 +14,6 @@ struct MerinoState: StateType, Equatable {
     var windowUUID: WindowUUID
     let merinoData: MerinoStoryResponse
     let hasMerinoResponseContent: Bool
-    let selectedCategoryID: String? // nil = All stories
     let shouldShowSection: Bool
 
     struct Constants {
@@ -34,7 +33,6 @@ struct MerinoState: StateType, Equatable {
             windowUUID: windowUUID,
             merinoData: MerinoStoryResponse(),
             hasMerinoResponseContent: false,
-            selectedCategoryID: nil,
             shouldShowSection: shouldShowSection
         )
     }
@@ -43,13 +41,11 @@ struct MerinoState: StateType, Equatable {
         windowUUID: WindowUUID,
         merinoData: MerinoStoryResponse,
         hasMerinoResponseContent: Bool,
-        selectedCategoryID: String?,
         shouldShowSection: Bool
     ) {
         self.windowUUID = windowUUID
         self.merinoData = merinoData
         self.hasMerinoResponseContent = hasMerinoResponseContent
-        self.selectedCategoryID = selectedCategoryID
         self.shouldShowSection = shouldShowSection
     }
 
@@ -64,8 +60,6 @@ struct MerinoState: StateType, Equatable {
             return handleMerinoStoriesAction(action, state: state)
         case MerinoActionType.toggleShowSectionSetting:
             return handleSettingsToggleAction(action, state: state)
-        case MerinoActionType.categorySelected:
-            return handleCategorySelectedAction(action, state: state)
         default:
             return defaultState(from: state)
         }
@@ -85,7 +79,6 @@ struct MerinoState: StateType, Equatable {
             windowUUID: state.windowUUID,
             merinoData: merinoResponse,
             hasMerinoResponseContent: merinoContentExists,
-            selectedCategoryID: state.selectedCategoryID,
             shouldShowSection: merinoContentExists && state.shouldShowSection
         )
     }
@@ -99,25 +92,6 @@ struct MerinoState: StateType, Equatable {
 
         return state.copyWithUpdates(
             shouldShowSection: isEnabled
-        )
-    }
-
-    private static func handleCategorySelectedAction(_ action: Action, state: MerinoState) -> MerinoState {
-        guard let merinoAction = action as? MerinoAction
-        else {
-            return defaultState(from: state)
-        }
-
-        /// `copyWithUpdates` uses a double-optional for optional fields:
-        /// - `.some(.some(value))` sets a concrete value
-        /// - `.some(nil)` leaves the existing value unchanged
-        /// - `nil` clears the property
-        /// We need to pass the outer optional explicitly here so tapping the client-side  "All" category can clear
-        /// `selectedCategoryID` back to `nil`.
-        return state.copyWithUpdates(
-            selectedCategoryID: merinoAction.selectedCategoryID == nil
-                ? (nil as String??)
-                : .some(merinoAction.selectedCategoryID)
         )
     }
 
@@ -142,10 +116,10 @@ extension MerinoState {
         (merinoData.categories ?? []).sorted { $0.rank < $1.rank }
     }
 
-    var visibleStories: [MerinoStoryConfiguration] {
+    func visibleStories(selectedNewsfeedCategoryID: String?) -> [MerinoStoryConfiguration] {
         if !availableCategories.isEmpty {
-            if let selectedCategoryID {
-                return availableCategories.first(where: { $0.feedID == selectedCategoryID })?.recommendations ?? []
+            if let selectedNewsfeedCategoryID {
+                return availableCategories.first(where: { $0.feedID == selectedNewsfeedCategoryID })?.recommendations ?? []
             }
             return availableCategories.flatMap(\.recommendations)
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
@@ -79,7 +79,7 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         theme: Theme,
         transitionEnabled: Bool = true,
         categories: [MerinoCategoryConfiguration] = [],
-        selectedCategoryID: String? = nil,
+        selectedNewsfeedCategoryID: String? = nil,
         onSelection: (@MainActor @Sendable (String?) -> Void)? = nil
     ) {
         self.transitionEnabled = transitionEnabled
@@ -93,7 +93,7 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         sectionTitleHeaderView.moreButton.isHidden = true
         storyCategoryPickerView.configure(
             categories: categories,
-            selectedCategoryID: selectedCategoryID,
+            selectedNewsfeedCategoryID: selectedNewsfeedCategoryID,
             onSelection: onSelection
         )
         storyCategoryPickerView.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/StoryCategoryPickerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/StoryCategoryPickerView.swift
@@ -27,11 +27,11 @@ final class StoryCategoryPickerView: UIView, ThemeApplicable {
 
     func configure(
         categories: [MerinoCategoryConfiguration],
-        selectedCategoryID: String?,
+        selectedNewsfeedCategoryID: String?,
         onSelection: (@MainActor (String?) -> Void)?
     ) {
         let items = pickerItems(from: categories)
-        let selectedPickerID = selectedCategoryID ?? Self.allCategoryID
+        let selectedPickerID = selectedNewsfeedCategoryID ?? Self.allCategoryID
 
         chipPickerView.configure(
             items: items,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
@@ -226,7 +226,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             )
         )
 
-        dataSource.updateSn apshot(
+        dataSource.updateSnapshot(
             state: categorizedState,
             selectedNewsfeedCategoryID: "technology",
             jumpBackInDisplayConfig: mockSectionConfig

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
@@ -84,11 +84,11 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         )
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(.systemCyan)), 20)
+        XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(.systemCyan, nil)), 20)
         let expectedSections: [HomepageSection] = [
             .header,
             .spacer,
-            .pocket(.systemCyan)
+            .pocket(.systemCyan, nil)
         ]
         XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
     }
@@ -182,11 +182,11 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.updateSnapshot(state: state, jumpBackInDisplayConfig: mockSectionConfig)
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil)), 20)
+        XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil, nil)), 20)
         let expectedSections: [HomepageSection] = [
             .header,
             .spacer,
-            .pocket(nil)
+            .pocket(nil, nil)
         ]
         XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
     }
@@ -207,7 +207,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.updateSnapshot(state: state, jumpBackInDisplayConfig: mockSectionConfig)
 
         let snapshot = dataSource.snapshot()
-        let items = snapshot.itemIdentifiers(inSection: .pocket(nil))
+        let items = snapshot.itemIdentifiers(inSection: .pocket(nil, nil))
 
         XCTAssertEqual(items.count, 3)
         XCTAssertEqual(merinoTitles(from: items), ["science 1", "science 2", "technology 1"])
@@ -225,19 +225,15 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
                 actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
             )
         )
-        let selectedState = HomepageState.reducer(
-            categorizedState,
-            MerinoAction(
-                selectedCategoryID: "technology",
-                windowUUID: .XCTestDefaultUUID,
-                actionType: MerinoActionType.categorySelected
-            )
+
+        dataSource.updateSn apshot(
+            state: categorizedState,
+            selectedNewsfeedCategoryID: "technology",
+            jumpBackInDisplayConfig: mockSectionConfig
         )
 
-        dataSource.updateSnapshot(state: selectedState, jumpBackInDisplayConfig: mockSectionConfig)
-
         let snapshot = dataSource.snapshot()
-        let items = snapshot.itemIdentifiers(inSection: .pocket(nil))
+        let items = snapshot.itemIdentifiers(inSection: .pocket(nil, "technology"))
 
         XCTAssertEqual(items.count, 1)
         XCTAssertEqual(merinoTitles(from: items), ["technology 1"])
@@ -255,20 +251,16 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
                 actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
             )
         )
-        let selectedState = HomepageState.reducer(
-            categorizedState,
-            MerinoAction(
-                selectedCategoryID: "missing-category",
-                windowUUID: .XCTestDefaultUUID,
-                actionType: MerinoActionType.categorySelected
-            )
-        )
 
-        dataSource.updateSnapshot(state: selectedState, jumpBackInDisplayConfig: mockSectionConfig)
+        dataSource.updateSnapshot(
+            state: categorizedState,
+            selectedNewsfeedCategoryID: "missing-category",
+            jumpBackInDisplayConfig: mockSectionConfig
+        )
 
         let snapshot = dataSource.snapshot()
 
-        XCTAssertFalse(snapshot.sectionIdentifiers.contains(.pocket(nil)))
+        XCTAssertFalse(snapshot.sectionIdentifiers.contains(.pocket(nil, "missing-category")))
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
@@ -95,46 +95,6 @@ final class MerinoStateTests: XCTestCase {
     }
 
     @MainActor
-    func test_categorySelected_withSpecificCategory_updatesSelectedCategoryID() {
-        let initialState = createSubject()
-        let reducer = pocketReducer()
-
-        let newState = reducer(
-            initialState,
-            MerinoAction(
-                selectedCategoryID: "technology",
-                windowUUID: .XCTestDefaultUUID,
-                actionType: MerinoActionType.categorySelected
-            )
-        )
-
-        XCTAssertEqual(newState.selectedCategoryID, "technology")
-    }
-
-    @MainActor
-    func test_categorySelected_withNilCategory_clearsSelectedCategoryID() {
-        let initialState = pocketReducer()(
-            createSubject(),
-            MerinoAction(
-                selectedCategoryID: "technology",
-                windowUUID: .XCTestDefaultUUID,
-                actionType: MerinoActionType.categorySelected
-            )
-        )
-
-        let newState = pocketReducer()(
-            initialState,
-            MerinoAction(
-                selectedCategoryID: nil,
-                windowUUID: .XCTestDefaultUUID,
-                actionType: MerinoActionType.categorySelected
-            )
-        )
-
-        XCTAssertNil(newState.selectedCategoryID)
-    }
-
-    @MainActor
     func test_availableCategories_returnsCategoriesSortedByRank() {
         let categories = [
             MerinoCategoryConfiguration(
@@ -183,13 +143,15 @@ final class MerinoStateTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(state.visibleStories.map(\.title), ["science1", "science2", "technology1"])
+        XCTAssertEqual(
+            state.visibleStories(selectedNewsfeedCategoryID: nil).map(\.title),
+            ["science1", "science2", "technology1"]
+        )
     }
 
     @MainActor
     func test_visibleStories_withSelectedCategory_returnsOnlySelectedCategoryStories() {
-        let reducer = pocketReducer()
-        let categorizedState = reducer(
+        let state = pocketReducer()(
             createSubject(),
             MerinoAction(
                 merinoStoryResponse: MerinoStoryResponse(categories: createTestCategories()),
@@ -197,16 +159,11 @@ final class MerinoStateTests: XCTestCase {
                 actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
             )
         )
-        let selectedState = reducer(
-            categorizedState,
-            MerinoAction(
-                selectedCategoryID: "technology",
-                windowUUID: .XCTestDefaultUUID,
-                actionType: MerinoActionType.categorySelected
-            )
-        )
 
-        XCTAssertEqual(selectedState.visibleStories.map(\.title), ["technology1"])
+        XCTAssertEqual(
+            state.visibleStories(selectedNewsfeedCategoryID: "technology").map(\.title),
+            ["technology1"]
+        )
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/StoryCategoryPickerViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/StoryCategoryPickerViewTests.swift
@@ -12,7 +12,7 @@ final class StoryCategoryPickerViewTests: XCTestCase {
     func test_configure_withEmptyCategories_hidesView() {
         let view = createSubject()
 
-        view.configure(categories: [], selectedCategoryID: nil, onSelection: nil)
+        view.configure(categories: [], selectedNewsfeedCategoryID: nil, onSelection: nil)
 
         XCTAssertTrue(view.isHidden)
         XCTAssertTrue(chipButtons(in: view).isEmpty)
@@ -21,7 +21,7 @@ final class StoryCategoryPickerViewTests: XCTestCase {
     func test_configure_withCategories_showsViewAndPrependsAllCategory() {
         let view = createSubject()
 
-        view.configure(categories: testCategories, selectedCategoryID: nil, onSelection: nil)
+        view.configure(categories: testCategories, selectedNewsfeedCategoryID: nil, onSelection: nil)
 
         let buttons = chipButtons(in: view)
 
@@ -37,7 +37,7 @@ final class StoryCategoryPickerViewTests: XCTestCase {
     func test_configure_withNilSelectedCategory_selectsAllCategory() {
         let view = createSubject()
 
-        view.configure(categories: testCategories, selectedCategoryID: nil, onSelection: nil)
+        view.configure(categories: testCategories, selectedNewsfeedCategoryID: nil, onSelection: nil)
 
         XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory,
                              in: view)?.isSelected == true)
@@ -48,7 +48,7 @@ final class StoryCategoryPickerViewTests: XCTestCase {
     func test_configure_withSelectedFeedID_selectsMatchingCategory() {
         let view = createSubject()
 
-        view.configure(categories: testCategories, selectedCategoryID: "technology", onSelection: nil)
+        view.configure(categories: testCategories, selectedNewsfeedCategoryID: "technology", onSelection: nil)
 
         XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory,
                              in: view)?.isSelected == false)
@@ -58,30 +58,30 @@ final class StoryCategoryPickerViewTests: XCTestCase {
 
     func test_selectingAllCategory_callsOnSelectionWithNil() {
         let view = createSubject()
-        var selectedCategoryID: String? = "technology"
+        var selectedNewsfeedCategoryID: String? = "technology"
 
-        view.configure(categories: testCategories, selectedCategoryID: "technology") { newSelection in
-            selectedCategoryID = newSelection
+        view.configure(categories: testCategories, selectedNewsfeedCategoryID: "technology") { newSelection in
+            selectedNewsfeedCategoryID = newSelection
         }
 
         button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory, in: view)?
             .sendActions(for: .touchUpInside)
 
-        XCTAssertNil(selectedCategoryID)
+        XCTAssertNil(selectedNewsfeedCategoryID)
     }
 
     func test_selectingSpecificCategory_callsOnSelectionWithFeedID() {
         let view = createSubject()
-        var selectedCategoryID: String?
+        var selectedNewsfeedCategoryID: String?
 
-        view.configure(categories: testCategories, selectedCategoryID: nil) { newSelection in
-            selectedCategoryID = newSelection
+        view.configure(categories: testCategories, selectedNewsfeedCategoryID: nil) { newSelection in
+            selectedNewsfeedCategoryID = newSelection
         }
 
         button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + ".science", in: view)?
             .sendActions(for: .touchUpInside)
 
-        XCTAssertEqual(selectedCategoryID, "science")
+        XCTAssertEqual(selectedNewsfeedCategoryID, "science")
     }
 
     private var testCategories: [MerinoCategoryConfiguration] {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15452)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33139)

## :bulb: Description
- Move homepage newsfeed category selection to per-tab state so each tab can preserve its own category when reusing the shared `HomepageViewController`

### 📝 Notes:
-  The selected category is now read from `HomepageTabStateStore` instead of `MerinoState` (because MerinoState is window-scoped, while category selection needs to follow the active tab), and the Pocket section identity includes the selected category to ensure the header updates correctly when switching tabs.

## :movie_camera: Demos

https://github.com/user-attachments/assets/5beb9fd5-a533-49a2-aa12-c2e057f88216

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

