### PR TITLE
Refactor NOTICKET [FeatureFlags] Alphabetize feature flag items correctly

### DIFF
--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -24,33 +24,34 @@ enum FeatureFlagID: String, CaseIterable {
     case homepageJumpBackinSectionDefault
     case homepageSearchBar
     case homepageStoryCategories
-    case needsReloadRefactor
-    case shouldUseBrandRefreshConfiguration
-    case shouldUseJapanConfiguration
+    case hostedSummarizer
+    case hostedSummarizerShakeGesture
+    case hostedSummarizerToolbarEntrypoint
+    case httpsUpgrade
+    case improvedAppStoreReviewTriggerFeature
     case microsurvey
     case modernOnboardingUI
     case nativeErrorPage
+    case needsReloadRefactor
     case noInternetConnectionErrorPage
+    case quickAnswers
     case recentSearches
-    case reportSiteIssue
     case relayIntegration
+    case reportSiteIssue
     case sentFromFirefox
     case sentFromFirefoxTreatmentA
+    case shouldUseBrandRefreshConfiguration
+    case shouldUseJapanConfiguration
     case snapkitRemovalRefactor
     case splashScreen
     case startAtHome
-    case hostedSummarizer
-    case hostedSummarizerToolbarEntrypoint
-    case hostedSummarizerShakeGesture
-    case httpsUpgrade
-    case improvedAppStoreReviewTriggerFeature
     case summarizerAppAttestAuth
     case summarizerLanguageExpansion
     case summarizerPermissiveGuardrails
     case tabScrollRefactorFeature
     case tabTrayiPadUIExperiments
-    case tabTrayUIExperiments
     case tabTrayTranslucency
+    case tabTrayUIExperiments
     case toolbarUpdateHint
     case tosFeature
     case touFeature
@@ -61,7 +62,6 @@ enum FeatureFlagID: String, CaseIterable {
     case unifiedSearch
     case videoIntroOnboarding
     case worldCupWidget
-    case quickAnswers
 
     /// The user preferences key for features that support user-togglable settings.
     /// Returns `nil` for features that are not user-configurable.
@@ -85,11 +85,11 @@ enum FeatureFlagID: String, CaseIterable {
     // Add in alphabetical order.
     var debugKey: String? {
         switch self {
-        case    .aiKillSwitch,
+        case    .addressBarMenu,
+                .adsClient,
+                .aiKillSwitch,
                 .appearanceMenu,
                 .appIconSelection,
-                .addressBarMenu,
-                .adsClient,
                 .badCertDomainErrorPage,
                 .bookmarksSearchFeature,
                 .deeplinkOptimizationRefactor,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -28,15 +28,9 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
 
     // swiftlint:disable:next function_body_length
     private func generateFeatureFlagToggleSettings() -> SettingSection {
-        // For better code readability and parsability in-app, please keep in alphabetical order by title
+        // For better code readability and parsability in-app, please keep in alphabetical
+        // order by titleText
         let children: [Setting] =  [
-            FeatureFlagsBoolSetting(
-                with: .httpsUpgrade,
-                titleText: format(string: "Automatic HTTPS upgrade"),
-                statusText: format(string: "Toggle to enable automatic HTTPS upgrade.")
-            ) { [weak self] _ in
-                self?.reloadView()
-            },
             FeatureFlagsBoolSetting(
                 with: .adsClient,
                 titleText: format(string: "Ads Client"),
@@ -55,6 +49,20 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 with: .appearanceMenu,
                 titleText: format(string: "Appearance Menu"),
                 statusText: format(string: "Toggle to show the new appearance menu")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
+                with: .httpsUpgrade,
+                titleText: format(string: "Automatic HTTPS upgrade"),
+                statusText: format(string: "Toggle to enable automatic HTTPS upgrade.")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
+                with: .badCertDomainErrorPage,
+                titleText: format(string: "Bad Cert Domain Native Error Page"),
+                statusText: format(string: "Toggle to display the natively created bad cert domain error page")
             ) { [weak self] _ in
                 self?.reloadView()
             },
@@ -101,6 +109,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .hostedSummarizer,
+                titleText: format(string: "Hosted Summarizer Feature"),
+                statusText: format(string: "Toggle to enable the hosted summarizer feature")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .improvedAppStoreReviewTriggerFeature,
                 titleText: format(string: "Improved App Store Review Trigger"),
                 statusText: format(string: "Toggle to enable App Store Review Trigger feature.")
@@ -123,6 +138,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .needsReloadRefactor,
+                titleText: format(string: "Needs Reload Refactor"),
+                statusText: format(string: "Toggle to enable the needs reload refactor")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .addressBarMenu,
                 titleText: format(string: "New AddressBar Menu"),
                 statusText: format(string: "Toggle to show the new address bar menu")
@@ -137,9 +159,9 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
-                with: .badCertDomainErrorPage,
-                titleText: format(string: "Bad Cert Domain Native Error Page"),
-                statusText: format(string: "Toggle to display the natively created bad cert domain error page")
+                with: .quickAnswers,
+                titleText: format(string: "Quick Answers"),
+                statusText: format(string: "Toggle to enable the Quick Answers feature")
             ) { [weak self] _ in
                 self?.reloadView()
             },
@@ -179,9 +201,23 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .summarizerAppAttestAuth,
+                titleText: format(string: "Summarizer App Attest Auth Feature"),
+                statusText: format(string: "Toggle to enable the app attest authentication for the summarizer feature")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .summarizerLanguageExpansion,
                 titleText: format(string: "Summarizer Language Expansion"),
                 statusText: format(string: "Toggle to enable Summarizer language expansion feature")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
+                with: .summarizerPermissiveGuardrails,
+                titleText: format(string: "Summarizer Permissive Guardrails Feature"),
+                statusText: format(string: "Toggle to enable the permissive guardrails for the summarizer feature")
             ) { [weak self] _ in
                 self?.reloadView()
             },
@@ -193,16 +229,16 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
-                with: .tabTrayUIExperiments,
-                titleText: format(string: "Tab Tray UI Experiment"),
-                statusText: format(string: "Toggle to use the new tab tray UI")
+                with: .tabTrayiPadUIExperiments,
+                titleText: format(string: "Tab Tray iPad UI Experiment"),
+                statusText: format(string: "Toggle to use the new tab tray UI on iPad")
             ) { [weak self] _ in
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
-                with: .tabTrayiPadUIExperiments,
-                titleText: format(string: "Tab Tray iPad UI Experiment"),
-                statusText: format(string: "Toggle to use the new tab tray UI on iPad")
+                with: .tabTrayUIExperiments,
+                titleText: format(string: "Tab Tray UI Experiment"),
+                statusText: format(string: "Toggle to use the new tab tray UI")
             ) { [weak self] _ in
                 self?.reloadView()
             },
@@ -214,16 +250,16 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
-                with: .translation,
-                titleText: format(string: "Translations"),
-                statusText: format(string: "Toggle to enable translations feature")
+                with: .translationLanguagePicker,
+                titleText: format(string: "Translation Language Picker"),
+                statusText: format(string: "Toggle to enable language picker for translations")
             ) { [weak self] _ in
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
-                with: .translationLanguagePicker,
-                titleText: format(string: "Translation Language Picker"),
-                statusText: format(string: "Toggle to enable language picker for translations")
+                with: .translation,
+                titleText: format(string: "Translations"),
+                statusText: format(string: "Toggle to enable translations feature")
             ) { [weak self] _ in
                 self?.reloadView()
             },
@@ -235,44 +271,9 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
-                with: .quickAnswers,
-                titleText: format(string: "Quick Answers"),
-                statusText: format(string: "Toggle to enable the Quick Answers feature")
-            ) { [weak self] _ in
-                self?.reloadView()
-            },
-            FeatureFlagsBoolSetting(
                 with: .worldCupWidget,
                 titleText: format(string: "World Cup Widget"),
                 statusText: format(string: "Toggle to enable the World Cup widget feature on the Homepage")
-            ) { [weak self] _ in
-                self?.reloadView()
-            },
-            FeatureFlagsBoolSetting(
-                with: .hostedSummarizer,
-                titleText: format(string: "Hosted Summarizer Feature"),
-                statusText: format(string: "Toggle to enable the hosted summarizer feature")
-            ) { [weak self] _ in
-                self?.reloadView()
-            },
-            FeatureFlagsBoolSetting(
-                with: .summarizerAppAttestAuth,
-                titleText: format(string: "Summarizer App Attest Auth Feature"),
-                statusText: format(string: "Toggle to enable the app attest authentication for the summarizer feature")
-            ) { [weak self] _ in
-                self?.reloadView()
-            },
-            FeatureFlagsBoolSetting(
-                with: .needsReloadRefactor,
-                titleText: format(string: "Needs Reload Refactor"),
-                statusText: format(string: "Toggle to enable the needs reload refactor")
-            ) { [weak self] _ in
-                self?.reloadView()
-            },
-            FeatureFlagsBoolSetting(
-                with: .summarizerPermissiveGuardrails,
-                titleText: format(string: "Summarizer Permissive Guardrails Feature"),
-                statusText: format(string: "Toggle to enable the permissive guardrails for the summarizer feature")
             ) { [weak self] _ in
                 self?.reloadView()
             },

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -24,6 +24,9 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .addressAutofillEdit:
             return checkAddressAutofillEditing()
 
+        case .addressBarMenu:
+            return checkAddressBarMenuFeature()
+
         case .adsClient:
             return checkAdsClientFeature()
 
@@ -36,8 +39,8 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .appIconSelection:
             return checkAppIconSelectionSetting()
 
-        case .addressBarMenu:
-            return checkAddressBarMenuFeature()
+        case .badCertDomainErrorPage:
+            return checkBadCertDomainErrorPageFeature()
 
         case .bookmarksSearchFeature:
             return checkBookmarksSearchFeature()
@@ -69,14 +72,20 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .homepageStoryCategories:
             return checkHomepageStoriesCaterogiesFeature()
 
-        case .needsReloadRefactor:
-            return checkNeedsReloadRefactorFeature()
+        case .hostedSummarizer:
+            return checkHostedSummarizerFeature()
 
-        case .shouldUseBrandRefreshConfiguration:
-            return checkShouldUseBrandRefreshConfigurationFeature()
+        case .hostedSummarizerShakeGesture:
+           return checkHostedSummarizerShakeGesture()
 
-        case .shouldUseJapanConfiguration:
-            return checkShouldUseJapanConfigurationFeature()
+        case .hostedSummarizerToolbarEntrypoint:
+           return checkHostedSummarizerToolbarEntrypoint()
+
+        case .httpsUpgrade:
+            return checkHttpsUpgradeFeature()
+
+        case .improvedAppStoreReviewTriggerFeature:
+            return checkImprovedAppStoreReviewTriggerFeature()
 
         case .microsurvey:
             return checkMicrosurveyFeature()
@@ -87,14 +96,20 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .nativeErrorPage:
             return checkNativeErrorPageFeature()
 
+        case .needsReloadRefactor:
+            return checkNeedsReloadRefactorFeature()
+
         case .noInternetConnectionErrorPage:
             return checkNICErrorPageFeature()
 
-        case .badCertDomainErrorPage:
-            return checkBadCertDomainErrorPageFeature()
+        case .quickAnswers:
+            return checkQuickAnswersFeature()
 
         case .recentSearches:
             return checkRecentSearchesFeature()
+
+        case .relayIntegration:
+            return checkRelayIntegration()
 
         case .reportSiteIssue:
             return checkGeneralFeature(for: featureID)
@@ -105,6 +120,12 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .sentFromFirefoxTreatmentA:
             return checkSentFromFirefoxFeatureTreatmentA()
 
+        case .shouldUseBrandRefreshConfiguration:
+            return checkShouldUseBrandRefreshConfigurationFeature()
+
+        case .shouldUseJapanConfiguration:
+            return checkShouldUseJapanConfigurationFeature()
+
         case .snapkitRemovalRefactor:
             return checkSnapKitRemovalRefactor()
 
@@ -114,24 +135,6 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .startAtHome:
             return checkStartAtHomeFeature(for: featureID) != .disabled
 
-        case .hostedSummarizer:
-            return checkHostedSummarizerFeature()
-
-        case .httpsUpgrade:
-            return checkHttpsUpgradeFeature()
-
-        case .improvedAppStoreReviewTriggerFeature:
-            return checkImprovedAppStoreReviewTriggerFeature()
-
-        case .relayIntegration:
-            return checkRelayIntegration()
-
-        case .hostedSummarizerToolbarEntrypoint:
-           return checkHostedSummarizerToolbarEntrypoint()
-
-        case .hostedSummarizerShakeGesture:
-           return checkHostedSummarizerShakeGesture()
-
         case .summarizerAppAttestAuth:
             return checkSummarizerAppAttestAuthFeature()
 
@@ -140,9 +143,6 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
 
         case .summarizerPermissiveGuardrails:
             return checkSummarizerPermissiveGuardrailsFeature()
-
-        case .unifiedSearch:
-            return checkUnifiedSearchFeature()
 
         case .tabScrollRefactorFeature:
             return checkTabScrollRefactorFeature()
@@ -177,11 +177,11 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .trendingSearches:
             return checkTrendingSearches()
 
+        case .unifiedSearch:
+            return checkUnifiedSearchFeature()
+
         case .videoIntroOnboarding:
             return checkVideoIntroOnboardingFeature()
-
-        case .quickAnswers:
-            return checkQuickAnswersFeature()
 
         case .worldCupWidget:
             return checkWorldCupWidgetFeature()


### PR DESCRIPTION
## :bulb: Description
Developers aren't adding feature flags alphabetically. Bad developers!
This fixes that

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

