### PR TITLE
Cookie persistence TAE migration

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
@@ -5,6 +5,9 @@
 import XCTest
 
 final class CookiePersistenceTests: BaseTestCase {
+    private var browserScreen: BrowserScreen!
+    private var toolbarScreen: ToolbarScreen!
+
     let cookieSiteURL = "http://localhost:\(serverPort)/test-fixture/test-cookie-store.html"
     let topSitesTitle = ["Facebook", "YouTube", "Wikipedia"]
 
@@ -17,6 +20,8 @@ final class CookiePersistenceTests: BaseTestCase {
 
         // The app is correctly installed
         try await super.setUp()
+        browserScreen = BrowserScreen(app: app)
+        toolbarScreen = ToolbarScreen(app: app)
     }
 
     func testCookiePersistenceBasic() {
@@ -50,11 +55,9 @@ final class CookiePersistenceTests: BaseTestCase {
 
         // Open a few tabs
         topSitesTitle.forEach { title in
-            navigator.performAction(Action.OpenNewTabFromTabTray)
-            navigator.nowAt(NewTabScreen)
+            toolbarScreen.openNewTabFromTabTray()
             app.collectionViews.links.staticTexts[title].waitAndTap()
             waitUntilPageLoad()
-            navigator.nowAt(BrowserTab)
         }
 
         // Relaunch app
@@ -67,11 +70,8 @@ final class CookiePersistenceTests: BaseTestCase {
 
     func testCookiePersistenceOpenRegularTabAfterPrivateTab() {
         // Go to private tab
-        navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
-        if userState.isPrivate {
-            app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].waitAndTap()
-            navigator.nowAt(BrowserTab)
-        }
+        toolbarScreen.switchToPrivateBrowsing()
+        app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].waitAndTap()
 
         // Open URL for Cookie login
         openCookieSite()
@@ -110,13 +110,8 @@ final class CookiePersistenceTests: BaseTestCase {
     }
 
     private func openCookieSite() {
-        navigator.openURL(path(forTestPage: "test-cookie-store.html"))
+        browserScreen.navigateToURL(cookieSiteURL)
         waitUntilPageLoad()
-        navigator.nowAt(BrowserTab)
-        let webview = app.webViews.firstMatch
-        mozWaitForElementToExist(webview.staticTexts["Cookie Test Page"])
-        mozWaitForElementToExist(webview.textFields.firstMatch)
-        mozWaitForElementToExist(webview.buttons["Login"])
-        mozWaitForElementToExist(webview.buttons["Logout"])
+        browserScreen.assertCookiePageLoaded()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
@@ -7,6 +7,7 @@ import XCTest
 final class CookiePersistenceTests: BaseTestCase {
     private var browserScreen: BrowserScreen!
     private var toolbarScreen: ToolbarScreen!
+    private var tabTrayScreen: TabTrayScreen!
 
     let cookieSiteURL = "http://localhost:\(serverPort)/test-fixture/test-cookie-store.html"
     let topSitesTitle = ["Facebook", "YouTube", "Wikipedia"]
@@ -22,6 +23,7 @@ final class CookiePersistenceTests: BaseTestCase {
         try await super.setUp()
         browserScreen = BrowserScreen(app: app)
         toolbarScreen = ToolbarScreen(app: app)
+        tabTrayScreen = TabTrayScreen(app: app)
     }
 
     func testCookiePersistenceBasic() {
@@ -71,7 +73,7 @@ final class CookiePersistenceTests: BaseTestCase {
     func testCookiePersistenceOpenRegularTabAfterPrivateTab() {
         // Go to private tab
         toolbarScreen.switchToPrivateBrowsing()
-        app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].waitAndTap()
+        tabTrayScreen.tapOnNewTabButton()
 
         // Open URL for Cookie login
         openCookieSite()
@@ -85,14 +87,14 @@ final class CookiePersistenceTests: BaseTestCase {
 
         // Open regular tabs
         // navigate to website and expect not to be login
-        app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
+        toolbarScreen.tapOnTabsButton()
         mozWaitForElementToExist(app.buttons["Private"])
         if iPad() {
             app.segmentedControls.buttons.firstMatch.waitAndTap()
         } else {
             app.buttons["Tabs"].tap()
         }
-        app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].waitAndTap()
+        tabTrayScreen.tapOnNewTabButton()
 
         openCookieSite()
         mozWaitForElementToExist(webview.staticTexts["LOGGED_OUT"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
@@ -72,7 +72,8 @@ final class CookiePersistenceTests: BaseTestCase {
 
     func testCookiePersistenceOpenRegularTabAfterPrivateTab() {
         // Go to private tab
-        toolbarScreen.switchToPrivateBrowsing()
+        toolbarScreen.tapOnTabsButton()
+        tabTrayScreen.switchToPrivateBrowsing()
         tabTrayScreen.tapOnNewTabButton()
 
         // Open URL for Cookie login

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -382,4 +382,12 @@ final class BrowserScreen {
         let privateMessage = sel.PRIVATE_MODE_HOMEPAGE_TITLE.element(in: app)
         BaseTestCase().mozWaitForElementToExist(privateMessage, timeout: timeout)
     }
+
+    func assertCookiePageLoaded() {
+        let webview = app.webViews.firstMatch
+        BaseTestCase().mozWaitForElementToExist(webview.staticTexts["Cookie Test Page"])
+        BaseTestCase().mozWaitForElementToExist(webview.textFields.firstMatch)
+        BaseTestCase().mozWaitForElementToExist(webview.buttons["Login"])
+        BaseTestCase().mozWaitForElementToExist(webview.buttons["Logout"])
+    }
  }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
@@ -90,6 +90,12 @@ final class TabTrayScreen {
         tabCell.waitAndTap()
     }
 
+    func switchToPrivateBrowsing() {
+        let privateModeButton = sel.tabSelectorButton(at: 0).element(in: app)
+        BaseTestCase().mozWaitForElementToExist(privateModeButton)
+        privateModeButton.waitAndTap()
+    }
+
     func assertTabButtonEnabled(at index: Int) {
         let tabButton = sel.tabSelectorButton(at: index).element(in: app)
         BaseTestCase().mozWaitForElementToExist(tabButton)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
@@ -15,12 +15,14 @@ final class ToolbarScreen {
     }
 
     private var tabsButton: XCUIElement { sel.TABS_BUTTON.element(in: app) }
-    private var newTabButton: XCUIElement { sel.NEW_TAB_BUTTON.element(in: app)}
-    private var backButton: XCUIElement { sel.BACK_BUTTON.element(in: app)}
+    private var newTabButton: XCUIElement { sel.NEW_TAB_BUTTON.element(in: app) }
+    private var backButton: XCUIElement { sel.BACK_BUTTON.element(in: app) }
     private var tabToolbarMenuButton: XCUIElement { sel.TABTOOLBAR_MENUBUTTON.element(in: app) }
     private var shareButton: XCUIElement { sel.SHARE_BUTTON.element(in: app) }
     private var translateButton: XCUIElement { sel.TRANSLATE_BUTTON.element(in: app) }
-    private var translateLoadingButton: XCUIElement { sel.TRANSLATE_LOADING_BUTTON.element(in: app) }
+    private var translateLoadingButton: XCUIElement {
+        sel.TRANSLATE_LOADING_BUTTON.element(in: app)
+    }
     private var translateActiveButton: XCUIElement { sel.TRANSLATE_ACTIVE_BUTTON.element(in: app) }
 
     func assertSettingsButtonExists(timeout: TimeInterval = TIMEOUT) {
@@ -46,7 +48,8 @@ final class ToolbarScreen {
         BaseTestCase().mozWaitForElementToExist(tabsButton)
 
         guard let tabsOpen = tabsButton.value as? String, tabsOpen == "\(expectedCount)" else {
-            XCTFail("Tabs button counter is not showing the correct count. Expected: \(expectedCount)")
+            XCTFail(
+                "Tabs button counter is not showing the correct count. Expected: \(expectedCount)")
             return
         }
     }
@@ -69,7 +72,8 @@ final class ToolbarScreen {
     func assertTabsButtonValue(expectedCount: String) {
         BaseTestCase().mozWaitForElementToExist(tabsButton)
         let tabsButtonValue = tabsButton.value as? String
-        XCTAssertEqual(expectedCount, tabsButtonValue, "Expected \(expectedCount) open tabs after switching")
+        XCTAssertEqual(
+            expectedCount, tabsButtonValue, "Expected \(expectedCount) open tabs after switching")
     }
 
     func pressBackButton(duration: TimeInterval) {
@@ -177,5 +181,13 @@ final class ToolbarScreen {
         case .active:
             BaseTestCase().mozWaitForElementToNotExist(translateActiveButton)
         }
+    }
+
+    func switchToPrivateBrowsing() {
+        tabsButton.waitAndTap()
+        let base = BaseTestCase()
+        let privateModeButton = app.buttons["\(AccessibilityIdentifiers.TabTray.selectorCell)0"]
+        base.mozWaitForElementToExist(privateModeButton)
+        privateModeButton.waitAndTap()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
@@ -15,14 +15,12 @@ final class ToolbarScreen {
     }
 
     private var tabsButton: XCUIElement { sel.TABS_BUTTON.element(in: app) }
-    private var newTabButton: XCUIElement { sel.NEW_TAB_BUTTON.element(in: app) }
-    private var backButton: XCUIElement { sel.BACK_BUTTON.element(in: app) }
+    private var newTabButton: XCUIElement { sel.NEW_TAB_BUTTON.element(in: app)}
+    private var backButton: XCUIElement { sel.BACK_BUTTON.element(in: app)}
     private var tabToolbarMenuButton: XCUIElement { sel.TABTOOLBAR_MENUBUTTON.element(in: app) }
     private var shareButton: XCUIElement { sel.SHARE_BUTTON.element(in: app) }
     private var translateButton: XCUIElement { sel.TRANSLATE_BUTTON.element(in: app) }
-    private var translateLoadingButton: XCUIElement {
-        sel.TRANSLATE_LOADING_BUTTON.element(in: app)
-    }
+    private var translateLoadingButton: XCUIElement { sel.TRANSLATE_LOADING_BUTTON.element(in: app) }
     private var translateActiveButton: XCUIElement { sel.TRANSLATE_ACTIVE_BUTTON.element(in: app) }
 
     func assertSettingsButtonExists(timeout: TimeInterval = TIMEOUT) {
@@ -48,8 +46,7 @@ final class ToolbarScreen {
         BaseTestCase().mozWaitForElementToExist(tabsButton)
 
         guard let tabsOpen = tabsButton.value as? String, tabsOpen == "\(expectedCount)" else {
-            XCTFail(
-                "Tabs button counter is not showing the correct count. Expected: \(expectedCount)")
+            XCTFail("Tabs button counter is not showing the correct count. Expected: \(expectedCount)")
             return
         }
     }
@@ -72,8 +69,7 @@ final class ToolbarScreen {
     func assertTabsButtonValue(expectedCount: String) {
         BaseTestCase().mozWaitForElementToExist(tabsButton)
         let tabsButtonValue = tabsButton.value as? String
-        XCTAssertEqual(
-            expectedCount, tabsButtonValue, "Expected \(expectedCount) open tabs after switching")
+        XCTAssertEqual(expectedCount, tabsButtonValue, "Expected \(expectedCount) open tabs after switching")
     }
 
     func pressBackButton(duration: TimeInterval) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
@@ -179,11 +179,4 @@ final class ToolbarScreen {
         }
     }
 
-    func switchToPrivateBrowsing() {
-        tabsButton.waitAndTap()
-        let base = BaseTestCase()
-        let privateModeButton = app.buttons["\(AccessibilityIdentifiers.TabTray.selectorCell)0"]
-        base.mozWaitForElementToExist(privateModeButton)
-        privateModeButton.waitAndTap()
-    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
@@ -178,5 +178,4 @@ final class ToolbarScreen {
             BaseTestCase().mozWaitForElementToNotExist(translateActiveButton)
         }
     }
-
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15481)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33206)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Migrates `CookiePersistenceTests` from the legacy navigator pattern to
  the TAE screen object framework.                                        
                                   
  - `openCookieSite()`: replaced `navigator.openURL` + `navigator.nowAt`  
  with `browserScreen.navigateToURL` and new
  `browserScreen.assertCookiePageLoaded()`                                
  - `testCookiePersistenceOpenNewTab`: replaced
  `navigator.performAction(OpenNewTabFromTabTray)` with                   
  `toolbarScreen.openNewTabFromTabTray()`
  - `testCookiePersistenceOpenRegularTabAfterPrivateTab`: replaced        
  `navigator.toggleOn(ToggleExperimentPrivateMode)` with new              
  `toolbarScreen.switchToPrivateBrowsing()`
  - All `navigator.nowAt()` state bookkeeping calls removed               
                                   
  New methods added:                     
  - `BrowserScreen.assertCookiePageLoaded()`
  - `ToolbarScreen.switchToPrivateBrowsing()`


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

