### PR TITLE
Bugfix FXIOS-33415 [Tests] Convert translation settings tests to TAE navigation

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
@@ -52,8 +52,7 @@ final class TranslationsTests: FeatureFlaggedTestBase {
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "translations-feature")
         app.launch()
 
-        toolBarScreen.tapSettingsMenuButton()
-        mainMenuScreen.tapSettings()
+        openSettingsFromToolbarMenu()
 
         // Check that translation feature setting is on
         settingsScreen.openTranslationSettings()
@@ -71,8 +70,7 @@ final class TranslationsTests: FeatureFlaggedTestBase {
     func testTranslationSettingsDoesNotAppear_translationExperimentOff() {
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "translations-feature")
         app.launch()
-        toolBarScreen.tapSettingsMenuButton()
-        mainMenuScreen.tapSettings()
+        openSettingsFromToolbarMenu()
 
         // Check that translation setting is hidden
         settingsScreen.assertTranslationSettingsDoesNotExist()
@@ -94,8 +92,7 @@ final class TranslationsTests: FeatureFlaggedTestBase {
         // Check that translation icon is shown in toolbar
         toolBarScreen.assertTranslateButtonExists(with: .inactive)
 
-        toolBarScreen.tapSettingsMenuButton()
-        mainMenuScreen.tapSettings()
+        openSettingsFromToolbarMenu()
 
         // Check that translation feature setting is on
         settingsScreen.openTranslationSettings()
@@ -110,8 +107,7 @@ final class TranslationsTests: FeatureFlaggedTestBase {
         // Check that translation icon is no longer shown in toolbar
         toolBarScreen.assertTranslateButtonDoesNotExist(with: .inactive)
 
-        toolBarScreen.tapSettingsMenuButton()
-        mainMenuScreen.tapSettings()
+        openSettingsFromToolbarMenu()
 
         // Check that translation feature setting is off
         settingsScreen.openTranslationSettings()
@@ -130,6 +126,11 @@ final class TranslationsTests: FeatureFlaggedTestBase {
     private func dismissTranslationSettingsScreen() {
         translationSettingScreen.tapOnBackButton()
         settingsScreen.closeSettingsWithDoneButton()
+    }
+
+    private func openSettingsFromToolbarMenu() {
+        toolBarScreen.tapSettingsMenuButton()
+        mainMenuScreen.tapSettings()
     }
 
     private func navigateToTranslationTestPage() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15598)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33415)

## :bulb: Description
  This updates `TranslationsTests` to use TAE screen interactions for opening Settings instead of the legacy navigator flow.

  Changes:
  - Replaced remaining `navigator.goto(SettingsScreen)` calls with:
    - `toolBarScreen.tapSettingsMenuButton()`
    - `mainMenuScreen.tapSettings()`
  - Removed stale `navigator.nowAt(...)` calls from `TranslationTests.swift`
  - Added `MainMenuScreen` setup for the updated navigation path

  Testing:
  - Verified no remaining `navigator.goto(...)` or `navigator.nowAt(...)` calls in `TranslationTests.swift`
  - Ran the affected simulator UI tests with `FullFunctionalTestPlan`; 3 tests passed
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
Not applicable. This PR updates UI test navigation code only.


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

