### PR TITLE
Bugfix FXIOS-15671 [Sentry crash] Offload background WebViews on memory warning

### DIFF
--- a/adr/0010-offload-background-webviews-on-memory-warning.md
+++ b/adr/0010-offload-background-webviews-on-memory-warning.md
@@ -1,0 +1,47 @@
+# 10. Offload Background WebViews on Memory Warning
+
+Date: 2026-04-30
+
+## Status
+
+Proposed
+
+## Context
+
+Firefox iOS has no meaningful response to OS memory warnings. `applicationDidReceiveMemoryWarning` logs the event and returns. When the app exceeds the system memory limit, the OS watchdog terminates it without warning and without a stacktrace — making the crash nearly invisible during development.
+
+Sentry issue (WatchdogTermination) has accumulated 7.8 million occurrences across 285,000 users since February 2023 and remains unresolved. Breadcrumb analysis of affected sessions consistently shows users with thousands of open tabs (one sample session had 3,629). The existing zombie-tab architecture already avoids creating WebViews for tabs that have never been selected, but background tabs that have been visited at any point hold live `WKWebView` instances. Each of those can consume memory.
+
+The crash is not a code defect but an architectural gap: the app accumulates memory and ignores the OS signals that precede the kill.
+
+## Decision
+
+We will respond to OS memory warnings by offloading the WebViews of all background tabs that currently have one, returning those tabs to zombie state.
+
+When `applicationDidReceiveMemoryWarning` fires, `AppDelegate` will iterate all active windows and call `offloadBackgroundWebViews()` on each `TabManager`. That method collects every tab whose `webView` is non-nil and that is not the currently selected tab, then offloads them sequentially in a single `Task`. The selected tab is never touched.
+
+Offloading a tab calls the existing `Tab.close()` method, which stops media playback, removes the WebView from the view hierarchy, notifies the `LegacyTabDelegate` so BVC can tear down its KVO observers, and sets `webView = nil`. The tab's URL, title, and metadata are preserved. When the user returns to the tab, `createWebview()` is called as usual and the page reloads from its URL, exactly as it does for tabs restored from a previous session.
+
+One consequence of reusing `close()` is that `TabContentScriptManager.uninstall()` must also clear its internal `helpers` dictionary. Previously `uninstall()` only removed script message handlers from the `WKUserContentController` but left `helpers` populated, which was harmless for permanent tab closure. For an offloaded tab that will be re-activated, leaving `helpers` populated would prevent `addContentScript` from re-registering scripts on the new WebView (the method guards against duplicate names). We extend `uninstall()` to call `helpers.removeAll()` so that content scripts are correctly reinstalled when the tab's WebView is recreated.
+
+A debug menu entry in the hidden settings section allows the behaviour to be triggered manually, since OS memory warnings are difficult to reproduce in development.
+
+## Consequences
+
+### Positive
+
+- Background WebView memory is freed on demand when the OS signals pressure.
+- The selected tab is never affected; the user's active browsing session is uninterrupted.
+- Offloaded tabs behave identically to zombie tabs restored from a previous session, so the re-activation path is already well-tested and understood.
+- Content scripts, login autofill, and all other tab helpers are correctly reinstalled on the new WebView when a tab is re-activated.
+
+### Negative
+
+- Background tabs that were loaded will need to be reloaded when the user returns to them after a memory warning.
+- Users who accumulate thousands of tabs will still encounter performance degradation and continued memory pressure from tab metadata serialisation.
+- `Tab.close()` now always clears `helpers`, which is a behaviour change for permanent tab closure as well. For permanently closed tabs this is harmless (the tab object is discarded), but it is a subtle semantic extension of what `uninstall()` does and must be kept in mind if `close()` is ever called in contexts where `helpers` state needs to persist.
+
+## References
+
+- [Sentry issue](https://mozilla.sentry.io/issues/3914209929/)
+- [FXIOS-15671](https://mozilla-hub.atlassian.net/browse/FXIOS-15671)

--- a/adr/README.md
+++ b/adr/README.md
@@ -16,6 +16,7 @@ This log lists the architectural decisions for MADR.
 - [ADR-0007](0007-deeplink-startup-flow-refactor.md) - Deeplink Startup Flow Refactor
 - [ADR-0008](0008-lazy-tab-screenshot-restoration.md) - Lazy Tab Screenshot Restoration
 - [ADR-0009](0009-feature-flags-refactor) - Feature Flags Refactor
+- [ADR-0010](0010-offload-background-webviews-on-memory-warning.md) - Offload Background WebViews on Memory Warning
 
 <!-- adrlogstop -->
 

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1023,6 +1023,7 @@
 		8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */; };
 		8A57519927AD80B800A84DBF /* ReaderModeStyleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */; };
 		8A590C6128C123100032F1AA /* OpenPassBookHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */; };
+		8A5A24C12FA3F85B00D11F8A /* OffloadBackgroundWebViewsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5A24C02FA3F85B00D11F8A /* OffloadBackgroundWebViewsSetting.swift */; };
 		8A5BC1EB2C4AA13F009A40A4 /* FeatureFlagsBoolSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BC1EA2C4AA13F009A40A4 /* FeatureFlagsBoolSetting.swift */; };
 		8A5BD95A28788A3D000FE773 /* TopSitesHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */; };
 		8A5BD95F2878B7B6000FE773 /* TopSitesWidgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BD95E2878B7B6000FE773 /* TopSitesWidgetManager.swift */; };
@@ -9394,6 +9395,7 @@
 		8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleViewModel.swift; sourceTree = "<group>"; };
 		8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPassBookHelper.swift; sourceTree = "<group>"; };
+		8A5A24C02FA3F85B00D11F8A /* OffloadBackgroundWebViewsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffloadBackgroundWebViewsSetting.swift; sourceTree = "<group>"; };
 		8A5BC1EA2C4AA13F009A40A4 /* FeatureFlagsBoolSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsBoolSetting.swift; sourceTree = "<group>"; };
 		8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesHelperTests.swift; sourceTree = "<group>"; };
 		8A5BD95B2878AA74000FE773 /* PinnedSiteInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedSiteInfo.swift; sourceTree = "<group>"; };
@@ -13759,6 +13761,7 @@
 				C72748232ECE1809003B394D /* MerinoTestDataSetting.swift */,
 				C2EA23532FA1B8AE004B6340 /* WorldCupNowOverrideSetting.swift */,
 				C2EA23552FA1B8AE004B6341 /* WorldCupResetDismissedSetting.swift */,
+				8A5A24C02FA3F85B00D11F8A /* OffloadBackgroundWebViewsSetting.swift */,
 				8A3EF8142A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift */,
 				C705FD572EF3545500AC5EE7 /* PrivacyNoticeUpdate.swift */,
 				8A3EF8122A2FD07A00796E3A /* ResetContextualHints.swift */,
@@ -19546,6 +19549,7 @@
 				1D5A117A2EAEC51100DD27F7 /* ResetSearchEnginePrefsSetting.swift in Sources */,
 				21618A932A4499FC00A5189E /* AppState.swift in Sources */,
 				81020C942BB5B026007B8481 /* OnboardingMultipleChoiceButtonViewModel.swift in Sources */,
+				8A5A24C12FA3F85B00D11F8A /* OffloadBackgroundWebViewsSetting.swift in Sources */,
 				E12BD0AE28AC38480029AAF0 /* UIImage+Extension.swift in Sources */,
 				0A7693692C81F2A300103A6D /* TrackingProtectionConnectionDetailsView.swift in Sources */,
 				F886218C270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -822,6 +822,10 @@ struct AccessibilityIdentifiers {
             static let blockAudio = "BlockAudio"
             static let blockAudioAndVideo = "BlockAudioAndVideo"
         }
+
+        struct Debug {
+            static let offloadBackgroundWebViews = "Settings.Debug.OffloadBackgroundWebViews"
+        }
     }
 
     struct Summarizer {

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -264,6 +264,11 @@ class AppDelegate: UIResponder,
 
     func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
         logger.log("Received memory warning", level: .info, category: .lifecycle)
+        Task { @MainActor in
+            windowManager.allWindowUUIDs(includingReserved: false).forEach { uuid in
+                windowManager.tabManager(for: uuid).offloadBackgroundWebViews()
+            }
+        }
     }
 
     private func updateTopSitesWidget() {

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -264,9 +264,9 @@ class AppDelegate: UIResponder,
 
     func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
         logger.log("Received memory warning", level: .info, category: .lifecycle)
-        Task { @MainActor in
-            windowManager.allWindowUUIDs(includingReserved: false).forEach { uuid in
-                windowManager.tabManager(for: uuid).offloadBackgroundWebViews()
+        Task {
+            for uuid in windowManager.allWindowUUIDs(includingReserved: false) {
+                await windowManager.tabManager(for: uuid).offloadBackgroundWebViews()
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -585,7 +585,9 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     func pressedOffloadBackgroundWebViews() {
-        tabManager?.offloadBackgroundWebViews()
+        Task {
+            await tabManager?.offloadBackgroundWebViews()
+        }
     }
 
     /// Adds 20 random shortcuts to the top sites / shortcuts library

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -529,6 +529,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
             SentryIDSetting(settings: self, settingsDelegate: self),
             TermsOfUseTimeout(settings: self, settingsDelegate: self),
             OpenFiftyTabsDebugOption(settings: self, settingsDelegate: self),
+            OffloadBackgroundWebViewsSetting(settings: self, settingsDelegate: self),
             FirefoxSuggestSettings(settings: self, settingsDelegate: self),
             ScreenshotSetting(settings: self),
             DeleteLoginsKeysSetting(settings: self),
@@ -581,6 +582,10 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
     func pressedOpenFiftyTabs() {
         parentCoordinator?.openDebugTestTabs(count: 50)
+    }
+
+    func pressedOffloadBackgroundWebViews() {
+        tabManager.offloadBackgroundWebViews()
     }
 
     /// Adds 20 random shortcuts to the top sites / shortcuts library

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -585,7 +585,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     func pressedOffloadBackgroundWebViews() {
-        tabManager.offloadBackgroundWebViews()
+        tabManager?.offloadBackgroundWebViews()
     }
 
     /// Adds 20 random shortcuts to the top sites / shortcuts library

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/DebugSettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/DebugSettingsDelegate.swift
@@ -14,4 +14,5 @@ protocol DebugSettingsDelegate: AnyObject, SharedSettingsDelegate {
     func pressedOpenFiftyTabs()
     func pressedDebugFeatureFlags()
     func pressedAddShortcuts()
+    func pressedOffloadBackgroundWebViews()
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/OffloadBackgroundWebViewsSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/OffloadBackgroundWebViewsSetting.swift
@@ -5,7 +5,9 @@
 import Foundation
 
 class OffloadBackgroundWebViewsSetting: HiddenSetting {
-    override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Debug.offloadBackgroundWebViews }
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.Debug.offloadBackgroundWebViews
+    }
     private weak var settingsDelegate: DebugSettingsDelegate?
 
     init(settings: SettingsTableViewController, settingsDelegate: DebugSettingsDelegate) {

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/OffloadBackgroundWebViewsSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/OffloadBackgroundWebViewsSetting.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class OffloadBackgroundWebViewsSetting: HiddenSetting {
+    override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Debug.offloadBackgroundWebViews }
+    private weak var settingsDelegate: DebugSettingsDelegate?
+
+    init(settings: SettingsTableViewController, settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
+
+    override var title: NSAttributedString? {
+        guard let theme else { return nil }
+        return NSAttributedString(
+            string: "Offload background WebViews (simulate memory warning)",
+            attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]
+        )
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        settingsDelegate?.pressedOffloadBackgroundWebViews()
+    }
+}

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -2715,6 +2715,28 @@ webview:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
+  memory_warning_offload:
+    type: event
+    extra_keys:
+      tab_count:
+        type: quantity
+        description: |
+          The total number of open tabs at the time of the memory warning.
+      webview_count:
+        type: quantity
+        description: |
+          The number of living WKWebViews at the time of the memory warning.
+    description: |
+      Recorded when a memory warning is received and background WebViews are offloaded.
+      Captures living WKWebView count vs total tab count to understand memory pressure
+      patterns leading to WatchdogTermination crashes.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/33562
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/33563
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2027-01-01"
 
 fx_suggest:
   ping_type:

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -646,6 +646,11 @@ class Tab: NSObject,
         deleteDownloadedDocuments(docsURL: temporaryDocumentsSession)
     }
 
+    func offloadWebView() async {
+        guard webView != nil else { return }
+        await close()
+    }
+
     func goBack() {
         // if the file was cancelled then return and avoid calling webView.goBack
         // since the previous page is already there

--- a/firefox-ios/Client/TabManagement/TabContentScriptManager.swift
+++ b/firefox-ios/Client/TabManagement/TabContentScriptManager.swift
@@ -15,6 +15,7 @@ final class TabContentScriptManager: NSObject, WKScriptMessageHandler {
             }
             helper.value.prepareForDeinit()
         }
+        helpers.removeAll()
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {

--- a/firefox-ios/Client/TabManagement/TabContentScriptManager.swift
+++ b/firefox-ios/Client/TabManagement/TabContentScriptManager.swift
@@ -15,6 +15,7 @@ final class TabContentScriptManager: NSObject, WKScriptMessageHandler {
             }
             helper.value.prepareForDeinit()
         }
+        // See ADR-10 for context on `helpers.removeAll()`
         helpers.removeAll()
     }
 

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -119,7 +119,7 @@ protocol TabManager: AnyObject {
 
     func addPopupForParentTab(profile: Profile, parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab
     func tabDidSetScreenshot(_ tab: Tab)
-    func offloadBackgroundWebViews()
+    func offloadBackgroundWebViews() async
 }
 
 extension TabManager {

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -119,6 +119,7 @@ protocol TabManager: AnyObject {
 
     func addPopupForParentTab(profile: Profile, parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab
     func tabDidSetScreenshot(_ tab: Tab)
+    func offloadBackgroundWebViews()
 }
 
 extension TabManager {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1013,6 +1013,16 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
     }
 
+    func offloadBackgroundWebViews() {
+        let backgroundTabsWithWebViews = tabs.filter { $0.webView != nil && $0 !== selectedTab }
+        logger.log("Offloading WebViews for \(backgroundTabsWithWebViews.count) background tabs", level: .info, category: .tabs)
+        for tab in backgroundTabsWithWebViews {
+            Task {
+                await tab.offloadWebView()
+            }
+        }
+    }
+
     func switchPrivacyMode() -> SwitchPrivacyModeResult {
         assert(Thread.isMainThread)
         var result = SwitchPrivacyModeResult.usedExistingTab

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1013,7 +1013,7 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
     }
 
-    func offloadBackgroundWebViews() {
+    func offloadBackgroundWebViews() async {
         let backgroundTabsWithWebViews = tabs.filter { $0.webView != nil && $0 !== selectedTab }
         logger.log("Offloading WebViews for \(backgroundTabsWithWebViews.count) background tabs",
                    level: .info,
@@ -1023,10 +1023,8 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
             tabCount: tabs.count,
             webViewCount: backgroundTabsWithWebViews.count + 1
         )
-        Task {
-            for tab in backgroundTabsWithWebViews {
-                await tab.offloadWebView()
-            }
+        for tab in backgroundTabsWithWebViews {
+            await tab.offloadWebView()
         }
     }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1018,6 +1018,11 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         logger.log("Offloading WebViews for \(backgroundTabsWithWebViews.count) background tabs",
                    level: .info,
                    category: .tabs)
+        // Sending telemetry for all webviews alive, even the selected tab one
+        tabsTelemetry.trackMemoryWarningOffload(
+            tabCount: tabs.count,
+            webViewCount: backgroundTabsWithWebViews.count + 1
+        )
         Task {
             for tab in backgroundTabsWithWebViews {
                 await tab.offloadWebView()

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1015,9 +1015,11 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
 
     func offloadBackgroundWebViews() {
         let backgroundTabsWithWebViews = tabs.filter { $0.webView != nil && $0 !== selectedTab }
-        logger.log("Offloading WebViews for \(backgroundTabsWithWebViews.count) background tabs", level: .info, category: .tabs)
-        for tab in backgroundTabsWithWebViews {
-            Task {
+        logger.log("Offloading WebViews for \(backgroundTabsWithWebViews.count) background tabs",
+                   level: .info,
+                   category: .tabs)
+        Task {
+            for tab in backgroundTabsWithWebViews {
                 await tab.offloadWebView()
             }
         }

--- a/firefox-ios/Client/Telemetry/TabsTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabsTelemetry.swift
@@ -31,4 +31,12 @@ final class TabsTelemetry {
         gleanWrapper.recordEvent(for: GleanMetrics.Webview.processDidTerminate,
                                  extras: extras)
     }
+
+    func trackMemoryWarningOffload(tabCount: Int, webViewCount: Int) {
+        let extras = GleanMetrics.Webview.MemoryWarningOffloadExtra(
+            tabCount: Int32(tabCount),
+            webviewCount: Int32(webViewCount)
+        )
+        gleanWrapper.recordEvent(for: GleanMetrics.Webview.memoryWarningOffload, extras: extras)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockAppSettingsDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockAppSettingsDelegate.swift
@@ -41,4 +41,6 @@ class MockDebugSettingsDelegate: DebugSettingsDelegate {
     func askedToReload() {
         askedToReloadCalled += 1
     }
+
+    func pressedOffloadBackgroundWebViews() {}
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -155,4 +155,5 @@ class MockTabManager: TabManager {
     }
 
     func tabDidSetScreenshot(_ tab: Client.Tab) {}
+    func offloadBackgroundWebViews() {}
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -155,5 +155,5 @@ class MockTabManager: TabManager {
     }
 
     func tabDidSetScreenshot(_ tab: Client.Tab) {}
-    func offloadBackgroundWebViews() {}
+    func offloadBackgroundWebViews() async {}
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -369,8 +369,8 @@ final class TabManagerTests: TabManagerTestsBase {
     func testOffloadBackgroundWebViews_tabCountUnchanged() async throws {
         let subject = createSubject()
         let tab1 = subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
-        subject.addTab(URLRequest(url: URL(string: "https://example.com")!), afterTab: nil, isPrivate: false)
-        subject.addTab(URLRequest(url: URL(string: "https://firefox.com")!), afterTab: nil, isPrivate: false)
+        _ = subject.addTab(URLRequest(url: URL(string: "https://example.com")!), afterTab: nil, isPrivate: false)
+        _ = subject.addTab(URLRequest(url: URL(string: "https://firefox.com")!), afterTab: nil, isPrivate: false)
         subject.selectTab(tab1)
 
         subject.offloadBackgroundWebViews()
@@ -401,7 +401,7 @@ final class TabManagerTests: TabManagerTestsBase {
     func testOffloadBackgroundWebViews_selectedTabWebViewPreserved() async throws {
         let subject = createSubject()
         let tab1 = subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
-        subject.addTab(URLRequest(url: URL(string: "https://example.com")!), afterTab: nil, isPrivate: false)
+        _ = subject.addTab(URLRequest(url: URL(string: "https://example.com")!), afterTab: nil, isPrivate: false)
         subject.selectTab(tab1)
 
         XCTAssertNotNil(tab1.webView)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -373,8 +373,7 @@ final class TabManagerTests: TabManagerTestsBase {
         _ = subject.addTab(URLRequest(url: URL(string: "https://firefox.com")!), afterTab: nil, isPrivate: false)
         subject.selectTab(tab1)
 
-        subject.offloadBackgroundWebViews()
-        try await Task.sleep(nanoseconds: sleepTime)
+        await subject.offloadBackgroundWebViews()
 
         XCTAssertEqual(subject.tabs.count, 3)
     }
@@ -389,8 +388,7 @@ final class TabManagerTests: TabManagerTestsBase {
         subject.selectTab(tab3)
         subject.selectTab(tab1)
 
-        subject.offloadBackgroundWebViews()
-        try await Task.sleep(nanoseconds: sleepTime)
+        await subject.offloadBackgroundWebViews()
 
         XCTAssertNil(tab2.webView)
         XCTAssertNil(tab3.webView)
@@ -405,8 +403,7 @@ final class TabManagerTests: TabManagerTestsBase {
 
         XCTAssertNotNil(tab1.webView)
 
-        subject.offloadBackgroundWebViews()
-        try await Task.sleep(nanoseconds: sleepTime)
+        await subject.offloadBackgroundWebViews()
 
         XCTAssertNotNil(tab1.webView, "The selected tab's WebView should not be offloaded")
     }
@@ -420,8 +417,7 @@ final class TabManagerTests: TabManagerTestsBase {
         XCTAssertNil(tabs[1].webView)
         XCTAssertNil(tabs[2].webView)
 
-        subject.offloadBackgroundWebViews()
-        try await Task.sleep(nanoseconds: sleepTime)
+        await subject.offloadBackgroundWebViews()
 
         XCTAssertNil(tabs[1].webView)
         XCTAssertNil(tabs[2].webView)
@@ -429,9 +425,9 @@ final class TabManagerTests: TabManagerTestsBase {
     }
 
     @MainActor
-    func testOffloadBackgroundWebViews_emptyTabList_doesNotCrash() {
+    func testOffloadBackgroundWebViews_emptyTabList_doesNotCrash() async {
         let subject = createSubject()
-        subject.offloadBackgroundWebViews()
+        await subject.offloadBackgroundWebViews()
         XCTAssertEqual(subject.tabs.count, 0)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -385,10 +385,9 @@ final class TabManagerTests: TabManagerTestsBase {
         let tab1 = subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
         let tab2 = subject.addTab(URLRequest(url: URL(string: "https://example.com")!), afterTab: nil, isPrivate: false)
         let tab3 = subject.addTab(URLRequest(url: URL(string: "https://firefox.com")!), afterTab: nil, isPrivate: false)
+        subject.selectTab(tab2)
+        subject.selectTab(tab3)
         subject.selectTab(tab1)
-
-        XCTAssertNotNil(tab2.webView)
-        XCTAssertNotNil(tab3.webView)
 
         subject.offloadBackgroundWebViews()
         try await Task.sleep(nanoseconds: sleepTime)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -362,4 +362,77 @@ final class TabManagerTests: TabManagerTestsBase {
             "Should choose the second private tab as the nearest neighbour on the right"
         )
     }
+
+    // MARK: - Offload Background WebViews
+
+    @MainActor
+    func testOffloadBackgroundWebViews_tabCountUnchanged() async throws {
+        let subject = createSubject()
+        let tab1 = subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
+        subject.addTab(URLRequest(url: URL(string: "https://example.com")!), afterTab: nil, isPrivate: false)
+        subject.addTab(URLRequest(url: URL(string: "https://firefox.com")!), afterTab: nil, isPrivate: false)
+        subject.selectTab(tab1)
+
+        subject.offloadBackgroundWebViews()
+        try await Task.sleep(nanoseconds: sleepTime)
+
+        XCTAssertEqual(subject.tabs.count, 3)
+    }
+
+    @MainActor
+    func testOffloadBackgroundWebViews_backgroundTabWebViewsAreNil() async throws {
+        let subject = createSubject()
+        let tab1 = subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
+        let tab2 = subject.addTab(URLRequest(url: URL(string: "https://example.com")!), afterTab: nil, isPrivate: false)
+        let tab3 = subject.addTab(URLRequest(url: URL(string: "https://firefox.com")!), afterTab: nil, isPrivate: false)
+        subject.selectTab(tab1)
+
+        XCTAssertNotNil(tab2.webView)
+        XCTAssertNotNil(tab3.webView)
+
+        subject.offloadBackgroundWebViews()
+        try await Task.sleep(nanoseconds: sleepTime)
+
+        XCTAssertNil(tab2.webView)
+        XCTAssertNil(tab3.webView)
+    }
+
+    @MainActor
+    func testOffloadBackgroundWebViews_selectedTabWebViewPreserved() async throws {
+        let subject = createSubject()
+        let tab1 = subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
+        subject.addTab(URLRequest(url: URL(string: "https://example.com")!), afterTab: nil, isPrivate: false)
+        subject.selectTab(tab1)
+
+        XCTAssertNotNil(tab1.webView)
+
+        subject.offloadBackgroundWebViews()
+        try await Task.sleep(nanoseconds: sleepTime)
+
+        XCTAssertNotNil(tab1.webView, "The selected tab's WebView should not be offloaded")
+    }
+
+    @MainActor
+    func testOffloadBackgroundWebViews_zombieTabsUnaffected() async throws {
+        let tabs = generateTabs(count: 3)
+        let subject = createSubject(tabs: tabs)
+        subject.selectTab(tabs[0])
+
+        XCTAssertNil(tabs[1].webView)
+        XCTAssertNil(tabs[2].webView)
+
+        subject.offloadBackgroundWebViews()
+        try await Task.sleep(nanoseconds: sleepTime)
+
+        XCTAssertNil(tabs[1].webView)
+        XCTAssertNil(tabs[2].webView)
+        XCTAssertEqual(subject.tabs.count, 3)
+    }
+
+    @MainActor
+    func testOffloadBackgroundWebViews_emptyTabList_doesNotCrash() {
+        let subject = createSubject()
+        subject.offloadBackgroundWebViews()
+        XCTAssertEqual(subject.tabs.count, 0)
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15671)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33562)

## :bulb: Description
Firefox iOS has no response to OS memory warnings, causing `WatchdogTermination` crashes for users with large tab counts. This PR attempts at reacting to one possible cause of the terminations.
- On `applicationDidReceiveMemoryWarning`, we'll now offload the `WebViews` of all background tabs, returning them to zombie state. 
- The selected tab is untouched. 
- Offloaded tabs reload from their URL when revisited, identical to session restore. 
- A debug menu option is added to trigger this manually for testing.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code