### PR TITLE
FXIOS-15361 refactor: [Technical Debt] [Redux] Use @CopyWithUpdates macro for PasswordGeneratorState

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
@@ -5,7 +5,9 @@
 import Foundation
 import Redux
 import Common
+import CopyWithUpdates
 
+@CopyWithUpdates
 struct PasswordGeneratorState: ScreenState {
     var windowUUID: WindowUUID
     var password: String
@@ -21,11 +23,7 @@ struct PasswordGeneratorState: ScreenState {
             return
         }
 
-        self.init(
-            windowUUID: passwordGeneratorState.windowUUID,
-            password: passwordGeneratorState.password,
-            passwordHidden: passwordGeneratorState.passwordHidden
-        )
+        self = passwordGeneratorState.copyWithUpdates()
     }
 
     init(
@@ -48,22 +46,19 @@ struct PasswordGeneratorState: ScreenState {
             else {
                 return defaultState(from: state)
             }
-            return PasswordGeneratorState(
-                windowUUID: action.windowUUID,
-                password: password,
-                passwordHidden: state.passwordHidden)
+            return state.copyWithUpdates(
+                password: password
+            )
 
         case PasswordGeneratorActionType.hidePassword:
-            return PasswordGeneratorState(
-                windowUUID: action.windowUUID,
-                password: state.password,
-                passwordHidden: true)
+            return state.copyWithUpdates(
+                passwordHidden: true
+            )
 
         case PasswordGeneratorActionType.showPassword:
-            return PasswordGeneratorState(
-                windowUUID: action.windowUUID,
-                password: state.password,
-                passwordHidden: false)
+            return state.copyWithUpdates(
+                passwordHidden: false
+            )
 
         default:
             return defaultState(from: state)
@@ -71,10 +66,6 @@ struct PasswordGeneratorState: ScreenState {
     }
 
     static func defaultState(from state: PasswordGeneratorState) -> PasswordGeneratorState {
-        return PasswordGeneratorState(
-            windowUUID: state.windowUUID,
-            password: state.password,
-            passwordHidden: state.passwordHidden
-        )
+        return state.copyWithUpdates()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15361)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32948)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Applies `@CopyWithUpdates` macro to `PasswordGeneratorState` to simplify reducer code.        
                                   
  Replaces manual `PasswordGeneratorState(windowUUID:...)` init calls with                      
  `state.copyWithUpdates(...)`, passing only changed fields. Updates `init(appState:uuid:)` to
  use `self = passwordGeneratorState.copyWithUpdates()`.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

