### PR TITLE
Bugfix FXIOS-15491 [Unit Test] failing SpeechAnalyzerTests

### DIFF
--- a/BrowserKit/.swiftpm/xcode/xcshareddata/xcschemes/QuickAnswersKit.xcscheme
+++ b/BrowserKit/.swiftpm/xcode/xcshareddata/xcschemes/QuickAnswersKit.xcscheme
@@ -28,7 +28,30 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldAutocreateTestPlan = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "QuickAnswers"
+            BuildableName = "QuickAnswers"
+            BlueprintName = "QuickAnswers"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "QuickAnswersTests"
+               BuildableName = "QuickAnswersTests"
+               BlueprintName = "QuickAnswersTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/BrowserKit/Tests/QuickAnswersKitTests/SpeechService/AudioManagerTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/SpeechService/AudioManagerTests.swift
@@ -10,9 +10,9 @@ import TestKit
 
 @Suite
 struct AudioManagerTests {
+    let testHelper = SwiftTestingHelper()
     let session = MockAudioSession()
     let engine = MockAudioEngine()
-    let testHelper = SwiftTestingHelper()
 
     // MARK: - Audio Session Configuration Tests
     @Test

--- a/BrowserKit/Tests/QuickAnswersKitTests/SpeechService/SpeechAnalyzerEngineTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/SpeechService/SpeechAnalyzerEngineTests.swift
@@ -11,15 +11,12 @@ import TestKit
 @Suite
 @MainActor
 struct SpeechAnalyzerEngineTests {
-    let audioManager = MockAudioManager()
     let testHelper = SwiftTestingHelper()
+    let audioManager = MockAudioManager()
 
+    @available(iOS 26.0, *)
     @Test
-    func test_prepare_microphoneDenied_speechDenied_throwsError() async {
-        guard #available(iOS 26.0, *) else {
-            return
-        }
-
+    func test_prepare_microphoneDenied_speechDenied_throwsError() async throws {
         let authorizer = MockAuthorizer(micAuthorized: false, speechAuthorized: false)
         let subject = createSubject(authorizer: authorizer)
 
@@ -30,12 +27,9 @@ struct SpeechAnalyzerEngineTests {
         #expect(audioManager.configureAudioSessionCallCount == 0)
     }
 
+    @available(iOS 26.0, *)
     @Test
-    func test_prepare_microphoneDenied_speechGranted_throwsError() async {
-        guard #available(iOS 26.0, *) else {
-            return
-        }
-
+    func test_prepare_microphoneDenied_speechGranted_throwsError() async throws {
         let authorizer = MockAuthorizer(micAuthorized: false, speechAuthorized: true)
         let subject = createSubject(authorizer: authorizer)
 
@@ -46,12 +40,9 @@ struct SpeechAnalyzerEngineTests {
         #expect(audioManager.configureAudioSessionCallCount == 0)
     }
 
+    @available(iOS 26.0, *)
     @Test
     func test_prepare_microphoneGranted_speechDenied_throwsError() async throws {
-        guard #available(iOS 26.0, *) else {
-            return
-        }
-
         let authorizer = MockAuthorizer(micAuthorized: true, speechAuthorized: false)
         let subject = createSubject(authorizer: authorizer)
 
@@ -60,12 +51,9 @@ struct SpeechAnalyzerEngineTests {
         #expect(audioManager.configureAudioSessionCallCount == 1)
     }
 
+    @available(iOS 26.0, *)
     @Test
     func test_prepare_microphoneGranted_speechGranted_throwsError() async throws {
-        guard #available(iOS 26.0, *) else {
-            return
-        }
-
         let authorizer = MockAuthorizer(micAuthorized: true, speechAuthorized: true)
         let subject = createSubject(authorizer: authorizer)
 
@@ -74,12 +62,9 @@ struct SpeechAnalyzerEngineTests {
         #expect(audioManager.configureAudioSessionCallCount == 1)
     }
 
+    @available(iOS 26.0, *)
     @Test
     func test_prepare_withPermissions_callsConfigureAudioSession() async throws {
-        guard #available(iOS 26.0, *) else {
-            return
-        }
-
         let authorizer = MockAuthorizer(micAuthorized: true, speechAuthorized: true)
         let subject = createSubject(authorizer: authorizer)
 
@@ -88,12 +73,9 @@ struct SpeechAnalyzerEngineTests {
         #expect(audioManager.configureAudioSessionCallCount == 1)
     }
 
+    @available(iOS 26.0, *)
     @Test
     func test_prepare_withPermissions_throwsError() async throws {
-        guard #available(iOS 26.0, *) else {
-            return
-        }
-
         let authorizer = MockAuthorizer(micAuthorized: true, speechAuthorized: true)
         let subject = createSubject(authorizer: authorizer)
         audioManager.shouldThrowOnConfigure = true
@@ -105,11 +87,9 @@ struct SpeechAnalyzerEngineTests {
         #expect(audioManager.configureAudioSessionCallCount == 1)
     }
 
+    @available(iOS 26.0, *)
     @Test
     func test_stop_callsStopEngine() async throws {
-        guard #available(iOS 26.0, *) else {
-            return
-        }
         let authorizer = MockAuthorizer(micAuthorized: true, speechAuthorized: true)
         let subject = createSubject(authorizer: authorizer)
 

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -225,20 +225,6 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "VoiceSearchKit"
-               BuildableName = "VoiceSearchKit"
-               BlueprintName = "VoiceSearchKit"
-               ReferencedContainer = "container:../BrowserKit">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "WebEngine"
                BuildableName = "WebEngine"
                BlueprintName = "WebEngine"
@@ -285,6 +271,20 @@
                BuildableName = "ClientTests.xctest"
                BlueprintName = "ClientTests"
                ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "QuickAnswersKitTests"
+               BuildableName = "QuickAnswersKitTests"
+               BlueprintName = "QuickAnswersKitTests"
+               ReferencedContainer = "container:../BrowserKit">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
@@ -474,6 +474,13 @@
             BlueprintIdentifier = "OnboardingKit"
             BuildableName = "OnboardingKit"
             BlueprintName = "OnboardingKit"
+            ReferencedContainer = "container:../BrowserKit">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "QuickAnswersKit"
+            BuildableName = "QuickAnswersKit"
+            BlueprintName = "QuickAnswersKit"
             ReferencedContainer = "container:../BrowserKit">
          </BuildableReference>
          <BuildableReference
@@ -783,9 +790,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "VoiceSearchKitTests"
-               BuildableName = "VoiceSearchKitTests"
-               BlueprintName = "VoiceSearchKitTests"
+               BlueprintIdentifier = "QuickAnswersKitTests"
+               BuildableName = "QuickAnswersKitTests"
+               BlueprintName = "QuickAnswersKitTests"
                ReferencedContainer = "container:../BrowserKit">
             </BuildableReference>
          </TestableReference>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15491)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33238)

## :bulb: Description
Fix failing `QuickAnswersKit` tests from the weekly pipeline (see bitrise [here](https://app.bitrise.io/app/6c06d3a40422d10f/build/542234c3-77f8-4965-b136-e6e74b713e91?tab=tests&tests_filter_status=failed))

It seems we need to move the `@available` above the `@Test` macro and keep it consistent with the `@available` we added about the `createSubject` method. Test are now able to pass successfully. 

Also, we weren't collecting code coverage properly, so I added the fixes based on the confluence page. Removed `VoiceSearchKit` since it was renamed to `QuickAnswersKit`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

