### PR TITLE
Bugfix FXIOS‑15323 [Bookmarks] Adjust bookmarks panel search bar insets

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -488,12 +488,21 @@ final class BookmarksViewController: SiteTableViewController,
         guard let keyboardHeight = keyboardState?.intersectionHeightForView(view),
               keyboardHeight > 0 else {
             bottomStackView.removeKeyboardSpacer()
+			updateInsets()
             return
         }
 
         let spacerHeight = keyboardHeight - UIConstants.BottomToolbarHeight
         bottomStackView.addKeyboardSpacer(spacerHeight: spacerHeight)
+		updateInsets()
     }
+
+	private func updateInsets() {
+		let bottomInset = bottomStackView.isHidden ? 0 : searchbar.bounds.height
+
+		tableView.contentInset.bottom = bottomInset
+		tableView.verticalScrollIndicatorInsets.bottom = bottomInset
+	}
 
     private func setupEmptyStateView() {
         view.addSubview(a11yEmptyStateScrollView)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -488,21 +488,20 @@ final class BookmarksViewController: SiteTableViewController,
         guard let keyboardHeight = keyboardState?.intersectionHeightForView(view),
               keyboardHeight > 0 else {
             bottomStackView.removeKeyboardSpacer()
-			updateInsets()
             return
         }
 
         let spacerHeight = keyboardHeight - UIConstants.BottomToolbarHeight
         bottomStackView.addKeyboardSpacer(spacerHeight: spacerHeight)
-		updateInsets()
     }
 
-	private func updateInsets() {
-		let bottomInset = bottomStackView.isHidden ? 0 : searchbar.bounds.height
+    private func updateBottomSearchBarLayout(isHidden: Bool) {
+        bottomStackView.isHidden = isHidden
 
-		tableView.contentInset.bottom = bottomInset
-		tableView.verticalScrollIndicatorInsets.bottom = bottomInset
-	}
+        let bottomInset = isHidden ? 0 : searchbar.bounds.height
+        tableView.contentInset.bottom = bottomInset
+        tableView.verticalScrollIndicatorInsets.bottom = bottomInset
+    }
 
     private func setupEmptyStateView() {
         view.addSubview(a11yEmptyStateScrollView)
@@ -930,7 +929,7 @@ extension BookmarksViewController: UISearchBarDelegate {
 
     func startSearchState() {
         updatePanelState(newState: .bookmarks(state: .search))
-        bottomStackView.isHidden = false
+        updateBottomSearchBarLayout(isHidden: false)
         searchbar.becomeFirstResponder()
         sendPanelChangeNotification()
     }
@@ -940,7 +939,7 @@ extension BookmarksViewController: UISearchBarDelegate {
 
         searchbar.text = ""
         searchbar.resignFirstResponder()
-        bottomStackView.isHidden = true
+        updateBottomSearchBarLayout(isHidden: true)
 
         // Transition back to non-searching state
         updatePanelState(newState: viewModel.isRootNode


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15323)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32897)


## :bulb: Description
- When the bookmarks panel search feature is enabled, the search bar can cover the last visible result in the list. This happened because the table view bottom inset was not updated when the keyboard and bottom search container changed state.
- This change adds an updateInsets() helper that updates both tableView.contentInset.bottom and tableView.verticalScrollIndicatorInsets.bottom based on the visible search bar height. The method is called when the keyboard spacer is added or removed, so the last result remains visible while searching.

This fix is currently applied to the Bookmarks panel only. The History panel uses a similar search UI with a bottom search bar, so it may be worth reviewing whether the same inset handling should also be applied there..


## :movie_camera: Demos
https://github.com/user-attachments/assets/613fb3d0-9ffb-4a8d-b1cd-038da2732d39


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

