### PR TITLE
Remove FXIOS-15007 [TabManager] BackupCloseTab is never niled when the undo toast is cleared

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
@@ -239,28 +239,7 @@ extension BrowserViewController: PhotonActionSheetProtocol {
                     )
                 )
                 self.updateTabCountUsingTabManager(self.tabManager)
-
-                if !self.featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
-                    || UIDevice.current.userInterfaceIdiom == .pad {
-                    self.showLegacyCloseTabToast(message: .TabsTray.CloseTabsToast.SingleTabTitle)
-                }
             }
         }.items
-    }
-
-    /// This toast was tied into the legacy main menu, moved it to it's own function.
-    /// New toasts should be piped through Redux.
-    func showLegacyCloseTabToast(message: String) {
-        let viewModel = ButtonToastViewModel(labelText: message,
-                                             buttonText: .UndoString)
-        let toast = ButtonToast(viewModel: viewModel,
-                                theme: currentTheme()) { [weak self] isButtonTapped in
-            guard let self,
-                  tabManager.backupCloseTab != nil,
-                  isButtonTapped
-            else { return }
-            self.tabManager.undoCloseTab()
-        }
-        show(toast: toast)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5085,10 +5085,6 @@ extension BrowserViewController: TopTabsDelegate {
     func topTabsDidPressPrivateMode() {
         updateZoomPageBarVisibility(visible: false)
     }
-
-    func topTabsShowCloseTabsToast() {
-        showLegacyCloseTabToast(message: .TabsTray.CloseTabsToast.SingleTabTitle)
-    }
 }
 
 extension BrowserViewController {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
@@ -46,7 +46,6 @@ enum RemoteTabsPanelActionType: ActionType {
     case closeTabCompatible
     case openSelectedURL
     case closeSelectedRemoteURL
-    case undoCloseSelectedRemoteURL
     case flushTabCommands
     case remoteDevicesChanged
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -136,9 +136,6 @@ final class TabManagerMiddleware: LegacyFeatureFlaggable,
         case RemoteTabsPanelActionType.closeSelectedRemoteURL:
             guard let url = action.url, let deviceId = action.targetDeviceId else { return }
             closeSelectedRemoteTab(deviceId: deviceId, url: url, windowUUID: action.windowUUID)
-        case RemoteTabsPanelActionType.undoCloseSelectedRemoteURL:
-            guard let url = action.url, let deviceId = action.targetDeviceId else { return }
-            undoCloseSelectedRemoteTab(deviceId: deviceId, url: url, windowUUID: action.windowUUID)
         case RemoteTabsPanelActionType.flushTabCommands:
             guard let deviceId = action.targetDeviceId else { return }
             flushTabCommands(deviceId: deviceId, windowUUID: action.windowUUID)
@@ -296,10 +293,6 @@ final class TabManagerMiddleware: LegacyFeatureFlaggable,
 
     private func closeSelectedRemoteTab(deviceId: String, url: URL, windowUUID: WindowUUID) {
         self.profile.addTabToCommandQueue(deviceId, url: url)
-    }
-
-    private func undoCloseSelectedRemoteTab(deviceId: String, url: URL, windowUUID: WindowUUID) {
-        self.profile.removeTabFromCommandQueue(deviceId, url: url)
     }
 
     private func flushTabCommands(deviceId: String, windowUUID: WindowUUID) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -232,10 +232,6 @@ class RemoteTabsPanel: UIViewController,
         handleCloseRemoteTab(deviceId, url: url)
     }
 
-    func remoteTabsClientAndTabsDataSourceDidUndo(deviceId: String, url: URL) {
-        handleUndoCloseTab(deviceId, url: url)
-    }
-
     func remoteTabsClientAndTabsDataSourceDidTabCommandsFlush(deviceId: String) {
         handleTabCommandsFlush(deviceId)
     }
@@ -268,16 +264,6 @@ class RemoteTabsPanel: UIViewController,
         store.dispatch(action)
         // Once we add the tab to the command queue, the rust tab store will start removing it from
         // the list, so refresh the tabs
-        refreshTabs(useCache: true)
-    }
-
-    private func handleUndoCloseTab(_ deviceId: String, url: URL) {
-        let action = RemoteTabsPanelAction(url: url,
-                                           targetDeviceId: deviceId,
-                                           windowUUID: windowUUID,
-                                           actionType: RemoteTabsPanelActionType.undoCloseSelectedRemoteURL)
-        store.dispatch(action)
-
         refreshTabs(useCache: true)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
@@ -56,8 +56,6 @@ class RemoteTabsViewController: UIViewController,
         }
     }()
 
-    private var closeTabRemoteDeviceId: String?
-    private var closeTab: RemoteTab?
     private var tabCommandsFlushTimer: Timer?
     private let tabCommandsFlushDelay = 6.0
 
@@ -382,24 +380,6 @@ class RemoteTabsViewController: UIViewController,
             }
             let tab = clientAndTabs.tabs[indexPath.item]
 
-            // Setting the two private variables below so that the toast button action function has access to them
-            // since that function cannot have any parameters.
-            self.closeTabRemoteDeviceId = fxaDeviceId
-            self.closeTab = tab
-
-            // Creating a modal with an undo button that will allow the user to undo closing the last remote tab
-            // they attempted to close
-            let viewModel = ButtonToastViewModel(labelText: .TabsTray.CloseTabsToast.SingleTabTitle,
-                                                 buttonText: .UndoString)
-            let toast = ButtonToast(viewModel: viewModel,
-                                    theme: retrieveTheme(),
-                                    completion: { didTapUndoButton in
-                                        if didTapUndoButton {
-                                            self.undo()
-                                        }
-                                    })
-            show(toast: toast)
-
             self.remoteTabsPanel?.remoteTabsClientAndTabsDataSourceDidCloseURL(deviceId: fxaDeviceId, url: tab.URL)
 
             // Initiating the process of sending (i.e. executing) any unsent commands
@@ -467,18 +447,6 @@ class RemoteTabsViewController: UIViewController,
         * This will be the real time that the other client uploaded tabs.
         */
         return headerView
-    }
-
-    private func undo() {
-        guard let tabUrl = self.closeTab?.URL, let deviceId = self.closeTabRemoteDeviceId else {
-            return
-        }
-
-        // Removing the close tab command from the command queue
-        remoteTabsPanel?.remoteTabsClientAndTabsDataSourceDidUndo(deviceId: deviceId, url: tabUrl)
-
-        // Initiating the process of sending any unsent commands
-        self.flushTabCommands(deviceId: deviceId)
     }
 
     private func flushTabCommands(deviceId: String) {

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -18,8 +18,6 @@ protocol TopTabsDelegate: AnyObject {
     func topTabsDidChangeTab()
     @MainActor
     func topTabsDidPressPrivateMode()
-    @MainActor
-    func topTabsShowCloseTabsToast()
 }
 
 class TopTabsViewController: UIViewController, Themeable, Notifiable, LegacyFeatureFlaggable {
@@ -373,7 +371,6 @@ extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(_ cell: UICollectionViewCell) {
         store.dispatch(ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.cancelEdit))
         topTabDisplayManager.closeActionPerformed(forCell: cell)
-        delegate?.topTabsShowCloseTabsToast()
         NotificationCenter.default.post(name: .TopTabsTabClosed, object: nil, userInfo: windowUUID.userInfo)
         store.dispatch(TopTabsAction(windowUUID: windowUUID, actionType: TopTabsActionType.didTapCloseTab))
 

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -23,7 +23,6 @@ protocol TabManager: AnyObject {
     var recentlyAccessedNormalTabs: [Tab] { get }
 
     var selectedTab: Tab? { get }
-    var backupCloseTab: BackupCloseTab? { get set }
 
     var tabs: [Tab] { get }
     var normalTabs: [Tab] { get }
@@ -86,9 +85,6 @@ protocol TabManager: AnyObject {
 
     /// Remove normal tabs older than a certain period of time
     func removeNormalTabsOlderThan(period: TabsDeletionPeriod, currentDate: Date)
-
-    // MARK: - Undo Close
-    func undoCloseTab()
 
     // MARK: Get Tab
     func getTabForUUID(uuid: TabUUID) -> Tab?

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -14,12 +14,6 @@ enum SwitchPrivacyModeResult {
     case usedExistingTab
 }
 
-struct BackupCloseTab {
-    var tab: Tab
-    var restorePosition: Int?
-    var isSelected: Bool
-}
-
 final class TabManagerImplementation: NSObject,
                                       TabManager,
                                       LegacyFeatureFlaggable, // TODO: ROUX remove with 15192
@@ -28,9 +22,6 @@ final class TabManagerImplementation: NSObject,
 
     var tabEventWindowResponseType: TabEventHandlerWindowResponseType { return .singleWindow(windowUUID) }
     var isRestoringTabs = false
-    // FXIOS-15007 - `backupCloseTab` is never niled when the undo toast is cleared,
-    // causing us to retain the tab object indefinitely
-    var backupCloseTab: BackupCloseTab?
     var notificationCenter: NotificationProtocol
     private(set) var tabs: [Tab] {
         didSet {
@@ -232,15 +223,6 @@ final class TabManagerImplementation: NSObject,
 
     func removeAllTabs(isPrivateMode: Bool) {
         let currentModeTabs = tabs.filter { $0.isPrivate == isPrivateMode }
-        var currentSelectedTab: BackupCloseTab?
-
-        // Backup the selected tab in separate variable as the `removeTab` method called below for each tab will
-        // automatically update tab selection as if there was a single tab removal.
-        if let tab = selectedTab, tab.isPrivate == isPrivateMode {
-            currentSelectedTab = BackupCloseTab(tab: tab,
-                                                restorePosition: tabs.firstIndex(of: tab),
-                                                isSelected: selectedTab?.tabUUID == tab.tabUUID)
-        }
 
         // Scroll position for most tabs has been stored via session data when we navigate away,
         // but we need to save the selected tabs session data to persist scroll position
@@ -261,8 +243,6 @@ final class TabManagerImplementation: NSObject,
                 }
             }
         }
-        // Save the tab state that existed prior to removals (preserves original selected tab)
-        backupCloseTab = currentSelectedTab
     }
 
     /// Remove a tab, will notify delegate of the tab removal
@@ -284,9 +264,6 @@ final class TabManagerImplementation: NSObject,
         }
 
         tab.cancelDocumentDownload()
-        backupCloseTab = BackupCloseTab(tab: tab,
-                                        restorePosition: removalIndex,
-                                        isSelected: selectedTab?.tabUUID == tab.tabUUID)
         let prevCount = count
         tabs.remove(at: removalIndex)
         assert(count == prevCount - 1, "Make sure the tab count was actually removed")
@@ -423,29 +400,6 @@ final class TabManagerImplementation: NSObject,
 
     func getTabForURL(_ url: URL) -> Tab? {
         return tabs.first(where: { $0.webView?.url == url })
-    }
-
-    // TODO: FXIOS-14751 Remove related work for undo close tabs (single and all tabs)
-    // MARK: - Undo Close Tab
-    func undoCloseTab() {
-        assert(Thread.isMainThread)
-        guard let backupCloseTab = self.backupCloseTab else { return }
-
-        let previouslySelectedTab = selectedTab
-        if let index = backupCloseTab.restorePosition {
-            tabs.insert(backupCloseTab.tab, at: index)
-        } else {
-            tabs.append(backupCloseTab.tab)
-        }
-
-        if backupCloseTab.isSelected {
-            self.selectTab(backupCloseTab.tab)
-        } else if let tabToSelect = previouslySelectedTab {
-            self.selectTab(tabToSelect)
-        }
-
-        delegates.forEach { $0.get()?.tabManagerUpdateCount() }
-        commitChanges()
     }
 
     // MARK: - Restore tabs

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -141,7 +141,6 @@ protocol Profile: AnyObject, Sendable {
     func storeAndSyncTabs(_ tabs: [RemoteTab]) -> Deferred<Maybe<Int>>
 
     func addTabToCommandQueue(_ deviceId: String, url: URL)
-    func removeTabFromCommandQueue(_ deviceId: String, url: URL)
     func flushTabCommands(toDeviceId: String?)
 
     func sendItem(_ item: ShareItem, toDevices devices: [RemoteDevice]) -> Success
@@ -542,10 +541,6 @@ open class BrowserProfile: Profile,
 
     func addTabToCommandQueue(_ deviceId: String, url: URL) {
         tabs.addRemoteCommand(deviceId: deviceId, url: url)
-    }
-
-    func removeTabFromCommandQueue(_ deviceId: String, url: URL) {
-        tabs.removeRemoteCommand(deviceId: deviceId, url: url)
     }
 
     public func sendItem(_ item: ShareItem, toDevices devices: [RemoteDevice]) -> Success {

--- a/firefox-ios/Storage/Rust/RustRemoteTabs.swift
+++ b/firefox-ios/Storage/Rust/RustRemoteTabs.swift
@@ -202,21 +202,6 @@ public class RustRemoteTabs: @unchecked Sendable {
         }
     }
 
-    public func removeRemoteCommand(deviceId: String, url: URL) {
-        queue.async { [unowned self] in
-            guard let tabsCommandQueue = self.tabsCommandQueue else {
-                let err = TabsApiError.UnexpectedTabsError(reason: "Command queue is not initialized") as MaybeErrorType
-                self.logger.log(err.description,
-                                level: .warning,
-                                category: .tabs)
-                return
-            }
-
-            tabsCommandQueue
-                .removeRemoteCommand(deviceId: deviceId, command: RemoteCommand.closeTab(url: url.absoluteString))
-        }
-    }
-
     public func getUnsentCommandUrlsByDeviceId(deviceId: String, completion: @Sendable @escaping ([String]) -> Void) {
         self.getUnsentCommandsByDeviceId(deviceId: deviceId) { commands in
             let urls = commands.map { item in

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/RemoteTabsPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/RemoteTabsPanelTests.swift
@@ -109,19 +109,6 @@ final class RemoteTabsPanelTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, RemoteTabsPanelActionType.closeSelectedRemoteURL)
     }
 
-    func testRemoteTabsClientAndTabsDataSourceDidUndo_dispatchesUndoCloseSelectedRemoteURL() throws {
-        let subject = createSubject()
-        subject.remoteTabsClientAndTabsDataSourceDidUndo(
-            deviceId: Constants.testDeviceId,
-            url: URL(string: Constants.testUrlString)!
-        )
-
-        let action = try XCTUnwrap(mockStore.dispatchedActions.first)
-        let actionType = try XCTUnwrap(action.actionType as? RemoteTabsPanelActionType)
-
-        XCTAssertEqual(actionType, RemoteTabsPanelActionType.undoCloseSelectedRemoteURL)
-    }
-
     func testRemoteTabsClientAndTabsDataSourceDidTabCommandsFlush_dispatchesFlushTabCommands() throws {
         let subject = createSubject()
         subject.remoteTabsClientAndTabsDataSourceDidTabCommandsFlush(deviceId: Constants.testDeviceId)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
@@ -319,10 +319,6 @@ final class MockProfile: Client.Profile, @unchecked Sendable {
         return
     }
 
-    public func removeTabFromCommandQueue(_ deviceId: String, url: URL) {
-        return
-    }
-
     public func flushTabCommands(toDeviceId: String?) {
         return
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -16,8 +16,6 @@ class MockTabManager: TabManager {
     var selectedIndex = 0
     var selectedTab: Tab?
     var selectedTabUUID: UUID?
-    var backupCloseTab: BackupCloseTab?
-    var backupCloseTabs = [Tab]()
     // Use to return in getTabForUUID()
     var tabForUUID: Tab?
 
@@ -95,8 +93,6 @@ class MockTabManager: TabManager {
     }
 
     func removeNormalTabsOlderThan(period: TabsDeletionPeriod, currentDate: Date) {}
-
-    func undoCloseTab() {}
 
     func clearAllTabsHistory() {}
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -153,31 +153,6 @@ final class TabManagerTests: XCTestCase {
         XCTAssertEqual(tab, addedTab)
     }
 
-    @MainActor
-    func testUndoCloseTab() {
-        let subject = createSubject()
-        let tab = Tab(profile: mockProfile, windowUUID: tabWindowUUID)
-        tab.url = URL(string: "https://mozilla.com/")!
-        XCTAssertEqual(subject.selectedIndex, -1)
-        subject.backupCloseTab = BackupCloseTab(tab: tab, isSelected: true)
-        subject.undoCloseTab()
-        XCTAssertEqual(subject.selectedIndex, 0)
-    }
-
-    @MainActor
-    func testUndoCloseTabWithSelectedTab() {
-        let closedTab = Tab(profile: mockProfile, windowUUID: tabWindowUUID)
-        closedTab.url = URL(string: "https://mozilla.com/")!
-        let selectedTab = Tab(profile: mockProfile, windowUUID: tabWindowUUID)
-        selectedTab.url = URL(string: "https://mozilla.com/1")!
-        let subject = createSubject(tabs: [selectedTab])
-        subject.selectTab(selectedTab)
-        XCTAssertEqual(subject.selectedIndex, 0)
-        subject.backupCloseTab = BackupCloseTab(tab: closedTab, isSelected: true)
-        subject.undoCloseTab()
-        XCTAssertEqual(subject.selectedIndex, 1)
-    }
-
     // MARK: - Document pause - restore
     @MainActor
     func testSelectTab_pauseCurrentDocumentDownload() throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15007)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32322)

## :bulb: Description
- Remove undo close tab feature to fix leak related to BackupCloseTab
- Remove undo close remote tabs and calls to Profile and RustRemoteTabs
- Fix test 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

