### PR TITLE
Bugfix FXIOS-15649/FXIOS-15655 [Translations] Fix page not reverting and auto-translate not re-triggering on settings toggle

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
@@ -103,6 +103,13 @@ final class TranslationSettingsMiddleware {
                 windowUUID: action.windowUUID,
                 actionType: TranslationSettingsMiddlewareActionType.didUpdateSettings
             ))
+            if newValue {
+                store.dispatch(ToolbarAction(
+                    translationConfiguration: TranslationConfiguration(prefs: prefs),
+                    windowUUID: action.windowUUID,
+                    actionType: ToolbarActionType.didTranslationSettingsChange
+                ))
+            }
 
         case TranslationSettingsViewActionType.addLanguage:
             guard let code = action.languageCode else { break }

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -87,17 +87,29 @@ final class TranslationsMiddleware: FeatureFlaggable {
 
         case ToolbarActionType.didTranslationSettingsChange:
             guard let action = (action as? ToolbarAction) else { return }
-            // Clear stale per-window state so eligibility is re-evaluated from scratch
-            // rather than acting on cached flow data from before the settings change.
-            self.selectedTargetLanguages[windowUUID] = nil
-            self.translationFlowIds[windowUUID] = nil
-            self.restoringWindows.remove(windowUUID)
-            guard action.translationConfiguration?.isTranslationFeatureEnabled == true else { return }
-            self.checkTranslationsAreEligible(for: action)
+            self.handleTranslationSettingsChange(action: action, windowUUID: windowUUID)
 
         default:
            break
         }
+    }
+
+    private func handleTranslationSettingsChange(action: ToolbarAction, windowUUID: WindowUUID) {
+        if action.translationConfiguration?.isTranslationFeatureEnabled == false {
+            for uuid in translationFlowIds.keys {
+                store.dispatch(GeneralBrowserAction(
+                    windowUUID: uuid,
+                    actionType: GeneralBrowserActionType.reloadWebsite
+                ))
+            }
+        }
+        // Clear stale per-window state so eligibility is re-evaluated from scratch
+        // rather than acting on cached flow data from before the settings change.
+        selectedTargetLanguages[windowUUID] = nil
+        translationFlowIds[windowUUID] = nil
+        restoringWindows.remove(windowUUID)
+        guard action.translationConfiguration?.isTranslationFeatureEnabled == true else { return }
+        checkTranslationsAreEligible(for: action)
     }
 
     private func handleTappingOnTranslateButton(for action: ToolbarMiddlewareAction, and state: AppState) {

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -97,6 +97,12 @@ final class TranslationsMiddleware: FeatureFlaggable {
     private func handleTranslationSettingsChange(action: ToolbarAction, windowUUID: WindowUUID) {
         if action.translationConfiguration?.isTranslationFeatureEnabled == false {
             for uuid in translationFlowIds.keys {
+                let translationState = store.state.componentState(
+                    ToolbarState.self,
+                    for: .toolbar,
+                    window: uuid
+                )?.addressToolbar.translationConfiguration?.state
+                guard translationState == .active || translationState == .loading else { continue }
                 store.dispatch(GeneralBrowserAction(
                     windowUUID: uuid,
                     actionType: GeneralBrowserActionType.reloadWebsite

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
@@ -91,6 +91,7 @@ const discardTranslations = ({from, to}) => {
 /// NOTE: This returns a promise that resolves when the translation process is "done".
 /// This is used mainly to turn the translations button to the active state in the UI.
 /// This should be called from swift.
+// TODO: FXIOS-15246 Translation spinner gets stuck indefinitely
 const TRANSLATION_TIMEOUT_MS = 15000;
 const isDone = () => {
     let timeoutId;

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
@@ -9,11 +9,13 @@ import "Assets/CC_Script/translations-engine.sys.mjs";
 /// In Gecko, we mark translations done when the engine is ready.
 /// In iOS, we will go a step further and wait for the first translation response to be received.
 let isDoneResolve;
+let isDoneReject;
 let isDonePromise;
 
 const resetIsDone = () => {
-    isDonePromise = new Promise(resolve => {
+    isDonePromise = new Promise((resolve, reject) => {
         isDoneResolve = resolve;
+        isDoneReject = reject;
     });
 };
 
@@ -32,6 +34,13 @@ const sendToEngine = (message) => {
 window.receive = (message) => {
     if (message.type === "TranslationsPort:TranslationResponse" && isDoneResolve) {
         isDoneResolve(true);
+        isDoneResolve = null;
+        isDoneReject = null;
+    }
+
+    if (message.type === "TranslationsPort:GetEngineStatusResponse" && message.status === "error" && isDoneReject) {
+        isDoneReject(new Error("translation engine failed to load"));
+        isDoneReject = null;
         isDoneResolve = null;
     }
 
@@ -83,10 +92,18 @@ const discardTranslations = ({from, to}) => {
 /// This is used mainly to turn the translations button to the active state in the UI.
 /// This should be called from swift.
 const TRANSLATION_TIMEOUT_MS = 15000;
-const isDone = () => Promise.race([
-    isDonePromise,
-    new Promise((_, reject) => setTimeout(() => reject(new Error("translation timed out")), TRANSLATION_TIMEOUT_MS))
-]);
+const isDone = () => {
+    let timeoutId;
+    return Promise.race([
+        isDonePromise,
+        new Promise((_, reject) => {
+            timeoutId = setTimeout(
+                () => reject(new Error("translation timed out")),
+                TRANSLATION_TIMEOUT_MS
+            );
+        })
+    ]).finally(() => clearTimeout(timeoutId));
+};
 
 /// NOTE: Expose the Translations API to the privileged context.
 /// Anything not exposed here will not be accessible outside this user script.

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
@@ -82,9 +82,10 @@ const discardTranslations = ({from, to}) => {
 /// NOTE: This returns a promise that resolves when the translation process is "done".
 /// This is used mainly to turn the translations button to the active state in the UI.
 /// This should be called from swift.
+const TRANSLATION_TIMEOUT_MS = 15000;
 const isDone = () => Promise.race([
     isDonePromise,
-    new Promise((_, reject) => setTimeout(() => reject(new Error("translation timed out")), 15000))
+    new Promise((_, reject) => setTimeout(() => reject(new Error("translation timed out")), TRANSLATION_TIMEOUT_MS))
 ]);
 
 /// NOTE: Expose the Translations API to the privileged context.

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
@@ -82,7 +82,10 @@ const discardTranslations = ({from, to}) => {
 /// NOTE: This returns a promise that resolves when the translation process is "done".
 /// This is used mainly to turn the translations button to the active state in the UI.
 /// This should be called from swift.
-const isDone = async () => isDonePromise;
+const isDone = () => Promise.race([
+    isDonePromise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error("translation timed out")), 15000))
+]);
 
 /// NOTE: Expose the Translations API to the privileged context.
 /// Anything not exposed here will not be accessible outside this user script.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
@@ -314,12 +314,15 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.translationSettingsProvider(mockStore.state, action)
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationSettingsMiddlewareAction)
-        let dispatchedActionType = try XCTUnwrap(dispatchedAction.actionType as? TranslationSettingsMiddlewareActionType)
-        XCTAssertEqual(dispatchedActionType, TranslationSettingsMiddlewareActionType.didUpdateSettings)
-        XCTAssertEqual(dispatchedAction.isAutoTranslateEnabled, true)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
+        let firstAction = try XCTUnwrap(mockStore.dispatchedActions[0] as? TranslationSettingsMiddlewareAction)
+        let firstActionType = try XCTUnwrap(firstAction.actionType as? TranslationSettingsMiddlewareActionType)
+        XCTAssertEqual(firstActionType, TranslationSettingsMiddlewareActionType.didUpdateSettings)
+        XCTAssertEqual(firstAction.isAutoTranslateEnabled, true)
         XCTAssertEqual(mockProfile.prefs.boolForKey(PrefsKeys.Settings.translationAutoTranslate), true)
+        let secondAction = try XCTUnwrap(mockStore.dispatchedActions[1] as? ToolbarAction)
+        let secondActionType = try XCTUnwrap(secondAction.actionType as? ToolbarActionType)
+        XCTAssertEqual(secondActionType, ToolbarActionType.didTranslationSettingsChange)
         subject.translationSettingsProvider = { _, _ in }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -844,7 +844,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: ToolbarActionType.didTranslationSettingsChange
         )
 
-        let expectation = XCTestExpectation(description: "reloadWebsite dispatched when disabling translations on active page")
+        let expectation = XCTestExpectation(description: "reloadWebsite dispatched when disabling translations")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
         subject.translationsProvider(mockStore.state, action)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -837,6 +837,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let subject = createSubject()
 
         seedTargetLanguage(in: subject, successDispatchCount: 2)
+        mockStore.state = setupAppState(translationState: .active)
 
         let action = ToolbarAction(
             translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
@@ -855,6 +856,31 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
         let dispatchedActionType = try XCTUnwrap(dispatchedAction.actionType as? GeneralBrowserActionType)
         XCTAssertEqual(dispatchedActionType, GeneralBrowserActionType.reloadWebsite)
+    }
+
+    func test_didTranslationSettingsChange_withFeatureDisabled_andInactivePage_doesNotReloadPage() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslatePromptShown)
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.Settings.translationsFeature)
+        let subject = createSubject()
+
+        seedTargetLanguage(in: subject, successDispatchCount: 2)
+        mockStore.state = setupAppState(translationState: .inactive)
+
+        let action = ToolbarAction(
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.didTranslationSettingsChange
+        )
+
+        let expectation = XCTestExpectation(description: "no reload dispatched for inactive translation")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
     }
 
     func test_didTranslationSettingsChange_clearsStoredTargetLanguageForRetry() throws {
@@ -1380,6 +1406,37 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
 
     // MARK: StoreTestUtility
     func setupAppState() -> AppState {
+        return setupAppState(translationState: nil)
+    }
+
+    private func setupAppState(translationState: TranslationConfiguration.IconState?) -> AppState {
+        let translationConfiguration = translationState.map {
+            TranslationConfiguration(prefs: mockProfile.prefs, state: $0)
+        }
+        let addressToolbar = AddressBarState(
+            windowUUID: .XCTestDefaultUUID,
+            navigationActions: [],
+            leadingPageActions: [],
+            trailingPageActions: [],
+            browserActions: [],
+            borderPosition: nil,
+            url: nil,
+            searchTerm: nil,
+            lockIconButtonA11yId: nil,
+            lockIconImageName: nil,
+            lockIconNeedsTheming: true,
+            safeListedURLImageName: nil,
+            isEditing: false,
+            shouldShowKeyboard: false,
+            shouldSelectSearchTerm: false,
+            isLoading: false,
+            readerModeState: nil,
+            canSummarize: false,
+            translationConfiguration: translationConfiguration,
+            didStartTyping: false,
+            isEmptySearch: true,
+            alternativeSearchEngine: nil
+        )
         return AppState(
             presentedComponents: PresentedComponentsState(
                 components: [
@@ -1390,7 +1447,25 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
                     ),
                     .toolbar(
                         ToolbarState(
-                            windowUUID: .XCTestDefaultUUID
+                            windowUUID: .XCTestDefaultUUID,
+                            toolbarPosition: .top,
+                            toolbarLayout: .version1,
+                            tabTrayButtonStyle: .number,
+                            isPrivateMode: false,
+                            addressToolbar: addressToolbar,
+                            navigationToolbar: NavigationBarState(windowUUID: .XCTestDefaultUUID),
+                            isShowingNavigationToolbar: true,
+                            isShowingTopTabs: false,
+                            canGoBack: false,
+                            canGoForward: false,
+                            numberOfTabs: 1,
+                            scrollAlpha: 1,
+                            showMenuWarningBadge: false,
+                            canShowNavigationHint: false,
+                            shouldAnimate: true,
+                            isTranslucent: false,
+                            previousTabScreenshot: nil,
+                            nextTabScreenshot: nil
                         )
                     )
                 ]

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -830,6 +830,33 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
     }
 
+    func test_didTranslationSettingsChange_withFeatureDisabled_andActivePage_reloadsPage() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslatePromptShown)
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.Settings.translationsFeature)
+        let subject = createSubject()
+
+        seedTargetLanguage(in: subject, successDispatchCount: 2)
+
+        let action = ToolbarAction(
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.didTranslationSettingsChange
+        )
+
+        let expectation = XCTestExpectation(description: "reloadWebsite dispatched when disabling translations on active page")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 0.5)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
+        let dispatchedActionType = try XCTUnwrap(dispatchedAction.actionType as? GeneralBrowserActionType)
+        XCTAssertEqual(dispatchedActionType, GeneralBrowserActionType.reloadWebsite)
+    }
+
     func test_didTranslationSettingsChange_clearsStoredTargetLanguageForRetry() throws {
         setTranslationsFeatureEnabled(enabled: true)
         mockProfile.prefs.setBool(false, forKey: PrefsKeys.Settings.translationsFeature)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -870,6 +870,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: ToolbarActionType.didTranslationSettingsChange
         )
         subject.translationsProvider(mockStore.state, toggleAction)
+        mockStore.dispatchedActions.removeAll()
 
         let retryAction = TranslationsAction(
             windowUUID: .XCTestDefaultUUID,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15649)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33521)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

 1. FXIOS-15649 — Disabling the Translations toggle now reloads translated pages so they revert to the original language immediately.
 2. FXIOS-15655 — Re-enabling auto-translate now re-evaluates the current page and auto-translates it.
 3. Spinner fix — A 15-second JS timeout in isDone() prevents the translate button from spinning forever when model downloads fail.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


