### PR TITLE
FXIOS-15352 refactor: [Technical Debt] [Redux] Use @CopyWithUpdates macro for TermsOfUseState

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
@@ -3,8 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import CopyWithUpdates
 import Redux
 
+@CopyWithUpdates
 struct TermsOfUseState: ScreenState {
     let windowUUID: WindowUUID
     var hasAccepted: Bool
@@ -20,10 +22,7 @@ struct TermsOfUseState: ScreenState {
             return
         }
 
-        self.init(windowUUID: termsOfUseState.windowUUID,
-                  hasAccepted: termsOfUseState.hasAccepted,
-                  wasDismissed: termsOfUseState.wasDismissed
-        )
+        self = termsOfUseState.copyWithUpdates()
     }
 
     init(windowUUID: WindowUUID) {
@@ -43,9 +42,7 @@ struct TermsOfUseState: ScreenState {
     }
 
     static func defaultState(from state: TermsOfUseState) -> TermsOfUseState {
-        return TermsOfUseState(windowUUID: state.windowUUID,
-                               hasAccepted: state.hasAccepted,
-                               wasDismissed: state.wasDismissed)
+        return state.copyWithUpdates()
     }
 
     static let reducer: Reducer<TermsOfUseState> = { state, action in
@@ -74,24 +71,21 @@ struct TermsOfUseState: ScreenState {
 
         switch type {
         case .termsShown:
-            return TermsOfUseState(windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                                    hasAccepted: false,
                                    wasDismissed: false)
         case .termsAccepted:
-            return TermsOfUseState(windowUUID: state.windowUUID,
+            return state.copyWithUpdates(
                                    hasAccepted: true,
                                    wasDismissed: false)
         case .gestureDismiss,
              .remindMeLaterTapped:
-            return TermsOfUseState(windowUUID: state.windowUUID,
-                                   hasAccepted: state.hasAccepted,
+            return state.copyWithUpdates(
                                    wasDismissed: true)
         case .learnMoreLinkTapped,
              .privacyLinkTapped,
              .termsLinkTapped:
-            return TermsOfUseState(windowUUID: state.windowUUID,
-                                   hasAccepted: state.hasAccepted,
-                                   wasDismissed: state.wasDismissed)
+            return state.copyWithUpdates()
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15352)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32939)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->Apply `@CopyWithUpdates` macro to `TermsOfUseState`. Replaces manual full init
   calls in reducer with `copyWithUpdates(...)` only changed fields passed. No
   behavior change.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

