### PR TITLE
Bugfix FXIOS-15583 [Translation] Fix language picker not dismissing when selecting filtered search result

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationLanguagePickerViewController.swift
@@ -124,6 +124,7 @@ final class TranslationLanguagePickerViewController: UIViewController,
             windowUUID: windowUUID,
             actionType: TranslationSettingsViewActionType.addLanguage
         ))
+        searchController.isActive = false
         dismiss(animated: true)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationLanguagePickerViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationLanguagePickerViewControllerTests.swift
@@ -93,6 +93,23 @@ final class TranslationLanguagePickerViewControllerTests: XCTestCase, StoreTestU
         XCTAssertNotNil(dispatchedAction.languageCode)
     }
 
+    func test_didSelectRow_afterSearchFilter_dispatchesFilteredLanguageCode() throws {
+        let subject = createSubject(
+            preferredLanguages: [],
+            supportedLanguages: ["fr", "de", "es"]
+        )
+        subject.loadViewIfNeeded()
+
+        let searchController = UISearchController()
+        searchController.searchBar.text = "fr"
+        subject.updateSearchResults(for: searchController)
+
+        subject.tableView(UITableView(), didSelectRowAt: IndexPath(row: 0, section: 0))
+
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationSettingsViewAction)
+        XCTAssertEqual(dispatchedAction.languageCode, "fr")
+    }
+
     // MARK: - StoreTestUtility
 
     func setupAppState() -> AppState {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationLanguagePickerViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationLanguagePickerViewControllerTests.swift
@@ -93,7 +93,7 @@ final class TranslationLanguagePickerViewControllerTests: XCTestCase, StoreTestU
         XCTAssertNotNil(dispatchedAction.languageCode)
     }
 
-    func test_didSelectRow_afterSearchFilter_dispatchesFilteredLanguageCode() throws {
+    func test_didSelectRow_afterSearchFilter_dispatchesCorrectLanguageCode() throws {
         let subject = createSubject(
             preferredLanguages: [],
             supportedLanguages: ["fr", "de", "es"]
@@ -108,6 +108,17 @@ final class TranslationLanguagePickerViewControllerTests: XCTestCase, StoreTestU
 
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationSettingsViewAction)
         XCTAssertEqual(dispatchedAction.languageCode, "fr")
+    }
+
+    func test_didSelectRow_deactivatesPickerSearchController() {
+        let subject = createSubject(
+            preferredLanguages: [],
+            supportedLanguages: ["fr", "de"]
+        )
+        subject.loadViewIfNeeded()
+
+        subject.tableView(UITableView(), didSelectRowAt: IndexPath(row: 0, section: 0))
+        XCTAssertEqual(subject.navigationItem.searchController?.isActive, false)
     }
 
     // MARK: - StoreTestUtility


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15583)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33384)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
When a user typed a query in the language picker search bar and tapped a filtered result, the search overlay        dismissed but the picker stayed on screen making it appear as if the selection was lost. The reason for it was `UISearchController` was active when `dismiss(animated:)` was called. UIKit intercepts the dismiss to collapse the search bar first, leaving the picker on screen.
                                                                                                                      
Fix: deactivate `searchController` before calling `dismiss` so UIKit dismisses the picker in one clean step.  

## :movie_camera: Demos

https://github.com/user-attachments/assets/83ea19b2-710d-4ad9-b585-4c26b82b2a65



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

