### PR TITLE
Bugfix FXIOS-15580 Fix flaky test_didSelectTargetLanguage_dispatchAction

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -295,27 +295,30 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: TranslationsActionType.didSelectTargetLanguage
         )
 
-        let expectation = XCTestExpectation(
-            description: "expect didStartTranslatingPage, translationCompleted action to be fired"
-        )
-        expectation.expectedFulfillmentCount = 2
-        mockStore.dispatchCalled = { expectation.fulfill() }
+        let didStartExpectation = XCTestExpectation(description: "didStartTranslatingPage dispatched")
+        let completedExpectation = XCTestExpectation(description: "translationCompleted dispatched")
+        mockStore.dispatchCalled = { [weak mockStore] in
+            guard let type = mockStore?.dispatchedActions.last?.actionType as? ToolbarActionType else { return }
+            switch type {
+            case .didStartTranslatingPage: didStartExpectation.fulfill()
+            case .translationCompleted: completedExpectation.fulfill()
+            default: break
+            }
+        }
         subject.translationsProvider(mockStore.state, action)
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [didStartExpectation, completedExpectation], timeout: 3.0, enforceOrder: true)
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
+        let toolbarActions = mockStore.dispatchedActions.compactMap { $0 as? ToolbarAction }
+        let didStart = try XCTUnwrap(toolbarActions.first {
+            ($0.actionType as? ToolbarActionType) == .didStartTranslatingPage
+        })
+        let completed = try XCTUnwrap(toolbarActions.first {
+            ($0.actionType as? ToolbarActionType) == .translationCompleted
+        })
 
-        let firstActionCalled = try XCTUnwrap(mockStore.dispatchedActions[0] as? ToolbarAction)
-        let firstActionType = try XCTUnwrap(firstActionCalled.actionType as? ToolbarActionType)
-
-        let secondActionCalled = try XCTUnwrap(mockStore.dispatchedActions[1] as? ToolbarAction)
-        let secondActionType = try XCTUnwrap(secondActionCalled.actionType as? ToolbarActionType)
-
-        XCTAssertEqual(firstActionCalled.translationConfiguration?.state, .loading)
-        XCTAssertEqual(firstActionType, ToolbarActionType.didStartTranslatingPage)
-        XCTAssertEqual(secondActionCalled.translationConfiguration?.state, .active)
-        XCTAssertEqual(secondActionType, ToolbarActionType.translationCompleted)
+        XCTAssertEqual(didStart.translationConfiguration?.state, .loading)
+        XCTAssertEqual(completed.translationConfiguration?.state, .active)
 
         XCTAssertEqual(mockTranslationsTelemetry.translateButtonTappedCalledCount, 1)
         XCTAssertEqual(mockTranslationsTelemetry.lastActionType, .willTranslate)


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33378)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Filter dispatchCalled fulfillment by the expected ToolbarActionType cases, enforce order between didStartTranslatingPage and translationCompleted, bump the wait timeout to 3.0s, and read dispatched actions by type-filter instead of by array index so an under-fulfilled run fails cleanly via XCTUnwrap rather than crashing on out-of-bounds access.


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


