### PR TITLE
Bugfix FXIOS-15601 [Translations] Inconsistent casing in language picker

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2953,8 +2953,8 @@ class BrowserViewController: UIViewController,
         }
 
         data.languages.forEach { code in
-            let native = Locale(identifier: code).localizedString(forLanguageCode: code) ?? code
-            let localized = Locale.current.localizedString(forLanguageCode: code) ?? code
+            let native = (Locale(identifier: code).localizedString(forLanguageCode: code) ?? code).localizedCapitalized
+            let localized = (Locale.current.localizedString(forLanguageCode: code) ?? code).localizedCapitalized
             let title = native == localized ? native : "\(native) (\(localized))"
             alert.addAction(UIAlertAction(title: title, style: .default) { [weak self] _ in
                 guard let self else { return }

--- a/firefox-ios/Client/Utils/LocaleProvider.swift
+++ b/firefox-ios/Client/Utils/LocaleProvider.swift
@@ -20,12 +20,12 @@ extension LocaleProvider {
 
     /// Returns the language name localized in the current locale (e.g. "French" for "fr" when current locale is "en").
     func localizedLanguageName(for code: String) -> String {
-        return current.localizedString(forLanguageCode: code) ?? code
+        return (current.localizedString(forLanguageCode: code) ?? code).localizedCapitalized
     }
 
-    /// Returns the language name in its own language (e.g. "français" for "fr").
+    /// Returns the language name in its own language (e.g. "Français" for "fr").
     func nativeLanguageName(for code: String) -> String {
-        return Locale(identifier: code).localizedString(forLanguageCode: code) ?? code
+        return (Locale(identifier: code).localizedString(forLanguageCode: code) ?? code).localizedCapitalized
     }
 }
 

--- a/firefox-ios/Client/Utils/LocaleProvider.swift
+++ b/firefox-ios/Client/Utils/LocaleProvider.swift
@@ -20,12 +20,12 @@ extension LocaleProvider {
 
     /// Returns the language name localized in the current locale (e.g. "French" for "fr" when current locale is "en").
     func localizedLanguageName(for code: String) -> String {
-        return (current.localizedString(forLanguageCode: code) ?? code).localizedCapitalized
+        return current.localizedString(forLanguageCode: code)?.localizedCapitalized ?? code
     }
 
     /// Returns the language name in its own language (e.g. "Français" for "fr").
     func nativeLanguageName(for code: String) -> String {
-        return (Locale(identifier: code).localizedString(forLanguageCode: code) ?? code).localizedCapitalized
+        return Locale(identifier: code).localizedString(forLanguageCode: code)?.localizedCapitalized ?? code
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/SystemLocaleProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/SystemLocaleProviderTests.swift
@@ -146,7 +146,7 @@ final class SystemLocaleProviderTests: XCTestCase {
 
     func test_nativeLanguageName_knownCode_returnsNameInItsOwnLanguage() {
         let subject = createSubject(with: Locale(identifier: "en_US"))
-        XCTAssertEqual(subject.nativeLanguageName(for: "fr"), "français")
+        XCTAssertEqual(subject.nativeLanguageName(for: "fr"), "Français")
     }
 
     func test_nativeLanguageName_unknownCode_returnsFallbackCode() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33417)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
  - Capitalize language names in the translate action sheet so both the native and localized names are consistent (e.g. "Português (Portuguese)" instead of "português (Portuguese)").                               
  - Capitalize the same names in Translation Settings (preferred languages list and "Add Language" picker) by applying .localizedCapitalized in the centralized LocaleProvider helpers.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->


<img height="400" alt="IMG_0003" src="https://github.com/user-attachments/assets/1bda5015-6f36-4525-b20f-bc87b26dba74" />
<img height="400" alt="IMG_0002" src="https://github.com/user-attachments/assets/20e209e3-c81b-4b51-a774-a5b6e264f3d0" />
<img height="400" alt="IMG_0001" src="https://github.com/user-attachments/assets/56415c5e-c33c-473d-8e27-e5667c3aa200" />




<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


