### PR TITLE
Revert "FXIOS-15348 [Technical Debt] [Redux] Use @CopyWithUpdates macro for RemoteTabsPanelState #32932"

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
 import Redux
 import Storage
 
@@ -49,13 +48,12 @@ enum RemoteTabsPanelEmptyStateReason {
 }
 
 /// State for RemoteTabsPanel. WIP.
-@CopyWithUpdates
 struct RemoteTabsPanelState: ScreenState, Sendable {
-    let windowUUID: WindowUUID
     let refreshState: RemoteTabsPanelRefreshState
     let allowsRefresh: Bool
     let clientAndTabs: [ClientAndTabs]
     let showingEmptyState: RemoteTabsPanelEmptyStateReason?// If showing empty (or error) state
+    let windowUUID: WindowUUID
     let devices: [Device]
 
     init(appState: AppState, uuid: WindowUUID) {
@@ -68,7 +66,12 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
             return
         }
 
-        self = panelState.copyWithUpdates()
+        self.init(windowUUID: panelState.windowUUID,
+                  refreshState: panelState.refreshState,
+                  allowsRefresh: panelState.allowsRefresh,
+                  clientAndTabs: panelState.clientAndTabs,
+                  showingEmptyState: panelState.showingEmptyState,
+                  devices: panelState.devices)
     }
 
     init(windowUUID: WindowUUID) {
@@ -123,39 +126,61 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
     }
 
     private static func handleRefreshDidBeginAction(state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return state.copyWithUpdates(refreshState: .refreshing)
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .refreshing,
+                                    allowsRefresh: state.allowsRefresh,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: state.showingEmptyState,
+                                    devices: state.devices)
     }
 
     private static func handleRefreshDidFailAction(reason: RemoteTabsPanelEmptyStateReason,
                                                    state: RemoteTabsPanelState) -> RemoteTabsPanelState {
         let allowsRefresh = reason.allowsRefresh
-        return state.copyWithUpdates(refreshState: .idle,
-                                     allowsRefresh: allowsRefresh,
-                                     showingEmptyState: reason)
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .idle,
+                                    allowsRefresh: allowsRefresh,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: reason,
+                                    devices: state.devices)
     }
 
     private static func handleRefreshDidSucceedAction(clientAndTabs: [ClientAndTabs],
                                                       state: RemoteTabsPanelState,
                                                       action: RemoteTabsPanelAction) -> RemoteTabsPanelState {
-        return state.copyWithUpdates(refreshState: .idle,
-                                     allowsRefresh: true,
-                                     clientAndTabs: clientAndTabs,
-                                     showingEmptyState: nil,
-                                     devices: action.devices ?? state.devices)
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .idle,
+                                    allowsRefresh: true,
+                                    clientAndTabs: clientAndTabs,
+                                    showingEmptyState: nil,
+                                    devices: action.devices ?? state.devices)
     }
 
     private static func handleRemoteDevicesChangedAction(devices: [Device],
                                                          state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return state.copyWithUpdates(refreshState: .idle,
-                                     devices: devices)
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .idle,
+                                    allowsRefresh: state.allowsRefresh,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: state.showingEmptyState,
+                                    devices: devices)
     }
 
     private static func handleSyncDidBeginAction(state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return state.copyWithUpdates(refreshState: .syncingTabs,
-                                     allowsRefresh: false)
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .syncingTabs,
+                                    allowsRefresh: false,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: state.showingEmptyState,
+                                    devices: state.devices)
     }
 
     static func defaultState(from state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return state.copyWithUpdates()
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: state.refreshState,
+                                    allowsRefresh: state.allowsRefresh,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: state.showingEmptyState,
+                                    devices: state.devices)
     }
 }


### PR DESCRIPTION
An issue was found with `CopyWithUpdates`. We are reverting those changes for now until we reassess and find a proper solution.

Reverts mozilla-mobile/firefox-ios#33309