### PR TITLE
Fix closing background tab interrupts in-flight navigation

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4661,7 +4661,7 @@ extension BrowserViewController: TabManagerDelegate {
             webView.accessibilityIdentifier = "contentView"
             webView.accessibilityElementsHidden = false
 
-            if selectedTab.isFxHomeTab && previousTab != nil {
+            if selectedTab.isFxHomeTab && previousTab != nil && !webView.isLoading {
                 store.dispatch(
                     GeneralBrowserAction(
                         windowUUID: windowUUID,
@@ -4674,14 +4674,14 @@ extension BrowserViewController: TabManagerDelegate {
 
             // FXIOS-14783: Experimentation on removing this code, do not add anything in there
             if !featureFlags.isFeatureEnabled(.needsReloadRefactor, checking: .buildOnly) {
-                if selectedTab.isFxHomeTab {
+                if selectedTab.isFxHomeTab && !webView.isLoading {
                     // Added as initial fix for WKWebView memory leak. Needs further investigation.
                     // See: https://mozilla-hub.atlassian.net/browse/FXIOS-10612] +
                     // [https://mozilla-hub.atlassian.net/browse/FXIOS-10335]
                     needsReload = true
                 }
 
-                if webView.url == nil {
+                if webView.url == nil && !webView.isLoading {
                     // The webView can go gray if it was zombified due to memory pressure.
                     // When this happens, the URL is nil, so try restoring the page upon selection.
                     needsReload = true
@@ -4702,7 +4702,7 @@ extension BrowserViewController: TabManagerDelegate {
                                          canGoForward: selectedTab.canGoForward,
                                          windowUUID: windowUUID)
 
-        if let url = selectedTab.webView?.url, !InternalURL.isValid(url: url) {
+        if let url = selectedTab.webView?.url, !InternalURL.isValid(url: url), !selectedTab.isLoading {
             addressToolbarContainer.hideProgressBar()
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15012)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32334)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
When a tab is closed, the tab selection function re runs on the already selected loading tab (that is intentional for running some side effects like saving session etc.). Three guards were missing !webView.isLoading, causing the app to incorrectly stopping the in-flight request.                              

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->

https://github.com/user-attachments/assets/4c1d47e4-b7bb-495e-adf1-a877b5fa6ff4


<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

