### PR TITLE
Refactor [No-TICKET] Rename addNewTabIfPrivate to improve readability

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -437,7 +437,7 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
                                               actionType: TabTrayActionType.dismissTabTray)
             store.dispatch(dismissAction)
 
-            addNewTabIfPrivate(uuid: uuid)
+            addNewNormalTabIfSelectedIsPrivate(uuid: uuid)
         }
     }
 
@@ -477,10 +477,7 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
         triggerRefresh(uuid: uuid, isPrivate: tabsState.isPrivateMode)
 
         if !tabsState.isPrivateMode {
-            addNewTabIfPrivate(uuid: uuid)
-        }
-
-        if !tabsState.isPrivateMode {
+            addNewNormalTabIfSelectedIsPrivate(uuid: uuid)
             let dismissAction = TabTrayAction(windowUUID: uuid,
                                               actionType: TabTrayActionType.dismissTabTray)
             store.dispatch(dismissAction)
@@ -500,8 +497,8 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
         store.dispatch(refreshAction)
     }
 
-    /// Add a new tab when privateMode is selected and all or last normal tabs/tab are/is going to be closed
-    private func addNewTabIfPrivate(uuid: WindowUUID) {
+    /// Add a new tab normal when privateMode is selected and all or last normal tabs/tab are/is going to be closed
+    private func addNewNormalTabIfSelectedIsPrivate(uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         if let selectedTab = tabManager.selectedTab, selectedTab.isPrivate {
             tabManager.addTab(nil, isPrivate: false)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -497,7 +497,9 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
         store.dispatch(refreshAction)
     }
 
-    /// Add a new tab normal when privateMode is selected and all or last normal tabs/tab are/is going to be closed
+    /// Adds a new non-private tab if the currently selected tab is private.
+    /// Used to ensure a normal tab exists when exiting or exhausting private tabs.
+    /// - Parameter uuid: The window identifier.
     private func addNewNormalTabIfSelectedIsPrivate(uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         if let selectedTab = tabManager.selectedTab, selectedTab.isPrivate {


### PR DESCRIPTION
## :scroll: Tickets
[NO-TICKET](https://mozilla-hub.atlassian.net/browse/FXIOS-NOTICKET)

## :bulb: Description
- Merge the consecutive if `!tabsState.isPrivateMode` conditions and rename plus update comment, name and comment were misleading.
- Previously `addNewTabIfPrivate` now renamed to `addNewNormalTabIfSelectedIsPrivate` now clearly indicates that it creates a new regular tab only if the selected tab is private


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

