### PR TITLE
FXIOS-15351 refactor: [Technical Debt] [Redux] Use @CopyWithUpdates macro for TabTrayState

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -5,12 +5,14 @@
 import Foundation
 import Redux
 import Common
+import CopyWithUpdates
 
 enum TabTrayLayoutType: Equatable {
     case regular // iPad
     case compact // iPhone
 }
 
+@CopyWithUpdates
 struct TabTrayState: ScreenState, Equatable {
     var isPrivateMode: Bool
     var selectedPanel: TabTrayPanelType
@@ -45,16 +47,7 @@ struct TabTrayState: ScreenState, Equatable {
             return
         }
 
-        self.init(windowUUID: panelState.windowUUID,
-                  isPrivateMode: panelState.isPrivateMode,
-                  selectedPanel: panelState.selectedPanel,
-                  normalTabsCount: panelState.normalTabsCount,
-                  privateTabsCount: panelState.privateTabsCount,
-                  hasSyncableAccount: panelState.hasSyncableAccount,
-                  shouldDismiss: panelState.shouldDismiss,
-                  toastType: panelState.toastType,
-                  showCloseConfirmation: panelState.showCloseConfirmation,
-                  enableDeleteTabsButton: panelState.enableDeleteTabsButton)
+        self = panelState.copyWithUpdates()
     }
 
     init(windowUUID: WindowUUID) {
@@ -121,7 +114,7 @@ struct TabTrayState: ScreenState, Equatable {
         switch action.actionType {
         case TabTrayActionType.didLoadTabTray:
             guard let tabTrayModel = action.tabTrayModel else { return defaultState(from: state) }
-            return TabTrayState(windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                                 isPrivateMode: tabTrayModel.isPrivateMode,
                                 selectedPanel: tabTrayModel.selectedPanel,
                                 normalTabsCount: tabTrayModel.normalTabsCount,
@@ -131,31 +124,19 @@ struct TabTrayState: ScreenState, Equatable {
 
         case TabTrayActionType.changePanel:
             guard let panelType = action.panelType else { return defaultState(from: state) }
-            return TabTrayState(windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                                 isPrivateMode: panelType == .privateTabs,
-                                selectedPanel: panelType,
-                                normalTabsCount: state.normalTabsCount,
-                                privateTabsCount: state.privateTabsCount,
-                                hasSyncableAccount: state.hasSyncableAccount)
+                                selectedPanel: panelType)
 
         case TabTrayActionType.dismissTabTray:
-            return TabTrayState(windowUUID: state.windowUUID,
-                                isPrivateMode: state.isPrivateMode,
-                                selectedPanel: state.selectedPanel,
-                                normalTabsCount: state.normalTabsCount,
-                                privateTabsCount: state.privateTabsCount,
-                                hasSyncableAccount: state.hasSyncableAccount,
+            return state.copyWithUpdates(
                                 shouldDismiss: true)
 
         case TabTrayActionType.firefoxAccountChanged:
             guard let isSyncAccountEnabled = action.hasSyncableAccount else { return defaultState(from: state) }
             // Account updates may occur in a global manner, independent of specific windows.
             let uuid = state.windowUUID
-            return TabTrayState(windowUUID: uuid,
-                                isPrivateMode: state.isPrivateMode,
-                                selectedPanel: state.selectedPanel,
-                                normalTabsCount: state.normalTabsCount,
-                                privateTabsCount: state.privateTabsCount,
+            return state.copyWithUpdates(
                                 hasSyncableAccount: isSyncAccountEnabled)
 
         default:
@@ -169,12 +150,11 @@ struct TabTrayState: ScreenState, Equatable {
         case TabPanelMiddlewareActionType.didChangeTabPanel:
             guard let tabDisplayModel = action.tabDisplayModel else { return defaultState(from: state) }
             let panelType = tabDisplayModel.isPrivateMode ? TabTrayPanelType.privateTabs : TabTrayPanelType.tabs
-            return TabTrayState(windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                                 isPrivateMode: tabDisplayModel.isPrivateMode,
                                 selectedPanel: panelType,
                                 normalTabsCount: tabDisplayModel.normalTabsCount,
                                 privateTabsCount: "\(tabDisplayModel.tabs.filter({ $0.isPrivate == true }).count)",
-                                hasSyncableAccount: state.hasSyncableAccount,
                                 enableDeleteTabsButton: tabDisplayModel.enableDeleteTabsButton)
 
         case TabPanelMiddlewareActionType.refreshTabs:
@@ -182,12 +162,9 @@ struct TabTrayState: ScreenState, Equatable {
             guard let tabDisplayModel = action.tabDisplayModel else { return defaultState(from: state) }
             let isPrivate = tabDisplayModel.tabs.first?.isPrivate ?? false
             let tabCount = isPrivate ? state.normalTabsCount : tabDisplayModel.normalTabsCount
-            return TabTrayState(windowUUID: state.windowUUID,
-                                isPrivateMode: state.isPrivateMode,
-                                selectedPanel: state.selectedPanel,
+            return state.copyWithUpdates(
                                 normalTabsCount: tabCount,
                                 privateTabsCount: tabDisplayModel.privateTabsCount,
-                                hasSyncableAccount: state.hasSyncableAccount,
                                 enableDeleteTabsButton: tabDisplayModel.enableDeleteTabsButton)
 
         default:
@@ -199,12 +176,7 @@ struct TabTrayState: ScreenState, Equatable {
     static func reduceTabPanelViewAction(action: TabPanelViewAction, state: TabTrayState) -> TabTrayState {
         switch action.actionType {
         case TabPanelViewActionType.closeAllTabs:
-            return TabTrayState(windowUUID: state.windowUUID,
-                                isPrivateMode: state.isPrivateMode,
-                                selectedPanel: state.selectedPanel,
-                                normalTabsCount: state.normalTabsCount,
-                                privateTabsCount: state.privateTabsCount,
-                                hasSyncableAccount: state.hasSyncableAccount,
+            return state.copyWithUpdates(
                                 showCloseConfirmation: true)
 
         default:
@@ -213,11 +185,6 @@ struct TabTrayState: ScreenState, Equatable {
     }
 
     static func defaultState(from state: TabTrayState) -> TabTrayState {
-        return TabTrayState(windowUUID: state.windowUUID,
-                            isPrivateMode: state.isPrivateMode,
-                            selectedPanel: state.selectedPanel,
-                            normalTabsCount: state.normalTabsCount,
-                            privateTabsCount: state.privateTabsCount,
-                            hasSyncableAccount: state.hasSyncableAccount)
+        return state.copyWithUpdates()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15351)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32938)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Apply `@CopyWithUpdates` macro to `TabTrayState`. Replaces manual full init calls in reducer handlers with `copyWithUpdates(...)` only changed fields passed. No behavior change.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

