### PR TITLE
  Bugfix FXIOS-15391 [Translations][Accessibility][iPad] PB icon is selected instead of loading (language Icon) while a translation is in progress on iPad with voice-over ON                                        

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -81,7 +81,7 @@ class ToolbarButton: UIButton,
 
         // TODO: FXIOS-13949 - To investigate if there's a better way to show loading spinner
         if let isLoading = element.loadingConfig?.isLoading, isLoading {
-            makeLoadingButton(startedA11yLabel: element.a11yLabel)
+            makeLoadingButton()
         } else {
             let completionA11yLabel = element.isSelected ? element.loadingConfig?.a11yLabel : nil
             hideLoadingIcon(completionA11yLabel: completionA11yLabel)
@@ -287,7 +287,7 @@ class ToolbarButton: UIButton,
     // TODO: FXIOS-13949 - To investigate if there's a better way to show loading spinner
     private var spinner: UIActivityIndicatorView?
 
-    private func makeLoadingButton(startedA11yLabel: String?, style: UIActivityIndicatorView.Style = .medium) {
+    private func makeLoadingButton(style: UIActivityIndicatorView.Style = .medium) {
         let isNewSpinner = spinner == nil
         if spinner == nil {
             let loadingView = UIActivityIndicatorView(style: style)
@@ -300,8 +300,8 @@ class ToolbarButton: UIButton,
             spinner = loadingView
         }
         spinner?.startAnimating()
-        if isNewSpinner && UIAccessibility.isVoiceOverRunning, let startedA11yLabel {
-            UIAccessibility.post(notification: .announcement, argument: startedA11yLabel)
+        if isNewSpinner && UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .layoutChanged, argument: self)
         }
     }
 

--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -81,9 +81,10 @@ class ToolbarButton: UIButton,
 
         // TODO: FXIOS-13949 - To investigate if there's a better way to show loading spinner
         if let isLoading = element.loadingConfig?.isLoading, isLoading {
-            makeLoadingButton()
+            makeLoadingButton(startedA11yLabel: element.a11yLabel)
         } else {
-            hideLoadingIcon()
+            let completionA11yLabel = element.isSelected ? element.loadingConfig?.a11yLabel : nil
+            hideLoadingIcon(completionA11yLabel: completionA11yLabel)
         }
         let image = imageConfiguredForRTL(for: element)
         let action = UIAction(title: element.title ?? element.a11yLabel,
@@ -286,7 +287,7 @@ class ToolbarButton: UIButton,
     // TODO: FXIOS-13949 - To investigate if there's a better way to show loading spinner
     private var spinner: UIActivityIndicatorView?
 
-    private func makeLoadingButton(style: UIActivityIndicatorView.Style = .medium) {
+    private func makeLoadingButton(startedA11yLabel: String?, style: UIActivityIndicatorView.Style = .medium) {
         let isNewSpinner = spinner == nil
         if spinner == nil {
             let loadingView = UIActivityIndicatorView(style: style)
@@ -299,19 +300,21 @@ class ToolbarButton: UIButton,
             spinner = loadingView
         }
         spinner?.startAnimating()
-        if isNewSpinner && UIAccessibility.isVoiceOverRunning {
-            UIAccessibility.post(notification: .layoutChanged, argument: self)
+        if isNewSpinner && UIAccessibility.isVoiceOverRunning, let startedA11yLabel {
+            UIAccessibility.post(notification: .announcement, argument: startedA11yLabel)
         }
     }
 
-    private func hideLoadingIcon() {
+    private func hideLoadingIcon(completionA11yLabel: String? = nil) {
         let hadSpinner = spinner != nil
         spinner?.stopAnimating()
         spinner?.removeFromSuperview()
         spinner = nil
-        if hadSpinner && UIAccessibility.isVoiceOverRunning {
-            UIAccessibility.post(notification: .layoutChanged, argument: self)
+        guard hadSpinner && UIAccessibility.isVoiceOverRunning else { return }
+        if let completionA11yLabel {
+            UIAccessibility.post(notification: .announcement, argument: completionA11yLabel)
         }
+        UIAccessibility.post(notification: .layoutChanged, argument: self)
     }
 
     private func removeLongPressGestureRecognizer() {

--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -82,7 +82,6 @@ class ToolbarButton: UIButton,
         // TODO: FXIOS-13949 - To investigate if there's a better way to show loading spinner
         if let isLoading = element.loadingConfig?.isLoading, isLoading {
             makeLoadingButton()
-            loadingA11yLabel = element.loadingConfig?.a11yLabel
         } else {
             hideLoadingIcon()
         }
@@ -286,9 +285,9 @@ class ToolbarButton: UIButton,
     // MARK: - Loading Icon for Translation Button
     // TODO: FXIOS-13949 - To investigate if there's a better way to show loading spinner
     private var spinner: UIActivityIndicatorView?
-    private var loadingA11yLabel: String?
 
     private func makeLoadingButton(style: UIActivityIndicatorView.Style = .medium) {
+        let isNewSpinner = spinner == nil
         if spinner == nil {
             let loadingView = UIActivityIndicatorView(style: style)
             loadingView.translatesAutoresizingMaskIntoConstraints = false
@@ -300,15 +299,19 @@ class ToolbarButton: UIButton,
             spinner = loadingView
         }
         spinner?.startAnimating()
+        if isNewSpinner && UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .layoutChanged, argument: self)
+        }
     }
 
     private func hideLoadingIcon() {
-        if let loadingA11yLabel, spinner != nil && UIAccessibility.isVoiceOverRunning {
-            UIAccessibility.post(notification: .announcement, argument: loadingA11yLabel)
-        }
+        let hadSpinner = spinner != nil
         spinner?.stopAnimating()
         spinner?.removeFromSuperview()
         spinner = nil
+        if hadSpinner && UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .layoutChanged, argument: self)
+        }
     }
 
     private func removeLongPressGestureRecognizer() {

--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -83,8 +83,7 @@ class ToolbarButton: UIButton,
         if let isLoading = element.loadingConfig?.isLoading, isLoading {
             makeLoadingButton()
         } else {
-            let completionA11yLabel = element.isSelected ? element.loadingConfig?.a11yLabel : nil
-            hideLoadingIcon(completionA11yLabel: completionA11yLabel)
+            hideLoadingIcon()
         }
         let image = imageConfiguredForRTL(for: element)
         let action = UIAction(title: element.title ?? element.a11yLabel,
@@ -292,6 +291,7 @@ class ToolbarButton: UIButton,
         if spinner == nil {
             let loadingView = UIActivityIndicatorView(style: style)
             loadingView.translatesAutoresizingMaskIntoConstraints = false
+            loadingView.isAccessibilityElement = false
             addSubview(loadingView)
             NSLayoutConstraint.activate([
                 loadingView.centerXAnchor.constraint(equalTo: centerXAnchor),
@@ -305,16 +305,14 @@ class ToolbarButton: UIButton,
         }
     }
 
-    private func hideLoadingIcon(completionA11yLabel: String? = nil) {
+    private func hideLoadingIcon() {
         let hadSpinner = spinner != nil
         spinner?.stopAnimating()
         spinner?.removeFromSuperview()
         spinner = nil
-        guard hadSpinner && UIAccessibility.isVoiceOverRunning else { return }
-        if let completionA11yLabel {
-            UIAccessibility.post(notification: .announcement, argument: completionA11yLabel)
+        if hadSpinner && UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .layoutChanged, argument: self)
         }
-        UIAccessibility.post(notification: .layoutChanged, argument: self)
     }
 
     private func removeLongPressGestureRecognizer() {

--- a/BrowserKit/Sources/ToolbarKit/ToolbarButtonCaching.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButtonCaching.swift
@@ -26,12 +26,12 @@ protocol ToolbarButtonCaching: AnyObject {
 // MARK: - Default Implementation
 extension ToolbarButtonCaching {
     func hasCachedButton(for toolbarElement: ToolbarElement) -> Bool {
-        let cacheKey = toolbarElement.a11yId
+        let cacheKey = toolbarElement.cacheId ?? toolbarElement.a11yId
         return cachedButtonReferences[cacheKey] != nil
     }
 
     func getToolbarButton(for toolbarElement: ToolbarElement) -> ToolbarButton {
-        let cacheKey = toolbarElement.a11yId
+        let cacheKey = toolbarElement.cacheId ?? toolbarElement.a11yId
         let button: ToolbarButton
 
         if let cachedButton = cachedButtonReferences[cacheKey] {

--- a/BrowserKit/Sources/ToolbarKit/ToolbarElement.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarElement.swift
@@ -59,6 +59,10 @@ public struct ToolbarElement: Equatable {
     /// Accessibility identifier of the toolbar element
     let a11yId: String
 
+    /// Stable cache key used to reuse the same button instance across visual state changes.
+    /// When set, the button cache uses this instead of `a11yId`.
+    let cacheId: String?
+
     /// Name for the custom accessibility action
     let a11yCustomActionName: String?
 
@@ -101,6 +105,7 @@ public struct ToolbarElement: Equatable {
                 a11yLabel: String,
                 a11yHint: String?,
                 a11yId: String,
+                cacheId: String? = nil,
                 a11yCustomActionName: String? = nil,
                 a11yCustomAction: (() -> Void)? = nil,
                 hasLongPressAction: Bool,
@@ -130,6 +135,7 @@ public struct ToolbarElement: Equatable {
         self.a11yLabel = a11yLabel
         self.a11yHint = a11yHint
         self.a11yId = a11yId
+        self.cacheId = cacheId
         self.a11yCustomActionName = a11yCustomActionName
         self.a11yCustomAction = a11yCustomAction
         self.hasLongPressAction = hasLongPressAction

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
@@ -107,6 +107,9 @@ extension BrowserViewController: PhotonActionSheetProtocol {
             presentedUsing: { [weak self] in
                 self?.presentContextualHint(for: .translation)
             },
+            actionOnDismiss: { [weak view] in
+                UIAccessibility.post(notification: .layoutChanged, argument: view)
+            },
             andActionForButton: { },
             overlayState: overlayManager)
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -286,6 +286,7 @@ final class AddressToolbarContainerModel: Equatable {
                 a11yLabel: action.a11yLabel,
                 a11yHint: action.a11yHint,
                 a11yId: action.a11yId,
+                cacheId: action.cacheId,
                 a11yCustomActionName: action.a11yCustomActionName,
                 a11yCustomAction: getA11yCustomAction(action: action, windowUUID: windowUUID),
                 hasLongPressAction: action.canPerformLongPressAction(isShowingTopTabs: isShowingTopTabs),

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -1500,7 +1500,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
             hasHighlightedColor: false,
             contextualHintType: ContextualHintType.translation.rawValue,
             a11yLabel: state.buttonA11yLabel,
-            a11yId: state.buttonA11yIdentifier
+            a11yId: state.buttonA11yIdentifier,
+            cacheId: AccessibilityIdentifiers.Toolbar.translateButton
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionConfiguration.swift
@@ -48,6 +48,7 @@ struct ToolbarActionConfiguration: Equatable {
     var a11yLabel: String
     var a11yHint: String?
     var a11yId: String
+    var cacheId: String?
     var a11yCustomActionName: String?
 
     func canPerformLongPressAction(isShowingTopTabs: Bool?) -> Bool {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15391)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32991)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

 The toolbar button cache uses `a11yId` as its key. Each translation state has a different `a11yId` (`translateButton`, `translateLoadingButton`, `translateActiveButton`), so each state was served a different `ToolbarButton` instance. The spinner was added to the loading instance, but `hideLoadingIcon` ran on a fresh active-state instance with `spinner == nil`, so the `layoutChanged` notification was never posted and VoiceOver focus was never redirected.       

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


