### PR TITLE
Bugfix FXIOS-15669 [Sentry crash] Fix constraint accumulation causing memory exhaustion crash

### DIFF
--- a/BrowserKit/Package.resolved
+++ b/BrowserKit/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7652867bf935281c038ad52d72ad40eec39f02d67b07ecfa159f26830b9f3f3f",
+  "originHash" : "f7769db9aa06ae33623b4c8785d7d9f26a9fdda24cd4057a8041d63d8e740b03",
   "pins" : [
     {
       "identity" : "dip",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftyBeaver/SwiftyBeaver.git",
       "state" : {
-        "revision" : "1080914828ef1c9ca9cd2bad50667b3d847dabff",
-        "version" : "2.0.0"
+        "revision" : "8cba041db09596183331d123f337d0eb2e6e8e91",
+        "version" : "2.1.1"
       }
     }
   ],

--- a/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
@@ -104,7 +104,9 @@ public final class ContextualHintView: UIView, ThemeApplicable, Notifiable {
         closeButtonTopConstraint?.constant = isArrowUp ? UX.closeButtonTop : UX.closeButtonBottom
 
         titleLabel.text = viewModel.title
-        if !viewModel.title.isEmpty && !stackView.arrangedSubviews.contains(titleLabel) {
+        if viewModel.title.isEmpty {
+            titleLabel.removeFromSuperview()
+        } else if !stackView.arrangedSubviews.contains(titleLabel) {
             stackView.insertArrangedSubview(titleLabel, at: 0)
         }
 

--- a/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
@@ -103,8 +103,8 @@ public final class ContextualHintView: UIView, ThemeApplicable, Notifiable {
                                                      : UX.stackViewBottomArrowTopConstraint
         closeButtonTopConstraint?.constant = isArrowUp ? UX.closeButtonTop : UX.closeButtonBottom
 
+        titleLabel.text = viewModel.title
         if !viewModel.title.isEmpty && !stackView.arrangedSubviews.contains(titleLabel) {
-            titleLabel.text = viewModel.title
             stackView.insertArrangedSubview(titleLabel, at: 0)
         }
 

--- a/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
@@ -10,6 +10,8 @@ public final class ContextualHintView: UIView, ThemeApplicable, Notifiable {
     private var viewModel: ContextualHintViewModel?
     private var closeButtonHeightConstraint: NSLayoutConstraint?
     private var closeButtonWidthConstraint: NSLayoutConstraint?
+    private var stackViewTopConstraint: NSLayoutConstraint?
+    private var closeButtonTopConstraint: NSLayoutConstraint?
 
     struct UX {
         static let closeButtonSize = CGSize(width: 35, height: 35)
@@ -27,6 +29,7 @@ public final class ContextualHintView: UIView, ThemeApplicable, Notifiable {
 
     override public init(frame: CGRect) {
         super.init(frame: frame)
+        setupLayout()
         startObservingNotifications(
             withNotificationCenter: NotificationCenter.default,
             forObserver: self,
@@ -95,6 +98,20 @@ public final class ContextualHintView: UIView, ThemeApplicable, Notifiable {
         closeButton.accessibilityLabel = viewModel.closeButtonA11yLabel
         descriptionLabel.text = viewModel.description
 
+        let isArrowUp = viewModel.arrowDirection == .up
+        stackViewTopConstraint?.constant = isArrowUp ? UX.stackViewTopArrowTopConstraint : UX.stackViewBottomArrowTopConstraint
+        closeButtonTopConstraint?.constant = isArrowUp ? UX.closeButtonTop : UX.closeButtonBottom
+
+        if !viewModel.title.isEmpty && !stackView.arrangedSubviews.contains(titleLabel) {
+            titleLabel.text = viewModel.title
+            stackView.insertArrangedSubview(titleLabel, at: 0)
+        }
+
+        setNeedsLayout()
+        layoutIfNeeded()
+    }
+
+    private func setupLayout() {
         layer.addSublayer(gradient)
 
         addSubview(scrollView)
@@ -102,28 +119,22 @@ public final class ContextualHintView: UIView, ThemeApplicable, Notifiable {
 
         scrollView.addSubview(contentContainer)
         contentContainer.addSubview(stackView)
-
-        if !viewModel.title.isEmpty {
-            titleLabel.text = viewModel.title
-            stackView.addArrangedSubview(titleLabel)
-        }
         stackView.addArrangedSubview(descriptionLabel)
-
-        setupConstraints()
-    }
-
-    private func setupConstraints() {
-        guard let viewModel else { return }
-
-        let isArrowUp = viewModel.arrowDirection == .up
-        let topPadding = isArrowUp ? UX.stackViewTopArrowTopConstraint : UX.stackViewBottomArrowTopConstraint
-        let closeButtonPadding = isArrowUp ? UX.closeButtonTop : UX.closeButtonBottom
 
         let heightConstraint = closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize.height)
         closeButtonHeightConstraint = heightConstraint
         let widthConstraint = closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize.width)
         closeButtonWidthConstraint = widthConstraint
         updateButtonSizeForDynamicFont()
+
+        let stackViewTop = stackView.topAnchor.constraint(
+            equalTo: contentContainer.topAnchor,
+            constant: UX.stackViewTopArrowTopConstraint
+        )
+        stackViewTopConstraint = stackViewTop
+
+        let closeButtonTop = closeButton.topAnchor.constraint(equalTo: topAnchor, constant: UX.closeButtonTop)
+        closeButtonTopConstraint = closeButtonTop
 
         NSLayoutConstraint.activate([
             heightAnchor.constraint(equalTo: stackView.heightAnchor, constant: UX.heightSpacing),
@@ -140,21 +151,18 @@ public final class ContextualHintView: UIView, ThemeApplicable, Notifiable {
             scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor),
             scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: contentContainer.bottomAnchor),
 
-            closeButton.topAnchor.constraint(equalTo: topAnchor, constant: closeButtonPadding),
+            closeButtonTop,
             closeButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.closeButtonTrailing),
             heightConstraint,
             widthConstraint,
 
-            stackView.topAnchor.constraint(equalTo: contentContainer.topAnchor, constant: topPadding),
+            stackViewTop,
             stackView.leadingAnchor.constraint(equalTo: contentContainer.leadingAnchor,
                                                constant: UX.stackViewLeading),
             stackView.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor,
                                                 constant: -UX.closeButtonSize.width - UX.stackViewTrailing),
             stackView.bottomAnchor.constraint(equalTo: contentContainer.bottomAnchor)
         ])
-
-        setNeedsLayout()
-        layoutIfNeeded()
     }
 
     @objc

--- a/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
@@ -99,7 +99,8 @@ public final class ContextualHintView: UIView, ThemeApplicable, Notifiable {
         descriptionLabel.text = viewModel.description
 
         let isArrowUp = viewModel.arrowDirection == .up
-        stackViewTopConstraint?.constant = isArrowUp ? UX.stackViewTopArrowTopConstraint : UX.stackViewBottomArrowTopConstraint
+        stackViewTopConstraint?.constant = isArrowUp ? UX.stackViewTopArrowTopConstraint
+                                                     : UX.stackViewBottomArrowTopConstraint
         closeButtonTopConstraint?.constant = isArrowUp ? UX.closeButtonTop : UX.closeButtonBottom
 
         if !viewModel.title.isEmpty && !stackView.arrangedSubviews.contains(titleLabel) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15669)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33556)

## :bulb: Description
FYI, this is an attempt with Claude to fix https://mozilla.sentry.io/issues/7361305435/?project=6176941. It found that our `ContextualHintView` doesn't follow the necessary pattern to setup the constraints only once. It was setup that way since we need the view model arrow direction to setup the said constraints properly. Now this PR changes that by:
1. Ensuring constraints are setup only once in the `init`
2. Keep the constraints in memory and update its value whenever we call `configure`

The stack trace in this Sentry crash shows that we update the CFR from a redux state update. The theory is that this is triggered multiple times (since `ToolbarAction` is triggering many times) and those constraints are setup multiple times which creates this crash (?). Anyhow, the changes below should not do any hurt. I'll also ask QA to test all CFRs.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

No changes affecting the current look of the CFR. It still looks bad 😆 I opened [another ticket for this](https://github.com/mozilla-mobile/firefox-ios/issues/33559). 

| Before (Top) | After (Top) |
|------------|-----------|
| ![Main top](https://github.com/user-attachments/assets/41114907-dd57-47dc-b064-d9fac2745356) | ![Fix top](https://github.com/user-attachments/assets/ecf38592-3d7a-4537-bb4c-95b179615144) |

| Before (Bottom) | After (Bottom) |
|---------------|--------------|
| ![Main bottom](https://github.com/user-attachments/assets/c968b96a-7323-4df6-9f29-1487ff1e37a1) | ![Fix bottom](https://github.com/user-attachments/assets/e46ba497-2eab-4ddb-9145-e539009d5029) |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code