### PR TITLE
Add FXIOS-15659 [WC] Missing strings for erorrs states

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1073,12 +1073,12 @@ extension String {
                 key: "WorldCup.HomepageWidget.FTLabel.v151",
                 tableName: "WorldCup",
                 value: "(Full Time)",
-                comment: "The label indicating that the displaying match as ended.")
+                comment: "The label indicating that the displaying match has ended.")
             public static let FullTimeNoParenthesisLabel = MZLocalizedString(
                 key: "WorldCup.HomepageWidget.FTNoParenthesisLabel.v151",
                 tableName: "WorldCup",
                 value: "Full Time",
-                comment: "The label indicating that the displaying match as ended.")
+                comment: "The label indicating that the displaying match has ended.")
             public static let FullTimePenaltiesLabel = MZLocalizedString(
                 key: "WorldCup.HomepageWidget.RoundPhase.FullTimePenaltiesLabel.v151",
                 tableName: "WorldCup",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1135,11 +1135,6 @@ extension String {
                     tableName: "WorldCup",
                     value: "View Schedule",
                     comment: "Label for the button that takes users to the World Cup schedule website on the countdown section.")
-                public static let TimerAccessibilityLabel = MZLocalizedString(
-                    key: "WorldCup.HomepageWidget.CountDown.TimerAccessibilityLabel.v151",
-                    tableName: "WorldCup",
-                    value: "%d days, %d hours, %d minutes remaining",
-                    comment: "Accessibility label for the countdown timer in the World Cup widget. The first parameter is the number of days, the second is hours, and the third is minutes remaining until the World Cup starts.")
             }
             public struct FollowTeamCard {
                 public static let Title = MZLocalizedString(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1107,7 +1107,7 @@ extension String {
             public static let OfflineLabel = MZLocalizedString(
                 key: "WorldCup.HomepageWidget.OfflineLabel.v151",
                 tableName: "WorldCup",
-                value: "Looks like you're offline. Check your internet connection and try again.",
+                value: "Looks like you’re offline. Check your internet connection and try again.",
                 comment: "Message shown in the World Cup widget when the device has no internet connection.")
             public struct CountDown {
                 public static let Title = MZLocalizedString(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1094,6 +1094,21 @@ extension String {
                 tableName: "WorldCup",
                 value: "Refresh",
                 comment: "The label for the button in the World Cup widget that refreshes the currently displayed match data when an error is displayed.")
+            public static let MatchUnavailableLabel = MZLocalizedString(
+                key: "WorldCup.HomepageWidget.MatchUnavailableLabel.v151",
+                tableName: "WorldCup",
+                value: "Match info is not available right now. Try refreshing in a few minutes.",
+                comment: "Message shown in the World Cup widget when match data is temporarily unavailable.")
+            public static let MatchUnavailableRefreshButtonLabel = MZLocalizedString(
+                key: "WorldCup.HomepageWidget.MatchUnavailableRefreshButtonLabel.v151",
+                tableName: "WorldCup",
+                value: "Refresh",
+                comment: "Button label shown below the match unavailable message in the World Cup widget. Tapping it retries loading match data.")
+            public static let OfflineLabel = MZLocalizedString(
+                key: "WorldCup.HomepageWidget.OfflineLabel.v151",
+                tableName: "WorldCup",
+                value: "Looks like you're offline. Check your internet connection and try again.",
+                comment: "Message shown in the World Cup widget when the device has no internet connection.")
             public struct CountDown {
                 public static let Title = MZLocalizedString(
                     key: "WorldCup.HomepageWidget.CountDown.Title.v151",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1074,6 +1074,11 @@ extension String {
                 tableName: "WorldCup",
                 value: "(Full Time)",
                 comment: "The label indicating that the displaying match as ended.")
+            public static let FullTimeNoParenthesisLabel = MZLocalizedString(
+                key: "WorldCup.HomepageWidget.FTNoParenthesisLabel.v151",
+                tableName: "WorldCup",
+                value: "Full Time",
+                comment: "The label indicating that the displaying match as ended.")
             public static let FullTimePenaltiesLabel = MZLocalizedString(
                 key: "WorldCup.HomepageWidget.RoundPhase.FullTimePenaltiesLabel.v151",
                 tableName: "WorldCup",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1135,6 +1135,11 @@ extension String {
                     tableName: "WorldCup",
                     value: "View Schedule",
                     comment: "Label for the button that takes users to the World Cup schedule website on the countdown section.")
+                public static let TimerAccessibilityLabel = MZLocalizedString(
+                    key: "WorldCup.HomepageWidget.CountDown.TimerAccessibilityLabel.v151",
+                    tableName: "WorldCup",
+                    value: "%d days, %d hours, %d minutes remaining",
+                    comment: "Accessibility label for the countdown timer in the World Cup widget. The first parameter is the number of days, the second is hours, and the third is minutes remaining until the World Cup starts.")
             }
             public struct FollowTeamCard {
                 public static let Title = MZLocalizedString(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15659)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33535)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Adds missing strings

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

