### PR TITLE
Bugfix FXIOS-15613 [Toolbar] Previous tabs url is displayed when opening new tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -353,7 +353,9 @@ struct AddressBarState: StateType, Sendable, Equatable {
                                                      isEditing: state.isEditing,
                                                      isEmptySearch: isEmptySearch),
             browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
-            url: toolbarAction.url,
+            url: toolbarAction.url == nil
+                ? (nil as URL??)
+                : .some(toolbarAction.url),
             searchTerm: nil,
             lockIconButtonA11yId: toolbarAction.lockIconButtonA11yId.map { Optional($0) } ?? .some(nil),
             lockIconImageName: toolbarAction.lockIconImageName.map { Optional($0) } ?? .some(nil),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15613)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33450)

## :bulb: Description
Fixes the url not being set correctly when it's nil.

## :movie_camera: Demos

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>

**Before:**

https://github.com/user-attachments/assets/85b345de-5f3b-453d-81b9-3295686ee4c9

**After:**

https://github.com/user-attachments/assets/e5fd798f-d08e-4642-b243-403c59e284ae
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

