### PR TITLE
Bugfix [no-ticket] testSearchEngine fails on iPad intermittently

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -206,7 +206,7 @@ class SearchTests: FeatureFlaggedTestBase {
 
         navigator.goto(URLBarOpen)
         navigator.openURL("foo bar")
-        browserScreen.assertAddressBarContains(value: searchEngine.lowercased())
+        browserScreen.addressToolbarContainValue(value: searchEngine.lowercased())
         waitUntilPageLoad()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -206,7 +206,7 @@ class SearchTests: FeatureFlaggedTestBase {
 
         navigator.goto(URLBarOpen)
         navigator.openURL("foo bar")
-        browserScreen.assertAddressBarContains(value: searchEngine.lowercased(), timeout: TIMEOUT_LONG)
+        browserScreen.assertAddressBarContains(value: searchEngine.lowercased())
         waitUntilPageLoad()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -195,23 +195,21 @@ class SearchTests: FeatureFlaggedTestBase {
         let searchSettingsScreen = SearchSettingsScreen(app: app)
 
         toolbarScreen.assertSettingsButtonExists(timeout: TIMEOUT)
-        // issue 28625: iOS 15 may not open the menu fully.
-        if #unavailable(iOS 16) {
-            navigator.goto(BrowserTabMenu)
-            app.swipeUp()
-        }
         navigator.goto(SettingsScreen)
         navigator.goto(SearchSettings)
         // Open the list of default search engines and select the desired
         app.tables.cells.element(boundBy: 0).waitAndTap()
         let tablesQuery2 = app.tables
-        tablesQuery2.staticTexts.elementContainingText(searchEngine).waitAndTap()
+        let engineText = tablesQuery2.staticTexts.elementContainingText(searchEngine)
+        scrollToElement(engineText, swipeableElement: tablesQuery2.firstMatch, isHittable: true)
+        engineText.waitAndTap()
 
         searchSettingsScreen.waitForSearchEngineSelectionComplete()
 
         navigator.goto(URLBarOpen)
         navigator.openURL("foo bar")
-        browserScreen.addressToolbarContainValue(value: searchEngine.lowercased())
+        browserScreen.assertAddressBarContains(value: searchEngine.lowercased(), timeout: TIMEOUT_LONG)
+        waitUntilPageLoad()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306940

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -200,9 +200,7 @@ class SearchTests: FeatureFlaggedTestBase {
         // Open the list of default search engines and select the desired
         app.tables.cells.element(boundBy: 0).waitAndTap()
         let tablesQuery2 = app.tables
-        let engineText = tablesQuery2.staticTexts.elementContainingText(searchEngine)
-        scrollToElement(engineText, swipeableElement: tablesQuery2.firstMatch, isHittable: true)
-        engineText.waitAndTap()
+        tablesQuery2.staticTexts.elementContainingText(searchEngine).waitAndTap()
 
         searchSettingsScreen.waitForSearchEngineSelectionComplete()
 


### PR DESCRIPTION
## :scroll: Tickets

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
testSearchEngine fails on iPad intermittently both on Jenkins CI/CD and locally. The "Settings" button exists but may not respond to tapping for opening the settings menu.

I suggest `waitUntilPageLoad()` to ensure that the settings button is ready.

I ran the test with the changes on both iPad and iPhone repeatedly (20 times).

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

