### PR TITLE
Bugfix FXIOS-15227 Translate icon flashes when restoring original language

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -485,7 +485,9 @@ struct AddressBarState: StateType, Sendable, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             canSummarize: state.canSummarize,
-            translationConfiguration: toolbarAction.translationConfiguration,
+            translationConfiguration: toolbarAction.translationConfiguration?.state != nil
+                ? toolbarAction.translationConfiguration
+                : state.translationConfiguration,
             didStartTyping: state.didStartTyping,
             isEmptySearch: isEmptySearch,
             alternativeSearchEngine: state.alternativeSearchEngine
@@ -1155,11 +1157,11 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let isFeatureEnabledFromState = addressBarState.translationConfiguration?.isTranslationFeatureEnabled ?? false
         let shouldShowTranslationIcon = isFeatureEnabledFromAction || isFeatureEnabledFromState
         guard shouldShowTranslationIcon else { return nil }
-        let configuration = action.translationConfiguration ?? addressBarState.translationConfiguration
-        guard let state = configuration?.state else { return nil }
+        let iconState = action.translationConfiguration?.state ?? addressBarState.translationConfiguration?.state
+        guard let iconState else { return nil }
         return translateAction(
             enabled: isLoading == false,
-            state: state,
+            state: iconState,
             hasAlternativeLocationColor: hasAlternativeLocationColor
         )
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -485,13 +485,25 @@ struct AddressBarState: StateType, Sendable, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             canSummarize: state.canSummarize,
-            translationConfiguration: toolbarAction.translationConfiguration?.state != nil
-                ? toolbarAction.translationConfiguration
-                : state.translationConfiguration,
+            translationConfiguration: resolveTranslationConfig(
+                from: toolbarAction,
+                existingConfig: state.translationConfiguration
+            ),
             didStartTyping: state.didStartTyping,
             isEmptySearch: isEmptySearch,
             alternativeSearchEngine: state.alternativeSearchEngine
         )
+    }
+
+    private static func resolveTranslationConfig(
+        from action: ToolbarAction,
+        existingConfig: TranslationConfiguration?
+    ) -> TranslationConfiguration? {
+        guard let actionConfig = action.translationConfiguration else { return nil }
+        if actionConfig.state == nil, let existingIconState = existingConfig?.state {
+            return TranslationConfiguration(prefs: actionConfig.prefs, state: existingIconState)
+        }
+        return actionConfig
     }
 
     @MainActor

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -247,7 +247,10 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
                     for: action.windowUUID,
                     using: preferredLanguages
                 )
-                guard isEligible else { return }
+                guard isEligible else {
+                    self.dispatchClearTranslationIcon(windowUUID: action.windowUUID)
+                    return
+                }
 
                 // Auto-translate handled the page load — skip the manual offer.
                 if await self.tryAutoTranslate(for: action) { return }
@@ -275,6 +278,14 @@ final class TranslationsMiddleware: LegacyFeatureFlaggable {
                 )
             }
         }
+    }
+
+    private func dispatchClearTranslationIcon(windowUUID: WindowUUID) {
+        store.dispatch(ToolbarAction(
+            translationConfiguration: nil,
+            windowUUID: windowUUID,
+            actionType: ToolbarActionType.receivedTranslationLanguage
+        ))
     }
 
     private func retrieveTranslations(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -564,6 +564,36 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.leadingPageActions[0].actionType, .share)
     }
 
+    func test_urlDidChangeAction_withNilIconState_preservesExistingTranslationConfig() {
+        setTranslationsFeatureEnabled(enabled: true)
+        setupStore()
+        let initialState = createSubject()
+        let reducer = addressBarReducer()
+
+        let stateWithInactiveIcon = reducer(
+            initialState,
+            ToolbarAction(
+                translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs, state: .inactive),
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.receivedTranslationLanguage
+            )
+        )
+
+        let newState = reducer(
+            stateWithInactiveIcon,
+            ToolbarAction(
+                url: URL(string: "http://mozilla.com"),
+                translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.urlDidChange
+            )
+        )
+
+        XCTAssertEqual(newState.translationConfiguration?.state, .inactive)
+        XCTAssertEqual(newState.leadingPageActions.count, 2)
+        XCTAssertEqual(newState.leadingPageActions[1].actionType, .translate)
+    }
+
     func test_traitCollectionDidChangedAction_returnsExpectedState() {
         setupStore()
         let initialState = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -215,6 +215,34 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
     }
 
+    func test_urlDidChangeAction_withNotEligiblePage_dispatchesClearAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let mockTranslationService = MockTranslationsService(
+            shouldOfferTranslationResult: .success(false)
+        )
+        let subject = createSubject(translationsService: mockTranslationService)
+        let action = ToolbarAction(
+            url: URL(string: "https://www.example.com"),
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.urlDidChange
+        )
+
+        let expectation = XCTestExpectation(description: "expect receivedTranslationLanguage clear action to be fired")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
+
+        XCTAssertNil(actionCalled.translationConfiguration)
+        XCTAssertEqual(actionType, ToolbarActionType.receivedTranslationLanguage)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+    }
+
     // MARK: - didTapButton tests
     func test_didTapButtonAction_withoutFF_doesNotDispatchAction() throws {
         setTranslationsFeatureEnabled(enabled: false)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15227)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32745)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Preserve the existing translation icon state across the reload cycle that occurs when the user taps the translate button to restore the original page.

- handleUrlDidChangeAction falls back to the current state's translation config when the incoming action carries a nil icon state, preventing the icon from disappearing during the reload
- configureTranslationIcon falls back to the state's icon state when the action's config has nil state, ensuring the button renders correctly during the urlDidChange action itself
- checkTranslationsAreEligible dispatches a clear action via the new dispatchClearTranslationIcon helper when the page is not eligible, so icons don't persist when navigating to non-translatable pages


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->
After

https://github.com/user-attachments/assets/999fa29e-572b-47aa-a5fd-6217dcb3401d

Before

https://github.com/user-attachments/assets/b3ae33fc-ea33-4426-b4e0-d07f765c1559 

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


