### PR TITLE
Refactor NOTICKET [FeauterFlags] Altenate way to inject feature flags in bootstrap

### DIFF
--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -51,16 +51,10 @@ class DependencyHelper {
         appDelegate.gleanUsageReportingMetricsService
         AppContainer.shared.register(service: gleanUsageReportingMetricsService)
 
-        let featureFlagsProvider = FeatureFlagsProvider(
-            prefs: profile.prefs,
-            backendLayer: NimbusManager.shared.featureFlagLayer
-        )
+        let featureFlagsProvider = FeatureFlagsProvider(prefs: profile.prefs)
         AppContainer.shared.register(service: featureFlagsProvider as FeatureFlagProviding)
 
-        let userFeaturePreferenceManager = UserFeaturePreferenceManager(
-            prefs: profile.prefs,
-            backendLayer: NimbusManager.shared.featureFlagLayer
-        )
+        let userFeaturePreferenceManager = UserFeaturePreferenceManager(prefs: profile.prefs)
         AppContainer.shared.register(service: userFeaturePreferenceManager as UserFeaturePreferring)
 
         // Tell the container we are done registering

--- a/firefox-ios/Client/FeatureFlags/FeatureFlagsProvider.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagsProvider.swift
@@ -19,7 +19,7 @@ final class FeatureFlagsProvider: FeatureFlagProviding, @unchecked Sendable {
 
     init(
         prefs: Prefs,
-        backendLayer: NimbusFeatureFlagLayerProviding
+        backendLayer: NimbusFeatureFlagLayerProviding = NimbusManager.shared.featureFlagLayer
     ) {
         self.prefs = prefs
         self.backendLayer = backendLayer

--- a/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
+++ b/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
@@ -27,7 +27,7 @@ final class UserFeaturePreferenceManager: UserFeaturePreferring, @unchecked Send
 
     init(
         prefs: Prefs,
-        backendLayer: NimbusFeatureFlagLayerProviding
+        backendLayer: NimbusFeatureFlagLayerProviding = NimbusManager.shared.featureFlagLayer
     ) {
         self.prefs = prefs
         self.backendLayer = backendLayer

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -15,7 +15,8 @@ final class DependencyHelperMock {
         injectedTabManager: TabManager? = nil,
         injectedMicrosurveyManager: MicrosurveyManager? = nil,
         injectedMerinoManager: MerinoManagerProvider? = nil,
-        injectedNimbusLayer: NimbusFeatureFlagLayerProviding? = nil
+        injectedFeatureFlagProvider: FeatureFlagProviding? = nil,
+        injectedUserFeaturePreferences: UserFeaturePreferring? = nil
     ) {
         AppContainer.shared.reset()
 
@@ -69,18 +70,13 @@ final class DependencyHelperMock {
         MockGleanUsageReportingMetricsService(profile: profile)
         AppContainer.shared.register(service: gleanUsageReportingMetricsService)
 
-        let nimbusLayer = injectedNimbusLayer ?? NimbusManager.shared.featureFlagLayer
-        let nimbusFeatureFlags = FeatureFlagsProvider(
-            prefs: profile.prefs,
-            backendLayer: nimbusLayer
-        )
-        AppContainer.shared.register(service: nimbusFeatureFlags as FeatureFlagProviding)
+        let featureFlagProvider = injectedFeatureFlagProvider ?? FeatureFlagsProvider(prefs: profile.prefs)
+        AppContainer.shared.register(service: featureFlagProvider as FeatureFlagProviding)
 
-        let userFeaturePreferenceManager = UserFeaturePreferenceManager(
-            prefs: profile.prefs,
-            backendLayer: nimbusLayer
+        let userFeatureProvider = injectedUserFeaturePreferences ?? UserFeaturePreferenceManager(
+            prefs: profile.prefs
         )
-        AppContainer.shared.register(service: userFeaturePreferenceManager as UserFeaturePreferring)
+        AppContainer.shared.register(service: userFeatureProvider as UserFeaturePreferring)
 
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()


### PR DESCRIPTION
## :scroll: Tickets
N/A

## :bulb: Description
I was thinking about what you two were saying, and am proposing a more direct approach to mocks, where we can then have access to both the nimbus layer AND the featureFlagProvider AND/OR the userPreferencesProvider.

We can discuss this more in the meeting tomorrow. Whether you approve or not, I won't be merging till then.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

