### PR TITLE
Add FXIOS-15146 [Quick Answers] creating llm client in results service

### DIFF
--- a/BrowserKit/Sources/LLMKit/LiteLLMCreator.swift
+++ b/BrowserKit/Sources/LLMKit/LiteLLMCreator.swift
@@ -4,8 +4,14 @@
 import Shared
 import MLPAKit
 
-public struct LiteLLMCreator {
-    public static func createAppAttestLiteLLM(using prefs: Prefs) -> LiteLLMClient? {
+public protocol LiteLLMCreating {
+    func createAppAttestLiteLLM(using prefs: Prefs) -> LiteLLMClientProtocol?
+}
+
+public struct LiteLLMCreator: LiteLLMCreating {
+    public init() { }
+
+    public func createAppAttestLiteLLM(using prefs: Prefs) -> LiteLLMClientProtocol? {
         let mlpaEnvironmentKey = prefs.stringForKey(PrefsKeys.MLPASettings.mlpaEndpointEnvironment) ?? ""
         let mlpaEnvironment = MLPAEnvironment(rawValue: mlpaEnvironmentKey) ?? .prod
         guard let endPoint = MLPAConstants.completionsEndpoint(with: mlpaEnvironment),

--- a/BrowserKit/Sources/MLPAKit/MLPAJWTPayload.swift
+++ b/BrowserKit/Sources/MLPAKit/MLPAJWTPayload.swift
@@ -19,6 +19,9 @@ public enum MLPAConstants {
     static let assertionObjParam = "assertion_obj_b64"
 
     static let serviceTypeHeader = "service-type"
+
+    // TODO: FXIOS-15123 - need to create an enum service type here
+    // eventually to also account for quick-answers
     static let serviceTypeValue = "s2s"
     static let useAppAttestHeader = "use-app-attest"
 

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/DefaultQuickAnswersService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/DefaultQuickAnswersService.swift
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import LLMKit
+import Shared
 
 /// A concrete `QuickAnswersService` that records speech and emits transcription results
 /// using an underlying `TranscriptionEngine`. As well as request results from the transcription via `ResultsService` flow.
@@ -26,10 +28,18 @@ final class DefaultQuickAnswersService: QuickAnswersService {
     /// Creates a new service with a platform-appropriate transcription engine and results service.
     init(
         engine: TranscriptionEngine? = nil,
-        resultsService: ResultsService? = nil
-    ) {
+        resultsServiceFactory: ResultsServiceFactory = DefaultResultsServiceFactory(
+            config: QuickAnswersConfig(),
+            liteLLMCreator: LiteLLMCreator()
+        ),
+        prefs: Prefs
+    ) throws {
         self.engine = engine ?? Self.makeDefaultEngine()
-        self.resultsService = resultsService ?? Self.makeResultsService()
+        let config = QuickAnswersConfig()
+        guard let resultsService = resultsServiceFactory.make(prefs: prefs, config: config) else {
+            throw ResultsServiceError.unableToCreateService
+        }
+        self.resultsService = resultsService
     }
 
     // MARK: Speech Service
@@ -113,12 +123,5 @@ final class DefaultQuickAnswersService: QuickAnswersService {
                 authorizer: authorizer
             )
         }
-    }
-
-    private static func makeResultsService() -> ResultsService {
-        let factory = DefaultResultsServiceFactory(
-            config: QuickAnswersConfig()
-        )
-        return factory.make()
     }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
@@ -12,11 +12,10 @@ protocol ResultsService: Sendable {
 }
 
 final class DefaultResultsService: ResultsService {
-    // TODO: FXIOS-15196 - Remove optional when creating the appropriate client
-    private let client: LiteLLMClientProtocol?
-    private let config: QuickAnswersConfig
+    private let client: LiteLLMClientProtocol
+    private let config: LLMConfig
 
-    init(client: LiteLLMClientProtocol?, config: QuickAnswersConfig) {
+    init(client: LiteLLMClientProtocol, config: LLMConfig) {
         self.client = client
         self.config = config
     }
@@ -37,8 +36,8 @@ final class DefaultResultsService: ResultsService {
     }
 
     private func requestChatCompletion(for message: LiteLLMMessage) async throws -> AsyncThrowingStream<String, Error>? {
-        // TODO: FXIOS-15196 - Remove optional when creating the appropriate client
-        return try await client?.requestChatCompletionStreamed(
+        // TODO: FXIOS-15198 Handle errors appropriately
+        return try await client.requestChatCompletionStreamed(
             messages: [message],
             config: config
         )

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersConfig.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersConfig.swift
@@ -4,12 +4,21 @@
 
 import LLMKit
 
-// TODO: FXIOS-15196 We may not need a configuration if we only want to pass in the transcription,
-// may need to refactor `LiteLLMClient`
 /// A configuration container for the quick answers results feature.
 public struct QuickAnswersConfig: LLMConfig, Sendable {
-    public let instructions = ""
+    public let instructions: String
     // FIXME: FXIOS-13417 We should strongly type options in the future so they can be any Sendable & Hashable
     // See `SummarizerConfig` for more details
-    nonisolated(unsafe) public let options: [String: AnyHashable] = [:]
+    nonisolated(unsafe) public let options: [String: AnyHashable]
+
+    // TODO: FXIOS-15123 - need confirm we want to pass these options, follow similar to S2S for now
+    /// Default initializer with production configuration
+    public init(instructions: String = "", options: [String: AnyHashable] = [
+        "max_tokens": LiteLLMConfig.maxTokens,
+        "model": LiteLLMConfig.apiModel,
+        "stream": true
+    ]) {
+        self.instructions = instructions
+        self.options = options
+    }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceError.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceError.swift
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+enum ResultsServiceError: Error {
+    case unableToCreateService
+    case unableToFetchResults
+}

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceFactory.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceFactory.swift
@@ -5,27 +5,42 @@
 import Foundation
 import MLPAKit
 import LLMKit
+import Shared
 
 // MARK: - Protocol
 /// Creates a ResultsService with using MLPA (App Attest) authentication and LiteLLM.
 protocol ResultsServiceFactory {
-    func make() -> ResultsService
+    func make(prefs: Prefs, config: QuickAnswersConfig) -> ResultsService?
 }
 
 // MARK: - Default Implementation
 public struct DefaultResultsServiceFactory: ResultsServiceFactory {
     let config: QuickAnswersConfig
+    let liteLLMCreator: LiteLLMCreating
 
-    func make() -> ResultsService {
-        // TODO: FXIOS-15196 - Create Results Service from the LiteLLMClient, remove optional when implementing appropriate
-        // LiteLLMClient
-        let client = makeLiteLLMClient()
+    public init(
+        config: QuickAnswersConfig,
+        liteLLMCreator: LiteLLMCreating
+    ) {
+        self.config = config
+        self.liteLLMCreator = liteLLMCreator
+    }
+
+    func make(
+        prefs: Prefs,
+        config: QuickAnswersConfig = QuickAnswersConfig()
+    ) -> ResultsService? {
+        guard let model = config.options["model"] as? String, !model.isEmpty,
+              let client = makeLiteLLMClient(prefs: prefs)
+        else {
+            return nil
+        }
+
         return DefaultResultsService(client: client, config: config)
     }
 
     // MARK: - Private Helpers
-    private func makeLiteLLMClient() -> LiteLLMClient? {
-        // TODO: FXIOS-15196 - Create LiteLLMClient with proper configurations and authenticator
-        return nil
+    private func makeLiteLLMClient(prefs: Prefs) -> LiteLLMClientProtocol? {
+        return liteLLMCreator.createAppAttestLiteLLM(using: prefs)
     }
 }

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerServiceFactory.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerServiceFactory.swift
@@ -92,18 +92,17 @@ public struct DefaultSummarizerServiceFactory: SummarizerServiceFactory {
         return 0
     }
 
-    // TODO: FXIOS-15146 - Add this to LLMKit and make creation more generic
     private func makeLiteLLMClient(
         config: SummarizerConfig,
         prefs: Prefs,
         isAppAttestAuthEnabled: Bool
-    ) -> LiteLLMClient? {
+    ) -> LiteLLMClientProtocol? {
         guard let model = config.options["model"] as? String, !model.isEmpty else {
             return nil
         }
 
         if isAppAttestAuthEnabled {
-            return LiteLLMCreator.createAppAttestLiteLLM(using: prefs)
+            return LiteLLMCreator().createAppAttestLiteLLM(using: prefs)
         } else {
             guard let endPoint = URL(string: LiteLLMConfig.apiEndpoint ?? ""),
                   let key = LiteLLMConfig.apiKey else {

--- a/BrowserKit/Tests/QuickAnswersKitTests/DefaultQuickAnswersServiceTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/DefaultQuickAnswersServiceTests.swift
@@ -2,23 +2,30 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Shared
 import Testing
+import TestKit
 
 @testable import QuickAnswersKit
 
 @MainActor
-struct DefaultQuickAnswersServiceTests {
-    let resultsService = MockResultsService()
-    // TODO: FXIOS-14891 Add more test to improve code coverage and check for memory leaks
+class DefaultQuickAnswersServiceTests {
+    let testHelper = SwiftTestingHelper()
+    let engine = MockTranscriptionEngine()
+    let resultsServiceFactory: MockResultsServiceFactory
+
+    init() {
+        resultsServiceFactory = MockResultsServiceFactory()
+    }
+
     @Test
     func test_record_returnsExpectCallsAndResults() async throws {
-        let engine = MockTranscriptionEngine()
         engine.resultsToYield = [
             SpeechResult(text: "What is the weather", isFinal: false),
             SpeechResult(text: "today?", isFinal: true)
         ]
 
-        let subject = DefaultQuickAnswersService(engine: engine, resultsService: resultsService)
+        let subject = try createSubject()
 
         let stream = try await subject.record()
 
@@ -37,11 +44,10 @@ struct DefaultQuickAnswersServiceTests {
     }
 
     @Test
-    func test_record_throwsWhenPrepareFails() async {
-        let engine = MockTranscriptionEngine()
+    func test_record_throwsWhenPrepareFails() async throws {
         engine.prepareError = TestError.prepareFailed
 
-        let subject = DefaultQuickAnswersService(engine: engine, resultsService: resultsService)
+        let subject = try createSubject()
 
         do {
             _ = try await subject.record()
@@ -56,10 +62,9 @@ struct DefaultQuickAnswersServiceTests {
 
     @Test
     func test_record_throwsWhenStartFails() async throws {
-        let engine = MockTranscriptionEngine()
         engine.startError = TestError.startFailed
 
-        let subject = DefaultQuickAnswersService(engine: engine, resultsService: resultsService)
+        let subject = try createSubject()
 
         let stream = try await subject.record()
 
@@ -77,9 +82,7 @@ struct DefaultQuickAnswersServiceTests {
 
     @Test
     func test_stopRecording_callsExpectedMethods() async throws {
-        let engine = MockTranscriptionEngine()
-
-        let subject = DefaultQuickAnswersService(engine: engine, resultsService: resultsService)
+        let subject = try createSubject()
 
         try await subject.stopRecording()
 
@@ -87,11 +90,10 @@ struct DefaultQuickAnswersServiceTests {
     }
 
     @Test
-    func test_stopRecording_throwsWhenError() async {
-        let engine = MockTranscriptionEngine()
+    func test_stopRecording_throwsWhenError() async throws {
         engine.stopError = TestError.stopFailed
 
-        let subject = DefaultQuickAnswersService(engine: engine, resultsService: resultsService)
+        let subject = try createSubject()
 
         do {
             try await subject.stopRecording()
@@ -104,9 +106,8 @@ struct DefaultQuickAnswersServiceTests {
     }
 
     @Test
-    func test_search_returnsEmptySuccess() async {
-        let engine = MockTranscriptionEngine()
-        let subject = DefaultQuickAnswersService(engine: engine, resultsService: resultsService)
+    func test_search_returnsEmptySuccess() async throws {
+        let subject = try createSubject()
 
         let result = await subject.search(text: "hello")
 
@@ -116,5 +117,16 @@ struct DefaultQuickAnswersServiceTests {
         case .failure(let error):
             Issue.record("Expected success(.empty()), got failure: \(error)")
         }
+    }
+
+    // MARK: - Helper
+    private func createSubject() throws -> DefaultQuickAnswersService {
+        let subject = try DefaultQuickAnswersService(
+            engine: engine,
+            resultsServiceFactory: resultsServiceFactory,
+            prefs: MockProfilePrefs()
+        )
+        testHelper.trackForMemoryLeaks(subject)
+        return subject
     }
 }

--- a/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockLLMClientCreator.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockLLMClientCreator.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import LLMKit
+import Shared
+
+@testable import QuickAnswersKit
+
+final class MockLLMClientCreator: LiteLLMCreating {
+    var clientToReturn: LiteLLMClientProtocol?
+    var shouldReturnNil = false
+    var createAppAttestLiteLLMCallCount = 0
+
+    func createAppAttestLiteLLM(using prefs: Prefs) -> LiteLLMClientProtocol? {
+        createAppAttestLiteLLMCallCount += 1
+        return shouldReturnNil ? nil : clientToReturn
+    }
+}

--- a/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockResultsService.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockResultsService.swift
@@ -6,18 +6,8 @@
 
 final class MockResultsService: ResultsService, @unchecked Sendable {
     var fetchResultsCallCount = 0
-    var lastTranscription: String?
-    var resultToReturn: SearchResult = .empty()
-    var errorToThrow: Error?
 
     func fetchResults(for transcription: String) async throws -> SearchResult {
-        fetchResultsCallCount += 1
-        lastTranscription = transcription
-
-        if let error = errorToThrow {
-            throw error
-        }
-
-        return resultToReturn
+        return SearchResult.empty()
     }
 }

--- a/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockResultsServiceFactory.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockResultsServiceFactory.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+@testable import QuickAnswersKit
+
+final class MockResultsServiceFactory: ResultsServiceFactory {
+    var makeCallCount = 0
+    var shouldReturnNil = false
+
+    func make(prefs: Prefs, config: QuickAnswersConfig) -> ResultsService? {
+        makeCallCount += 1
+
+        if shouldReturnNil {
+            return nil
+        }
+
+        return MockResultsService()
+    }
+}

--- a/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/ResultsServiceFactoryTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/ResultsServiceFactoryTests.swift
@@ -3,29 +3,75 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import LLMKit
+import MLPAKit
+import Shared
 import Testing
 import TestKit
 
 @testable import QuickAnswersKit
 
 struct ResultsServiceFactoryTests {
-    // TODO: FXIOS-15196 - Improve testing to be more valuable
     @Test
-    func test_make_storesConfig() {
-        let config = QuickAnswersConfig()
-        let subject = createSubject(config: config)
+    func test_make_withValidConfig_returnsConfiguredService() {
+        let mockLLMCreator = MockLLMClientCreator()
+        mockLLMCreator.clientToReturn = MockLiteLLMClient()
+        let prefs = MockProfilePrefs()
+        let config = QuickAnswersConfig(options: ["model": "test-model"])
+        let subject = createSubject(liteLLMCreator: mockLLMCreator, config: config)
 
-        _ = subject.make()
+        let result = subject.make(prefs: prefs, config: config)
 
-        #expect(subject.config.instructions.isEmpty)
-        #expect(subject.config.options.isEmpty)
+        #expect(result != nil, "Factory should return configured service when LLM client is available")
+        #expect(mockLLMCreator.createAppAttestLiteLLMCallCount == 1, "Should call createAppAttestLiteLLM once")
+    }
+
+    @Test
+    func test_make_withNoModelOption_returnsNil() {
+        let mockLLMCreator = MockLLMClientCreator()
+        mockLLMCreator.clientToReturn = MockLiteLLMClient()
+        let prefs = MockProfilePrefs()
+        let config = QuickAnswersConfig(options: [:])
+        let subject = createSubject(liteLLMCreator: mockLLMCreator, config: config)
+
+        let result = subject.make(prefs: prefs, config: config)
+
+        #expect(result == nil, "Factory should return nil when config is missing model options")
+        #expect(mockLLMCreator.createAppAttestLiteLLMCallCount == 0, "Should not call when model is missing")
+    }
+
+    @Test
+    func test_make_withEmptyModel_returnsNil() {
+        let mockLLMCreator = MockLLMClientCreator()
+        mockLLMCreator.clientToReturn = MockLiteLLMClient()
+        let prefs = MockProfilePrefs()
+        let config = QuickAnswersConfig(options: ["model": ""])
+        let subject = createSubject(liteLLMCreator: mockLLMCreator, config: config)
+
+        let result = subject.make(prefs: prefs, config: config)
+
+        #expect(result == nil, "Factory should return nil when model is empty")
+        #expect(mockLLMCreator.createAppAttestLiteLLMCallCount == 0, "Should not call when model is empty")
+    }
+
+    @Test
+    func test_make_withNilLLMClient_returnsNil() {
+        let mockLLMCreator = MockLLMClientCreator()
+        mockLLMCreator.shouldReturnNil = true
+        let prefs = MockProfilePrefs()
+        let config = QuickAnswersConfig(options: ["model": "test-model"])
+        let subject = createSubject(liteLLMCreator: mockLLMCreator, config: config)
+
+        let result = subject.make(prefs: prefs, config: config)
+
+        #expect(result == nil, "Factory should return nil when LLM client creation fails")
+        #expect(mockLLMCreator.createAppAttestLiteLLMCallCount == 1, "Should attempt to create LLM client")
     }
 
     // MARK: - Helper
     private func createSubject(
+        liteLLMCreator: LiteLLMCreating = MockLLMClientCreator(),
         config: QuickAnswersConfig = QuickAnswersConfig()
     ) -> DefaultResultsServiceFactory {
-        let subject = DefaultResultsServiceFactory(config: config)
-        return subject
+        return DefaultResultsServiceFactory(config: config, liteLLMCreator: liteLLMCreator)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15146)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32599)

## :bulb: Description
- Hook up creating a LiteLLMClient in results service using similar configuration as S2S for now until we get more details from AI team
- Add more tests for results service factory
- Add trackForMemoryLeaks check for quick answers service

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

