### PR TITLE
FXIOS-15348 [Technical Debt] [Redux] Use @CopyWithUpdates macro for RemoteTabsPanelState #32932

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import CopyWithUpdates
 import Redux
 import Storage
 
@@ -48,6 +49,7 @@ enum RemoteTabsPanelEmptyStateReason {
 }
 
 /// State for RemoteTabsPanel. WIP.
+@CopyWithUpdates
 struct RemoteTabsPanelState: ScreenState, Sendable {
     let refreshState: RemoteTabsPanelRefreshState
     let allowsRefresh: Bool
@@ -66,12 +68,7 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
             return
         }
 
-        self.init(windowUUID: panelState.windowUUID,
-                  refreshState: panelState.refreshState,
-                  allowsRefresh: panelState.allowsRefresh,
-                  clientAndTabs: panelState.clientAndTabs,
-                  showingEmptyState: panelState.showingEmptyState,
-                  devices: panelState.devices)
+        self = panelState.copyWithUpdates()
     }
 
     init(windowUUID: WindowUUID) {
@@ -126,30 +123,21 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
     }
 
     private static func handleRefreshDidBeginAction(state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                    refreshState: .refreshing,
-                                    allowsRefresh: state.allowsRefresh,
-                                    clientAndTabs: state.clientAndTabs,
-                                    showingEmptyState: state.showingEmptyState,
-                                    devices: state.devices)
+        return state.copyWithUpdates(refreshState: .refreshing)
     }
 
     private static func handleRefreshDidFailAction(reason: RemoteTabsPanelEmptyStateReason,
                                                    state: RemoteTabsPanelState) -> RemoteTabsPanelState {
         let allowsRefresh = reason.allowsRefresh
-        return RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                    refreshState: .idle,
+        return state.copyWithUpdates(refreshState: .idle,
                                     allowsRefresh: allowsRefresh,
-                                    clientAndTabs: state.clientAndTabs,
-                                    showingEmptyState: reason,
-                                    devices: state.devices)
+                                    showingEmptyState: reason)
     }
 
     private static func handleRefreshDidSucceedAction(clientAndTabs: [ClientAndTabs],
                                                       state: RemoteTabsPanelState,
                                                       action: RemoteTabsPanelAction) -> RemoteTabsPanelState {
-        return RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                    refreshState: .idle,
+        return state.copyWithUpdates(refreshState: .idle,
                                     allowsRefresh: true,
                                     clientAndTabs: clientAndTabs,
                                     showingEmptyState: nil,
@@ -158,29 +146,16 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
 
     private static func handleRemoteDevicesChangedAction(devices: [Device],
                                                          state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                    refreshState: .idle,
-                                    allowsRefresh: state.allowsRefresh,
-                                    clientAndTabs: state.clientAndTabs,
-                                    showingEmptyState: state.showingEmptyState,
+        return state.copyWithUpdates(refreshState: .idle,
                                     devices: devices)
     }
 
     private static func handleSyncDidBeginAction(state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                    refreshState: .syncingTabs,
-                                    allowsRefresh: false,
-                                    clientAndTabs: state.clientAndTabs,
-                                    showingEmptyState: state.showingEmptyState,
-                                    devices: state.devices)
+        return state.copyWithUpdates(refreshState: .syncingTabs,
+                                    allowsRefresh: false)
     }
 
     static func defaultState(from state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return RemoteTabsPanelState(windowUUID: state.windowUUID,
-                                    refreshState: state.refreshState,
-                                    allowsRefresh: state.allowsRefresh,
-                                    clientAndTabs: state.clientAndTabs,
-                                    showingEmptyState: state.showingEmptyState,
-                                    devices: state.devices)
+        return state.copyWithUpdates()
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -130,29 +130,29 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
                                                    state: RemoteTabsPanelState) -> RemoteTabsPanelState {
         let allowsRefresh = reason.allowsRefresh
         return state.copyWithUpdates(refreshState: .idle,
-                                    allowsRefresh: allowsRefresh,
-                                    showingEmptyState: reason)
+                                     allowsRefresh: allowsRefresh,
+                                     showingEmptyState: reason)
     }
 
     private static func handleRefreshDidSucceedAction(clientAndTabs: [ClientAndTabs],
                                                       state: RemoteTabsPanelState,
                                                       action: RemoteTabsPanelAction) -> RemoteTabsPanelState {
         return state.copyWithUpdates(refreshState: .idle,
-                                    allowsRefresh: true,
-                                    clientAndTabs: clientAndTabs,
-                                    showingEmptyState: nil,
-                                    devices: action.devices ?? state.devices)
+                                     allowsRefresh: true,
+                                     clientAndTabs: clientAndTabs,
+                                     showingEmptyState: nil,
+                                     devices: action.devices ?? state.devices)
     }
 
     private static func handleRemoteDevicesChangedAction(devices: [Device],
                                                          state: RemoteTabsPanelState) -> RemoteTabsPanelState {
         return state.copyWithUpdates(refreshState: .idle,
-                                    devices: devices)
+                                     devices: devices)
     }
 
     private static func handleSyncDidBeginAction(state: RemoteTabsPanelState) -> RemoteTabsPanelState {
         return state.copyWithUpdates(refreshState: .syncingTabs,
-                                    allowsRefresh: false)
+                                     allowsRefresh: false)
     }
 
     static func defaultState(from state: RemoteTabsPanelState) -> RemoteTabsPanelState {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -51,11 +51,11 @@ enum RemoteTabsPanelEmptyStateReason {
 /// State for RemoteTabsPanel. WIP.
 @CopyWithUpdates
 struct RemoteTabsPanelState: ScreenState, Sendable {
+    let windowUUID: WindowUUID
     let refreshState: RemoteTabsPanelRefreshState
     let allowsRefresh: Bool
     let clientAndTabs: [ClientAndTabs]
     let showingEmptyState: RemoteTabsPanelEmptyStateReason?// If showing empty (or error) state
-    let windowUUID: WindowUUID
     let devices: [Device]
 
     init(appState: AppState, uuid: WindowUUID) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15348)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32932)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Apply `@CopyWithUpdates` macro to `RemoteTabsPanelState`. Replaces manual full init calls in reducer handlers with `copyWithUpdates(...)` only changed fields passed. No behavior change.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

