### PR TITLE
Refactor FXIOS-33203 [UI Tests] Converted HomeButtonTests to new framework

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
@@ -5,6 +5,15 @@
 import XCTest
 
 class HomeButtonTests: BaseTestCase {
+    private var browserScreen: BrowserScreen!
+    private var toolbarScreen: ToolbarScreen!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        browserScreen = BrowserScreen(app: app)
+        toolbarScreen = ToolbarScreen(app: app)
+    }
+
     override func tearDown() async throws {
         XCUIDevice.shared.orientation = .portrait
         try await super.tearDown()
@@ -12,46 +21,41 @@ class HomeButtonTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306925
     func testGoHome() throws {
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"), waitForLoading: true)
+        browserScreen.navigateToURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
-        navigator.nowAt(BrowserTab)
-        navigator.performAction(Action.GoToHomePage)
-        navigator.nowAt(URLBarOpen)
+        toolbarScreen.tapHomeButton()
         waitForTabsButton()
         if !iPad() {
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")
         }
-        navigator.openURL(path(forTestPage: "test-mozilla-book.html"), waitForLoading: true)
+        browserScreen.navigateToURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
+        toolbarScreen.assertNewTabButtonExists()
 
         XCUIDevice.shared.orientation = .landscapeRight
-        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
-        navigator.nowAt(NewTabScreen)
+        toolbarScreen.tapOnNewTabButton()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306883
     func testSwitchHomepageKeyboardRaisedUp() {
         // Open a new tab and load a web page
-        navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+        browserScreen.navigateToURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
         waitUntilPageLoad()
 
         // Switch to Homepage by taping the home button
-        navigator.nowAt(BrowserTab)
-        navigator.performAction(Action.GoToHomePage)
+        toolbarScreen.tapHomeButton()
 
         validateHomePageAndKeyboardRaisedUp(showKeyboard: true)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306881
     func testAppLaunchKeyboardNotRaisedUp() {
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
+        toolbarScreen.assertSettingsButtonExists()
         validateHomePageAndKeyboardRaisedUp()
     }
 
     private func validateHomePageAndKeyboardRaisedUp(showKeyboard: Bool = false) {
         // The home page is loaded. The keyboard is not raised up
-        navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         if !showKeyboard {
             XCTAssertFalse(app.keyboards.element.isVisible(), "The keyboard is shown")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
@@ -19,6 +19,7 @@ final class ToolbarScreen {
     private var backButton: XCUIElement { sel.BACK_BUTTON.element(in: app)}
     private var tabToolbarMenuButton: XCUIElement { sel.TABTOOLBAR_MENUBUTTON.element(in: app) }
     private var shareButton: XCUIElement { sel.SHARE_BUTTON.element(in: app) }
+    private var homeButton: XCUIElement { sel.HOME_BUTTON.element(in: app) }
     private var translateButton: XCUIElement { sel.TRANSLATE_BUTTON.element(in: app) }
     private var translateLoadingButton: XCUIElement { sel.TRANSLATE_LOADING_BUTTON.element(in: app) }
     private var translateActiveButton: XCUIElement { sel.TRANSLATE_ACTIVE_BUTTON.element(in: app) }
@@ -137,6 +138,10 @@ final class ToolbarScreen {
 
     func tapOnNewTabButton() {
         newTabButton.waitAndTap()
+    }
+
+    func tapHomeButton() {
+        homeButton.waitAndTap()
     }
 
     // MARK: - Translate Button

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/ToolbarSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/ToolbarSelectors.swift
@@ -13,6 +13,7 @@ protocol ToolbarSelectorsSet {
     var TABTOOLBAR_MENUBUTTON: Selector { get }
     var RELOAD_BUTTON: Selector { get }
     var SHARE_BUTTON: Selector { get }
+    var HOME_BUTTON: Selector { get }
     var TRANSLATE_BUTTON: Selector { get }
     var TRANSLATE_LOADING_BUTTON: Selector { get }
     var TRANSLATE_ACTIVE_BUTTON: Selector { get }
@@ -29,6 +30,7 @@ struct ToolbarSelectors: ToolbarSelectorsSet {
         static let tabToolbar_MenuButton = "TabToolbar.menuButton"
         static let reloadButton = AccessibilityIdentifiers.Toolbar.reloadButton
         static let shareButton = AccessibilityIdentifiers.Toolbar.shareButton
+        static let homeButton = AccessibilityIdentifiers.Toolbar.addNewTabButton
         static let translateButton = AccessibilityIdentifiers.Toolbar.translateButton
         static let translateLoadingButton = AccessibilityIdentifiers.Toolbar.translateLoadingButton
         static let translateActiveButton = AccessibilityIdentifiers.Toolbar.translateActiveButton
@@ -82,6 +84,12 @@ struct ToolbarSelectors: ToolbarSelectorsSet {
         groups: ["browser", "toolbar"]
     )
 
+    let HOME_BUTTON = Selector.buttonId(
+        IDs.homeButton,
+        description: "Home button in the toolbar",
+        groups: ["browser", "toolbar"]
+    )
+
     let TRANSLATE_BUTTON = Selector.buttonId(
         IDs.translateButton,
         description: "Translate button on browser toolbar",
@@ -109,6 +117,7 @@ struct ToolbarSelectors: ToolbarSelectorsSet {
         TABTOOLBAR_MENUBUTTON,
         RELOAD_BUTTON,
         SHARE_BUTTON,
+        HOME_BUTTON,
         TRANSLATE_BUTTON,
         TRANSLATE_LOADING_BUTTON,
         TRANSLATE_ACTIVE_BUTTON


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15479)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33203)

## :bulb: Description
The navigator calls in HomeButtonTests were replaced with calls to methods in the BrowserScreen and ToolbarScreen classes. A new method tapHomeButton() was added to the ToolbarScreen class. Beyond the details provided in the GitHub issue, I noticed that occurrences of mozWaitForElementToExist(...) can be replaced with calls to toolbarScreen.assert...().

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

