### PR TITLE
Test FXIOS-15230 [Translations Phase 2] Add unit tests for long-press translate button

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -937,22 +937,32 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
     }
 
     private func setupAppStateWithTranslationConfig(
-        for translationIconState: TranslationConfiguration.IconState = .inactive,
-        translatedToLanguage: String? = nil,
-        sourceLanguage: String? = nil
+        for translationIconState: TranslationConfiguration.IconState = .inactive
     ) -> AppState {
         let initialAction = ToolbarAction(
             url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(
-                prefs: mockProfile.prefs,
-                state: translationIconState,
-                translatedToLanguage: translatedToLanguage,
-                sourceLanguage: sourceLanguage
-            ),
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs, state: translationIconState),
             windowUUID: .XCTestDefaultUUID,
             actionType: ToolbarActionType.urlDidChange
         )
         return AppState.reducer(mockStore.state, initialAction)
+    }
+
+    private func setupAppStateWithTranslationLanguage(
+        translatedToLanguage: String,
+        sourceLanguage: String? = nil
+    ) -> AppState {
+        let action = ToolbarAction(
+            translationConfiguration: TranslationConfiguration(
+                prefs: mockProfile.prefs,
+                state: .active,
+                translatedToLanguage: translatedToLanguage,
+                sourceLanguage: sourceLanguage
+            ),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.translationCompleted
+        )
+        return AppState.reducer(mockStore.state, action)
     }
 
     // MARK: - Helpers
@@ -1053,7 +1063,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         mockStore.dispatchCalled = { expectation.fulfill() }
 
         subject.translationsProvider(
-            setupAppStateWithTranslationConfig(for: .active, translatedToLanguage: "da"),
+            setupAppStateWithTranslationLanguage(translatedToLanguage: "da"),
             action
         )
 
@@ -1101,7 +1111,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         mockStore.dispatchCalled = { expectation.fulfill() }
 
         subject.translationsProvider(
-            setupAppStateWithTranslationConfig(for: .active, translatedToLanguage: "da", sourceLanguage: "de"),
+            setupAppStateWithTranslationLanguage(translatedToLanguage: "da", sourceLanguage: "de"),
             action
         )
 
@@ -1121,7 +1131,10 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: TranslationsActionType.didSelectTargetLanguage
         )
 
-        let expectation = XCTestExpectation(description: "translationCompleted carries sourceLanguage")
+        // didSelectTargetLanguage triggers two dispatches:
+        // 1. didStartTranslatingPage (loading icon)
+        // 2. translationCompleted (active icon, with detected source language)
+        let expectation = XCTestExpectation(description: "didStartTranslatingPage and translationCompleted dispatched")
         expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
 
@@ -1129,9 +1142,15 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
 
         wait(for: [expectation], timeout: 1.0)
 
+        let startAction = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
+        let startActionType = try XCTUnwrap(startAction.actionType as? ToolbarActionType)
+        XCTAssertEqual(startActionType, ToolbarActionType.didStartTranslatingPage)
+        XCTAssertEqual(startAction.translationConfiguration?.state, .loading)
+
         let completedAction = try XCTUnwrap(mockStore.dispatchedActions.last as? ToolbarAction)
         let completedActionType = try XCTUnwrap(completedAction.actionType as? ToolbarActionType)
         XCTAssertEqual(completedActionType, ToolbarActionType.translationCompleted)
+        XCTAssertEqual(completedAction.translationConfiguration?.state, .active)
         XCTAssertEqual(completedAction.translationConfiguration?.sourceLanguage, "en")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -937,11 +937,18 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
     }
 
     private func setupAppStateWithTranslationConfig(
-        for translationIconState: TranslationConfiguration.IconState = .inactive
+        for translationIconState: TranslationConfiguration.IconState = .inactive,
+        translatedToLanguage: String? = nil,
+        sourceLanguage: String? = nil
     ) -> AppState {
         let initialAction = ToolbarAction(
             url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs, state: translationIconState),
+            translationConfiguration: TranslationConfiguration(
+                prefs: mockProfile.prefs,
+                state: translationIconState,
+                translatedToLanguage: translatedToLanguage,
+                sourceLanguage: sourceLanguage
+            ),
             windowUUID: .XCTestDefaultUUID,
             actionType: ToolbarActionType.urlDidChange
         )
@@ -1028,5 +1035,103 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
     // similar to production
     func resetStore() {
         StoreTestUtilityHelper.resetStore()
+    }
+
+    // MARK: - Long-press tests
+
+    func test_longPress_withActiveState_andFeatureEnabled_dispatchesShowPickerAction() throws {
+        setTranslationsFeatureEnabled(enabled: true, languagePickerEnabled: true)
+        let subject = createSubject()
+        let action = ToolbarMiddlewareAction(
+            buttonType: .translate,
+            gestureType: .longPress,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
+        )
+
+        let expectation = XCTestExpectation(description: "showTranslationLanguagePicker dispatched on long press")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(
+            setupAppStateWithTranslationConfig(for: .active, translatedToLanguage: "da"),
+            action
+        )
+
+        wait(for: [expectation], timeout: 1.0)
+
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
+        let dispatchedActionType = try XCTUnwrap(dispatchedAction.actionType as? GeneralBrowserActionType)
+        XCTAssertEqual(dispatchedActionType, GeneralBrowserActionType.showTranslationLanguagePicker)
+        XCTAssertEqual(dispatchedAction.isPageTranslated, true)
+        XCTAssertEqual(dispatchedAction.translatedToLanguage, "da")
+    }
+
+    func test_longPress_withInactiveState_doesNotDispatch() throws {
+        setTranslationsFeatureEnabled(enabled: true, languagePickerEnabled: true)
+        let subject = createSubject()
+        let action = ToolbarMiddlewareAction(
+            buttonType: .translate,
+            gestureType: .longPress,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
+        )
+
+        let expectation = XCTestExpectation(description: "no action dispatched on long press inactive")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(setupAppStateWithTranslationConfig(for: .inactive), action)
+
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+    }
+
+    func test_longPress_filtersSourceAndTranslatedLanguageFromPicker() throws {
+        setTranslationsFeatureEnabled(enabled: true, languagePickerEnabled: true)
+        mockProfile.prefs.setString("de,da,en", forKey: PrefsKeys.Settings.translationPreferredLanguages)
+        let subject = createSubject()
+        let action = ToolbarMiddlewareAction(
+            buttonType: .translate,
+            gestureType: .longPress,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
+        )
+
+        let expectation = XCTestExpectation(description: "picker dispatched with source and translated languages filtered")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(
+            setupAppStateWithTranslationConfig(for: .active, translatedToLanguage: "da", sourceLanguage: "de"),
+            action
+        )
+
+        wait(for: [expectation], timeout: 1.0)
+
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
+        XCTAssertEqual(dispatchedAction.translationLanguages, ["en"])
+    }
+
+    func test_translationCompleted_storesSourceLanguageInConfiguration() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslatePromptShown)
+        let subject = createSubject()
+        let action = TranslationLanguageSelectedAction(
+            windowUUID: .XCTestDefaultUUID,
+            targetLanguage: "da",
+            actionType: TranslationsActionType.didSelectTargetLanguage
+        )
+
+        let expectation = XCTestExpectation(description: "translationCompleted carries sourceLanguage")
+        expectation.expectedFulfillmentCount = 2
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        let completedAction = try XCTUnwrap(mockStore.dispatchedActions.last as? ToolbarAction)
+        let completedActionType = try XCTUnwrap(completedAction.actionType as? ToolbarActionType)
+        XCTAssertEqual(completedActionType, ToolbarActionType.translationCompleted)
+        XCTAssertEqual(completedAction.translationConfiguration?.sourceLanguage, "en")
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15230)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32750)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

  Follow-up test coverage for the long-press translate-button feature shipped in #33157. The 4 unit tests cover behavior that was implemented but never had tests committed:                                         
                                                                                                                                                                                                                     
  - `test_longPress_withActiveState_andFeatureEnabled_dispatchesShowPickerAction` — long-press on the translate button dispatches `showTranslationLanguagePicker` when translation is active                         
  - `test_longPress_withInactiveState_doesNotDispatch` — no dispatch when translation is inactive                                                                                                                    
  - `test_longPress_filtersSourceAndTranslatedLanguageFromPicker` — both source and translated languages are filtered out of the language picker                                                                     
  - `test_translationCompleted_storesSourceLanguageInConfiguration` — source language is persisted on `translationCompleted`         

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


