### PR TITLE
Add FXIOS-15424 [News Categories] Improve news transition header accessibility

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
@@ -20,7 +20,10 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
     private lazy var newsAffordanceHeaderView: NewsAffordanceHeaderView = .build()
     private lazy var sectionTitleHeaderView: LabelButtonHeaderView = .build()
     private lazy var storyCategoryPickerView: StoryCategoryPickerView = .build()
-    private lazy var headerContainerView: UIView = .build()
+    private lazy var headerContainerView: UIView = .build { view in
+        view.isAccessibilityElement = true
+        view.accessibilityTraits = .header
+    }
 
     private var headerContainerHeightConstraint: NSLayoutConstraint?
     private var hasCategories = false
@@ -29,8 +32,7 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        isAccessibilityElement = true
-        accessibilityTraits = .header
+        isAccessibilityElement = false
         setupLayout()
         updateViewState()
     }
@@ -90,6 +92,7 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
             textColor: textColor,
             theme: theme
         )
+        headerContainerView.accessibilityIdentifier = sectionHeaderConfiguration.a11yIdentifier
         sectionTitleHeaderView.moreButton.isHidden = true
         storyCategoryPickerView.configure(
             categories: categories,
@@ -183,9 +186,6 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
                 translationX: 0,
                 y: pickerTranslationOffset() * (1 - pickerProgress)
             )
-            accessibilityLabel = progress < 0.5
-                ? newsAffordanceHeaderView.accessibilityLabel
-                : sectionTitleHeaderView.title
 
         // Static section title header + category picker
         } else {
@@ -197,8 +197,13 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
             )
             storyCategoryPickerView.alpha = hasCategories ? 1 : 0
             storyCategoryPickerView.transform = .identity
-            accessibilityLabel = sectionTitleHeaderView.title
         }
+
+        headerContainerView.accessibilityLabel = transitionEnabled && progress < 0.5
+            ? newsAffordanceHeaderView.accessibilityLabel
+            : sectionTitleHeaderView.title
+        storyCategoryPickerView.accessibilityElementsHidden = !hasCategories
+        accessibilityElements = hasCategories ? [headerContainerView, storyCategoryPickerView] : [headerContainerView]
     }
 
     /// Map the overall scroll progress onto a delayed 0...1 range so the category


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15424)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33083)

## :bulb: Description
- Allow voiceover to go into the `StoryCategoryPickerView` to scan through story categories

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

