### PR TITLE
Refactor FXIOS-15603 Fix Site Data clearable and remove deprecated WKWebsiteDataTypeOfflineWebApplicationCache

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
@@ -88,6 +88,9 @@ public final class WKEngine: Engine {
     }
 
     public func clearCookies() {
+        // Include localStorage; some sites store authentication/session
+        // state there in addition to cookies. Clearing cookies should remove
+        // login state, not just WK cookie records.
         let dataTypes = Set([WKWebsiteDataTypeCookies, WKWebsiteDataTypeLocalStorage])
         WKWebsiteDataStore.default().removeData(ofTypes: dataTypes, modifiedSince: .distantPast, completionHandler: {})
     }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
@@ -88,20 +88,18 @@ public final class WKEngine: Engine {
     }
 
     public func clearCookies() {
-        let dataTypes = Set(
-            [
-                WKWebsiteDataTypeCookies,
-                WKWebsiteDataTypeLocalStorage,
-                WKWebsiteDataTypeSessionStorage,
-                WKWebsiteDataTypeWebSQLDatabases,
-                WKWebsiteDataTypeIndexedDBDatabases
-            ]
-        )
+        let dataTypes = Set([WKWebsiteDataTypeCookies])
         WKWebsiteDataStore.default().removeData(ofTypes: dataTypes, modifiedSince: .distantPast, completionHandler: {})
     }
 
     public func clearOfflineWebsiteData() {
-        let dataTypes = Set([WKWebsiteDataTypeOfflineWebApplicationCache])
+        let dataTypes = Set([
+            WKWebsiteDataTypeLocalStorage,
+            WKWebsiteDataTypeSessionStorage,
+            WKWebsiteDataTypeWebSQLDatabases,
+            WKWebsiteDataTypeIndexedDBDatabases,
+            WKWebsiteDataTypeFetchCache,
+        ])
         WKWebsiteDataStore.default().removeData(ofTypes: dataTypes, modifiedSince: .distantPast, completionHandler: {})
     }
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
@@ -88,7 +88,7 @@ public final class WKEngine: Engine {
     }
 
     public func clearCookies() {
-        let dataTypes = Set([WKWebsiteDataTypeCookies])
+        let dataTypes = Set([WKWebsiteDataTypeCookies, WKWebsiteDataTypeLocalStorage])
         WKWebsiteDataStore.default().removeData(ofTypes: dataTypes, modifiedSince: .distantPast, completionHandler: {})
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Clearables.swift
+++ b/firefox-ios/Client/Frontend/Settings/Clearables.swift
@@ -137,7 +137,13 @@ class SiteDataClearable: Clearable {
     }
 
     func clear() -> Success {
-        let dataTypes = Set([WKWebsiteDataTypeOfflineWebApplicationCache])
+        let dataTypes = Set([
+            WKWebsiteDataTypeLocalStorage,
+            WKWebsiteDataTypeSessionStorage,
+            WKWebsiteDataTypeWebSQLDatabases,
+            WKWebsiteDataTypeIndexedDBDatabases,
+            WKWebsiteDataTypeFetchCache,
+        ])
         WKWebsiteDataStore.default().removeData(ofTypes: dataTypes, modifiedSince: .distantPast, completionHandler: {})
 
         logger.log("SiteDataClearable succeeded.",
@@ -153,14 +159,6 @@ class CookiesClearable: Clearable {
     private let logger: Logger
     private let dataStore: WKWebsiteDataStore
 
-    static let cookieDataTypes: Set<String> = [
-        WKWebsiteDataTypeCookies,
-        WKWebsiteDataTypeLocalStorage,
-        WKWebsiteDataTypeSessionStorage,
-        WKWebsiteDataTypeWebSQLDatabases,
-        WKWebsiteDataTypeIndexedDBDatabases
-    ]
-
     @MainActor
     init(logger: Logger = DefaultLogger.shared,
          dataStore: WKWebsiteDataStore = .default()) {
@@ -170,7 +168,7 @@ class CookiesClearable: Clearable {
 
     func clear() -> Success {
         dataStore.removeData(
-            ofTypes: Self.cookieDataTypes,
+            ofTypes: WKWebsiteDataTypeCookies,
             modifiedSince: .distantPast,
             completionHandler: {}
         )
@@ -183,7 +181,7 @@ class CookiesClearable: Clearable {
 
     @MainActor
     func clear(forDomain domain: String) async {
-        let records = await dataStore.dataRecords(ofTypes: Self.cookieDataTypes)
+        let records = await dataStore.dataRecords(ofTypes: WKWebsiteDataTypeCookies)
         let targets = records.filter { $0.displayName == domain.lowercased() }
         guard !targets.isEmpty else { return }
         await dataStore.removeData(ofTypes: Self.cookieDataTypes, for: targets)

--- a/firefox-ios/Client/Frontend/Settings/Clearables.swift
+++ b/firefox-ios/Client/Frontend/Settings/Clearables.swift
@@ -168,7 +168,7 @@ class CookiesClearable: Clearable {
 
     func clear() -> Success {
         dataStore.removeData(
-            ofTypes: [WKWebsiteDataTypeCookies],
+            ofTypes: [WKWebsiteDataTypeCookies, WKWebsiteDataTypeLocalStorage],
             modifiedSince: .distantPast,
             completionHandler: {}
         )
@@ -181,10 +181,10 @@ class CookiesClearable: Clearable {
 
     @MainActor
     func clear(forDomain domain: String) async {
-        let records = await dataStore.dataRecords(ofTypes: [WKWebsiteDataTypeCookies])
+        let records = await dataStore.dataRecords(ofTypes: [WKWebsiteDataTypeCookies, WKWebsiteDataTypeLocalStorage])
         let targets = records.filter { $0.displayName == domain.lowercased() }
         guard !targets.isEmpty else { return }
-        await dataStore.removeData(ofTypes: [WKWebsiteDataTypeCookies], for: targets)
+        await dataStore.removeData(ofTypes: [WKWebsiteDataTypeCookies, WKWebsiteDataTypeLocalStorage], for: targets)
         logger.log(
             "CookiesClearable removed domain-scoped data for \(domain).",
             level: .debug,

--- a/firefox-ios/Client/Frontend/Settings/Clearables.swift
+++ b/firefox-ios/Client/Frontend/Settings/Clearables.swift
@@ -168,7 +168,7 @@ class CookiesClearable: Clearable {
 
     func clear() -> Success {
         dataStore.removeData(
-            ofTypes: WKWebsiteDataTypeCookies,
+            ofTypes: [WKWebsiteDataTypeCookies],
             modifiedSince: .distantPast,
             completionHandler: {}
         )
@@ -181,7 +181,7 @@ class CookiesClearable: Clearable {
 
     @MainActor
     func clear(forDomain domain: String) async {
-        let records = await dataStore.dataRecords(ofTypes: WKWebsiteDataTypeCookies)
+        let records = await dataStore.dataRecords(ofTypes: [WKWebsiteDataTypeCookies])
         let targets = records.filter { $0.displayName == domain.lowercased() }
         guard !targets.isEmpty else { return }
         await dataStore.removeData(ofTypes: Self.cookieDataTypes, for: targets)

--- a/firefox-ios/Client/Frontend/Settings/Clearables.swift
+++ b/firefox-ios/Client/Frontend/Settings/Clearables.swift
@@ -184,7 +184,7 @@ class CookiesClearable: Clearable {
         let records = await dataStore.dataRecords(ofTypes: [WKWebsiteDataTypeCookies])
         let targets = records.filter { $0.displayName == domain.lowercased() }
         guard !targets.isEmpty else { return }
-        await dataStore.removeData(ofTypes: Self.cookieDataTypes, for: targets)
+        await dataStore.removeData(ofTypes: [WKWebsiteDataTypeCookies], for: targets)
         logger.log(
             "CookiesClearable removed domain-scoped data for \(domain).",
             level: .debug,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
@@ -232,6 +232,7 @@ class TrackingProtectionModel {
         guard let domain = url.baseDomain else { return }
         Task {
             await CookiesClearable().clear(forDomain: domain)
+            await SiteDataClearable().clear(forDomain: domain)
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ClearablesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ClearablesTests.swift
@@ -13,12 +13,8 @@ import Shared
 struct CookiesClearableTests {
     @Test
     func test_cookieDataTypes_containsExpectedTypes() {
-        let types = CookiesClearable.cookieDataTypes
+        let types = WKWebsiteDataTypeCookies
         #expect(types.contains(WKWebsiteDataTypeCookies))
-        #expect(types.contains(WKWebsiteDataTypeLocalStorage))
-        #expect(types.contains(WKWebsiteDataTypeSessionStorage))
-        #expect(types.contains(WKWebsiteDataTypeWebSQLDatabases))
-        #expect(types.contains(WKWebsiteDataTypeIndexedDBDatabases))
     }
 
     @MainActor
@@ -35,7 +31,7 @@ struct CookiesClearableTests {
     func test_clearForDomain_withEmptyStore_storeRemainsEmpty() async {
         let store = WKWebsiteDataStore.nonPersistent()
         await makeSubject(dataStore: store).clear(forDomain: "example.com")
-        let records = await store.dataRecords(ofTypes: CookiesClearable.cookieDataTypes)
+        let records = await store.dataRecords(ofTypes: [WKWebsiteDataTypeCookies])
         #expect(records.isEmpty)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ClearablesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ClearablesTests.swift
@@ -13,8 +13,9 @@ import Shared
 struct CookiesClearableTests {
     @Test
     func test_cookieDataTypes_containsExpectedTypes() {
-        let types = WKWebsiteDataTypeCookies
+        let types = Set([WKWebsiteDataTypeCookies, WKWebsiteDataTypeLocalStorage])
         #expect(types.contains(WKWebsiteDataTypeCookies))
+        #expect(types.contains(WKWebsiteDataTypeLocalStorage))
     }
 
     @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15603)

## :bulb: Description

@issammani Let me know if you have some time to chat about this. I don't think our Clearables were working correctly previously. 🤔 I believe the deprecated data type used previously for Site Data should be replaced with the DB and website data types, and the Cookies clearable should be clearing cookies.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

