### PR TITLE
Refactor FXIOS-15079 [Tab manager] Readability of didSelectedTabChange

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -66,6 +66,7 @@ struct AccessibilityIdentifiers {
         struct WebView {
             static let documentLoadingLabel = "WebView.documentLoadingLabel"
             static let automationTestLeakIndicator = "WebView.LeakIndicatorElement"
+            static let contentView = "contentView"
         }
 
         static let overKeyboardContainer = "Browser.overKeyboardContainer"

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4629,6 +4629,7 @@ extension BrowserViewController: TabManagerDelegate {
             previousWebView.removeFromSuperview()
         }
 
+        let needsReloadRefactorEnabled = featureFlagsProvider.isEnabled(.needsReloadRefactor)
         var needsReload = false
         if let webView = selectedTab.webView {
             webView.accessibilityLabel = .WebViewAccessibilityLabel
@@ -4638,7 +4639,7 @@ extension BrowserViewController: TabManagerDelegate {
             updateSelectedTabWebview(selectedTab: selectedTab, previousTab: previousTab, webView: webView)
 
             // FXIOS-14783: Experimentation on removing this code, do not add anything in there
-            if !featureFlagsProvider.isEnabled(.needsReloadRefactor) {
+            if !needsReloadRefactorEnabled {
                 if selectedTab.isFxHomeTab {
                     // Added as initial fix for WKWebView memory leak. Needs further investigation.
                     // See: https://mozilla-hub.atlassian.net/browse/FXIOS-10612] +
@@ -4660,7 +4661,7 @@ extension BrowserViewController: TabManagerDelegate {
 
         // FXIOS-14783: Experimentation on removing this code, do not add anything in there
         /// If the selectedTab is showing an error page trigger a reload
-        if !featureFlagsProvider.isEnabled(.needsReloadRefactor),
+        if !needsReloadRefactorEnabled,
            let url = selectedTab.url,
            let internalUrl = InternalURL(url),
            internalUrl.isErrorPage {
@@ -4668,7 +4669,7 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
         // FXIOS-14783: Experimentation on removing this code, do not add anything in there
-        if !featureFlagsProvider.isEnabled(.needsReloadRefactor) {
+        if !needsReloadRefactorEnabled {
             // Do not reload when it's an about:blank page or has a temporary document
             if selectedTab.temporaryDocument != nil || selectedTab.url?.absoluteString == "about:blank" {
                 needsReload = false

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4651,8 +4651,8 @@ extension BrowserViewController: TabManagerDelegate {
             // Do not reload if it's an about:blank page [FXIOS-14782]
             if webView.url == nil && selectedTab.url?.absoluteString != "about:blank" {
                 logger.log("Webview was zombified, reloading tab upon selection", level: .debug, category: .lifecycle)
-                // The webView can go gray if it was zombified due to memory pressure.
-                // When this happens, the URL is nil, so try restoring the page upon selection.
+                // [FXIOS-15440] Blank page when opening inactive tabs from tab tray
+                // The URL is nil when this happens so we reload that tab upon selection
                 needsReload = true
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4619,12 +4619,6 @@ extension BrowserViewController: TabManagerDelegate {
         // back/forward buttons never to become enabled, etc. on tab restore after launch. [FXIOS-9785, FXIOS-9781]
         assert(selectedTab.webView != nil, "Setup will fail if the webView is not initialized for selectedTab")
 
-        if selectedTab.isDownloadingDocument() {
-            navigationHandler?.showDocumentLoading()
-        } else {
-            navigationHandler?.removeDocumentLoading()
-        }
-
         // Remove the old accessibilityLabel only when the selected tab isn't the previous tab.
         // When the previous webview isn't visible anymore we ensure proper clean up for tests.
         if let previousWebView = previousTab?.webView, selectedTab != previousTab {
@@ -4635,6 +4629,81 @@ extension BrowserViewController: TabManagerDelegate {
             previousWebView.removeFromSuperview()
         }
 
+        var needsReload = false
+        if let webView = selectedTab.webView {
+            webView.accessibilityLabel = .WebViewAccessibilityLabel
+            webView.accessibilityIdentifier = AccessibilityIdentifiers.Browser.WebView.contentView
+            webView.accessibilityElementsHidden = false
+
+            updateSelectedTabWebview(selectedTab: selectedTab, previousTab: previousTab, webView: webView)
+
+            // FXIOS-14783: Experimentation on removing this code, do not add anything in there
+            if !featureFlagsProvider.isEnabled(.needsReloadRefactor) {
+                if selectedTab.isFxHomeTab {
+                    // Added as initial fix for WKWebView memory leak. Needs further investigation.
+                    // See: https://mozilla-hub.atlassian.net/browse/FXIOS-10612] +
+                    // [https://mozilla-hub.atlassian.net/browse/FXIOS-10335]
+                    needsReload = true
+                }
+            }
+
+            // Do not reload if it's an about:blank page [FXIOS-14782]
+            if webView.url == nil && selectedTab.url?.absoluteString != "about:blank" {
+                logger.log("Webview was zombified, reloading tab upon selection", level: .debug, category: .lifecycle)
+                // The webView can go gray if it was zombified due to memory pressure.
+                // When this happens, the URL is nil, so try restoring the page upon selection.
+                needsReload = true
+            }
+        }
+
+        updateUIAfterTabSelection(selectedTab: selectedTab, previousTab: previousTab)
+
+        // FXIOS-14783: Experimentation on removing this code, do not add anything in there
+        /// If the selectedTab is showing an error page trigger a reload
+        if !featureFlagsProvider.isEnabled(.needsReloadRefactor),
+           let url = selectedTab.url,
+           let internalUrl = InternalURL(url),
+           internalUrl.isErrorPage {
+            needsReload = true
+        }
+
+        // FXIOS-14783: Experimentation on removing this code, do not add anything in there
+        if !featureFlagsProvider.isEnabled(.needsReloadRefactor) {
+            // Do not reload when it's an about:blank page or has a temporary document
+            if selectedTab.temporaryDocument != nil || selectedTab.url?.absoluteString == "about:blank" {
+                needsReload = false
+            }
+        }
+
+        if needsReload {
+            selectedTab.reload()
+        }
+    }
+
+    private func updateSelectedTabWebview(selectedTab: Tab, previousTab: Tab?, webView: TabWebView) {
+        if selectedTab.isFxHomeTab && previousTab != nil {
+            store.dispatch(
+                GeneralBrowserAction(
+                    windowUUID: windowUUID,
+                    actionType: GeneralBrowserActionType.didSelectedTabChangeToHomepage
+                )
+            )
+        } else if let url = webView.url, InternalURL(url)?.isErrorPage == true {
+            updateInContentHomePanel(url)
+        }
+    }
+
+    // Selecting a new tab triggers a lot of UI updates, with some of them being to ensure the content
+    // shown is the right one for that particular tab content.
+    private func updateUIAfterTabSelection(selectedTab: Tab, previousTab: Tab?) {
+        // Ensure tab PDF content is up-to-date
+        if selectedTab.isDownloadingDocument() {
+            navigationHandler?.showDocumentLoading()
+        } else {
+            navigationHandler?.removeDocumentLoading()
+        }
+
+        // Update theme upon tab selection
         if previousTab == nil || selectedTab.isPrivate != previousTab?.isPrivate {
             applyTheme()
 
@@ -4665,42 +4734,6 @@ extension BrowserViewController: TabManagerDelegate {
             scrollController.tab = selectedTab
         } else {
             scrollController.tabProvider = TabProviderAdapter(selectedTab)
-        }
-
-        var needsReload = false
-        if let webView = selectedTab.webView {
-            webView.accessibilityLabel = .WebViewAccessibilityLabel
-            webView.accessibilityIdentifier = "contentView"
-            webView.accessibilityElementsHidden = false
-
-            if selectedTab.isFxHomeTab && previousTab != nil {
-                store.dispatch(
-                    GeneralBrowserAction(
-                        windowUUID: windowUUID,
-                        actionType: GeneralBrowserActionType.didSelectedTabChangeToHomepage
-                    )
-                )
-            } else if let url = webView.url, InternalURL(url)?.isErrorPage == true {
-                updateInContentHomePanel(url)
-            }
-
-            // FXIOS-14783: Experimentation on removing this code, do not add anything in there
-            if !featureFlagsProvider.isEnabled(.needsReloadRefactor) {
-                if selectedTab.isFxHomeTab {
-                    // Added as initial fix for WKWebView memory leak. Needs further investigation.
-                    // See: https://mozilla-hub.atlassian.net/browse/FXIOS-10612] +
-                    // [https://mozilla-hub.atlassian.net/browse/FXIOS-10335]
-                    needsReload = true
-                }
-            }
-
-            // Do not reload if it's an about:blank page [FXIOS-14782]
-            if webView.url == nil && selectedTab.url?.absoluteString != "about:blank" {
-                logger.log("Webview was zombified, reloading tab upon selection", level: .debug, category: .lifecycle)
-                // The webView can go gray if it was zombified due to memory pressure.
-                // When this happens, the URL is nil, so try restoring the page upon selection.
-                needsReload = true
-            }
         }
 
         updateTabCountUsingTabManager(tabManager)
@@ -4740,27 +4773,6 @@ extension BrowserViewController: TabManagerDelegate {
             topTabsDidChangeTab()
         } else if isSwipingTabsEnabled {
             addressToolbarContainer.updateSkeletonAddressBarsVisibility(tabManager: tabManager)
-        }
-
-        // FXIOS-14783: Experimentation on removing this code, do not add anything in there
-        /// If the selectedTab is showing an error page trigger a reload
-        if !featureFlagsProvider.isEnabled(.needsReloadRefactor),
-           let url = selectedTab.url,
-           let internalUrl = InternalURL(url),
-           internalUrl.isErrorPage {
-            needsReload = true
-        }
-
-        // FXIOS-14783: Experimentation on removing this code, do not add anything in there
-        if !featureFlagsProvider.isEnabled(.needsReloadRefactor) {
-            // Do not reload when it's an about:blank page or has a temporary document
-            if selectedTab.temporaryDocument != nil || selectedTab.url?.absoluteString == "about:blank" {
-                needsReload = false
-            }
-        }
-
-        if needsReload {
-            selectedTab.reload()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
@@ -136,7 +136,7 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         subject.tabManager(tabManager, didSelectedTabChange: testTab, previousTab: testTab, isRestoring: false)
         wait(for: [expectation])
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions[2] as? GeneralBrowserAction)
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions[0] as? GeneralBrowserAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? GeneralBrowserActionType)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 5)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
@@ -186,7 +186,7 @@ class ShareLongPressTests: FeatureFlaggedTestBase {
     private func longPressLinkAndSelectShareOption(option: String) {
         navigator.openURL(path(forTestPage: "test-example.html"))
         waitUntilPageLoad()
-        app.webViews["contentView"].links.element(boundBy: 0).press(forDuration: 1.5)
+        app.webViews[AccessibilityIdentifiers.Browser.WebView.contentView].links.element(boundBy: 0).press(forDuration: 1.5)
         mozWaitForElementToExist(app.buttons["Open in New Tab"])
         app.buttons["Share Link"].waitAndTap()
         if #available(iOS 16, *) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15079)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32458)

## :bulb: Description
Update: just realized we have a ticket for this specifically, so updated the ticket number.

Follow-up on https://github.com/mozilla-mobile/firefox-ios/pull/33181. I had first opened https://github.com/mozilla-mobile/firefox-ios/pull/33144 which included those extra changes to try to improve this delegate method readability, but it was making the bugfix hard to understand. So I am instead making those changes in a separate PR. This PR:
- Adds an a11y identifier for the `contentView`
- Create two sub-functions under the `didSelectedTabChange` delegate method. This does change the order of operation for a couple of things, but I haven't noticed any side effect so far. I'll be on the lookout for those and revert if need be. New methods are named:
    - `func updateSelectedTabWebview(:::)`
    - `func updateUIAfterTabSelection(::)`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

