### PR TITLE
Revert NO-TICKET 150.2/150.3 CopyWithUpdates Changes

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
 import Redux
 import Storage
 
@@ -49,13 +48,12 @@ enum RemoteTabsPanelEmptyStateReason {
 }
 
 /// State for RemoteTabsPanel. WIP.
-@CopyWithUpdates
 struct RemoteTabsPanelState: ScreenState, Sendable {
-    let windowUUID: WindowUUID
     let refreshState: RemoteTabsPanelRefreshState
     let allowsRefresh: Bool
     let clientAndTabs: [ClientAndTabs]
     let showingEmptyState: RemoteTabsPanelEmptyStateReason?// If showing empty (or error) state
+    let windowUUID: WindowUUID
     let devices: [Device]
 
     init(appState: AppState, uuid: WindowUUID) {
@@ -68,7 +66,12 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
             return
         }
 
-        self = panelState.copyWithUpdates()
+        self.init(windowUUID: panelState.windowUUID,
+                  refreshState: panelState.refreshState,
+                  allowsRefresh: panelState.allowsRefresh,
+                  clientAndTabs: panelState.clientAndTabs,
+                  showingEmptyState: panelState.showingEmptyState,
+                  devices: panelState.devices)
     }
 
     init(windowUUID: WindowUUID) {
@@ -123,39 +126,61 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
     }
 
     private static func handleRefreshDidBeginAction(state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return state.copyWithUpdates(refreshState: .refreshing)
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .refreshing,
+                                    allowsRefresh: state.allowsRefresh,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: state.showingEmptyState,
+                                    devices: state.devices)
     }
 
     private static func handleRefreshDidFailAction(reason: RemoteTabsPanelEmptyStateReason,
                                                    state: RemoteTabsPanelState) -> RemoteTabsPanelState {
         let allowsRefresh = reason.allowsRefresh
-        return state.copyWithUpdates(refreshState: .idle,
-                                     allowsRefresh: allowsRefresh,
-                                     showingEmptyState: reason)
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .idle,
+                                    allowsRefresh: allowsRefresh,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: reason,
+                                    devices: state.devices)
     }
 
     private static func handleRefreshDidSucceedAction(clientAndTabs: [ClientAndTabs],
                                                       state: RemoteTabsPanelState,
                                                       action: RemoteTabsPanelAction) -> RemoteTabsPanelState {
-        return state.copyWithUpdates(refreshState: .idle,
-                                     allowsRefresh: true,
-                                     clientAndTabs: clientAndTabs,
-                                     showingEmptyState: nil,
-                                     devices: action.devices ?? state.devices)
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .idle,
+                                    allowsRefresh: true,
+                                    clientAndTabs: clientAndTabs,
+                                    showingEmptyState: nil,
+                                    devices: action.devices ?? state.devices)
     }
 
     private static func handleRemoteDevicesChangedAction(devices: [Device],
                                                          state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return state.copyWithUpdates(refreshState: .idle,
-                                     devices: devices)
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .idle,
+                                    allowsRefresh: state.allowsRefresh,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: state.showingEmptyState,
+                                    devices: devices)
     }
 
     private static func handleSyncDidBeginAction(state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return state.copyWithUpdates(refreshState: .syncingTabs,
-                                     allowsRefresh: false)
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: .syncingTabs,
+                                    allowsRefresh: false,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: state.showingEmptyState,
+                                    devices: state.devices)
     }
 
     static func defaultState(from state: RemoteTabsPanelState) -> RemoteTabsPanelState {
-        return state.copyWithUpdates()
+        return RemoteTabsPanelState(windowUUID: state.windowUUID,
+                                    refreshState: state.refreshState,
+                                    allowsRefresh: state.allowsRefresh,
+                                    clientAndTabs: state.clientAndTabs,
+                                    showingEmptyState: state.showingEmptyState,
+                                    devices: state.devices)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -4,11 +4,8 @@
 
 import Redux
 import Common
-import CopyWithUpdates
 
-@CopyWithUpdates
 struct TabPeekState: ScreenState {
-    let windowUUID: WindowUUID
     let showAddToBookmarks: Bool
     let showRemoveBookmark: Bool
     let showSendToDevice: Bool
@@ -16,6 +13,7 @@ struct TabPeekState: ScreenState {
     let showCloseTab: Bool
     let previewAccessibilityLabel: String
     let screenshot: UIImage
+    let windowUUID: WindowUUID
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let tabPeekState = appState.componentState(
@@ -27,7 +25,14 @@ struct TabPeekState: ScreenState {
             return
         }
 
-        self = tabPeekState.copyWithUpdates()
+        self.init(windowUUID: tabPeekState.windowUUID,
+                  showAddToBookmarks: tabPeekState.showAddToBookmarks,
+                  showRemoveBookmark: tabPeekState.showRemoveBookmark,
+                  showSendToDevice: tabPeekState.showSendToDevice,
+                  showCopyURL: tabPeekState.showCopyURL,
+                  showCloseTab: tabPeekState.showCloseTab,
+                  previewAccessibilityLabel: tabPeekState.previewAccessibilityLabel,
+                  screenshot: tabPeekState.screenshot)
     }
 
     init(windowUUID: WindowUUID,
@@ -57,7 +62,7 @@ struct TabPeekState: ScreenState {
         switch action.actionType {
         case TabPeekActionType.loadTabPeek:
             guard let tabPeekModel = action.tabPeekModel else { return state }
-            return state.copyWithUpdates(
+            return TabPeekState(windowUUID: state.windowUUID,
                                 showAddToBookmarks: tabPeekModel.canTabBeSaved,
                                 showRemoveBookmark: tabPeekModel.canTabBeRemoved,
                                 showSendToDevice: tabPeekModel.isSyncEnabled && tabPeekModel.canTabBeSaved,
@@ -70,6 +75,6 @@ struct TabPeekState: ScreenState {
     }
 
     static func defaultState(from state: TabPeekState) -> TabPeekState {
-        return state.copyWithUpdates()
+        return TabPeekState(windowUUID: state.windowUUID)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
@@ -3,10 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
 import Redux
 
-@CopyWithUpdates
 struct TermsOfUseState: ScreenState {
     let windowUUID: WindowUUID
     var hasAccepted: Bool
@@ -22,7 +20,10 @@ struct TermsOfUseState: ScreenState {
             return
         }
 
-        self = termsOfUseState.copyWithUpdates()
+        self.init(windowUUID: termsOfUseState.windowUUID,
+                  hasAccepted: termsOfUseState.hasAccepted,
+                  wasDismissed: termsOfUseState.wasDismissed
+        )
     }
 
     init(windowUUID: WindowUUID) {
@@ -42,7 +43,9 @@ struct TermsOfUseState: ScreenState {
     }
 
     static func defaultState(from state: TermsOfUseState) -> TermsOfUseState {
-        return state.copyWithUpdates()
+        return TermsOfUseState(windowUUID: state.windowUUID,
+                               hasAccepted: state.hasAccepted,
+                               wasDismissed: state.wasDismissed)
     }
 
     static let reducer: Reducer<TermsOfUseState> = { state, action in
@@ -71,21 +74,24 @@ struct TermsOfUseState: ScreenState {
 
         switch type {
         case .termsShown:
-            return state.copyWithUpdates(
+            return TermsOfUseState(windowUUID: state.windowUUID,
                                    hasAccepted: false,
                                    wasDismissed: false)
         case .termsAccepted:
-            return state.copyWithUpdates(
+            return TermsOfUseState(windowUUID: state.windowUUID,
                                    hasAccepted: true,
                                    wasDismissed: false)
         case .gestureDismiss,
              .remindMeLaterTapped:
-            return state.copyWithUpdates(
+            return TermsOfUseState(windowUUID: state.windowUUID,
+                                   hasAccepted: state.hasAccepted,
                                    wasDismissed: true)
         case .learnMoreLinkTapped,
              .privacyLinkTapped,
              .termsLinkTapped:
-            return state.copyWithUpdates()
+            return TermsOfUseState(windowUUID: state.windowUUID,
+                                   hasAccepted: state.hasAccepted,
+                                   wasDismissed: state.wasDismissed)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -353,9 +353,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
                                                      isEditing: state.isEditing,
                                                      isEmptySearch: isEmptySearch),
             browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
-            url: toolbarAction.url == nil
-                ? (nil as URL??)
-                : .some(toolbarAction.url),
+            url: toolbarAction.url,
             searchTerm: nil,
             lockIconButtonA11yId: toolbarAction.lockIconButtonA11yId.map { Optional($0) } ?? .some(nil),
             lockIconImageName: toolbarAction.lockIconImageName.map { Optional($0) } ?? .some(nil),

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -3,12 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
 import Redux
 import ToolbarKit
 import SummarizeKit
 
-@CopyWithUpdates
 struct AddressBarState: StateType, Sendable, Equatable {
     var windowUUID: WindowUUID
     var navigationActions: [ToolbarActionConfiguration]
@@ -77,10 +75,10 @@ struct AddressBarState: StateType, Sendable, Equatable {
             isLoading: false,
             readerModeState: nil,
             canSummarize: false,
+            translationConfiguration: nil,
             didStartTyping: false,
             isEmptySearch: true,
-            alternativeSearchEngine: nil,
-            translationConfiguration: nil
+            alternativeSearchEngine: nil
         )
     }
 
@@ -102,10 +100,10 @@ struct AddressBarState: StateType, Sendable, Equatable {
          isLoading: Bool,
          readerModeState: ReaderModeState?,
          canSummarize: Bool,
+         translationConfiguration: TranslationConfiguration?,
          didStartTyping: Bool,
          isEmptySearch: Bool,
-         alternativeSearchEngine: SearchEngineModel?,
-         translationConfiguration: TranslationConfiguration?) {
+         alternativeSearchEngine: SearchEngineModel?) {
         self.windowUUID = windowUUID
         self.navigationActions = navigationActions
         self.leadingPageActions = leadingPageActions
@@ -229,7 +227,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
             return defaultState(from: state)
         }
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
             navigationActions: [ToolbarActionConfiguration](),
             leadingPageActions: [ToolbarActionConfiguration](),
             trailingPageActions: [ToolbarActionConfiguration](),
@@ -247,9 +246,10 @@ struct AddressBarState: StateType, Sendable, Equatable {
             isLoading: false,
             readerModeState: nil,
             canSummarize: false,
+            translationConfiguration: nil,
             didStartTyping: false,
             isEmptySearch: true,
-            translationConfiguration: nil,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -257,8 +257,29 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleNumberOfTabsChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
-            browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing)
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
+            trailingPageActions: state.trailingPageActions,
+            browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -266,8 +287,29 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleDidSetTabScreenshotAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
-            browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing)
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
+            trailingPageActions: state.trailingPageActions,
+            browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -277,11 +319,31 @@ struct AddressBarState: StateType, Sendable, Equatable {
             return defaultState(from: state)
         }
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
             leadingPageActions: leadingPageActions(action: toolbarAction,
                                                    addressBarState: state,
                                                    isEditing: state.isEditing),
-            translationConfiguration: toolbarAction.translationConfiguration
+            trailingPageActions: state.trailingPageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: toolbarAction.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -295,9 +357,29 @@ struct AddressBarState: StateType, Sendable, Equatable {
                                                       addressBarState: state,
                                                       isEditing: state.isEditing,
                                                       isEmptySearch: state.isEmptySearch)
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
             trailingPageActions: trailingPageActions,
-            canSummarize: toolbarAction.canSummarize)
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: toolbarAction.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine)
     }
 
     @MainActor
@@ -309,11 +391,29 @@ struct AddressBarState: StateType, Sendable, Equatable {
                                                       addressBarState: state,
                                                       isEditing: state.isEditing,
                                                       isEmptySearch: state.isEmptySearch)
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
             trailingPageActions: trailingPageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
             lockIconImageName: lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
             readerModeState: toolbarAction.readerModeState,
-            canSummarize: toolbarAction.canSummarize
+            canSummarize: toolbarAction.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -321,7 +421,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleWebsiteLoadingStateDidChangeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
             navigationActions: navigationActions(action: toolbarAction,
                                                  addressBarState: state,
                                                  isEditing: state.isEditing),
@@ -331,7 +432,24 @@ struct AddressBarState: StateType, Sendable, Equatable {
             trailingPageActions: trailingPageActions(action: toolbarAction,
                                                      addressBarState: state,
                                                      isEditing: state.isEditing),
-            isLoading: toolbarAction.isLoading ?? state.isLoading
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: toolbarAction.isLoading ?? state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -341,7 +459,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
         let isEmptySearch = toolbarAction.url == nil
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
             navigationActions: navigationActions(action: toolbarAction,
                                                  addressBarState: state,
                                                  isEditing: state.isEditing),
@@ -353,17 +472,26 @@ struct AddressBarState: StateType, Sendable, Equatable {
                                                      isEditing: state.isEditing,
                                                      isEmptySearch: isEmptySearch),
             browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
+            borderPosition: state.borderPosition,
             url: toolbarAction.url,
             searchTerm: nil,
-            lockIconButtonA11yId: toolbarAction.lockIconButtonA11yId.map { Optional($0) } ?? .some(nil),
-            lockIconImageName: toolbarAction.lockIconImageName.map { Optional($0) } ?? .some(nil),
+            lockIconButtonA11yId: toolbarAction.lockIconButtonA11yId ?? state.lockIconButtonA11yId,
+            lockIconImageName: toolbarAction.lockIconImageName ?? state.lockIconImageName,
             lockIconNeedsTheming: toolbarAction.lockIconNeedsTheming ?? state.lockIconNeedsTheming,
             safeListedURLImageName: toolbarAction.safeListedURLImageName,
-            isEmptySearch: isEmptySearch,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
             translationConfiguration: resolveTranslationConfig(
                 from: toolbarAction,
                 existingConfig: state.translationConfiguration
-            )
+            ),
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -382,7 +510,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleBackForwardButtonStateChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
             navigationActions: navigationActions(action: toolbarAction,
                                                  addressBarState: state,
                                                  isEditing: state.isEditing),
@@ -392,7 +521,24 @@ struct AddressBarState: StateType, Sendable, Equatable {
             trailingPageActions: trailingPageActions(action: toolbarAction,
                                                      addressBarState: state,
                                                      isEditing: state.isEditing),
-            searchTerm: nil
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: nil,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -400,43 +546,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleTraitCollectionDidChangeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
-            navigationActions: navigationActions(action: toolbarAction,
-                                                 addressBarState: state,
-                                                 isEditing: state.isEditing),
-            leadingPageActions: leadingPageActions(action: toolbarAction,
-                                                   addressBarState: state,
-                                                   isEditing: state.isEditing),
-            trailingPageActions: trailingPageActions(action: toolbarAction,
-                                                     addressBarState: state,
-                                                     isEditing: state.isEditing),
-            browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing)
-        )
-    }
-
-    @MainActor
-    private static func handleShowMenuWarningBadgeAction(state: Self, action: Action) -> Self {
-        guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
-
-        return state.copyWithUpdates(
-            navigationActions: navigationActions(action: toolbarAction,
-                                                 addressBarState: state,
-                                                 isEditing: state.isEditing),
-            leadingPageActions: leadingPageActions(action: toolbarAction,
-                                                   addressBarState: state,
-                                                   isEditing: state.isEditing),
-            trailingPageActions: trailingPageActions(action: toolbarAction,
-                                                     addressBarState: state,
-                                                     isEditing: state.isEditing),
-            browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing)
-        )
-    }
-
-    @MainActor
-    private static func handlePositionChangedAction(state: Self, action: Action) -> Self {
-        guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
-
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
             navigationActions: navigationActions(action: toolbarAction,
                                                  addressBarState: state,
                                                  isEditing: state.isEditing),
@@ -447,7 +558,95 @@ struct AddressBarState: StateType, Sendable, Equatable {
                                                      addressBarState: state,
                                                      isEditing: state.isEditing),
             browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
-            borderPosition: toolbarAction.addressBorderPosition
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
+    }
+
+    @MainActor
+    private static func handleShowMenuWarningBadgeAction(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: navigationActions(action: toolbarAction,
+                                                 addressBarState: state,
+                                                 isEditing: state.isEditing),
+            leadingPageActions: leadingPageActions(action: toolbarAction,
+                                                   addressBarState: state,
+                                                   isEditing: state.isEditing),
+            trailingPageActions: trailingPageActions(action: toolbarAction,
+                                                     addressBarState: state,
+                                                     isEditing: state.isEditing),
+            browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
+    }
+
+    @MainActor
+    private static func handlePositionChangedAction(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: navigationActions(action: toolbarAction,
+                                                 addressBarState: state,
+                                                 isEditing: state.isEditing),
+            leadingPageActions: leadingPageActions(action: toolbarAction,
+                                                   addressBarState: state,
+                                                   isEditing: state.isEditing),
+            trailingPageActions: trailingPageActions(action: toolbarAction,
+                                                     addressBarState: state,
+                                                     isEditing: state.isEditing),
+            browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
+            borderPosition: toolbarAction.addressBorderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -457,7 +656,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
         let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
             navigationActions: navigationActions(action: toolbarAction, addressBarState: state, isEditing: true),
             leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state, isEditing: true),
             trailingPageActions: trailingPageActions(action: toolbarAction,
@@ -465,12 +665,23 @@ struct AddressBarState: StateType, Sendable, Equatable {
                                                      isEditing: true,
                                                      isEmptySearch: isEmptySearch),
             browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: true),
+            borderPosition: state.borderPosition,
+            url: state.url,
             searchTerm: toolbarAction.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
             isEditing: true,
             shouldShowKeyboard: true,
             shouldSelectSearchTerm: false,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
             didStartTyping: false,
-            isEmptySearch: isEmptySearch
+            isEmptySearch: isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -482,7 +693,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let locationText = searchTerm ?? state.url?.absoluteString
         let isEmptySearch = locationText == nil || locationText?.isEmpty == true
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
             navigationActions: navigationActions(action: toolbarAction, addressBarState: state, isEditing: true),
             leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state, isEditing: true),
             trailingPageActions: trailingPageActions(action: toolbarAction,
@@ -490,12 +702,23 @@ struct AddressBarState: StateType, Sendable, Equatable {
                                                      isEditing: true,
                                                      isEmptySearch: isEmptySearch),
             browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: true),
+            borderPosition: state.borderPosition,
+            url: state.url,
             searchTerm: searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
             isEditing: true,
             shouldShowKeyboard: true,
             shouldSelectSearchTerm: true,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
             didStartTyping: false,
-            isEmptySearch: isEmptySearch
+            isEmptySearch: isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -515,7 +738,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let url = toolbarAction.url ?? state.url
         let isEmptySearch = url == nil
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
             navigationActions: navigationActions(action: toolbarAction, addressBarState: state),
             leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state),
             trailingPageActions: trailingPageActions(action: toolbarAction,
@@ -523,13 +747,23 @@ struct AddressBarState: StateType, Sendable, Equatable {
                                                      isEditing: false,
                                                      isEmptySearch: isEmptySearch),
             browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: false),
+            borderPosition: state.borderPosition,
             url: url,
             searchTerm: nil,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
             isEditing: false,
             shouldShowKeyboard: false,
             shouldSelectSearchTerm: false,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
             didStartTyping: false,
-            isEmptySearch: isEmptySearch
+            isEmptySearch: isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -539,7 +773,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
         let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
             navigationActions: navigationActions(action: toolbarAction, addressBarState: state, isEditing: true),
             leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state, isEditing: true),
             trailingPageActions: trailingPageActions(action: toolbarAction,
@@ -547,12 +782,23 @@ struct AddressBarState: StateType, Sendable, Equatable {
                                                      isEditing: true,
                                                      isEmptySearch: isEmptySearch),
             browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: true),
+            borderPosition: state.borderPosition,
+            url: state.url,
             searchTerm: toolbarAction.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
             isEditing: true,
             shouldShowKeyboard: true,
             shouldSelectSearchTerm: false,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
             didStartTyping: false,
-            isEmptySearch: isEmptySearch
+            isEmptySearch: isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -562,8 +808,29 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleShouldShowKeyboardAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
-            shouldShowKeyboard: toolbarAction.shouldShowKeyboard ?? false
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
+            trailingPageActions: state.trailingPageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: toolbarAction.shouldShowKeyboard ?? false,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -571,14 +838,32 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleClearSearchAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
             trailingPageActions: trailingPageActions(action: toolbarAction,
                                                      addressBarState: state,
                                                      isEditing: true,
                                                      isEmptySearch: true),
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
             searchTerm: nil,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
             isEditing: true,
-            isEmptySearch: true
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: true,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -586,15 +871,32 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleDidDeleteSearchTermAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
             trailingPageActions: trailingPageActions(action: toolbarAction,
                                                      addressBarState: state,
                                                      isEditing: true,
                                                      isEmptySearch: true),
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
             isEditing: true,
+            shouldShowKeyboard: state.shouldShowKeyboard,
             shouldSelectSearchTerm: false,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
             didStartTyping: true,
-            isEmptySearch: true
+            isEmptySearch: true,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -602,33 +904,90 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleDidEnterSearchTermAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
             trailingPageActions: trailingPageActions(action: toolbarAction,
                                                      addressBarState: state,
                                                      isEditing: true,
                                                      isEmptySearch: false),
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
             isEditing: true,
+            shouldShowKeyboard: state.shouldShowKeyboard,
             shouldSelectSearchTerm: false,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
             didStartTyping: true,
-            isEmptySearch: false
+            isEmptySearch: false,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
     private static func handleDidSetSearchTermAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
+            trailingPageActions: state.trailingPageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
             searchTerm: toolbarAction.searchTerm,
-            didStartTyping: false
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: false,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
     private static func handleDidStartTypingAction(state: Self, action: Action) -> Self {
         guard action is ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
+            trailingPageActions: state.trailingPageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
             shouldSelectSearchTerm: false,
-            didStartTyping: true
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: true,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -637,7 +996,28 @@ struct AddressBarState: StateType, Sendable, Equatable {
               let selectedSearchEngine = searchEngineSelectionAction.selectedSearchEngine
         else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
+            trailingPageActions: state.trailingPageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
             alternativeSearchEngine: selectedSearchEngine
         )
     }
@@ -645,13 +1025,57 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleDidClearAlternativeSearchEngine(state: Self, action: Action) -> Self {
         guard action is SearchEngineSelectionAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
+            trailingPageActions: state.trailingPageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
             alternativeSearchEngine: nil
         )
     }
 
     static func defaultState(from state: AddressBarState) -> Self {
-        return state.copyWithUpdates()
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
+            trailingPageActions: state.trailingPageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
     }
 
     // MARK: - Address Toolbar Actions

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
 import Redux
 
 enum NavigationBarMiddleButtonType: String, Equatable, CaseIterable {
@@ -29,7 +28,6 @@ enum NavigationBarMiddleButtonType: String, Equatable, CaseIterable {
     }
 }
 
-@CopyWithUpdates
 struct NavigationBarState: StateType, Equatable {
     var windowUUID: WindowUUID
     var actions: [ToolbarActionConfiguration]
@@ -120,7 +118,8 @@ struct NavigationBarState: StateType, Equatable {
             return defaultState(from: state)
         }
 
-        return state.copyWithUpdates(
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
             actions: navigationActions(action: toolbarAction, navigationBarState: state),
             displayBorder: displayBorder,
             middleButton: middleButton
@@ -131,8 +130,11 @@ struct NavigationBarState: StateType, Equatable {
     private static func handleUrlDidChangeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
-            actions: navigationActions(action: toolbarAction, navigationBarState: state)
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: navigationActions(action: toolbarAction, navigationBarState: state),
+            displayBorder: state.displayBorder,
+            middleButton: state.middleButton
         )
     }
 
@@ -140,8 +142,11 @@ struct NavigationBarState: StateType, Equatable {
     private static func handleNumberOfTabsChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
-            actions: navigationActions(action: toolbarAction, navigationBarState: state)
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: navigationActions(action: toolbarAction, navigationBarState: state),
+            displayBorder: state.displayBorder,
+            middleButton: state.middleButton
         )
     }
 
@@ -149,8 +154,11 @@ struct NavigationBarState: StateType, Equatable {
     private static func handleDidSetTabScreenshotAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
-            actions: navigationActions(action: toolbarAction, navigationBarState: state)
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: navigationActions(action: toolbarAction, navigationBarState: state),
+            displayBorder: state.displayBorder,
+            middleButton: state.middleButton
         )
     }
 
@@ -158,8 +166,11 @@ struct NavigationBarState: StateType, Equatable {
     private static func handleBackForwardButtonStateChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
-            actions: navigationActions(action: toolbarAction, navigationBarState: state)
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: navigationActions(action: toolbarAction, navigationBarState: state),
+            displayBorder: state.displayBorder,
+            middleButton: state.middleButton
         )
     }
 
@@ -167,8 +178,11 @@ struct NavigationBarState: StateType, Equatable {
     private static func handleShowMenuWarningBadgeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
-            actions: navigationActions(action: toolbarAction, navigationBarState: state)
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: navigationActions(action: toolbarAction, navigationBarState: state),
+            displayBorder: state.displayBorder,
+            middleButton: state.middleButton
         )
     }
 
@@ -178,8 +192,11 @@ struct NavigationBarState: StateType, Equatable {
             return defaultState(from: state)
         }
 
-        return state.copyWithUpdates(
-            displayBorder: displayBorder
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: state.actions,
+            displayBorder: displayBorder,
+            middleButton: state.middleButton
         )
     }
 
@@ -189,14 +206,21 @@ struct NavigationBarState: StateType, Equatable {
               let middleButton = toolbarAction.middleButton
         else { return defaultState(from: state) }
 
-        return state.copyWithUpdates(
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
             actions: navigationActions(action: toolbarAction, navigationBarState: state),
+            displayBorder: state.displayBorder,
             middleButton: middleButton
         )
     }
 
     static func defaultState(from state: NavigationBarState) -> NavigationBarState {
-        return state.copyWithUpdates()
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: state.actions,
+            displayBorder: state.displayBorder,
+            middleButton: state.middleButton
+        )
     }
 
     // MARK: - Navigation Toolbar Actions

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -5,9 +5,7 @@
 import Foundation
 import Redux
 import Common
-import CopyWithUpdates
 
-@CopyWithUpdates
 struct MicrosurveyPromptState: StateType, Equatable {
     var windowUUID: WindowUUID
     var showPrompt: Bool
@@ -50,14 +48,18 @@ struct MicrosurveyPromptState: StateType, Equatable {
     }
 
     static func defaultState(from state: MicrosurveyPromptState) -> MicrosurveyPromptState {
-        return state.copyWithUpdates(
-            showSurvey: false
+        return MicrosurveyPromptState(
+            windowUUID: state.windowUUID,
+            showPrompt: state.showPrompt,
+            showSurvey: false,
+            model: state.model
         )
     }
 
     private static func handleInitializeAction(state: Self, action: Action) -> Self {
         let model = (action as? MicrosurveyPromptMiddlewareAction)?.microsurveyModel
-        return state.copyWithUpdates(
+        return MicrosurveyPromptState(
+            windowUUID: state.windowUUID,
             showPrompt: true,
             showSurvey: false,
             model: model
@@ -65,16 +67,20 @@ struct MicrosurveyPromptState: StateType, Equatable {
     }
 
     private static func handleClosePromptAction(state: Self) -> Self {
-        return state.copyWithUpdates(
+        return MicrosurveyPromptState(
+            windowUUID: state.windowUUID,
             showPrompt: false,
-            showSurvey: false
+            showSurvey: false,
+            model: state.model
         )
     }
 
     private static func handleContinueToSurveyAction(state: Self) -> Self {
-        return state.copyWithUpdates(
+        return MicrosurveyPromptState(
+            windowUUID: state.windowUUID,
             showPrompt: true,
-            showSurvey: true
+            showSurvey: true,
+            model: state.model
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
@@ -4,9 +4,7 @@
 
 import Redux
 import Common
-import CopyWithUpdates
 
-@CopyWithUpdates
 struct MicrosurveyState: ScreenState {
     var windowUUID: WindowUUID
     var shouldDismiss: Bool
@@ -22,7 +20,11 @@ struct MicrosurveyState: ScreenState {
             return
         }
 
-        self = microsurveyState.copyWithUpdates()
+        self.init(
+            windowUUID: microsurveyState.windowUUID,
+            shouldDismiss: microsurveyState.shouldDismiss,
+            showPrivacy: microsurveyState.showPrivacy
+        )
     }
 
     init(
@@ -49,12 +51,14 @@ struct MicrosurveyState: ScreenState {
 
         switch action.actionType {
         case MicrosurveyActionType.closeSurvey:
-            return state.copyWithUpdates(
+            return MicrosurveyState(
+                windowUUID: state.windowUUID,
                 shouldDismiss: true,
                 showPrivacy: false
             )
         case MicrosurveyActionType.tapPrivacyNotice:
-            return state.copyWithUpdates(
+            return MicrosurveyState(
+                windowUUID: state.windowUUID,
                 shouldDismiss: false,
                 showPrivacy: true
             )
@@ -64,7 +68,8 @@ struct MicrosurveyState: ScreenState {
     }
 
     static func defaultState(from state: MicrosurveyState) -> MicrosurveyState {
-        return state.copyWithUpdates(
+        return MicrosurveyState(
+            windowUUID: state.windowUUID,
             shouldDismiss: false,
             showPrivacy: false
         )

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
@@ -2,11 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import CopyWithUpdates
 import Redux
 import Common
 
-@CopyWithUpdates
 struct NativeErrorPageState: ScreenState {
     var windowUUID: WindowUUID
     var title: String
@@ -65,7 +63,8 @@ struct NativeErrorPageState: ScreenState {
             guard let action = action as? NativeErrorPageAction, let model = action.nativePageErrorModel else {
                 return defaultState(from: state)
             }
-            return state.copyWithUpdates(
+            return NativeErrorPageState(
+                windowUUID: state.windowUUID,
                 title: model.errorTitle,
                 description: model.errorDescription,
                 foxImage: model.foxImageName,
@@ -79,6 +78,14 @@ struct NativeErrorPageState: ScreenState {
     }
 
     static func defaultState(from state: NativeErrorPageState) -> NativeErrorPageState {
-        return state.copyWithUpdates()
+        return NativeErrorPageState(
+            windowUUID: state.windowUUID,
+            title: state.title,
+            description: state.description,
+            foxImage: state.foxImage,
+            url: state.url,
+            advancedSection: state.advancedSection,
+            showGoBackButton: state.showGoBackButton
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Onboarding/State/OnboardingViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/State/OnboardingViewControllerState.swift
@@ -5,9 +5,7 @@
 import Foundation
 import Redux
 import Common
-import CopyWithUpdates
 
-@CopyWithUpdates
 struct OnboardingViewControllerState: ScreenState {
     let windowUUID: WindowUUID
 
@@ -42,6 +40,6 @@ struct OnboardingViewControllerState: ScreenState {
     }
 
     static func defaultState(from state: OnboardingViewControllerState) -> OnboardingViewControllerState {
-		return state.copyWithUpdates()
+        return OnboardingViewControllerState(windowUUID: state.windowUUID)
     }
 }

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
@@ -5,9 +5,7 @@
 import Foundation
 import Redux
 import Common
-import CopyWithUpdates
 
-@CopyWithUpdates
 struct PasswordGeneratorState: ScreenState {
     var windowUUID: WindowUUID
     var password: String
@@ -23,7 +21,11 @@ struct PasswordGeneratorState: ScreenState {
             return
         }
 
-        self = passwordGeneratorState.copyWithUpdates()
+        self.init(
+            windowUUID: passwordGeneratorState.windowUUID,
+            password: passwordGeneratorState.password,
+            passwordHidden: passwordGeneratorState.passwordHidden
+        )
     }
 
     init(
@@ -46,19 +48,22 @@ struct PasswordGeneratorState: ScreenState {
             else {
                 return defaultState(from: state)
             }
-            return state.copyWithUpdates(
-                password: password
-            )
+            return PasswordGeneratorState(
+                windowUUID: action.windowUUID,
+                password: password,
+                passwordHidden: state.passwordHidden)
 
         case PasswordGeneratorActionType.hidePassword:
-            return state.copyWithUpdates(
-                passwordHidden: true
-            )
+            return PasswordGeneratorState(
+                windowUUID: action.windowUUID,
+                password: state.password,
+                passwordHidden: true)
 
         case PasswordGeneratorActionType.showPassword:
-            return state.copyWithUpdates(
-                passwordHidden: false
-            )
+            return PasswordGeneratorState(
+                windowUUID: action.windowUUID,
+                password: state.password,
+                passwordHidden: false)
 
         default:
             return defaultState(from: state)
@@ -66,6 +71,10 @@ struct PasswordGeneratorState: ScreenState {
     }
 
     static func defaultState(from state: PasswordGeneratorState) -> PasswordGeneratorState {
-        return state.copyWithUpdates()
+        return PasswordGeneratorState(
+            windowUUID: state.windowUUID,
+            password: state.password,
+            passwordHidden: state.passwordHidden
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -94,7 +94,7 @@ final class ThemeManagerMiddleware: ThemeManagerProvider {
     func getCurrentThemeManagerState(windowUUID: WindowUUID) -> ThemeSettingsState {
         ThemeSettingsState(windowUUID: windowUUID,
                            useSystemAppearance: themeManager.systemThemeIsOn,
-                           isAutomaticBrightnessEnabled: themeManager.automaticBrightnessIsOn,
+                           isAutomaticBrightnessEnable: themeManager.automaticBrightnessIsOn,
                            manualThemeSelected: themeManager.getUserManualTheme(),
                            userBrightnessThreshold: themeManager.automaticBrightnessValue,
                            systemBrightness: getScreenBrightness())

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -3,17 +3,15 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
 import Redux
 
-@CopyWithUpdates
 struct ThemeSettingsState: ScreenState {
-    var windowUUID: WindowUUID
     var useSystemAppearance: Bool
     var isAutomaticBrightnessEnabled: Bool
     var manualThemeSelected: ThemeType
     var userBrightnessThreshold: Float
     var systemBrightness: Float
+    var windowUUID: WindowUUID
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let themeState = appState.componentState(
@@ -27,7 +25,7 @@ struct ThemeSettingsState: ScreenState {
 
         self.init(windowUUID: themeState.windowUUID,
                   useSystemAppearance: themeState.useSystemAppearance,
-                  isAutomaticBrightnessEnabled: themeState.isAutomaticBrightnessEnabled,
+                  isAutomaticBrightnessEnable: themeState.isAutomaticBrightnessEnabled,
                   manualThemeSelected: themeState.manualThemeSelected,
                   userBrightnessThreshold: themeState.userBrightnessThreshold,
                   systemBrightness: themeState.systemBrightness)
@@ -36,7 +34,7 @@ struct ThemeSettingsState: ScreenState {
     init(windowUUID: WindowUUID) {
         self.init(windowUUID: windowUUID,
                   useSystemAppearance: false,
-                  isAutomaticBrightnessEnabled: false,
+                  isAutomaticBrightnessEnable: false,
                   manualThemeSelected: ThemeType.light,
                   userBrightnessThreshold: 0,
                   systemBrightness: 1)
@@ -44,13 +42,13 @@ struct ThemeSettingsState: ScreenState {
 
     init(windowUUID: WindowUUID,
          useSystemAppearance: Bool,
-         isAutomaticBrightnessEnabled: Bool,
+         isAutomaticBrightnessEnable: Bool,
          manualThemeSelected: ThemeType,
          userBrightnessThreshold: Float,
          systemBrightness: Float) {
         self.windowUUID = windowUUID
         self.useSystemAppearance = useSystemAppearance
-        self.isAutomaticBrightnessEnabled = isAutomaticBrightnessEnabled
+        self.isAutomaticBrightnessEnabled = isAutomaticBrightnessEnable
         self.manualThemeSelected = manualThemeSelected
         self.userBrightnessThreshold = userBrightnessThreshold
         self.systemBrightness = systemBrightness
@@ -85,32 +83,62 @@ struct ThemeSettingsState: ScreenState {
     }
 
     static func defaultState(from state: ThemeSettingsState) -> ThemeSettingsState {
-        return state.copyWithUpdates()
+        return ThemeSettingsState(windowUUID: state.windowUUID,
+                                  useSystemAppearance: state.useSystemAppearance,
+                                  isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
+                                  manualThemeSelected: state.manualThemeSelected,
+                                  userBrightnessThreshold: state.userBrightnessThreshold,
+                                  systemBrightness: state.systemBrightness)
     }
 
     private static func handleSystemThemeChangedAction(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
         let useSystemAppearance = action.themeSettingsState?.useSystemAppearance ?? state.useSystemAppearance
-        return state.copyWithUpdates(useSystemAppearance: useSystemAppearance)
+        return ThemeSettingsState(windowUUID: state.windowUUID,
+                                  useSystemAppearance: useSystemAppearance,
+                                  isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
+                                  manualThemeSelected: state.manualThemeSelected,
+                                  userBrightnessThreshold: state.userBrightnessThreshold,
+                                  systemBrightness: state.systemBrightness)
     }
 
     private static func handleAutomaticBrightnessChangedAction(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
         let enabled = action.themeSettingsState?.isAutomaticBrightnessEnabled ?? state.isAutomaticBrightnessEnabled
-        return state.copyWithUpdates(isAutomaticBrightnessEnabled: enabled)
+        return ThemeSettingsState(windowUUID: state.windowUUID,
+                                  useSystemAppearance: state.useSystemAppearance,
+                                  isAutomaticBrightnessEnable: enabled,
+                                  manualThemeSelected: state.manualThemeSelected,
+                                  userBrightnessThreshold: state.userBrightnessThreshold,
+                                  systemBrightness: state.systemBrightness)
     }
 
     private static func handleManualThemeChangedAction(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
         let theme = action.themeSettingsState?.manualThemeSelected ?? state.manualThemeSelected
-        return state.copyWithUpdates(manualThemeSelected: theme)
+        return ThemeSettingsState(windowUUID: state.windowUUID,
+                                  useSystemAppearance: state.useSystemAppearance,
+                                  isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
+                                  manualThemeSelected: theme,
+                                  userBrightnessThreshold: state.userBrightnessThreshold,
+                                  systemBrightness: state.systemBrightness)
     }
 
     private static func handleUserBrightnessChangedAction(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
         let brightnessValue = action.themeSettingsState?.userBrightnessThreshold ?? state.userBrightnessThreshold
-        return state.copyWithUpdates(userBrightnessThreshold: brightnessValue)
+        return ThemeSettingsState(windowUUID: state.windowUUID,
+                                  useSystemAppearance: state.useSystemAppearance,
+                                  isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
+                                  manualThemeSelected: state.manualThemeSelected,
+                                  userBrightnessThreshold: brightnessValue,
+                                  systemBrightness: state.systemBrightness)
     }
 
     private static func handleSystemBrightnessChangedAction(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
         let brightnessValue = action.themeSettingsState?.systemBrightness ?? state.systemBrightness
-        return state.copyWithUpdates(systemBrightness: brightnessValue)
+        return ThemeSettingsState(windowUUID: state.windowUUID,
+                                  useSystemAppearance: state.useSystemAppearance,
+                                  isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
+                                  manualThemeSelected: state.manualThemeSelected,
+                                  userBrightnessThreshold: state.userBrightnessThreshold,
+                                  systemBrightness: brightnessValue)
     }
 
     static func == (lhs: ThemeSettingsState, rhs: ThemeSettingsState) -> Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsStateTests.swift
@@ -26,7 +26,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let subject = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: true,
-            isAutomaticBrightnessEnabled: true,
+            isAutomaticBrightnessEnable: true,
             manualThemeSelected: .dark,
             userBrightnessThreshold: 0.5,
             systemBrightness: 0.8
@@ -50,7 +50,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let newStateData = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: true,
-            isAutomaticBrightnessEnabled: true,
+            isAutomaticBrightnessEnable: true,
             manualThemeSelected: .dark,
             userBrightnessThreshold: 0.7,
             systemBrightness: 0.6
@@ -95,7 +95,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let initialState = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -105,7 +105,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let newStateData = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: true,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -129,7 +129,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let initialState = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: true,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -139,7 +139,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let newStateData = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -166,7 +166,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let newStateData = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: true,
+            isAutomaticBrightnessEnable: true,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -190,7 +190,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let initialState = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: true,
+            isAutomaticBrightnessEnable: true,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -200,7 +200,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let newStateData = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -227,7 +227,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let newStateData = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .dark,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -251,7 +251,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let initialState = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .dark,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -261,7 +261,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let newStateData = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -288,7 +288,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let newStateData = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0.75,
             systemBrightness: 1
@@ -311,7 +311,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let initialState = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0.5,
             systemBrightness: 1
@@ -321,7 +321,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let newStateData = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -348,7 +348,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let newStateData = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 0.3
@@ -374,7 +374,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let newStateData = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1.0
@@ -397,7 +397,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let state1 = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: true,
-            isAutomaticBrightnessEnabled: true,
+            isAutomaticBrightnessEnable: true,
             manualThemeSelected: .dark,
             userBrightnessThreshold: 0.5,
             systemBrightness: 0.8
@@ -406,7 +406,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let state2 = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: true,
-            isAutomaticBrightnessEnabled: true,
+            isAutomaticBrightnessEnable: true,
             manualThemeSelected: .dark,
             userBrightnessThreshold: 0.5,
             systemBrightness: 0.8
@@ -420,7 +420,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let state2 = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: true,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -434,7 +434,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let state2 = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: true,
+            isAutomaticBrightnessEnable: true,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -448,7 +448,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let state2 = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .dark,
             userBrightnessThreshold: 0,
             systemBrightness: 1
@@ -462,7 +462,7 @@ final class ThemeSettingsStateTests: XCTestCase {
         let state2 = ThemeSettingsState(
             windowUUID: .XCTestDefaultUUID,
             useSystemAppearance: false,
-            isAutomaticBrightnessEnabled: false,
+            isAutomaticBrightnessEnable: false,
             manualThemeSelected: .light,
             userBrightnessThreshold: 0.5,
             systemBrightness: 1

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -281,10 +281,10 @@ final class AddressToolbarContainerModelTests: XCTestCase {
                                isLoading: false,
                                readerModeState: nil,
                                canSummarize: false,
+                               translationConfiguration: nil,
                                didStartTyping: false,
                                isEmptySearch: true,
-                               alternativeSearchEngine: withSearchEngine,
-                               translationConfiguration: nil)
+                               alternativeSearchEngine: withSearchEngine)
     }
 
     private func createBasicNavigationBarState() -> NavigationBarState {


### PR DESCRIPTION
## :bulb: Description
- Reverts the following commits implementing `CopyWithUpdates`

f22d33b12d3960861fc2f26bf71b8ab22dbce6ba
d718acd86511723933591e7d8acea767b43f9fdc
ec4ab4c540f9fd5213e7a51a3804f6982f676adf
d694f0a15ee3413bb22b676e581d6cba7b930f15
fc0df8669fa4602382680871190c8e96465864f6
8eb0e45b2f5ec9aeafb1bdad0d0cc97064be7f7a
ad7da3eb61f44dd2e94009ee50036ba805456bad 
48800a37e8b7c71f7773daabe926bb6d57b2a707 
27078a7ccf67f345505465f54da042071bbe4aa3 
fe52515ae1a128dbc24bcc385de28c9fc74fcacb 
51acf960f771c51d1cce357034dc22d17cf52d90

and the following bugfix commit resulting from 51acf960f771c51d1cce357034dc22d17cf52d90:
24bb8d2b938baf9d9e5250883ac491835ec8cdb5

This does not revert `CopyWithUpdates`-related commits from v150.0 and v150.1

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

