### PR TITLE
Refactor FXIOS-15508 [FeatureFlags] Update feature flag user settings

### DIFF
--- a/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
@@ -29,7 +29,8 @@ final class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol,
 
     /// Schedules the ingestion task to run when the app is backgrounded.
     func scheduleTaskOnAppBackground() {
-        guard featureFlagsProvider.isEnabled(.firefoxSuggestFeature) && userPreferences.isFirefoxSuggestEnabled
+        guard featureFlagsProvider.isEnabled(.firefoxSuggestFeature)
+                && userPreferences.getPreferenceFor(.firefoxSuggestFeature)
         else { return }
 
         logger.log("Scheduling background ingestion",
@@ -75,7 +76,8 @@ final class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol,
 
     /// Registers a launch handler for the background ingestion task.
     private func setUp() {
-        guard featureFlagsProvider.isEnabled(.firefoxSuggestFeature) && userPreferences.isFirefoxSuggestEnabled
+        guard featureFlagsProvider.isEnabled(.firefoxSuggestFeature)
+                && userPreferences.getPreferenceFor(.firefoxSuggestFeature)
         else { return }
         BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.taskIdentifier, using: nil) { task in
             task.expirationHandler = {

--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -63,7 +63,26 @@ enum FeatureFlagID: String, CaseIterable {
     case worldCupWidget
     case quickAnswers
 
-    // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`. Add in alphabetical order.
+    /// The user preferences key for features that support user-togglable settings.
+    /// Returns `nil` for features that are not user-configurable.
+    var userPrefsKey: String? {
+        typealias FlagKeys = PrefsKeys.FeatureFlags
+        typealias HomepageKeys = PrefsKeys.HomepageSettings
+
+        switch self {
+        case .aiKillSwitch: return PrefsKeys.Settings.aiKillSwitchFeature
+        case .firefoxSuggestFeature: return FlagKeys.FirefoxSuggest
+        case .homepageBookmarksSectionDefault: return HomepageKeys.BookmarksSection
+        case .homepageJumpBackinSectionDefault: return HomepageKeys.JumpBackInSection
+        case .hntSponsoredShortcuts: return FlagKeys.SponsoredShortcuts
+        case .sentFromFirefox: return FlagKeys.SentFromFirefox
+        case .startAtHome: return FlagKeys.StartAtHome
+        default: return nil
+        }
+    }
+
+    // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`.
+    // Add in alphabetical order.
     var debugKey: String? {
         switch self {
         case    .aiKillSwitch,

--- a/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
+++ b/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
@@ -6,27 +6,17 @@ import Common
 import Shared
 
 /// Protocol for reading/writing user feature preferences.
-/// Each property reads from Prefs, falling back to the Nimbus default.
+/// Bool preferences use the generic get/set keyed by FeatureFlagID.
+/// Typed (non-bool) preferences have named properties.
 protocol UserFeaturePreferring: Sendable {
-    // Bool preferences (read)
-    var isAIKillSwitchEnabled: Bool { get }
-    var isFirefoxSuggestEnabled: Bool { get }
-    var isSentFromFirefoxEnabled: Bool { get }
-    var isSponsoredShortcutsEnabled: Bool { get }
-    var isHomepageBookmarksSectionEnabled: Bool { get }
-    var isHomepageJumpBackInSectionEnabled: Bool { get }
+    // Generic bool preference
+    func getPreferenceFor(_ flag: FeatureFlagID) -> Bool
+    func setPreferenceFor(_ flag: FeatureFlagID, to value: Bool)
 
-    // Typed preferences (read)
+    // Typed preferences
     var searchBarPosition: SearchBarPosition { get }
     var startAtHomeSetting: StartAtHome { get }
 
-    // Setters
-    func setAIKillSwitchEnabled(_ enabled: Bool)
-    func setFirefoxSuggestEnabled(_ enabled: Bool)
-    func setSentFromFirefoxEnabled(_ enabled: Bool)
-    func setSponsoredShortcutsEnabled(_ enabled: Bool)
-    func setHomepageBookmarksSectionEnabled(_ enabled: Bool)
-    func setHomepageJumpBackInSectionEnabled(_ enabled: Bool)
     func setSearchBarPosition(_ position: SearchBarPosition)
     func setStartAtHomeSetting(_ setting: StartAtHome)
 }
@@ -43,36 +33,28 @@ final class UserFeaturePreferenceManager: UserFeaturePreferring, @unchecked Send
         self.nimbusLayer = nimbusLayer
     }
 
-    // MARK: - Bool preferences
+    // MARK: - Generic bool preferences
 
-    var isAIKillSwitchEnabled: Bool {
-        // Even when this feature is on in Nimbus, the user preference default value should be false
-        prefs.boolForKey(PrefsKeys.Settings.aiKillSwitchFeature) ?? false
+    func getPreferenceFor(_ flag: FeatureFlagID) -> Bool {
+        guard let key = flag.userPrefsKey else {
+            return checkDefaultValue(for: flag)
+        }
+        return prefs.boolForKey(key) ?? checkDefaultValue(for: flag)
     }
 
-    var isFirefoxSuggestEnabled: Bool {
-        prefs.boolForKey(PrefsKeys.FeatureFlags.FirefoxSuggest)
-        ?? nimbusLayer.checkNimbusConfigFor(.firefoxSuggestFeature)
+    // Some features might have a differnt default value than what's provided by
+    // the backend. Here, we can set our own default values.
+    private func checkDefaultValue(for flag: FeatureFlagID) -> Bool {
+        if flag == .aiKillSwitch {
+            return false
+        } else {
+            return nimbusLayer.checkNimbusConfigFor(flag)
+        }
     }
 
-    var isSentFromFirefoxEnabled: Bool {
-        prefs.boolForKey(PrefsKeys.FeatureFlags.SentFromFirefox)
-        ?? nimbusLayer.checkNimbusConfigFor(.sentFromFirefox)
-    }
-
-    var isSponsoredShortcutsEnabled: Bool {
-        prefs.boolForKey(PrefsKeys.FeatureFlags.SponsoredShortcuts)
-        ?? nimbusLayer.checkNimbusConfigFor(.hntSponsoredShortcuts)
-    }
-
-    var isHomepageBookmarksSectionEnabled: Bool {
-        prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection)
-        ?? nimbusLayer.checkNimbusConfigFor(.homepageBookmarksSectionDefault)
-    }
-
-    var isHomepageJumpBackInSectionEnabled: Bool {
-        prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection)
-        ?? nimbusLayer.checkNimbusConfigFor(.homepageJumpBackinSectionDefault)
+    func setPreferenceFor(_ flag: FeatureFlagID, to value: Bool) {
+        guard let key = flag.userPrefsKey else { return }
+        prefs.setBool(value, forKey: key)
     }
 
     // MARK: - Typed preferences
@@ -93,31 +75,7 @@ final class UserFeaturePreferenceManager: UserFeaturePreferring, @unchecked Send
         return FxNimbus.shared.features.startAtHomeFeature.value().setting
     }
 
-    // MARK: - Setters
-
-    func setAIKillSwitchEnabled(_ enabled: Bool) {
-        prefs.setBool(enabled, forKey: PrefsKeys.Settings.aiKillSwitchFeature)
-    }
-
-    func setFirefoxSuggestEnabled(_ enabled: Bool) {
-        prefs.setBool(enabled, forKey: PrefsKeys.FeatureFlags.FirefoxSuggest)
-    }
-
-    func setSentFromFirefoxEnabled(_ enabled: Bool) {
-        prefs.setBool(enabled, forKey: PrefsKeys.FeatureFlags.SentFromFirefox)
-    }
-
-    func setSponsoredShortcutsEnabled(_ enabled: Bool) {
-        prefs.setBool(enabled, forKey: PrefsKeys.FeatureFlags.SponsoredShortcuts)
-    }
-
-    func setHomepageBookmarksSectionEnabled(_ enabled: Bool) {
-        prefs.setBool(enabled, forKey: PrefsKeys.HomepageSettings.BookmarksSection)
-    }
-
-    func setHomepageJumpBackInSectionEnabled(_ enabled: Bool) {
-        prefs.setBool(enabled, forKey: PrefsKeys.HomepageSettings.JumpBackInSection)
-    }
+    // MARK: - Typed setters
 
     func setSearchBarPosition(_ position: SearchBarPosition) {
         prefs.setString(position.rawValue, forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
@@ -131,7 +89,6 @@ final class UserFeaturePreferenceManager: UserFeaturePreferring, @unchecked Send
 // MARK: - DI Access Protocol
 
 /// Adopt this protocol to access user feature preferences via AppContainer.
-/// Replaces FeatureFlaggable for user preference checks.
 protocol UserFeaturePreferenceProvider {
     var userPreferences: UserFeaturePreferring { get }
 }

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -629,7 +629,8 @@ class SearchViewController: SiteTableViewController,
                     }
                 }
             case .firefoxSuggestions:
-                if featureFlagsProvider.isEnabled(.firefoxSuggestFeature) && userPreferences.isFirefoxSuggestEnabled {
+                if featureFlagsProvider.isEnabled(.firefoxSuggestFeature)
+                    && userPreferences.getPreferenceFor(.firefoxSuggestFeature) {
                     let firefoxSuggestion = viewModel.firefoxSuggestions[indexPath.row]
                     if searchTelemetry?.visibleFirefoxSuggestions
                         .contains(where: { $0.url == firefoxSuggestion.url }) == false {

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
@@ -303,7 +303,8 @@ class SearchViewModel: FeatureFlaggable,
         let includeNonSponsored = shouldShowNonSponsoredSuggestions
         let includeSponsored = shouldShowSponsoredSuggestions
 
-        guard featureFlagsProvider.isEnabled(.firefoxSuggestFeature) && userPreferences.isFirefoxSuggestEnabled
+        guard featureFlagsProvider.isEnabled(.firefoxSuggestFeature)
+                && userPreferences.getPreferenceFor(.firefoxSuggestFeature)
                 && (includeNonSponsored || includeSponsored) else {
             if !firefoxSuggestions.isEmpty {
                 firefoxSuggestions = []

--- a/firefox-ios/Client/Frontend/Home/Homepage/Bookmark/BookmarksSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Bookmark/BookmarksSectionState.swift
@@ -27,7 +27,7 @@ struct BookmarksSectionState: StateType, Equatable, Hashable {
     init(profile: Profile = AppContainer.shared.resolve(), windowUUID: WindowUUID) {
         // TODO: FXIOS-11412 - Move profile dependency
         let userPreferences: UserFeaturePreferring = AppContainer.shared.resolve()
-        let shouldShowSection = userPreferences.isHomepageBookmarksSectionEnabled
+        let shouldShowSection = userPreferences.getPreferenceFor(.homepageBookmarksSectionDefault)
         self.init(
             windowUUID: windowUUID,
             bookmarks: [],

--- a/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/JumpBackInSectionState.swift
@@ -35,7 +35,7 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
             windowUUID: windowUUID,
             jumpBackInTabs: [],
             mostRecentSyncedTab: nil,
-            shouldShowSection: userPreferences.isHomepageJumpBackInSectionEnabled
+            shouldShowSection: userPreferences.getPreferenceFor(.homepageJumpBackinSectionDefault)
         )
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesManager.swift
@@ -122,7 +122,7 @@ final class TopSitesManager: TopSitesManagerInterface, UserFeaturePreferenceProv
     }
 
     private var shouldLoadSponsoredTiles: Bool {
-        return userPreferences.isSponsoredShortcutsEnabled
+        return userPreferences.getPreferenceFor(.hntSponsoredShortcuts)
     }
 
     @MainActor

--- a/firefox-ios/Client/Frontend/Settings/AIControls/AIControlsModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/AIControls/AIControlsModel.swift
@@ -82,7 +82,7 @@ class AIControlsModel: ObservableObject,
         pageSummariesVisible = self.summarizerConfiguration.isSummarizeFeatureEnabled
         translationsVisible = featureFlagsProvider.isEnabled(.translation)
 
-        killSwitchIsOn = featureFlagsProvider.isEnabled(.aiKillSwitch) && userPreferences.isAIKillSwitchEnabled
+        killSwitchIsOn = featureFlagsProvider.isEnabled(.aiKillSwitch) && userPreferences.getPreferenceFor(.aiKillSwitch)
     }
 
     @MainActor

--- a/firefox-ios/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
@@ -34,7 +34,8 @@ class FirefoxSuggestSettingsViewController: SettingsTableViewController,
         }
 
         var sections: [SettingSection] = [SettingSection(title: nil, children: [enabled])]
-        if featureFlagsProvider.isEnabled(.firefoxSuggestFeature) && userPreferences.isFirefoxSuggestEnabled {
+        if featureFlagsProvider.isEnabled(.firefoxSuggestFeature)
+            && userPreferences.getPreferenceFor(.firefoxSuggestFeature) {
             sections.append(SettingSection(
                 title: nil,
                 children: [

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -134,7 +134,7 @@ class HomePageSettingViewController: SettingsTableViewController,
                 prefs: profile.prefs,
                 theme: themeManager.getCurrentTheme(for: windowUUID),
                 prefKey: PrefsKeys.HomepageSettings.JumpBackInSection,
-                defaultValue: userPreferences.isHomepageJumpBackInSectionEnabled,
+                defaultValue: userPreferences.getPreferenceFor(.homepageJumpBackinSectionDefault),
                 titleText: .Settings.Homepage.CustomizeFirefoxHome.JumpBackIn
             ) { value in
                 store.dispatch(
@@ -151,7 +151,7 @@ class HomePageSettingViewController: SettingsTableViewController,
                 prefs: profile.prefs,
                 theme: themeManager.getCurrentTheme(for: windowUUID),
                 prefKey: PrefsKeys.HomepageSettings.BookmarksSection,
-                defaultValue: userPreferences.isHomepageBookmarksSectionEnabled,
+                defaultValue: userPreferences.getPreferenceFor(.homepageBookmarksSectionDefault),
                 titleText: .Settings.Homepage.CustomizeFirefoxHome.Bookmarks
             ) { value in
                 store.dispatch(

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -51,7 +51,7 @@ final class TopSitesSettingsViewController: SettingsTableViewController, UserFea
                     prefs: profile.prefs,
                     theme: themeManager.getCurrentTheme(for: windowUUID),
                     prefKey: PrefsKeys.FeatureFlags.SponsoredShortcuts,
-                    defaultValue: userPreferences.isSponsoredShortcutsEnabled,
+                    defaultValue: userPreferences.getPreferenceFor(.hntSponsoredShortcuts),
                     titleText: .Settings.Homepage.Shortcuts.SponsoredShortcutsToggle
                 ) { _ in
                     store.dispatch(

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -413,7 +413,8 @@ final class SearchSettingsTableViewController: ThemedTableViewController,
     }
 
     private func configureCellForNonSponsoredAction(cell: ThemedSubtitleTableViewCell) {
-        if featureFlagsProvider.isEnabled(.firefoxSuggestFeature) && userPreferences.isFirefoxSuggestEnabled {
+        if featureFlagsProvider.isEnabled(.firefoxSuggestFeature)
+            && userPreferences.getPreferenceFor(.firefoxSuggestFeature) {
             buildSettingWith(
                 prefKey: PrefsKeys.SearchSettings.showFirefoxNonSponsoredSuggestions,
                 defaultValue: model.shouldShowFirefoxSuggestions,
@@ -431,7 +432,8 @@ final class SearchSettingsTableViewController: ThemedTableViewController,
     }
 
     private func configureCellForSponsoredAction(cell: ThemedSubtitleTableViewCell) {
-        if featureFlagsProvider.isEnabled(.firefoxSuggestFeature) && userPreferences.isFirefoxSuggestEnabled {
+        if featureFlagsProvider.isEnabled(.firefoxSuggestFeature)
+            && userPreferences.getPreferenceFor(.firefoxSuggestFeature) {
             buildSettingWith(
                 prefKey: PrefsKeys.SearchSettings.showFirefoxSponsoredSuggestions,
                 defaultValue: model.shouldShowSponsoredSuggestions,
@@ -490,7 +492,8 @@ final class SearchSettingsTableViewController: ThemedTableViewController,
         case .searchEnginesSuggestions:
             return SearchSuggestItem.allCases.count
         case .firefoxSuggestSettings:
-            return featureFlagsProvider.isEnabled(.firefoxSuggestFeature) && userPreferences.isFirefoxSuggestEnabled
+            return featureFlagsProvider.isEnabled(.firefoxSuggestFeature)
+            && userPreferences.getPreferenceFor(.firefoxSuggestFeature)
             ? FirefoxSuggestItem.allCases.count : 3
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -223,7 +223,7 @@ class PaddedSwitch: UIView {
 
 // A helper class for settings with a UISwitch.
 // Takes and optional settingsDidChange callback and status text.
-class BoolSetting: Setting, LegacyFeatureFlaggable {
+class BoolSetting: Setting, UserFeaturePreferenceProvider {
     // Sometimes a subclass will manage its own pref setting. In that case the prefkey will be nil
     let prefKey: String?
     let prefs: Prefs?
@@ -375,7 +375,7 @@ class BoolSetting: Setting, LegacyFeatureFlaggable {
     // These methods allow a subclass to control how the pref is saved
     func displayBool(_ control: UISwitch) {
         if let featureFlagName = featureFlagName {
-            control.isOn = featureFlags.isFeatureEnabled(featureFlagName, checking: .userOnly)
+            control.isOn = userPreferences.getPreferenceFor(featureFlagName)
         } else {
             guard let key = prefKey, let defaultValue = defaultValue else { return }
             control.isOn = prefs?.boolForKey(key) ?? defaultValue
@@ -384,7 +384,7 @@ class BoolSetting: Setting, LegacyFeatureFlaggable {
 
     func writeBool(_ control: UISwitch) {
         if let featureFlagName = featureFlagName {
-            featureFlags.set(feature: featureFlagName, to: control.isOn)
+            userPreferences.setPreferenceFor(featureFlagName, to: control.isOn)
         } else {
             guard let key = prefKey else { return }
             prefs?.setBool(control.isOn, forKey: key)
@@ -397,7 +397,7 @@ class BoolNotificationSetting: BoolSetting {
 
     override func displayBool(_ control: UISwitch) {
         if let featureFlagName = getFeatureFlagName() {
-            control.isOn = featureFlags.isFeatureEnabled(featureFlagName, checking: .userOnly)
+            control.isOn = userPreferences.getPreferenceFor(featureFlagName)
         } else {
             guard let key = prefKey, let defaultValue = getDefaultValue() else { return }
 
@@ -410,7 +410,7 @@ class BoolNotificationSetting: BoolSetting {
 
     override func writeBool(_ control: UISwitch) {
         if let featureFlagName = getFeatureFlagName() {
-            featureFlags.set(feature: featureFlagName, to: control.isOn)
+            userPreferences.setPreferenceFor(featureFlagName, to: control.isOn)
         } else {
             Task { @MainActor in
                 let isSystemNotificationOn = await isSystemNotificationOn()

--- a/firefox-ios/Client/Frontend/Share/ShareTelemetryActivityItemProvider.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTelemetryActivityItemProvider.swift
@@ -22,7 +22,7 @@ class ShareTelemetryActivityItemProvider: UIActivityItemProvider,
 
     // FXIOS-9879 For the Sent from Firefox experiment
     private var isOptedInSentFromFirefox: Bool {
-        return userPreferences.isSentFromFirefoxEnabled
+        return userPreferences.getPreferenceFor(.sentFromFirefox)
     }
 
     init(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryActivityItemProviderTests.swift
@@ -88,7 +88,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
 
         // Opt in the user preference
         let userPreferences: UserFeaturePreferring = AppContainer.shared.resolve()
-        userPreferences.setSentFromFirefoxEnabled(testUserOptIn)
+        userPreferences.setPreferenceFor(.sentFromFirefox, to: testUserOptIn)
 
         let shareTelemetryActivityItemProvider = ShareTelemetryActivityItemProvider(
             shareTypeName: testShareType.typeName,
@@ -120,7 +120,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
 
         // Opt in the user preference
         let userPreferences: UserFeaturePreferring = AppContainer.shared.resolve()
-        userPreferences.setSentFromFirefoxEnabled(testUserOptIn)
+        userPreferences.setPreferenceFor(.sentFromFirefox, to: testUserOptIn)
 
         let shareTelemetryActivityItemProvider = ShareTelemetryActivityItemProvider(
             shareTypeName: testShareType.typeName,
@@ -152,7 +152,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
 
         // Opt in the user preference
         let userPreferences: UserFeaturePreferring = AppContainer.shared.resolve()
-        userPreferences.setSentFromFirefoxEnabled(testUserOptIn)
+        userPreferences.setPreferenceFor(.sentFromFirefox, to: testUserOptIn)
 
         let shareTelemetryActivityItemProvider = ShareTelemetryActivityItemProvider(
             shareTypeName: testShareType.typeName,
@@ -184,7 +184,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
 
         // Opt in the user preference
         let userPreferences: UserFeaturePreferring = AppContainer.shared.resolve()
-        userPreferences.setSentFromFirefoxEnabled(testUserOptIn)
+        userPreferences.setPreferenceFor(.sentFromFirefox, to: testUserOptIn)
 
         let shareTelemetryActivityItemProvider = ShareTelemetryActivityItemProvider(
             shareTypeName: testShareType.typeName,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/UserFeaturePreferenceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/UserFeaturePreferenceManagerTests.swift
@@ -27,53 +27,53 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
     // MARK: - Bool preferences: defaults from Nimbus
 
     func testBoolDefaults_returnNimbusValues_whenNoUserPrefSet() {
-        // With no prefs set, each property should return the Nimbus default.
+        // With no prefs set, each flag should return the Nimbus default.
         // We just verify they return without crashing — the actual Nimbus defaults
         // may vary by config, so we check the type is correct.
-        _ = subject.isAIKillSwitchEnabled
-        _ = subject.isFirefoxSuggestEnabled
-        _ = subject.isSentFromFirefoxEnabled
-        _ = subject.isSponsoredShortcutsEnabled
-        _ = subject.isHomepageBookmarksSectionEnabled
-        _ = subject.isHomepageJumpBackInSectionEnabled
+        _ = subject.getPreferenceFor(.aiKillSwitch)
+        _ = subject.getPreferenceFor(.firefoxSuggestFeature)
+        _ = subject.getPreferenceFor(.sentFromFirefox)
+        _ = subject.getPreferenceFor(.hntSponsoredShortcuts)
+        _ = subject.getPreferenceFor(.homepageBookmarksSectionDefault)
+        _ = subject.getPreferenceFor(.homepageJumpBackinSectionDefault)
     }
 
     // MARK: - Bool preferences: user overrides
 
     func testFirefoxSuggest_readsUserPref() {
         prefs.setBool(false, forKey: PrefsKeys.FeatureFlags.FirefoxSuggest)
-        XCTAssertFalse(subject.isFirefoxSuggestEnabled)
+        XCTAssertFalse(subject.getPreferenceFor(.firefoxSuggestFeature))
 
         prefs.setBool(true, forKey: PrefsKeys.FeatureFlags.FirefoxSuggest)
-        XCTAssertTrue(subject.isFirefoxSuggestEnabled)
+        XCTAssertTrue(subject.getPreferenceFor(.firefoxSuggestFeature))
     }
 
     func testSentFromFirefox_readsUserPref() {
         prefs.setBool(true, forKey: PrefsKeys.FeatureFlags.SentFromFirefox)
-        XCTAssertTrue(subject.isSentFromFirefoxEnabled)
+        XCTAssertTrue(subject.getPreferenceFor(.sentFromFirefox))
     }
 
     func testSponsoredShortcuts_readsUserPref() {
         prefs.setBool(false, forKey: PrefsKeys.FeatureFlags.SponsoredShortcuts)
-        XCTAssertFalse(subject.isSponsoredShortcutsEnabled)
+        XCTAssertFalse(subject.getPreferenceFor(.hntSponsoredShortcuts))
     }
 
     func testHomepageBookmarksSection_readsUserPref() {
         prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.BookmarksSection)
-        XCTAssertFalse(subject.isHomepageBookmarksSectionEnabled)
+        XCTAssertFalse(subject.getPreferenceFor(.homepageBookmarksSectionDefault))
     }
 
     func testHomepageJumpBackInSection_readsUserPref() {
         prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.JumpBackInSection)
-        XCTAssertFalse(subject.isHomepageJumpBackInSectionEnabled)
+        XCTAssertFalse(subject.getPreferenceFor(.homepageJumpBackinSectionDefault))
     }
 
     func testAIKillSwitch_readsUserPref() {
         prefs.setBool(true, forKey: PrefsKeys.Settings.aiKillSwitchFeature)
-        XCTAssertTrue(subject.isAIKillSwitchEnabled)
+        XCTAssertTrue(subject.getPreferenceFor(.aiKillSwitch))
 
         prefs.setBool(false, forKey: PrefsKeys.Settings.aiKillSwitchFeature)
-        XCTAssertFalse(subject.isAIKillSwitchEnabled)
+        XCTAssertFalse(subject.getPreferenceFor(.aiKillSwitch))
     }
 
     // MARK: - Typed preferences
@@ -113,35 +113,35 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
     // MARK: - Setters
 
     func testSetFirefoxSuggestEnabled_writesPref() {
-        subject.setFirefoxSuggestEnabled(true)
+        subject.setPreferenceFor(.firefoxSuggestFeature, to: true)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.FirefoxSuggest), true)
 
-        subject.setFirefoxSuggestEnabled(false)
+        subject.setPreferenceFor(.firefoxSuggestFeature, to: false)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.FirefoxSuggest), false)
     }
 
     func testSetSentFromFirefoxEnabled_writesPref() {
-        subject.setSentFromFirefoxEnabled(true)
+        subject.setPreferenceFor(.sentFromFirefox, to: true)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.SentFromFirefox), true)
     }
 
     func testSetSponsoredShortcutsEnabled_writesPref() {
-        subject.setSponsoredShortcutsEnabled(false)
+        subject.setPreferenceFor(.hntSponsoredShortcuts, to: false)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.SponsoredShortcuts), false)
     }
 
     func testSetHomepageBookmarksSectionEnabled_writesPref() {
-        subject.setHomepageBookmarksSectionEnabled(true)
+        subject.setPreferenceFor(.homepageBookmarksSectionDefault, to: true)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection), true)
     }
 
     func testSetHomepageJumpBackInSectionEnabled_writesPref() {
-        subject.setHomepageJumpBackInSectionEnabled(false)
+        subject.setPreferenceFor(.homepageJumpBackinSectionDefault, to: false)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection), false)
     }
 
     func testSetAIKillSwitchEnabled_writesPref() {
-        subject.setAIKillSwitchEnabled(true)
+        subject.setPreferenceFor(.aiKillSwitch, to: true)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.Settings.aiKillSwitchFeature), true)
     }
 
@@ -164,11 +164,11 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
     // MARK: - Roundtrip: set then read
 
     func testRoundtrip_boolPreferences() {
-        subject.setFirefoxSuggestEnabled(false)
-        XCTAssertFalse(subject.isFirefoxSuggestEnabled)
+        subject.setPreferenceFor(.firefoxSuggestFeature, to: false)
+        XCTAssertFalse(subject.getPreferenceFor(.firefoxSuggestFeature))
 
-        subject.setFirefoxSuggestEnabled(true)
-        XCTAssertTrue(subject.isFirefoxSuggestEnabled)
+        subject.setPreferenceFor(.firefoxSuggestFeature, to: true)
+        XCTAssertTrue(subject.getPreferenceFor(.firefoxSuggestFeature))
     }
 
     func testRoundtrip_searchBarPosition() {
@@ -187,12 +187,25 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
         XCTAssertEqual(subject.startAtHomeSetting, .disabled)
     }
 
+    // MARK: - Generic API: flag with no userPrefsKey falls back to Nimbus
+
+    func testGetPreference_flagWithNoUserPrefsKey_fallsBackToNimbus() {
+        // .microsurvey has no userPrefsKey, so should return the Nimbus value
+        _ = subject.getPreferenceFor(.microsurvey)
+    }
+
+    func testSetPreference_flagWithNoUserPrefsKey_isNoOp() {
+        // .microsurvey has no userPrefsKey, so set should be a no-op
+        subject.setPreferenceFor(.microsurvey, to: true)
+        // No crash, no pref written
+    }
+
     // MARK: - Mock protocol conformance
 
     func testMockConformance() {
         let mock = MockUserFeaturePreferences()
-        mock.isFirefoxSuggestEnabled = false
-        XCTAssertFalse(mock.isFirefoxSuggestEnabled)
+        mock.setPreferenceFor(.firefoxSuggestFeature, to: false)
+        XCTAssertFalse(mock.getPreferenceFor(.firefoxSuggestFeature))
 
         mock.searchBarPosition = .bottom
         XCTAssertEqual(mock.searchBarPosition, .bottom)
@@ -205,21 +218,18 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
 // MARK: - Test Helpers
 
 final class MockUserFeaturePreferences: UserFeaturePreferring, @unchecked Sendable {
-    var isAIKillSwitchEnabled = true
-    var isFirefoxSuggestEnabled = true
-    var isSentFromFirefoxEnabled = false
-    var isSponsoredShortcutsEnabled = true
-    var isHomepageBookmarksSectionEnabled = true
-    var isHomepageJumpBackInSectionEnabled = true
+    var boolPreferences: [FeatureFlagID: Bool] = [:]
     var searchBarPosition = SearchBarPosition.bottom
     var startAtHomeSetting = StartAtHome.afterFourHours
 
-    func setAIKillSwitchEnabled(_ enabled: Bool) { isAIKillSwitchEnabled = enabled }
-    func setFirefoxSuggestEnabled(_ enabled: Bool) { isFirefoxSuggestEnabled = enabled }
-    func setSentFromFirefoxEnabled(_ enabled: Bool) { isSentFromFirefoxEnabled = enabled }
-    func setSponsoredShortcutsEnabled(_ enabled: Bool) { isSponsoredShortcutsEnabled = enabled }
-    func setHomepageBookmarksSectionEnabled(_ enabled: Bool) { isHomepageBookmarksSectionEnabled = enabled }
-    func setHomepageJumpBackInSectionEnabled(_ enabled: Bool) { isHomepageJumpBackInSectionEnabled = enabled }
+    func getPreferenceFor(_ flag: FeatureFlagID) -> Bool {
+        return boolPreferences[flag] ?? false
+    }
+
+    func setPreferenceFor(_ flag: FeatureFlagID, to value: Bool) {
+        boolPreferences[flag] = value
+    }
+
     func setSearchBarPosition(_ position: SearchBarPosition) { searchBarPosition = position }
     func setStartAtHomeSetting(_ setting: StartAtHome) { startAtHomeSetting = setting }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15508)

## :bulb: Description
Unfortunately, the previous design wasn't gonig to work with the existing settings screen implementation, so I streamlined it to be more similar in interface with the feature flags manager. This will allow it to work with the current setting without actually refactoring those.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

