### PR TITLE
Bugfix #33172 [AI Controls] Capitalize "You" in blocked status text

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -3092,7 +3092,7 @@ extension String {
                 public static let BlockedStatusDescription = MZLocalizedString(
                     key: "Settings.AIControls.AIPoweredFeaturesSection.BlockedStatusDescription.v151",
                     tableName: "Settings",
-                    value: "**Blocked**: you won’t see and can’t use the feature. For on-device AI, any downloaded models are removed.",
+                    value: "**Blocked**: You won’t see and can’t use the feature. For on-device AI, any downloaded models are removed.",
                     comment: "In the AI Controls settings, in the AI powered features section, this is the text that what the blocked status means. The content between the ** ** is bolded. Please do not remove these in translation."
                 )
             }


### PR DESCRIPTION
## Description
Capitalizes "You" in the AI Controls blocked status description.

## Changes
- Updated blocked status text from "you" to "You"

## Issue
Fixes #33172