### PR TITLE
Bugfix FXIOS-15645 [Top 10 Bugs] Investigate top crashes in Sentry StartAtHome unavailable WindowUUID

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -856,12 +856,12 @@ class BrowserViewController: UIViewController,
         defer { AppEventQueue.completed(.browserUpdatedForAppActivation(uuid)) }
 
         let allWindowUUIDs = (AppContainer.shared.resolve() as WindowManager).windows.keys.map { $0.uuidString.prefix(4) }
-        logger.log("BrowserDidBecomeActive. UUID = \(windowUUID.uuidString.prefix(4)). All windows: \(allWindowUUIDs)",
+        logger.log("BrowserDidBecomeActive. UUID = \(uuid.uuidString.prefix(4)). All windows: \(allWindowUUIDs)",
                    level: .info,
                    category: .lifecycle)
 
         NightModeHelper.cleanNightModeDefaults()
-        dispatchStartAtHomeAction()
+        dispatchStartAtHomeAction(windowUUID: uuid)
     }
 
     // MARK: - Summarize
@@ -877,7 +877,7 @@ class BrowserViewController: UIViewController,
     }
 
     // MARK: - Start At Home
-    private func dispatchStartAtHomeAction() {
+    private func dispatchStartAtHomeAction(windowUUID: WindowUUID) {
         let startAtHomeAction = StartAtHomeAction(
             windowUUID: windowUUID,
             actionType: StartAtHomeActionType.didBrowserBecomeActive

--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
@@ -38,13 +38,19 @@ final class StartAtHomeMiddleware {
         }
     }
 
-    private func fetchTabManager(for uuid: WindowUUID) -> TabManager {
+    private func fetchTabManager(for uuid: WindowUUID) -> TabManager? {
         guard uuid != .unavailable else {
             assertionFailure()
-            logger.log("Unexpected or unavailable window UUID for requested TabManager.", level: .fatal, category: .tabs)
-            return windowManager.allWindowTabManagers().first!
+            logger.log("Unexpected or unavailable window UUID for requested TabManager.", level: .warning, category: .tabs)
+            return windowManager.allWindowTabManagers().first
         }
-        return windowManager.tabManager(for: uuid)
+
+        guard let tabManager = windowManager.windows[uuid]?.tabManager else {
+            logger.log("TabManager not ready for UUID, skipping start-at-home check.", level: .warning, category: .tabs)
+            return nil
+        }
+
+        return tabManager
     }
 
     /// Checks whether the app should start at the homepage and initiates the process if applicable.
@@ -54,7 +60,7 @@ final class StartAtHomeMiddleware {
     /// - Returns: `true` if a homepage tab was selected and displayed, `false` otherwise.
     @MainActor
     private func startAtHomeCheck(windowUUID: WindowUUID) -> Bool {
-        let tabManager = fetchTabManager(for: windowUUID)
+        guard let tabManager = fetchTabManager(for: windowUUID) else { return false }
         let startAtHomeManager = StartAtHomeHelper(
             prefs: prefs,
             isRestoringTabs: !tabManager.tabRestoreHasFinished

--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
@@ -38,21 +38,6 @@ final class StartAtHomeMiddleware {
         }
     }
 
-    private func fetchTabManager(for uuid: WindowUUID) -> TabManager? {
-        guard uuid != .unavailable else {
-            assertionFailure()
-            logger.log("Unexpected or unavailable window UUID for requested TabManager.", level: .warning, category: .tabs)
-            return windowManager.allWindowTabManagers().first
-        }
-
-        guard let tabManager = windowManager.windows[uuid]?.tabManager else {
-            logger.log("TabManager not ready for UUID, skipping start-at-home check.", level: .warning, category: .tabs)
-            return nil
-        }
-
-        return tabManager
-    }
-
     /// Checks whether the app should start at the homepage and initiates the process if applicable.
     /// This method uses `StartAtHomeHelper` to determine if the app should launch with a homepage tab,
     /// based on user preferences and session state.
@@ -60,7 +45,7 @@ final class StartAtHomeMiddleware {
     /// - Returns: `true` if a homepage tab was selected and displayed, `false` otherwise.
     @MainActor
     private func startAtHomeCheck(windowUUID: WindowUUID) -> Bool {
-        guard let tabManager = fetchTabManager(for: windowUUID) else { return false }
+        let tabManager = windowManager.tabManager(for: windowUUID)
         let startAtHomeManager = StartAtHomeHelper(
             prefs: prefs,
             isRestoringTabs: !tabManager.tabRestoreHasFinished

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHome/StartAtHomeMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHome/StartAtHomeMiddlewareTests.swift
@@ -25,6 +25,7 @@ final class StartAtHomeMiddlewareTests: XCTestCase, StoreTestUtility {
             wrappedManager: WindowManagerImplementation(),
             tabManager: mockTabManager
         )
+        mockWindowManager.overrideWindows = true
         // Inject the mock profile so that `UserFeaturePreferring` resolved from the
         // AppContainer reads from `mockProfile.prefs` (which the tests configure).
         DependencyHelperMock().bootstrapDependencies(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15645)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33513)

## :bulb: Description
This event is in our top 10 Sentry events. After investigation, it appears to be a race condition where `TabManager` is not yet resolved because the `WindowUUID` for `TabManager` is requested before it is properly set up. We already skip the process when this happens, so I propose downgrading the log from `fatal` to `warning` to reduce noise.
I also removed a force-unwrap. We should create an investigation ticket to fix this issue properly.      
- Remove force unwrap and downgrade log level for known issue StartAtHome


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

