### PR TITLE
Bugfix FXIOS-15551 Tab leak investigation

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -112,9 +112,9 @@ class ScreenshotHelper {
             }
             webView.setPullRefreshVisibility(isVisible: false)
 
-            webView.takeSnapshot(with: configuration) { image, error in
+            webView.takeSnapshot(with: configuration) { [weak tab] image, error in
                 webView.setPullRefreshVisibility(isVisible: true)
-                if let image {
+                if let image, let tab {
                     tab.hasHomeScreenshot = false
                     tab.setScreenshot(image)
                     store.dispatch(

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageManager.swift
@@ -26,7 +26,7 @@ class ZoomPageManager: TabEventHandler, LegacyFeatureFlaggable {
          zoomStore: ZoomLevelStorage = ZoomLevelStore.shared) {
         self.windowUUID = windowUUID
         self.zoomStore = zoomStore
-        register(self, forTabEvents: .didGainFocus, .didChangeURL)
+        register(self, forTabEvents: .didGainFocus, .didLoseFocus, .didClose, .didChangeURL)
     }
 
     @MainActor
@@ -150,6 +150,16 @@ class ZoomPageManager: TabEventHandler, LegacyFeatureFlaggable {
         if tab.pageZoom != getZoomLevel() {
             updatePageZoom()
         }
+    }
+
+    func tabDidLoseFocus(_ tab: Tab) {
+        guard tab == self.tab else { return }
+        self.tab = nil
+    }
+
+    func tabDidClose(_ tab: Tab) {
+        guard tab == self.tab else { return }
+        self.tab = nil
     }
 
     func tab(_ tab: Tab, didChangeURL url: URL) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15551)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33329)

## :bulb: Description
- Fix Tab retention cycle related to `ZoomPageManager` and `ScreenshotHelper`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

