### PR TITLE
Add [World Cup] FXIOS-15667 Feature flag check to HomepageSectionLayoutProvider for WorldCup Section

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -9,7 +9,7 @@ import UIKit
 
 /// Holds section layout logic for the new homepage as part of the rebuild project
 @MainActor
-final class HomepageSectionLayoutProvider {
+final class HomepageSectionLayoutProvider: FeatureFlaggable {
     struct UX {
         static let topSpacing: CGFloat = 40
         static let standardInset: CGFloat = 16
@@ -844,7 +844,8 @@ final class HomepageSectionLayoutProvider {
     /// Returns the estimated height of the World Cup section when it is visible, or 0 when hidden.
     private func getWorldcupSectionHeight(environment: NSCollectionLayoutEnvironment) -> CGFloat {
         guard let state = store.state.componentState(HomepageState.self, for: .homepage, window: windowUUID),
-              state.worldcupState.shouldShowSection else { return 0 }
+              state.worldcupState.shouldShowSection,
+              featureFlagsProvider.isEnabled(.worldCupWidget) else { return 0 }
 
         let containerWidth = normalizedDimension(environment.container.contentSize.width)
         let cell = WorldCupTimerCell()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15667)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33533)

## :bulb: Description
Add Feature flag check to `HomepageSectionLayoutProvider` for WorldCup section 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

