### PR TITLE
Refactor FXIOS-33487 [UI Tests] Convert OpeningScreenTests to new framework

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
@@ -4,19 +4,24 @@
 
 import Foundation
 class OpeningScreenTests: BaseTestCase {
-    // https://mozilla.testrail.io/index.php?/cases/view/2307039
+    private var browserScreen: BrowserScreen!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        browserScreen = BrowserScreen(app: app)
+    }
+
     func testLastOpenedTab() {
         // Open a web page
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"), waitForLoading: true)
+        browserScreen.navigateToURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
         // Close the app from app switcher. Relaunch the app
         closeFromAppSwitcherAndRelaunch()
         // After re-launching the app, the last visited page is displayed
-        let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
-        mozWaitForValueContains(url, value: "localhost")
+        browserScreen.assertAddressBarContains(value: "localhost")
         // Background and restore Firefox
         restartInBackground()
         // After re-launching the app, the last visited page is displayed
-        mozWaitForValueContains(url, value: "localhost")
+        browserScreen.assertAddressBarContains(value: "localhost")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
@@ -4,19 +4,25 @@
 
 import Foundation
 class OpeningScreenTests: BaseTestCase {
+    private var browserScreen: BrowserScreen!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        browserScreen = BrowserScreen(app: app)
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2307039
     func testLastOpenedTab() {
         // Open a web page
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"), waitForLoading: true)
+        browserScreen.navigateToURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
         // Close the app from app switcher. Relaunch the app
         closeFromAppSwitcherAndRelaunch()
         // After re-launching the app, the last visited page is displayed
-        let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
-        mozWaitForValueContains(url, value: "localhost")
+        browserScreen.assertAddressBarContains(value: "localhost")
         // Background and restore Firefox
         restartInBackground()
         // After re-launching the app, the last visited page is displayed
-        mozWaitForValueContains(url, value: "localhost")
+        browserScreen.assertAddressBarContains(value: "localhost")
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15628)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33487)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Replaced navigator calls to use BrowserScreen to open a web page and verify the last web page is displayed on relaunch.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

