### PR TITLE
Bugfix FXIOS-15609 [History] Add bottom inset when search bar is visible

### DIFF
--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
@@ -32,13 +32,14 @@ extension HistoryPanel: UISearchBarDelegate {
 
         bottomStackView.isHidden = true
         searchBar.resignFirstResponder()
+		updateBottomSearchBarLayout(isHidden: true)
     }
 
     func startSearchState() {
         logger.log("User initiated history search", level: .info, category: .library)
 
         updatePanelState(newState: .history(state: .search))
-        bottomStackView.isHidden = false
+		updateBottomSearchBarLayout(isHidden: false)
         searchbar.becomeFirstResponder()
     }
 
@@ -47,7 +48,8 @@ extension HistoryPanel: UISearchBarDelegate {
         applySnapshot()
         self.searchbar.text = ""
         self.searchbar.resignFirstResponder()
-        bottomStackView.isHidden = true
+		updatePanelState(newState: .history(state: .mainView))
+		updateBottomSearchBarLayout(isHidden: true)
     }
 
     func performSearch(term: String) {

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -249,8 +249,15 @@ class HistoryPanel: UIViewController,
 
         let spacerHeight = keyboardHeight - UIConstants.BottomToolbarHeight
         bottomStackView.addKeyboardSpacer(spacerHeight: spacerHeight)
-        bottomStackView.isHidden = false
     }
+
+	func updateBottomSearchBarLayout(isHidden: Bool) {
+		bottomStackView.isHidden = isHidden
+
+		let bottomInset = isHidden ? 0 : searchbar.bounds.height
+		tableView.contentInset.bottom = bottomInset
+		tableView.verticalScrollIndicatorInsets.bottom = bottomInset
+	}
 
     func shouldDismissOnDone() -> Bool {
         guard state != .history(state: .search) else { return false }
@@ -811,7 +818,6 @@ extension HistoryPanel {
     func handleRightTopButton() {
         if state == .history(state: .search) {
             exitSearchState()
-            updatePanelState(newState: .history(state: .mainView))
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15609)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33442)

## :bulb: Description
Applies the same bottom inset fix to the History panel search UI.

- When search is active, the bottom search bar could cover the last visible result because the table view bottom inset was not updated with the search container height.
- This change updates both `tableView.contentInset.bottom` and `tableView.verticalScrollIndicatorInsets.bottom` based on the visible search bar height, keeping the last result visible while searching.

A similar fix was previously applied to the Bookmarks panel #33215 

## :movie_camera: Demos
https://github.com/user-attachments/assets/bc544707-38f7-4b31-9975-c0d5ff10513c

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

