### PR TITLE
BugFix FXIOS-15470 [Translations Phase 2] Fix toggle firing in edit mode and picker selection with search

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
@@ -135,16 +135,14 @@ final class TranslationLanguagePickerViewController: UIViewController,
 
     func updateSearchResults(for searchController: UISearchController) {
         let query = searchController.searchBar.text ?? ""
-        if query.isEmpty {
-            filteredLanguages = allLanguages
-        } else {
-            filteredLanguages = allLanguages.filter { code in
-                let native = localeProvider.nativeLanguageName(for: code)
-                let localized = localeProvider.localizedLanguageName(for: code)
-                return native.localizedCaseInsensitiveContains(query)
-                    || localized.localizedCaseInsensitiveContains(query)
-            }
+        let newFiltered = query.isEmpty ? allLanguages : allLanguages.filter { code in
+            let native = localeProvider.nativeLanguageName(for: code)
+            let localized = localeProvider.localizedLanguageName(for: code)
+            return native.localizedCaseInsensitiveContains(query)
+                || localized.localizedCaseInsensitiveContains(query)
         }
+        guard newFiltered != filteredLanguages else { return }
+        filteredLanguages = newFiltered
         tableView.reloadData()
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
@@ -135,14 +135,16 @@ final class TranslationLanguagePickerViewController: UIViewController,
 
     func updateSearchResults(for searchController: UISearchController) {
         let query = searchController.searchBar.text ?? ""
-        let newFiltered = query.isEmpty ? allLanguages : allLanguages.filter { code in
-            let native = localeProvider.nativeLanguageName(for: code)
-            let localized = localeProvider.localizedLanguageName(for: code)
-            return native.localizedCaseInsensitiveContains(query)
-                || localized.localizedCaseInsensitiveContains(query)
+        if query.isEmpty {
+            filteredLanguages = allLanguages
+        } else {
+            filteredLanguages = allLanguages.filter { code in
+                let native = localeProvider.nativeLanguageName(for: code)
+                let localized = localeProvider.localizedLanguageName(for: code)
+                return native.localizedCaseInsensitiveContains(query)
+                    || localized.localizedCaseInsensitiveContains(query)
+            }
         }
-        guard newFiltered != filteredLanguages else { return }
-        filteredLanguages = newFiltered
         tableView.reloadData()
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
@@ -303,6 +303,10 @@ final class TranslationPickerSettingsViewController: UIViewController,
     // MARK: - Toggle actions
 
     @objc private func didToggleTranslations(_ sender: UISwitch) {
+        guard !state.isEditing else {
+            sender.setOn(state.isTranslationsEnabled, animated: false)
+            return
+        }
         store.dispatch(TranslationSettingsViewAction(
             windowUUID: windowUUID,
             actionType: TranslationSettingsViewActionType.toggleTranslationsEnabled
@@ -310,6 +314,10 @@ final class TranslationPickerSettingsViewController: UIViewController,
     }
 
     @objc private func didToggleAutoTranslate(_ sender: UISwitch) {
+        guard !state.isEditing else {
+            sender.setOn(state.isAutoTranslateEnabled, animated: false)
+            return
+        }
         store.dispatch(TranslationSettingsViewAction(
             windowUUID: windowUUID,
             actionType: TranslationSettingsViewActionType.toggleAutoTranslate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33178)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Guard toggle action handlers against edit mode: if a touch-up reaches the UISwitch after edit mode was entered, reset the switch visually and skip the dispatch instead of toggling the setting
- Skip reloadData in updateSearchResults when filtered results are unchanged, preventing UIKit from cancelling an in-progress cell tap when the search controller re-fires the callback during the touch

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


