### PR TITLE
Add FXIOS-15406 [Newsfeed Categories] Improved newsfeed header transition

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/ChipPickerView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ChipPickerView.swift
@@ -31,7 +31,6 @@ public final class ChipPickerView: UIView, ThemeApplicable, UIScrollViewDelegate
 
     override public init(frame: CGRect) {
         super.init(frame: frame)
-        clipsToBounds = false
         setupLayout()
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -98,7 +98,7 @@ final class HomepageDiffableDataSource:
         state: HomepageState,
         selectedNewsfeedCategoryID: String? = nil,
         jumpBackInDisplayConfig: JumpBackInSectionLayoutConfiguration,
-        animatingDifferences: Bool,
+        animatingDifferences: Bool = true,
         completion: (() -> Void)? = nil
     ) {
         var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeItem>()

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -98,6 +98,7 @@ final class HomepageDiffableDataSource:
         state: HomepageState,
         selectedNewsfeedCategoryID: String? = nil,
         jumpBackInDisplayConfig: JumpBackInSectionLayoutConfiguration,
+        animatingDifferences: Bool,
         completion: (() -> Void)? = nil
     ) {
         var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeItem>()
@@ -151,7 +152,7 @@ final class HomepageDiffableDataSource:
             snapshot.appendItems(stories, toSection: pocketSection)
         }
 
-        apply(snapshot, animatingDifferences: true, completion: completion)
+        apply(snapshot, animatingDifferences: animatingDifferences, completion: completion)
     }
 
     /// Gets the proper amount of top sites based on layout configuration

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -388,9 +388,10 @@ final class HomepageViewController: UIViewController,
         // TODO: - FXIOS-13346 / FXIOS-13343 - fix collection view being reloaded all the time also when data don't change
         // this is a quick workaround to avoid blocking the main thread by calling apply snapshot many times.
         if homepageState != state {
+            let animatingDifferences = state.availableContentHeight == homepageState.availableContentHeight
             self.homepageState = state
 
-            refreshHomepageDataSourceSnapshot { [weak self] in
+            refreshHomepageDataSourceSnapshot(animatingDifferences: animatingDifferences) { [weak self] in
                 self?.collectionView?.layoutIfNeeded()
                 self?.updateNewsTransitionHeaderProgress()
             }
@@ -722,7 +723,7 @@ final class HomepageViewController: UIViewController,
         at indexPath: IndexPath,
         with newsTransitionHeaderCell: NewsTransitionHeaderCell
     ) -> NewsTransitionHeaderCell {
-        let transitionEnabled = isNewsTransitionEnabled(for: collectionView, at: indexPath)
+        let transitionEnabled = isNewsTransitionEnabled()
         newsTransitionHeaderCell.configure(
             sectionHeaderConfiguration: MerinoState.Constants.sectionHeaderConfiguration,
             textColor: homepageState.wallpaperState.wallpaperConfiguration.textColor,
@@ -788,6 +789,18 @@ final class HomepageViewController: UIViewController,
 
     /// Updates the `NewsTransitionHeaderCell`s transition progress
     private func updateNewsTransitionHeaderProgress() {
+        guard let headerView = getNewsTransitionHeader()  else { return }
+
+        // We only want the stories header to transition if there is enough empty space on the homepage,
+        // which is denoted by the existence of the spacer
+        let transitionEnabled = isNewsTransitionEnabled()
+        headerView.setTransitionEnabled(transitionEnabled)
+        headerView.setTransitionProgress(newsTransitionProgress())
+    }
+
+    /// Returns whether there is enough room at the bottom of the unscrolled homepage for the header to transition.
+    /// This is determined by the existence of the spacer with a meaningful height
+    private func isNewsTransitionEnabled() -> Bool {
         guard MerinoState.Constants.sectionHeaderConfiguration.style == .newsAffordance,
               let collectionView,
               let spacerSectionIndex = dataSource?.snapshot().sectionIdentifiers.firstIndex(where: {
@@ -797,30 +810,12 @@ final class HomepageViewController: UIViewController,
                   return false
               }),
               let spacerAttributes = collectionView.layoutAttributesForItem(at: IndexPath(item: 0,
-                                                                                          section: spacerSectionIndex)),
-              let headerView = getNewsTransitionHeader()
+                                                                                          section: spacerSectionIndex))
         else {
-            return
+            return true
         }
 
-        // We only want the stories header to transition if there is enough empty space on the homepage,
-        // which is denoted by the existence of the spacer
-        let transitionEnabled = spacerAttributes.size.height > 0.1
-        headerView.setTransitionEnabled(transitionEnabled)
-        headerView.setTransitionProgress(newsTransitionProgress())
-    }
-
-    /// Returns whether the pocket header is currently in the affordance-height layout state.
-    /// We use the header height as the source of truth for whether the news affordance transition should be active
-    /// since it is only active when there is room for the affordance at the bottom of the unscrolled homepage
-    private func isNewsTransitionEnabled(for collectionView: UICollectionView, at indexPath: IndexPath) -> Bool {
-        let headerHeight = collectionView.layoutAttributesForSupplementaryElement(
-            ofKind: UICollectionView.elementKindSectionHeader,
-            at: indexPath
-        )?.size.height ?? 0
-        let expectedHeaderHeight = HomepageDimensionCalculator.fittingHeight(for: NewsTransitionHeaderCell(),
-                                                                             width: collectionView.bounds.width)
-        return headerHeight >= expectedHeaderHeight
+        return spacerAttributes.size.height > 0.1
     }
 
     /// Converts the homepage's vertical scroll offset into normalized transition progress for the
@@ -1067,11 +1062,12 @@ final class HomepageViewController: UIViewController,
         }
     }
 
-    private func refreshHomepageDataSourceSnapshot(completion: (() -> Void)? = nil) {
+    private func refreshHomepageDataSourceSnapshot(animatingDifferences: Bool = true, completion: (() -> Void)? = nil) {
         dataSource?.updateSnapshot(
             state: homepageState,
             selectedNewsfeedCategoryID: currentHomepageTabState.selectedNewsfeedCategoryID,
-            jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
+            jumpBackInDisplayConfig: getJumpBackInDisplayConfig(),
+            animatingDifferences: animatingDifferences
         ) {
             completion?()
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -50,6 +50,7 @@ final class HomepageSectionLayoutProvider: LegacyFeatureFlaggable {
             static let minimumCellsPerRow = 1
             static let interItemSpacing: CGFloat = 16
             static let interGroupSpacing: CGFloat = 16
+            static let newsHeaderZIndex = -1
 
             /// `storiesPeekOffset` is how much we want the stories (cards only, not including section header/spacing)
             /// to peek in vertically from the bottom of the homepage viewport (above the fold)
@@ -213,11 +214,7 @@ final class HomepageSectionLayoutProvider: LegacyFeatureFlaggable {
         return section
     }
 
-    private func createStoriesSectionLayout(for environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
-        return createVerticalStoriesSectionLayout(for: environment)
-    }
-
-    private func createVerticalStoriesSectionLayout(
+    private func createStoriesSectionLayout(
         for environment: NSCollectionLayoutEnvironment
     ) -> NSCollectionLayoutSection {
         let itemSize: NSCollectionLayoutSize
@@ -272,6 +269,7 @@ final class HomepageSectionLayoutProvider: LegacyFeatureFlaggable {
             elementKind: UICollectionView.elementKindSectionHeader,
             alignment: .top
         )
+        header.zIndex = UX.PocketConstants.newsHeaderZIndex
         section.boundarySupplementaryItems = [header]
 
         section.contentInsets = NSDirectionalEdgeInsets(

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
@@ -13,17 +13,17 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
     struct UX {
         /// The scroll distance of the homepage over which the headers will crossfade
         static let transitionDistance: CGFloat = 96
+        /// Overall header transition progress where the picker starts moving; 0.2 means 20% into the transition.
+        static let pickerTranslationStartProgress: CGFloat = 0.2
     }
 
-    private lazy var newsAffordanceContentView: NewsAffordanceHeaderView = .build()
+    private lazy var newsAffordanceHeaderView: NewsAffordanceHeaderView = .build()
     private lazy var sectionTitleHeaderView: LabelButtonHeaderView = .build()
     private lazy var storyCategoryPickerView: StoryCategoryPickerView = .build()
-    private lazy var sectionTitleStackView: UIStackView = .build { stackView in
-        stackView.axis = .vertical
-        stackView.alignment = .fill
-        stackView.distribution = .fill
-    }
+    private lazy var headerContainerView: UIView = .build()
 
+    private var headerContainerHeightConstraint: NSLayoutConstraint?
+    private var hasCategories = false
     private var progress: CGFloat = 0
     private var transitionEnabled = true
 
@@ -43,20 +43,19 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         super.prepareForReuse()
         progress = 0
         transitionEnabled = true
+        hasCategories = false
         sectionTitleHeaderView.prepareForReuse()
         updateViewState()
     }
 
+    /// Report the stable layout height for the header's resting content.
+    /// The affordance is treated as an overlay during the transition, so layout only reserves space
+    /// for the section title (plus picker when categories are present).
     override func systemLayoutSizeFitting(
         _ targetSize: CGSize,
         withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
         verticalFittingPriority: UILayoutPriority
     ) -> CGSize {
-        let affordanceSize = newsAffordanceContentView.systemLayoutSizeFitting(
-            targetSize,
-            withHorizontalFittingPriority: horizontalFittingPriority,
-            verticalFittingPriority: verticalFittingPriority
-        )
         let headerSize = sectionTitleHeaderView.systemLayoutSizeFitting(
             targetSize,
             withHorizontalFittingPriority: horizontalFittingPriority,
@@ -67,10 +66,9 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
             withHorizontalFittingPriority: horizontalFittingPriority,
             verticalFittingPriority: verticalFittingPriority
         )
-        return CGSize(
-            width: affordanceSize.width,
-            height: max(affordanceSize.height, headerSize.height + pickerSize.height)
-        )
+
+        let headerHeight = hasCategories ? headerSize.height + pickerSize.height : headerSize.height
+        return CGSize(width: max(headerSize.width, pickerSize.width), height: headerHeight)
     }
 
     func configure(
@@ -85,7 +83,7 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         onSelection: (@MainActor @Sendable (String?) -> Void)? = nil
     ) {
         self.transitionEnabled = transitionEnabled
-        newsAffordanceContentView.applyTheme(theme: theme)
+        newsAffordanceHeaderView.applyTheme(theme: theme)
         sectionTitleHeaderView.configure(
             sectionHeaderConfiguration: sectionHeaderConfiguration,
             moreButtonAction: nil,
@@ -101,6 +99,7 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
             onSelection: onSelection
         )
         storyCategoryPickerView.applyTheme(theme: theme)
+        hasCategories = !categories.isEmpty
 
         updateViewState()
     }
@@ -127,42 +126,106 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
     }
 
     func applyTheme(theme: Theme) {
-        newsAffordanceContentView.applyTheme(theme: theme)
+        newsAffordanceHeaderView.applyTheme(theme: theme)
         sectionTitleHeaderView.applyTheme(theme: theme)
         storyCategoryPickerView.applyTheme(theme: theme)
     }
 
     private func setupLayout() {
-        clipsToBounds = false
+        headerContainerView.addSubview(newsAffordanceHeaderView)
+        headerContainerView.addSubview(sectionTitleHeaderView)
 
-        sectionTitleStackView.addArrangedSubview(sectionTitleHeaderView)
-        sectionTitleStackView.addArrangedSubview(storyCategoryPickerView)
+        addSubview(storyCategoryPickerView)
+        addSubview(headerContainerView)
 
-        addSubview(newsAffordanceContentView)
-        addSubview(sectionTitleStackView)
+        // The crossfading header views are bottom-aligned overlays, so the container needs an explicit
+        // measured height instead of relying on intrinsic height from stacked subviews.
+        let headerContainerHeightConstraint = headerContainerView.heightAnchor.constraint(equalToConstant: 0)
+        headerContainerHeightConstraint.priority = .defaultLow
+        self.headerContainerHeightConstraint = headerContainerHeightConstraint
 
         NSLayoutConstraint.activate([
-            newsAffordanceContentView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            newsAffordanceContentView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            newsAffordanceContentView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            headerContainerHeightConstraint,
 
-            sectionTitleStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            sectionTitleStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            sectionTitleStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            storyCategoryPickerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            storyCategoryPickerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            storyCategoryPickerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            headerContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            headerContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            headerContainerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            newsAffordanceHeaderView.leadingAnchor.constraint(equalTo: headerContainerView.leadingAnchor),
+            newsAffordanceHeaderView.trailingAnchor.constraint(equalTo: headerContainerView.trailingAnchor),
+            newsAffordanceHeaderView.topAnchor.constraint(greaterThanOrEqualTo: headerContainerView.topAnchor),
+            newsAffordanceHeaderView.bottomAnchor.constraint(equalTo: headerContainerView.bottomAnchor),
+
+            sectionTitleHeaderView.leadingAnchor.constraint(equalTo: headerContainerView.leadingAnchor),
+            sectionTitleHeaderView.trailingAnchor.constraint(equalTo: headerContainerView.trailingAnchor),
+            sectionTitleHeaderView.topAnchor.constraint(greaterThanOrEqualTo: headerContainerView.topAnchor),
+            sectionTitleHeaderView.bottomAnchor.constraint(equalTo: headerContainerView.bottomAnchor),
         ])
     }
 
     private func updateViewState() {
+        // Transitioning header + category picker
         if transitionEnabled {
-            newsAffordanceContentView.alpha = 1 - progress
-            sectionTitleStackView.alpha = progress
+            newsAffordanceHeaderView.alpha = 1 - progress
+            sectionTitleHeaderView.alpha = progress
+
+            let pickerProgress = pickerProgress(for: progress)
+            headerContainerView.transform = CGAffineTransform(
+                translationX: 0,
+                y: -pickerTranslationOffset() * pickerProgress
+            )
+            storyCategoryPickerView.alpha = pickerProgress
+            storyCategoryPickerView.transform = CGAffineTransform(
+                translationX: 0,
+                y: pickerTranslationOffset() * (1 - pickerProgress)
+            )
             accessibilityLabel = progress < 0.5
-                ? newsAffordanceContentView.accessibilityLabel
+                ? newsAffordanceHeaderView.accessibilityLabel
                 : sectionTitleHeaderView.title
+
+        // Static section title header + category picker
         } else {
-            newsAffordanceContentView.alpha = 0
-            sectionTitleStackView.alpha = 1
+            newsAffordanceHeaderView.alpha = 0
+            sectionTitleHeaderView.alpha = 1
+            headerContainerView.transform = CGAffineTransform(
+                translationX: 0,
+                y: -pickerTranslationOffset()
+            )
+            storyCategoryPickerView.alpha = hasCategories ? 1 : 0
+            storyCategoryPickerView.transform = .identity
             accessibilityLabel = sectionTitleHeaderView.title
         }
+    }
+
+    /// Map the overall scroll progress onto a delayed 0...1 range so the category
+    /// picker begins revealing only after the header crossfade has started.
+    private func pickerProgress(for progress: CGFloat) -> CGFloat {
+        guard hasCategories else { return 0 }
+
+        let start = UX.pickerTranslationStartProgress
+        guard progress > start else { return 0 }
+        return min(max((progress - start) / (1 - start), 0), 1)
+    }
+
+    /// Use the picker's height as the translation distance.
+    /// Prefer the real laid-out bounds and falling back to a fitting measurement
+    private func pickerTranslationOffset() -> CGFloat {
+        guard hasCategories else { return 0 }
+
+        if storyCategoryPickerView.bounds.height > 0 {
+            return storyCategoryPickerView.bounds.height
+        }
+
+        let targetSize = CGSize(width: bounds.width, height: UIView.layoutFittingCompressedSize.height)
+        let pickerSize = storyCategoryPickerView.systemLayoutSizeFitting(
+            targetSize,
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        return pickerSize.height
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/NewsTransitionHeaderCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/NewsTransitionHeaderCellTests.swift
@@ -30,7 +30,7 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
         view.layoutIfNeeded()
 
         XCTAssertEqual(affordanceView(in: view)?.alpha, 1)
-        XCTAssertEqual(sectionTitleStackView(in: view)?.alpha, 0)
+        XCTAssertEqual(labelHeaderView(in: view)?.alpha, 0)
     }
 
     func test_configure_withTransitionEnabledAndFullProgress_showsSectionTitle() {
@@ -47,7 +47,7 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
         view.layoutIfNeeded()
 
         XCTAssertEqual(affordanceView(in: view)?.alpha, 0)
-        XCTAssertEqual(sectionTitleStackView(in: view)?.alpha, 1)
+        XCTAssertEqual(labelHeaderView(in: view)?.alpha, 1)
     }
 
     func test_configure_withTransitionDisabled_showsSectionTitleOnly() {
@@ -64,7 +64,7 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
         view.layoutIfNeeded()
 
         XCTAssertEqual(affordanceView(in: view)?.alpha, 0)
-        XCTAssertEqual(sectionTitleStackView(in: view)?.alpha, 1)
+        XCTAssertEqual(labelHeaderView(in: view)?.alpha, 1)
     }
 
     func test_updatePickerState_updatesCategorySelection() {
@@ -126,10 +126,6 @@ final class NewsTransitionHeaderCellTests: XCTestCase {
 
     private func labelHeaderView(in view: UIView) -> LabelButtonHeaderView? {
         return allSubviews(in: view).compactMap { $0 as? LabelButtonHeaderView }.first
-    }
-
-    private func sectionTitleStackView(in view: UIView) -> UIStackView? {
-        return allSubviews(in: view).compactMap { $0 as? UIStackView }.first
     }
 
     private func button(withA11yID a11yID: String, in view: UIView) -> UIButton? {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15406)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33027)

## :bulb: Description
- Improve the newsfeed header transition by aligning "News" header labels and applying a translation to the category picker

### 📝 Technical Notes:
- Category picker translation transition is delayed to begin at 20% of the way through the header crossfade transition
- Disable diffable data source snapshot update animations for homepage snapshot updates when `availableContentHeight` changes, so transient layout updates such as rotation do not visibly animate intermediate states.

## :movie_camera: Demos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/2f59aeb3-cd37-441d-b7ee-951934b3e2b0

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/17a2bc2d-ff8e-4e80-b0e8-bfbbd796f6ed

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

