### PR TITLE
Refactor FXIOS-15327 [Technical Debt] [Redux] Swift CopyWithUpdates macro should not add computed properties to the `copyWith` method

### DIFF
--- a/CopyWithUpdatesMacro/Sources/CopyWithUpdatesClient/main.swift
+++ b/CopyWithUpdatesMacro/Sources/CopyWithUpdatesClient/main.swift
@@ -35,3 +35,18 @@ let r3 = r1.copyWithUpdates(
     complexStructure: [:],
     budget: 0
 )
+
+@CopyWithUpdates
+struct TestType {
+    let constantProperty: [Int]
+    var variableProperty: Int
+
+    var filteredArray: [Int] {
+        return constantProperty.filter { value in
+            value > 0
+        }
+    }
+
+    let extraPropertyAfterComputedProperty: Int
+
+}

--- a/CopyWithUpdatesMacro/Sources/CopyWithUpdatesClient/main.swift
+++ b/CopyWithUpdatesMacro/Sources/CopyWithUpdatesClient/main.swift
@@ -48,5 +48,4 @@ struct TestType {
     }
 
     let extraPropertyAfterComputedProperty: Int
-
 }

--- a/CopyWithUpdatesMacro/Sources/CopyWithUpdatesMacros/CopyWithUpdates.swift
+++ b/CopyWithUpdatesMacro/Sources/CopyWithUpdatesMacros/CopyWithUpdates.swift
@@ -25,18 +25,25 @@ public struct CopyWithUpdatesMacro: MemberMacro {
             return []
         }
 
+        // Gather all the struct/class's properties, except for static and computed properties,
         let variableDecls = members.compactMap { member -> VariableDeclSyntax? in
             guard let variableDecl = member.decl.as(VariableDeclSyntax.self) else {
                 return nil
             }
 
-            // Check if the 'static' modifier is present; we don't want these properties copied into the generated copyWith
-            // method.
-            let isStatic = variableDecl.modifiers.contains { modifier in
-                modifier.name.tokenKind == .keyword(.static)
+            // Check if this is a computed value; we don't want computed values copied into the generated copyWith method.
+            guard !variableDecl.bindings.contains(where: { $0.accessorBlock != nil }) else {
+                // Stored properties (i.e. regular `let` and `var` properties) do NOT contain `accessorBlocks`
+                return nil
             }
 
-            return isStatic ? nil : variableDecl
+            // Check if the `static` modifier is present; we don't want these properties copied into the generated copyWith
+            // method.
+            guard !variableDecl.modifiers.contains(where: { $0.name.tokenKind == .keyword(.static) }) else {
+                return nil
+            }
+
+            return variableDecl
         }
 
         let bindings = variableDecls.flatMap { $0.bindings }

--- a/CopyWithUpdatesMacro/Tests/CopyWithUpdatesTests/CopyWithUpdatesTests.swift
+++ b/CopyWithUpdatesMacro/Tests/CopyWithUpdatesTests/CopyWithUpdatesTests.swift
@@ -136,6 +136,53 @@ final class CopyWithUpdatesTests: XCTestCase {
         #endif
     }
 
+    func testMacro_withComputedProperty() throws {
+        #if canImport(CopyWithUpdatesMacros)
+        assertMacroExpansion(
+            """
+            @CopyWithUpdates
+            struct TestType {
+                let constantProperty: [Int]
+                var variableProperty: Int
+
+                var filteredArray: [Int] {
+                    return constantProperty.filter { value in
+                        value > 0
+                    }
+                }
+            
+                let extraPropertyAfterComputedProperty: Int
+            }
+            """,
+            expandedSource: """
+            struct TestType {
+                let constantProperty: [Int]
+                var variableProperty: Int
+
+                var filteredArray: [Int] {
+                    return constantProperty.filter { value in
+                        value > 0
+                    }
+                }
+            
+                let extraPropertyAfterComputedProperty: Int
+
+                public func copyWithUpdates(constantProperty: [Int]? = nil, variableProperty: Int? = nil, extraPropertyAfterComputedProperty: Int? = nil) -> Self {
+                    return Self (
+                    constantProperty: constantProperty ?? self.constantProperty,
+                        variableProperty: variableProperty ?? self.variableProperty,
+                        extraPropertyAfterComputedProperty: extraPropertyAfterComputedProperty ?? self.extraPropertyAfterComputedProperty
+                    )
+                }
+            }
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
     func testMacro_withPropertyAndTrailingLineComment() throws {
         #if canImport(CopyWithUpdatesMacros)
         assertMacroExpansion(

--- a/CopyWithUpdatesMacro/Tests/CopyWithUpdatesTests/CopyWithUpdatesTests.swift
+++ b/CopyWithUpdatesMacro/Tests/CopyWithUpdatesTests/CopyWithUpdatesTests.swift
@@ -138,6 +138,7 @@ final class CopyWithUpdatesTests: XCTestCase {
 
     func testMacro_withComputedProperty() throws {
         #if canImport(CopyWithUpdatesMacros)
+        // swiftlint:disable line_length
         assertMacroExpansion(
             """
             @CopyWithUpdates
@@ -150,7 +151,7 @@ final class CopyWithUpdatesTests: XCTestCase {
                         value > 0
                     }
                 }
-            
+
                 let extraPropertyAfterComputedProperty: Int
             }
             """,
@@ -164,7 +165,7 @@ final class CopyWithUpdatesTests: XCTestCase {
                         value > 0
                     }
                 }
-            
+
                 let extraPropertyAfterComputedProperty: Int
 
                 public func copyWithUpdates(constantProperty: [Int]? = nil, variableProperty: Int? = nil, extraPropertyAfterComputedProperty: Int? = nil) -> Self {
@@ -178,6 +179,7 @@ final class CopyWithUpdatesTests: XCTestCase {
             """,
             macros: testMacros
         )
+        // swiftlint:enable line_length
         #else
         throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "774fbafba0eedfc3be17feddbd7e0b8c7ed81f9ea7a231b5489699bb420194a5",
+  "originHash" : "a38af2bd88cbd2543d16410fb70e56ccdd5a0269a5a146536ed9c7725a286aaf",
   "pins" : [
     {
       "identity" : "a-star",
@@ -134,6 +134,15 @@
       "state" : {
         "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
         "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
       }
     },
     {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e7d8931d67761f37e7664664586e08ff85dd2fa89878e390b6c48f85c6b6e85c",
+  "originHash" : "774fbafba0eedfc3be17feddbd7e0b8c7ed81f9ea7a231b5489699bb420194a5",
   "pins" : [
     {
       "identity" : "a-star",
@@ -134,15 +134,6 @@
       "state" : {
         "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
         "version" : "3.15.1"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
-      "state" : {
-        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
-        "version" : "509.1.1"
       }
     },
     {

--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
@@ -16,6 +16,20 @@ struct MerinoState: StateType, Equatable {
     let hasMerinoResponseContent: Bool
     let shouldShowSection: Bool
 
+    var availableCategories: [MerinoCategoryConfiguration] {
+        (merinoData.categories ?? []).sorted { $0.rank < $1.rank }
+    }
+
+    func visibleStories(selectedNewsfeedCategoryID: String?) -> [MerinoStoryConfiguration] {
+        if !availableCategories.isEmpty {
+            if let selectedNewsfeedCategoryID {
+                return availableCategories.first(where: { $0.feedID == selectedNewsfeedCategoryID })?.recommendations ?? []
+            }
+            return availableCategories.flatMap(\.recommendations)
+        }
+        return merinoData.stories ?? []
+    }
+
     struct Constants {
         static var sectionHeaderConfiguration: SectionHeaderConfiguration {
             // Computed property because feature flag configuration can change after launch
@@ -105,24 +119,5 @@ struct MerinoState: StateType, Equatable {
             a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.merino,
             style: .newsAffordance
         )
-    }
-}
-
-/// `@CopyWithUpdates` currently treats computed properties declared inside the struct as
-/// initializer/copy fields, which breaks generation with "extra arguments" errors.
-/// Keep derived accessors in this extension as a workaround.
-extension MerinoState {
-    var availableCategories: [MerinoCategoryConfiguration] {
-        (merinoData.categories ?? []).sorted { $0.rank < $1.rank }
-    }
-
-    func visibleStories(selectedNewsfeedCategoryID: String?) -> [MerinoStoryConfiguration] {
-        if !availableCategories.isEmpty {
-            if let selectedNewsfeedCategoryID {
-                return availableCategories.first(where: { $0.feedID == selectedNewsfeedCategoryID })?.recommendations ?? []
-            }
-            return availableCategories.flatMap(\.recommendations)
-        }
-        return merinoData.stories ?? []
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15696)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33598)

## :bulb: Description
Ideally our Redux States should only contain simple stored properties, but it turns out a few of our States actually also have computed properties. This is getting a bit into the purview of presentation logic in my opinion, but regardless, a generalized `@CopyWithUpdates` macro really should not be trying to add computed properties to the `copyWith` method. This PR adds extra logic and a test to handle this edge case.

P.S. To run the tests you need to open the CopyWithUpdates folder in Xcode, and then execute the unit test class that way.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

