### PR TITLE
Bugfix FXIOS-15571 [Homepage] Homepage section header action button wrapping

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/LabelButtonHeaderView.swift
@@ -32,6 +32,10 @@ class LabelButtonHeaderView: UIView, ThemeApplicable, Notifiable {
         button.isHidden = true
         button.setContentHuggingPriority(.required, for: .horizontal)
         button.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        var updatedConfiguration = button.configuration
+        updatedConfiguration?.titleLineBreakMode = .byTruncatingTail
+        button.configuration = updatedConfiguration
     }
 
     // MARK: - Variables


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15571)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33363)

## :bulb: Description
- Prevent homepage section header action button from needlessly wrapping. 

### 📝 Technical Notes:
- Issue came as a result of #33063
- Setting truncation works because it disables wrapping, and the button already has enough horizontal space.

## :movie_camera: Demos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/944c8777-fe32-4d6c-912a-5788963312a5

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/da7e0196-510a-4ffb-aa27-6a4ef9bd1529

</details>


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

