### PR TITLE
Refactor FXIOS-15358 [Technical Debt] [Redux] Use @CopyWithUpdates macro for MicrosurveyState

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
@@ -4,7 +4,9 @@
 
 import Redux
 import Common
+import CopyWithUpdates
 
+@CopyWithUpdates
 struct MicrosurveyState: ScreenState {
     var windowUUID: WindowUUID
     var shouldDismiss: Bool
@@ -20,11 +22,7 @@ struct MicrosurveyState: ScreenState {
             return
         }
 
-        self.init(
-            windowUUID: microsurveyState.windowUUID,
-            shouldDismiss: microsurveyState.shouldDismiss,
-            showPrivacy: microsurveyState.showPrivacy
-        )
+        self = microsurveyState.copyWithUpdates()
     }
 
     init(
@@ -51,14 +49,12 @@ struct MicrosurveyState: ScreenState {
 
         switch action.actionType {
         case MicrosurveyActionType.closeSurvey:
-            return MicrosurveyState(
-                windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                 shouldDismiss: true,
                 showPrivacy: false
             )
         case MicrosurveyActionType.tapPrivacyNotice:
-            return MicrosurveyState(
-                windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                 shouldDismiss: false,
                 showPrivacy: true
             )
@@ -68,8 +64,7 @@ struct MicrosurveyState: ScreenState {
     }
 
     static func defaultState(from state: MicrosurveyState) -> MicrosurveyState {
-        return MicrosurveyState(
-            windowUUID: state.windowUUID,
+        return state.copyWithUpdates(
             shouldDismiss: false,
             showPrivacy: false
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15358)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32945)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Apply `@CopyWithUpdates` macro to `MicrosurveyState`. Removes manual field forwarding in `copyWithUpdates` calls only changed fields now passed explicitly. No behaviour change.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

