### PR TITLE
Bugfix FXIOS-10183 [Private Browsing Mode] Close private browsing mode session when the last private tab is closed.

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
@@ -50,11 +50,12 @@ public struct WKWebViewParameters {
 @MainActor
 public protocol WKEngineConfigurationProvider {
     func createConfiguration(parameters: WKWebViewParameters) -> WKEngineConfiguration
+    func endPrivateBrowsingSession()
 }
 
 /// FXIOS-11986 - This will be internal when the WebEngine is fully integrated in Firefox iOS
-public struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvider {
-    private static let nonPersistentStore = WKWebsiteDataStore.nonPersistent()
+public final class DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvider {
+    private var nonPersistentStore = WKWebsiteDataStore.nonPersistent()
     private static let defaultStore = WKWebsiteDataStore.default()
     private static let defaultDataDetectorTypes: WKDataDetectorTypes = [.phoneNumber]
     private let configuration: WKWebViewConfiguration
@@ -79,7 +80,7 @@ public struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvide
         // may safely share cookies.
         // The cookie store should only be created once, otherwise we can loose them. See FXIOS-11833
         configuration.websiteDataStore = parameters.isPrivate
-            ? Self.nonPersistentStore
+            ? nonPersistentStore
             : Self.defaultStore
 
         // Popup WKWebViewConfiguration can have the scheme already registered thus registering again
@@ -90,5 +91,9 @@ public struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvide
         }
 
         return DefaultEngineConfiguration(webViewConfiguration: configuration)
+    }
+
+    public func endPrivateBrowsingSession() {
+        nonPersistentStore = .nonPersistent()
     }
 }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineConfigurationProvider.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineConfigurationProvider.swift
@@ -10,4 +10,6 @@ struct MockWKEngineConfigurationProvider: WKEngineConfigurationProvider {
     func createConfiguration(parameters: WKWebViewParameters) -> WKEngineConfiguration {
         return MockWKEngineConfiguration(webViewConfiguration: WKWebViewConfiguration())
     }
+
+    func endPrivateBrowsingSession() {}
 }

--- a/BrowserKit/Tests/WebEngineTests/WKEngineConfigurationProviderIntegrationTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineConfigurationProviderIntegrationTests.swift
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import WebKit
+@testable import WebEngine
+
+// Exercises the data store via `WKHTTPCookieStore` rather than a real `WKWebView`:
+// WKWebView navigation is non-deterministic in a unit-test target with no host
+// `UIApplication` (`didFinish` does not fire reliably). The data store is the same
+// surface a `WKWebView` writes through.
+@MainActor
+final class WKEngineConfigurationProviderIntegrationTests: XCTestCase {
+    func testPrivateCookies_areClearedAfterSessionBoundary() async {
+        let subject = createSubject()
+
+        let firstStore = subject.createConfiguration(parameters: privateParams())
+            .webViewConfiguration.websiteDataStore
+        await setCookie(name: "leaked", value: "yes", in: firstStore)
+        let firstCookies = await allCookies(in: firstStore)
+        XCTAssertTrue(firstCookies.contains(where: { $0.name == "leaked" }))
+
+        subject.endPrivateBrowsingSession()
+
+        let secondStore = subject.createConfiguration(parameters: privateParams())
+            .webViewConfiguration.websiteDataStore
+        let secondCookies = await allCookies(in: secondStore)
+        XCTAssertFalse(secondCookies.contains(where: { $0.name == "leaked" }))
+    }
+
+    func testPrivateCookies_areVisibleAcrossSiblingTabsWithinSession() async {
+        let subject = createSubject()
+
+        let firstStore = subject.createConfiguration(parameters: privateParams())
+            .webViewConfiguration.websiteDataStore
+        await setCookie(name: "shared", value: "visible", in: firstStore)
+
+        let siblingStore = subject.createConfiguration(parameters: privateParams())
+            .webViewConfiguration.websiteDataStore
+        let siblingCookies = await allCookies(in: siblingStore)
+        XCTAssertTrue(siblingCookies.contains(where: { $0.name == "shared" && $0.value == "visible" }))
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> DefaultWKEngineConfigurationProvider {
+        return DefaultWKEngineConfigurationProvider()
+    }
+
+    private func privateParams() -> WKWebViewParameters {
+        return WKWebViewParameters(
+            blockPopups: true,
+            isPrivate: true,
+            autoPlay: .all,
+            schemeHandler: WKInternalSchemeHandler()
+        )
+    }
+
+    private func setCookie(name: String, value: String, in store: WKWebsiteDataStore) async {
+        let cookie = HTTPCookie(properties: [
+            .domain: "example.com",
+            .path: "/",
+            .name: name,
+            .value: value,
+            .secure: "FALSE"
+        ])!
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            store.httpCookieStore.setCookie(cookie) {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func allCookies(in store: WKWebsiteDataStore) async -> [HTTPCookie] {
+        await withCheckedContinuation { (continuation: CheckedContinuation<[HTTPCookie], Never>) in
+            store.httpCookieStore.getAllCookies { cookies in
+                continuation.resume(returning: cookies)
+            }
+        }
+    }
+}

--- a/BrowserKit/Tests/WebEngineTests/WKEngineConfigurationProviderTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineConfigurationProviderTests.swift
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import WebKit
+@testable import WebEngine
+
+@MainActor
+final class WKEngineConfigurationProviderTests: XCTestCase {
+    func testPrivateStore_isSharedWithinSession() {
+        let subject = createSubject()
+
+        let first = subject.createConfiguration(parameters: privateParams())
+        let second = subject.createConfiguration(parameters: privateParams())
+
+        XCTAssertTrue(
+            first.webViewConfiguration.websiteDataStore === second.webViewConfiguration.websiteDataStore
+        )
+    }
+
+    func testPrivateStore_isFreshAcrossSessionBoundary() {
+        let subject = createSubject()
+
+        let beforeStore = subject.createConfiguration(parameters: privateParams())
+            .webViewConfiguration.websiteDataStore
+        subject.endPrivateBrowsingSession()
+        let afterStore = subject.createConfiguration(parameters: privateParams())
+            .webViewConfiguration.websiteDataStore
+
+        XCTAssertFalse(beforeStore === afterStore)
+    }
+
+    func testNormalStore_isUnaffectedBySessionBoundary() {
+        let subject = createSubject()
+
+        let before = subject.createConfiguration(parameters: normalParams())
+            .webViewConfiguration.websiteDataStore
+        subject.endPrivateBrowsingSession()
+        let after = subject.createConfiguration(parameters: normalParams())
+            .webViewConfiguration.websiteDataStore
+
+        XCTAssertTrue(before === after)
+        XCTAssertTrue(before.isPersistent)
+    }
+
+    func testPrivateStore_isNonPersistentAcrossBoundary() {
+        let subject = createSubject()
+
+        let beforeStore = subject.createConfiguration(parameters: privateParams())
+            .webViewConfiguration.websiteDataStore
+        XCTAssertFalse(beforeStore.isPersistent)
+
+        subject.endPrivateBrowsingSession()
+
+        let afterStore = subject.createConfiguration(parameters: privateParams())
+            .webViewConfiguration.websiteDataStore
+        XCTAssertFalse(afterStore.isPersistent)
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> DefaultWKEngineConfigurationProvider {
+        return DefaultWKEngineConfigurationProvider()
+    }
+
+    private func privateParams() -> WKWebViewParameters {
+        return WKWebViewParameters(
+            blockPopups: true,
+            isPrivate: true,
+            autoPlay: .all,
+            schemeHandler: WKInternalSchemeHandler()
+        )
+    }
+
+    private func normalParams() -> WKWebViewParameters {
+        return WKWebViewParameters(
+            blockPopups: true,
+            isPrivate: false,
+            autoPlay: .all,
+            schemeHandler: WKInternalSchemeHandler()
+        )
+    }
+}

--- a/firefox-ios/Client/TabManagement/TabConfigurationProvider.swift
+++ b/firefox-ios/Client/TabManagement/TabConfigurationProvider.swift
@@ -43,6 +43,10 @@ class TabConfigurationProvider {
         privateConfiguration.webViewConfiguration.mediaTypesRequiringUserActionForPlayback = mediaType
     }
 
+    func endPrivateBrowsingSession() {
+        configurationProvider.endPrivateBrowsingSession()
+    }
+
     private func configuration(from prefs: Prefs, isPrivate: Bool) -> WKEngineConfiguration {
         let blockPopups = prefs.boolForKey(PrefsKeys.KeyBlockPopups) ?? true
         let autoPlay = AutoplayAccessors.getMediaTypesRequiringUserActionForPlayback(prefs)

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -282,6 +282,10 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
         TabEvent.post(.didClose, for: tab)
 
+        if tab.isPrivate, privateTabs.isEmpty {
+            tabConfigurationProvider.endPrivateBrowsingSession()
+        }
+
         if flushToDisk {
             // Only preserve tabs if restore has finished
             if tabRestoreHasFinished {
@@ -881,6 +885,7 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
 
         tabs = normalTabs
+        tabConfigurationProvider.endPrivateBrowsingSession()
     }
 
     private func willSelectTab(_ url: URL?) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10183)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22296)

## :bulb: Description
Clears non-persistent data store on PBM session end. Works both with closing the last tab and closing all tabs at once.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

