### PR TITLE
WIP: Add gluecode for Firefox-VPN

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Danger.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Danger.xcscheme
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DangerDeps"
+               BuildableName = "DangerDeps"
+               BlueprintName = "DangerDeps"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DangerDeps"
+            BuildableName = "DangerDeps"
+            BlueprintName = "DangerDeps"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
@@ -3,7 +3,16 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Network
 import WebKit
+
+public struct ProxyScope: OptionSet, Sendable {
+    public let rawValue: Int
+    public init(rawValue: Int) { self.rawValue = rawValue }
+    public static let normal   = ProxyScope(rawValue: 1 << 0)
+    public static let `private` = ProxyScope(rawValue: 1 << 1)
+    public static let all: ProxyScope = [.normal, .private]
+}
 
 @MainActor
 public struct WKWebViewParameters {
@@ -90,5 +99,14 @@ public struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvide
         }
 
         return DefaultEngineConfiguration(webViewConfiguration: configuration)
+    }
+
+    @available(iOS 17.0, *)
+    public static func applyProxyConfigurations(
+        _ configs: [ProxyConfiguration],
+        scope: ProxyScope = .all
+    ) {
+        if scope.contains(.normal)  { defaultStore.proxyConfigurations = configs }
+        if scope.contains(.private) { nonPersistentStore.proxyConfigurations = configs }
     }
 }

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountOAuth.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountOAuth.swift
@@ -13,4 +13,6 @@ public enum OAuthScope {
     public static let session: String = "https://identity.mozilla.com/tokens/session"
     // Necessary for Relay email masking support.
     public static let relay: String = "https://identity.mozilla.com/apps/relay"
+    // Necessary to mint access tokens for Mozilla VPN.
+    public static let vpn: String = "https://identity.mozilla.com/apps/vpn"
 }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -505,6 +505,8 @@
 		401F68F62D94966D00786D0C /* RemoteTabsPanelDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401F68F52D94966600786D0C /* RemoteTabsPanelDelegateMock.swift */; };
 		407468182F9A839800301FD6 /* VPNControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407468172F9A839800301FD6 /* VPNControllerProtocol.swift */; };
 		407468192F9A839800301FD6 /* VPNController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407468162F9A839800301FD6 /* VPNController.swift */; };
+		40746CEB2F9FC05B00301FD6 /* VPNGuardian.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40746CEA2F9FC05400301FD6 /* VPNGuardian.swift */; };
+		878C659CFC3280C45A920578 /* VPNServerlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7017266EE45BABE0311D26 /* VPNServerlist.swift */; };
 		43017ECB278E0C6700CED011 /* RustMozillaAppServices.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 43BE578A278BA4D900491291 /* RustMozillaAppServices.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		430234162E3B862E00FF85CA /* Summarizer.strings in Resources */ = {isa = PBXBuildFile; fileRef = 430234142E3B862E00FF85CA /* Summarizer.strings */; };
 		43079D1F2C85D3BB0047C28D /* Bookmarks.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43079D1D2C85D3BB0047C28D /* Bookmarks.strings */; };
@@ -3476,6 +3478,8 @@
 		406E4E6094EB97EBD3574628 /* gd */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gd; path = gd.lproj/Search.strings; sourceTree = "<group>"; };
 		407468162F9A839800301FD6 /* VPNController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNController.swift; sourceTree = "<group>"; };
 		407468172F9A839800301FD6 /* VPNControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNControllerProtocol.swift; sourceTree = "<group>"; };
+		40746CEA2F9FC05400301FD6 /* VPNGuardian.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNGuardian.swift; sourceTree = "<group>"; };
+		CF7017266EE45BABE0311D26 /* VPNServerlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNServerlist.swift; sourceTree = "<group>"; };
 		40A64D0FB8B16BBEA2A423A1 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
 		40C446CF9007C978AF889496 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/Intro.strings; sourceTree = "<group>"; };
 		40FD4BA2A53836F727F13D58 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = "vi.lproj/Default Browser.strings"; sourceTree = "<group>"; };
@@ -15573,6 +15577,8 @@
 		D3A994941A368691008AD1AC /* Browser */ = {
 			isa = PBXGroup;
 			children = (
+				40746CEA2F9FC05400301FD6 /* VPNGuardian.swift */,
+				CF7017266EE45BABE0311D26 /* VPNServerlist.swift */,
 				407468162F9A839800301FD6 /* VPNController.swift */,
 				407468172F9A839800301FD6 /* VPNControllerProtocol.swift */,
 				2140E4622E71FC240054173A /* RecordVisitObservationManager.swift */,
@@ -18689,6 +18695,8 @@
 				C84655E62887398700861B4A /* WallpaperCollection.swift in Sources */,
 				EBF47E701F7979DF00899189 /* TelemetryWrapper.swift in Sources */,
 				31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */,
+				40746CEB2F9FC05B00301FD6 /* VPNGuardian.swift in Sources */,
+				878C659CFC3280C45A920578 /* VPNServerlist.swift in Sources */,
 				8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */,
 				8A855C032D1EE9EF00C1A2F3 /* ContextMenuCoordinator.swift in Sources */,
 				EB9A179D20E69A7F00B12184 /* PrivateModeUI.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -503,6 +503,8 @@
 		3DEFED081F55EBE300F8620C /* TrackingProtectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DEFED071F55EBE300F8620C /* TrackingProtectionTests.swift */; };
 		401F68A52D84726700786D0C /* RemoteTabsPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401F68A42D84726700786D0C /* RemoteTabsPanelTests.swift */; };
 		401F68F62D94966D00786D0C /* RemoteTabsPanelDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401F68F52D94966600786D0C /* RemoteTabsPanelDelegateMock.swift */; };
+		407468182F9A839800301FD6 /* VPNControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407468172F9A839800301FD6 /* VPNControllerProtocol.swift */; };
+		407468192F9A839800301FD6 /* VPNController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407468162F9A839800301FD6 /* VPNController.swift */; };
 		43017ECB278E0C6700CED011 /* RustMozillaAppServices.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 43BE578A278BA4D900491291 /* RustMozillaAppServices.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		430234162E3B862E00FF85CA /* Summarizer.strings in Resources */ = {isa = PBXBuildFile; fileRef = 430234142E3B862E00FF85CA /* Summarizer.strings */; };
 		43079D1F2C85D3BB0047C28D /* Bookmarks.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43079D1D2C85D3BB0047C28D /* Bookmarks.strings */; };
@@ -3472,6 +3474,8 @@
 		401F68F52D94966600786D0C /* RemoteTabsPanelDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanelDelegateMock.swift; sourceTree = "<group>"; };
 		40364407BBB70494930FE68D /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		406E4E6094EB97EBD3574628 /* gd */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gd; path = gd.lproj/Search.strings; sourceTree = "<group>"; };
+		407468162F9A839800301FD6 /* VPNController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNController.swift; sourceTree = "<group>"; };
+		407468172F9A839800301FD6 /* VPNControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNControllerProtocol.swift; sourceTree = "<group>"; };
 		40A64D0FB8B16BBEA2A423A1 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
 		40C446CF9007C978AF889496 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/Intro.strings; sourceTree = "<group>"; };
 		40FD4BA2A53836F727F13D58 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = "vi.lproj/Default Browser.strings"; sourceTree = "<group>"; };
@@ -15569,6 +15573,8 @@
 		D3A994941A368691008AD1AC /* Browser */ = {
 			isa = PBXGroup;
 			children = (
+				407468162F9A839800301FD6 /* VPNController.swift */,
+				407468172F9A839800301FD6 /* VPNControllerProtocol.swift */,
 				2140E4622E71FC240054173A /* RecordVisitObservationManager.swift */,
 				034784BA2E2690F600D04A84 /* TermsOfUse */,
 				81A3F6EE2C2DAED500BDD86B /* MainMenu */,
@@ -19024,6 +19030,8 @@
 				DFACBF85277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift in Sources */,
 				612194E62CE50A93001664BB /* WallpaperAction.swift in Sources */,
 				9614BF4428AD1C6700D3F7EA /* AccountSyncHandler.swift in Sources */,
+				407468182F9A839800301FD6 /* VPNControllerProtocol.swift in Sources */,
+				407468192F9A839800301FD6 /* VPNController.swift in Sources */,
 				8C2447EA2DFADF6300BD2C91 /* OnboardingServiceDelegate.swift in Sources */,
 				8A13FA8D2AD834FA007527AB /* BackgroundTabLoader.swift in Sources */,
 				D04CD74B216CF86B004FF5B0 /* DevicePickerViewController.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -842,6 +842,11 @@
             value = "1"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "CFNETWORK_DIAGNOSTICS"
+            value = "3"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -37,6 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
     lazy var tabDataStore = DefaultTabDataStore()
     lazy var windowManager = WindowManagerImplementation()
     lazy var relayController: RelayControllerProtocol = RelayController()
+    lazy var vpnController: VPNControllerProtocol = VPNController()
     lazy var backgroundTabLoader: BackgroundTabLoader = {
         return DefaultBackgroundTabLoader(tabQueue: (AppContainer.shared.resolve() as Profile).queue)
     }()

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -37,7 +37,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
     lazy var tabDataStore = DefaultTabDataStore()
     lazy var windowManager = WindowManagerImplementation()
     lazy var relayController: RelayControllerProtocol = RelayController()
-    lazy var vpnController: VPNControllerProtocol = VPNController()
+    lazy var vpnController: VPNControllerProtocol = {
+        if #available(iOS 17.0, *) {
+            return VPNController()
+        } else {
+            return StubVPNController()
+        }
+    }()
     lazy var backgroundTabLoader: BackgroundTabLoader = {
         return DefaultBackgroundTabLoader(tabQueue: (AppContainer.shared.resolve() as Profile).queue)
     }()

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -87,6 +87,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
             menuSections.append(getHorizontalTabsSection(with: uuid, tabInfo: tabInfo))
             menuSections.append(getAccountSection(with: uuid, tabInfo: tabInfo, profileImage: profileImage))
         }
+        menuSections.append(MenuSection(options: [configureVPNItem(with: uuid)]))
 
         return menuSections
     }
@@ -407,6 +408,30 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
                                                      hasChangedUserAgent: tabInfo.hasChangedUserAgent)
                     )
                 )
+            }
+        )
+    }
+
+    @MainActor
+    private func configureVPNItem(with uuid: WindowUUID) -> MenuElement {
+        let vpn = (UIApplication.shared.delegate as? AppDelegate)?.vpnController
+        let isOn = vpn?.isRunning ?? false
+        return MenuElement(
+            title: "VPN",
+            iconName: "",
+            isEnabled: true,
+            isActive: isOn,
+            a11yLabel: "VPN",
+            a11yHint: "Toggle Mozilla VPN",
+            a11yId: "VPNMenuItem",
+            infoTitle: isOn ? "On" : "Off",
+            action: {
+                guard let vpn = (UIApplication.shared.delegate as? AppDelegate)?.vpnController else { return }
+                if vpn.isRunning {
+                    vpn.stop()
+                } else {
+                    vpn.start(privateOnly: false) { _ in }
+                }
             }
         )
     }

--- a/firefox-ios/Client/Frontend/Browser/VPNController.swift
+++ b/firefox-ios/Client/Frontend/Browser/VPNController.swift
@@ -9,6 +9,7 @@ import Network
 import WebEngine
 import Foundation
 
+@available(iOS 17.0, *)
 @MainActor
 final class VPNController: VPNControllerProtocol {
     enum VPNClientConfiguration {
@@ -17,16 +18,9 @@ final class VPNController: VPNControllerProtocol {
 
         var guardianBaseURL: URL {
             switch self {
-            case .prod, .staging: return URL(string: "https://vpn.mozilla.com")!
+            case .prod, .staging: return URL(string: "https://vpn.mozilla.org")!
             }
         }
-    }
-
-    enum VPNError: Error {
-        case unsupportedOS
-        case notSignedIn
-        case guardianHTTP(status: Int)
-        case guardianBodyInvalid
     }
 
     struct ProxyPass {
@@ -72,10 +66,6 @@ final class VPNController: VPNControllerProtocol {
     }
 
     func start(privateOnly: Bool = false, completion: @escaping (Result<Void, Error>) -> Void) {
-        guard #available(iOS 17.0, *) else {
-            completion(.failure(VPNError.unsupportedOS))
-            return
-        }
         Task { [weak self] in
             guard let self else { return }
             do {
@@ -91,6 +81,9 @@ final class VPNController: VPNControllerProtocol {
                     level: .info,
                     category: .sync
                 )
+                let config = self.toProxyConf(server: server, pass: pass)
+                let scope: ProxyScope = privateOnly ? .private : .all
+                DefaultWKEngineConfigurationProvider.applyProxyConfigurations([config], scope: scope)
                 self.isRunning = true
                 // TODO: Start a watcher to re-fetch and rotate the token before the lifetime ends.
                 completion(.success(()))
@@ -102,11 +95,28 @@ final class VPNController: VPNControllerProtocol {
     }
 
     func stop() {
-        if #available(iOS 17.0, *) {
-            DefaultWKEngineConfigurationProvider.applyProxyConfigurations([], scope: .all)
-        }
+        DefaultWKEngineConfigurationProvider.applyProxyConfigurations([], scope: .all)
         cachedToken = nil
         isRunning = false
+    }
+
+    // MARK: - Proxy configuration
+
+    private func toProxyConf(server: Server, pass: ProxyPass) -> ProxyConfiguration {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = server.hostname
+        components.port = Int(server.port)
+        let endpoint = NWEndpoint.url(components.url!)
+        let hop = ProxyConfiguration.RelayHop(
+            http2RelayEndpoint: endpoint,
+            // TODO: http3RelayEndpoint bricks it, we get quic errors, need to reach out to fstly
+            tlsOptions: NWProtocolTLS.Options(),
+            additionalHTTPHeaderFields: [
+                "Proxy-Authorization": "Bearer \(pass.bearerToken)"
+            ]
+        )
+        return ProxyConfiguration(relayHops: [hop])
     }
 
     // MARK: - Guardian proxy pass

--- a/firefox-ios/Client/Frontend/Browser/VPNController.swift
+++ b/firefox-ios/Client/Frontend/Browser/VPNController.swift
@@ -14,12 +14,43 @@ final class VPNController: VPNControllerProtocol {
     enum VPNClientConfiguration {
         case prod
         case staging
+
+        var guardianBaseURL: URL {
+            switch self {
+            case .prod, .staging: return URL(string: "https://vpn.mozilla.com")!
+            }
+        }
     }
 
     enum VPNError: Error {
         case unsupportedOS
         case notSignedIn
+        case guardianHTTP(status: Int)
+        case guardianBodyInvalid
     }
+
+    struct ProxyPass {
+        let bearerToken: String
+        let notBefore: Date
+        let expiresAt: Date
+        let rotationTime: Date
+        let usage: ProxyUsage?
+    }
+
+    struct ProxyUsage {
+        let max: Int64
+        let remaining: Int64
+        let reset: Date
+    }
+
+    struct Server {
+        let hostname: String
+        let port: UInt16
+        let city: String
+        let countryCode: String
+    }
+
+    private static let rotateBeforeExpiry: TimeInterval = 120
 
     private let logger: Logger
     private let accountManagerProvider: () -> FxAccountManager?
@@ -45,25 +76,27 @@ final class VPNController: VPNControllerProtocol {
             completion(.failure(VPNError.unsupportedOS))
             return
         }
-        guard let acct = accountManagerProvider(), acct.hasAccount() else {
-            completion(.failure(VPNError.notSignedIn))
-            return
-        }
-        acct.getAccessToken(scope: OAuthScope.vpn, useCache: false) { [weak self] result in
+        Task { [weak self] in
             guard let self else { return }
-            switch result {
-            case .failure(let error):
-                self.logger.log("VPN token mint failed: \(error)", level: .warning, category: .sync)
-                completion(.failure(error))
-            case .success(let tokenInfo):
-                self.cachedToken = tokenInfo
-                if #available(iOS 17.0, *) {
-                    let configs = self.buildProxyConfigurations(token: tokenInfo.token)
-                    let scope: ProxyScope = privateOnly ? .private : .all
-                    DefaultWKEngineConfigurationProvider.applyProxyConfigurations(configs, scope: scope)
-                }
+            do {
+                let pass = try await self.getPass()
+                let server = Server(
+                    hostname: "muc139.m1.fastly-masque.net",
+                    port: 2499,
+                    city: "MUC",
+                    countryCode: "DE"
+                )
+                self.logger.log(
+                    "Got Guardian proxy pass — expires \(pass.expiresAt), rotate at \(pass.rotationTime), usage \(String(describing: pass.usage)); server \(server.hostname):\(server.port) (\(server.city), \(server.countryCode))",
+                    level: .info,
+                    category: .sync
+                )
                 self.isRunning = true
+                // TODO: Start a watcher to re-fetch and rotate the token before the lifetime ends.
                 completion(.success(()))
+            } catch {
+                self.logger.log("VPN start failed: \(error)", level: .warning, category: .sync)
+                completion(.failure(error))
             }
         }
     }
@@ -76,9 +109,97 @@ final class VPNController: VPNControllerProtocol {
         isRunning = false
     }
 
-    // Confirm exact proxy endpoint + auth scheme with the Mozilla VPN team before filling this in.
-    @available(iOS 17.0, *)
-    private func buildProxyConfigurations(token: String) -> [ProxyConfiguration] {
-        return []
+    // MARK: - Guardian proxy pass
+
+    private func getPass() async throws -> ProxyPass {
+        guard let acct = accountManagerProvider(), acct.hasAccount() else {
+            throw VPNError.notSignedIn
+        }
+        let fxaToken = try await mintFxAToken(account: acct)
+        return try await fetchProxyPass(fxaToken: fxaToken)
+    }
+
+    private func mintFxAToken(account: FxAccountManager) async throws -> String {
+        let info: AccessTokenInfo = try await withCheckedThrowingContinuation { continuation in
+            account.getAccessToken(scope: OAuthScope.vpn, useCache: false) { result in
+                switch result {
+                case .success(let info): continuation.resume(returning: info)
+                case .failure(let err): continuation.resume(throwing: err)
+                }
+            }
+        }
+        cachedToken = info
+        return info.token
+    }
+
+    private func fetchProxyPass(fxaToken: String) async throws -> ProxyPass {
+        let url = clientConfig.guardianBaseURL.appendingPathComponent("api/v1/fpn/token")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(fxaToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw VPNError.guardianBodyInvalid
+        }
+        guard http.statusCode == 200 else {
+            throw VPNError.guardianHTTP(status: http.statusCode)
+        }
+
+        struct TokenResponse: Decodable { let token: String }
+        let parsed: TokenResponse
+        do {
+            parsed = try JSONDecoder().decode(TokenResponse.self, from: data)
+        } catch {
+            throw VPNError.guardianBodyInvalid
+        }
+
+        let claims = try Self.decodeJWTClaims(parsed.token)
+        let nbf = Date(timeIntervalSince1970: claims.nbf)
+        let exp = Date(timeIntervalSince1970: claims.exp)
+        let rotation = exp.addingTimeInterval(-Self.rotateBeforeExpiry)
+        let usage = Self.parseUsage(headers: http.allHeaderFields)
+
+        return ProxyPass(
+            bearerToken: parsed.token,
+            notBefore: nbf,
+            expiresAt: exp,
+            rotationTime: rotation,
+            usage: usage
+        )
+    }
+
+    private struct JWTClaims: Decodable {
+        let nbf: TimeInterval
+        let exp: TimeInterval
+    }
+
+    private static func decodeJWTClaims(_ jwt: String) throws -> JWTClaims {
+        let parts = jwt.split(separator: ".")
+        guard parts.count == 3 else { throw VPNError.guardianBodyInvalid }
+        var payload = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while payload.count % 4 != 0 { payload += "=" }
+        guard let data = Data(base64Encoded: payload) else { throw VPNError.guardianBodyInvalid }
+        do {
+            return try JSONDecoder().decode(JWTClaims.self, from: data)
+        } catch {
+            throw VPNError.guardianBodyInvalid
+        }
+    }
+
+    private static func parseUsage(headers: [AnyHashable: Any]) -> ProxyUsage? {
+        func header(_ name: String) -> String? {
+            headers.first { ($0.key as? String)?.caseInsensitiveCompare(name) == .orderedSame }?.value as? String
+        }
+        guard let limit = header("X-Quota-Limit").flatMap(Int64.init),
+              let remaining = header("X-Quota-Remaining").flatMap(Int64.init),
+              let resetStr = header("X-Quota-Reset"),
+              let reset = ISO8601DateFormatter().date(from: resetStr)
+        else { return nil }
+        return ProxyUsage(max: limit, remaining: remaining, reset: reset)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/VPNController.swift
+++ b/firefox-ios/Client/Frontend/Browser/VPNController.swift
@@ -12,57 +12,30 @@ import Foundation
 @available(iOS 17.0, *)
 @MainActor
 final class VPNController: VPNControllerProtocol {
-    enum VPNClientConfiguration {
-        case prod
-        case staging
-
-        var guardianBaseURL: URL {
-            switch self {
-            case .prod, .staging: return URL(string: "https://vpn.mozilla.org")!
-            }
-        }
-    }
-
-    struct ProxyPass {
-        let bearerToken: String
-        let notBefore: Date
-        let expiresAt: Date
-        let rotationTime: Date
-        let usage: ProxyUsage?
-    }
-
-    struct ProxyUsage {
-        let max: Int64
-        let remaining: Int64
-        let reset: Date
-    }
-
-    struct Server {
-        let hostname: String
-        let port: UInt16
-        let city: String
-        let countryCode: String
-    }
-
-    private static let rotateBeforeExpiry: TimeInterval = 120
-
     private let logger: Logger
     private let accountManagerProvider: () -> FxAccountManager?
-    private let clientConfig: VPNClientConfiguration
+    private let guardian: VPNGuardian
 
     private(set) var isRunning = false
-    private var cachedToken: AccessTokenInfo?
 
     init(
         logger: Logger = DefaultLogger.shared,
         accountManager: @escaping () -> FxAccountManager? = {
             RustFirefoxAccounts.shared.accountManager
         },
-        clientConfig: VPNClientConfiguration = .prod
+        clientConfig: VPNGuardian.Configuration = .prod
     ) {
         self.logger = logger
         self.accountManagerProvider = accountManager
-        self.clientConfig = clientConfig
+        self.guardian = VPNGuardian(
+            authHeaderProvider: {
+                let token = try await Self.mintFxAToken(accountManager: accountManager)
+                return ["Authorization": "Bearer \(token)"]
+            },
+            configuration: clientConfig,
+            logger: logger
+        )
+        self.serverlist = VPNServerlist(rsService: rsService, logger: logger)
     }
 
     func start(privateOnly: Bool = false, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -77,12 +50,17 @@ final class VPNController: VPNControllerProtocol {
                     countryCode: "DE"
                 )
                 self.logger.log(
-                    "Got Guardian proxy pass — expires \(pass.expiresAt), rotate at \(pass.rotationTime), usage \(String(describing: pass.usage)); server \(server.hostname):\(server.port) (\(server.city), \(server.countryCode))",
+                    "Got Guardian proxy pass — expires \(pass.expiresAt), usage \(String(describing: pass.usage)); server \(server.hostname):\(server.port) (\(server.city), \(server.countryCode))",
                     level: .info,
                     category: .sync
                 )
                 let config = self.toProxyConf(server: server, pass: pass)
                 let scope: ProxyScope = privateOnly ? .private : .all
+                /**
+                TODO: Ask the ios team for help here.
+                 It seems webkit keeps a Connection Pool alive. So i.e if you load google.com, set the proxy and reload,
+                 you might still have a connection to that server, and it will be re-used for the http request. Might need to invalidate it.
+                 */
                 DefaultWKEngineConfigurationProvider.applyProxyConfigurations([config], scope: scope)
                 self.isRunning = true
                 // TODO: Start a watcher to re-fetch and rotate the token before the lifetime ends.
@@ -96,13 +74,10 @@ final class VPNController: VPNControllerProtocol {
 
     func stop() {
         DefaultWKEngineConfigurationProvider.applyProxyConfigurations([], scope: .all)
-        cachedToken = nil
         isRunning = false
     }
 
-    // MARK: - Proxy configuration
-
-    private func toProxyConf(server: Server, pass: ProxyPass) -> ProxyConfiguration {
+    private func toProxyConf(server: VPNGuardian.Server, pass: VPNGuardian.ProxyPass) -> ProxyConfiguration {
         var components = URLComponents()
         components.scheme = "https"
         components.host = server.hostname
@@ -119,97 +94,18 @@ final class VPNController: VPNControllerProtocol {
         return ProxyConfiguration(relayHops: [hop])
     }
 
-    // MARK: - Guardian proxy pass
-
-    private func getPass() async throws -> ProxyPass {
-        guard let acct = accountManagerProvider(), acct.hasAccount() else {
+    private static func mintFxAToken(accountManager: () -> FxAccountManager?) async throws -> String {
+        guard let acct = accountManager(), acct.hasAccount() else {
             throw VPNError.notSignedIn
         }
-        let fxaToken = try await mintFxAToken(account: acct)
-        return try await fetchProxyPass(fxaToken: fxaToken)
-    }
-
-    private func mintFxAToken(account: FxAccountManager) async throws -> String {
         let info: AccessTokenInfo = try await withCheckedThrowingContinuation { continuation in
-            account.getAccessToken(scope: OAuthScope.vpn, useCache: false) { result in
+            acct.getAccessToken(scope: OAuthScope.vpn, useCache: false) { result in
                 switch result {
                 case .success(let info): continuation.resume(returning: info)
                 case .failure(let err): continuation.resume(throwing: err)
                 }
             }
         }
-        cachedToken = info
         return info.token
-    }
-
-    private func fetchProxyPass(fxaToken: String) async throws -> ProxyPass {
-        let url = clientConfig.guardianBaseURL.appendingPathComponent("api/v1/fpn/token")
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(fxaToken)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.cachePolicy = .reloadIgnoringLocalCacheData
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let http = response as? HTTPURLResponse else {
-            throw VPNError.guardianBodyInvalid
-        }
-        guard http.statusCode == 200 else {
-            throw VPNError.guardianHTTP(status: http.statusCode)
-        }
-
-        struct TokenResponse: Decodable { let token: String }
-        let parsed: TokenResponse
-        do {
-            parsed = try JSONDecoder().decode(TokenResponse.self, from: data)
-        } catch {
-            throw VPNError.guardianBodyInvalid
-        }
-
-        let claims = try Self.decodeJWTClaims(parsed.token)
-        let nbf = Date(timeIntervalSince1970: claims.nbf)
-        let exp = Date(timeIntervalSince1970: claims.exp)
-        let rotation = exp.addingTimeInterval(-Self.rotateBeforeExpiry)
-        let usage = Self.parseUsage(headers: http.allHeaderFields)
-
-        return ProxyPass(
-            bearerToken: parsed.token,
-            notBefore: nbf,
-            expiresAt: exp,
-            rotationTime: rotation,
-            usage: usage
-        )
-    }
-
-    private struct JWTClaims: Decodable {
-        let nbf: TimeInterval
-        let exp: TimeInterval
-    }
-
-    private static func decodeJWTClaims(_ jwt: String) throws -> JWTClaims {
-        let parts = jwt.split(separator: ".")
-        guard parts.count == 3 else { throw VPNError.guardianBodyInvalid }
-        var payload = String(parts[1])
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        while payload.count % 4 != 0 { payload += "=" }
-        guard let data = Data(base64Encoded: payload) else { throw VPNError.guardianBodyInvalid }
-        do {
-            return try JSONDecoder().decode(JWTClaims.self, from: data)
-        } catch {
-            throw VPNError.guardianBodyInvalid
-        }
-    }
-
-    private static func parseUsage(headers: [AnyHashable: Any]) -> ProxyUsage? {
-        func header(_ name: String) -> String? {
-            headers.first { ($0.key as? String)?.caseInsensitiveCompare(name) == .orderedSame }?.value as? String
-        }
-        guard let limit = header("X-Quota-Limit").flatMap(Int64.init),
-              let remaining = header("X-Quota-Remaining").flatMap(Int64.init),
-              let resetStr = header("X-Quota-Reset"),
-              let reset = ISO8601DateFormatter().date(from: resetStr)
-        else { return nil }
-        return ProxyUsage(max: limit, remaining: remaining, reset: reset)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/VPNController.swift
+++ b/firefox-ios/Client/Frontend/Browser/VPNController.swift
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import MozillaAppServices
+import Account
+import Network
+import WebEngine
+import Foundation
+
+@MainActor
+final class VPNController: VPNControllerProtocol {
+    enum VPNClientConfiguration {
+        case prod
+        case staging
+    }
+
+    enum VPNError: Error {
+        case unsupportedOS
+        case notSignedIn
+    }
+
+    private let logger: Logger
+    private let accountManagerProvider: () -> FxAccountManager?
+    private let clientConfig: VPNClientConfiguration
+
+    private(set) var isRunning = false
+    private var cachedToken: AccessTokenInfo?
+
+    init(
+        logger: Logger = DefaultLogger.shared,
+        accountManager: @escaping () -> FxAccountManager? = {
+            RustFirefoxAccounts.shared.accountManager
+        },
+        clientConfig: VPNClientConfiguration = .prod
+    ) {
+        self.logger = logger
+        self.accountManagerProvider = accountManager
+        self.clientConfig = clientConfig
+    }
+
+    func start(privateOnly: Bool = false, completion: @escaping (Result<Void, Error>) -> Void) {
+        guard #available(iOS 17.0, *) else {
+            completion(.failure(VPNError.unsupportedOS))
+            return
+        }
+        guard let acct = accountManagerProvider(), acct.hasAccount() else {
+            completion(.failure(VPNError.notSignedIn))
+            return
+        }
+        acct.getAccessToken(scope: OAuthScope.vpn, useCache: false) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .failure(let error):
+                self.logger.log("VPN token mint failed: \(error)", level: .warning, category: .sync)
+                completion(.failure(error))
+            case .success(let tokenInfo):
+                self.cachedToken = tokenInfo
+                if #available(iOS 17.0, *) {
+                    let configs = self.buildProxyConfigurations(token: tokenInfo.token)
+                    let scope: ProxyScope = privateOnly ? .private : .all
+                    DefaultWKEngineConfigurationProvider.applyProxyConfigurations(configs, scope: scope)
+                }
+                self.isRunning = true
+                completion(.success(()))
+            }
+        }
+    }
+
+    func stop() {
+        if #available(iOS 17.0, *) {
+            DefaultWKEngineConfigurationProvider.applyProxyConfigurations([], scope: .all)
+        }
+        cachedToken = nil
+        isRunning = false
+    }
+
+    // Confirm exact proxy endpoint + auth scheme with the Mozilla VPN team before filling this in.
+    @available(iOS 17.0, *)
+    private func buildProxyConfigurations(token: String) -> [ProxyConfiguration] {
+        return []
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/VPNController.swift
+++ b/firefox-ios/Client/Frontend/Browser/VPNController.swift
@@ -15,6 +15,7 @@ final class VPNController: VPNControllerProtocol {
     private let logger: Logger
     private let accountManagerProvider: () -> FxAccountManager?
     private let guardian: VPNGuardian
+    private let serverlist: VPNServerlist
 
     private(set) var isRunning = false
 
@@ -23,6 +24,7 @@ final class VPNController: VPNControllerProtocol {
         accountManager: @escaping () -> FxAccountManager? = {
             RustFirefoxAccounts.shared.accountManager
         },
+        rsService: RemoteSettingsService = (AppContainer.shared.resolve() as Profile).remoteSettingsService,
         clientConfig: VPNGuardian.Configuration = .prod
     ) {
         self.logger = logger
@@ -42,13 +44,17 @@ final class VPNController: VPNControllerProtocol {
         Task { [weak self] in
             guard let self else { return }
             do {
-                let pass = try await self.getPass()
-                let server = Server(
-                    hostname: "muc139.m1.fastly-masque.net",
-                    port: 2499,
-                    city: "MUC",
-                    countryCode: "DE"
-                )
+                let pass = try await self.guardian.getPass()
+                // TODO: If that fails with a 403, we must enroll the account into ff-vpn first.
+                // let entitlement = try await self.guardian.activate()
+                // self.logger.log("Entitlement: \(String(describing: entitlement))",
+                //                level: .info,
+                //                category: .sync)
+                
+                guard let server = self.serverlist.selectServer() else {
+                    throw VPNError.noServerFound
+                }
+
                 self.logger.log(
                     "Got Guardian proxy pass — expires \(pass.expiresAt), usage \(String(describing: pass.usage)); server \(server.hostname):\(server.port) (\(server.city), \(server.countryCode))",
                     level: .info,

--- a/firefox-ios/Client/Frontend/Browser/VPNControllerProtocol.swift
+++ b/firefox-ios/Client/Frontend/Browser/VPNControllerProtocol.swift
@@ -12,10 +12,9 @@ protocol VPNControllerProtocol {
 }
 
 enum VPNError: Error {
-    case unsupportedOS
-    case notSignedIn
-    case guardianHTTP(status: Int)
-    case guardianBodyInvalid
+    case unsupportedOS    // used by StubVPNController on iOS < 17
+    case notSignedIn      // used by VPNController's FxA mint strategy
+    case noServerFound    // Thrown when the Selected Server was not dound
 }
 
 @MainActor

--- a/firefox-ios/Client/Frontend/Browser/VPNControllerProtocol.swift
+++ b/firefox-ios/Client/Frontend/Browser/VPNControllerProtocol.swift
@@ -10,3 +10,19 @@ protocol VPNControllerProtocol {
     func start(privateOnly: Bool, completion: @escaping (Result<Void, Error>) -> Void)
     func stop()
 }
+
+enum VPNError: Error {
+    case unsupportedOS
+    case notSignedIn
+    case guardianHTTP(status: Int)
+    case guardianBodyInvalid
+}
+
+@MainActor
+final class StubVPNController: VPNControllerProtocol {
+    var isRunning: Bool { false }
+    func start(privateOnly: Bool, completion: @escaping (Result<Void, Error>) -> Void) {
+        completion(.failure(VPNError.unsupportedOS))
+    }
+    func stop() {}
+}

--- a/firefox-ios/Client/Frontend/Browser/VPNControllerProtocol.swift
+++ b/firefox-ios/Client/Frontend/Browser/VPNControllerProtocol.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@MainActor
+protocol VPNControllerProtocol {
+    var isRunning: Bool { get }
+    func start(privateOnly: Bool, completion: @escaping (Result<Void, Error>) -> Void)
+    func stop()
+}

--- a/firefox-ios/Client/Frontend/Browser/VPNGuardian.swift
+++ b/firefox-ios/Client/Frontend/Browser/VPNGuardian.swift
@@ -1,0 +1,217 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+
+@MainActor
+final class VPNGuardian {
+    /*
+     * All Requests to Guardian need to be authenticated.
+     * Guardian RN supports multiple auth tokens.
+     */
+    typealias AuthHeaderProvider = () async throws -> [String: String]
+
+    enum Configuration {
+        case prod
+        case staging
+
+        var baseURL: URL {
+            switch self {
+            case .prod, .staging: return URL(string: "https://vpn.mozilla.org")!
+            }
+        }
+    }
+
+    /**
+     * A Proxy Pass contains the Token to Authenticate to the Proxy Servers
+     *
+     */
+    struct ProxyPass {
+        let bearerToken: String
+        let notBefore: Date
+        let expiresAt: Date
+        let usage: ProxyUsage
+    }
+
+    struct ProxyUsage {
+        // Bytes the User can consume in each Period
+        let max: Int64
+        // Bytes the User has left in each Period
+        let remaining: Int64
+        // Date when the next Period begins
+        let reset: Date
+    }
+
+    struct Server {
+        let hostname: String
+        let port: UInt16
+        let city: String
+        let countryCode: String
+    }
+    /**
+     * An Entitlement describes that the level of access.
+     */
+    struct Entitlement {
+        /**
+         * True when the User has upgraded to a subscription to *Mozilla* VPN.
+         */
+        let subscribed: Bool
+        let uid: Int64
+        // The Amount of Bytes the user can consume per period
+        let maxBytes: Int64
+    }
+
+    enum GuardianError: Error {
+        case http(status: Int)
+        case bodyInvalid
+    }
+
+    static let rotateBeforeExpiry: TimeInterval = 120
+
+    private let authHeaderProvider: AuthHeaderProvider
+    private let configuration: Configuration
+    private let logger: Logger
+
+    init(
+        authHeaderProvider: @escaping AuthHeaderProvider,
+        configuration: Configuration,
+        logger: Logger
+    ) {
+        self.authHeaderProvider = authHeaderProvider
+        self.configuration = configuration
+        self.logger = logger
+    }
+
+    func getPass() async throws -> ProxyPass {
+        let headers = try await authHeaderProvider()
+        return try await fetchProxyPass(authHeaders: headers)
+    }
+    /**
+     * Tries to enroll the User Into Firefox-VPN using the Auth info from the authHeaderProvider.
+     * On success an entitlement is created for the user and returned. From that point on they may request tokens.
+     * If the user already has an entitlement, it is returned.
+     */
+    func activate() async throws -> Entitlement {
+        let headers = try await authHeaderProvider()
+        return try await createEntitlement(authHeaders: headers)
+    }
+
+    private func fetchProxyPass(authHeaders: [String: String]) async throws -> ProxyPass {
+        let url = configuration.baseURL.appendingPathComponent("api/v1/fpn/token")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        for (name, value) in authHeaders {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw GuardianError.bodyInvalid
+        }
+        guard http.statusCode == 200 else {
+            throw GuardianError.http(status: http.statusCode)
+        }
+
+        struct TokenResponse: Decodable { let token: String }
+        let parsed: TokenResponse
+        do {
+            parsed = try JSONDecoder().decode(TokenResponse.self, from: data)
+        } catch {
+            throw GuardianError.bodyInvalid
+        }
+
+        let claims = try Self.decodeJWTClaims(parsed.token)
+        let nbf = Date(timeIntervalSince1970: claims.nbf)
+        let exp = Date(timeIntervalSince1970: claims.exp)
+        guard let usage = Self.parseUsage(response: http) else {
+            throw GuardianError.bodyInvalid
+        }
+        return ProxyPass(
+            bearerToken: parsed.token,
+            notBefore: nbf,
+            expiresAt: exp,
+            usage: usage
+        )
+    }
+
+    private func createEntitlement(authHeaders: [String: String]) async throws -> Entitlement {
+        let url = configuration.baseURL.appendingPathComponent("api/v1/fpn/activate")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        for (name, value) in authHeaders {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw GuardianError.bodyInvalid
+        }
+        guard http.statusCode == 200 else {
+            throw GuardianError.http(status: http.statusCode)
+        }
+
+        // Guardian encodes maxBytes as a string (BigInt on the wire); decode as String
+        // and convert. subscribed and uid are plain JSON primitives.
+        struct Wire: Decodable {
+            let subscribed: Bool
+            let uid: Int64
+            let maxBytes: String
+        }
+        let wire: Wire
+        do {
+            wire = try JSONDecoder().decode(Wire.self, from: data)
+        } catch {
+            throw GuardianError.bodyInvalid
+        }
+        guard let maxBytes = Int64(wire.maxBytes) else {
+            throw GuardianError.bodyInvalid
+        }
+        return Entitlement(subscribed: wire.subscribed, uid: wire.uid, maxBytes: maxBytes)
+    }
+
+    private struct JWTClaims: Decodable {
+        let nbf: TimeInterval
+        let exp: TimeInterval
+    }
+
+    private static func decodeJWTClaims(_ jwt: String) throws -> JWTClaims {
+        let parts = jwt.split(separator: ".")
+        guard parts.count == 3 else { throw GuardianError.bodyInvalid }
+        var payload = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while payload.count % 4 != 0 { payload += "=" }
+        guard let data = Data(base64Encoded: payload) else { throw GuardianError.bodyInvalid }
+        do {
+            return try JSONDecoder().decode(JWTClaims.self, from: data)
+        } catch {
+            throw GuardianError.bodyInvalid
+        }
+    }
+
+    /// Guardian emits `X-Quota-Reset` as RFC3339 with millisecond fractional seconds
+    /// (e.g. `2026-05-01T00:00:00.000Z`). ISO8601DateFormatter's default options reject
+    /// fractional seconds, so we have to opt in.
+    private static let resetDateFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static func parseUsage(response: HTTPURLResponse) -> ProxyUsage? {
+        guard let limitStr = response.value(forHTTPHeaderField: "X-Quota-Limit"),
+              let limit = Int64(limitStr),
+              let remainingStr = response.value(forHTTPHeaderField: "X-Quota-Remaining"),
+              let remaining = Int64(remainingStr),
+              let resetStr = response.value(forHTTPHeaderField: "X-Quota-Reset"),
+              let reset = resetDateFormatter.date(from: resetStr)
+        else { return nil }
+        return ProxyUsage(max: limit, remaining: remaining, reset: reset)
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/VPNServerlist.swift
+++ b/firefox-ios/Client/Frontend/Browser/VPNServerlist.swift
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import MozillaAppServices
+import Foundation
+
+/// Reads the `vpn-serverlist` Remote Settings collection (the same collection desktop Firefox
+/// uses — see `toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs`) and exposes a
+/// flat selection API. Records are Country-rooted: Country → City → Server → Protocol.
+@MainActor
+final class VPNServerlist {
+    static let collectionName = "vpn-serverlist"
+    static let recommendedCountryCode = "REC"
+
+    private struct Country: Decodable {
+        let name: String
+        let code: String
+        let cities: [City]
+    }
+    private struct City: Decodable {
+        let name: String
+        let code: String
+        let servers: [ServerRecord]
+    }
+    private struct ServerRecord: Decodable {
+        let hostname: String
+        let port: Int?
+        let quarantined: Bool?
+        let protocols: [ProtocolRecord]?
+    }
+    private struct ProtocolRecord: Decodable {
+        let name: String
+        let host: String?
+        let port: Int?
+        let scheme: String?
+        let templateString: String?
+    }
+
+    private let client: RemoteSettingsClient
+    private let logger: Logger
+
+    init(rsService: RemoteSettingsService, logger: Logger = DefaultLogger.shared) {
+        self.client = rsService.makeClient(collectionName: Self.collectionName)
+        self.logger = logger
+    }
+
+    /// Picks a non-quarantined server. Prefers `countryCode` if given, else "REC", else the
+    /// first country with any usable server. Returns the masque protocol's host/port when
+    /// present (matches what we plumb into NWRelay), otherwise the server's top-level
+    /// hostname/port (default 443).
+    func selectServer(countryCode: String? = nil) -> VPNGuardian.Server? {
+        let countries = decodeCountries()
+        let preferred = countryCode ?? Self.recommendedCountryCode
+        if let pick = pickServer(in: countries.first(where: { $0.code == preferred })) {
+            return pick
+        }
+        for country in countries {
+            if let pick = pickServer(in: country) { return pick }
+        }
+        return nil
+    }
+
+    private func decodeCountries() -> [Country] {
+        guard let records = client.getRecords(syncIfEmpty: true) else { return [] }
+        let decoder = JSONDecoder()
+        return records.compactMap { record in
+            guard let data = record.fields.data(using: .utf8) else { return nil }
+            return try? decoder.decode(Country.self, from: data)
+        }
+    }
+
+    private func pickServer(in country: Country?) -> VPNGuardian.Server? {
+        guard let country else { return nil }
+        for city in country.cities {
+            for server in city.servers where !(server.quarantined ?? false) {
+                return flatten(server: server, city: city, country: country)
+            }
+        }
+        return nil
+    }
+
+    private func flatten(server: ServerRecord, city: City, country: Country) -> VPNGuardian.Server {
+        let masque = server.protocols?.first(where: { $0.name == "masque" })
+        let host = masque?.host ?? server.hostname
+        let portInt = masque?.port ?? server.port ?? 443
+        let port = UInt16(clamping: portInt)
+        return VPNGuardian.Server(
+            hostname: host,
+            port: port,
+            city: city.code,
+            countryCode: country.code
+        )
+    }
+}

--- a/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
@@ -308,7 +308,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
                     // We ask for the session scope because the web content never
                     // got the session as the user never entered their email and
                     // password
-                    scopes: [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.session]
+                    scopes: [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.session, OAuthScope.vpn]
                 ) { [weak self] result in
                     guard self != nil else { return }
 

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -125,7 +125,7 @@ class FxAWebViewModel: FeatureFlaggable {
                 case .emailLoginFlow:
                     accountManager.beginAuthentication(
                         entrypoint: "email_\(entrypoint)",
-                        scopes: [OAuthScope.profile, OAuthScope.oldSync]
+                        scopes: [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.vpn]
                     ) { [weak self] result in
                         guard let self = self else { return }
 

--- a/firefox-ios/RustFxA/RustFirefoxAccounts.swift
+++ b/firefox-ios/RustFxA/RustFirefoxAccounts.swift
@@ -180,7 +180,7 @@ public final class RustFirefoxAccounts: @unchecked Sendable {
         return FxAccountManager(
             config: config,
             deviceConfig: deviceConfig,
-            applicationScopes: [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.session],
+            applicationScopes: [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.session, OAuthScope.vpn],
             keychainAccessGroup: accessGroupIdentifier
         )
     }


### PR DESCRIPTION
## :bulb: Description

This pr adds a a few classes: 

-> VPNGuardian, that allows to get Proxy Access to Firefox-VPN
-> VPNServerlist, that allows pulling the Firefox-VPN servers from Remote Settings and choosing one. 
-> VPNController, that using the 2 Creates a Webkit Proxy Configuration and injects it into the webkitconf

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

