### PR TITLE
[UI Test] Convert SearchSettingsUITests to new framework #33413

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
@@ -156,6 +156,12 @@ final class SettingScreen {
         cell.waitAndTap()
     }
 
+    func navigateToSearchSettings() {
+        let searchCell = sel.SEARCH_CELL.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(searchCell)
+        searchCell.waitAndTap()
+    }
+
     func navigateToDisplaySettings() {
         let cell = sel.DISPLAY_THEME_CELL.element(in: app)
         BaseTestCase().mozWaitForElementToExist(cell)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -9,10 +9,14 @@ let defaultSearchEngine2 = "Bing"
 let customSearchEngine = ["name": "youtube", "url": "https://youtube.com/search?q=%s"]
 
 class SearchSettingsUITests: BaseTestCase {
+    private var settingScreen: SettingScreen!
+    override func setUp() {
+            super.setUp()
+            settingScreen = SettingScreen(app: app)
+    }
     // https://mozilla.testrail.io/index.php?/cases/view/2435664
     func testDefaultSearchEngine() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(SearchSettings)
+        settingScreen.navigateToSearchSettings()
         // Check the default browser
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
         mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine1])
@@ -26,8 +30,7 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353247
     func testCustomSearchEngineIsEditable() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(SearchSettings)
+        settingScreen.navigateToSearchSettings()
         // Add a custom search engine
         addCustomSearchEngine()
         // Check that the custom search appears on the list
@@ -57,8 +60,7 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353248
     func testCustomSearchEngineAsDefaultIsNotEditable() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(SearchSettings)
+        settingScreen.navigateToSearchSettings()
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
 
@@ -77,8 +79,7 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353249
     func testNavigateToSearchPickerTurnsOffEditing() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(SearchSettings)
+        settingScreen.navigateToSearchSettings()
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
 
@@ -103,8 +104,7 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353250
     func testDeletingLastCustomEngineExitsEditing() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(SearchSettings)
+        settingScreen.navigateToSearchSettings()
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
         // Add a custom search engine

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -9,7 +9,6 @@ let defaultSearchEngine2 = "Bing"
 let customSearchEngine = ["name": "youtube", "url": "https://youtube.com/search?q=%s"]
 
 class SearchSettingsUITests: BaseTestCase {
-
     // https://mozilla.testrail.io/index.php?/cases/view/2435664
     func testDefaultSearchEngine() {
         let settingScreen = SettingScreen(app: app)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -9,13 +9,10 @@ let defaultSearchEngine2 = "Bing"
 let customSearchEngine = ["name": "youtube", "url": "https://youtube.com/search?q=%s"]
 
 class SearchSettingsUITests: BaseTestCase {
-    private var settingScreen: SettingScreen!
-    override func setUp() {
-            super.setUp()
-            settingScreen = SettingScreen(app: app)
-    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2435664
     func testDefaultSearchEngine() {
+        let settingScreen = SettingScreen(app: app)
         settingScreen.navigateToSearchSettings()
         // Check the default browser
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
@@ -30,6 +27,7 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353247
     func testCustomSearchEngineIsEditable() {
+        let settingScreen = SettingScreen(app: app)
         settingScreen.navigateToSearchSettings()
         // Add a custom search engine
         addCustomSearchEngine()
@@ -60,6 +58,7 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353248
     func testCustomSearchEngineAsDefaultIsNotEditable() {
+        let settingScreen = SettingScreen(app: app)
         settingScreen.navigateToSearchSettings()
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
@@ -79,6 +78,7 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353249
     func testNavigateToSearchPickerTurnsOffEditing() {
+        let settingScreen = SettingScreen(app: app)
         settingScreen.navigateToSearchSettings()
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
@@ -104,6 +104,7 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353250
     func testDeletingLastCustomEngineExitsEditing() {
+        let settingScreen = SettingScreen(app: app)
         settingScreen.navigateToSearchSettings()
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SettingsSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SettingsSelectors.swift
@@ -42,6 +42,7 @@ protocol SettingsSelectorsSet {
     var BLOCK_POPUPS_SWITCH: Selector { get }
     var TOOLBAR_CELL: Selector { get }
     var DEFAULT_BROWSER_CELL: Selector { get }
+    var SEARCH_CELL: Selector { get }
     var BROWSING_CELL_TITLE: Selector { get }
     var BLOCK_IMAGES_SWITCH_TITLE: Selector { get }
 
@@ -78,6 +79,7 @@ struct SettingsSelectors: SettingsSelectorsSet {
         static let settingTitle = "Settings"
         static let toolbarCellSettings = AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting
         static let defaultBrowserSettings = AccessibilityIdentifiers.Settings.DefaultBrowser.defaultBrowser
+        static let searchCellTitle = AccessibilityIdentifiers.Settings.Search.title
         static let browsingCellTitle = AccessibilityIdentifiers.Settings.Browsing.title
         static let blockImages = AccessibilityIdentifiers.Settings.BlockImages.title
         static let noImageModeStatus = "NoImageModeStatus"
@@ -250,6 +252,12 @@ struct SettingsSelectors: SettingsSelectorsSet {
         groups: ["settings"]
     )
 
+    let SEARCH_CELL = Selector.tableCellById(
+        IDs.searchCellTitle,
+        description: "Search settings cell",
+        groups: ["settings"]
+    )
+
     let BROWSING_CELL_TITLE = Selector.tableCellById(
         IDs.browsingCellTitle,
         description: "Browsing settings cell",
@@ -371,12 +379,13 @@ struct SettingsSelectors: SettingsSelectorsSet {
     }
 
     var all: [Selector] {
-        [SETTINGS_TABLE, DONE_BUTTON, SETTINGS_TITLE, AUTOFILLS_PASSWORDS_CELL, CLEAR_DATA_CELL,
-         CLOSE_PRIVATE_TABS_SWITCH, CONTENT_BLOCKER_CELL, NOTIFICATIONS_CELL,
-         PRIVACY_POLICY_CELL, LOGINS_CELL, CREDIT_CARDS_CELL, ADDRESS_CELL,
-         CLEAR_PRIVATE_DATA_CELL, ALERT_OK_BUTTON, NEW_TAB_CELL, TITLE, TABLE, BROWSING_LINKS_SECTION,
-         NAVIGATIONBAR, CONNECT_SETTING, BLOCK_POPUPS_SWITCH, TOOLBAR_CELL, DEFAULT_BROWSER_CELL,
-         BROWSING_CELL_TITLE, BLOCK_IMAGES_SWITCH_TITLE, NO_IMAGE_MODE_STATUS_SWITCH, TRANSLATION_CELL_TITLE,
-         SEND_DATA_CELL, SEND_CRASH_REPORTS_CELL]
-    }
+            [SETTINGS_TABLE, DONE_BUTTON, SETTINGS_TITLE, AUTOFILLS_PASSWORDS_CELL, CLEAR_DATA_CELL,
+             CLOSE_PRIVATE_TABS_SWITCH, CONTENT_BLOCKER_CELL, NOTIFICATIONS_CELL,
+             PRIVACY_POLICY_CELL, LOGINS_CELL, CREDIT_CARDS_CELL, ADDRESS_CELL,
+             CLEAR_PRIVATE_DATA_CELL, ALERT_OK_BUTTON, NEW_TAB_CELL, TITLE, TABLE,
+             BROWSING_LINKS_SECTION, NAVIGATIONBAR, CONNECT_SETTING, BLOCK_POPUPS_SWITCH,
+             TOOLBAR_CELL, DEFAULT_BROWSER_CELL, SEARCH_CELL, BROWSING_CELL_TITLE,
+             BLOCK_IMAGES_SWITCH_TITLE, NO_IMAGE_MODE_STATUS_SWITCH, TRANSLATION_CELL_TITLE,
+             SEND_DATA_CELL, SEND_CRASH_REPORTS_CELL]
+        }
 }


### PR DESCRIPTION
## Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-33413)

##  Description
- Convert `SearchSettingsUITests` to the new UI test framework
- Update related screen and selector files

##  Demos
Not applicable.

##  Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
