### PR TITLE
Refactor FXIOS-15544 [AI Controls] Cancel task on deint and fix feature flag logic

### DIFF
--- a/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
+++ b/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
@@ -46,7 +46,7 @@ final class UserFeaturePreferenceManager: UserFeaturePreferring, @unchecked Send
     // MARK: - Bool preferences
 
     var isAIKillSwitchEnabled: Bool {
-        // Even when this feature is on the default value should be false
+        // Even when this feature is on in Nimbus, the user preference default value should be false
         prefs.boolForKey(PrefsKeys.Settings.aiKillSwitchFeature) ?? false
     }
 

--- a/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
+++ b/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
@@ -46,8 +46,8 @@ final class UserFeaturePreferenceManager: UserFeaturePreferring, @unchecked Send
     // MARK: - Bool preferences
 
     var isAIKillSwitchEnabled: Bool {
-        prefs.boolForKey(PrefsKeys.Settings.aiKillSwitchFeature)
-        ?? nimbusLayer.checkNimbusConfigFor(.aiKillSwitch)
+        // Even when this feature is on the default value should be false
+        prefs.boolForKey(PrefsKeys.Settings.aiKillSwitchFeature) ?? false
     }
 
     var isFirefoxSuggestEnabled: Bool {

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsAction.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsAction.swift
@@ -69,5 +69,4 @@ enum TranslationSettingsViewActionType: ActionType {
 enum TranslationSettingsMiddlewareActionType: ActionType {
     case didLoadSettings
     case didUpdateSettings
-    case didResetStorage
 }

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
@@ -12,6 +12,7 @@ final class TranslationSettingsMiddleware {
     private let manager: PreferredTranslationLanguagesManager
     private let modelsFetcher: TranslationModelsFetcherProtocol
     private let localeProvider: LocaleProvider
+    private var resetStorageTask: Task<Void, Never>?
 
     private var isAutoTranslateEnabled: Bool {
         prefs.boolForKey(PrefsKeys.Settings.translationAutoTranslate) ?? false
@@ -25,6 +26,10 @@ final class TranslationSettingsMiddleware {
         self.manager = manager ?? PreferredTranslationLanguagesManager(prefs: profile.prefs)
         self.modelsFetcher = modelsFetcher
         self.localeProvider = localeProvider
+    }
+
+    deinit {
+        resetStorageTask?.cancel()
     }
 
     lazy var translationSettingsProvider: Middleware<AppState> = { state, action in
@@ -72,13 +77,9 @@ final class TranslationSettingsMiddleware {
                 actionType: TranslationSettingsMiddlewareActionType.didUpdateSettings
             ))
             if !newValue {
-                Task {
+                resetStorageTask?.cancel()
+                resetStorageTask = Task { [modelsFetcher] in
                     await modelsFetcher.resetStorage()
-                    store.dispatch(TranslationSettingsMiddlewareAction(
-                        isTranslationsEnabled: newValue,
-                        windowUUID: action.windowUUID,
-                        actionType: TranslationSettingsMiddlewareActionType.didResetStorage
-                    ))
                 }
             }
         case TranslationSettingsViewActionType.toggleAutoTranslate:

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
@@ -13,6 +13,7 @@ final class TranslationSettingsMiddleware {
     private let modelsFetcher: TranslationModelsFetcherProtocol
     private let localeProvider: LocaleProvider
     private var resetStorageTask: Task<Void, Never>?
+    private var loadSettingsTask: Task<Void, Never>?
 
     private var isAutoTranslateEnabled: Bool {
         prefs.boolForKey(PrefsKeys.Settings.translationAutoTranslate) ?? false
@@ -30,6 +31,7 @@ final class TranslationSettingsMiddleware {
 
     deinit {
         resetStorageTask?.cancel()
+        loadSettingsTask?.cancel()
     }
 
     lazy var translationSettingsProvider: Middleware<AppState> = { state, action in
@@ -54,7 +56,8 @@ final class TranslationSettingsMiddleware {
                 windowUUID: action.windowUUID,
                 actionType: TranslationSettingsMiddlewareActionType.didLoadSettings
             ))
-            Task { await self.loadSettings(windowUUID: action.windowUUID) }
+            loadSettingsTask?.cancel()
+            loadSettingsTask = Task { await self.loadSettings(windowUUID: action.windowUUID) }
 
         case TranslationSettingsViewActionType.toggleTranslationsEnabled:
             let current = prefs.boolForKey(PrefsKeys.Settings.translationsFeature) ?? true

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
@@ -57,7 +57,9 @@ final class TranslationSettingsMiddleware {
                 actionType: TranslationSettingsMiddlewareActionType.didLoadSettings
             ))
             loadSettingsTask?.cancel()
-            loadSettingsTask = Task { await self.loadSettings(windowUUID: action.windowUUID) }
+            loadSettingsTask = Task { [weak self] in
+                await self?.loadSettings(windowUUID: action.windowUUID)
+            }
 
         case TranslationSettingsViewActionType.toggleTranslationsEnabled:
             let current = prefs.boolForKey(PrefsKeys.Settings.translationsFeature) ?? true

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
@@ -204,7 +204,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         )
 
         let expectation = XCTestExpectation(description: "wait for actions to dispatch")
-        expectation.expectedFulfillmentCount = 3
+        expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
 
         subject.translationSettingsProvider(mockStore.state, action)
@@ -212,7 +212,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         wait(for: [expectation], timeout: 1.0)
 
         // Expects ToolbarAction + TranslationSettingsMiddlewareAction
-        XCTAssertEqual(mockStore.dispatchedActions.count, 3)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
 
         let toolbarAction = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let toolbarActionType = try XCTUnwrap(toolbarAction.actionType as? ToolbarActionType)
@@ -224,11 +224,6 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(settingsActionType, TranslationSettingsMiddlewareActionType.didUpdateSettings)
         XCTAssertEqual(settingsAction.isTranslationsEnabled, false)
         XCTAssertEqual(mockProfile.prefs.boolForKey(PrefsKeys.Settings.translationsFeature), false)
-
-        let resetStorageAction = try XCTUnwrap(mockStore.dispatchedActions.last as? TranslationSettingsMiddlewareAction)
-        let resetStorageActionType = try XCTUnwrap(resetStorageAction.actionType as? TranslationSettingsMiddlewareActionType)
-
-        XCTAssertEqual(resetStorageActionType, TranslationSettingsMiddlewareActionType.didResetStorage)
         subject.translationSettingsProvider = { _, _ in }
     }
 
@@ -260,8 +255,11 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationsFeature)
 
         let expectation = XCTestExpectation(description: "wait for actions to dispatch")
-        expectation.expectedFulfillmentCount = 3
+        expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
+
+        let resetExpectation = XCTestExpectation(description: "reset storage was called")
+        mockModelsFetcher.resetStorageExpectation = resetExpectation
 
         let subject = createSubject()
         let action = TranslationSettingsViewAction(
@@ -271,9 +269,10 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.translationSettingsProvider(mockStore.state, action)
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation, resetExpectation], timeout: 1.0)
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 3)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
+
         subject.translationSettingsProvider = { _, _ in }
     }
 
@@ -284,6 +283,10 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         expectation.assertForOverFulfill = true
         mockStore.dispatchCalled = { expectation.fulfill() }
 
+        let resetExpectation = XCTestExpectation(description: "reset storage was called")
+        mockModelsFetcher.resetStorageExpectation = resetExpectation
+        resetExpectation.isInverted = true
+
         let subject = createSubject()
         let action = TranslationSettingsViewAction(
             windowUUID: .XCTestDefaultUUID,
@@ -292,7 +295,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.translationSettingsProvider(mockStore.state, action)
 
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation, resetExpectation], timeout: 2.0)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 2)
         subject.translationSettingsProvider = { _, _ in }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationModelsFetcher.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationModelsFetcher.swift
@@ -34,7 +34,22 @@ final class MockTranslationModelsFetcher: TranslationModelsFetcherProtocol, @unc
         return supportedTargetLanguages
     }
 
+    var resetStorageExpectation: XCTestExpectation?
+    var resetStorageStartedExpectation: XCTestExpectation?
+    var resetStorageCancelledExpectation: XCTestExpectation?
+    var shouldSuspendResetStorage = false
+    private let resetStorageLock = NSLock()
+    private var resetStorageContinuation: CheckedContinuation<Void, Never>?
+
     func resetStorage() async {
-        // no-op for now
+        resetStorageExpectation?.fulfill()
+    }
+
+    private func resumeResetStorageIfNeeded() {
+        resetStorageLock.lock()
+        let continuation = resetStorageContinuation
+        resetStorageContinuation = nil
+        resetStorageLock.unlock()
+        continuation?.resume()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationModelsFetcher.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationModelsFetcher.swift
@@ -8,6 +8,7 @@ import XCTest
 
 /// Minimal mock  for TranslationModelsFetcherProtocol tests. This avoids going through remote settings.
 final class MockTranslationModelsFetcher: TranslationModelsFetcherProtocol, @unchecked Sendable {
+    var resetStorageExpectation: XCTestExpectation?
     var translatorWASMResult: Data?
     var modelsResult: Data?
     var modelBufferResult: Data?
@@ -34,22 +35,7 @@ final class MockTranslationModelsFetcher: TranslationModelsFetcherProtocol, @unc
         return supportedTargetLanguages
     }
 
-    var resetStorageExpectation: XCTestExpectation?
-    var resetStorageStartedExpectation: XCTestExpectation?
-    var resetStorageCancelledExpectation: XCTestExpectation?
-    var shouldSuspendResetStorage = false
-    private let resetStorageLock = NSLock()
-    private var resetStorageContinuation: CheckedContinuation<Void, Never>?
-
     func resetStorage() async {
         resetStorageExpectation?.fulfill()
-    }
-
-    private func resumeResetStorageIfNeeded() {
-        resetStorageLock.lock()
-        let continuation = resetStorageContinuation
-        resetStorageContinuation = nil
-        resetStorageLock.unlock()
-        continuation?.resume()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15544)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
It is generally best practice to cancel tasks when objects are deinited. It was also causing memory leaks in these tests.

Also update feature flag logic to respect the default state of off for the ai control

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

