### PR TITLE
Small clipboard test fix

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
@@ -84,7 +84,7 @@ class ClipBoardTests: BaseTestCase {
                 urlBarAddress.press(forDuration: 1)
             }
             app.otherElements.buttons["Paste"].waitAndTap()
-            mozWaitForValueContains(urlBarAddress, value: "http://www.example.com/")
+            mozWaitForValueContains(urlBarAddress, value: "https://www.example.com/")
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets


## :bulb: Description
Small fix for testClipboard, adding "https" in the URL

