### PR TITLE
Add [World Cup] FXIOS-15596 Homepage settings to enable/disable world cup widget

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -112,6 +112,7 @@ public struct PrefsKeys {
     public struct HomepageSettings {
         public static let BookmarksSection = "BookmarksSectionUserPrefsKey"
         public static let JumpBackInSection = "JumpBackInSectionUserPrefsKey"
+        public static let WorldCupSection = "WorldCupSectionUserPrefsKey"
     }
 
     public struct SearchSettings {

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1621,6 +1621,7 @@
 		C2D71B972A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D71B962A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift */; };
 		C2D71B992A384F6A003DEC7A /* ThemedLeftAlignedTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D71B982A384F6A003DEC7A /* ThemedLeftAlignedTableViewCell.swift */; };
 		C2D71B9B2A3850B4003DEC7A /* ThemedTableViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D71B9A2A3850B4003DEC7A /* ThemedTableViewCellViewModel.swift */; };
+		C2D7AC3D2F9B5DC30090EC28 /* WorldCupAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D7AC3C2F9B5DC30090EC28 /* WorldCupAction.swift */; };
 		C2D80BE72AADE38100CDF7A9 /* CredentialAutofillCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D80BE62AADE38100CDF7A9 /* CredentialAutofillCoordinator.swift */; };
 		C2D80BEB2AAF395200CDF7A9 /* CredentialAutofillCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D80BEA2AAF395200CDF7A9 /* CredentialAutofillCoordinatorTests.swift */; };
 		C2D80BED2AAF3C6B00CDF7A9 /* MockBrowserCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D80BEC2AAF3C6B00CDF7A9 /* MockBrowserCoordinator.swift */; };
@@ -10327,6 +10328,7 @@
 		C2D71B962A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedSubtitleTableViewCell.swift; sourceTree = "<group>"; };
 		C2D71B982A384F6A003DEC7A /* ThemedLeftAlignedTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedLeftAlignedTableViewCell.swift; sourceTree = "<group>"; };
 		C2D71B9A2A3850B4003DEC7A /* ThemedTableViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedTableViewCellViewModel.swift; sourceTree = "<group>"; };
+		C2D7AC3C2F9B5DC30090EC28 /* WorldCupAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupAction.swift; sourceTree = "<group>"; };
 		C2D80BE62AADE38100CDF7A9 /* CredentialAutofillCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialAutofillCoordinator.swift; sourceTree = "<group>"; };
 		C2D80BEA2AAF395200CDF7A9 /* CredentialAutofillCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialAutofillCoordinatorTests.swift; sourceTree = "<group>"; };
 		C2D80BEC2AAF3C6B00CDF7A9 /* MockBrowserCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBrowserCoordinator.swift; sourceTree = "<group>"; };
@@ -13947,6 +13949,7 @@
 		8A7D08E12CAAF79F0035999C /* Homepage */ = {
 			isa = PBXGroup;
 			children = (
+				C2D7AC3B2F9B5D750090EC28 /* WorldCup */,
 				8AD8FAF52EBAFA2400FDFD78 /* HomepageUX.swift */,
 				C7FA9B672E4B9A13004F2CA1 /* Layout */,
 				8A7C125F2E01DB0600F2D7FA /* SearchBar */,
@@ -14965,6 +14968,14 @@
 				0AD3EEAB2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift */,
 			);
 			path = ThemedTableViewCells;
+			sourceTree = "<group>";
+		};
+		C2D7AC3B2F9B5D750090EC28 /* WorldCup */ = {
+			isa = PBXGroup;
+			children = (
+				C2D7AC3C2F9B5DC30090EC28 /* WorldCupAction.swift */,
+			);
+			path = WorldCup;
 			sourceTree = "<group>";
 		};
 		C2F336E92ECE44740071588A /* Service */ = {
@@ -19006,6 +19017,7 @@
 				8A1CBB992BE01839008BE4D4 /* MicrosurveyPromptState.swift in Sources */,
 				C28094312ECF877D0083BC16 /* TranslationsServiceError.swift in Sources */,
 				23D57E6E25ED6F2700883FAD /* SearchViewController.swift in Sources */,
+				C2D7AC3D2F9B5DC30090EC28 /* WorldCupAction.swift in Sources */,
 				C82A94F2269F68ED00624AA7 /* LegacyFeatureFlagsManager.swift in Sources */,
 				C8610DAA2A0EBF7100B79FF1 /* OnboardingCardDelegate.swift in Sources */,
 				C7CDBEFD2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAction.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Redux
+import Common
+
+struct WorldCupAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: any ActionType
+    let shouldShowHomepageWorldCupSection: Bool
+}
+
+enum WorldCupActionType: ActionType {
+    case didChangeHomepageSettings
+}

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -163,7 +163,7 @@ class HomePageSettingViewController: SettingsTableViewController,
                 )
             }
             sectionItems.append(bookmarksSetting)
-            
+
             if featureFlags.isFeatureEnabled(.worldCupWidget, checking: .buildOnly) {
                 let windowUUID = self.windowUUID
                 let worldCupSetting = BoolSetting(

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -163,6 +163,26 @@ class HomePageSettingViewController: SettingsTableViewController,
                 )
             }
             sectionItems.append(bookmarksSetting)
+            
+            if featureFlags.isFeatureEnabled(.worldCupWidget, checking: .buildOnly) {
+                let windowUUID = self.windowUUID
+                let worldCupSetting = BoolSetting(
+                    prefs: profile.prefs,
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    prefKey: PrefsKeys.HomepageSettings.WorldCupSection,
+                    defaultValue: true,
+                    titleText: .Settings.Homepage.CustomizeFirefoxHome.WorldCup
+                ) { value in
+                    store.dispatch(
+                        WorldCupAction(
+                            windowUUID: windowUUID,
+                            actionType: WorldCupActionType.didChangeHomepageSettings,
+                            shouldShowHomepageWorldCupSection: value
+                        )
+                    )
+                }
+                sectionItems.append(worldCupSetting)
+            }
         }
 
         // TODO: FXIOS-12980: Replace "Stories" title with "Top Stories" string once it is translated in v143

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -961,7 +961,7 @@ extension String {
                 key: "WorldCup.CountryPicker.SkipButton.Title.v151",
                 tableName: "WorldCup",
                 value: "Skip",
-                comment: "Title for the skip button on the country picker for the World Cup widget. This shows to the user that you could skip the selection of a country to follow.")
+                comment: "Label for the skip button on the country picker for the World Cup widget. This shows to the user that you could skip the selection of a country to follow.")
             public static let CloseButtonAccessibilityLabel = MZLocalizedString(
                 key: "WorldCup.CountryPicker.Close.AccessibilityLabel.v151",
                 tableName: "WorldCup",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -957,11 +957,11 @@ extension String {
                 tableName: "WorldCup",
                 value: "Follow Your Team",
                 comment: "Title for the country picker for the World Cup widget. This is shown when the user clicks the widget on the Firefox homepage to allow users to select a team to follow for the World Cup event.")
-            public static let DoneButtonTitle = MZLocalizedString(
-                key: "WorldCup.CountryPicker.DoneButtonTitle.v151",
+            public static let SkipButtonTitle = MZLocalizedString(
+                key: "WorldCup.CountryPicker.SkipButton.Title.v151",
                 tableName: "WorldCup",
-                value: "Done",
-                comment: "Label for the done button on the country picker for the World Cup widget. This allows users to confirm their selection of a team to follow for the World Cup event.")
+                value: "Skip",
+                comment: "Title for the skip button on the country picker for the World Cup widget. This shows to the user that you could skip the selection of a country to follow.")
             public static let CloseButtonAccessibilityLabel = MZLocalizedString(
                 key: "WorldCup.CountryPicker.Close.AccessibilityLabel.v151",
                 tableName: "WorldCup",
@@ -1049,6 +1049,11 @@ extension String {
                 tableName: "WorldCup",
                 value: "Change team",
                 comment: "The label for the button that allows to change the team displayed in the World Cup widget more options panel.")
+            public static let FollowTeamLabel = MZLocalizedString(
+                key: "WorldCup.HomepageWidget.FollowTeamLabel.v151",
+                tableName: "WorldCup",
+                value: "Follow team",
+                comment: "The label for the button that allows to follow a team displayed in the World Cup widget more options panel when no previous team was selected.")
             public static let GetCustomWallpaperLabel = MZLocalizedString(
                 key: "WorldCup.HomepageWidget.GetCustomWallpaperLabel.v151",
                 tableName: "WorldCup",
@@ -1105,6 +1110,11 @@ extension String {
                     tableName: "WorldCup",
                     value: "M",
                     comment: "M is short for Minutes. The layout only allows for 1–2 characters: if there is an equivalent single character for your language, use that (e.g. Mi for German). Your translation will be automatically truncated at 2 characters to avoid layout issues.")
+                public static let ViewScheduleButtonLabel = MZLocalizedString(
+                    key: "WorldCup.HomepageWidget.CountDown.ViewScheduleButtonLabel.v151",
+                    tableName: "WorldCup",
+                    value: "View Schedule",
+                    comment: "Label for the button that takes users to the World Cup schedule website on the countdown section.")
             }
             public struct FollowTeamCard {
                 public static let Title = MZLocalizedString(
@@ -1246,6 +1256,11 @@ extension String {
                     tableName: "WorldCup",
                     value: "Upcoming",
                     comment: "The label for an upcoming match in the World Cup widget round phase.")
+                public static let ThirdPlaceLabel = MZLocalizedString(
+                    key: "WorldCup.HomepageWidget.RoundPhase.ThirdPlaceLabel.v151",
+                    tableName: "WorldCup",
+                    value: "THIRD PLACE",
+                    comment: "The label for the 'Third place' winner in the World Cup widget.")
                 public static let WinWorldCupLabel = MZLocalizedString(
                     key: "WorldCup.HomepageWidget.RoundPhase.WinWorldCupLabel.v151",
                     tableName: "WorldCup",
@@ -9008,6 +9023,11 @@ extension String {
                 value: "**Blocked**: you won’t see and can’t use the feature. For on-device AI, any downloaded models are removed.",
                 comment: "In the AI Controls settings, in the AI powered features section, this is the text that what the blocked status means. The content between the ** ** is bolded. Please do not remove these in translation."
             )
+            public static let DoneButtonTitle = MZLocalizedString(
+                key: "WorldCup.CountryPicker.DoneButtonTitle.v151",
+                tableName: "WorldCup",
+                value: "Done",
+                comment: "Label for the done button on the country picker for the World Cup widget. This allows users to confirm their selection of a team to follow for the World Cup event.")
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
@@ -17,6 +17,7 @@ final class HomePageSettingViewControllerTests: XCTestCase {
         try await super.setUp()
         profile = MockProfile()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
+        setIsWorldCupFeatureFlagEnabled(false)
         DependencyHelperMock().bootstrapDependencies()
         self.profile = MockProfile()
         self.delegate = MockSettingsDelegate()
@@ -78,8 +79,35 @@ final class HomePageSettingViewControllerTests: XCTestCase {
         XCTAssertFalse(bookmarksSectionSettingValue)
     }
 
-    // MARK: - Helper
+    func testHomepageSettings_generateSettings_worldCupSectionDefaultValue_whenFFEnabled_isTrue() throws {
+        let subject = createSubject()
+        subject.profile = profile
+        setIsWorldCupFeatureFlagEnabled(true)
 
+        let settingsList = subject.generateSettings()
+
+        let customizeFirefoxHomeSettingsList = settingsList.first(
+            where: {
+                $0.title?.string == .Settings.Homepage.CustomizeFirefoxHome.Title
+            })
+
+        let worldCupSectionSetting = customizeFirefoxHomeSettingsList?.children.first(
+            where: {
+                ($0 as? BoolSetting)?.prefKey == PrefsKeys.HomepageSettings.WorldCupSection
+            }) as? BoolSetting
+
+        let worldCupSectionSettingValue = try XCTUnwrap(worldCupSectionSetting?.getDefaultValue())
+
+        XCTAssertTrue(worldCupSectionSettingValue)
+    }
+
+    // MARK: - Helper
+    private func setIsWorldCupFeatureFlagEnabled(_ isEnabled: Bool) {
+        FxNimbus.shared.features.worldCupWidgetFeature.with { _,_ in
+            return WorldCupWidgetFeature(enabled: isEnabled)
+        }
+    }
+    
     private func createSubject() -> HomePageSettingViewController {
         let subject = HomePageSettingViewController(prefs: profile.prefs,
                                                     wallpaperManager: wallpaperManager,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
@@ -103,11 +103,11 @@ final class HomePageSettingViewControllerTests: XCTestCase {
 
     // MARK: - Helper
     private func setIsWorldCupFeatureFlagEnabled(_ isEnabled: Bool) {
-        FxNimbus.shared.features.worldCupWidgetFeature.with { _,_ in
+        FxNimbus.shared.features.worldCupWidgetFeature.with { _, _ in
             return WorldCupWidgetFeature(enabled: isEnabled)
         }
     }
-    
+
     private func createSubject() -> HomePageSettingViewController {
         let subject = HomePageSettingViewController(prefs: profile.prefs,
                                                     wallpaperManager: wallpaperManager,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15596)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33412)

## :bulb: Description
Add Settings to enable Homepage World cup widget to Homepage settings.
Added missing string from design.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

