### PR TITLE
Refactor FXIOS-14751 [iPad Tab Tray Design] Consistent design with new design use experiment segment control and cell size

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -132,7 +132,9 @@ final class TabsSectionManager: LegacyFeatureFlaggable {
 
     /// Uses aspect ratio math to derive cell height from actual cell width so that portrait
     /// gets taller cells and landscape gets shorter cells
-    private func experimentLayoutSectionIpad(_ layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+    private func experimentLayoutSectionIpad(
+        _ layoutEnvironment: NSCollectionLayoutEnvironment
+    ) -> NSCollectionLayoutSection {
         let availableWidth = layoutEnvironment.container.effectiveContentSize.width
         let availableHeight = layoutEnvironment.container.effectiveContentSize.height
         let maxNumberOfCellsPerRow = Int(availableWidth / UX.cellEstimatedWidth)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -19,6 +19,8 @@ final class TabsSectionManager: LegacyFeatureFlaggable {
         static let iPadTopSiteInset: CGFloat = 25
         static let verticalInset: CGFloat = 20
         static let experimentTitleHeight: CGFloat = 20
+        static let experimentCellPortraitAspectRatio: CGFloat = 1.4
+        static let experimentCellLandscapeAspectRatio: CGFloat = 0.67
     }
 
     static func leadingInset(traitCollection: UITraitCollection,
@@ -68,6 +70,10 @@ final class TabsSectionManager: LegacyFeatureFlaggable {
     }
 
     func experimentLayoutSection(_ layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        guard UIDevice.current.userInterfaceIdiom != .pad else {
+            return experimentLayoutSectionIpad(layoutEnvironment)
+        }
+
         let availableWidth = layoutEnvironment.container.effectiveContentSize.width
         let maxNumberOfCellsPerRow = Int(availableWidth / UX.cellEstimatedWidth)
         let minNumberOfCellsPerRow = 2
@@ -78,7 +84,7 @@ final class TabsSectionManager: LegacyFeatureFlaggable {
                                     ? minNumberOfCellsPerRow
                                     : maxNumberOfCellsPerRow
 
-        let cellHeight: CGFloat = UX.cellAbsoluteHeight
+        let cellHeight = UX.cellAbsoluteHeight
         let itemWidth: CGFloat = 1.0 / CGFloat(numberOfCellsPerRow)
 
         let itemSize = NSCollectionLayoutSize(
@@ -111,6 +117,73 @@ final class TabsSectionManager: LegacyFeatureFlaggable {
 
         let isAccessibilitySize = layoutEnvironment.traitCollection.preferredContentSizeCategory.isAccessibilityCategory
         let horizontalInset = TabsSectionManager.leadingInset(traitCollection: layoutEnvironment.traitCollection)
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: UX.verticalInset,
+            leading: horizontalInset,
+            bottom: isAccessibilitySize ? UX.experimentA11yCardSpacing : UX.experimentCardSpacing,
+            trailing: horizontalInset
+        )
+        section.interGroupSpacing = isAccessibilitySize ? UX.experimentA11yCardSpacing : UX.experimentCardSpacing
+
+        return section
+    }
+
+    // MARK: - iPad experiment layout
+
+    /// Uses aspect ratio math to derive cell height from actual cell width so that portrait
+    /// gets taller cells and landscape gets shorter cells
+    private func experimentLayoutSectionIpad(_ layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        let availableWidth = layoutEnvironment.container.effectiveContentSize.width
+        let availableHeight = layoutEnvironment.container.effectiveContentSize.height
+        let maxNumberOfCellsPerRow = Int(availableWidth / UX.cellEstimatedWidth)
+        let minNumberOfCellsPerRow = 2
+
+        // maxNumberOfCellsPerRow returns 1 on smaller screen sizes which is inconvenient to scroll through
+        // so here we check we have 2 cells per row at minimum.
+        let numberOfCellsPerRow = maxNumberOfCellsPerRow < minNumberOfCellsPerRow
+                                    ? minNumberOfCellsPerRow
+                                    : maxNumberOfCellsPerRow
+
+        let horizontalInset = TabsSectionManager.leadingInset(traitCollection: layoutEnvironment.traitCollection)
+        let totalSpacing = CGFloat(numberOfCellsPerRow - 1) * UX.cardSpacing
+        let totalHorizontalInset = horizontalInset * 2
+        let usableWidth = availableWidth - totalHorizontalInset - totalSpacing
+        let cellWidth = usableWidth / CGFloat(numberOfCellsPerRow)
+        let aspectRatio = availableWidth > availableHeight
+                            ? UX.experimentCellLandscapeAspectRatio
+                            : UX.experimentCellPortraitAspectRatio
+        let cellHeight = (cellWidth * aspectRatio).rounded()
+        let itemWidth: CGFloat = 1.0 / CGFloat(numberOfCellsPerRow)
+
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(itemWidth),
+            heightDimension: .absolute(cellHeight)
+        )
+
+        let titleSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(UX.experimentTitleHeight)
+        )
+
+        let titleSupplementary = NSCollectionLayoutSupplementaryItem(
+            layoutSize: titleSize,
+            elementKind: TabTitleSupplementaryView.cellIdentifier,
+            containerAnchor: NSCollectionLayoutAnchor(edges: [.bottom])
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize, supplementaryItems: [titleSupplementary])
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .absolute(cellHeight)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
+                                                       subitem: item,
+                                                       count: numberOfCellsPerRow)
+        group.interItemSpacing = .fixed(UX.cardSpacing)
+
+        let section = NSCollectionLayoutSection(group: group)
+
+        let isAccessibilitySize = layoutEnvironment.traitCollection.preferredContentSizeCategory.isAccessibilityCategory
         section.contentInsets = NSDirectionalEdgeInsets(
             top: UX.verticalInset,
             leading: horizontalInset,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -87,16 +87,25 @@ final class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCe
 
         closeButtonBlurView.addBlurEffectWithClearBackgroundAndClipping(using: .systemUltraThinMaterialDark)
         closeButtonBlurView.layer.cornerRadius = closeButtonBlurView.frame.height / 2
+
+        // Handles initial draw and non-rotation layout changes (e.g. multitasking resize).
+        guard isSelectedTab, backgroundHolder.bounds != borderLayer.frame else { return }
+        redrawExternalBorder()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        guard isSelectedTab else { return }
+        // Defers redraw via Task so the border updates after the rotation animation completes.
+        guard isSelectedTab,
+              previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass
+              || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass
+        else { return }
+
         Task {
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                redrawExternalBorder()
+                self.redrawExternalBorder()
             }
         }
     }
@@ -309,6 +318,8 @@ final class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCe
     override func prepareForReuse() {
         // Reset any close animations.
         super.prepareForReuse()
+        tabModel = nil
+        accessibilityLabel = nil
         screenshotView.image = nil
         smallFaviconView.isHidden = true
         removeExternalBorder(from: backgroundHolder)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -27,7 +27,6 @@ final class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCe
         static let shadowRadius: CGFloat = 4
         static let shadowOffset = CGSize(width: 0, height: 2)
         static let shadowOpacity: Float = 1
-        static let thumbnailScreenshotHeight: CGFloat = 200
         static let borderLayerName = "externalBorder"
     }
     // MARK: - Properties
@@ -337,7 +336,6 @@ final class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCe
             backgroundHolder.topAnchor.constraint(equalTo: contentView.topAnchor),
             backgroundHolder.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             backgroundHolder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            backgroundHolder.heightAnchor.constraint(equalToConstant: UX.thumbnailScreenshotHeight),
             backgroundHolder.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
 
             closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonHitTarget),

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -236,6 +236,8 @@ final class TabCell: UICollectionViewCell,
     override func prepareForReuse() {
         // Reset any close animations.
         super.prepareForReuse()
+        tabModel = nil
+        accessibilityLabel = nil
         screenshotView.image = nil
         backgroundHolder.transform = .identity
         backgroundHolder.alpha = 1

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -40,6 +40,7 @@ final class TabTrayViewController: UIViewController,
     private struct UX {
         struct NavigationMenu {
             static let width: CGFloat = 343
+            static let iPadWidth: CGFloat = 500
         }
 
         static let fixedSpaceWidth: CGFloat = 32
@@ -345,7 +346,7 @@ final class TabTrayViewController: UIViewController,
                 navigationItem.rightBarButtonItems = [doneButton]
             }
         case .regular:
-            navigationItem.titleView = segmentedControl
+            navigationItem.titleView = tabTrayUtils.shouldDisplayExperimentUI() ? experimentSegmentControl : segmentedControl
         }
         updateToolbarItems()
     }
@@ -620,6 +621,11 @@ final class TabTrayViewController: UIViewController,
     }
 
     private func setupForiPad() {
+        guard !tabTrayUtils.shouldDisplayExperimentUI() else {
+            setupForiPadExperiment()
+            return
+        }
+
         navigationItem.titleView = segmentedControl
         view.addSubviews(containerView)
         setupBlurView()
@@ -637,6 +643,30 @@ final class TabTrayViewController: UIViewController,
             containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             containerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+
+    private func setupForiPadExperiment() {
+        navigationItem.titleView = experimentSegmentControl
+        view.addSubviews(containerView)
+        containerView.addSubview(panelContainer)
+        setupBlurView()
+
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: view.topAnchor),
+            containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            containerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            panelContainer.topAnchor.constraint(equalTo: containerView.topAnchor),
+            panelContainer.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            panelContainer.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            panelContainer.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+
+            // Because experimentSegmentControl doesn't inherit from UISegmentControl
+            // we need to set height and width constraints
+            experimentSegmentControl.widthAnchor.constraint(equalToConstant: UX.NavigationMenu.iPadWidth),
+            experimentSegmentControl.heightAnchor.constraint(equalToConstant: tabTrayUtils.segmentedControlHeight)
         ])
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14751)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31856)

## :bulb: Description
- Setup TabTrayViewController to use experiment views like panelContainer and experimentSegmentControl
- Use aspect ratio and calculate available width to match UX design where cells are shorter in landscape mode and taller in portrait.
- Update logic for redrawExternalBorder to fix bug where after rotation the selectedCell border was draw using the previous cell bounds
- Fix bug for experiment and regular cell where tabModel wasn't reset what caused selected cell was render multiple times

To test, enable `iPad_update_enabled: true` under tabTrayUIExperiments.yaml or debug menu
Note: This is WIP bugs in experiment version are expected but there shouldn't be regression for not experiment version and iPhone Tab tray

## :movie_camera: Demos

https://github.com/user-attachments/assets/d0a04970-1420-46c1-8c50-d341d3c76f43



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

