### PR TITLE
Bugfix FXIOS-15602 - Clear site data should only clear the current window's data

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1609,6 +1609,7 @@
 		C2A72A672A76938C002ACCE2 /* DownloadsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A662A76938C002ACCE2 /* DownloadsCoordinator.swift */; };
 		C2A72A692A769460002ACCE2 /* ReadingListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A682A769460002ACCE2 /* ReadingListCoordinator.swift */; };
 		C2A72A6B2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A6A2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift */; };
+		C2A853E42F9BA3EA005D4C7E /* ClearablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A853E32F9BA3DE005D4C7E /* ClearablesTests.swift */; };
 		C2B065512ECF37F000C479CA /* TranslationsTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B065502ECF37E900C479CA /* TranslationsTelemetry.swift */; };
 		C2B31EC92EDCE79100D53FF5 /* TranslationsVersionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B31EC82EDCE78600D53FF5 /* TranslationsVersionHelper.swift */; };
 		C2B31ECD2EDCEB1B00D53FF5 /* TranslationsVersionHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B31ECC2EDCEB0D00D53FF5 /* TranslationsVersionHelperTests.swift */; };
@@ -10312,6 +10313,7 @@
 		C2A72A662A76938C002ACCE2 /* DownloadsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsCoordinator.swift; sourceTree = "<group>"; };
 		C2A72A682A769460002ACCE2 /* ReadingListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListCoordinator.swift; sourceTree = "<group>"; };
 		C2A72A6A2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListCoordinatorTests.swift; sourceTree = "<group>"; };
+		C2A853E32F9BA3DE005D4C7E /* ClearablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearablesTests.swift; sourceTree = "<group>"; };
 		C2A943CF800ADCD8E96ACA5B /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		C2B065502ECF37E900C479CA /* TranslationsTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsTelemetry.swift; sourceTree = "<group>"; };
 		C2B31EC82EDCE78600D53FF5 /* TranslationsVersionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsVersionHelper.swift; sourceTree = "<group>"; };
@@ -16660,6 +16662,7 @@
 		F84B21D61A090F8100AAB793 /* ClientTests */ = {
 			isa = PBXGroup;
 			children = (
+				C2A853E32F9BA3DE005D4C7E /* ClearablesTests.swift */,
 				C24A0D2E2F3A7E7200BF08B7 /* KeyChainAppAttestKeyIDStoreTests.swift */,
 				2151EF582F2AB962007B67A6 /* BrowserViewController */,
 				218457C42F22A3FA00B4FF23 /* Downloads */,
@@ -19891,6 +19894,7 @@
 				213B67A827CE721E000542F5 /* StartAtHomeHelperTests.swift in Sources */,
 				033C94F72E2FBCDD00C2382F /* TermsOfUseMiddlewareTests.swift in Sources */,
 				8A13FA892AD82BC8007527AB /* AppSendTabDelegateTests.swift in Sources */,
+				C2A853E42F9BA3EA005D4C7E /* ClearablesTests.swift in Sources */,
 				0ABCD45D2D356015005D704A /* TermsOfServiceTelemetryTests.swift in Sources */,
 				C8CD80D42A1E268C0097C3AE /* MockGleanPlumbEvaluationUtility.swift in Sources */,
 				C705FA782EF30C4F00AC5EE7 /* PrivacyNoticeHelperTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Settings/Clearables.swift
+++ b/firefox-ios/Client/Frontend/Settings/Clearables.swift
@@ -14,7 +14,17 @@ import WebEngine
 protocol Clearable {
     @MainActor
     func clear() -> Success
+    /// Clears data scoped to a single domain (eTLD+1).
+    /// Default implementation is a no-op for clearables where domain scoping is not meaningful
+    /// (e.g. history, downloads, spotlight).
+    @MainActor
+    func clear(forDomain domain: String) async
     var label: String { get }
+}
+
+extension Clearable {
+    @MainActor
+    func clear(forDomain domain: String) async { }
 }
 
 // TODO: FXIOS-14152 - HistoryClearable shouldn't be @unchecked Sendable
@@ -115,6 +125,9 @@ class SpotlightClearable: Clearable {
 }
 
 // Removes all app cache storage.
+// NOTE(FXIOS-15603): WKWebsiteDataTypeOfflineWebApplicationCache targets the
+// HTML offline web app cache, which was deprecated in the HTML spec and removed from WebKit.
+// This should be removed.
 class SiteDataClearable: Clearable {
     var label: String { .ClearableOfflineData }
     private let logger: Logger
@@ -138,27 +151,46 @@ class SiteDataClearable: Clearable {
 class CookiesClearable: Clearable {
     var label: String { .ClearableCookies }
     private let logger: Logger
+    private let dataStore: WKWebsiteDataStore
 
-    init(logger: Logger = DefaultLogger.shared) {
+    static let cookieDataTypes: Set<String> = [
+        WKWebsiteDataTypeCookies,
+        WKWebsiteDataTypeLocalStorage,
+        WKWebsiteDataTypeSessionStorage,
+        WKWebsiteDataTypeWebSQLDatabases,
+        WKWebsiteDataTypeIndexedDBDatabases
+    ]
+
+    @MainActor
+    init(logger: Logger = DefaultLogger.shared,
+         dataStore: WKWebsiteDataStore = .default()) {
         self.logger = logger
+        self.dataStore = dataStore
     }
 
     func clear() -> Success {
-        let dataTypes = Set(
-            [
-                WKWebsiteDataTypeCookies,
-                WKWebsiteDataTypeLocalStorage,
-                WKWebsiteDataTypeSessionStorage,
-                WKWebsiteDataTypeWebSQLDatabases,
-                WKWebsiteDataTypeIndexedDBDatabases
-            ]
+        dataStore.removeData(
+            ofTypes: Self.cookieDataTypes,
+            modifiedSince: .distantPast,
+            completionHandler: {}
         )
-        WKWebsiteDataStore.default().removeData(ofTypes: dataTypes, modifiedSince: .distantPast, completionHandler: {})
 
         logger.log("CookiesClearable succeeded.",
                    level: .debug,
                    category: .storage)
         return succeed()
+    }
+
+    @MainActor
+    func clear(forDomain domain: String) async {
+        let records = await dataStore.dataRecords(ofTypes: Self.cookieDataTypes)
+        let targets = records.filter { $0.displayName == domain.lowercased() }
+        guard !targets.isEmpty else { return }
+        await dataStore.removeData(ofTypes: Self.cookieDataTypes, for: targets)
+        logger.log(
+            "CookiesClearable removed domain-scoped data for \(domain).",
+            level: .debug,
+            category: .storage)
     }
 }
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
@@ -229,8 +229,8 @@ class TrackingProtectionModel {
 
     @MainActor
     func clearCookiesAndSiteData() {
+        guard let domain = url.baseDomain else { return }
         Task {
-            guard let domain = url.baseDomain else { return }
             await CookiesClearable().clear(forDomain: domain)
         }
     }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
@@ -229,7 +229,9 @@ class TrackingProtectionModel {
 
     @MainActor
     func clearCookiesAndSiteData() {
-        _ = CookiesClearable().clear()
-        _ = SiteDataClearable().clear()
+        Task {
+            guard let domain = url.baseDomain else { return }
+            await CookiesClearable().clear(forDomain: domain)
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ClearablesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ClearablesTests.swift
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Testing
+import TestKit
+import WebKit
+import Combine
+import Shared
+@testable import Client
+
+@Suite("CookiesClearable")
+struct CookiesClearableTests {
+    @Test
+    func test_cookieDataTypes_containsExpectedTypes() {
+        let types = CookiesClearable.cookieDataTypes
+        #expect(types.contains(WKWebsiteDataTypeCookies))
+        #expect(types.contains(WKWebsiteDataTypeLocalStorage))
+        #expect(types.contains(WKWebsiteDataTypeSessionStorage))
+        #expect(types.contains(WKWebsiteDataTypeWebSQLDatabases))
+        #expect(types.contains(WKWebsiteDataTypeIndexedDBDatabases))
+    }
+
+    @MainActor
+    @Test
+    func test_clear_returnsSuccess() async {
+        let result: Maybe<Void> = await withCheckedContinuation { continuation in
+            makeSubject().clear().upon { continuation.resume(returning: $0) }
+        }
+        #expect(result.isSuccess)
+    }
+
+    @MainActor
+    @Test
+    func test_clearForDomain_withEmptyStore_storeRemainsEmpty() async {
+        let store = WKWebsiteDataStore.nonPersistent()
+        await makeSubject(dataStore: store).clear(forDomain: "example.com")
+        let records = await store.dataRecords(ofTypes: CookiesClearable.cookieDataTypes)
+        #expect(records.isEmpty)
+    }
+
+    @MainActor
+    @Test
+    func test_clearForDomain_withMatchingDomain_removesOnlyMatchingCookies() async {
+        let store = WKWebsiteDataStore.nonPersistent()
+        await store.httpCookieStore.setCookie(makeCookie(domain: "example.com"))
+        await store.httpCookieStore.setCookie(makeCookie(domain: "other.com"))
+
+        #expect(await store.httpCookieStore.allCookies().count == 2)
+
+        await makeSubject(dataStore: store).clear(forDomain: "example.com")
+
+        let after = await store.httpCookieStore.allCookies()
+        #expect(after.count == 1)
+        #expect(after.first?.domain == "other.com")
+    }
+
+    @MainActor
+    @Test
+    func test_clearForDomain_withBaseDomain_removesSubdomainCookies() async {
+        let store = WKWebsiteDataStore.nonPersistent()
+        await store.httpCookieStore.setCookie(makeCookie(domain: "mail.example.com"))
+        await store.httpCookieStore.setCookie(makeCookie(domain: "docs.example.com"))
+        await store.httpCookieStore.setCookie(makeCookie(domain: "other.com"))
+
+        await makeSubject(dataStore: store).clear(forDomain: "example.com")
+
+        let after = await store.httpCookieStore.allCookies()
+        #expect(after.count == 1)
+        #expect(after.first?.domain == "other.com")
+    }
+
+    @MainActor
+    private func makeSubject(dataStore: WKWebsiteDataStore = .nonPersistent()) -> CookiesClearable {
+        CookiesClearable(logger: MockLogger(), dataStore: dataStore)
+    }
+
+    private func makeCookie(domain: String) -> HTTPCookie {
+        HTTPCookie(properties: [
+            .name: "test",
+            .value: "1",
+            .domain: domain,
+            .path: "/"
+        ])!
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15602)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33419)

## :bulb: Description
This PR:
- Adds a new method `clear(forDomain:)` that clear site data for a specific domain.
- Adds tests
- Adds comment about removing `WKWebsiteDataTypeOfflineWebApplicationCache`.

## :movie_camera: Demos
### Before (notice clearing data on wikipedia also logs out user on hackernews)

https://github.com/user-attachments/assets/8b1641ed-eb29-46e2-ba28-0fa9ec5395cd


### After (only data for wikipedia is cleared and still logged in hackernews)

https://github.com/user-attachments/assets/c7126147-8407-4a7f-af9f-10fad16f7c98

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

