### PR TITLE
Bugfix FXIOS-15666 [Translations] Announce translation state with VoiceOver in three-dot menu

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuElement.swift
+++ b/BrowserKit/Sources/MenuKit/MenuElement.swift
@@ -12,8 +12,8 @@ public struct MenuElement: Equatable, Sendable {
     let needsReAuth: Bool?
     let isEnabled: Bool
     let isActive: Bool
-    let a11yLabel: String?
-    let a11yHint: String?
+    public let a11yLabel: String?
+    public let a11yHint: String?
     let a11yId: String
     let isOptional: Bool
     let infoTitle: String?

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -448,7 +448,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
             isEnabled: true,
             isActive: isActive,
             a11yLabel: a11yLabel,
-            a11yHint: nil,
+            a11yHint: infoTitle,
             a11yId: AccessibilityIdentifiers.MainMenu.translatePage,
             infoTitle: infoTitle,
             action: {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
@@ -172,6 +172,45 @@ final class MainMenuConfigurationUtilityTests: XCTestCase {
         XCTAssertNotNil(translateItem)
     }
 
+    func test_translateItem_inactive_a11yHintIsOff() {
+        setLanguagePickerEnabled(true)
+        let mockProfile = MockProfile()
+        let config = TranslationConfiguration(prefs: mockProfile.prefs, state: .inactive)
+        let tabInfo = getTabInfo(translationConfiguration: config)
+
+        let sections = configUtility.generateMenuElements(
+            with: tabInfo,
+            and: windowUUID,
+            isExpanded: true,
+            localeProvider: MockLocaleProvider(current: Locale(identifier: "en"))
+        )
+        let allItems = sections.flatMap { $0.options }
+        let translateItem = allItems.first { $0.title == .MainMenu.ToolsSection.Translation.TranslatePageTitle }
+
+        XCTAssertEqual(translateItem?.a11yHint, .MainMenu.ToolsSection.Translation.Off)
+    }
+
+    func test_translateItem_active_a11yHintIsLanguageName() {
+        setLanguagePickerEnabled(true)
+        let mockProfile = MockProfile()
+        let config = TranslationConfiguration(prefs: mockProfile.prefs, state: .active, translatedToLanguage: "fr")
+        let tabInfo = getTabInfo(translationConfiguration: config)
+
+        let locale = Locale(identifier: "en")
+        let sections = configUtility.generateMenuElements(
+            with: tabInfo,
+            and: windowUUID,
+            isExpanded: true,
+            localeProvider: MockLocaleProvider(current: locale)
+        )
+        let allItems = sections.flatMap { $0.options }
+        let title = String.MainMenu.ToolsSection.Translation.TranslatedPageTitle
+        let translateItem = allItems.first { $0.title == title }
+        let expectedHint = locale.localizedString(forLanguageCode: "fr")
+
+        XCTAssertEqual(translateItem?.a11yHint, expectedHint)
+    }
+
     private func setIsSummarizerLanguageExpansionEnabled(_ enabled: Bool) {
         FxNimbus.shared.features.summarizerLanguageExpansionFeature.with { _, _ in
             return SummarizerLanguageExpansionFeature(enabled: enabled)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15666)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33548)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

The Translation menu item in the three-dot menu was not announcing its ON/OFF state to VoiceOver, unlike Desktop Site and Website Dark Mode which both correctly announce their status.

MenuInfoCell sets isAccessibilityElement = true on the cell itself, so VoiceOver reads the cell as a single element and never reaches the info badge subview. The fix sets a11yHint to the badge text (infoTitle), which is already the localized language name when active or "Off" when inactive.

Also makes a11yLabel and a11yHint public on MenuElement to allow testing accessibility properties, and adds tests covering both states.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


