### PR TITLE
Add FXIOS-15407 [Newsfeed Categories] Pin news section header when scrolling homepage

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/UIColorExtensions.swift
+++ b/BrowserKit/Sources/Common/Extensions/UIColorExtensions.swift
@@ -64,4 +64,15 @@ extension UIColor {
             with: UITraitCollection(userInterfaceStyle: .dark)
         )
     }
+
+    /// Dynamic text color that resolves to primary text color for the current interface style.
+    /// Use this when text needs to transition with UIKit's adaptive color resolution, such as labels in pinned
+    /// headers moving over system material or changing backdrop content.
+    public static let adaptiveTextPrimary = UIColor { traitCollection in
+        if traitCollection.userInterfaceStyle == .dark {
+            return DarkTheme().colors.textPrimary
+        } else {
+            return LightTheme().colors.textPrimary
+        }
+    }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/ChipButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/ChipButton.swift
@@ -33,7 +33,6 @@ public final class ChipButton: UIButton, ThemeApplicable {
         configuration?.background.backgroundColorTransformer = nil
         configuration?.titleLineBreakMode = .byTruncatingTail
         layer.masksToBounds = false
-        titleTextLayer.contentsScale = UIScreen.main.scale
         titleTextLayer.alignmentMode = .center
         titleTextLayer.truncationMode = .end
         titleTextLayer.actions = [
@@ -121,6 +120,13 @@ public final class ChipButton: UIButton, ThemeApplicable {
             accessibilityTraits = [.button, .selected]
         } else {
             accessibilityTraits = [.button]
+        }
+    }
+
+    override public func didMoveToWindow() {
+        super.didMoveToWindow()
+        if viewModel?.titleRendering == .coreAnimationLayer {
+            titleTextLayer.contentsScale = window?.windowScene?.screen.scale ?? 1
         }
     }
 

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/ChipButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/ChipButton.swift
@@ -21,6 +21,10 @@ public final class ChipButton: UIButton, ThemeApplicable {
     private var disabledBackgroundColor: UIColor = .clear
     private var disabledForegroundColor: UIColor = .clear
 
+    // Some pinned collection view headers use a system backdrop that can be visually disturbed
+    // by UIKit text in scrolling chips, so this mode draws title text in a layer.
+    private let titleTextLayer = CATextLayer()
+
     override public init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -29,6 +33,15 @@ public final class ChipButton: UIButton, ThemeApplicable {
         configuration?.background.backgroundColorTransformer = nil
         configuration?.titleLineBreakMode = .byTruncatingTail
         layer.masksToBounds = false
+        titleTextLayer.contentsScale = UIScreen.main.scale
+        titleTextLayer.alignmentMode = .center
+        titleTextLayer.truncationMode = .end
+        titleTextLayer.actions = [
+            "bounds": NSNull(),
+            "position": NSNull(),
+            "contents": NSNull()
+        ]
+        layer.addSublayer(titleTextLayer)
 
         addTarget(self, action: #selector(tapped), for: .touchUpInside)
     }
@@ -38,7 +51,7 @@ public final class ChipButton: UIButton, ThemeApplicable {
     }
 
     override public var intrinsicContentSize: CGSize {
-        guard let title = configuration?.title, !title.isEmpty else {
+        guard let title = viewModel?.title, !title.isEmpty else {
             return super.intrinsicContentSize
         }
 
@@ -60,6 +73,9 @@ public final class ChipButton: UIButton, ThemeApplicable {
     override public func layoutSubviews() {
         super.layoutSubviews()
         layer.shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: bounds.height / 2).cgPath
+        performWithoutLayerAnimation {
+            titleTextLayer.frame = bounds.insetBy(dx: UX.horizontalInset, dy: UX.verticalInset)
+        }
     }
 
     override public func updateConfiguration() {
@@ -67,25 +83,33 @@ public final class ChipButton: UIButton, ThemeApplicable {
 
         let foregroundColor: UIColor
         let backgroundColor: UIColor
+        let font: UIFont
 
         if !isEnabled {
             foregroundColor = disabledForegroundColor
             backgroundColor = disabledBackgroundColor
+            font = FXFontStyles.Regular.body.scaledFont()
         } else if isSelected {
             foregroundColor = selectedForegroundColor
             backgroundColor = selectedBackgroundColor
+            font = FXFontStyles.Bold.body.scaledFont()
         } else {
             foregroundColor = normalForegroundColor
             backgroundColor = normalBackgroundColor
+            font = FXFontStyles.Regular.body.scaledFont()
         }
 
-        updatedConfiguration.baseForegroundColor = foregroundColor
         updatedConfiguration.background.backgroundColor = backgroundColor
-        updatedConfiguration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
-            var outgoing = incoming
-            outgoing.font = self.isSelected ? FXFontStyles.Bold.body.scaledFont() : FXFontStyles.Regular.body.scaledFont()
-            outgoing.foregroundColor = foregroundColor
-            return outgoing
+        if viewModel?.titleRendering == .coreAnimationLayer {
+            updateTitleTextLayer(font: font, foregroundColor: foregroundColor)
+        } else {
+            updatedConfiguration.baseForegroundColor = foregroundColor
+            updatedConfiguration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+                var outgoing = incoming
+                outgoing.font = font
+                outgoing.foregroundColor = foregroundColor
+                return outgoing
+            }
         }
 
         configuration = updatedConfiguration
@@ -106,7 +130,13 @@ public final class ChipButton: UIButton, ThemeApplicable {
         isSelected = viewModel.isSelected
 
         guard var updatedConfiguration = configuration else { return }
-        updatedConfiguration.title = viewModel.title
+        if viewModel.titleRendering == .coreAnimationLayer {
+            accessibilityLabel = viewModel.title
+            titleTextLayer.isHidden = false
+        } else {
+            titleTextLayer.isHidden = true
+            updatedConfiguration.title = viewModel.title
+        }
         updatedConfiguration.contentInsets = NSDirectionalEdgeInsets(
             top: UX.verticalInset,
             leading: UX.horizontalInset,
@@ -125,6 +155,30 @@ public final class ChipButton: UIButton, ThemeApplicable {
         disabledForegroundColor = theme.colors.textDisabled
         applyShadow(FxShadow.shadow200, theme: theme)
         setNeedsUpdateConfiguration()
+    }
+
+    private func updateTitleTextLayer(font: UIFont, foregroundColor: UIColor) {
+        guard let title = viewModel?.title else {
+            titleTextLayer.string = nil
+            return
+        }
+
+        titleTextLayer.string = NSAttributedString(
+            string: title,
+            attributes: [
+                .font: font,
+                .foregroundColor: foregroundColor
+            ]
+        )
+    }
+
+    /// CATextLayer updates implicitly animate by default; disable actions so dynamic type
+    /// changes update the chip title immediately like UIKit button titles.
+    private func performWithoutLayerAnimation(_ updates: () -> Void) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        updates()
+        CATransaction.commit()
     }
 
     @objc

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/ChipButtonViewModel.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/ChipButtonViewModel.swift
@@ -5,21 +5,31 @@
 import Foundation
 import UIKit
 
+/// Controls how chip titles are rendered. Prefer `.configuration` unless text
+/// visually disturbs system-provided backdrops, such as in pinned collection view headers.
+public enum ChipButtonTitleRendering {
+    case configuration
+    case coreAnimationLayer
+}
+
 public struct ChipButtonViewModel {
     public let title: String
     public let a11yIdentifier: String?
     public let isSelected: Bool
+    public let titleRendering: ChipButtonTitleRendering
     public var tappedAction: (@MainActor (UIButton) -> Void)?
 
     public init(
         title: String,
         a11yIdentifier: String,
         isSelected: Bool,
+        titleRendering: ChipButtonTitleRendering = .configuration,
         touchUpAction: (@MainActor (UIButton) -> Void)?
     ) {
         self.title = title
         self.a11yIdentifier = a11yIdentifier
         self.isSelected = isSelected
+        self.titleRendering = titleRendering
         self.tappedAction = touchUpAction
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/ChipPickerView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ChipPickerView.swift
@@ -26,6 +26,7 @@ public final class ChipPickerView: UIView, ThemeApplicable, UIScrollViewDelegate
     private var currentTheme: Theme?
     private var items = [ChipPickerItem]()
     private var selectedID: String?
+    private var titleRendering = ChipButtonTitleRendering.configuration
     private var onSelection: (@MainActor (String) -> Void)?
     private var onScroll: ((CGFloat) -> Void)?
 
@@ -42,11 +43,13 @@ public final class ChipPickerView: UIView, ThemeApplicable, UIScrollViewDelegate
         items: [ChipPickerItem],
         selectedID: String?,
         contentOffsetX: CGFloat = 0,
+        titleRendering: ChipButtonTitleRendering = .configuration,
         onScroll: ((CGFloat) -> Void)? = nil,
         onSelection: (@MainActor (String) -> Void)? = nil
     ) {
         self.items = items
         self.selectedID = selectedID
+        self.titleRendering = titleRendering
         self.onSelection = onSelection
         self.onScroll = onScroll
         rebuildButtons()
@@ -101,6 +104,7 @@ public final class ChipPickerView: UIView, ThemeApplicable, UIScrollViewDelegate
                     title: item.title,
                     a11yIdentifier: item.a11yIdentifier,
                     isSelected: item.id == selectedID,
+                    titleRendering: titleRendering,
                     touchUpAction: { [weak self] _ in
                         self?.handleSelection(id: item.id)
                     }

--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -22,6 +22,7 @@ enum FeatureFlagID: String, CaseIterable {
     case hntSponsoredShortcuts
     case homepageBookmarksSectionDefault
     case homepageJumpBackinSectionDefault
+    case homepagePinnedHeader
     case homepageSearchBar
     case homepageStoryCategories
     case hostedSummarizer
@@ -93,6 +94,7 @@ enum FeatureFlagID: String, CaseIterable {
                 .bookmarksSearchFeature,
                 .deeplinkOptimizationRefactor,
                 .downloadLiveActivities,
+                .homepagePinnedHeader,
                 .homepageSearchBar,
                 .homepageStoryCategories,
                 .hostedSummarizer,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -346,10 +346,14 @@ class BrowserViewController: UIViewController,
         return topTabsViewController != nil
     }
 
+    private var isHomepagePinnedHeaderEnabled: Bool {
+        featureFlagsProvider.isEnabled(.homepagePinnedHeader) && featureFlagsProvider.isEnabled(.homepageStoryCategories)
+    }
+
     private var shouldPinContentContainerToScreenTop: Bool {
-        featureFlagsProvider.isEnabled(.homepagePinnedHeader)
-            && contentContainer.hasHomepage
-            && header.arrangedSubviews.isEmpty
+        isHomepagePinnedHeaderEnabled
+        && contentContainer.hasHomepage
+        && header.arrangedSubviews.isEmpty
     }
 
     // MARK: Data management
@@ -1628,8 +1632,17 @@ class BrowserViewController: UIViewController,
     }
 
     func updateContentContainerTopConstraint() {
+        guard isHomepagePinnedHeaderEnabled else {
+            activateLegacyContentContainerTopConstraint()
+            return
+        }
+
         guard isViewLoaded else { return }
 
+        // Rebuild the top constraint and z-order only when the homepage pinning state changes,
+        // or when the constraint has not been created yet. When homepage content has a pinned header,
+        // we move the content to the front so the pinned section header can sit above the other views.
+        // Otherwise, the other views stays in front of the content container.
         if isContentContainerPinnedToScreenTop != shouldPinContentContainerToScreenTop
            || contentContainerTopConstraint == nil {
             isContentContainerPinnedToScreenTop = shouldPinContentContainerToScreenTop
@@ -1648,12 +1661,28 @@ class BrowserViewController: UIViewController,
 
         guard let homepageViewController = contentContainer.contentController as? HomepageViewController else { return }
 
-        // When the homepage is pinned to the screen top, BVC owns the status bar overlay space.
-        // Pass that obstruction to the homepage as scroll inset instead of baking it into section layout.
-        // For example, an empty BVC header with a 54pt status bar overlay gives the homepage a 54pt top inset;
-        // when BVC has header content, the homepage starts below the header and this inset is 0.
+        // When the homepage is pinned to the top of the screen, BVC needs to account for
+        // the status bar overlay height (safe area insets).
+        // Otherwise, the homepage remains pinned to header.bottomAnchor and no extra inset is needed.
         let homepageTopContentInset = shouldPinContentContainerToScreenTop ? statusBarOverlay.frame.height : 0
         homepageViewController.updateTopContentInset(homepageTopContentInset)
+    }
+
+    /// Keeps the original content container top constraint in place when homepage pinned header is disabled,
+    /// pinning the content container top to the header bottom.
+    private func activateLegacyContentContainerTopConstraint() {
+        let hasActiveLegacyConstraint = isContentContainerPinnedToScreenTop == false
+            && contentContainerTopConstraint?.isActive == true
+        guard !hasActiveLegacyConstraint else { return }
+
+        contentContainerTopConstraint?.isActive = false
+        contentContainerTopConstraint = contentContainer.topAnchor.constraint(equalTo: header.bottomAnchor)
+        isContentContainerPinnedToScreenTop = false
+
+        guard contentContainer.superview != nil,
+              header.superview != nil else { return }
+
+        contentContainerTopConstraint?.isActive = true
     }
 
     // MARK: - Snapkit related

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1552,31 +1552,6 @@ class BrowserViewController: UIViewController,
 
     // MARK: - Constraints
 
-    func updateContentContainerTopConstraint() {
-        let shouldPinContentContainerToScreenTop = contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
-        let pinToScreenTop = shouldPinContentContainerToScreenTop
-        contentContainerTopConstraint?.isActive = false
-        contentContainerTopConstraint = contentContainer.topAnchor.constraint(
-            equalTo: pinToScreenTop ? view.topAnchor : header.bottomAnchor
-        )
-        contentContainerTopConstraint?.isActive = true
-
-        let frontViews = pinToScreenTop
-            ? [contentContainer, bottomContentStackView, bottomContainer, overKeyboardContainer]
-            : [topBlurView, bottomBlurView, topTouchArea, statusBarOverlay, header,
-               bottomContentStackView, bottomContainer, overKeyboardContainer]
-        frontViews.filter { $0.superview === view }.forEach(view.bringSubviewToFront)
-
-        guard let homepageViewController = contentContainer.contentController as? HomepageViewController else { return }
-
-        // When the homepage is pinned to the screen top, BVC owns the status bar overlay space.
-        // Pass that obstruction to the homepage as scroll inset instead of baking it into section layout.
-        // For example, an empty BVC header with a 54pt status bar overlay gives the homepage a 54pt top inset;
-        // when BVC has header content, the homepage starts below the header and this inset is 0.
-        let homepageTopContentInset = shouldPinContentContainerToScreenTop ? statusBarOverlay.frame.height : 0
-        homepageViewController.updateTopContentInset(homepageTopContentInset)
-    }
-
     private func setupConstraints() {
         updateContentContainerTopConstraint()
 
@@ -1647,6 +1622,33 @@ class BrowserViewController: UIViewController,
             backgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             backgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+    }
+
+    func updateContentContainerTopConstraint() {
+        guard isViewLoaded else { return }
+
+        let shouldPinContentContainerToScreenTop = contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
+        let pinToScreenTop = shouldPinContentContainerToScreenTop
+        contentContainerTopConstraint?.isActive = false
+        contentContainerTopConstraint = contentContainer.topAnchor.constraint(
+            equalTo: pinToScreenTop ? view.topAnchor : header.bottomAnchor
+        )
+        contentContainerTopConstraint?.isActive = true
+
+        let frontViews = pinToScreenTop
+            ? [contentContainer, bottomContentStackView, bottomContainer, overKeyboardContainer]
+            : [topBlurView, bottomBlurView, topTouchArea, statusBarOverlay, header,
+               bottomContentStackView, bottomContainer, overKeyboardContainer]
+        frontViews.filter { $0.superview === view }.forEach(view.bringSubviewToFront)
+
+        guard let homepageViewController = contentContainer.contentController as? HomepageViewController else { return }
+
+        // When the homepage is pinned to the screen top, BVC owns the status bar overlay space.
+        // Pass that obstruction to the homepage as scroll inset instead of baking it into section layout.
+        // For example, an empty BVC header with a 54pt status bar overlay gives the homepage a 54pt top inset;
+        // when BVC has header content, the homepage starts below the header and this inset is 0.
+        let homepageTopContentInset = shouldPinContentContainerToScreenTop ? statusBarOverlay.frame.height : 0
+        homepageViewController.updateTopContentInset(homepageTopContentInset)
     }
 
     // MARK: - Snapkit related

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1633,7 +1633,7 @@ class BrowserViewController: UIViewController,
 
     func updateContentContainerTopConstraint() {
         guard isHomepagePinnedHeaderEnabled else {
-            activateLegacyContentContainerTopConstraint()
+            activateDefaultContentContainerTopConstraint()
             return
         }
 
@@ -1670,7 +1670,7 @@ class BrowserViewController: UIViewController,
 
     /// Keeps the original content container top constraint in place when homepage pinned header is disabled,
     /// pinning the content container top to the header bottom.
-    private func activateLegacyContentContainerTopConstraint() {
+    private func activateDefaultContentContainerTopConstraint() {
         let hasActiveLegacyConstraint = isContentContainerPinnedToScreenTop == false
             && contentContainerTopConstraint?.isActive == true
         guard !hasActiveLegacyConstraint else { return }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -347,7 +347,9 @@ class BrowserViewController: UIViewController,
     }
 
     private var shouldPinContentContainerToScreenTop: Bool {
-        contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
+        featureFlagsProvider.isEnabled(.homepagePinnedHeader)
+            && contentContainer.hasHomepage
+            && header.arrangedSubviews.isEmpty
     }
 
     // MARK: Data management

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3248,12 +3248,17 @@ class BrowserViewController: UIViewController,
     private func getAvailableHomepageWallpaperHeight(availableContentHeight: CGFloat) -> CGFloat {
         guard let window = view.window else {
             // Fallback before window attachment, this gets corrected on the next layout/state update.
-            return availableContentHeight + contentContainer.frame.origin.y
+            let topOffset = shouldPinContentContainerToScreenTop
+                ? statusBarOverlay.frame.height
+                : contentContainer.frame.origin.y
+            return availableContentHeight + topOffset
         }
 
-        // Homepage pins wallpaper to window top, so include the content container's window Y offset.
-        let contentTopOffset = contentContainer.convert(CGPoint.zero, to: window).y
-        return availableContentHeight + contentTopOffset
+        // Homepage pins wallpaper to window top, so add back the top space excluded from content height.
+        let topOffset = shouldPinContentContainerToScreenTop
+            ? statusBarOverlay.frame.height
+            : contentContainer.convert(CGPoint.zero, to: window).y
+        return availableContentHeight + topOffset
     }
 
     func showTabTray(withFocusOnUnselectedTab tabToFocus: Tab? = nil,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1571,6 +1571,8 @@ class BrowserViewController: UIViewController,
 
         // When the homepage is pinned to the screen top, BVC owns the status bar overlay space.
         // Pass that obstruction to the homepage as scroll inset instead of baking it into section layout.
+        // For example, an empty BVC header with a 54pt status bar overlay gives the homepage a 54pt top inset;
+        // when BVC has header content, the homepage starts below the header and this inset is 0.
         let homepageTopContentInset = shouldPinContentContainerToScreenTop ? statusBarOverlay.frame.height : 0
         homepageViewController.updateTopContentInset(homepageTopContentInset)
     }
@@ -3195,6 +3197,8 @@ class BrowserViewController: UIViewController,
 
         // Keep this in sync with the top inset passed to HomepageViewController so spacer layout
         // and scroll-view geometry describe the same visible viewport.
+        // Example: if the visible viewport is 800pt high and BVC contributes a 54pt overlay inset,
+        // spacer calculations should use 746pt of usable homepage content height.
         let shouldPinContentContainerToScreenTop = contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
         let homepageTopContentInset = shouldPinContentContainerToScreenTop ? statusBarOverlay.frame.height : 0
         let availableContentHeight = getAvailableHomepageContentHeight(topContentInset: homepageTopContentInset)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -155,11 +155,12 @@ class BrowserViewController: UIViewController,
     }
 
     // Constraints used to show/hide toolbars
-    private var contentContainerTopConstraint: NSLayoutConstraint?
     var headerTopConstraint: ConstraintReference?
     var overKeyboardContainerConstraint: ConstraintReference?
     var bottomContainerConstraint: ConstraintReference?
     var topTouchAreaHeightConstraint: NSLayoutConstraint?
+    private var contentContainerTopConstraint: NSLayoutConstraint?
+    private var isContentContainerPinnedToScreenTop: Bool?
 
     // Overlay dimming view for private mode
     private lazy var privateModeDimmingView: UIView = .build { view in
@@ -743,7 +744,6 @@ class BrowserViewController: UIViewController,
             topTabsViewController?.removeFromParent()
             topTabsViewController = nil
         }
-        updateContentContainerTopConstraint()
     }
 
     func dismissVisibleMenus() {
@@ -1077,7 +1077,6 @@ class BrowserViewController: UIViewController,
         header.addArrangedViewToTop(topTabsViewController.view)
         topTabsViewController.didMove(toParent: self)
         self.topTabsViewController = topTabsViewController
-        updateContentContainerTopConstraint()
     }
 
     private func setupAccessibleActions() {
@@ -1553,8 +1552,6 @@ class BrowserViewController: UIViewController,
     // MARK: - Constraints
 
     private func setupConstraints() {
-        updateContentContainerTopConstraint()
-
         NSLayoutConstraint.activate([
             contentContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -1627,19 +1624,22 @@ class BrowserViewController: UIViewController,
     func updateContentContainerTopConstraint() {
         guard isViewLoaded else { return }
 
-        let shouldPinContentContainerToScreenTop = contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
-        let pinToScreenTop = shouldPinContentContainerToScreenTop
-        contentContainerTopConstraint?.isActive = false
-        contentContainerTopConstraint = contentContainer.topAnchor.constraint(
-            equalTo: pinToScreenTop ? view.topAnchor : header.bottomAnchor
-        )
-        contentContainerTopConstraint?.isActive = true
+        let shouldPinToScreenTop = contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
 
-        let frontViews = pinToScreenTop
-            ? [contentContainer, bottomContentStackView, bottomContainer, overKeyboardContainer]
-            : [topBlurView, bottomBlurView, topTouchArea, statusBarOverlay, header,
-               bottomContentStackView, bottomContainer, overKeyboardContainer]
-        frontViews.filter { $0.superview === view }.forEach(view.bringSubviewToFront)
+        if isContentContainerPinnedToScreenTop != shouldPinToScreenTop || contentContainerTopConstraint == nil {
+            isContentContainerPinnedToScreenTop = shouldPinToScreenTop
+            contentContainerTopConstraint?.isActive = false
+            contentContainerTopConstraint = contentContainer.topAnchor.constraint(
+                equalTo: shouldPinToScreenTop ? view.topAnchor : header.bottomAnchor
+            )
+            contentContainerTopConstraint?.isActive = true
+
+            let frontViews = shouldPinToScreenTop
+                ? [contentContainer, bottomContentStackView, bottomContainer, overKeyboardContainer]
+                : [topBlurView, bottomBlurView, topTouchArea, statusBarOverlay, header,
+                   bottomContentStackView, bottomContainer, overKeyboardContainer]
+            frontViews.filter { $0.superview === view }.forEach(view.bringSubviewToFront)
+        }
 
         guard let homepageViewController = contentContainer.contentController as? HomepageViewController else { return }
 
@@ -1647,7 +1647,7 @@ class BrowserViewController: UIViewController,
         // Pass that obstruction to the homepage as scroll inset instead of baking it into section layout.
         // For example, an empty BVC header with a 54pt status bar overlay gives the homepage a 54pt top inset;
         // when BVC has header content, the homepage starts below the header and this inset is 0.
-        let homepageTopContentInset = shouldPinContentContainerToScreenTop ? statusBarOverlay.frame.height : 0
+        let homepageTopContentInset = shouldPinToScreenTop ? statusBarOverlay.frame.height : 0
         homepageViewController.updateTopContentInset(homepageTopContentInset)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -346,6 +346,10 @@ class BrowserViewController: UIViewController,
         return topTabsViewController != nil
     }
 
+    private var shouldPinContentContainerToScreenTop: Bool {
+        contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
+    }
+
     // MARK: Data management
 
     let profile: Profile
@@ -1624,17 +1628,16 @@ class BrowserViewController: UIViewController,
     func updateContentContainerTopConstraint() {
         guard isViewLoaded else { return }
 
-        let shouldPinToScreenTop = contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
-
-        if isContentContainerPinnedToScreenTop != shouldPinToScreenTop || contentContainerTopConstraint == nil {
-            isContentContainerPinnedToScreenTop = shouldPinToScreenTop
+        if isContentContainerPinnedToScreenTop != shouldPinContentContainerToScreenTop
+           || contentContainerTopConstraint == nil {
+            isContentContainerPinnedToScreenTop = shouldPinContentContainerToScreenTop
             contentContainerTopConstraint?.isActive = false
             contentContainerTopConstraint = contentContainer.topAnchor.constraint(
-                equalTo: shouldPinToScreenTop ? view.topAnchor : header.bottomAnchor
+                equalTo: shouldPinContentContainerToScreenTop ? view.topAnchor : header.bottomAnchor
             )
             contentContainerTopConstraint?.isActive = true
 
-            let frontViews = shouldPinToScreenTop
+            let frontViews = shouldPinContentContainerToScreenTop
                 ? [contentContainer, bottomContentStackView, bottomContainer, overKeyboardContainer]
                 : [topBlurView, bottomBlurView, topTouchArea, statusBarOverlay, header,
                    bottomContentStackView, bottomContainer, overKeyboardContainer]
@@ -1647,7 +1650,7 @@ class BrowserViewController: UIViewController,
         // Pass that obstruction to the homepage as scroll inset instead of baking it into section layout.
         // For example, an empty BVC header with a 54pt status bar overlay gives the homepage a 54pt top inset;
         // when BVC has header content, the homepage starts below the header and this inset is 0.
-        let homepageTopContentInset = shouldPinToScreenTop ? statusBarOverlay.frame.height : 0
+        let homepageTopContentInset = shouldPinContentContainerToScreenTop ? statusBarOverlay.frame.height : 0
         homepageViewController.updateTopContentInset(homepageTopContentInset)
     }
 
@@ -3197,13 +3200,11 @@ class BrowserViewController: UIViewController,
            let homepageState = store.state.componentState(HomepageState.self, for: .homepage, window: windowUUID)
         else { return }
 
-        // Keep this in sync with the top inset passed to HomepageViewController so spacer layout
-        // and scroll-view geometry describe the same visible viewport.
-        // Example: if the visible viewport is 800pt high and BVC contributes a 54pt overlay inset,
+        // Account for the status bar overlay so spacer layout and scroll-view geometry describe
+        // the same visible viewport.
+        // Example: if the visible viewport is 800pt high and BVC contributes a 54pt overlay,
         // spacer calculations should use 746pt of usable homepage content height.
-        let shouldPinContentContainerToScreenTop = contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
-        let homepageTopContentInset = shouldPinContentContainerToScreenTop ? statusBarOverlay.frame.height : 0
-        let availableContentHeight = getAvailableHomepageContentHeight(topContentInset: homepageTopContentInset)
+        let availableContentHeight = getAvailableHomepageContentHeight()
         let availableWallpaperHeight = getAvailableHomepageWallpaperHeight(availableContentHeight: availableContentHeight)
 
         guard homepageState.availableContentHeight != availableContentHeight
@@ -3224,7 +3225,7 @@ class BrowserViewController: UIViewController,
     // This is accomplished by taking BVC's height and subtracting the height of all of it's immediate subviews
     // This is used to keep the homepage layout constant, such that it doesn't shift when the homepage's view size changes
     // eg when the address bar is tapped and the keyboard is presented
-    private func getAvailableHomepageContentHeight(topContentInset: CGFloat) -> CGFloat {
+    private func getAvailableHomepageContentHeight() -> CGFloat {
         // We only have to worry about the bottom address bar when it is part of the homepage layout (can be presented
         // without the keyboard)
         var addressBarHeight = isHomepageSearchBarEnabled ? 0 : overKeyboardContainer.frame.height
@@ -3237,13 +3238,8 @@ class BrowserViewController: UIViewController,
             addressBarHeight -= keyboardSpacerHeight
         }
 
-        let shouldPinContentContainerToScreenTop = contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
-        let topChromeHeight = shouldPinContentContainerToScreenTop ? topContentInset : statusBarOverlay.frame.height
-
         // Subtracts all of BVC's immediate subviews to get the space left to allocate to the homepage.
-        // When the homepage is pinned to the screen top, the status bar overlay is instead represented by
-        // the homepage collection view's top content inset, so use that same inset in the layout height.
-        return view.frame.height - topChromeHeight
+        return view.frame.height - statusBarOverlay.frame.height
                                  - bottomContentStackView.frame.height
                                  - bottomContainer.frame.height
                                  - addressBarHeight

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -155,6 +155,7 @@ class BrowserViewController: UIViewController,
     }
 
     // Constraints used to show/hide toolbars
+    private var contentContainerTopConstraint: NSLayoutConstraint?
     var headerTopConstraint: ConstraintReference?
     var overKeyboardContainerConstraint: ConstraintReference?
     var bottomContainerConstraint: ConstraintReference?
@@ -546,6 +547,7 @@ class BrowserViewController: UIViewController,
             readerModeBar.addToParent(parent: newParent, addToTop: isBottomSearchBar)
         }
 
+        updateContentContainerTopConstraint()
         updateViewConstraints()
         updateHeaderConstraints()
         addressToolbarContainer.updateConstraints()
@@ -741,6 +743,7 @@ class BrowserViewController: UIViewController,
             topTabsViewController?.removeFromParent()
             topTabsViewController = nil
         }
+        updateContentContainerTopConstraint()
     }
 
     func dismissVisibleMenus() {
@@ -1074,6 +1077,7 @@ class BrowserViewController: UIViewController,
         header.addArrangedViewToTop(topTabsViewController.view)
         topTabsViewController.didMove(toParent: self)
         self.topTabsViewController = topTabsViewController
+        updateContentContainerTopConstraint()
     }
 
     private func setupAccessibleActions() {
@@ -1429,6 +1433,7 @@ class BrowserViewController: UIViewController,
         // toolbar translucency needs to be updated
         // This also required for iPad rotation
         addOrUpdateMaskViewIfNeeded()
+        updateContentContainerTopConstraint()
 
         // Update available height for the homepage
         dispatchAvailableContentHeightChangedAction()
@@ -1546,9 +1551,34 @@ class BrowserViewController: UIViewController,
     }
 
     // MARK: - Constraints
+
+    func updateContentContainerTopConstraint() {
+        let shouldPinContentContainerToScreenTop = contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
+        let pinToScreenTop = shouldPinContentContainerToScreenTop
+        contentContainerTopConstraint?.isActive = false
+        contentContainerTopConstraint = contentContainer.topAnchor.constraint(
+            equalTo: pinToScreenTop ? view.topAnchor : header.bottomAnchor
+        )
+        contentContainerTopConstraint?.isActive = true
+
+        let frontViews = pinToScreenTop
+            ? [contentContainer, bottomContentStackView, bottomContainer, overKeyboardContainer]
+            : [topBlurView, bottomBlurView, topTouchArea, statusBarOverlay, header,
+               bottomContentStackView, bottomContainer, overKeyboardContainer]
+        frontViews.filter { $0.superview === view }.forEach(view.bringSubviewToFront)
+
+        guard let homepageViewController = contentContainer.contentController as? HomepageViewController else { return }
+
+        // When the homepage is pinned to the screen top, BVC owns the status bar overlay space.
+        // Pass that obstruction to the homepage as scroll inset instead of baking it into section layout.
+        let homepageTopContentInset = shouldPinContentContainerToScreenTop ? statusBarOverlay.frame.height : 0
+        homepageViewController.updateTopContentInset(homepageTopContentInset)
+    }
+
     private func setupConstraints() {
+        updateContentContainerTopConstraint()
+
         NSLayoutConstraint.activate([
-            contentContainer.topAnchor.constraint(equalTo: header.bottomAnchor),
             contentContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             contentContainer.bottomAnchor.constraint(equalTo: overKeyboardContainer.topAnchor),
@@ -1589,6 +1619,7 @@ class BrowserViewController: UIViewController,
             updateHeaderConstraints()
         }
         setupBlurViews()
+        updateContentContainerTopConstraint()
     }
 
     private func setupBlurViews() {
@@ -1858,6 +1889,7 @@ class BrowserViewController: UIViewController,
     func frontEmbeddedContent(_ viewController: ContentContainable) {
         contentContainer.update(content: viewController)
         statusBarOverlay.resetState(isHomepage: contentContainer.hasHomepage)
+        updateContentContainerTopConstraint()
 
         // Documentation found in https://mozilla-hub.atlassian.net/browse/FXIOS-10952
         // FXIOS-11036 - Investigate improvement to JavaScript alert dequeueing
@@ -1875,6 +1907,7 @@ class BrowserViewController: UIViewController,
         contentContainer.add(content: viewController)
         viewController.didMove(toParent: self)
         statusBarOverlay.resetState(isHomepage: contentContainer.hasHomepage)
+        updateContentContainerTopConstraint()
 
         // To make sure the content views content is extending under the toolbars we disable clip to bounds
         // for the first two layers of views other than a web view
@@ -3160,7 +3193,11 @@ class BrowserViewController: UIViewController,
            let homepageState = store.state.componentState(HomepageState.self, for: .homepage, window: windowUUID)
         else { return }
 
-        let availableContentHeight = getAvailableHomepageContentHeight()
+        // Keep this in sync with the top inset passed to HomepageViewController so spacer layout
+        // and scroll-view geometry describe the same visible viewport.
+        let shouldPinContentContainerToScreenTop = contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
+        let homepageTopContentInset = shouldPinContentContainerToScreenTop ? statusBarOverlay.frame.height : 0
+        let availableContentHeight = getAvailableHomepageContentHeight(topContentInset: homepageTopContentInset)
         let availableWallpaperHeight = getAvailableHomepageWallpaperHeight(availableContentHeight: availableContentHeight)
 
         guard homepageState.availableContentHeight != availableContentHeight
@@ -3181,7 +3218,7 @@ class BrowserViewController: UIViewController,
     // This is accomplished by taking BVC's height and subtracting the height of all of it's immediate subviews
     // This is used to keep the homepage layout constant, such that it doesn't shift when the homepage's view size changes
     // eg when the address bar is tapped and the keyboard is presented
-    private func getAvailableHomepageContentHeight() -> CGFloat {
+    private func getAvailableHomepageContentHeight(topContentInset: CGFloat) -> CGFloat {
         // We only have to worry about the bottom address bar when it is part of the homepage layout (can be presented
         // without the keyboard)
         var addressBarHeight = isHomepageSearchBarEnabled ? 0 : overKeyboardContainer.frame.height
@@ -3194,8 +3231,13 @@ class BrowserViewController: UIViewController,
             addressBarHeight -= keyboardSpacerHeight
         }
 
-        // Subtracts all of BVC's immediate subviews to get the space left to allocate to the homepage
-        return view.frame.height - statusBarOverlay.frame.height
+        let shouldPinContentContainerToScreenTop = contentContainer.hasHomepage && header.arrangedSubviews.isEmpty
+        let topChromeHeight = shouldPinContentContainerToScreenTop ? topContentInset : statusBarOverlay.frame.height
+
+        // Subtracts all of BVC's immediate subviews to get the space left to allocate to the homepage.
+        // When the homepage is pinned to the screen top, the status bar overlay is instead represented by
+        // the homepage collection view's top content inset, so use that same inset in the layout height.
+        return view.frame.height - topChromeHeight
                                  - bottomContentStackView.frame.height
                                  - bottomContainer.frame.height
                                  - addressBarHeight

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -57,6 +57,7 @@ final class HomepageViewController: UIViewController,
     private var didFinishFirstLayout = false
     private var wallpaperTopConstraint: NSLayoutConstraint?
     private var wallpaperHeightConstraint: NSLayoutConstraint?
+    private var collectionViewTopContentInset: CGFloat = 0
 
     private var currentHomepageTabState: HomepageTabState {
         guard let activeTabUUID else { return HomepageTabState() }
@@ -271,6 +272,19 @@ final class HomepageViewController: UIViewController,
     func scrollToTop(animated: Bool = false) {
         if let collectionView = collectionView {
             collectionView.setContentOffset(CGPoint(x: 0, y: -collectionView.adjustedContentInset.top), animated: animated)
+            handleScroll(collectionView, isUserInteraction: false)
+        }
+    }
+
+    func updateTopContentInset(_ topInset: CGFloat) {
+        guard collectionViewTopContentInset != topInset else { return }
+        let previousAdjustedTopInset = collectionView?.adjustedContentInset.top ?? collectionViewTopContentInset
+        collectionViewTopContentInset = topInset
+        updateCollectionViewContentInset()
+        if let collectionView {
+            // Preserve the visible content when BVC chrome changes the collection view's top inset.
+            let adjustedTopInsetDelta = collectionView.adjustedContentInset.top - previousAdjustedTopInset
+            collectionView.contentOffset.y -= adjustedTopInsetDelta
             handleScroll(collectionView, isUserInteraction: false)
         }
     }
@@ -500,17 +514,22 @@ final class HomepageViewController: UIViewController,
         collectionView.backgroundColor = .clear
         collectionView.accessibilityIdentifier = a11y.collectionView
         collectionView.delegate = self
-        // Per design requirement, set spacing on top. We may want to revisit this spacing when implement liquid glass.
+        self.collectionView = collectionView
+        updateCollectionViewContentInset()
+
+        view.addSubview(collectionView)
+    }
+
+    private func updateCollectionViewContentInset() {
+        guard let collectionView else { return }
+
         collectionView.contentInset = UIEdgeInsets(
-            top: HomepageSectionLayoutProvider.UX.topSpacing,
+            top: collectionViewTopContentInset,
             left: 0,
             bottom: 0,
             right: 0
         )
         collectionView.scrollIndicatorInsets = collectionView.contentInset
-        self.collectionView = collectionView
-
-        view.addSubview(collectionView)
     }
 
     private func createLayout() -> UICollectionViewCompositionalLayout {
@@ -532,10 +551,11 @@ final class HomepageViewController: UIViewController,
                 return sectionProvider.makeEmptyLayoutSection()
             }
 
-            return sectionProvider.createLayoutSection(
+            let layoutSection = sectionProvider.createLayoutSection(
                 for: section,
                 with: environment
             )
+            return layoutSection
         }
         return layout
     }
@@ -796,13 +816,14 @@ final class HomepageViewController: UIViewController,
 
     /// Updates the `NewsTransitionHeaderCell`s transition progress
     private func updateNewsTransitionHeaderProgress() {
-        guard let headerView = getNewsTransitionHeader()  else { return }
-
         // We only want the stories header to transition if there is enough empty space on the homepage,
         // which is denoted by the existence of the spacer
         let transitionEnabled = isNewsTransitionEnabled()
+        let transitionProgress = newsTransitionProgress()
+
+        guard let headerView = getNewsTransitionHeader()  else { return }
         headerView.setTransitionEnabled(transitionEnabled)
-        headerView.setTransitionProgress(newsTransitionProgress())
+        headerView.setTransitionProgress(transitionProgress)
     }
 
     /// Returns whether there is enough room at the bottom of the unscrolled homepage for the header to transition.

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -279,12 +279,20 @@ final class HomepageViewController: UIViewController,
     func updateTopContentInset(_ topInset: CGFloat) {
         guard collectionViewTopContentInset != topInset else { return }
         let previousAdjustedTopInset = collectionView?.adjustedContentInset.top ?? collectionViewTopContentInset
+        let wasScrolledToTop = collectionView.map { $0.contentOffset.y <= 0 } ?? true
         collectionViewTopContentInset = topInset
         updateCollectionViewContentInset()
         if let collectionView {
-            // Preserve the visible content when BVC chrome changes the collection view's top inset.
-            let adjustedTopInsetDelta = collectionView.adjustedContentInset.top - previousAdjustedTopInset
-            collectionView.contentOffset.y -= adjustedTopInsetDelta
+            if wasScrolledToTop {
+                // Top of scrollable content is always -topInset, e.g. a 54pt top inset means y = -54.
+                collectionView.contentOffset.y = -collectionView.adjustedContentInset.top
+            } else {
+                // Preserve the visible content when BVC chrome changes the collection view's top inset.
+                // Example: offset 120 + inset 0 shows normalized y = 120. If inset becomes 54,
+                // move offset to 66 so 66 + 54 still shows normalized y = 120.
+                let adjustedTopInsetDelta = collectionView.adjustedContentInset.top - previousAdjustedTopInset
+                collectionView.contentOffset.y -= adjustedTopInsetDelta
+            }
             handleScroll(collectionView, isUserInteraction: false)
         }
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -16,6 +16,7 @@ final class HomepageViewController: UIViewController,
                                     ContentContainable,
                                     Screenshotable,
                                     Themeable,
+                                    FeatureFlaggable,
                                     StoreSubscriber {
     // MARK: - Typealiases
     typealias SubscriberStateType = HomepageState
@@ -277,10 +278,13 @@ final class HomepageViewController: UIViewController,
     }
 
     func updateTopContentInset(_ topInset: CGFloat) {
-        guard collectionViewTopContentInset != topInset else { return }
+        // Pinned header mode lets BVC represent its status bar overlay as homepage content inset.
+        // When disabled, use the legacy zero-inset layout so collection view offsets are not adjusted.
+        let effectiveTopInset = featureFlagsProvider.isEnabled(.homepagePinnedHeader) ? topInset : 0
+        guard collectionViewTopContentInset != effectiveTopInset else { return }
         let previousAdjustedTopInset = collectionView?.adjustedContentInset.top ?? collectionViewTopContentInset
         let wasScrolledToTop = collectionView.map { $0.contentOffset.y <= 0 } ?? true
-        collectionViewTopContentInset = topInset
+        collectionViewTopContentInset = effectiveTopInset
         updateCollectionViewContentInset()
         if let collectionView {
             if wasScrolledToTop {

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -288,19 +288,20 @@ final class HomepageViewController: UIViewController,
         let wasScrolledToTop = collectionView.map { $0.contentOffset.y <= 0 } ?? true
         collectionViewTopContentInset = effectiveTopInset
         updateCollectionViewContentInset()
-        if let collectionView {
-            if wasScrolledToTop {
-                // Top of scrollable content is always -topInset, e.g. a 54pt top inset means y = -54.
-                collectionView.contentOffset.y = -collectionView.adjustedContentInset.top
-            } else {
-                // Preserve the visible content when BVC chrome changes the collection view's top inset.
-                // Example: offset 120 + inset 0 shows normalized y = 120. If inset becomes 54,
-                // move offset to 66 so 66 + 54 still shows normalized y = 120.
-                let adjustedTopInsetDelta = collectionView.adjustedContentInset.top - previousAdjustedTopInset
-                collectionView.contentOffset.y -= adjustedTopInsetDelta
-            }
-            handleScroll(collectionView, isUserInteraction: false)
+
+        guard let collectionView else { return }
+
+        if wasScrolledToTop {
+            // Top of scrollable content is always -topInset, e.g. a 54pt top inset means y = -54.
+            collectionView.contentOffset.y = -collectionView.adjustedContentInset.top
+        } else {
+            // Preserve the visible content when BVC chrome changes the collection view's top inset.
+            // Example: offset 120 + inset 0 shows normalized y = 120. If inset becomes 54,
+            // move offset to 66 so 66 + 54 still shows normalized y = 120.
+            let adjustedTopInsetDelta = collectionView.adjustedContentInset.top - previousAdjustedTopInset
+            collectionView.contentOffset.y -= adjustedTopInsetDelta
         }
+        handleScroll(collectionView, isUserInteraction: false)
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -280,7 +280,9 @@ final class HomepageViewController: UIViewController,
     func updateTopContentInset(_ topInset: CGFloat) {
         // Pinned header mode lets BVC represent its status bar overlay as homepage content inset.
         // When disabled, use the legacy zero-inset layout so collection view offsets are not adjusted.
-        let effectiveTopInset = featureFlagsProvider.isEnabled(.homepagePinnedHeader) ? topInset : 0
+        let shouldPinNewsHeader = featureFlagsProvider.isEnabled(.homepagePinnedHeader)
+                                  && featureFlagsProvider.isEnabled(.homepageStoryCategories)
+        let effectiveTopInset = shouldPinNewsHeader ? topInset : 0
         guard collectionViewTopContentInset != effectiveTopInset else { return }
         let previousAdjustedTopInset = collectionView?.adjustedContentInset.top ?? collectionViewTopContentInset
         let wasScrolledToTop = collectionView.map { $0.contentOffset.y <= 0 } ?? true

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -311,7 +311,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             elementKind: UICollectionView.elementKindSectionHeader,
             alignment: .top
         )
-        header.pinToVisibleBounds = true
+        header.pinToVisibleBounds = featureFlagsProvider.isEnabled(.homepagePinnedHeader)
         section.boundarySupplementaryItems = [header]
 
         section.contentInsets = NSDirectionalEdgeInsets(

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -54,7 +54,8 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             static let minimumCellsPerRow = 1
             static let interItemSpacing: CGFloat = 16
             static let interGroupSpacing: CGFloat = 16
-            static let newsHeaderZIndex = -1
+            static let newsHeaderTopSpacing: CGFloat = 16
+            static let newsHeaderZIndex = 1
 
             /// `storiesPeekOffset` is how much we want the stories (cards only, not including section header/spacing)
             /// to peek in vertically from the bottom of the homepage viewport (above the fold)
@@ -244,8 +245,10 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         let horizontalInset = UX.leadingInset(traitCollection: environment.traitCollection)
 
+        // The normal homepage top spacing belongs to the logo header section, not the collection view inset.
+        // status bar overlay space is handled separately as a scroll inset by the homepage.
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
+            top: UX.topSpacing,
             leading: horizontalInset,
             bottom: UX.spacingBetweenSections,
             trailing: horizontalInset)
@@ -299,16 +302,15 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         let headerFooterSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
-            heightDimension: .absolute(getHeaderHeight(sectionHeaderConfiguration: sectionHeaderConfiguration,
-                                                       environment: environment)
-            )
+            heightDimension: .absolute(getStoriesHeaderHeight(sectionHeaderConfiguration: sectionHeaderConfiguration,
+                                                              environment: environment))
         )
         let header = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerFooterSize,
             elementKind: UICollectionView.elementKindSectionHeader,
             alignment: .top
         )
-        header.zIndex = UX.PocketConstants.newsHeaderZIndex
+        header.pinToVisibleBounds = true
         section.boundarySupplementaryItems = [header]
 
         section.contentInsets = NSDirectionalEdgeInsets(
@@ -524,8 +526,8 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         let rawSpacerHeight = getRawSpacerHeight(environment: environment)
 
         let merinoHeaderConfiguration = MerinoState.Constants.sectionHeaderConfiguration
-        let headerHeight = getHeaderHeight(sectionHeaderConfiguration: merinoHeaderConfiguration,
-                                           environment: environment)
+        let headerHeight = getStoriesHeaderHeight(sectionHeaderConfiguration: merinoHeaderConfiguration,
+                                                  environment: environment)
 
         // Dimensions of <= 0.0 cause runtime warnings, so use a minimum height of 0.1
         var spacerHeight = max(0.1, rawSpacerHeight)
@@ -581,6 +583,8 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         let headerLogoCell = HomepageHeaderCell()
         headerLogoCell.configure(headerState: state.headerState)
+        // Match createHeaderSectionLayout so spacer calculations include the logo header's top spacing.
+        totalHeight += UX.topSpacing
         totalHeight += HomepageDimensionCalculator.fittingHeight(for: headerLogoCell, width: containerWidth)
         totalHeight += UX.spacingBetweenSections
         return totalHeight
@@ -813,6 +817,15 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
     }
 
     /// Creates a "dummy" header and returns its height
+    private func getStoriesHeaderHeight(
+        sectionHeaderConfiguration: SectionHeaderConfiguration,
+        environment: NSCollectionLayoutEnvironment
+    ) -> CGFloat {
+        return getHeaderHeight(sectionHeaderConfiguration: sectionHeaderConfiguration, environment: environment)
+            + UX.PocketConstants.newsHeaderTopSpacing
+    }
+
+    /// Creates a "dummy" header and returns its height
     private func getHeaderHeight(
         sectionHeaderConfiguration: SectionHeaderConfiguration,
         environment: NSCollectionLayoutEnvironment
@@ -875,7 +888,6 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         let searchBarHeight = getSearchBarSectionHeight(environment: environment)
 
         return height
-            - UX.topSpacing
             - headerLogoHeight
             - privacyNoticeHeight
             - topSitesHeight

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -311,7 +311,10 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             elementKind: UICollectionView.elementKindSectionHeader,
             alignment: .top
         )
-        header.pinToVisibleBounds = featureFlagsProvider.isEnabled(.homepagePinnedHeader)
+
+        let shouldPinNewsHeader = featureFlagsProvider.isEnabled(.homepagePinnedHeader)
+                                  && featureFlagsProvider.isEnabled(.homepageStoryCategories)
+        header.pinToVisibleBounds = shouldPinNewsHeader
         section.boundarySupplementaryItems = [header]
 
         section.contentInsets = NSDirectionalEdgeInsets(

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -247,6 +247,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         // The normal homepage top spacing belongs to the logo header section, not the collection view inset.
         // status bar overlay space is handled separately as a scroll inset by the homepage.
+        // Example: 40pt logo spacing stays in this section; a 54pt status bar overlay stays in scroll insets.
         section.contentInsets = NSDirectionalEdgeInsets(
             top: UX.topSpacing,
             leading: horizontalInset,

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/LabelButtonHeaderView.swift
@@ -146,7 +146,7 @@ class LabelButtonHeaderView: UIView, ThemeApplicable, Notifiable {
 
     // MARK: - ThemeApplicable
     func applyTheme(theme: Theme) {
-        titleLabel.textColor = theme.colors.textPrimary
+        titleLabel.textColor = .adaptiveTextPrimary
         moreButton.foregroundColorNormal = theme.colors.textAccent
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
@@ -15,6 +15,8 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         static let transitionDistance: CGFloat = 96
         /// Overall header transition progress where the picker starts moving; 0.2 means 20% into the transition.
         static let pickerTranslationStartProgress: CGFloat = 0.2
+        static let transitioningZPosition: CGFloat = -1
+        static let pinnedZPosition: CGFloat = 1
     }
 
     private lazy var newsAffordanceHeaderView: NewsAffordanceHeaderView = .build()
@@ -171,6 +173,8 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
     }
 
     private func updateViewState() {
+        layer.zPosition = transitionEnabled && progress < 1 ? UX.transitioningZPosition : UX.pinnedZPosition
+
         // Transitioning header + category picker
         if transitionEnabled {
             newsAffordanceHeaderView.alpha = 1 - progress

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/StoryCategoryPickerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/StoryCategoryPickerView.swift
@@ -39,6 +39,7 @@ final class StoryCategoryPickerView: UIView, ThemeApplicable {
             items: items,
             selectedID: selectedPickerID,
             contentOffsetX: newsfeedCategoryPickerOffsetX ?? 0,
+            titleRendering: .coreAnimationLayer,
             onScroll: onScroll,
             onSelection: { selectedID in
                 onSelection?(selectedID == Self.allCategoryID ? nil : selectedID)

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -95,6 +95,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .homepagePinnedHeader,
+                titleText: format(string: "Homepage Pinned Header"),
+                statusText: format(string: "Toggle to enable the pinned homepage newsfeed header")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .homepageSearchBar,
                 titleText: format(string: "Homepage Search Bar"),
                 statusText: format(string: "Toggle to enable homepage search bar for redesign")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -66,6 +66,9 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .homepageJumpBackinSectionDefault:
             return checkHomepageJumpBackInSectionDefault()
 
+        case .homepagePinnedHeader:
+            return checkHomepagePinnedHeaderFeature()
+
         case .homepageSearchBar:
             return checkHomepageSearchBarFeature()
 
@@ -215,6 +218,10 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
 
     private func checkHomepageJumpBackInSectionDefault() -> Bool {
         return nimbus.features.homepageRedesignFeature.value().jbiSectionDefault
+    }
+
+    private func checkHomepagePinnedHeaderFeature() -> Bool {
+        return nimbus.features.homepageRedesignFeature.value().pinnedHeaderEnabled
     }
 
     private func checkHomepageSearchBarFeature() -> Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/LabelButtonHeaderViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/LabelButtonHeaderViewTests.swift
@@ -24,7 +24,7 @@ final class LabelButtonHeaderViewTests: XCTestCase {
         let view = createSubject()
         view.configure(sectionHeaderConfiguration: sectionHeaderConfiguration, textColor: nil, theme: theme)
 
-        XCTAssertEqual(view.titleLabel.textColor, theme.colors.textPrimary)
+        XCTAssertEqual(view.titleLabel.textColor, .adaptiveTextPrimary)
         XCTAssertEqual(view.moreButton.foregroundColorNormal, theme.colors.textAccent)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/StoryCategoryPickerViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/StoryCategoryPickerViewTests.swift
@@ -27,7 +27,7 @@ final class StoryCategoryPickerViewTests: XCTestCase {
 
         XCTAssertFalse(view.isHidden)
         XCTAssertEqual(buttons.count, 3)
-        XCTAssertEqual(buttons.map { $0.configuration?.title }, [
+        XCTAssertEqual(buttons.map { $0.accessibilityLabel }, [
             .FirefoxHomepage.Pocket.AllStoryCategories,
             "Technology",
             "Science",
@@ -118,7 +118,7 @@ final class StoryCategoryPickerViewTests: XCTestCase {
     }
 
     private func chipButtons(in view: UIView) -> [UIButton] {
-        allSubviews(in: view).compactMap { $0 as? UIButton }.filter { $0.configuration?.title != nil }
+        allSubviews(in: view).compactMap { $0 as? UIButton }
     }
 
     private func button(withA11yID a11yID: String, in view: UIView) -> UIButton? {

--- a/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
@@ -24,6 +24,11 @@ features:
           If true, enables the categories flow in the stories
         type: Boolean
         default: false
+      pinned-header-enabled:
+        description: >
+          If true, enables the pinned newsfeed header on homepage.
+        type: Boolean
+        default: false
     defaults:
       - channel: beta
         value:
@@ -31,6 +36,7 @@ features:
           bookmarks-section-default: false
           jbi-section-default: false
           categories-enabled: false
+          pinned-header-enabled: false
 
       - channel: developer
         value:
@@ -38,3 +44,4 @@ features:
           bookmarks-section-default: false
           jbi-section-default: false
           categories-enabled: false
+          pinned-header-enabled: false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15407)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33028)

## :bulb: Description
- Pins the news section header to the top of the homepage when scrolling

### 📝 Technical notes:
- Updates BVC to dynamically pin homepage content to the screen top when the BVC header is empty
- Passes BVC status bar overlay height to the homepage as a top collection view inset (bottom address bar).
- Moves normal homepage top spacing into the logo header section instead of the collection view inset
- Adds an opt-in `CATextLayer` title rendering mode for `ChipButton` to avoid UIKit button title rendering disturbing the system header backdrop while horizontally scrolling.
- Feature behind `pinned-header-enabled` flag

## :movie_camera: Demos
https://github.com/user-attachments/assets/bacfabe5-b504-4401-8801-01194c6c0267


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

