### PR TITLE
[FXIOS-15569] Fix bug where matching engine names were both checked incorrectly

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
@@ -63,7 +63,7 @@ final class ASSearchEngineSelector: ASSearchEngineSelectorProtocol {
 
             var searchResultsConfig = try engineSelector.filterEngineConfiguration(userEnvironment: env)
 
-            let serverName = remoteSettingsEnv == .stage ? "STAGE" : "PROD"
+            let serverName: String = remoteSettingsEnv.rawValue.uppercased()
             let engineLogList = searchResultsConfig.engines.map {
                 let isOptional = $0.optional ? " (OPTIONAL)" : ""
                 return $0.name + isOptional

--- a/firefox-ios/Client/Frontend/Settings/SearchEnginePicker.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchEnginePicker.swift
@@ -7,7 +7,7 @@ import UIKit
 class SearchEnginePicker: ThemedTableViewController {
     weak var delegate: SearchEnginePickerDelegate?
     var engines: [OpenSearchEngine] = []
-    var selectedSearchEngineName: String?
+    var selectedSearchEngineID: String?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -33,7 +33,7 @@ class SearchEnginePicker: ThemedTableViewController {
         let size = CGSize(width: OpenSearchEngine.UX.preferredIconSize,
                           height: OpenSearchEngine.UX.preferredIconSize)
         cell.imageView?.image = engine.image.createScaled(size)
-        if engine.shortName == selectedSearchEngineName {
+        if engine.engineID == selectedSearchEngineID {
             cell.accessoryType = .checkmark
         }
         return cell

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -507,7 +507,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController,
             // Every engine is a valid choice for the default engine, even the current default engine.
             searchEnginePicker.engines = model.orderedEngines.sorted { e, f in e.shortName < f.shortName }
             searchEnginePicker.delegate = self
-            searchEnginePicker.selectedSearchEngineName = model.defaultEngine?.shortName
+            searchEnginePicker.selectedSearchEngineID = model.defaultEngine?.engineID
             navigationController?.pushViewController(searchEnginePicker, animated: true)
         case .alternateEngines:
             let isLastItem = indexPath.item + 1 == model.orderedEngines.count


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15570)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15569)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33357)

## :bulb: Description

Our default search engine picker was incorrectly using the older `shortName` rather than `engineID` to determine if a row should be checked.

Also fixes a bug with the server name in the SEC logging.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

