### PR TITLE
Refactor FXIOS-15630 [UI Tests] Migrate toolbarmenu tests to TAE

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MainMenuScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MainMenuScreen.swift
@@ -35,6 +35,7 @@ final class MainMenuScreen {
 			sel.BOOKMARKS_BUTTON.element(in: app),
 			sel.HISTORY_BUTTON.element(in: app),
 			sel.DOWNLOADS_BUTTON.element(in: app),
+			sel.PASSWORDS_BUTTON.element(in: app),
 			sel.SIGN_IN_CELL.element(in: app)
 		]
 		BaseTestCase().waitForElementsToExist(elements)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MainMenuScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MainMenuScreen.swift
@@ -29,6 +29,26 @@ final class MainMenuScreen {
         BaseTestCase().waitForElementsToExist(elements)
     }
 
+	func assertMenuOptionsExist() {
+		let elements = [
+			sel.SETTINGS_CELL.element(in: app),
+			sel.BOOKMARKS_BUTTON.element(in: app),
+			sel.HISTORY_BUTTON.element(in: app),
+			sel.DOWNLOADS_BUTTON.element(in: app),
+			sel.SIGN_IN_CELL.element(in: app)
+		]
+		BaseTestCase().waitForElementsToExist(elements)
+	}
+
+	func dismissMenu() {
+		app.otherElements["PopoverDismissRegion"].firstMatch.tap()
+	}
+
+	func assertMenuIsDismissed(timeout: TimeInterval = TIMEOUT) {
+		let settings = sel.SETTINGS_CELL.element(in: app)
+		BaseTestCase().mozWaitForElementToNotExist(settings, timeout: timeout)
+	}
+
     func assertMainMenuSettingsExist() {
         let settings = sel.SETTINGS_CELL.element(in: app)
         BaseTestCase().mozWaitForElementToExist(settings)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
@@ -16,6 +16,7 @@ final class ToolbarScreen {
 
     private var tabsButton: XCUIElement { sel.TABS_BUTTON.element(in: app) }
     private var newTabButton: XCUIElement { sel.NEW_TAB_BUTTON.element(in: app)}
+    private var forwardButton: XCUIElement { sel.FORWARD_BUTTON.element(in: app)}
     private var backButton: XCUIElement { sel.BACK_BUTTON.element(in: app)}
     private var tabToolbarMenuButton: XCUIElement { sel.TABTOOLBAR_MENUBUTTON.element(in: app) }
     private var shareButton: XCUIElement { sel.SHARE_BUTTON.element(in: app) }
@@ -92,6 +93,10 @@ final class ToolbarScreen {
         BaseTestCase().mozWaitForElementToExist(backButton)
     }
 
+	func assertForwardButtonExists() {
+		BaseTestCase().mozWaitForElementToExist(forwardButton)
+	}
+
     func tapBackButton() {
         backButton.waitAndTap()
     }
@@ -130,6 +135,16 @@ final class ToolbarScreen {
         let settingMenuButton = sel.SETTINGS_MENU_BUTTON.element(in: app)
         BaseTestCase().mozWaitForElementToExist(settingMenuButton, timeout: TIMEOUT)
         return settingMenuButton
+    }
+
+    func getTabsButtonElement() -> XCUIElement {
+        BaseTestCase().mozWaitForElementToExist(tabsButton)
+        return tabsButton
+    }
+
+    func getForwardButtonElement() -> XCUIElement {
+        BaseTestCase().mozWaitForElementToExist(forwardButton)
+        return forwardButton
     }
 
     func tapShareButton() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/MainMenuSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/MainMenuSelectors.swift
@@ -10,6 +10,7 @@ protocol MainMenuSelectorSet {
     var HISTORY_BUTTON: Selector { get }
     var DOWNLOADS_BUTTON: Selector { get }
     var PASSWORDS_BUTTON: Selector { get }
+	var SIGN_IN_CELL: Selector { get }
     var SETTINGS_CELL: Selector { get }
     var all: [Selector] { get }
 }
@@ -21,6 +22,7 @@ struct MainMenuSelectors: MainMenuSelectorSet {
         static let history   = AccessibilityIdentifiers.MainMenu.history
         static let downloads = AccessibilityIdentifiers.MainMenu.downloads
         static let passwords = AccessibilityIdentifiers.MainMenu.passwords
+        static let signIn = AccessibilityIdentifiers.MainMenu.signIn
         static let settings  = AccessibilityIdentifiers.MainMenu.settings
     }
 
@@ -54,6 +56,11 @@ struct MainMenuSelectors: MainMenuSelectorSet {
         groups: ["MainMenu"]
     )
 
+	let SIGN_IN_CELL = Selector.cellById(
+		IDs.signIn,
+		description: "Sign In"
+	)
+
     let SETTINGS_CELL = Selector.tableCellById(
         IDs.settings,
         description: "Settings cell in Main Menu",
@@ -61,5 +68,5 @@ struct MainMenuSelectors: MainMenuSelectorSet {
     )
 
     var all: [Selector] { [DESKTOP_SITE, BOOKMARKS_BUTTON, HISTORY_BUTTON, DOWNLOADS_BUTTON,
-                           PASSWORDS_BUTTON, SETTINGS_CELL] }
+                           PASSWORDS_BUTTON, SIGN_IN_CELL, SETTINGS_CELL] }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarMenuTests.swift
@@ -6,6 +6,17 @@ import Foundation
 import XCTest
 
 class ToolbarMenuTests: BaseTestCase {
+	private var browserScreen: BrowserScreen!
+	private var toolbarScreen: ToolbarScreen!
+	private var mainMenuScreen: MainMenuScreen!
+
+	override func setUp() async throws {
+		try await super.setUp()
+		browserScreen = BrowserScreen(app: app)
+		toolbarScreen = ToolbarScreen(app: app)
+		mainMenuScreen = MainMenuScreen(app: app)
+	}
+
     override func tearDown() async throws {
         XCUIDevice.shared.orientation = .portrait
         try await super.tearDown()
@@ -13,22 +24,11 @@ class ToolbarMenuTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306840
     func testToolbarMenu() {
-        let hamburgerMenu = app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton]
-        let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
-        let backButton = app.buttons[AccessibilityIdentifiers.Toolbar.backButton]
-        let forwardButton = app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton]
-        let searchField = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
-        waitForElementsToExist(
-            [
-                hamburgerMenu,
-                backButton,
-                forwardButton,
-                searchField,
-                tabsButton
-            ]
-        )
-        mozWaitForElementToExist(tabsButton)
-        XCTAssertTrue(
+        let hamburgerMenu = toolbarScreen.getToolbarSettingsMenuButtonElement()
+        let tabsButton = toolbarScreen.getTabsButtonElement()
+        let forwardButton = toolbarScreen.getForwardButtonElement()
+		assertToolbarMenusAndAddressBarExist()
+		XCTAssertTrue(
             hamburgerMenu.isLeftOf(rightElement: tabsButton),
             "Menu button is not on the left side of tabs button"
         )
@@ -36,26 +36,19 @@ class ToolbarMenuTests: BaseTestCase {
             hamburgerMenu.isRightOf(rightElement: forwardButton),
             "Menu button is not below the pocket cells area"
         )
-        navigator.goto(BrowserTabMenu)
+
+		toolbarScreen.tapSettingsMenuButton()
         // issue 28625: iOS 15 may not open the menu fully.
         if #unavailable(iOS 16) {
             app.swipeUp()
         }
-        mozWaitForElementToExist(app.tables.cells[AccessibilityIdentifiers.MainMenu.settings])
-        validateMenuOptions()
+		mainMenuScreen.assertMenuOptionsExist()
+
         // issue 28629: menu not available in landscape mode (iOS 15 only)
         if #available(iOS 16, *) {
-            app.otherElements["PopoverDismissRegion"].firstMatch.tap()
+			mainMenuScreen.dismissMenu()
             XCUIDevice.shared.orientation = .landscapeLeft
-            waitForElementsToExist(
-                [
-                    hamburgerMenu,
-                    backButton,
-                    forwardButton,
-                    searchField,
-                    tabsButton
-                ]
-            )
+			assertToolbarMenusAndAddressBarExist()
             XCTAssertTrue(
                 hamburgerMenu.isLeftOf(rightElement: tabsButton),
                 "Menu button is not on the left side of tabs button"
@@ -64,23 +57,20 @@ class ToolbarMenuTests: BaseTestCase {
                 hamburgerMenu.isRightOf(rightElement: forwardButton),
                 "Menu button is not below the pocket cells area"
             )
-            hamburgerMenu.waitAndTap()
-            mozWaitForElementToExist(app.tables.cells[AccessibilityIdentifiers.MainMenu.settings])
-            validateMenuOptions()
-            app.otherElements["PopoverDismissRegion"].firstMatch.tap()
-            mozWaitForElementToNotExist(app.tables.cells[AccessibilityIdentifiers.MainMenu.settings])
+
+			toolbarScreen.tapSettingsMenuButton()
+			mainMenuScreen.assertMenuOptionsExist()
+
+			mainMenuScreen.dismissMenu()
+			mainMenuScreen.assertMenuIsDismissed()
         }
     }
 
-    private func validateMenuOptions() {
-        waitForElementsToExist(
-            [
-                app.tables.cells[AccessibilityIdentifiers.MainMenu.settings],
-                app.tables.cells.buttons[AccessibilityIdentifiers.MainMenu.bookmarks],
-                app.tables.cells.buttons[AccessibilityIdentifiers.MainMenu.history],
-                app.tables.cells.buttons[AccessibilityIdentifiers.MainMenu.downloads],
-                app.cells[AccessibilityIdentifiers.MainMenu.signIn]
-            ]
-        )
-    }
+	private func assertToolbarMenusAndAddressBarExist() {
+		toolbarScreen.assertSettingsButtonExists()
+		toolbarScreen.assertTabsButtonExists()
+		toolbarScreen.assertForwardButtonExists()
+		toolbarScreen.assertBackButtonExists()
+		browserScreen.assertAddressBarExists()
+	}
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15630)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33489)

## :bulb: Description
- Added `SIGN_IN_CELL` to `MainMenuSelectors` so the existing toolbar menu option validation can be  represented through `MainMenuScreen`.
- Implemented the issue-requested TAE/POM updates for ToolbarMenuTests and related PageScreen helpers.
- Passwords button is included in `MainMenuScreen.assertMenuOptionsExist()` because it is part of the visible Main Menu options.



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

