### PR TITLE
Fix: remove unused functions in LocationView and BrowserAddressToolbar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -485,10 +485,6 @@ public class BrowserAddressToolbar: UIView,
         toolbarDelegate?.addressToolbarAccessibilityActions()
     }
 
-    func locationViewDidBeginDragInteraction() {
-        toolbarDelegate?.addressToolbarDidBeginDragInteraction()
-    }
-
     func locationTextFieldNeedsSearchReset() {
         toolbarDelegate?.addressToolbarNeedsSearchReset()
     }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -789,15 +789,6 @@ final class LocationView: UIView,
             attributes: [.foregroundColor: color]
         )
     }
-
-    // MARK: - UIGestureRecognizerDelegate
-    func gestureRecognizer(
-        _ gestureRecognizer: UIGestureRecognizer,
-        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
-    ) -> Bool {
-        // When long pressing a button make sure the textfield's long press gesture is not triggered
-        return !(otherGestureRecognizer.view is UIButton)
-    }
 }
 
 fileprivate extension UIImage {


### PR DESCRIPTION
Fixes #33126

Removed unused methods identified by Periphery:
- `gestureRecognizer(_:shouldRecognizeSimultaneouslyWith:)` in `LocationView`
- `locationViewDidBeginDragInteraction()` in `BrowserAddressToolbar`

Confirmed there are no references to these methods and the project builds successfully.