### PR TITLE
Bugfix FXIOS-15653 [SearchBar] Fix searchBarPosition iPad bug

### DIFF
--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -101,7 +101,9 @@ final class AppLaunchUtil: FeatureFlaggable, Sendable {
         }
 
         // Save toolbar position to user prefs
-        SearchBarLocationSaver().saveUserSearchBarLocation(profile: profile)
+        let searchBarLocationSaver = SearchBarLocationSaver()
+        searchBarLocationSaver.migrateBottomBarPositionToTopOnIPad(profile: profile)
+        searchBarLocationSaver.saveUserSearchBarLocation(profile: profile)
         let deviceName = UIDevice.current.name
 
         NotificationCenter.default.addObserver(

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -201,6 +201,8 @@ final class SettingsCoordinator: BaseCoordinator,
             return BrowsingSettingsViewController(profile: profile, windowUUID: windowUUID)
 
         case .toolbar:
+            // Toolbar position cannot be changed on iPad
+            guard UIDeviceDetails.userInterfaceIdiom != .pad else { return nil }
             let viewModel = SearchBarSettingsViewModel(prefs: profile.prefs)
             return featureFlagsProvider.isEnabled(.addressBarMenu)
             ? UIHostingController(
@@ -430,6 +432,8 @@ final class SettingsCoordinator: BaseCoordinator,
     }
 
     func pressedToolbar() {
+        // Toolbar position cannot be changed on iPad
+        guard UIDeviceDetails.userInterfaceIdiom != .pad else { return }
         let viewModel = SearchBarSettingsViewModel(prefs: profile.prefs)
         if featureFlagsProvider.isEnabled(.addressBarMenu) {
             let viewController = UIHostingController(

--- a/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
+++ b/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
@@ -24,13 +24,16 @@ protocol UserFeaturePreferring: Sendable {
 final class UserFeaturePreferenceManager: UserFeaturePreferring, @unchecked Sendable {
     private let prefs: Prefs
     private let backendLayer: NimbusFeatureFlagLayerProviding
+    private let userInterfaceIdiom: UIUserInterfaceIdiom
 
     init(
         prefs: Prefs,
-        backendLayer: NimbusFeatureFlagLayerProviding = NimbusManager.shared.featureFlagLayer
+        backendLayer: NimbusFeatureFlagLayerProviding = NimbusManager.shared.featureFlagLayer,
+        userInterfaceIdiom: UIUserInterfaceIdiom = UIDeviceDetails.userInterfaceIdiom
     ) {
         self.prefs = prefs
         self.backendLayer = backendLayer
+        self.userInterfaceIdiom = userInterfaceIdiom
     }
 
     // MARK: - Generic bool preferences
@@ -61,6 +64,9 @@ final class UserFeaturePreferenceManager: UserFeaturePreferring, @unchecked Send
     // MARK: - Typed preferences
 
     var searchBarPosition: SearchBarPosition {
+        // Bottom search bar is not supported on iPad; clamp to `.top` regardless
+        // of any value persisted in prefs so a stale write can't surface in the UI.
+        guard userInterfaceIdiom != .pad else { return .top }
         if let raw = prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition),
            let position = SearchBarPosition(rawValue: raw) {
             return position

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/SearchBarLocationSaver.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/SearchBarLocationSaver.swift
@@ -7,9 +7,14 @@ import Shared
 protocol SearchBarLocationSaverProtocol {
     @MainActor
     func saveUserSearchBarLocation(profile: Profile, userInterfaceIdiom: UIUserInterfaceIdiom)
+
+    @MainActor
+    func migrateBottomBarPositionToTopOnIPad(profile: Profile, userInterfaceIdiom: UIUserInterfaceIdiom)
 }
 
-struct SearchBarLocationSaver: SearchBarLocationProvider, UserFeaturePreferenceProvider, SearchBarLocationSaverProtocol {
+struct SearchBarLocationSaver: SearchBarLocationProvider,
+                               UserFeaturePreferenceProvider,
+                               SearchBarLocationSaverProtocol {
     /// Saves the search bar location position to user preferences for existing users
     /// that didn't have the position saved yet. For users on iPhone with version1 or version2 as layout the
     /// search bar location position is set to bottom, otherwise the default is used.
@@ -33,5 +38,22 @@ struct SearchBarLocationSaver: SearchBarLocationProvider, UserFeaturePreferenceP
         }
 
         userPreferences.setSearchBarPosition(.bottom)
+    }
+
+    /// One-shot migration: iPad users who landed on `.bottom` due to the FXIOS-15232
+    /// regression (which briefly exposed the toolbar setting on iPad) are reset to
+    /// `.top`. The pref is read directly because the regular getter clamps to `.top`
+    /// on iPad and would mask the stale write.
+    /// TODO: FXIOS-15668 Remove this migration after enough release cycles have
+    /// passed for affected users to launch a fixed build.
+    @MainActor
+    func migrateBottomBarPositionToTopOnIPad(
+        profile: Profile,
+        userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+    ) {
+        guard userInterfaceIdiom == .pad else { return }
+        let saved = profile.prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition)
+        guard saved == SearchBarPosition.bottom.rawValue else { return }
+        userPreferences.setSearchBarPosition(.top)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingServiceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingServiceTests.swift
@@ -84,9 +84,19 @@ class MockSearchBarLocationSaver: SearchBarLocationSaverProtocol {
     var saveUserSearchBarLocationCalled = false
     var savedProfile: Profile?
 
-    func saveUserSearchBarLocation(profile: Profile, userInterfaceIdiom: UIUserInterfaceIdiom) {
+    func saveUserSearchBarLocation(
+        profile: Profile,
+        userInterfaceIdiom: UIUserInterfaceIdiom
+    ) {
         saveUserSearchBarLocationCalled = true
         savedProfile = profile
+    }
+
+    func migrateBottomBarPositionToTopOnIPad(
+        profile: Profile,
+        userInterfaceIdiom: UIUserInterfaceIdiom
+    ) {
+        // no-op for now
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchBarLocationSaverTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchBarLocationSaverTests.swift
@@ -93,6 +93,53 @@ class SearchBarLocationSaverTests: XCTestCase {
         XCTAssertEqual(searchBarPosition, SearchBarPosition.top.rawValue)
     }
 
+    // MARK: - iPad bottom-bar migration (FXIOS-15653)
+
+    @MainActor
+    func test_migrateBottomBarPositionToTopOnIPad_resetsBottomToTop_onIPad() async throws {
+        let subject = createSubject()
+        profile.prefs.setString(SearchBarPosition.bottom.rawValue,
+                                forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.migrateBottomBarPositionToTopOnIPad(profile: profile, userInterfaceIdiom: .pad)
+
+        XCTAssertEqual(profile.prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition),
+                       SearchBarPosition.top.rawValue)
+    }
+
+    @MainActor
+    func test_migrateBottomBarPositionToTopOnIPad_doesNothing_whenAlreadyTop_onIPad() async throws {
+        let subject = createSubject()
+        profile.prefs.setString(SearchBarPosition.top.rawValue,
+                                forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.migrateBottomBarPositionToTopOnIPad(profile: profile, userInterfaceIdiom: .pad)
+
+        XCTAssertEqual(profile.prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition),
+                       SearchBarPosition.top.rawValue)
+    }
+
+    @MainActor
+    func test_migrateBottomBarPositionToTopOnIPad_doesNothing_whenNoPositionSaved_onIPad() async throws {
+        let subject = createSubject()
+
+        subject.migrateBottomBarPositionToTopOnIPad(profile: profile, userInterfaceIdiom: .pad)
+
+        XCTAssertNil(profile.prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition))
+    }
+
+    @MainActor
+    func test_migrateBottomBarPositionToTopOnIPad_doesNothing_onIPhone_evenWhenBottom() async throws {
+        let subject = createSubject()
+        profile.prefs.setString(SearchBarPosition.bottom.rawValue,
+                                forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.migrateBottomBarPositionToTopOnIPad(profile: profile, userInterfaceIdiom: .phone)
+
+        XCTAssertEqual(profile.prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition),
+                       SearchBarPosition.bottom.rawValue)
+    }
+
     // MARK: - Helper
     private func createSubject() -> SearchBarLocationSaver {
         return SearchBarLocationSaver()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/UserFeaturePreferenceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/UserFeaturePreferenceManagerTests.swift
@@ -10,26 +10,26 @@ import XCTest
 
 final class UserFeaturePreferenceManagerTests: XCTestCase {
     private var prefs: MockProfilePrefs!
-    private var subject: UserFeaturePreferenceManager!
     private var mockLayer: MockNimbusFeatureFlagLayer!
 
     override func setUp() {
         super.setUp()
         prefs = MockProfilePrefs()
         mockLayer = MockNimbusFeatureFlagLayer()
-        subject = UserFeaturePreferenceManager(prefs: prefs, backendLayer: mockLayer)
     }
 
     override func tearDown() {
-        prefs = nil
-        subject = nil
         mockLayer = nil
+        prefs = nil
         super.tearDown()
     }
 
     // MARK: - Bool preferences: defaults from Nimbus
 
+    @MainActor
     func testBoolDefaults_returnNimbusValues_whenNoUserPrefSet() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         // With no prefs set, each flag should return the Nimbus default.
         // We just verify they return without crashing — the actual Nimbus defaults
         // may vary by config, so we check the type is correct.
@@ -43,7 +43,10 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
 
     // MARK: - Bool preferences: user overrides
 
+    @MainActor
     func testFirefoxSuggest_readsUserPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         prefs.setBool(false, forKey: PrefsKeys.FeatureFlags.FirefoxSuggest)
         XCTAssertFalse(subject.getPreferenceFor(.firefoxSuggestFeature))
 
@@ -51,27 +54,42 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
         XCTAssertTrue(subject.getPreferenceFor(.firefoxSuggestFeature))
     }
 
+    @MainActor
     func testSentFromFirefox_readsUserPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         prefs.setBool(true, forKey: PrefsKeys.FeatureFlags.SentFromFirefox)
         XCTAssertTrue(subject.getPreferenceFor(.sentFromFirefox))
     }
 
+    @MainActor
     func testSponsoredShortcuts_readsUserPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         prefs.setBool(false, forKey: PrefsKeys.FeatureFlags.SponsoredShortcuts)
         XCTAssertFalse(subject.getPreferenceFor(.hntSponsoredShortcuts))
     }
 
+    @MainActor
     func testHomepageBookmarksSection_readsUserPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.BookmarksSection)
         XCTAssertFalse(subject.getPreferenceFor(.homepageBookmarksSectionDefault))
     }
 
+    @MainActor
     func testHomepageJumpBackInSection_readsUserPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.JumpBackInSection)
         XCTAssertFalse(subject.getPreferenceFor(.homepageJumpBackinSectionDefault))
     }
 
+    @MainActor
     func testAIKillSwitch_readsUserPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         prefs.setBool(true, forKey: PrefsKeys.Settings.aiKillSwitchFeature)
         XCTAssertTrue(subject.getPreferenceFor(.aiKillSwitch))
 
@@ -81,13 +99,19 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
 
     // MARK: - Typed preferences
 
+    @MainActor
     func testSearchBarPosition_defaultsToNimbus() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         let position = subject.searchBarPosition
         // Default from NimbusSearchBarLayer — just verify it's a valid value
         XCTAssertTrue(position == .top || position == .bottom)
     }
 
+    @MainActor
     func testSearchBarPosition_readsUserPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         prefs.setString(SearchBarPosition.bottom.rawValue,
                         forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
         XCTAssertEqual(subject.searchBarPosition, .bottom)
@@ -97,13 +121,56 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
         XCTAssertEqual(subject.searchBarPosition, .top)
     }
 
+    @MainActor
+    func testSearchBarPosition_returnsTopOnIPad_whenStoredIsBottom() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .pad)
+
+        prefs.setString(SearchBarPosition.bottom.rawValue,
+                        forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        XCTAssertEqual(subject.searchBarPosition, .top)
+    }
+
+    @MainActor
+    func testSearchBarPosition_returnsTopOnIPad_whenStoredIsTop() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .pad)
+
+        prefs.setString(SearchBarPosition.top.rawValue,
+                        forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        XCTAssertEqual(subject.searchBarPosition, .top)
+    }
+
+    @MainActor
+    func testSearchBarPosition_returnsTopOnIPad_whenNothingStored() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .pad)
+
+        XCTAssertEqual(subject.searchBarPosition, .top)
+    }
+
+    @MainActor
+    func testSearchBarPosition_readsStoredValueOnIPhone() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
+        prefs.setString(SearchBarPosition.bottom.rawValue,
+                        forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        XCTAssertEqual(subject.searchBarPosition, .bottom)
+    }
+
+    @MainActor
     func testStartAtHomeSetting_defaultsToNimbus() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         let setting = subject.startAtHomeSetting
         // Verify it's a valid StartAtHome value
         XCTAssertTrue([.afterFourHours, .always, .disabled].contains(setting))
     }
 
+    @MainActor
     func testStartAtHomeSetting_readsUserPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         prefs.setString(StartAtHome.always.rawValue,
                         forKey: PrefsKeys.FeatureFlags.StartAtHome)
         XCTAssertEqual(subject.startAtHomeSetting, .always)
@@ -115,7 +182,10 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
 
     // MARK: - Setters
 
+    @MainActor
     func testSetFirefoxSuggestEnabled_writesPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         subject.setPreferenceFor(.firefoxSuggestFeature, to: true)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.FirefoxSuggest), true)
 
@@ -123,32 +193,50 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.FirefoxSuggest), false)
     }
 
+    @MainActor
     func testSetSentFromFirefoxEnabled_writesPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         subject.setPreferenceFor(.sentFromFirefox, to: true)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.SentFromFirefox), true)
     }
 
+    @MainActor
     func testSetSponsoredShortcutsEnabled_writesPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         subject.setPreferenceFor(.hntSponsoredShortcuts, to: false)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.FeatureFlags.SponsoredShortcuts), false)
     }
 
+    @MainActor
     func testSetHomepageBookmarksSectionEnabled_writesPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         subject.setPreferenceFor(.homepageBookmarksSectionDefault, to: true)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.HomepageSettings.BookmarksSection), true)
     }
 
+    @MainActor
     func testSetHomepageJumpBackInSectionEnabled_writesPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         subject.setPreferenceFor(.homepageJumpBackinSectionDefault, to: false)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.HomepageSettings.JumpBackInSection), false)
     }
 
+    @MainActor
     func testSetAIKillSwitchEnabled_writesPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         subject.setPreferenceFor(.aiKillSwitch, to: true)
         XCTAssertEqual(prefs.boolForKey(PrefsKeys.Settings.aiKillSwitchFeature), true)
     }
 
+    @MainActor
     func testSetSearchBarPosition_writesPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         subject.setSearchBarPosition(.bottom)
         XCTAssertEqual(prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition),
                        SearchBarPosition.bottom.rawValue)
@@ -158,7 +246,10 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
                        SearchBarPosition.top.rawValue)
     }
 
+    @MainActor
     func testSetStartAtHomeSetting_writesPref() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         subject.setStartAtHomeSetting(.always)
         XCTAssertEqual(prefs.stringForKey(PrefsKeys.FeatureFlags.StartAtHome),
                        StartAtHome.always.rawValue)
@@ -166,7 +257,10 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
 
     // MARK: - Roundtrip: set then read
 
+    @MainActor
     func testRoundtrip_boolPreferences() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         subject.setPreferenceFor(.firefoxSuggestFeature, to: false)
         XCTAssertFalse(subject.getPreferenceFor(.firefoxSuggestFeature))
 
@@ -174,7 +268,10 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
         XCTAssertTrue(subject.getPreferenceFor(.firefoxSuggestFeature))
     }
 
+    @MainActor
     func testRoundtrip_searchBarPosition() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         subject.setSearchBarPosition(.bottom)
         XCTAssertEqual(subject.searchBarPosition, .bottom)
 
@@ -182,7 +279,10 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
         XCTAssertEqual(subject.searchBarPosition, .top)
     }
 
+    @MainActor
     func testRoundtrip_startAtHome() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         subject.setStartAtHomeSetting(.always)
         XCTAssertEqual(subject.startAtHomeSetting, .always)
 
@@ -192,12 +292,18 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
 
     // MARK: - Generic API: flag with no userPrefsKey falls back to Nimbus
 
+    @MainActor
     func testGetPreference_flagWithNoUserPrefsKey_fallsBackToNimbus() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         // .microsurvey has no userPrefsKey, so should return the Nimbus value
         _ = subject.getPreferenceFor(.microsurvey)
     }
 
+    @MainActor
     func testSetPreference_flagWithNoUserPrefsKey_isNoOp() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
         // .microsurvey has no userPrefsKey, so set should be a no-op
         subject.setPreferenceFor(.microsurvey, to: true)
         // No crash, no pref written
@@ -215,6 +321,25 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
 
         mock.setSearchBarPosition(.top)
         XCTAssertEqual(mock.searchBarPosition, .top)
+    }
+
+    // MARK: - Helpers
+    @MainActor
+    private func createSubject(
+        prefs: Prefs,
+        backendLayer: NimbusFeatureFlagLayerProviding,
+        userInterfaceIdiom: UIUserInterfaceIdiom,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> UserFeaturePreferenceManager {
+        let subject = UserFeaturePreferenceManager(
+            prefs: prefs,
+            backendLayer: backendLayer,
+            userInterfaceIdiom: userInterfaceIdiom
+        )
+        trackForMemoryLeaks(subject, file: file, line: line)
+
+        return subject
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15653)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33528)

## :bulb: Description
PR #33208  inadvertently removed the iPad guard around the address bar position setting, letting iPad users select Bottom and persist it. MY BAD, YA'LL!! Because `userPreferences.searchBarPosition` had no idiom check, that stale `.bottom` value flowed through `BrowserViewController.subscribeToRedux()` and other unguarded call sites at launch, resulting in the relaunch mismatch where Settings showed "Bottom" while the bar rendered on Top, and other layout symptoms. PR #33552 hid the Settings row on iPad, partially solving the problem, but didn't address the stuck preference or the unguarded reads.

This PR adds mitigation for that:
- `UserFeaturePreferenceManager.searchBarPosition` now clamps to `.top` on iPad regardless of what's persisted
- a one-shot launch-time migration in `SearchBarLocationSaver` rewrites any stale `.bottom` to .`top` on iPad
- `SettingsCoordinator` short-circuits both the deep-link and push paths to the toolbar settings on iPad so the SwiftUI `AddressBarSettingsView` can no longer be reached, given that those *should be* unreachable on iPad
- Unit tests cover the iPad clamp and each migration branch

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

