### PR TITLE
Add FXIOS-5867 - Enable https auto upgrade

### DIFF
--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -42,6 +42,7 @@ enum FeatureFlagID: String, CaseIterable {
     case hostedSummarizer
     case hostedSummarizerToolbarEntrypoint
     case hostedSummarizerShakeGesture
+    case httpsUpgrade
     case improvedAppStoreReviewTriggerFeature
     case summarizerAppAttestAuth
     case summarizerLanguageExpansion
@@ -77,6 +78,7 @@ enum FeatureFlagID: String, CaseIterable {
                 .homepageSearchBar,
                 .homepageStoryCategories,
                 .hostedSummarizer,
+                .httpsUpgrade,
                 .improvedAppStoreReviewTriggerFeature,
                 .microsurvey,
                 .nativeErrorPage,

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -59,6 +59,7 @@ struct NimbusFlaggableFeature {
                 .hostedSummarizer,
                 .hostedSummarizerToolbarEntrypoint,
                 .hostedSummarizerShakeGesture,
+                .httpsUpgrade,
                 .quickAnswers,
                 .relayIntegration,
                 .summarizerAppAttestAuth,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -31,6 +31,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Legacy
         // For better code readability and parsability in-app, please keep in alphabetical order by title
         let children: [Setting] =  [
             FeatureFlagsBoolSetting(
+                with: .httpsUpgrade,
+                titleText: format(string: "Automatic HTTPS upgrade"),
+                statusText: format(string: "Toggle to enable automatic HTTPS upgrade.")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .adsClient,
                 titleText: format(string: "Ads Client"),
                 statusText: format(string: "Toggle to enable the rust ads client")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -109,6 +109,9 @@ final class NimbusFeatureFlagLayer: Sendable {
         case .hostedSummarizer:
             return checkHostedSummarizerFeature(from: nimbus)
 
+        case .httpsUpgrade:
+            return checkHttpsUpgradeFeature(from: nimbus)
+
         case .improvedAppStoreReviewTriggerFeature:
             return checkImprovedAppStoreReviewTriggerFeature(from: nimbus)
 
@@ -390,6 +393,10 @@ final class NimbusFeatureFlagLayer: Sendable {
 
     private func checkHostedSummarizerShakeGesture(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.hostedSummarizerFeature.value().shakeGesture
+    }
+
+    private func checkHttpsUpgradeFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.httpsUpgradeFeature.value().enabled
     }
 
     private func checkSummarizerAppAttestAuthFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -520,7 +520,7 @@ class Tab: NSObject,
         self.configuration = requiredConfiguration
 
         if #available(iOS 18.2, *),
-        featureFlags.isFeatureEnabled(.httpsUpgrade, checking: .buildAndUser) {
+           featureFlagsProvider.isEnabled(.httpsUpgrade) {
             let pagePrefs = requiredConfiguration.defaultWebpagePreferences ?? WKWebpagePreferences()
             pagePrefs.preferredHTTPSNavigationPolicy = .automaticFallbackToHTTP
             requiredConfiguration.defaultWebpagePreferences = pagePrefs

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -520,9 +520,9 @@ class Tab: NSObject,
         self.configuration = requiredConfiguration
 
         if #available(iOS 18.2, *),
-        featureFlags.isFeatureEnabled(.httpsOnlyMode, checking: .buildAndUser) {
+        featureFlags.isFeatureEnabled(.httpsUpgrade, checking: .buildAndUser) {
             let pagePrefs = requiredConfiguration.defaultWebpagePreferences ?? WKWebpagePreferences()
-            pagePrefs.preferredHTTPSNavigationPolicy = .upgradeToHTTPS
+            pagePrefs.preferredHTTPSNavigationPolicy = .automaticFallbackToHTTP
             requiredConfiguration.defaultWebpagePreferences = pagePrefs
         }
 

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -518,6 +518,14 @@ class Tab: NSObject,
         // Ensures we inject scripts into a new content controller
         requiredConfiguration.userContentController = .init()
         self.configuration = requiredConfiguration
+
+        if #available(iOS 18.2, *),
+        featureFlags.isFeatureEnabled(.httpsOnlyMode, checking: .buildAndUser) {
+            let pagePrefs = requiredConfiguration.defaultWebpagePreferences ?? WKWebpagePreferences()
+            pagePrefs.preferredHTTPSNavigationPolicy = .upgradeToHTTPS
+            requiredConfiguration.defaultWebpagePreferences = pagePrefs
+        }
+
         let webView = TabWebView(frame: .zero, configuration: requiredConfiguration, windowUUID: windowUUID)
         webView.configure(delegate: self, navigationDelegate: navigationDelegate)
         webView.accessibilityLabel = .WebViewAccessibilityLabel

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -542,20 +542,37 @@ class TabTests: XCTestCase {
 
     // MARK: - HTTPS Navigation Policy
     @MainActor
-    func testCreateWebview_setsHTTPSNavigationPolicy() throws {
+    func testCreateWebview_whenHTTPSUpgradeEnabled_setsUpgradePolicy() throws {
         guard #available(iOS 18.2, *) else {
             throw XCTSkip("preferredHTTPSNavigationPolicy requires iOS 18.2+")
         }
 
-        let subject = createSubject()
-        let configuration = WKWebViewConfiguration()
+        setHTTPSUpgradeFeature(isEnabled: true)
 
-        subject.createWebview(configuration: configuration)
+        let subject = createSubject()
+        subject.createWebview(configuration: WKWebViewConfiguration())
 
         let policy = subject.webView?.configuration
             .defaultWebpagePreferences?
             .preferredHTTPSNavigationPolicy
-        XCTAssertEqual(policy, .upgradeToHTTPS)
+        XCTAssertEqual(policy, .automaticFallbackToHTTP)
+
+        subject.close()
+    }
+
+    @MainActor
+    func testCreateWebview_whenHTTPSUpgradeDisabled_doesNotSetUpgradePolicy() throws {
+        guard #available(iOS 18.2, *) else {
+            throw XCTSkip("preferredHTTPSNavigationPolicy requires iOS 18.2+")
+        }
+        setHTTPSUpgradeFeature(isEnabled: false)
+        let subject = createSubject()
+        subject.createWebview(configuration: WKWebViewConfiguration())
+
+        let policy = subject.webView?.configuration
+            .defaultWebpagePreferences?
+            .preferredHTTPSNavigationPolicy
+        XCTAssertNotEqual(policy, .automaticFallbackToHTTP)
         subject.close()
     }
 
@@ -570,6 +587,12 @@ class TabTests: XCTestCase {
         )
         trackForMemoryLeaks(subject)
         return subject
+    }
+
+    private func setHTTPSUpgradeFeature(isEnabled: Bool = true) {
+        FxNimbus.shared.features.httpsUpgradeFeature.with { _, _ in
+            return HttpsUpgradeFeature(enabled: isEnabled)
+        }
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -542,7 +542,7 @@ class TabTests: XCTestCase {
 
     // MARK: - HTTPS Navigation Policy
     @MainActor
-    func testCreateWebview_whenHTTPSUpgradeEnabled_setsUpgradePolicy() throws {
+    func testCreateWebview_whenHTTPSUpgradeEnabled_setsUpgradePolicy() async throws {
         guard #available(iOS 18.2, *) else {
             throw XCTSkip("preferredHTTPSNavigationPolicy requires iOS 18.2+")
         }
@@ -556,10 +556,11 @@ class TabTests: XCTestCase {
             .defaultWebpagePreferences?
             .preferredHTTPSNavigationPolicy
         XCTAssertEqual(policy, .automaticFallbackToHTTP)
+        await subject.close()
     }
 
     @MainActor
-    func testCreateWebview_whenHTTPSUpgradeDisabled_doesNotSetUpgradePolicy() throws {
+    func testCreateWebview_whenHTTPSUpgradeDisabled_doesNotSetUpgradePolicy() async throws {
         guard #available(iOS 18.2, *) else {
             throw XCTSkip("preferredHTTPSNavigationPolicy requires iOS 18.2+")
         }
@@ -571,6 +572,7 @@ class TabTests: XCTestCase {
             .defaultWebpagePreferences?
             .preferredHTTPSNavigationPolicy
         XCTAssertNotEqual(policy, .automaticFallbackToHTTP)
+        await subject.close()
     }
 
     // MARK: - Helpers

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -556,8 +556,6 @@ class TabTests: XCTestCase {
             .defaultWebpagePreferences?
             .preferredHTTPSNavigationPolicy
         XCTAssertEqual(policy, .automaticFallbackToHTTP)
-
-        subject.close()
     }
 
     @MainActor
@@ -573,7 +571,6 @@ class TabTests: XCTestCase {
             .defaultWebpagePreferences?
             .preferredHTTPSNavigationPolicy
         XCTAssertNotEqual(policy, .automaticFallbackToHTTP)
-        subject.close()
     }
 
     // MARK: - Helpers

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -540,6 +540,25 @@ class TabTests: XCTestCase {
         XCTAssertEqual(mockFileManager.removeItemAtURLCalled, session.count)
     }
 
+    // MARK: - HTTPS Navigation Policy
+    @MainActor
+    func testCreateWebview_setsHTTPSNavigationPolicy() throws {
+        guard #available(iOS 18.2, *) else {
+            throw XCTSkip("preferredHTTPSNavigationPolicy requires iOS 18.2+")
+        }
+
+        let subject = createSubject()
+        let configuration = WKWebViewConfiguration()
+
+        subject.createWebview(configuration: configuration)
+
+        let policy = subject.webView?.configuration
+            .defaultWebpagePreferences?
+            .preferredHTTPSNavigationPolicy
+        XCTAssertEqual(policy, .upgradeToHTTPS)
+        subject.close()
+    }
+
     // MARK: - Helpers
     @MainActor
     private func createSubject() -> Tab {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -448,7 +448,7 @@ class HistoryTests: BaseTestCase {
     }
 
     private func navigateToPage(isTabTrayOff: Bool = true) {
-        navigator.openURL("example.com")
+        navigator.openURL("https://example.com")
         waitUntilPageLoad()
         waitForTabsButton()
         navigator.goto(TabTray)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/HistorySelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/HistorySelectors.swift
@@ -13,7 +13,7 @@ protocol HistorySelectorsSet {
 
 struct HistorySelectors: HistorySelectorsSet {
     private enum IDs {
-        static let exampleEntry = "http://example.com/"
+        static let exampleEntry = "https://example.com/"
         static let deleteButton = "Delete"
         static let emptyMsg     = emptyRecentlyClosedMesg
         static let tableViewId  = AccessibilityIdentifiers.LibraryPanels.HistoryPanel.tableView

--- a/firefox-ios/nimbus-features/httpsUpgradeFeature.yaml
+++ b/firefox-ios/nimbus-features/httpsUpgradeFeature.yaml
@@ -1,0 +1,18 @@
+# The configuration for the automatic https upgrade feature
+features:
+  https-upgrade-feature:
+    description: >
+      This feature enables automatic https upgrade. This is only available for 18.2+.
+    variables:
+      enabled:
+        description: >
+          Enables automatic https upgrade.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: true
+      - channel: developer
+        value:
+          enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -28,6 +28,7 @@ include:
   - nimbus-features/hntSponsoredShortcutsFeature.yaml
   - nimbus-features/homepageRedesignFeature.yaml
   - nimbus-features/hostedSummarizerFeature.yaml
+  - nimbus-features/httpsUpgradeFeature.yaml
   - nimbus-features/improvedAppStoreReviewTriggerFeature.yaml
   - nimbus-features/messagingFeature.yaml
   - nimbus-features/microsurveyFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5867)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13387)

## :bulb: Description
This PR:
- Adds automatic HTTPS upgrading for top-level navigations using WebKit's `preferredHTTPSNavigationPolicy` API (iOS 18.2+), which silently upgrades `http://` to `https://` and falls back to HTTP if the upgrade fails
- Gates the behavior behind the `httpsUpgradeFeature` Nimbus flag.
- Adds tests.

**NOTE1:** I opened a [follow-up ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15489
) to add this to the webengine when we have a full rollout. Doing nimbus stuff in BrowserKit will just introduce unnecessary code. 
**NOTE2:** Tested on internal pages and it doesn't seem to affect them.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

## Before
### HTTP request with site that supports HTTPS (stays HTTP)
https://github.com/user-attachments/assets/3d5e8752-e00a-416c-810a-9f5ebdd951f1


## After
### HTTP request with site that supports HTTPS (upgrades to HTTPS)
https://github.com/user-attachments/assets/e882aedc-913a-4c5c-a9fb-2565fb66caa6
### HTTP request with site that doesn't supports HTTPS (silently fails and switches)
https://github.com/user-attachments/assets/6bbfdc10-b9a1-42f6-90e7-5e8aa0fbc804
<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

