### PR TITLE
Add [World Cup] FXIOS-15581 world cup feature flag

### DIFF
--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -59,6 +59,7 @@ enum FeatureFlagID: String, CaseIterable {
     case trendingSearches
     case unifiedSearch
     case videoIntroOnboarding
+    case worldCupWidget
     case quickAnswers
 
     // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`. Add in alphabetical order.
@@ -96,7 +97,8 @@ enum FeatureFlagID: String, CaseIterable {
                 .translation,
                 .translationLanguagePicker,
                 .trendingSearches,
-                .unifiedSearch:
+                .unifiedSearch,
+                .worldCupWidget:
             return rawValue + PrefsKeys.FeatureFlags.DebugSuffixKey
         default:
             return nil

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -76,7 +76,8 @@ struct NimbusFlaggableFeature {
                 .translationLanguagePicker,
                 .trendingSearches,
                 .unifiedSearch,
-                .videoIntroOnboarding:
+                .videoIntroOnboarding,
+                .worldCupWidget:
             return nil
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -235,6 +235,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Legacy
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .worldCupWidget,
+                titleText: format(string: "World Cup Widget"),
+                statusText: format(string: "Toggle to enable the World Cup widget feature on the Homepage")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .hostedSummarizer,
                 titleText: format(string: "Hosted Summarizer Feature"),
                 statusText: format(string: "Toggle to enable the hosted summarizer feature")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -171,6 +171,9 @@ final class NimbusFeatureFlagLayer: Sendable {
 
         case .quickAnswers:
             return checkQuickAnswersFeature(from: nimbus)
+
+        case .worldCupWidget:
+            return checkWorldCupWidgetFeature(from: nimbus)
         }
     }
 
@@ -427,5 +430,9 @@ final class NimbusFeatureFlagLayer: Sendable {
 
     private func checkBookmarksSearchFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.bookmarksSearchFeature.value().enabled
+    }
+
+    private func checkWorldCupWidgetFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.worldCupWidgetFeature.value().enabled
     }
 }

--- a/firefox-ios/nimbus-features/worldCupWidgetFeature.yaml
+++ b/firefox-ios/nimbus-features/worldCupWidgetFeature.yaml
@@ -15,4 +15,4 @@ features:
           enabled: false
       - channel: developer
         value:
-          enabled: true
+          enabled: false

--- a/firefox-ios/nimbus-features/worldCupWidgetFeature.yaml
+++ b/firefox-ios/nimbus-features/worldCupWidgetFeature.yaml
@@ -1,0 +1,18 @@
+# The configuration for the worldCupWidgetFeature feature
+features:
+  world-cup-widget-feature:
+    description: >
+      The feature flag to manage the roll out of the world cup widget feature
+    variables:
+      enabled:
+        description: >
+          Whether or not this feature is enabled
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -56,3 +56,4 @@ include:
   - nimbus-features/trackingProtectionRefactor.yaml
   - nimbus-features/translationsFeature.yaml
   - nimbus-features/trendingSearchesFeature.yaml
+  - nimbus-features/worldCupWidgetFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15581)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33379)

## :bulb: Description
Add World cup widget feature flag.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

