### PR TITLE
Add FXIOS-15196 [Quick Answers] support for exa via /chat/completions

### DIFF
--- a/BrowserKit/Sources/LLMKit/LiteLLMClient.swift
+++ b/BrowserKit/Sources/LLMKit/LiteLLMClient.swift
@@ -33,10 +33,10 @@ public final class LiteLLMClient: LiteLLMClientProtocol, Sendable {
     /// - Parameters:
     ///   - messages: Array of `LiteLLMMessage`.
     ///   - config: inference options ( includes model name, max tokens, temperature...).
-    public func requestChatCompletion(
-        messages: [LiteLLMMessage],
+    public func requestChatCompletion<ProviderFields: Codable & Sendable>(
+        messages: [LiteLLMMessage<ProviderFields>],
         config: LLMConfig
-    ) async throws -> String {
+    ) async throws -> LiteLLMMessage<ProviderFields> {
         let request: URLRequest
         do {
             request = try await makeRequest(messages: messages, config: config)
@@ -50,8 +50,8 @@ public final class LiteLLMClient: LiteLLMClientProtocol, Sendable {
     /// - Parameters:
     ///   - messages: Array of `LiteLLMMessage`.
     ///   - config: inference options ( includes model name, max tokens, ...).
-    public func requestChatCompletionStreamed(
-        messages: [LiteLLMMessage],
+    public func requestChatCompletionStreamed<ProviderFields: Codable & Sendable>(
+        messages: [LiteLLMMessage<ProviderFields>],
         config: LLMConfig
     ) async throws -> AsyncThrowingStream<String, Error> {
         let request: URLRequest
@@ -63,12 +63,14 @@ public final class LiteLLMClient: LiteLLMClientProtocol, Sendable {
         return handleStreamingRequest(request: request)
     }
 
-    private func handleNonStreamingRequest(request: URLRequest) async throws -> String {
+    private func handleNonStreamingRequest<ProviderFields: Codable & Sendable>(
+        request: URLRequest
+    ) async throws -> LiteLLMMessage<ProviderFields> {
         let (data, response) = try await session.data(for: request)
         try validate(response: response)
-        let decodedResponse = try JSONDecoder().decode(LiteLLMResponse.self, from: data)
-        guard let content = decodedResponse.choices.first?.message?.content else { throw LiteLLMClientError.noContent }
-        return content
+        let decodedResponse = try JSONDecoder().decode(LiteLLMResponse<ProviderFields>.self, from: data)
+        guard let message = decodedResponse.choices.first?.message else { throw LiteLLMClientError.noContent }
+        return message
     }
 
     /// TODO(FXIOS-12994): Add tests for streaming requests.
@@ -101,8 +103,8 @@ public final class LiteLLMClient: LiteLLMClientProtocol, Sendable {
 
     // MARK: - Helpers
 
-    func makeRequest(
-        messages: [LiteLLMMessage],
+    func makeRequest<ProviderFields: Codable & Sendable>(
+        messages: [LiteLLMMessage<ProviderFields>],
         config: LLMConfig
     ) async throws -> URLRequest {
         let endpoint = baseURL.appendingPathComponent("chat/completions")

--- a/BrowserKit/Sources/LLMKit/LiteLLMClientProtocol.swift
+++ b/BrowserKit/Sources/LLMKit/LiteLLMClientProtocol.swift
@@ -8,14 +8,14 @@ import Foundation
 /// This used because we want to be able to replace the real `LiteLLMClient` with a mock during testing.
 public protocol LiteLLMClientProtocol: Sendable {
     /// Sends a non-streaming chat completion request.
-    func requestChatCompletion(
-        messages: [LiteLLMMessage],
+    func requestChatCompletion<ProviderFields: Codable & Sendable>(
+        messages: [LiteLLMMessage<ProviderFields>],
         config: LLMConfig
-    ) async throws -> String
+    ) async throws -> LiteLLMMessage<ProviderFields>
 
     /// Sends a streaming chat completion request.
-    func requestChatCompletionStreamed(
-        messages: [LiteLLMMessage],
+    func requestChatCompletionStreamed<ProviderFields: Codable & Sendable>(
+        messages: [LiteLLMMessage<ProviderFields>],
         config: LLMConfig
     ) async throws -> AsyncThrowingStream<String, Error>
 }

--- a/BrowserKit/Sources/LLMKit/LiteLLMCreator.swift
+++ b/BrowserKit/Sources/LLMKit/LiteLLMCreator.swift
@@ -5,20 +5,20 @@ import Shared
 import MLPAKit
 
 public protocol LiteLLMCreating {
-    func createAppAttestLiteLLM(using prefs: Prefs) -> LiteLLMClientProtocol?
+    func createAppAttestLiteLLM(using prefs: Prefs, serviceType: MLPAServiceType) -> LiteLLMClientProtocol?
 }
 
 public struct LiteLLMCreator: LiteLLMCreating {
     public init() { }
 
-    public func createAppAttestLiteLLM(using prefs: Prefs) -> LiteLLMClientProtocol? {
+    public func createAppAttestLiteLLM(using prefs: Prefs, serviceType: MLPAServiceType) -> LiteLLMClientProtocol? {
         let mlpaEnvironmentKey = prefs.stringForKey(PrefsKeys.MLPASettings.mlpaEndpointEnvironment) ?? ""
         let mlpaEnvironment = MLPAEnvironment(rawValue: mlpaEnvironmentKey) ?? .prod
         guard let endPoint = MLPAConstants.completionsEndpoint(with: mlpaEnvironment),
               let client = try? AppAttestClient(remoteServer: MLPAAppAttestServer(with: mlpaEnvironment)) else {
             return nil
         }
-        let authenticator = AppAttestRequestAuth(appAttestClient: client)
+        let authenticator = AppAttestRequestAuth(appAttestClient: client, serviceType: serviceType)
         return LiteLLMClient(authenticator: authenticator, baseURL: endPoint)
     }
 }

--- a/BrowserKit/Sources/LLMKit/LiteLLMMessage.swift
+++ b/BrowserKit/Sources/LLMKit/LiteLLMMessage.swift
@@ -5,12 +5,22 @@
 import Foundation
 
 /// Represents a single message exchanged with the LLM.
-public struct LiteLLMMessage: Codable, Sendable {
+public struct LiteLLMMessage<ProviderFields: Codable & Sendable>: Codable, Sendable {
     public let role: LiteLLMRole
     public let content: String
+    // Parameters or response data that are unique to a particular model provider and
+    // not part of the standard OpenAI API format.
+    public let providerSpecificFields: ProviderFields?
 
-    public init(role: LiteLLMRole, content: String) {
+    public init(role: LiteLLMRole, content: String, providerSpecificFields: ProviderFields? = nil) {
         self.role = role
         self.content = content
+        self.providerSpecificFields = providerSpecificFields
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case role
+        case content
+        case providerSpecificFields = "provider_specific_fields"
     }
 }

--- a/BrowserKit/Sources/LLMKit/LiteLLMResponse.swift
+++ b/BrowserKit/Sources/LLMKit/LiteLLMResponse.swift
@@ -4,14 +4,14 @@
 
 import Foundation
 
-struct LiteLLMResponse: Codable {
+struct LiteLLMResponse<ProviderFields: Codable & Sendable>: Codable {
     let id: String
-    let choices: [LiteLLMChoice]
+    let choices: [LiteLLMChoice<ProviderFields>]
 }
 
-struct LiteLLMChoice: Codable {
+struct LiteLLMChoice<ProviderFields: Codable & Sendable>: Codable {
     let index: Int
-    let message: LiteLLMMessage?
-    let delta: LiteLLMMessage?
+    let message: LiteLLMMessage<ProviderFields>?
+    let delta: LiteLLMMessage<ProviderFields>?
     let finishReason: String?
 }

--- a/BrowserKit/Sources/LLMKit/ProviderSpecificFields.swift
+++ b/BrowserKit/Sources/LLMKit/ProviderSpecificFields.swift
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/// `LiteLLMMessage` can return a field called `providerSpecificFields`, which
+/// corresponds to response data that are unique to a particular model provider and
+/// not part of the standard OpenAI API format. This file contains types that help
+/// define these provider-specific field structures and provides convenient type aliases
+/// for common message types used throughout the app.
+
+public typealias QuickAnswersMessage = LiteLLMMessage<QuickAnswersProviderFields>
+public typealias StandardMessage = LiteLLMMessage<EmptyProviderFields>
+
+/// Empty provider fields for messages that don't have provider-specific data
+public struct EmptyProviderFields: Codable, Sendable {
+    public init() {}
+}
+
+/// Provider-specific data for Quick Answers (using exa endpoint)
+public struct QuickAnswersProviderFields: Codable, Sendable {
+    public let citations: [Citation]?
+}
+
+public struct Citation: Codable, Sendable {
+    public let id: String
+    public let title: String?
+    public let url: String?
+    public let image: String?
+    public let favicon: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case url
+        case image
+        case favicon
+    }
+
+    public init(
+        id: String,
+        title: String? = nil,
+        url: String? = nil,
+        image: String? = nil,
+        favicon: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.url = url
+        self.image = image
+        self.favicon = favicon
+    }
+}

--- a/BrowserKit/Sources/MLPAKit/AppAttestRequestAuth.swift
+++ b/BrowserKit/Sources/MLPAKit/AppAttestRequestAuth.swift
@@ -14,10 +14,16 @@ import Common
 public struct AppAttestRequestAuth: RequestAuthProtocol {
     private let appAttestClient: AppAttestClient
     private let bundleIdentifier: String
+    private let serviceType: MLPAServiceType
 
-    public init(appAttestClient: AppAttestClient, bundleIdentifier: String = AppInfo.bundleIdentifier) {
+    public init(
+        appAttestClient: AppAttestClient,
+        bundleIdentifier: String = AppInfo.bundleIdentifier,
+        serviceType: MLPAServiceType
+    ) {
         self.appAttestClient = appAttestClient
         self.bundleIdentifier = bundleIdentifier
+        self.serviceType = serviceType
     }
 
     public func authenticate(request: inout URLRequest) async throws {
@@ -39,7 +45,7 @@ public struct AppAttestRequestAuth: RequestAuthProtocol {
         ).encode()
 
         request.setValue(MLPAConstants.bearerPrefix + jwt, forHTTPHeaderField: MLPAConstants.authorizationHeader)
-        request.setValue(MLPAConstants.serviceTypeValue, forHTTPHeaderField: MLPAConstants.serviceTypeHeader)
+        request.setValue(serviceType.rawValue, forHTTPHeaderField: MLPAConstants.serviceTypeHeader)
         request.setValue("true", forHTTPHeaderField: MLPAConstants.useAppAttestHeader)
         request.httpBody = result.payload
     }

--- a/BrowserKit/Sources/MLPAKit/MLPAJWTPayload.swift
+++ b/BrowserKit/Sources/MLPAKit/MLPAJWTPayload.swift
@@ -7,6 +7,11 @@ import JWTKit
 
 /// Constants used for MLPA (Mozilla LLM Proxy Auth)
 /// request construction and server contract fields.
+public enum MLPAServiceType: String, Sendable {
+    case s2s = "s2s"
+    case quickAnswers = "search"
+}
+
 public enum MLPAConstants {
     static let authorizationHeader = "Authorization"
     static let bearerPrefix = "Bearer "
@@ -19,10 +24,6 @@ public enum MLPAConstants {
     static let assertionObjParam = "assertion_obj_b64"
 
     static let serviceTypeHeader = "service-type"
-
-    // TODO: FXIOS-15123 - need to create an enum service type here
-    // eventually to also account for quick-answers
-    static let serviceTypeValue = "s2s"
     static let useAppAttestHeader = "use-app-attest"
 
     static let contentTypeHeader = "Content-Type"

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/DefaultQuickAnswersService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/DefaultQuickAnswersService.swift
@@ -60,21 +60,15 @@ final class DefaultQuickAnswersService: QuickAnswersService {
         state = .idle
     }
 
-    // MARK: Results Service
-    // TODO: FXIOS-15197 - Implement parsing logic based on response format and update Search Result
-    // also remove search terminology while we are here
-
     /// Performs a search for the given transcription using the ResultsService.
     func search(text: String) async -> Result<SearchResult, SearchResultError> {
-        // TODO: FXIOS-15123 Add back call when integration with backend
-//        do {
-//            let result = try await resultsService.fetchResults(for: text)
-//            return .success(result)
-//        } catch {
-//            // TODO: FXIOS-15198 Handle errors appropriately
-//            return .failure(.unknown)
-//        }
-        return .success(SearchResult.empty())
+        do {
+            let result = try await resultsService.fetchResults(for: text)
+            return .success(result)
+        } catch {
+            // TODO: FXIOS-15198 Handle errors appropriately
+            return .failure(.unknown)
+        }
     }
 
     // MARK: Private Methods

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
@@ -21,13 +21,16 @@ final class DefaultResultsService: ResultsService {
     }
 
     func fetchResults(for transcription: String) async throws -> SearchResult {
-        let message = LiteLLMMessage(role: .user, content: transcription)
+        let message: QuickAnswersMessage = LiteLLMMessage(role: .user, content: transcription)
         // TODO: FXIOS-15198 - Handle mapping errors from request
         let fullResponse = try await requestChatCompletion(for: message)
-        return try formatResult(from: fullResponse)
+
+        let citations = fullResponse.providerSpecificFields?.citations ?? []
+
+        return try formatResult(from: fullResponse.content, and: citations)
     }
 
-    private func requestChatCompletion(for message: LiteLLMMessage) async throws -> String {
+    private func requestChatCompletion(for message: QuickAnswersMessage) async throws -> QuickAnswersMessage {
         // TODO: FXIOS-15198 Handle errors appropriately
         // and may need to change type and not use String,
         // but waiting for what we get on server side
@@ -37,15 +40,14 @@ final class DefaultResultsService: ResultsService {
         )
     }
 
-    private func formatResult(from response: String) throws -> SearchResult {
-        // TODO: FXIOS-15197 - Implement parsing logic based on response format and update Search Result
-        return SearchResult(
-            resultText: response,
-            sources: [SearchResult.Source(
-                title: "",
-                thumbnailURL: nil,
-                faviconURL: nil
-            )]
-        )
+    private func formatResult(from answer: String, and citations: [Citation]) throws -> SearchResult {
+        let sources = citations.map { citation in
+            SearchResult.Source(
+                title: citation.title ?? "",
+                thumbnailURL: URL(string: citation.image ?? ""),
+                faviconURL: URL(string: citation.favicon ?? "")
+            )
+        }
+        return SearchResult(resultText: answer, sources: sources)
     }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersConfig.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersConfig.swift
@@ -14,9 +14,8 @@ public struct QuickAnswersConfig: LLMConfig, Sendable {
     // TODO: FXIOS-15123 - need confirm we want to pass these options, follow similar to S2S for now
     /// Default initializer with production configuration
     public init(instructions: String = "", options: [String: AnyHashable] = [
-        "max_tokens": LiteLLMConfig.maxTokens,
-        "model": LiteLLMConfig.apiModel,
-        "stream": true
+        "model": "exa",
+        "stream": false
     ]) {
         self.instructions = instructions
         self.options = options

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceFactory.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceFactory.swift
@@ -36,6 +36,6 @@ public struct DefaultResultsServiceFactory: ResultsServiceFactory {
 
     // MARK: - Private Helpers
     private func makeLiteLLMClient(prefs: Prefs) -> LiteLLMClientProtocol? {
-        return liteLLMCreator.createAppAttestLiteLLM(using: prefs)
+        return liteLLMCreator.createAppAttestLiteLLM(using: prefs, serviceType: .quickAnswers)
     }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
@@ -150,6 +150,14 @@ public final class QuickAnswersViewController: UIViewController, Themeable {
         audioWaveform.startAnimating()
     }
 
+    override public func viewDidDisappear(_ animated: Bool) {
+        // TODO: FXIOS-14880 - Possibly investigate a better way to call this via view model
+        Task {
+            try await viewModel.stopRecordingVoice()
+        }
+        super.viewDidDisappear(animated)
+    }
+
     override public func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         contentView.adjustBottomInsets(for: privacyButton.frame.height)

--- a/BrowserKit/Sources/SummarizeKit/Backend/LLM/LiteLLMSummarizer.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/LLM/LiteLLMSummarizer.swift
@@ -27,7 +27,8 @@ final class LiteLLMSummarizer: SummarizerProtocol {
         // System message is used for the `modelInstructions`, user message for the `contentToSummarize`.
         let messages = makeMessages(modelInstructions: config.instructions, contentToSummarize: contentToSummarize)
         do {
-            return try await client.requestChatCompletion(messages: messages, config: config)
+            let response = try await client.requestChatCompletion(messages: messages, config: config)
+            return response.content
         } catch {
             throw mapError(error)
         }
@@ -75,7 +76,7 @@ final class LiteLLMSummarizer: SummarizerProtocol {
     }
 
     /// Helper to build a typed message array from `modelInstructions and `contentToSummarize`.
-    private func makeMessages(modelInstructions: String, contentToSummarize: String) -> [LiteLLMMessage] {
+    private func makeMessages(modelInstructions: String, contentToSummarize: String) -> [StandardMessage] {
         return [
             LiteLLMMessage(role: .system, content: modelInstructions),
             LiteLLMMessage(role: .user, content: contentToSummarize)

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerServiceFactory.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerServiceFactory.swift
@@ -102,7 +102,7 @@ public struct DefaultSummarizerServiceFactory: SummarizerServiceFactory {
         }
 
         if isAppAttestAuthEnabled {
-            return LiteLLMCreator().createAppAttestLiteLLM(using: prefs)
+            return LiteLLMCreator().createAppAttestLiteLLM(using: prefs, serviceType: .s2s)
         } else {
             guard let endPoint = URL(string: LiteLLMConfig.apiEndpoint ?? ""),
                   let key = LiteLLMConfig.apiKey else {

--- a/BrowserKit/Tests/LLMKitTests/LiteLLMClientTests.swift
+++ b/BrowserKit/Tests/LLMKitTests/LiteLLMClientTests.swift
@@ -12,9 +12,9 @@ import MLPAKit
 final class LiteLLMClientTests: XCTestCase {
     private static let mockAPIEndpoint = "https://test-api-url.com"
     private static let mockAPIKey =  "test-api-key"
-    private static let mockMessages = [
-        LiteLLMMessage(role: .system, content: "Init chat"),
-        LiteLLMMessage(role: .user, content: "Hello")
+    private static let mockMessages: [StandardMessage] = [
+        StandardMessage(role: .system, content: "Init chat"),
+        StandardMessage(role: .user, content: "Hello")
     ]
 
     private static let liteLLMMessagePayload = """
@@ -60,13 +60,13 @@ final class LiteLLMClientTests: XCTestCase {
     """.data(using: .utf8)!
 
     func testLiteLLMMessageCodable() throws {
-        let msg = try JSONDecoder().decode(LiteLLMMessage.self, from: Self.liteLLMMessagePayload)
+        let msg = try JSONDecoder().decode(StandardMessage.self, from: Self.liteLLMMessagePayload)
         XCTAssertEqual(msg.role, .user)
         XCTAssertEqual(msg.content, "Hello !")
     }
 
     func testLiteLLMResponseCodable() throws {
-        let response = try JSONDecoder().decode(LiteLLMResponse.self, from: Self.liteLLMResponsePayload)
+        let response = try JSONDecoder().decode(LiteLLMResponse<EmptyProviderFields>.self, from: Self.liteLLMResponsePayload)
         XCTAssertEqual(response.id, "resp-1")
         let firstChoice = response.choices.first
         XCTAssertEqual(firstChoice?.message?.role, .assistant)
@@ -144,6 +144,56 @@ final class LiteLLMClientTests: XCTestCase {
         let json = try JSONSerialization.jsonObject(with: bodyData, options: [])
                     as? [String: Any]
         XCTAssertEqual(json?["stream"] as? Bool, true)
+    }
+
+    func testQuickAnswersMessageCodableWithCitations() throws {
+        let payload = """
+        {
+          "role": "assistant",
+          "content": "Quick answer here",
+          "provider_specific_fields": {
+            "citations": [
+              {
+                "id": "cite-1",
+                "title": "Source Title",
+                "url": "https://source.com",
+                "image": "https://source.com/image.png",
+                "favicon": "https://source.com/favicon.ico"
+              }
+            ]
+          }
+        }
+        """.data(using: .utf8)!
+
+        let message = try JSONDecoder().decode(QuickAnswersMessage.self, from: payload)
+        XCTAssertEqual(message.role, .assistant)
+        XCTAssertEqual(message.content, "Quick answer here")
+        XCTAssertEqual(message.providerSpecificFields?.citations?.count, 1)
+
+        let citation = try XCTUnwrap(message.providerSpecificFields?.citations?.first)
+        XCTAssertEqual(citation.id, "cite-1")
+        XCTAssertEqual(citation.title, "Source Title")
+        XCTAssertEqual(citation.url, "https://source.com")
+        XCTAssertEqual(citation.image, "https://source.com/image.png")
+        XCTAssertEqual(citation.favicon, "https://source.com/favicon.ico")
+    }
+
+    func testMakeRequestWithQuickAnswersMessages() async throws {
+        let subject = createSubject()
+        let messages: [QuickAnswersMessage] = [
+            QuickAnswersMessage(role: .user, content: "What is the weather?")
+        ]
+        let config = MockConfig(instructions: "", options: ["model": "exa"])
+
+        let urlRequest = try await subject.makeRequest(messages: messages, config: config)
+
+        let bodyData = try XCTUnwrap(urlRequest.httpBody)
+        let json = try JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+        let messagesArray = try XCTUnwrap(json?["messages"] as? [[String: Any]])
+
+        XCTAssertEqual(messagesArray.count, 1)
+        XCTAssertEqual(messagesArray[0]["role"] as? String, "user")
+        XCTAssertEqual(messagesArray[0]["content"] as? String, "What is the weather?")
     }
 
     private func createSubject() -> LiteLLMClient {

--- a/BrowserKit/Tests/MLPAKitTests/AppAttestRequestAuthTests.swift
+++ b/BrowserKit/Tests/MLPAKitTests/AppAttestRequestAuthTests.swift
@@ -18,7 +18,7 @@ final class AppAttestRequestAuthTests: XCTestCase {
         XCTAssertTrue(auth?.hasPrefix(MLPAConstants.bearerPrefix) == true)
     }
 
-    func test_authenticate_setsServiceTypeHeader() async throws {
+    func test_authenticate_withS2S_setsServiceTypeHeader() async throws {
         let subject = try createSubject()
         var request = try makeRequest()
 
@@ -26,7 +26,7 @@ final class AppAttestRequestAuthTests: XCTestCase {
 
         XCTAssertEqual(
             request.value(forHTTPHeaderField: MLPAConstants.serviceTypeHeader),
-            MLPAConstants.serviceTypeValue
+            MLPAServiceType.s2s.rawValue
         )
     }
 
@@ -102,7 +102,8 @@ final class AppAttestRequestAuthTests: XCTestCase {
 
         return AppAttestRequestAuth(
             appAttestClient: client,
-            bundleIdentifier: bundleIdentifier
+            bundleIdentifier: bundleIdentifier,
+            serviceType: .s2s
         )
     }
 

--- a/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockLLMClientCreator.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockLLMClientCreator.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import LLMKit
+import MLPAKit
 import Shared
 
 @testable import QuickAnswersKit
@@ -11,7 +12,7 @@ final class MockLLMClientCreator: LiteLLMCreating {
     var shouldReturnNil = false
     var createAppAttestLiteLLMCallCount = 0
 
-    func createAppAttestLiteLLM(using prefs: Prefs) -> LiteLLMClientProtocol? {
+    func createAppAttestLiteLLM(using prefs: Prefs, serviceType: MLPAServiceType) -> LiteLLMClientProtocol? {
         createAppAttestLiteLLMCallCount += 1
         return shouldReturnNil ? nil : clientToReturn
     }

--- a/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockLiteLLMClient.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockLiteLLMClient.swift
@@ -10,26 +10,36 @@ import Foundation
 /// Mock implementation of LiteLLMClient for testing.
 final class MockLiteLLMClient: LiteLLMClientProtocol, @unchecked Sendable {
     var respondWith: [String] = [""]
+    var respondWithCitations: [Citation]?
     var respondWithError: Error?
     var requestChatCompletionCallCount = 0
     var requestChatCompletionStreamedCallCount = 0
-    var lastMessages: [LiteLLMMessage]?
+    var lastMessages: [Any] = []
     var lastConfig: LLMConfig?
 
-    func requestChatCompletion(
-        messages: [LiteLLMMessage],
+    func requestChatCompletion<ProviderFields: Codable & Sendable>(
+        messages: [LiteLLMMessage<ProviderFields>],
         config: LLMConfig
-    ) async throws -> String {
+    ) async throws -> LiteLLMMessage<ProviderFields> {
         requestChatCompletionCallCount += 1
         lastMessages = messages
         lastConfig = config
 
         if let error = respondWithError { throw error }
-        return respondWith.joined(separator: " ")
+
+        let content = respondWith.joined(separator: " ")
+
+        // For QuickAnswersProviderFields, include citations
+        if ProviderFields.self == QuickAnswersProviderFields.self {
+            let providerFields = respondWithCitations.map { QuickAnswersProviderFields(citations: $0) } as? ProviderFields
+            return LiteLLMMessage(role: .assistant, content: content, providerSpecificFields: providerFields)
+        } else {
+            return LiteLLMMessage(role: .assistant, content: content, providerSpecificFields: nil)
+        }
     }
 
-    func requestChatCompletionStreamed(
-        messages: [LiteLLMMessage],
+    func requestChatCompletionStreamed<ProviderFields: Codable & Sendable>(
+        messages: [LiteLLMMessage<ProviderFields>],
         config: LLMConfig
     ) -> AsyncThrowingStream<String, Error> {
         requestChatCompletionStreamedCallCount += 1

--- a/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/DefaultResultsServiceTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/DefaultResultsServiceTests.swift
@@ -15,16 +15,42 @@ struct DefaultResultsServiceTests {
     func test_fetchResults_returnsResult() async throws {
         let client = MockLiteLLMClient()
         client.respondWith = ["This is a quick answer"]
+        client.respondWithCitations = [
+            Citation(
+                id: "1",
+                title: "Weather Source",
+                url: "https://example.com"
+            )
+        ]
         let subject = createSubject(client: client)
 
         let result = try await subject.fetchResults(for: "What is the weather?")
 
+        // Verify the request message
+        let firstMessage = client.lastMessages.first as? QuickAnswersMessage
+        #expect(client.lastMessages.count == 1)
+        #expect(firstMessage?.content == "What is the weather?")
+        #expect(firstMessage?.role == .user)
+
+        // Verify the search result
         #expect(result.resultText == "This is a quick answer")
         #expect(result.sources.count == 1)
+        let source = result.sources.first
+        #expect(source?.title == "Weather Source")
         #expect(client.requestChatCompletionCallCount == 1)
-        #expect(client.lastMessages?.count == 1)
-        #expect(client.lastMessages?.first?.content == "What is the weather?")
-        #expect(client.lastMessages?.first?.role == .user)
+    }
+
+    @Test
+    func test_fetchResults_handlesNoCitations() async throws {
+        let client = MockLiteLLMClient()
+        client.respondWith = ["Answer without citations"]
+        client.respondWithCitations = nil
+        let subject = createSubject(client: client)
+
+        let result = try await subject.fetchResults(for: "Query")
+
+        #expect(result.resultText == "Answer without citations")
+        #expect(result.sources.isEmpty)
     }
 
     // MARK: - Helper

--- a/BrowserKit/Tests/SummarizeKitTests/Mocks/MockLiteLLMClient.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/Mocks/MockLiteLLMClient.swift
@@ -13,16 +13,17 @@ public final class MockLiteLLMClient: LiteLLMClientProtocol, @unchecked Sendable
     var respondWith: [String] = [""]
     var respondWithError: Error?
 
-    public func requestChatCompletion(
-        messages: [LiteLLMMessage],
+    public func requestChatCompletion<ProviderFields: Codable & Sendable>(
+        messages: [LiteLLMMessage<ProviderFields>],
         config: LLMConfig
-    ) async throws -> String {
+    ) async throws -> LiteLLMMessage<ProviderFields> {
         if let error = respondWithError { throw error }
-        return respondWith.joined(separator: " ")
+        let content = respondWith.joined(separator: " ")
+        return LiteLLMMessage(role: .assistant, content: content, providerSpecificFields: nil)
     }
 
-    public func requestChatCompletionStreamed(
-        messages: [LiteLLMMessage],
+    public func requestChatCompletionStreamed<ProviderFields: Codable & Sendable>(
+        messages: [LiteLLMMessage<ProviderFields>],
         config: LLMConfig
     ) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream<String, Error> { continuation in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15196)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32703)

## :bulb: Description
Hook up integration via MLPA through the `chat/completions` endpoint. Previously we were testing with [search](https://github.com/mozilla-mobile/firefox-ios/pull/33500), but it did not give us the proper data as expected. Therefore, we will be using the existing `chat/completions` path, but refactored some portions so it is not heavily tied to Shake to Summarize.

- Created generalized `MLPAServiceType`
- Added Provider Specific Fields - more details here: https://docs.litellm.ai/docs/completion/provider_specific_params
- Some messages may or may not have the provider specific fields and those that do may be specific to the provider. `QuickAnswersProviderFields` is used for messages specific to the Quick Answers since we have a provider specific field to fetch citations, other messages will use `EmptyProviderFields` since it does not have the field (i.e. Shake to Summarize)
- Created `QuickAnswersMessage` and `StandardMessage` for readability

Example Response
```
{
  "model": "exa",
  "object": "chat.completion",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "Recent developments in AI as of April 2026 highlight rapid advancements in model capabilities, infrastructure, and application scope. OpenAI has introduced GPT-5.5, its most advanced and intuitive model yet, which excels at coding, research, data analysis, and multi-tool workflows. GPT-5.5 is designed to understand tasks faster, use fewer tokens, and operate with enhanced safeguards, bringing the company closer to creating an \"AI super app\" that integrates multiple functionalities seamlessly ([OpenAI](https://openai.com/index/introducing-gpt-5-5), [TechCrunch](https://techcrunch.com/2026/04/23/openai-chatgpt-gpt-5-5-ai-model-superapp), [The Verge](https://theverge.com/ai-artificial-intelligence/917612/openai-gpt-5-5-chatgpt)). \n\nSimultaneously, OpenAI has raised $122 billion to expand its infrastructure and accelerate AI deployment across industries, emphasizing its role as a core technological backbone for both consumers and enterprises. The company is also making its models more accessible by partnering with Amazon Web Services, ending its exclusive relationship with Microsoft, and enabling broader cloud deployment ([OpenAI](https://openai.com/index/accelerating-the-next-phase-ai), [CNBC](https://www.cnbc.com/2026/04/28/openai-brings-models-to-aws.html)). \n\nIn addition to model improvements, AI research is pushing into new territories, such as DeepMind's recent $1.1 billion funding to develop AI systems that learn without human data, leveraging reinforcement learning to create \"superlearners\" capable of discovering knowledge independently ([TechCrunch](https://techcrunch.com/2026/04/27/deepminds-david-silver-just-raised-1-1b-to-build-an-ai-that-learns-without-human-data)). Other innovations include NVIDIA's Nemotron 3 Nano Omni, a multimodal model unifying vision, audio, and language for more efficient AI agents, and IBM's new AI development platform, IBM Bob, which automates the full software lifecycle with enterprise-grade governance ([NVIDIA Blog](https://blogs.nvidia.com/blog/nemotron-3-nano-omni-multimodal-ai-agents), [IBM](https://newsroom.ibm.com/2026-04-28-introducing-ibm-bob)). Overall, AI continues to evolve rapidly, integrating more sophisticated reasoning, multimodal understanding, and enterprise applications.",
        "role": "assistant",
        "provider_specific_fields": {
          "citations": [
            {
              "id": "https://openai.com/index/introducing-gpt-5-5",
              "title": "Introducing GPT-5.5",
              "url": "https://openai.com/index/introducing-gpt-5-5",
              "publishedDate": "2026-04-23T18:03:05.000Z",
              "image": "https://images.ctfassets.net/kftzwdyauwt9/2Bh47W4cA48dvG5FbDtNQH/5897109fb0de6fc3125c0c35c4f60001/Hero_Art_Card_16x9.jpg?w=1600&h=900&fit=fill",
              "favicon": "https://openai.com/favicon.ico?favicon.0w1tl_z9koc07.ico"
            },
            {
              "id": "https://openai.com/index/accelerating-the-next-phase-ai",
              "title": "OpenAI raises $122 billion to accelerate the next phase of AI | OpenAI",
              "url": "https://openai.com/index/accelerating-the-next-phase-ai",
              "image": "https://images.ctfassets.net/kftzwdyauwt9/6OSKcUkJputeSfEUssuwQk/ca93432564e7748ab08ee2b5be907f29/Frame-1.png?w=1600&h=900&fit=fill",
              "favicon": "https://openai.com/favicon.ico?favicon.0w1tl_z9koc07.ico"
            }
          ]
        }
      }
    }
  ],
  "usage": {
    "completion_tokens": 0,
    "prompt_tokens": 0,
    "total_tokens": 0
  }
}
```

## :movie_camera: Demos
https://github.com/user-attachments/assets/54633dc8-36e4-47d1-aeae-11217f97a50f

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

