### PR TITLE
Add FXIOS-15485 [Newsfeed Categories] Per-tab newsfeed category picker content offset

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/ChipPickerView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ChipPickerView.swift
@@ -122,7 +122,7 @@ public final class ChipPickerView: UIView, ThemeApplicable, UIScrollViewDelegate
     }
 
     // MARK: = UIScrollViewDelegate
-    
+
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         onScroll?(scrollView.contentOffset.x)
     }

--- a/BrowserKit/Sources/ComponentLibrary/ChipPickerView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ChipPickerView.swift
@@ -6,7 +6,7 @@ import Common
 import UIKit
 
 /// A horizontally scrolling picker that renders selectable options as chip buttons.
-public final class ChipPickerView: UIView, ThemeApplicable {
+public final class ChipPickerView: UIView, ThemeApplicable, UIScrollViewDelegate {
     public struct UX {
         public static let itemSpacing: CGFloat = 10
     }
@@ -26,6 +26,7 @@ public final class ChipPickerView: UIView, ThemeApplicable {
     private var items = [ChipPickerItem]()
     private var selectedID: String?
     private var onSelection: (@MainActor (String) -> Void)?
+    private var onScroll: ((CGFloat) -> Void)?
 
     override public init(frame: CGRect) {
         super.init(frame: frame)
@@ -39,17 +40,31 @@ public final class ChipPickerView: UIView, ThemeApplicable {
     public func configure(
         items: [ChipPickerItem],
         selectedID: String?,
+        contentOffsetX: CGFloat = 0,
+        onScroll: ((CGFloat) -> Void)? = nil,
         onSelection: (@MainActor (String) -> Void)? = nil
     ) {
         self.items = items
         self.selectedID = selectedID
         self.onSelection = onSelection
+        self.onScroll = onScroll
         rebuildButtons()
+        updateContentOffsetX(contentOffsetX)
     }
 
     public func applyTheme(theme: Theme) {
         currentTheme = theme
         chipButtons.forEach { $0.applyTheme(theme: theme) }
+    }
+
+    public func updateSelectedID(_ selectedID: String?) {
+        self.selectedID = selectedID
+        rebuildButtons()
+        scrollView.layoutIfNeeded()
+    }
+
+    public func updateContentOffsetX(_ contentOffsetX: CGFloat) {
+        scrollView.setContentOffset(CGPoint(x: contentOffsetX, y: 0), animated: false)
     }
 
     private var chipButtons: [ChipButton] {
@@ -59,6 +74,7 @@ public final class ChipPickerView: UIView, ThemeApplicable {
     private func setupLayout() {
         addSubview(scrollView)
         scrollView.addSubview(stackView)
+        scrollView.delegate = self
 
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: topAnchor),
@@ -103,5 +119,11 @@ public final class ChipPickerView: UIView, ThemeApplicable {
         selectedID = id
         rebuildButtons()
         onSelection?(id)
+    }
+
+    // MARK: = UIScrollViewDelegate
+    
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        onScroll?(scrollView.contentOffset.x)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -30,7 +30,7 @@ final class HomepageDiffableDataSource:
         case searchBar
         case jumpBackIn(TextColor?, JumpBackInSectionLayoutConfiguration)
         case bookmarks(TextColor?)
-        case pocket(TextColor?, String?)
+        case pocket(TextColor?)
         case spacer
 
         var canHandleLongPress: Bool {
@@ -146,7 +146,7 @@ final class HomepageDiffableDataSource:
         }
 
         if let stories = getMerinoStories(with: state.merinoState, selectedNewsfeedCategoryID: selectedNewsfeedCategoryID) {
-            let pocketSection = HomeSection.pocket(textColor, selectedNewsfeedCategoryID)
+            let pocketSection = HomeSection.pocket(textColor)
             snapshot.appendSections([pocketSection])
             snapshot.appendItems(stories, toSection: pocketSection)
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageTabStateStore.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageTabStateStore.swift
@@ -7,6 +7,7 @@ import Foundation
 struct HomepageTabState: Equatable {
     var scrollOffsetY: CGFloat?
     var selectedNewsfeedCategoryID: String?
+    var newsfeedCategoryPickerOffsetX: CGFloat?
 }
 
 protocol HomepageTabStateStoring: AnyObject {

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -172,7 +172,9 @@ final class HomepageViewController: UIViewController,
         super.viewWillAppear(animated)
 
         activeTabUUID = tabManager.selectedTab?.tabUUID
-        refreshHomepageDataSourceSnapshot()
+        refreshHomepageDataSourceSnapshot { [weak self] in
+            self?.updateNewsHeaderPickerState()
+        }
 
         /// Used as a trigger for showing a microsurvey based on viewing the homepage
         Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
@@ -387,13 +389,7 @@ final class HomepageViewController: UIViewController,
         if homepageState != state {
             self.homepageState = state
 
-            dataSource?.updateSnapshot(
-                state: state,
-                selectedNewsfeedCategoryID: currentHomepageTabState.selectedNewsfeedCategoryID,
-                jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
-            ) { [weak self] in
-                // Force the collection view to finish applying the latest layout before re-syncing the
-                // visible stories header, since transition progress depends on the resolved header frame.
+            refreshHomepageDataSourceSnapshot { [weak self] in
                 self?.collectionView?.layoutIfNeeded()
                 self?.updateNewsTransitionHeaderProgress()
             }
@@ -661,7 +657,7 @@ final class HomepageViewController: UIViewController,
         at indexPath: IndexPath
     ) -> UICollectionViewCell {
         let position = indexPath.item + 1
-        let currentSection = dataSource?.snapshot().sectionIdentifiers[indexPath.section] ?? .pocket(.clear, nil)
+        let currentSection = dataSource?.snapshot().sectionIdentifiers[indexPath.section] ?? .pocket(.clear)
         let totalCount = dataSource?.snapshot().numberOfItems(inSection: currentSection)
 
         return configuredCell(cellType: StoryCell.self, at: indexPath) { cell in
@@ -728,6 +724,8 @@ final class HomepageViewController: UIViewController,
             transitionEnabled: transitionEnabled,
             categories: homepageState.merinoState.availableCategories,
             selectedNewsfeedCategoryID: currentHomepageTabState.selectedNewsfeedCategoryID,
+            newsfeedCategoryPickerOffsetX: currentHomepageTabState.newsfeedCategoryPickerOffsetX,
+            onCategoryPickerScroll: updateNewsfeedCategoryPickerOffsetX,
             onSelection: updatedSelectedNewsfeedCategory
         )
         newsTransitionHeaderCell.setTransitionProgress(newsTransitionProgress())
@@ -770,7 +768,7 @@ final class HomepageViewController: UIViewController,
                 theme: currentTheme
             )
             return sectionLabelCell
-        case .pocket(let textColor, _):
+        case .pocket(let textColor):
             sectionLabelCell.configure(
                 sectionHeaderConfiguration: MerinoState.Constants.sectionHeaderConfiguration,
                 textColor: textColor,
@@ -786,12 +784,6 @@ final class HomepageViewController: UIViewController,
     private func updateNewsTransitionHeaderProgress() {
         guard MerinoState.Constants.sectionHeaderConfiguration.style == .newsAffordance,
               let collectionView,
-              let pocketSectionIndex = dataSource?.snapshot().sectionIdentifiers.firstIndex(where: {
-                  if case .pocket = $0 {
-                      return true
-                  }
-                  return false
-              }),
               let spacerSectionIndex = dataSource?.snapshot().sectionIdentifiers.firstIndex(where: {
                   if case .spacer = $0 {
                       return true
@@ -800,9 +792,7 @@ final class HomepageViewController: UIViewController,
               }),
               let spacerAttributes = collectionView.layoutAttributesForItem(at: IndexPath(item: 0,
                                                                                           section: spacerSectionIndex)),
-              let headerView = collectionView.supplementaryView(forElementKind: UICollectionView.elementKindSectionHeader,
-                                                                at: IndexPath(item: 0, section: pocketSectionIndex)
-              ) as? NewsTransitionHeaderCell
+              let headerView = getNewsTransitionHeader()
         else {
             return
         }
@@ -1064,12 +1054,47 @@ final class HomepageViewController: UIViewController,
         refreshHomepageDataSourceSnapshot()
     }
 
-    private func refreshHomepageDataSourceSnapshot() {
+    private func updateNewsfeedCategoryPickerOffsetX(_ newsfeedCategoryPickerOffsetX: CGFloat) {
+        guard let activeTabUUID else { return }
+        homepageTabStateStore.updateState(for: activeTabUUID) { state in
+            state.newsfeedCategoryPickerOffsetX = newsfeedCategoryPickerOffsetX
+        }
+    }
+
+    private func refreshHomepageDataSourceSnapshot(completion: (() -> Void)? = nil) {
         dataSource?.updateSnapshot(
             state: homepageState,
             selectedNewsfeedCategoryID: currentHomepageTabState.selectedNewsfeedCategoryID,
             jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
+        ) {
+            completion?()
+        }
+    }
+
+    /// Applies the active `HomepageTabState`'s relevant properties to the category picker without rebuilding the section.
+    /// This keeps the category picker selection and horizontal offset in sync across tab switches
+    private func updateNewsHeaderPickerState() {
+        guard let headerView = getNewsTransitionHeader() else { return }
+        headerView.updatePickerState(
+            selectedNewsfeedCategoryID: currentHomepageTabState.selectedNewsfeedCategoryID,
+            newsfeedCategoryPickerOffsetX: currentHomepageTabState.newsfeedCategoryPickerOffsetX
         )
+    }
+
+    private func getNewsTransitionHeader() -> NewsTransitionHeaderCell? {
+        guard let collectionView,
+              let pocketSectionIndex = dataSource?.snapshot().sectionIdentifiers.firstIndex(where: {
+                  if case .pocket = $0 { return true }
+                  return false
+              })
+        else {
+            return nil
+        }
+
+        return collectionView.supplementaryView(
+            forElementKind: UICollectionView.elementKindSectionHeader,
+            at: IndexPath(item: 0, section: pocketSectionIndex)
+        ) as? NewsTransitionHeaderCell
     }
 
     private func getSiteForContextMenu(for item: HomepageItem) -> Site? {

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
@@ -80,6 +80,8 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         transitionEnabled: Bool = true,
         categories: [MerinoCategoryConfiguration] = [],
         selectedNewsfeedCategoryID: String? = nil,
+        newsfeedCategoryPickerOffsetX: CGFloat? = nil,
+        onCategoryPickerScroll: ((CGFloat) -> Void)? = nil,
         onSelection: (@MainActor @Sendable (String?) -> Void)? = nil
     ) {
         self.transitionEnabled = transitionEnabled
@@ -94,6 +96,8 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         storyCategoryPickerView.configure(
             categories: categories,
             selectedNewsfeedCategoryID: selectedNewsfeedCategoryID,
+            newsfeedCategoryPickerOffsetX: newsfeedCategoryPickerOffsetX,
+            onScroll: onCategoryPickerScroll,
             onSelection: onSelection
         )
         storyCategoryPickerView.applyTheme(theme: theme)
@@ -110,6 +114,16 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         guard self.transitionEnabled != transitionEnabled else { return }
         self.transitionEnabled = transitionEnabled
         updateViewState()
+    }
+
+    func updatePickerState(
+        selectedNewsfeedCategoryID: String?,
+        newsfeedCategoryPickerOffsetX: CGFloat?
+    ) {
+        storyCategoryPickerView.applyNewsfeedPickerState(
+            selectedNewsfeedCategoryID: selectedNewsfeedCategoryID,
+            newsfeedCategoryPickerOffsetX: newsfeedCategoryPickerOffsetX
+        )
     }
 
     func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/StoryCategoryPickerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/StoryCategoryPickerView.swift
@@ -28,7 +28,9 @@ final class StoryCategoryPickerView: UIView, ThemeApplicable {
     func configure(
         categories: [MerinoCategoryConfiguration],
         selectedNewsfeedCategoryID: String?,
-        onSelection: (@MainActor (String?) -> Void)?
+        newsfeedCategoryPickerOffsetX: CGFloat? = nil,
+        onScroll: ((CGFloat) -> Void)? = nil,
+        onSelection: (@MainActor (String?) -> Void)? = nil
     ) {
         let items = pickerItems(from: categories)
         let selectedPickerID = selectedNewsfeedCategoryID ?? Self.allCategoryID
@@ -36,6 +38,8 @@ final class StoryCategoryPickerView: UIView, ThemeApplicable {
         chipPickerView.configure(
             items: items,
             selectedID: selectedPickerID,
+            contentOffsetX: newsfeedCategoryPickerOffsetX ?? 0,
+            onScroll: onScroll,
             onSelection: { selectedID in
                 onSelection?(selectedID == Self.allCategoryID ? nil : selectedID)
             }
@@ -45,6 +49,11 @@ final class StoryCategoryPickerView: UIView, ThemeApplicable {
 
     func applyTheme(theme: Theme) {
         chipPickerView.applyTheme(theme: theme)
+    }
+
+    func applyNewsfeedPickerState(selectedNewsfeedCategoryID: String?, newsfeedCategoryPickerOffsetX: CGFloat?) {
+        chipPickerView.updateSelectedID(selectedNewsfeedCategoryID ?? Self.allCategoryID)
+        chipPickerView.updateContentOffsetX(newsfeedCategoryPickerOffsetX ?? 0)
     }
 
     private func setupLayout() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -680,24 +680,43 @@ final class BrowserCoordinatorTests: XCTestCase, LegacyFeatureFlaggable, StoreTe
     func testDidRemoveTab_removesHomepageTabStateForTab() throws {
         let subject = createSubject()
         let tab = MockTab(profile: profile, windowUUID: windowUUID)
-        homepageTabStateStore.updateState(for: tab.tabUUID) { $0.scrollOffsetY = 180 }
+        homepageTabStateStore.updateState(for: tab.tabUUID) { state in
+            state.scrollOffsetY = 180
+            state.selectedNewsfeedCategoryID = "technology"
+            state.newsfeedCategoryPickerOffsetX = 64
+        }
 
         subject.tabManager(tabManager, didRemoveTab: tab, isRestoring: false)
 
-        XCTAssertNil(homepageTabStateStore.state(for: tab.tabUUID).scrollOffsetY)
+        XCTAssertEqual(homepageTabStateStore.state(for: tab.tabUUID), HomepageTabState())
     }
 
     func testDidRemoveTab_keepsHomepageTabStateForOtherTabs() throws {
         let subject = createSubject()
         let removedTab = MockTab(profile: profile, windowUUID: windowUUID)
         let otherTab = MockTab(profile: profile, windowUUID: windowUUID)
-        homepageTabStateStore.updateState(for: removedTab.tabUUID) { $0.scrollOffsetY = 120 }
-        homepageTabStateStore.updateState(for: otherTab.tabUUID) { $0.scrollOffsetY = 240 }
+        homepageTabStateStore.updateState(for: removedTab.tabUUID) { state in
+            state.scrollOffsetY = 120
+            state.selectedNewsfeedCategoryID = "science"
+            state.newsfeedCategoryPickerOffsetX = 40
+        }
+        homepageTabStateStore.updateState(for: otherTab.tabUUID) { state in
+            state.scrollOffsetY = 240
+            state.selectedNewsfeedCategoryID = "technology"
+            state.newsfeedCategoryPickerOffsetX = 72
+        }
 
         subject.tabManager(tabManager, didRemoveTab: removedTab, isRestoring: false)
 
-        XCTAssertNil(homepageTabStateStore.state(for: removedTab.tabUUID).scrollOffsetY)
-        XCTAssertEqual(homepageTabStateStore.state(for: otherTab.tabUUID).scrollOffsetY, 240)
+        XCTAssertEqual(homepageTabStateStore.state(for: removedTab.tabUUID), HomepageTabState())
+        XCTAssertEqual(
+            homepageTabStateStore.state(for: otherTab.tabUUID),
+            HomepageTabState(
+                scrollOffsetY: 240,
+                selectedNewsfeedCategoryID: "technology",
+                newsfeedCategoryPickerOffsetX: 72
+            )
+        )
     }
 
     // MARK: - Search route

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
@@ -84,11 +84,11 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         )
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(.systemCyan, nil)), 20)
+        XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(.systemCyan)), 20)
         let expectedSections: [HomepageSection] = [
             .header,
             .spacer,
-            .pocket(.systemCyan, nil)
+            .pocket(.systemCyan)
         ]
         XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
     }
@@ -182,11 +182,11 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.updateSnapshot(state: state, jumpBackInDisplayConfig: mockSectionConfig)
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil, nil)), 20)
+        XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil)), 20)
         let expectedSections: [HomepageSection] = [
             .header,
             .spacer,
-            .pocket(nil, nil)
+            .pocket(nil)
         ]
         XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
     }
@@ -207,7 +207,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.updateSnapshot(state: state, jumpBackInDisplayConfig: mockSectionConfig)
 
         let snapshot = dataSource.snapshot()
-        let items = snapshot.itemIdentifiers(inSection: .pocket(nil, nil))
+        let items = snapshot.itemIdentifiers(inSection: .pocket(nil))
 
         XCTAssertEqual(items.count, 3)
         XCTAssertEqual(merinoTitles(from: items), ["science 1", "science 2", "technology 1"])
@@ -233,7 +233,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         )
 
         let snapshot = dataSource.snapshot()
-        let items = snapshot.itemIdentifiers(inSection: .pocket(nil, "technology"))
+        let items = snapshot.itemIdentifiers(inSection: .pocket(nil))
 
         XCTAssertEqual(items.count, 1)
         XCTAssertEqual(merinoTitles(from: items), ["technology 1"])
@@ -260,7 +260,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
 
-        XCTAssertFalse(snapshot.sectionIdentifiers.contains(.pocket(nil, "missing-category")))
+        XCTAssertFalse(snapshot.sectionIdentifiers.contains(.pocket(nil)))
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/NewsTransitionHeaderCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/NewsTransitionHeaderCellTests.swift
@@ -67,6 +67,53 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
         XCTAssertEqual(sectionTitleStackView(in: view)?.alpha, 1)
     }
 
+    func test_updatePickerState_updatesCategorySelection() {
+        let view = createSubject()
+
+        view.configure(
+            sectionHeaderConfiguration: sectionHeaderConfiguration,
+            textColor: nil,
+            theme: theme,
+            transitionEnabled: false,
+            categories: testCategories,
+            selectedNewsfeedCategoryID: nil
+        )
+
+        view.updatePickerState(selectedNewsfeedCategoryID: "science", newsfeedCategoryPickerOffsetX: 0)
+
+        XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory,
+                             in: view)?.isSelected == false)
+        XCTAssertTrue(button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + ".science",
+                             in: view)?.isSelected == true)
+    }
+
+    private var testCategories: [MerinoCategoryConfiguration] {
+        [
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "technology",
+                    recommendations: [],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Technology",
+                    subtitle: nil,
+                    receivedFeedRank: 2
+                )
+            ),
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "science",
+                    recommendations: [],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Science",
+                    subtitle: nil,
+                    receivedFeedRank: 1
+                )
+            ),
+        ]
+    }
+
     private func createSubject() -> NewsTransitionHeaderCell {
         let view = NewsTransitionHeaderCell(frame: CGRect(x: 0, y: 0, width: 320, height: 72))
         trackForMemoryLeaks(view)
@@ -83,6 +130,12 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
 
     private func sectionTitleStackView(in view: UIView) -> UIStackView? {
         return allSubviews(in: view).compactMap { $0 as? UIStackView }.first
+    }
+
+    private func button(withA11yID a11yID: String, in view: UIView) -> UIButton? {
+        return allSubviews(in: view)
+            .compactMap { $0 as? UIButton }
+            .first(where: { $0.accessibilityIdentifier == a11yID })
     }
 
     private func allSubviews(in view: UIView) -> [UIView] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/StoryCategoryPickerViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/StoryCategoryPickerViewTests.swift
@@ -60,9 +60,9 @@ final class StoryCategoryPickerViewTests: XCTestCase {
         let view = createSubject()
         var selectedNewsfeedCategoryID: String? = "technology"
 
-        view.configure(categories: testCategories, selectedNewsfeedCategoryID: "technology") { newSelection in
+        view.configure(categories: testCategories, selectedNewsfeedCategoryID: "technology", onSelection: { newSelection in
             selectedNewsfeedCategoryID = newSelection
-        }
+        })
 
         button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory, in: view)?
             .sendActions(for: .touchUpInside)
@@ -74,9 +74,9 @@ final class StoryCategoryPickerViewTests: XCTestCase {
         let view = createSubject()
         var selectedNewsfeedCategoryID: String?
 
-        view.configure(categories: testCategories, selectedNewsfeedCategoryID: nil) { newSelection in
+        view.configure(categories: testCategories, selectedNewsfeedCategoryID: nil, onSelection: { newSelection in
             selectedNewsfeedCategoryID = newSelection
-        }
+        })
 
         button(withA11yID: AccessibilityIdentifiers.FirefoxHomepage.Pocket.allCategory + ".science", in: view)?
             .sendActions(for: .touchUpInside)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15485)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33225)

## :bulb: Description
- Preserve each tabs `newsfeedCategoryPickerOffsetX` value in `HomepageTabStateStore` so that the horizontal content offset of the newsfeed category picker can be restored to it's per tab value across tab switches

## :movie_camera: Demos
https://github.com/user-attachments/assets/ab69952a-c314-4070-a13d-6d3e61d1d488

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

