### PR TITLE
Bugfix FXIOS-15386 [Translations Phase 2] Auto-translate prompt not visible in landscape

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -564,6 +564,7 @@ class BrowserViewController: UIViewController,
         updateHeaderConstraints()
         addressToolbarContainer.updateConstraints()
         updateMicrosurveyConstraints()
+        updateAutoTranslatePromptConstraints()
         updateToolbarDisplay()
         addOrUpdateMaskViewIfNeeded()
 
@@ -2070,13 +2071,27 @@ class BrowserViewController: UIViewController,
     private func removeAutoTranslatePrompt() {
         guard let prompt = autoTranslatePrompt else { return }
 
-        if isBottomSearchBar {
-            overKeyboardContainer.removeArrangedView(prompt)
-        } else {
-            bottomContainer.removeArrangedView(prompt)
+        if let parent = prompt.superview as? BaseAlphaStackView {
+            parent.removeArrangedView(prompt)
         }
 
         autoTranslatePrompt = nil
+    }
+
+    private func updateAutoTranslatePromptConstraints() {
+        guard let prompt = autoTranslatePrompt else { return }
+
+        if let parent = prompt.superview as? BaseAlphaStackView {
+            parent.removeArrangedView(prompt)
+        }
+
+        if isBottomSearchBar {
+            overKeyboardContainer.addArrangedViewToTop(prompt, animated: false, completion: nil)
+        } else {
+            bottomContainer.addArrangedViewToTop(prompt, animated: false, completion: nil)
+        }
+
+        prompt.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
     }
 
     // MARK: - Native Error Page

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2070,20 +2070,13 @@ class BrowserViewController: UIViewController,
 
     private func removeAutoTranslatePrompt() {
         guard let prompt = autoTranslatePrompt else { return }
-
-        if let parent = prompt.superview as? BaseAlphaStackView {
-            parent.removeArrangedView(prompt)
-        }
-
+        prompt.removeFromSuperview()
         autoTranslatePrompt = nil
     }
 
     private func updateAutoTranslatePromptConstraints() {
         guard let prompt = autoTranslatePrompt else { return }
-
-        if let parent = prompt.superview as? BaseAlphaStackView {
-            parent.removeArrangedView(prompt)
-        }
+        prompt.removeFromSuperview()
 
         if isBottomSearchBar {
             overKeyboardContainer.addArrangedViewToTop(prompt, animated: false, completion: nil)

--- a/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
+++ b/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
@@ -41,6 +41,8 @@ final class AutoTranslatePromptView: UIView, ThemeApplicable, Notifiable {
         button.accessibilityLabel = .Translations.AutoTranslatePrompt.EnableButton
         button.accessibilityIdentifier = AccessibilityIdentifiers.Translations.AutoTranslatePrompt.enableButton
         button.addTarget(self, action: #selector(self.didTapEnable), for: .touchUpInside)
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        button.setContentCompressionResistancePriority(.required, for: .vertical)
     }
 
     private lazy var closeButton: CloseButton = .build { button in
@@ -97,8 +99,14 @@ final class AutoTranslatePromptView: UIView, ThemeApplicable, Notifiable {
 
             contentRow.topAnchor.constraint(equalTo: topBorderView.bottomAnchor, constant: UX.contentPadding.top),
             contentRow.bottomAnchor.constraint(equalTo: bottomAnchor, constant: UX.contentPadding.bottom),
-            contentRow.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.contentPadding.leading),
-            contentRow.trailingAnchor.constraint(equalTo: trailingAnchor, constant: UX.contentPadding.trailing),
+            contentRow.leadingAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.leadingAnchor,
+                constant: UX.contentPadding.leading
+            ),
+            contentRow.trailingAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.trailingAnchor,
+                constant: UX.contentPadding.trailing
+            ),
         ])
 
         adjustLayout()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15386)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32985)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Moves the auto-translate prompt to the correct container when the URL bar position changes (e.g. rotating to iPhone landscape, where the URL bar is force-relocated to the top and overKeyboardContainer collapses to height = 0). Also respects safe area insets for content and locks the Enable button's compression resistance.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<img height="600" alt="IMG_0049" src="https://github.com/user-attachments/assets/c91d648e-fdb4-4fc2-986e-626e84988927" />



<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


