### PR TITLE
Bugfix FXIOS-15626 [Settings] Fix redundant section borders for insetGrouped style in Website Data

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -23,6 +23,10 @@ class WebsiteDataManagementViewController: UIViewController,
             guard #available(iOS 26.0, *) else { return .grouped }
             return .insetGrouped
         }
+        static var shouldShowSectionBorders: Bool {
+            guard #available(iOS 26.0, *) else { return true }
+            return false
+        }
         static var sectionTopMarginForCurrentOS: CGFloat {
             guard #available(iOS 26.0, *) else { return 0 }
             return UX.sectionTopMargin
@@ -104,7 +108,7 @@ class WebsiteDataManagementViewController: UIViewController,
                           height: SettingsUX.TableViewHeaderFooterHeight)
         )
         footer.applyTheme(theme: currentTheme())
-        footer.showBorder(for: .top, true)
+        footer.showBorder(for: .top, UX.shouldShowSectionBorders)
         tableView.tableFooterView = footer
 
         view.addSubview(tableView)
@@ -305,8 +309,8 @@ class WebsiteDataManagementViewController: UIViewController,
 
         headerView.titleLabel.text = section == Section.sites.rawValue ? .SettingsWebsiteDataTitle : nil
 
-        headerView.showBorder(for: .top, true)
-        headerView.showBorder(for: .bottom, true)
+        headerView.showBorder(for: .top, UX.shouldShowSectionBorders)
+        headerView.showBorder(for: .bottom, UX.shouldShowSectionBorders)
 
         // top section: no top border (this is a plain table)
         guard let section = Section(rawValue: section) else { return headerView }
@@ -321,7 +325,7 @@ class WebsiteDataManagementViewController: UIViewController,
             }
         } else if section == .clearButton {
             headerView.showBorder(for: .top, false)
-            headerView.showBorder(for: .bottom, true)
+            headerView.showBorder(for: .bottom, UX.shouldShowSectionBorders)
         }
 
         return headerView
@@ -344,8 +348,8 @@ class WebsiteDataManagementViewController: UIViewController,
             withIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier
         ) as? ThemedTableSectionHeaderFooterView else { return nil }
 
-        footerView.showBorder(for: .top, true)
-        footerView.showBorder(for: .bottom, true)
+        footerView.showBorder(for: .top, UX.shouldShowSectionBorders)
+        footerView.showBorder(for: .bottom, UX.shouldShowSectionBorders)
         return footerView
     }
 

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
@@ -20,6 +20,11 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
     private var filteredSiteRecords = [WKWebsiteDataRecord]()
     private var currentSearchText = ""
 
+    private var shouldShowSectionBorders: Bool {
+        guard #available(iOS 26.0, *) else { return true }
+        return false
+    }
+
     init(viewModel: WebsiteDataManagementViewModel,
          windowUUID: WindowUUID,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
@@ -43,7 +48,7 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
         let footer = ThemedTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width,
                                                                       height: SettingsUX.TableViewHeaderFooterHeight))
         footer.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
-        footer.showBorder(for: .top, true)
+        footer.showBorder(for: .top, shouldShowSectionBorders)
         tableView.tableFooterView = footer
 
         KeyboardHelper.defaultHelper.addDelegate(self)
@@ -151,8 +156,8 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
 
         headerView.titleLabel.text = section == Section.sites.rawValue ? .SettingsWebsiteDataTitle : nil
 
-        headerView.showBorder(for: .top, true)
-        headerView.showBorder(for: .bottom, true)
+        headerView.showBorder(for: .top, shouldShowSectionBorders)
+        headerView.showBorder(for: .bottom, shouldShowSectionBorders)
 
         // top section: no top border (this is a plain table)
         guard let section = Section(rawValue: section) else { return headerView }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15626)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33482)

## :bulb: Description
When the table view style is set to `.insetGrouped` (iOS 26+), manual custom borders (`.showBorder(for: .top, true)`) were still being drawn, resulting in redundant UI lines.
- Added `shouldShowSectionBorders` computed property to conditionally check the OS version.
- Replaced hardcoded `true` with `shouldShowSectionBorders` to ensure custom borders are hidden when using `.insetGrouped`.

## :movie_camera: Demos

https://github.com/user-attachments/assets/0ed49ff3-c5a8-4332-b7cc-7e63d9d25015

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

