### PR TITLE
FXIOS-15350 refactor: [Technical Debt] [Redux] Use @CopyWithUpdates macro for TabsPanelState 

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -14,17 +14,12 @@ struct TabsPanelState: ScreenState, Equatable {
         let withAnimation: Bool
     }
 
+    var windowUUID: WindowUUID
     var isPrivateMode: Bool
     var tabs: [TabModel]
-    var windowUUID: WindowUUID
     var scrollState: ScrollState?
     var didTapAddTab: Bool
     var urlRequest: URLRequest?
-
-    var isPrivateTabsEmpty: Bool {
-        guard isPrivateMode else { return true }
-        return tabs.isEmpty
-    }
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let panelState = appState.componentState(
@@ -57,9 +52,9 @@ struct TabsPanelState: ScreenState, Equatable {
          scrollState: ScrollState? = nil,
          didTapAddTab: Bool = false,
          urlRequest: URLRequest? = nil) {
+        self.windowUUID = windowUUID
         self.isPrivateMode = isPrivateMode
         self.tabs = tabs
-        self.windowUUID = windowUUID
         self.scrollState = scrollState
         self.didTapAddTab = didTapAddTab
         self.urlRequest = urlRequest
@@ -143,5 +138,12 @@ struct TabsPanelState: ScreenState, Equatable {
 
         // This can happen if the user changes tab panels and one of the panels is empty (nothing to scroll to)
         return nil
+    }
+}
+
+extension TabsPanelState {
+    var isPrivateTabsEmpty: Bool {
+        guard isPrivateMode else { return true }
+        return tabs.isEmpty
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -141,6 +141,9 @@ struct TabsPanelState: ScreenState, Equatable {
     }
 }
 
+/// `@CopyWithUpdates` currently treats computed properties declared inside the struct as
+/// initializer/copy fields, which breaks generation with "extra arguments" errors.
+/// Keep derived accessors in this extension as a workaround.
 extension TabsPanelState {
     var isPrivateTabsEmpty: Bool {
         guard isPrivateMode else { return true }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -5,7 +5,9 @@
 import Foundation
 import Redux
 import Common
+import CopyWithUpdates
 
+@CopyWithUpdates
 struct TabsPanelState: ScreenState, Equatable {
     struct ScrollState: Equatable {
         let toIndex: Int
@@ -34,12 +36,7 @@ struct TabsPanelState: ScreenState, Equatable {
             return
         }
 
-        self.init(windowUUID: panelState.windowUUID,
-                  isPrivateMode: panelState.isPrivateMode,
-                  tabs: panelState.tabs,
-                  scrollState: panelState.scrollState,
-                  didTapAddTab: panelState.didTapAddTab,
-                  urlRequest: panelState.urlRequest)
+        self = panelState.copyWithUpdates()
     }
 
     init(windowUUID: WindowUUID, isPrivateMode: Bool = false) {
@@ -88,7 +85,7 @@ struct TabsPanelState: ScreenState, Equatable {
             TabPanelMiddlewareActionType.didChangeTabPanel:
             guard let tabsModel = action.tabDisplayModel else { return defaultState(from: state) }
 
-            return TabsPanelState(windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                                   isPrivateMode: tabsModel.isPrivateMode,
                                   tabs: tabsModel.tabs)
 
@@ -97,23 +94,18 @@ struct TabsPanelState: ScreenState, Equatable {
                 forState: state,
                 withScrollBehavior: .scrollToSelectedTab(shouldAnimate: false)
             )
-            return TabsPanelState(windowUUID: state.windowUUID,
-                                  isPrivateMode: state.isPrivateMode,
-                                  tabs: state.tabs,
+            return state.copyWithUpdates(
                                   scrollState: scrollModel)
 
         case TabPanelMiddlewareActionType.refreshTabs:
             guard let tabModel = action.tabDisplayModel else { return defaultState(from: state) }
-            return TabsPanelState(windowUUID: state.windowUUID,
-                                  isPrivateMode: state.isPrivateMode,
+            return state.copyWithUpdates(
                                   tabs: tabModel.tabs)
 
         case TabPanelMiddlewareActionType.scrollToTab:
             guard let scrollBehavior = action.scrollBehavior else { return defaultState(from: state) }
             let scrollModel = createTabScrollBehavior(forState: state, withScrollBehavior: scrollBehavior)
-            return TabsPanelState(windowUUID: state.windowUUID,
-                                  isPrivateMode: state.isPrivateMode,
-                                  tabs: state.tabs,
+            return state.copyWithUpdates(
                                   scrollState: scrollModel)
 
         default:
@@ -122,9 +114,7 @@ struct TabsPanelState: ScreenState, Equatable {
     }
 
     static func defaultState(from state: TabsPanelState) -> TabsPanelState {
-        return TabsPanelState(windowUUID: state.windowUUID,
-                              isPrivateMode: state.isPrivateMode,
-                              tabs: state.tabs)
+        return state.copyWithUpdates()
     }
 
     static func createTabScrollBehavior(

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
@@ -124,6 +124,9 @@ final class TranslationLanguagePickerViewController: UIViewController,
             windowUUID: windowUUID,
             actionType: TranslationSettingsViewActionType.addLanguage
         ))
+        UIView.performWithoutAnimation {
+            searchController.isActive = false
+        }
         dismiss(animated: true)
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
@@ -124,9 +124,6 @@ final class TranslationLanguagePickerViewController: UIViewController,
             windowUUID: windowUUID,
             actionType: TranslationSettingsViewActionType.addLanguage
         ))
-        UIView.performWithoutAnimation {
-            searchController.isActive = false
-        }
         dismiss(animated: true)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15350)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32937)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Apply `@CopyWithUpdates` macro to `TabsPanelState`. Replaces manual full init 
  calls in reducer with `copyWithUpdates(...)`  only changed fields passed. No 
  behavior change.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

