### PR TITLE
FXIOS-15595 [Redux] Break up @CopyWithUpdates generated expressions to avoid type-check timeout

### DIFF
--- a/CopyWithUpdatesMacro/Sources/CopyWithUpdatesMacros/CopyWithUpdates.swift
+++ b/CopyWithUpdatesMacro/Sources/CopyWithUpdatesMacros/CopyWithUpdates.swift
@@ -43,7 +43,8 @@ public struct CopyWithUpdatesMacro: MemberMacro {
 
         // Based on the each property's name and type, construct the copyWith function arguments and internal assignments
         var arguments: [String] = []
-        var assignments: [String] = []
+        var resolvedAssignments: [String] = []
+        var initializerAssignments: [String] = []
 
         for binding in bindings {
             guard let propertyName = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
@@ -58,6 +59,7 @@ public struct CopyWithUpdatesMacro: MemberMacro {
 
             // Strip comments after the property definition
             let propertyTypeString = stripCommentsFromTypeDefinition(ofProperty: propertyType.description)
+            let resolvedVariableName = "_new_\(propertyName)"
 
             if propertyType.is(OptionalTypeSyntax.self) {
                 /// Optionals are treated as double optionals (`??`)
@@ -65,18 +67,22 @@ public struct CopyWithUpdatesMacro: MemberMacro {
 
                 /// We treat a top-level `nil` argument semantically as setting the property to `nil`, instead of passing
                 /// `.some(nil)`, which would feel odd at call sites.
-                assignments.append("\(propertyName): \(propertyName).map { $0 ?? self.\(propertyName) } ?? nil")
+                resolvedAssignments.append("let \(resolvedVariableName) = \(propertyName).map { $0 ?? self.\(propertyName) } ?? nil")
             } else {
                 arguments.append("\(propertyName): \(propertyTypeString)? = nil")
-                assignments.append("\(propertyName): \(propertyName) ?? self.\(propertyName)")
+                resolvedAssignments.append("let \(resolvedVariableName) = \(propertyName) ?? self.\(propertyName)")
             }
+
+            initializerAssignments.append("\(propertyName): \(resolvedVariableName)")
         }
 
         // Construct the return statement with proper syntax
         let copyWithFunction = try FunctionDeclSyntax("public func copyWithUpdates(\(raw: arguments.joined(separator: ", "))) -> Self") {
             return """
+                \(raw: resolvedAssignments.joined(separator: "\n"))
+
                 return Self(
-                \(raw: assignments.joined(separator: ",\n"))
+                \(raw: initializerAssignments.joined(separator: ",\n"))
                 )
             """
         }
@@ -152,3 +158,4 @@ struct CopyWithUpdatesPlugin: CompilerPlugin {
         CopyWithUpdatesMacro.self,
     ]
 }
+

--- a/CopyWithUpdatesMacro/Sources/CopyWithUpdatesMacros/CopyWithUpdates.swift
+++ b/CopyWithUpdatesMacro/Sources/CopyWithUpdatesMacros/CopyWithUpdates.swift
@@ -158,4 +158,3 @@ struct CopyWithUpdatesPlugin: CompilerPlugin {
         CopyWithUpdatesMacro.self,
     ]
 }
-


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15595)  
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33407)

## :bulb: Description
This PR fixes a compiler type-check timeout caused by code generated by `@CopyWithUpdates`.

`CopyWithUpdatesMacro` currently generates `copyWithUpdates(...)` as one large `return Self(...)` expression,which is correct, but expression can become too complex and trigger compiler failure at scale, which is happening while migrating some state files where there are multiple optional heavy expressions.

For optional fields, generated code includes:

`field.map { $0 ?? self.field } ?? nil`

With many fields (especially optional-handling closures), Swift may fail to type-check in reasonable time and throw errors in macro-expanded files.

### Solution
macro expansion now generates:

1. A local `let` binding for each resolved field value.
2. A final `return Self(...)` that only passes precomputed variables.

Conceptually changed from inline resolution inside `Self(...)`:

```swift
Self(
  a: a.map { $0 ?? self.a } ?? nil,
  b: b.map { $0 ?? self.b } ?? nil,
  c: c.map { $0 ?? self.c } ?? nil
)
```

to precomputed values and construction:

```swift
let newA = a.map { $0 ?? self.a } ?? nil
let newB = b.map { $0 ?? self.b } ?? nil

return Self(
  a: newA,
  b: newB
)
```

### Testing
I tested this change by building affected issue branches that previously failed with:

`@__swiftmacro_6Client26........15CopyWithUpdatesfMm_.swift:2:12 The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions`

All those builds completed successfully after this change.

fixes: #33322 #33312 #33311 #33315

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [] If needed, I updated documentation and added comments to complex code