### PR TITLE
Bugfix MTE-5291 Workaround for reCAPTCHA from Mozilla account login

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/README.md
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/README.md
@@ -5,9 +5,14 @@ you have these, make sure you're in the `SyncIntegrationTests` directory and
 run the following:
 
 ```
+$ export FXA_CI_SECRET=[secret]
 $ pipenv install --python 3.12
 $ pipenv run pytest
 ```
+
+`FXA_CI_SECRET` can be obtained via the FxA team. This variable will be used 
+in the `fxa-ci` header to bypass reCAPTCHA-like challenges during automated
+testing.
 
 The tests will build and install the application to the simulator, which can
 cause a delay where there will be no feedback to the user. Also, note that each

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/conftest.py
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/conftest.py
@@ -73,8 +73,32 @@ def tps_log(pytestconfig, tmpdir):
     yield tps_log
 
 
+@pytest.fixture(scope='session')
+def fxa_ci_addon(tmpdir_factory):
+    secret = os.getenv('FXA_CI_SECRET', '')
+    addon_dir = tmpdir_factory.mktemp('fxa_ci_addon')
+    addon_dir.join('manifest.json').write(json.dumps({
+        'manifest_version': 2,
+        'name': 'FxA CI Header',
+        'version': '1.0',
+        'browser_specific_settings': {
+            'gecko': {'id': 'fxa-ci-header@mozilla.org'},
+        },
+        'permissions': ['webRequest', 'webRequestBlocking', '<all_urls>'],
+        'background': {'scripts': ['background.js']},
+    }))
+    addon_dir.join('background.js').write(
+        'browser.webRequest.onBeforeSendHeaders.addListener('
+        '(d) => { d.requestHeaders.push({ name: "fxa-ci", value: %s });'
+        ' return { requestHeaders: d.requestHeaders }; },'
+        ' { urls: ["<all_urls>"] }, ["blocking", "requestHeaders"]);'
+        % json.dumps(secret)
+    )
+    return str(addon_dir)
+
+
 @pytest.fixture
-def tps_profile(pytestconfig, tps_addon, tps_config, tps_log, fxa_urls):
+def tps_profile(pytestconfig, tps_addon, fxa_ci_addon, tps_config, tps_log, fxa_urls):
     preferences = {
         'app.update.enabled': False,
         'security.turn_off_all_security_so_that_viruses_can_take_over_this_computer': True,
@@ -112,7 +136,7 @@ def tps_profile(pytestconfig, tps_addon, tps_config, tps_log, fxa_urls):
         'tps.seconds_since_epoch': int(time.time()),
         'xpinstall.signatures.required': False
     }
-    profile = Profile(addons=[tps_addon], preferences=preferences)
+    profile = Profile(addons=[tps_addon, fxa_ci_addon], preferences=preferences)
     pytestconfig._profile = profile.profile
     yield profile
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5291)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Since last week, all sync integration tests fail because the Mozilla accounts page now requires the user to bypass a challenge before the login page is presented.
<img width="1267" height="801" alt="Screenshot 2026-04-20 at 17 00 54" src="https://github.com/user-attachments/assets/b2373bfc-083a-4667-9fdc-3514b4889dc6" />

The automated tests can bypass this reCAPTCHA-like page by including the `fxa-ci` header with an appropriate key. After this PR, we need to add `FXA_CI_SECRET` in the environment variable in any place that run these tests.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

