### PR TITLE
BugFix FXIOS-15583 [Translations Phase 2] Fix language picker selection when searching

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1326,6 +1326,7 @@
 		8C3B1A1F2F73C8F300E2C370 /* TranslationAddLanguageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3B1A1E2F73C8F300E2C370 /* TranslationAddLanguageCell.swift */; };
 		8C3B1A212F73C91000E2C370 /* TranslationPickerLanguageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3B1A202F73C91000E2C370 /* TranslationPickerLanguageCell.swift */; };
 		8C3BF7052F6BEB3D00E2C370 /* TranslationLanguagePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3BF7042F6BEB3D00E2C370 /* TranslationLanguagePickerViewController.swift */; };
+		8CB1A0012F99000000E2C370 /* TranslationLanguagePickerResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB1A0022F99000000E2C370 /* TranslationLanguagePickerResultsController.swift */; };
 		8C4B0F5D2C076B12008B3E74 /* UpdatableAddressFields+Decodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4B0F5C2C076B12008B3E74 /* UpdatableAddressFields+Decodable.swift */; };
 		8C50DD752F56E1D00020E5C4 /* PreferredTranslationLanguagesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C50DD742F56E1D00020E5C4 /* PreferredTranslationLanguagesManagerTests.swift */; };
 		8C51ED6C2DE0A49800B3E58A /* NimbusOnboardingKitFeatureLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C51ED6B2DE0A49800B3E58A /* NimbusOnboardingKitFeatureLayer.swift */; };
@@ -9636,6 +9637,7 @@
 		8C3B1A1E2F73C8F300E2C370 /* TranslationAddLanguageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationAddLanguageCell.swift; sourceTree = "<group>"; };
 		8C3B1A202F73C91000E2C370 /* TranslationPickerLanguageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationPickerLanguageCell.swift; sourceTree = "<group>"; };
 		8C3BF7042F6BEB3D00E2C370 /* TranslationLanguagePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationLanguagePickerViewController.swift; sourceTree = "<group>"; };
+		8CB1A0022F99000000E2C370 /* TranslationLanguagePickerResultsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationLanguagePickerResultsController.swift; sourceTree = "<group>"; };
 		8C4B0F5C2C076B12008B3E74 /* UpdatableAddressFields+Decodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UpdatableAddressFields+Decodable.swift"; sourceTree = "<group>"; };
 		8C50DD742F56E1D00020E5C4 /* PreferredTranslationLanguagesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferredTranslationLanguagesManagerTests.swift; sourceTree = "<group>"; };
 		8C514AFEABEF8DE46CE7B8D4 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
@@ -14645,6 +14647,7 @@
 				AAD861AA2E9E75A100F6E0E0 /* TranslationSettingsViewController.swift */,
 				F84988A6047D42DBB38FFAC1 /* TranslationPickerSettingsViewController.swift */,
 				8C3BF7042F6BEB3D00E2C370 /* TranslationLanguagePickerViewController.swift */,
+				8CB1A0022F99000000E2C370 /* TranslationLanguagePickerResultsController.swift */,
 				E0865C80F73A49F08E2B17E2 /* TranslationSettingsDiffableDataSource.swift */,
 				AAD861AD2E9E75C000F6E0E0 /* TranslationSettingsAction.swift */,
 				AAD861AF2E9E75C000F6E0E0 /* TranslationSettingsState.swift */,
@@ -19333,6 +19336,7 @@
 				AAD861AB2E9E75AB00F6E0E0 /* TranslationSettingsViewController.swift in Sources */,
 				B326EA470451415F90D8F722 /* TranslationPickerSettingsViewController.swift in Sources */,
 				8C3BF7052F6BEB3D00E2C370 /* TranslationLanguagePickerViewController.swift in Sources */,
+				8CB1A0012F99000000E2C370 /* TranslationLanguagePickerResultsController.swift in Sources */,
 				74B8478AACB3429E827FE642 /* TranslationSettingsDiffableDataSource.swift in Sources */,
 				AAD861AC2E9E75C000F6E0E0 /* TranslationSettingsAction.swift in Sources */,
 				AAD861AE2E9E75C000F6E0E0 /* TranslationSettingsState.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerResultsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerResultsController.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+
+final class TranslationLanguagePickerResultsController: UITableViewController {
+    var filteredLanguages: [String] = []
+    var onSelectLanguage: ((String) -> Void)?
+    var localeProvider: LocaleProvider = SystemLocaleProvider()
+    var theme: Theme?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.register(TranslationPickerLanguageCell.self,
+                           forCellReuseIdentifier: TranslationPickerLanguageCell.cellIdentifier)
+        tableView.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Translation.languagePickerList
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return filteredLanguages.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: TranslationPickerLanguageCell.cellIdentifier,
+            for: indexPath
+        ) as? TranslationPickerLanguageCell ?? TranslationPickerLanguageCell()
+        let code = filteredLanguages[indexPath.row]
+        let native = localeProvider.nativeLanguageName(for: code)
+        let localized = localeProvider.localizedLanguageName(for: code)
+        cell.configure(native: native, localized: native == localized ? nil : localized)
+        if let theme { cell.applyTheme(theme: theme) }
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        onSelectLanguage?(filteredLanguages[indexPath.row])
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerResultsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerResultsController.swift
@@ -5,18 +5,59 @@
 import Common
 import UIKit
 
-final class TranslationLanguagePickerResultsController: UITableViewController {
-    var filteredLanguages: [String] = []
-    var onSelectLanguage: ((String) -> Void)?
-    var localeProvider: LocaleProvider = SystemLocaleProvider()
-    var theme: Theme?
+final class TranslationLanguagePickerResultsController: UITableViewController, Themeable {
+    // MARK: - Themeable
+
+    var themeManager: ThemeManager
+    var themeListenerCancellable: Any?
+    var notificationCenter: NotificationProtocol
+    var currentWindowUUID: WindowUUID? { windowUUID }
+
+    // MARK: - Properties
+
+    let windowUUID: WindowUUID
+    private let localeProvider: LocaleProvider
+    private let onSelectLanguage: (String) -> Void
+    private(set) var filteredLanguages: [String] = []
+
+    // MARK: - Init
+
+    init(windowUUID: WindowUUID,
+         localeProvider: LocaleProvider,
+         themeManager: ThemeManager,
+         notificationCenter: NotificationProtocol = NotificationCenter.default,
+         onSelectLanguage: @escaping (String) -> Void) {
+        self.windowUUID = windowUUID
+        self.localeProvider = localeProvider
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        self.onSelectLanguage = onSelectLanguage
+        super.init(style: .insetGrouped)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.register(TranslationPickerLanguageCell.self,
                            forCellReuseIdentifier: TranslationPickerLanguageCell.cellIdentifier)
         tableView.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Translation.languagePickerList
+        listenForThemeChanges(withNotificationCenter: notificationCenter)
+        applyTheme()
     }
+
+    // MARK: - Configuration
+
+    func configure(filteredLanguages: [String]) {
+        self.filteredLanguages = filteredLanguages
+        tableView.reloadData()
+    }
+
+    // MARK: - UITableViewDataSource
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return filteredLanguages.count
@@ -31,12 +72,24 @@ final class TranslationLanguagePickerResultsController: UITableViewController {
         let native = localeProvider.nativeLanguageName(for: code)
         let localized = localeProvider.localizedLanguageName(for: code)
         cell.configure(native: native, localized: native == localized ? nil : localized)
-        if let theme { cell.applyTheme(theme: theme) }
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return cell
     }
 
+    // MARK: - UITableViewDelegate
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        onSelectLanguage?(filteredLanguages[indexPath.row])
+        onSelectLanguage(filteredLanguages[indexPath.row])
+    }
+
+    // MARK: - Themeable
+
+    func applyTheme() {
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        tableView.backgroundColor = theme.colors.layer1
+        tableView.visibleCells.compactMap { $0 as? TranslationPickerLanguageCell }.forEach {
+            $0.applyTheme(theme: theme)
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
@@ -36,12 +36,13 @@ final class TranslationLanguagePickerViewController: UIViewController,
     }()
 
     lazy var resultsController: TranslationLanguagePickerResultsController = {
-        let controller = TranslationLanguagePickerResultsController(style: .insetGrouped)
-        controller.localeProvider = localeProvider
-        controller.onSelectLanguage = { [weak self] code in
-            self?.addLanguage(code)
-        }
-        return controller
+        return TranslationLanguagePickerResultsController(
+            windowUUID: windowUUID,
+            localeProvider: localeProvider,
+            themeManager: themeManager,
+            notificationCenter: notificationCenter,
+            onSelectLanguage: { [weak self] code in self?.addLanguage(code) }
+        )
     }()
 
     private lazy var searchController: UISearchController = {
@@ -152,8 +153,7 @@ final class TranslationLanguagePickerViewController: UIViewController,
             return native.localizedCaseInsensitiveContains(query)
                 || localized.localizedCaseInsensitiveContains(query)
         }
-        resultsController.filteredLanguages = newFiltered
-        resultsController.tableView.reloadData()
+        resultsController.configure(filteredLanguages: newFiltered)
     }
 
     // MARK: - Theming
@@ -162,8 +162,6 @@ final class TranslationLanguagePickerViewController: UIViewController,
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
         tableView.backgroundColor = theme.colors.layer1
-        resultsController.tableView.backgroundColor = theme.colors.layer1
-        resultsController.theme = theme
         searchController.searchBar.tintColor = theme.colors.actionPrimary
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
         tableView.visibleCells.compactMap { $0 as? TranslationPickerLanguageCell }.forEach {

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
@@ -6,46 +6,6 @@ import Common
 import Redux
 import UIKit
 
-// MARK: - Results Table Controller
-
-final class TranslationLanguagePickerResultsController: UITableViewController {
-    var filteredLanguages: [String] = []
-    var onSelectLanguage: ((String) -> Void)?
-    var localeProvider: LocaleProvider = SystemLocaleProvider()
-    var theme: Theme?
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        tableView.register(TranslationPickerLanguageCell.self,
-                           forCellReuseIdentifier: TranslationPickerLanguageCell.cellIdentifier)
-        tableView.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Translation.languagePickerList
-    }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return filteredLanguages.count
-    }
-
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(
-            withIdentifier: TranslationPickerLanguageCell.cellIdentifier,
-            for: indexPath
-        ) as? TranslationPickerLanguageCell ?? TranslationPickerLanguageCell()
-        let code = filteredLanguages[indexPath.row]
-        let native = localeProvider.nativeLanguageName(for: code)
-        let localized = localeProvider.localizedLanguageName(for: code)
-        cell.configure(native: native, localized: native == localized ? nil : localized)
-        if let theme { cell.applyTheme(theme: theme) }
-        return cell
-    }
-
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        onSelectLanguage?(filteredLanguages[indexPath.row])
-    }
-}
-
-// MARK: - Language Picker View Controller
-
 final class TranslationLanguagePickerViewController: UIViewController,
                                                      UITableViewDataSource,
                                                      UITableViewDelegate,

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
@@ -6,6 +6,47 @@ import Common
 import Redux
 import UIKit
 
+// MARK: - Results Table Controller
+
+final class TranslationLanguagePickerResultsController: UITableViewController {
+    var filteredLanguages: [String] = []
+    var onSelectLanguage: ((String) -> Void)?
+    var localeProvider: LocaleProvider = SystemLocaleProvider()
+    var theme: Theme?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.register(TranslationPickerLanguageCell.self,
+                           forCellReuseIdentifier: TranslationPickerLanguageCell.cellIdentifier)
+        tableView.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Translation.languagePickerList
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return filteredLanguages.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: TranslationPickerLanguageCell.cellIdentifier,
+            for: indexPath
+        ) as? TranslationPickerLanguageCell ?? TranslationPickerLanguageCell()
+        let code = filteredLanguages[indexPath.row]
+        let native = localeProvider.nativeLanguageName(for: code)
+        let localized = localeProvider.localizedLanguageName(for: code)
+        cell.configure(native: native, localized: native == localized ? nil : localized)
+        if let theme { cell.applyTheme(theme: theme) }
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard indexPath.row < filteredLanguages.count else { return }
+        onSelectLanguage?(filteredLanguages[indexPath.row])
+    }
+}
+
+// MARK: - Language Picker View Controller
+
 final class TranslationLanguagePickerViewController: UIViewController,
                                                      UITableViewDataSource,
                                                      UITableViewDelegate,
@@ -23,7 +64,6 @@ final class TranslationLanguagePickerViewController: UIViewController,
     let windowUUID: WindowUUID
     private let localeProvider: LocaleProvider
     private let allLanguages: [String]
-    private var filteredLanguages: [String]
 
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .insetGrouped)
@@ -36,10 +76,18 @@ final class TranslationLanguagePickerViewController: UIViewController,
         return tableView
     }()
 
+    lazy var resultsController: TranslationLanguagePickerResultsController = {
+        let controller = TranslationLanguagePickerResultsController(style: .insetGrouped)
+        controller.localeProvider = localeProvider
+        controller.onSelectLanguage = { [weak self] code in
+            self?.addLanguage(code)
+        }
+        return controller
+    }()
+
     private lazy var searchController: UISearchController = {
-        let searchController = UISearchController(searchResultsController: nil)
+        let searchController = UISearchController(searchResultsController: resultsController)
         searchController.searchResultsUpdater = self
-        searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.placeholder = .Settings.Translation.LanguagePicker.SearchPlaceholder
         return searchController
     }()
@@ -56,7 +104,6 @@ final class TranslationLanguagePickerViewController: UIViewController,
         self.notificationCenter = notificationCenter
         self.localeProvider = localeProvider
         self.allLanguages = languages
-        self.filteredLanguages = languages
         super.init(nibName: nil, bundle: nil)
         title = .Settings.Translation.LanguagePicker.NavTitle
     }
@@ -98,7 +145,7 @@ final class TranslationLanguagePickerViewController: UIViewController,
     // MARK: - UITableViewDataSource
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return filteredLanguages.count
+        return allLanguages.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -106,7 +153,7 @@ final class TranslationLanguagePickerViewController: UIViewController,
             withIdentifier: TranslationPickerLanguageCell.cellIdentifier,
             for: indexPath
         ) as? TranslationPickerLanguageCell ?? TranslationPickerLanguageCell()
-        let code = filteredLanguages[indexPath.row]
+        let code = allLanguages[indexPath.row]
         let native = localeProvider.nativeLanguageName(for: code)
         let localized = localeProvider.localizedLanguageName(for: code)
         cell.configure(native: native, localized: native == localized ? nil : localized)
@@ -118,34 +165,37 @@ final class TranslationLanguagePickerViewController: UIViewController,
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        let languageCode = filteredLanguages[indexPath.row]
+        guard indexPath.row < allLanguages.count else { return }
+        addLanguage(allLanguages[indexPath.row])
+    }
+
+    // MARK: - Selection
+
+    private func addLanguage(_ languageCode: String) {
         store.dispatch(TranslationSettingsViewAction(
             languageCode: languageCode,
             windowUUID: windowUUID,
             actionType: TranslationSettingsViewActionType.addLanguage
         ))
-        dismiss(animated: true)
+        (presentingViewController ?? self).dismiss(animated: true)
     }
 
     @objc private func didTapCancel() {
-        dismiss(animated: true)
+        (presentingViewController ?? self).dismiss(animated: true)
     }
 
     // MARK: - UISearchResultsUpdating
 
     func updateSearchResults(for searchController: UISearchController) {
         let query = searchController.searchBar.text ?? ""
-        if query.isEmpty {
-            filteredLanguages = allLanguages
-        } else {
-            filteredLanguages = allLanguages.filter { code in
-                let native = localeProvider.nativeLanguageName(for: code)
-                let localized = localeProvider.localizedLanguageName(for: code)
-                return native.localizedCaseInsensitiveContains(query)
-                    || localized.localizedCaseInsensitiveContains(query)
-            }
+        let newFiltered = query.isEmpty ? allLanguages : allLanguages.filter { code in
+            let native = localeProvider.nativeLanguageName(for: code)
+            let localized = localeProvider.localizedLanguageName(for: code)
+            return native.localizedCaseInsensitiveContains(query)
+                || localized.localizedCaseInsensitiveContains(query)
         }
-        tableView.reloadData()
+        resultsController.filteredLanguages = newFiltered
+        resultsController.tableView.reloadData()
     }
 
     // MARK: - Theming
@@ -154,6 +204,9 @@ final class TranslationLanguagePickerViewController: UIViewController,
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
         tableView.backgroundColor = theme.colors.layer1
+        resultsController.view.backgroundColor = theme.colors.layer1
+        resultsController.tableView.backgroundColor = theme.colors.layer1
+        resultsController.theme = theme
         searchController.searchBar.tintColor = theme.colors.actionPrimary
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
         tableView.visibleCells.compactMap { $0 as? TranslationPickerLanguageCell }.forEach {

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
@@ -40,7 +40,6 @@ final class TranslationLanguagePickerResultsController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        guard indexPath.row < filteredLanguages.count else { return }
         onSelectLanguage?(filteredLanguages[indexPath.row])
     }
 }
@@ -165,7 +164,6 @@ final class TranslationLanguagePickerViewController: UIViewController,
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        guard indexPath.row < allLanguages.count else { return }
         addLanguage(allLanguages[indexPath.row])
     }
 
@@ -177,11 +175,11 @@ final class TranslationLanguagePickerViewController: UIViewController,
             windowUUID: windowUUID,
             actionType: TranslationSettingsViewActionType.addLanguage
         ))
-        (presentingViewController ?? self).dismiss(animated: true)
+        presentingViewController?.dismiss(animated: true)
     }
 
     @objc private func didTapCancel() {
-        (presentingViewController ?? self).dismiss(animated: true)
+        presentingViewController?.dismiss(animated: true)
     }
 
     // MARK: - UISearchResultsUpdating
@@ -204,7 +202,6 @@ final class TranslationLanguagePickerViewController: UIViewController,
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
         tableView.backgroundColor = theme.colors.layer1
-        resultsController.view.backgroundColor = theme.colors.layer1
         resultsController.tableView.backgroundColor = theme.colors.layer1
         resultsController.theme = theme
         searchController.searchBar.tintColor = theme.colors.actionPrimary

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationLanguagePickerViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationLanguagePickerViewControllerTests.swift
@@ -84,7 +84,7 @@ final class TranslationLanguagePickerViewControllerTests: XCTestCase, StoreTestU
             supportedLanguages: ["fr", "de"]
         )
         subject.loadViewIfNeeded()
-        subject.resultsController.filteredLanguages = ["fr", "de"]
+        subject.resultsController.configure(filteredLanguages: ["fr", "de"])
 
         subject.resultsController.tableView(
             subject.resultsController.tableView,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationLanguagePickerViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationLanguagePickerViewControllerTests.swift
@@ -64,7 +64,7 @@ final class TranslationLanguagePickerViewControllerTests: XCTestCase, StoreTestU
 
     // MARK: - Search filtering
 
-    func test_updateSearchResults_withEmptyQuery_showsAllLanguages() {
+    func test_updateSearchResults_withEmptyQuery_populatesResultsWithAllLanguages() {
         let subject = createSubject(
             preferredLanguages: [],
             supportedLanguages: ["en", "fr", "de"]
@@ -73,24 +73,28 @@ final class TranslationLanguagePickerViewControllerTests: XCTestCase, StoreTestU
 
         subject.updateSearchResults(for: UISearchController())
 
-        XCTAssertEqual(subject.tableView(UITableView(), numberOfRowsInSection: 0), 3)
+        XCTAssertEqual(subject.resultsController.filteredLanguages.count, 3)
     }
 
     // MARK: - Selection
 
-    func test_didSelectRow_dispatchesAddLanguageAction() throws {
+    func test_didSelectRowInResults_dispatchesAddLanguageAction() throws {
         let subject = createSubject(
             preferredLanguages: [],
             supportedLanguages: ["fr", "de"]
         )
         subject.loadViewIfNeeded()
+        subject.resultsController.filteredLanguages = ["fr", "de"]
 
-        subject.tableView(UITableView(), didSelectRowAt: IndexPath(row: 0, section: 0))
+        subject.resultsController.tableView(
+            subject.resultsController.tableView,
+            didSelectRowAt: IndexPath(row: 0, section: 0)
+        )
 
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationSettingsViewAction)
         let dispatchedActionType = try XCTUnwrap(dispatchedAction.actionType as? TranslationSettingsViewActionType)
         XCTAssertEqual(dispatchedActionType, TranslationSettingsViewActionType.addLanguage)
-        XCTAssertNotNil(dispatchedAction.languageCode)
+        XCTAssertEqual(dispatchedAction.languageCode, "fr")
     }
 
     // MARK: - StoreTestUtility


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15583)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Tapping a filtered row in the language picker would dismiss only the search overlay, leaving the picker on screen and the selection seemingly lost. Root cause: the view controller was using UISearchController(searchResultsController: nil) with in-place filtering on its own table view, which makes UIKit treat taps on result rows as "tap outside the search UI" and deactivate the search instead of forwarding the tap to the cell.

Follow Apple's TableSearch sample pattern: introduce a dedicated TranslationLanguagePickerResultsController as the searchResultsController, have it own its own didSelectRowAt and invoke an onSelectLanguage callback. Route both tables (main and results) through a shared addLanguage helper that dispatches the Redux action and calls presentingViewController?.dismiss to tear down the full modal stack, including the search overlay.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |


Before


https://github.com/user-attachments/assets/731de36a-139f-4d67-b805-585d89adf0e3

After


https://github.com/user-attachments/assets/f3f033a5-da31-4b1c-8d6d-74faa005fab9





<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

