### PR TITLE
Refactor FXIOS-15544 [AI Controls] Remove duplicate setting of toggles

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AIControls/AIControlsModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/AIControls/AIControlsModel.swift
@@ -76,12 +76,6 @@ class AIControlsModel: ObservableObject, LegacyFeatureFlaggable {
         prefs.setBool(newValue, forKey: PrefsKeys.Settings.aiKillSwitchFeature)
         pageSummariesEnabled = !newValue
         translationEnabled = !newValue
-        prefs.setBool(!newValue, forKey: PrefsKeys.Summarizer.summarizeContentFeature)
-        store.dispatch(TranslationSettingsViewAction(
-            newSettingValue: !newValue,
-            windowUUID: windowUUID,
-            actionType: TranslationSettingsViewActionType.toggleTranslationsEnabled
-        ))
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AI Controls/AIControlsModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AI Controls/AIControlsModelTests.swift
@@ -109,22 +109,6 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
         } else {
             XCTFail("No pref value for ai kill switch feature")
         }
-
-        if let prefVal = mockPrefs.boolForKey(PrefsKeys.Settings.translationsFeature) {
-            XCTAssertFalse(prefVal)
-        } else {
-            XCTFail("No pref value for translations feature")
-        }
-
-        if let prefVal = mockPrefs.boolForKey(PrefsKeys.Summarizer.summarizeContentFeature) {
-            XCTAssertFalse(prefVal)
-        } else {
-            XCTFail("No pref value for translations feature")
-        }
-
-        wait(for: [expectation], timeout: 1.0)
-        let action = try XCTUnwrap(mockStore.dispatchedActions.last as? TranslationSettingsViewAction)
-        XCTAssertFalse(try XCTUnwrap(action.newSettingValue))
     }
 
     @MainActor
@@ -141,19 +125,6 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
         } else {
             XCTFail("No pref value for ai kill switch feature")
         }
-
-        if let prefVal = mockPrefs.boolForKey(PrefsKeys.Summarizer.summarizeContentFeature) {
-            XCTAssertTrue(prefVal)
-        } else {
-            XCTFail("No pref value for translations feature")
-        }
-
-        XCTAssertTrue(aiControlsModel.pageSummariesEnabled)
-
-        wait(for: [expectation], timeout: 1.0)
-        let action = try XCTUnwrap(mockStore.dispatchedActions.last as? TranslationSettingsViewAction)
-        XCTAssertTrue(try XCTUnwrap(action.newSettingValue))
-        XCTAssertTrue(aiControlsModel.translationEnabled)
     }
 
     @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15544)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Toggling the AI Control toggles the settings controls so there is no need to set the settings values in the ai control toggle listener.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

