### PR TITLE
[MTE-5296] - fix testNavigateToSearchPickerTurnsOffEditing test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -98,7 +98,13 @@ class SearchSettingsUITests: BaseTestCase {
         mozWaitForElementToNotExist(app.buttons["Done"])
 
         // Make sure switches are there
-        XCTAssertEqual(app.tables.cells.switches.count, app.tables.cells.count - 3)
+        if isFennec {
+            XCTAssertEqual(app.tables.cells.switches.count, app.tables.cells.count - 3)
+        } else {
+            // Enhanced search suggestion experiment is turned off on firefox
+            // Suggestion switches are not available
+            XCTAssertEqual(app.tables.cells.switches.count, app.tables.cells.count - 2)
+        }
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353250


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5296

## :bulb: Description
Small fix for testNavigateToSearchPickerTurnsOffEditing test.
Suggestion switches are not available on firefox schema because Enhanced search suggestion experiment is turned off
