### PR TITLE
Bugfix FXIOS-15650 [Translations Phase 2] Fix single language flow toggle and direct language switching

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -21,7 +21,7 @@ struct GeneralBrowserAction: Action {
     let summarizerConfig: SummarizerConfig?
     let summarizerTrigger: SummarizerTrigger
     let translationLanguages: [String]?
-    let isPageTranslated: Bool?
+    let isPageTranslated: Bool
     let translatedToLanguage: String?
     init(selectedTabURL: URL? = nil,
          isPrivateBrowsing: Bool? = nil,
@@ -33,7 +33,7 @@ struct GeneralBrowserAction: Action {
          summarizerConfig: SummarizerConfig? = nil,
          summarizerTrigger: SummarizerTrigger = .shakeGesture,
          translationLanguages: [String]? = nil,
-         isPageTranslated: Bool? = nil,
+         isPageTranslated: Bool = false,
          translatedToLanguage: String? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -734,7 +734,7 @@ struct BrowserViewControllerState: ScreenState {
             browserViewType: state.browserViewType,
             displayView: .translationLanguagePicker(TranslationLanguagePickerData(
                 languages: action.translationLanguages ?? [],
-                isTranslated: action.isPageTranslated ?? false,
+                isTranslated: action.isPageTranslated,
                 translatedToLanguage: action.translatedToLanguage
             )),
             buttonTapped: action.buttonTapped,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -173,17 +173,17 @@ class MainMenuCoordinator: BaseCoordinator {
             } else {
                 false
             }
+            if isSingleLanguageFlow && isTranslated {
+                store.dispatch(ToolbarMiddlewareAction(
+                    buttonType: .translate,
+                    gestureType: .tap,
+                    windowUUID: windowUUID,
+                    actionType: ToolbarMiddlewareActionType.didTapButton
+                ))
+                return
+            }
             let prefs = profile.prefs
             Task {
-                if isSingleLanguageFlow && isTranslated {
-                    store.dispatch(ToolbarMiddlewareAction(
-                        buttonType: .translate,
-                        gestureType: .tap,
-                        windowUUID: windowUUID,
-                        actionType: ToolbarMiddlewareActionType.didTapButton
-                    ))
-                    return
-                }
                 let manager = PreferredTranslationLanguagesManager(prefs: prefs)
                 let supported = await ASTranslationModelsFetcher.shared.fetchSupportedTargetLanguages()
                 let languages = manager.preferredLanguages(supportedTargetLanguages: supported)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -175,6 +175,15 @@ class MainMenuCoordinator: BaseCoordinator {
             }
             let prefs = profile.prefs
             Task {
+                if isSingleLanguageFlow && isTranslated {
+                    store.dispatch(ToolbarMiddlewareAction(
+                        buttonType: .translate,
+                        gestureType: .tap,
+                        windowUUID: windowUUID,
+                        actionType: ToolbarMiddlewareActionType.didTapButton
+                    ))
+                    return
+                }
                 let manager = PreferredTranslationLanguagesManager(prefs: prefs)
                 let supported = await ASTranslationModelsFetcher.shared.fetchSupportedTargetLanguages()
                 let languages = manager.preferredLanguages(supportedTargetLanguages: supported)
@@ -182,7 +191,7 @@ class MainMenuCoordinator: BaseCoordinator {
                     ? translationConfig?.sourceLanguage
                     : (try? await TranslationsService().detectPageLanguage(for: windowUUID))
                 let filteredLanguages = languages.filter { $0 != pageLanguage && $0 != translatedLanguage }
-                if isSingleLanguageFlow, let language = filteredLanguages.first, !isTranslated {
+                if isSingleLanguageFlow, let language = filteredLanguages.first {
                     store.dispatch(TranslationLanguageSelectedAction(
                         windowUUID: windowUUID,
                         targetLanguage: language,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionConfiguration.swift
@@ -58,7 +58,7 @@ struct ToolbarActionConfiguration: Equatable {
                actionType == .readerMode ||
                actionType == .readerModeWithSummarizer ||
                actionType == .summarizer ||
-               (actionType == .translate && isSelected) ||
+               actionType == .translate ||
                (actionType == .tabs && isShowingTopTabs == false)
     }
 }

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
@@ -56,10 +56,11 @@ final class TranslationsService: TranslationsServiceProtocol {
     /// Initiates translation of the current page to the specified target language.
     func translateCurrentPage(
         for windowUUID: WindowUUID,
+        from sourceLanguage: String? = nil,
         to targetLanguage: String,
         onLanguageIdentified: ((String, String) -> Void)?
     ) async throws {
-        let pageLanguage = try await detectPageLanguage(for: windowUUID)
+        let pageLanguage = try sourceLanguage ?? (await detectPageLanguage(for: windowUUID))
         onLanguageIdentified?(pageLanguage, targetLanguage)
         let webView = try currentWebView(for: windowUUID)
         // Prewarm resources prior to calling the JS translation API.

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
@@ -60,7 +60,12 @@ final class TranslationsService: TranslationsServiceProtocol {
         to targetLanguage: String,
         onLanguageIdentified: ((String, String) -> Void)?
     ) async throws {
-        let pageLanguage = try sourceLanguage ?? (await detectPageLanguage(for: windowUUID))
+        let pageLanguage: String
+        if let sourceLanguage {
+            pageLanguage = sourceLanguage
+        } else {
+            pageLanguage = try await detectPageLanguage(for: windowUUID)
+        }
         onLanguageIdentified?(pageLanguage, targetLanguage)
         let webView = try currentWebView(for: windowUUID)
         // Prewarm resources prior to calling the JS translation API.

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceProtocol.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceProtocol.swift
@@ -19,6 +19,7 @@ protocol TranslationsServiceProtocol {
     /// For now `onLanguageIdentified` is used to notify caller when language detection is done.
     func translateCurrentPage(
         for windowUUID: WindowUUID,
+        from sourceLanguage: String?,
         to targetLanguage: String,
         onLanguageIdentified: ((String, String) -> Void)?
     ) async throws

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -268,7 +268,9 @@ final class TranslationsMiddleware: FeatureFlaggable {
         ) else { return }
 
         let originatingTab = selectedTab(for: action.windowUUID)
-        let isCurrentlyTranslated = toolbarState.addressToolbar.translationConfiguration?.state == .active
+        let storedSourceLanguage = toolbarState.addressToolbar.translationConfiguration?.state == .active
+            ? toolbarState.addressToolbar.translationConfiguration?.sourceLanguage
+            : nil
         let newFlowId = UUID()
         translationFlowIds[action.windowUUID] = newFlowId
         selectedTargetLanguages[action.windowUUID] = action.targetLanguage
@@ -282,7 +284,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
             for: action,
             targetLanguage: action.targetLanguage,
             isPrivate: toolbarState.isPrivateMode,
-            discardFirst: isCurrentlyTranslated,
+            sourceLanguage: storedSourceLanguage,
             on: originatingTab
         )
     }
@@ -409,7 +411,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
         targetLanguage: String,
         isPrivate: Bool,
         autoTranslate: Bool = false,
-        discardFirst: Bool = false,
+        sourceLanguage: String? = nil,
         on tab: Tab? = nil
     ) {
         Task {
@@ -418,7 +420,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
                 targetLanguage: targetLanguage,
                 isPrivate: isPrivate,
                 autoTranslate: autoTranslate,
-                discardFirst: discardFirst,
+                sourceLanguage: sourceLanguage,
                 on: tab
             )
         }
@@ -429,16 +431,14 @@ final class TranslationsMiddleware: FeatureFlaggable {
         targetLanguage: String,
         isPrivate: Bool,
         autoTranslate: Bool,
-        discardFirst: Bool = false,
+        sourceLanguage: String? = nil,
         on tab: Tab?
     ) async {
         do {
-            if discardFirst {
-                try await translationsService.discardTranslations(for: action.windowUUID)
-            }
             var detectedSourceLanguage: String?
             try await translationsService.translateCurrentPage(
                 for: action.windowUUID,
+                from: sourceLanguage,
                 to: targetLanguage,
                 onLanguageIdentified: { identifiedLanguage, deviceLanguage in
                     detectedSourceLanguage = identifiedLanguage

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -30,6 +30,10 @@ final class TranslationsMiddleware: FeatureFlaggable {
     /// Each entry is a one-shot flag: auto-translate is skipped for the immediately following
     /// page load for that window, then the entry is removed. On iPhone only one window exists.
     private var restoringWindows: Set<WindowUUID> = []
+    /// Stores a target language for windows mid language-switch. When the page reloads after
+    /// the active translation is discarded, tryAutoTranslate picks this up and translates to the
+    /// requested language instead of the user's top preferred language.
+    private var pendingLanguageSwitchTargets: [WindowUUID: String] = [:]
 
     init(profile: Profile = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared,
@@ -268,9 +272,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
         ) else { return }
 
         let originatingTab = selectedTab(for: action.windowUUID)
-        let storedSourceLanguage = toolbarState.addressToolbar.translationConfiguration?.state == .active
-            ? toolbarState.addressToolbar.translationConfiguration?.sourceLanguage
-            : nil
+        let isCurrentlyTranslated = toolbarState.addressToolbar.translationConfiguration?.state == .active
         let newFlowId = UUID()
         translationFlowIds[action.windowUUID] = newFlowId
         selectedTargetLanguages[action.windowUUID] = action.targetLanguage
@@ -279,14 +281,22 @@ final class TranslationsMiddleware: FeatureFlaggable {
             actionType: .willTranslate,
             translationFlowId: newFlowId
         )
-        self.handleUpdatingTranslationIcon(for: action, with: .loading, on: originatingTab)
-        self.retrieveTranslations(
-            for: action,
-            targetLanguage: action.targetLanguage,
-            isPrivate: toolbarState.isPrivateMode,
-            sourceLanguage: storedSourceLanguage,
-            on: originatingTab
-        )
+        if isCurrentlyTranslated {
+            pendingLanguageSwitchTargets[action.windowUUID] = action.targetLanguage
+            handleUpdatingTranslationIcon(for: action, with: .inactive, on: originatingTab)
+            store.dispatch(GeneralBrowserAction(
+                windowUUID: action.windowUUID,
+                actionType: GeneralBrowserActionType.reloadWebsite
+            ))
+        } else {
+            handleUpdatingTranslationIcon(for: action, with: .loading, on: originatingTab)
+            retrieveTranslations(
+                for: action,
+                targetLanguage: action.targetLanguage,
+                isPrivate: toolbarState.isPrivateMode,
+                on: originatingTab
+            )
+        }
     }
 
     private func handleUpdatingTranslationIcon(
@@ -320,6 +330,21 @@ final class TranslationsMiddleware: FeatureFlaggable {
     /// Returns `true` if auto-translation was initiated (caller should skip manual offer).
     private func tryAutoTranslate(for action: ToolbarAction, on tab: Tab?) async -> Bool {
         if restoringWindows.remove(action.windowUUID) != nil { return false }
+
+        if let pendingLanguage = pendingLanguageSwitchTargets.removeValue(forKey: action.windowUUID) {
+            let isPrivate = store.state.componentState(
+                ToolbarState.self,
+                for: .toolbar,
+                window: action.windowUUID
+            )?.isPrivateMode ?? false
+            let newFlowId = UUID()
+            translationFlowIds[action.windowUUID] = newFlowId
+            selectedTargetLanguages[action.windowUUID] = pendingLanguage
+            handleUpdatingTranslationIcon(for: action, with: .loading, on: tab)
+            retrieveTranslations(for: action, targetLanguage: pendingLanguage, isPrivate: isPrivate, on: tab)
+            return true
+        }
+
         guard profile.prefs.boolForKey(PrefsKeys.Settings.translationAutoTranslate) ?? false else { return false }
         let manager = PreferredTranslationLanguagesManager(prefs: profile.prefs)
         let supported = await translationsService.fetchSupportedTargetLanguages()
@@ -411,7 +436,6 @@ final class TranslationsMiddleware: FeatureFlaggable {
         targetLanguage: String,
         isPrivate: Bool,
         autoTranslate: Bool = false,
-        sourceLanguage: String? = nil,
         on tab: Tab? = nil
     ) {
         Task {
@@ -420,7 +444,6 @@ final class TranslationsMiddleware: FeatureFlaggable {
                 targetLanguage: targetLanguage,
                 isPrivate: isPrivate,
                 autoTranslate: autoTranslate,
-                sourceLanguage: sourceLanguage,
                 on: tab
             )
         }
@@ -431,14 +454,13 @@ final class TranslationsMiddleware: FeatureFlaggable {
         targetLanguage: String,
         isPrivate: Bool,
         autoTranslate: Bool,
-        sourceLanguage: String? = nil,
         on tab: Tab?
     ) async {
         do {
             var detectedSourceLanguage: String?
             try await translationsService.translateCurrentPage(
                 for: action.windowUUID,
-                from: sourceLanguage,
+                from: nil,
                 to: targetLanguage,
                 onLanguageIdentified: { identifiedLanguage, deviceLanguage in
                     detectedSourceLanguage = identifiedLanguage

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -120,11 +120,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
         }
 
         if gestureType == .longPress {
-            handleLongPressOnTranslateButton(
-                for: action,
-                toolbarState: toolbarState,
-                translationConfiguration: translationConfiguration
-            )
+            handleLongPressOnTranslateButton(for: action, translationConfiguration: translationConfiguration)
             return
         }
 
@@ -217,7 +213,6 @@ final class TranslationsMiddleware: FeatureFlaggable {
 
     private func handleLongPressOnTranslateButton(
         for action: ToolbarMiddlewareAction,
-        toolbarState: ToolbarState,
         translationConfiguration: TranslationConfiguration
     ) {
         guard featureFlagsProvider.isEnabled(.translationLanguagePicker) else { return }
@@ -230,38 +225,19 @@ final class TranslationsMiddleware: FeatureFlaggable {
                 let languages = manager.preferredLanguages(supportedTargetLanguages: supported)
                 let pageLanguage = try? await translationsService.detectPageLanguage(for: action.windowUUID)
                 let filteredLanguages = languages.filter { $0 != pageLanguage }
-                if !translationConfiguration.isMultiLanguageFlow, let singleLanguage = filteredLanguages.first {
-                    store.dispatch(TranslationLanguageSelectedAction(
-                        windowUUID: action.windowUUID,
-                        targetLanguage: singleLanguage,
-                        actionType: TranslationsActionType.didSelectTargetLanguage
-                    ))
-                } else {
-                    store.dispatch(GeneralBrowserAction(
-                        buttonTapped: capturedButton,
-                        translationLanguages: filteredLanguages,
-                        windowUUID: action.windowUUID,
-                        actionType: GeneralBrowserActionType.showTranslationLanguagePicker
-                    ))
-                }
+                store.dispatch(GeneralBrowserAction(
+                    buttonTapped: capturedButton,
+                    translationLanguages: filteredLanguages,
+                    windowUUID: action.windowUUID,
+                    actionType: GeneralBrowserActionType.showTranslationLanguagePicker
+                ))
             }
         } else if translationConfiguration.state == .active {
-            if translationConfiguration.isMultiLanguageFlow {
-                showLanguagePickerForActiveTranslation(
-                    for: action,
-                    translatedToLanguage: translationConfiguration.translatedToLanguage,
-                    sourceLanguage: translationConfiguration.sourceLanguage
-                )
-            } else {
-                translationsTelemetry.translateButtonTapped(
-                    isPrivate: toolbarState.isPrivateMode,
-                    actionType: .willRestore,
-                    translationFlowId: flowId(for: action.windowUUID)
-                )
-                handleUpdatingTranslationIcon(for: action, with: .inactive)
-                restoringWindows.insert(action.windowUUID)
-                reloadPage(for: action)
-            }
+            showLanguagePickerForActiveTranslation(
+                for: action,
+                translatedToLanguage: translationConfiguration.translatedToLanguage,
+                sourceLanguage: translationConfiguration.sourceLanguage
+            )
         }
     }
 

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -292,6 +292,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
         ) else { return }
 
         let originatingTab = selectedTab(for: action.windowUUID)
+        let isCurrentlyTranslated = toolbarState.addressToolbar.translationConfiguration?.state == .active
         let newFlowId = UUID()
         translationFlowIds[action.windowUUID] = newFlowId
         selectedTargetLanguages[action.windowUUID] = action.targetLanguage
@@ -305,6 +306,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
             for: action,
             targetLanguage: action.targetLanguage,
             isPrivate: toolbarState.isPrivateMode,
+            discardFirst: isCurrentlyTranslated,
             on: originatingTab
         )
     }
@@ -431,6 +433,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
         targetLanguage: String,
         isPrivate: Bool,
         autoTranslate: Bool = false,
+        discardFirst: Bool = false,
         on tab: Tab? = nil
     ) {
         Task {
@@ -439,6 +442,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
                 targetLanguage: targetLanguage,
                 isPrivate: isPrivate,
                 autoTranslate: autoTranslate,
+                discardFirst: discardFirst,
                 on: tab
             )
         }
@@ -449,9 +453,13 @@ final class TranslationsMiddleware: FeatureFlaggable {
         targetLanguage: String,
         isPrivate: Bool,
         autoTranslate: Bool,
+        discardFirst: Bool = false,
         on tab: Tab?
     ) async {
         do {
+            if discardFirst {
+                try await translationsService.discardTranslations(for: action.windowUUID)
+            }
             var detectedSourceLanguage: String?
             try await translationsService.translateCurrentPage(
                 for: action.windowUUID,

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -120,13 +120,10 @@ final class TranslationsMiddleware: FeatureFlaggable {
         }
 
         if gestureType == .longPress {
-            guard translationConfiguration.state == .active,
-                  featureFlagsProvider.isEnabled(.translationLanguagePicker)
-            else { return }
-            showLanguagePickerForActiveTranslation(
+            handleLongPressOnTranslateButton(
                 for: action,
-                translatedToLanguage: translationConfiguration.translatedToLanguage,
-                sourceLanguage: translationConfiguration.sourceLanguage
+                toolbarState: toolbarState,
+                translationConfiguration: translationConfiguration
             )
             return
         }
@@ -215,6 +212,56 @@ final class TranslationsMiddleware: FeatureFlaggable {
                 windowUUID: action.windowUUID,
                 actionType: GeneralBrowserActionType.showTranslationLanguagePicker
             ))
+        }
+    }
+
+    private func handleLongPressOnTranslateButton(
+        for action: ToolbarMiddlewareAction,
+        toolbarState: ToolbarState,
+        translationConfiguration: TranslationConfiguration
+    ) {
+        guard featureFlagsProvider.isEnabled(.translationLanguagePicker) else { return }
+
+        if translationConfiguration.state == .inactive {
+            let capturedButton = action.buttonTapped
+            Task {
+                let manager = PreferredTranslationLanguagesManager(prefs: profile.prefs)
+                let supported = await translationsService.fetchSupportedTargetLanguages()
+                let languages = manager.preferredLanguages(supportedTargetLanguages: supported)
+                let pageLanguage = try? await translationsService.detectPageLanguage(for: action.windowUUID)
+                let filteredLanguages = languages.filter { $0 != pageLanguage }
+                if !translationConfiguration.isMultiLanguageFlow, let singleLanguage = filteredLanguages.first {
+                    store.dispatch(TranslationLanguageSelectedAction(
+                        windowUUID: action.windowUUID,
+                        targetLanguage: singleLanguage,
+                        actionType: TranslationsActionType.didSelectTargetLanguage
+                    ))
+                } else {
+                    store.dispatch(GeneralBrowserAction(
+                        buttonTapped: capturedButton,
+                        translationLanguages: filteredLanguages,
+                        windowUUID: action.windowUUID,
+                        actionType: GeneralBrowserActionType.showTranslationLanguagePicker
+                    ))
+                }
+            }
+        } else if translationConfiguration.state == .active {
+            if translationConfiguration.isMultiLanguageFlow {
+                showLanguagePickerForActiveTranslation(
+                    for: action,
+                    translatedToLanguage: translationConfiguration.translatedToLanguage,
+                    sourceLanguage: translationConfiguration.sourceLanguage
+                )
+            } else {
+                translationsTelemetry.translateButtonTapped(
+                    isPrivate: toolbarState.isPrivateMode,
+                    actionType: .willRestore,
+                    translationFlowId: flowId(for: action.windowUUID)
+                )
+                handleUpdatingTranslationIcon(for: action, with: .inactive)
+                restoringWindows.insert(action.windowUUID)
+                reloadPage(for: action)
+            }
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
@@ -37,11 +37,12 @@ final class MockTranslationsService: TranslationsServiceProtocol {
 
     func translateCurrentPage(
         for windowUUID: WindowUUID,
+        from sourceLanguage: String? = nil,
         to targetLanguage: String,
         onLanguageIdentified: ((String, String) -> Void)?
     ) async throws {
         try translateResult.get()
-        onLanguageIdentified?("en", targetLanguage)
+        onLanguageIdentified?(sourceLanguage ?? "en", targetLanguage)
     }
 
     func firstResponseReceived(for windowUUID: WindowUUID) async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -1430,7 +1430,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
         let dispatchedActionType = try XCTUnwrap(dispatchedAction.actionType as? GeneralBrowserActionType)
         XCTAssertEqual(dispatchedActionType, GeneralBrowserActionType.showTranslationLanguagePicker)
-        XCTAssertEqual(dispatchedAction.isPageTranslated, false)
+        XCTAssertNil(dispatchedAction.isPageTranslated)
     }
 
     func test_longPress_filtersSourceAndTranslatedLanguageFromPicker() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -1430,7 +1430,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
         let dispatchedActionType = try XCTUnwrap(dispatchedAction.actionType as? GeneralBrowserActionType)
         XCTAssertEqual(dispatchedActionType, GeneralBrowserActionType.showTranslationLanguagePicker)
-        XCTAssertNil(dispatchedAction.isPageTranslated)
+        XCTAssertEqual(dispatchedAction.isPageTranslated, false)
     }
 
     func test_longPress_filtersSourceAndTranslatedLanguageFromPicker() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -1410,7 +1410,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(dispatchedAction.translatedToLanguage, "da")
     }
 
-    func test_longPress_withInactiveState_doesNotDispatch() throws {
+    func test_longPress_withInactiveState_andFeatureEnabled_dispatchesShowPickerAction() throws {
         setTranslationsFeatureEnabled(enabled: true, languagePickerEnabled: true)
         let subject = createSubject()
         let action = ToolbarMiddlewareAction(
@@ -1420,14 +1420,17 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: ToolbarMiddlewareActionType.didTapButton
         )
 
-        let expectation = XCTestExpectation(description: "no action dispatched on long press inactive")
-        expectation.isInverted = true
+        let expectation = XCTestExpectation(description: "showTranslationLanguagePicker dispatched on long press inactive")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
         subject.translationsProvider(setupAppStateWithTranslationConfig(for: .inactive), action)
 
-        wait(for: [expectation], timeout: 0.5)
-        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        wait(for: [expectation], timeout: 1.0)
+
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
+        let dispatchedActionType = try XCTUnwrap(dispatchedAction.actionType as? GeneralBrowserActionType)
+        XCTAssertEqual(dispatchedActionType, GeneralBrowserActionType.showTranslationLanguagePicker)
+        XCTAssertEqual(dispatchedAction.isPageTranslated, false)
     }
 
     func test_longPress_filtersSourceAndTranslatedLanguageFromPicker() throws {


### PR DESCRIPTION
  ## :scroll: Tickets                                    
  [FXIOS-15650](https://mozilla-hub.atlassian.net/browse/FXIOS-15650) — [Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33524)                                                             
  [FXIOS-15651](https://mozilla-hub.atlassian.net/browse/FXIOS-15651) — [Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33525)                                                             
  [FXIOS-15652](https://mozilla-hub.atlassian.net/browse/FXIOS-15652) — [Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33527)   

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Implemented three related fixes for the Translations Phase 2 single language flow:

- Updated menu behavior: Tapping “Translated” while a page is already translated now directly reverts to the original page instead of displaying the language picker.

- Fixed toolbar long-press behavior: When inactive, the toolbar immediately translates to the preferred single language. When active, it directly reverts the translation.

- Enabled direct language switching while translation is already active: By discarding the current translation first, restoring the original page for accurate source language detection before applying the new translation, direct language switching is now possible.

- Multi-language flow behavior remains unchanged.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code



[FXIOS-15650]: https://mozilla-hub.atlassian.net/browse/FXIOS-15650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-15651]: https://mozilla-hub.atlassian.net/browse/FXIOS-15651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-15652]: https://mozilla-hub.atlassian.net/browse/FXIOS-15652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ