### PR TITLE
Bugfix FXIOS-14599 [Tab Tray] Tab dismissal animation stutters on landscape fixed

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -324,7 +324,11 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
 
         // Trigger animation async to be non blocking and allow UI to render
         DispatchQueue.main.async {
-            let tabSnapshot = self.buildTabSnapshot(selectedTab: selectedTab, contentContainer: contentContainer)
+            let tabSnapshot = self.buildTabSnapshot(
+                selectedTab: selectedTab,
+                contentContainer: contentContainer,
+                browserVC: browserVC
+            )
             context.containerView.addSubview(tabSnapshot)
 
             var tabCell: ExperimentTabCell?
@@ -359,16 +363,31 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         }
     }
 
-    private func buildTabSnapshot(selectedTab: Tab, contentContainer: UIView) -> UIView {
+    private func buildTabSnapshot(
+        selectedTab: Tab,
+        contentContainer: UIView,
+        browserVC: BrowserViewController
+    ) -> UIView {
         let tabSnapshot = UIImageView(image: selectedTab.screenshot)
-        // crop the tab screenshot to the contentContainer frame so the animation
-        // and the initial transform doesn't stutter
+
+        let isIpad = browserVC.traitCollection.userInterfaceIdiom == .pad &&
+                     browserVC.traitCollection.horizontalSizeClass == .regular
+
+        // ScreenshotHelper applies contentContainer bounds only on iPhone portrait.
+        // Otherwise, the stored tab screenshot is based on the webView bounds.
         if let image = tabSnapshot.image, let croppedImage = image.cgImage?.cropping(
-            to: CGRect(
+            to: UIWindow.isPortrait && !isIpad
+            ? CGRect(
                 x: contentContainer.frame.origin.x * image.scale,
                 y: contentContainer.frame.origin.y * image.scale,
                 width: contentContainer.frame.width * image.scale,
                 height: contentContainer.frame.height * image.scale
+            )
+            : CGRect(
+                x: 0,
+                y: 0,
+                width: contentContainer.bounds.width * image.scale,
+                height: contentContainer.bounds.height * image.scale
             )
         ) {
             tabSnapshot.image = UIImage(cgImage: croppedImage)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -376,22 +376,27 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
 
         // ScreenshotHelper applies contentContainer bounds only on iPhone portrait.
         // Otherwise, the stored tab screenshot is based on the webView bounds.
-        if let image = tabSnapshot.image, let croppedImage = image.cgImage?.cropping(
-            to: shouldCropUsingContentContainerFrame
-            ? CGRect(
-                x: contentContainer.frame.origin.x * image.scale,
-                y: contentContainer.frame.origin.y * image.scale,
-                width: contentContainer.frame.width * image.scale,
-                height: contentContainer.frame.height * image.scale
-            )
-            : CGRect(
-                x: 0,
-                y: 0,
-                width: contentContainer.bounds.width * image.scale,
-                height: contentContainer.bounds.height * image.scale
-            )
-        ) {
-            tabSnapshot.image = UIImage(cgImage: croppedImage)
+        if let image = tabSnapshot.image {
+            let cropRect: CGRect
+            if shouldCropUsingContentContainerFrame {
+                cropRect = CGRect(
+                    x: contentContainer.frame.origin.x * image.scale,
+                    y: contentContainer.frame.origin.y * image.scale,
+                    width: contentContainer.frame.width * image.scale,
+                    height: contentContainer.frame.height * image.scale
+                )
+            } else {
+                cropRect = CGRect(
+                    x: 0,
+                    y: 0,
+                    width: contentContainer.bounds.width * image.scale,
+                    height: contentContainer.bounds.height * image.scale
+                )
+            }
+
+            if let croppedImage = image.cgImage?.cropping(to: cropRect) {
+                tabSnapshot.image = UIImage(cgImage: croppedImage)
+            }
         }
 
         tabSnapshot.clipsToBounds = true

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -322,12 +322,16 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
 
         context.containerView.addSubview(toView)
 
+        let isIpad = browserVC.traitCollection.userInterfaceIdiom == .pad &&
+                     browserVC.traitCollection.horizontalSizeClass == .regular
+        let shouldCropUsingContentContainerFrame = UIWindow.isPortrait && !isIpad
+
         // Trigger animation async to be non blocking and allow UI to render
         DispatchQueue.main.async {
             let tabSnapshot = self.buildTabSnapshot(
                 selectedTab: selectedTab,
                 contentContainer: contentContainer,
-                browserVC: browserVC
+                shouldCropUsingContentContainerFrame: shouldCropUsingContentContainerFrame
             )
             context.containerView.addSubview(tabSnapshot)
 
@@ -366,17 +370,14 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
     private func buildTabSnapshot(
         selectedTab: Tab,
         contentContainer: UIView,
-        browserVC: BrowserViewController
+        shouldCropUsingContentContainerFrame: Bool
     ) -> UIView {
         let tabSnapshot = UIImageView(image: selectedTab.screenshot)
-
-        let isIpad = browserVC.traitCollection.userInterfaceIdiom == .pad &&
-                     browserVC.traitCollection.horizontalSizeClass == .regular
 
         // ScreenshotHelper applies contentContainer bounds only on iPhone portrait.
         // Otherwise, the stored tab screenshot is based on the webView bounds.
         if let image = tabSnapshot.image, let croppedImage = image.cgImage?.cropping(
-            to: UIWindow.isPortrait && !isIpad
+            to: shouldCropUsingContentContainerFrame
             ? CGRect(
                 x: contentContainer.frame.origin.x * image.scale,
                 y: contentContainer.frame.origin.y * image.scale,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14599)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31584)

## :bulb: Description
Fixed the Tab Tray dismissal stutter by matching TabAnimation snapshot cropping with how ScreenshotHelper stores tab screenshots.
ScreenshotHelper captures iPhone portrait screenshots with a custom content container rect, while landscape and iPad screenshots are stored from the web view bounds. 

TabAnimation now uses the same distinction when cropping the saved tab screenshot for the dismissal animation!


## :movie_camera: Demos
https://github.com/user-attachments/assets/d21c0da3-ff58-4e0e-8354-a227c42da3a5

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

