### PR TITLE
Refactor FXIOS-15197 [Quick Answers] search result to include sources

### DIFF
--- a/BrowserKit/Sources/QuickAnswersKit/Backend/MockQuickAnswersService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/MockQuickAnswersService.swift
@@ -43,11 +43,8 @@ struct MockQuickAnswersService: QuickAnswersService {
         }
         return .success(
             SearchResult(
-                title: "The weather in Paris is cloudy",
-                body: "The weather is cloudy with a chance of rain at 18:00",
-                url: URL(
-                    string: "https://weather.com/weather/today"
-                )
+                resultText: "The weather is cloudy with a chance of rain at 18:00",
+                sources: [SearchResult.Source(title: "Weather Channel", thumbnailURL: nil, faviconURL: nil)]
             )
         )
     }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/QuickAnswersService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/QuickAnswersService.swift
@@ -14,12 +14,17 @@ struct SpeechResult: Equatable {
 }
 
 struct SearchResult: Equatable {
-    let title: String
-    let body: String
-    let url: URL?
+    struct Source: Equatable {
+        let title: String
+        let thumbnailURL: URL?
+        let faviconURL: URL?
+    }
+
+    let resultText: String
+    let sources: [SearchResult.Source]
 
     static func empty() -> Self {
-        return SearchResult(title: "", body: "", url: nil)
+        return SearchResult(resultText: "", sources: [])
     }
 }
 

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
@@ -22,22 +22,16 @@ final class DefaultResultsService: ResultsService {
 
     func fetchResults(for transcription: String) async throws -> SearchResult {
         let message = LiteLLMMessage(role: .user, content: transcription)
-        guard let stream = try await requestChatCompletion(for: message) else {
-            // TODO: FXIOS-15196 - Remove error once LLMCLient is not nil
-            throw SpeechError.unknown
-        }
-
-        var fullResponse = ""
-        for try await chunk in stream {
-            fullResponse += chunk
-        }
-
+        // TODO: FXIOS-15198 - Handle mapping errors from request
+        let fullResponse = try await requestChatCompletion(for: message)
         return try formatResult(from: fullResponse)
     }
 
-    private func requestChatCompletion(for message: LiteLLMMessage) async throws -> AsyncThrowingStream<String, Error>? {
+    private func requestChatCompletion(for message: LiteLLMMessage) async throws -> String {
         // TODO: FXIOS-15198 Handle errors appropriately
-        return try await client.requestChatCompletionStreamed(
+        // and may need to change type and not use String,
+        // but waiting for what we get on server side
+        return try await client.requestChatCompletion(
             messages: [message],
             config: config
         )
@@ -45,7 +39,13 @@ final class DefaultResultsService: ResultsService {
 
     private func formatResult(from response: String) throws -> SearchResult {
         // TODO: FXIOS-15197 - Implement parsing logic based on response format and update Search Result
-        // depending on UI to be a stream instead. For now, return the full response as the body.
-        return SearchResult(title: "Quick Answer", body: response, url: nil)
+        return SearchResult(
+            resultText: response,
+            sources: [SearchResult.Source(
+                title: "",
+                thumbnailURL: nil,
+                faviconURL: nil
+            )]
+        )
     }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersContentView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersContentView.swift
@@ -140,7 +140,7 @@ final class QuickAnswersContentView: UIView, ThemeApplicable {
         }
     }
 
-    func configureSources(_ items: [QuickAnswersSourceCell.Item]) {
+    func configureSources(_ items: [SearchResult.Source]) {
         sourceView.configure(with: items)
         UIView.animate(withDuration: UX.animationDuration) { [self] in
             sourceView.alpha = 1.0

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
@@ -19,12 +19,6 @@ final class QuickAnswersSourceCell: UICollectionViewCell, ReusableCell, ThemeApp
         static let faviconCornerRadius: CGFloat = faviconSize / 2.0
     }
 
-    struct Item {
-        let title: String
-        let thumbnailURL: URL?
-        let faviconURL: URL?
-    }
-
     private let thumbnailImageView: HeroImageView = .build()
     private let faviconImageView: FaviconImageView = .build {
         $0.contentMode = .scaleAspectFill
@@ -75,7 +69,7 @@ final class QuickAnswersSourceCell: UICollectionViewCell, ReusableCell, ThemeApp
     }
 
     // MARK: - Configuration
-    func configure(with item: Item) {
+    func configure(with item: SearchResult.Source) {
         if let thumbnailURLString = item.thumbnailURL?.absoluteString {
             let heroImageViewModel = DefaultHeroImageViewModel(
                 urlStringRequest: thumbnailURLString,
@@ -148,7 +142,7 @@ final class QuickAnswersSourceView: UIView,
         return collectionView
     }()
 
-    private var items: [QuickAnswersSourceCell.Item] = []
+    private var items: [SearchResult.Source] = []
     private var theme: Theme?
     private var contentSizeObservation: NSKeyValueObservation?
 
@@ -199,7 +193,7 @@ final class QuickAnswersSourceView: UIView,
     }
 
     // MARK: - Configuration
-    func configure(with items: [QuickAnswersSourceCell.Item]) {
+    func configure(with items: [SearchResult.Source]) {
         self.items = items
         collectionView.reloadData()
     }

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
@@ -201,7 +201,8 @@ public final class QuickAnswersViewController: UIViewController, Themeable {
                 self?.audioWaveform.stopAnimating()
                 self?.contentView.configureSearching()
             case .showSearchResult(let result, _):
-                self?.contentView.configureAnswer(result.body)
+                self?.contentView.configureAnswer(result.resultText)
+                self?.contentView.configureSources(result.sources)
             }
         }
         viewModel.startRecordingVoice()

--- a/BrowserKit/Tests/QuickAnswersKitTests/QuickAnswersViewModelTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/QuickAnswersViewModelTests.swift
@@ -23,7 +23,14 @@ final class QuickAnswersViewModelTests: XCTestCase {
     func testStartRecordingVoice_receivesSpeechResult_triggersSearch() {
         let partialResult = SpeechResult(text: "Hello", isFinal: false)
         let finalResult = SpeechResult(text: "Hello world", isFinal: true)
-        let searchResult = SearchResult(title: "Test", body: "Body", url: nil)
+        let searchResult = SearchResult(
+            resultText: "Test",
+            sources: [SearchResult.Source(
+                title: "SourceTest",
+                thumbnailURL: nil,
+                faviconURL: nil
+            )]
+        )
         mockService.speechResults = [partialResult, finalResult]
         mockService.searchResult = .success(searchResult)
         let expectation = XCTestExpectation()
@@ -92,7 +99,14 @@ final class QuickAnswersViewModelTests: XCTestCase {
 
     func testStopRecordingVoice_withRecentResult_triggersSearch() {
         let finalResult = SpeechResult(text: "Hello", isFinal: true)
-        let searchResult = SearchResult(title: "Test", body: "Test", url: nil)
+        let searchResult = SearchResult(
+            resultText: "Test",
+            sources: [SearchResult.Source(
+                title: "SourceTest",
+                thumbnailURL: nil,
+                faviconURL: nil
+            )]
+        )
         mockService.speechResults = [finalResult]
         mockService.searchResult = .success(searchResult)
 

--- a/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/DefaultResultsServiceTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/DefaultResultsServiceTests.swift
@@ -12,33 +12,18 @@ struct DefaultResultsServiceTests {
     let testHelper = SwiftTestingHelper()
 
     @Test
-    func test_fetchResults_returnsResultFromSingleChunk() async throws {
+    func test_fetchResults_returnsResult() async throws {
         let client = MockLiteLLMClient()
         client.respondWith = ["This is a quick answer"]
         let subject = createSubject(client: client)
 
         let result = try await subject.fetchResults(for: "What is the weather?")
 
-        #expect(result.body == "This is a quick answer")
-        #expect(result.title == "Quick Answer")
-        #expect(client.requestChatCompletionStreamedCallCount == 1)
+        #expect(result.resultText == "This is a quick answer")
+        #expect(result.sources.count == 1)
+        #expect(client.requestChatCompletionCallCount == 1)
         #expect(client.lastMessages?.count == 1)
         #expect(client.lastMessages?.first?.content == "What is the weather?")
-        #expect(client.lastMessages?.first?.role == .user)
-    }
-
-    @Test
-    func test_fetchResults_accumulatesMultipleChunks() async throws {
-        let client = MockLiteLLMClient()
-        client.respondWith = ["The ", "weather ", "is ", "sunny"]
-        let subject = createSubject(client: client)
-
-        let result = try await subject.fetchResults(for: "weather today")
-
-        #expect(result.body == "The weather is sunny")
-        #expect(client.requestChatCompletionStreamedCallCount == 1)
-        #expect(client.lastMessages?.count == 1)
-        #expect(client.lastMessages?.first?.content == "weather today")
         #expect(client.lastMessages?.first?.role == .user)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15197)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32704)

## :bulb: Description
Update `SearchResult` to also include sources details. While we are still waiting for the actual response from the server, this is closer to what is expected and matches the UI more that the previous `SearchResult`. We also only care about completion and not streamed option for the results so change the method we are hitting.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

