### PR TITLE
Bugfix FXIOS-15482 [Tests] Fix flaky AIControlsModelTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AI Controls/AIControlsModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AI Controls/AIControlsModelTests.swift
@@ -49,24 +49,34 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
     }
 
     @MainActor
-    func testHasVisibleAIFeatures() {
+    func testHasVisibleAIFeaturesWithTranslationsOnly() {
         setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: true, isSummariesEnabled: false)
-        let aiControlsModel1 = createSubject(prefs: mockPrefs)
-        XCTAssertTrue(aiControlsModel1.hasVisibleAIFeatures)
+        let mockSummarizer = createMockSummarizerConfig(isEnabled: false)
+        let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
+        XCTAssertTrue(aiControlsModel.hasVisibleAIFeatures)
+    }
 
+    @MainActor
+    func testHasVisibleAIFeaturesWithSummariesOnly() {
         setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: false, isSummariesEnabled: true)
-        let aiControlsModel2 = createSubject(prefs: mockPrefs)
-        XCTAssertTrue(aiControlsModel2.hasVisibleAIFeatures)
+        let mockSummarizer = createMockSummarizerConfig(isEnabled: true)
+        let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
+        XCTAssertTrue(aiControlsModel.hasVisibleAIFeatures)
+    }
 
+    @MainActor
+    func testHasVisibleAIFeaturesWithNoneEnabled() {
         setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: false, isSummariesEnabled: false)
-        let aiControlsModel3 = createSubject(prefs: mockPrefs)
-        XCTAssertFalse(aiControlsModel3.hasVisibleAIFeatures)
+        let mockSummarizer = createMockSummarizerConfig(isEnabled: false)
+        let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
+        XCTAssertFalse(aiControlsModel.hasVisibleAIFeatures)
     }
 
     @MainActor
     func testInitialize() {
         setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: true, isSummariesEnabled: true)
-        let aiControlsModel = createSubject(prefs: mockPrefs)
+        let mockSummarizer = createMockSummarizerConfig(isEnabled: true)
+        let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
         XCTAssertTrue(aiControlsModel.killSwitchIsOn)
         XCTAssertTrue(aiControlsModel.pageSummariesEnabled)
         XCTAssertFalse(aiControlsModel.translationEnabled)
@@ -75,7 +85,8 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
     @MainActor
     func testInitializeWithTranslationFeatureFlagDisabled() {
         setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: false, isSummariesEnabled: true)
-        let aiControlsModel = createSubject(prefs: mockPrefs)
+        let mockSummarizer = createMockSummarizerConfig(isEnabled: true)
+        let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
         XCTAssertTrue(aiControlsModel.pageSummariesVisible)
         XCTAssertFalse(aiControlsModel.translationsVisible)
     }
@@ -83,7 +94,8 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
     @MainActor
     func testInitializeWithPageSummariesFeatureFlagDisabled() {
         setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: true, isSummariesEnabled: false)
-        let aiControlsModel = createSubject(prefs: mockPrefs)
+        let mockSummarizer = createMockSummarizerConfig(isEnabled: false)
+        let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
         XCTAssertFalse(aiControlsModel.pageSummariesVisible)
         XCTAssertTrue(aiControlsModel.translationsVisible)
     }
@@ -203,9 +215,23 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
         }
     }
 
+    private func createMockSummarizerConfig(isEnabled: Bool) -> MockSummarizerNimbusUtils {
+        let mock = MockSummarizerNimbusUtils()
+        mock.isSummarizeFeatureEnabled = isEnabled
+        mock.isSummarizeFeatureToggledOn = isEnabled
+        return mock
+    }
+
     @MainActor
-    private func createSubject(prefs: Prefs) -> AIControlsModel {
-        let subject = AIControlsModel(prefs: prefs, windowUUID: .XCTestDefaultUUID)
+    private func createSubject(
+        prefs: Prefs,
+        summarizerConfiguration: SummarizerNimbusUtils = DefaultSummarizerNimbusUtils()
+    ) -> AIControlsModel {
+        let subject = AIControlsModel(
+            prefs: prefs,
+            windowUUID: .XCTestDefaultUUID,
+            summarizerConfiguration: summarizerConfiguration
+        )
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AI Controls/AIControlsModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AI Controls/AIControlsModelTests.swift
@@ -22,7 +22,7 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
         ], prefix: "")
         mockProfile.prefs = mockPrefs
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
-        await DependencyHelperMock().bootstrapDependencies(injectedProfile: mockProfile)
+        DependencyHelperMock().bootstrapDependencies(injectedProfile: mockProfile)
     }
 
     override func tearDown() async throws {
@@ -50,7 +50,7 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
 
     @MainActor
     func testHasVisibleAIFeaturesWithTranslationsOnly() {
-        setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: true, isSummariesEnabled: false)
+        setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: true)
         let mockSummarizer = createMockSummarizerConfig(isEnabled: false)
         let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
         XCTAssertTrue(aiControlsModel.hasVisibleAIFeatures)
@@ -58,23 +58,15 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
 
     @MainActor
     func testHasVisibleAIFeaturesWithSummariesOnly() {
-        setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: false, isSummariesEnabled: true)
+        setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: false)
         let mockSummarizer = createMockSummarizerConfig(isEnabled: true)
         let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
         XCTAssertTrue(aiControlsModel.hasVisibleAIFeatures)
     }
 
     @MainActor
-    func testHasVisibleAIFeaturesWithNoneEnabled() {
-        setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: false, isSummariesEnabled: false)
-        let mockSummarizer = createMockSummarizerConfig(isEnabled: false)
-        let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
-        XCTAssertFalse(aiControlsModel.hasVisibleAIFeatures)
-    }
-
-    @MainActor
     func testInitialize() {
-        setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: true, isSummariesEnabled: true)
+        setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: true)
         let mockSummarizer = createMockSummarizerConfig(isEnabled: true)
         let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
         XCTAssertTrue(aiControlsModel.killSwitchIsOn)
@@ -84,7 +76,7 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
 
     @MainActor
     func testInitializeWithTranslationFeatureFlagDisabled() {
-        setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: false, isSummariesEnabled: true)
+        setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: false)
         let mockSummarizer = createMockSummarizerConfig(isEnabled: true)
         let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
         XCTAssertTrue(aiControlsModel.pageSummariesVisible)
@@ -93,7 +85,7 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
 
     @MainActor
     func testInitializeWithPageSummariesFeatureFlagDisabled() {
-        setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: true, isSummariesEnabled: false)
+        setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: true)
         let mockSummarizer = createMockSummarizerConfig(isEnabled: false)
         let aiControlsModel = createSubject(prefs: mockPrefs, summarizerConfiguration: mockSummarizer)
         XCTAssertFalse(aiControlsModel.pageSummariesVisible)
@@ -205,13 +197,9 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
         }
     }
 
-    private func setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: Bool, isSummariesEnabled: Bool) {
+    private func setupNimbusSentFromFirefoxTesting(isTranslationsEnabled: Bool) {
         FxNimbus.shared.features.translationsFeature.with { _, _ in
             return TranslationsFeature(enabled: isTranslationsEnabled)
-        }
-
-        FxNimbus.shared.features.hostedSummarizerFeature.with { _, _ in
-            return HostedSummarizerFeature(enabled: isSummariesEnabled)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15482)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Two tests in AIControls​Model​Tests `test​Has​Visible​AIFeatures​With​None​Enabled`, `test​Initialize​With​Page​Summaries​Feature​Flag​Disabled` were failing for me, on xcode 26.3, and both failures trace back to `page​Summaries​Visible` unexpectedly being true.

I think think what's happening is this: `AIControls​Model` determines `page​Summaries​Visible` via `Default​Summarizer​Nimbus​Utils​.is​Summarize​Feature​Enabled`, which returns `isAppleSummarizerEnabled() || isHostedSummarizerEnabled()`. The tests were mocking the Nimbus hosted​Summarizer​Feature config to control is​`Hosted​Summarizer​Enabled()`, but `is​Apple​Summarizer​Enabled()` has a runtime dependency on `Apple​Intelligence​Util​.is​Apple​Intelligence​Available`. On machines where Apple Intelligence is available, I _believe_ this always returns true, short-circuiting the OR check and making `is​Summarize​Feature​Enabled` always true - regardless of the Nimbus mock, which caused page​Summaries​Visible to be true even when the test intended it to be false, breaking both assertions.

The proposed fix:
- Injects `Mock​Summarizer​Nimbus​Utils` (which already existed in the test target) into the affected tests via `AIControls​Model`'s existing `summarizer​Configuration` parameter, giving full control over `is​Summarize​Feature​Enabled` status
- split the original `test​Has​Visible​AIFeatures` that was testing multiple Nimbus configurations within a single method into three separate test methods to better isolate and more clearly identify failures

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

