### PR TITLE
FXIOS-15349 refactor: [Technical Debt] [Redux] Use @CopyWithUpdates macro for TabPeekState 

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -8,6 +8,7 @@ import CopyWithUpdates
 
 @CopyWithUpdates
 struct TabPeekState: ScreenState {
+    let windowUUID: WindowUUID
     let showAddToBookmarks: Bool
     let showRemoveBookmark: Bool
     let showSendToDevice: Bool
@@ -15,7 +16,6 @@ struct TabPeekState: ScreenState {
     let showCloseTab: Bool
     let previewAccessibilityLabel: String
     let screenshot: UIImage
-    let windowUUID: WindowUUID
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let tabPeekState = appState.componentState(

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -4,7 +4,9 @@
 
 import Redux
 import Common
+import CopyWithUpdates
 
+@CopyWithUpdates
 struct TabPeekState: ScreenState {
     let showAddToBookmarks: Bool
     let showRemoveBookmark: Bool
@@ -25,14 +27,7 @@ struct TabPeekState: ScreenState {
             return
         }
 
-        self.init(windowUUID: tabPeekState.windowUUID,
-                  showAddToBookmarks: tabPeekState.showAddToBookmarks,
-                  showRemoveBookmark: tabPeekState.showRemoveBookmark,
-                  showSendToDevice: tabPeekState.showSendToDevice,
-                  showCopyURL: tabPeekState.showCopyURL,
-                  showCloseTab: tabPeekState.showCloseTab,
-                  previewAccessibilityLabel: tabPeekState.previewAccessibilityLabel,
-                  screenshot: tabPeekState.screenshot)
+        self = tabPeekState.copyWithUpdates()
     }
 
     init(windowUUID: WindowUUID,
@@ -62,7 +57,7 @@ struct TabPeekState: ScreenState {
         switch action.actionType {
         case TabPeekActionType.loadTabPeek:
             guard let tabPeekModel = action.tabPeekModel else { return state }
-            return TabPeekState(windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                                 showAddToBookmarks: tabPeekModel.canTabBeSaved,
                                 showRemoveBookmark: tabPeekModel.canTabBeRemoved,
                                 showSendToDevice: tabPeekModel.isSyncEnabled && tabPeekModel.canTabBeSaved,
@@ -75,6 +70,6 @@ struct TabPeekState: ScreenState {
     }
 
     static func defaultState(from state: TabPeekState) -> TabPeekState {
-        return TabPeekState(windowUUID: state.windowUUID)
+        return state.copyWithUpdates()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15349)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32936)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->Apply `@CopyWithUpdates` macro to `TabPeekState`. Replaces manual full init calls in reducer with `copyWithUpdates(...)` only changed fields passed. No behavior change.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

