### PR TITLE
Bugfix FXIOS-15694 [Tab Tray iPad design] UISegmentControl since experiment version used on iPhone can't be used

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -348,6 +348,7 @@
 		217C6A792F3A7A370085D9B9 /* BrowserViewControllerDynamicViewConstraintsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217C6A782F3A7A090085D9B9 /* BrowserViewControllerDynamicViewConstraintsTests.swift */; };
 		217C6F312F3BD5E00085D9B9 /* BrowserViewControllerConstraintTestsBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217C6F302F3BD5D20085D9B9 /* BrowserViewControllerConstraintTestsBase.swift */; };
 		217C7C2D2F4507170085D9B9 /* BrowserViewControllerKeyboardConstraintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217C7C2C2F4507000085D9B9 /* BrowserViewControllerKeyboardConstraintTests.swift */; };
+		218208DC2F9C0D1D00A899D1 /* TabTrayIpadSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218208DB2F9C0D1300A899D1 /* TabTrayIpadSelectorView.swift */; };
 		218457C62F22A4E800B4FF23 /* TabTrayStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218457C52F22A4E200B4FF23 /* TabTrayStateTests.swift */; };
 		21872A232E3CFEA500241A8A /* TabScrollHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21872A222E3CFEA500241A8A /* TabScrollHandlerTests.swift */; };
 		2191D4472DC3BC1200E1A839 /* ZoomTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2191D4462DC3BC1200E1A839 /* ZoomTelemetry.swift */; };
@@ -3180,6 +3181,7 @@
 		217C6A782F3A7A090085D9B9 /* BrowserViewControllerDynamicViewConstraintsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerDynamicViewConstraintsTests.swift; sourceTree = "<group>"; };
 		217C6F302F3BD5D20085D9B9 /* BrowserViewControllerConstraintTestsBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerConstraintTestsBase.swift; sourceTree = "<group>"; };
 		217C7C2C2F4507000085D9B9 /* BrowserViewControllerKeyboardConstraintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerKeyboardConstraintTests.swift; sourceTree = "<group>"; };
+		218208DB2F9C0D1300A899D1 /* TabTrayIpadSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayIpadSelectorView.swift; sourceTree = "<group>"; };
 		218457C52F22A4E200B4FF23 /* TabTrayStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayStateTests.swift; sourceTree = "<group>"; };
 		21872A222E3CFEA500241A8A /* TabScrollHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollHandlerTests.swift; sourceTree = "<group>"; };
 		2191D4462DC3BC1200E1A839 /* ZoomTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomTelemetry.swift; sourceTree = "<group>"; };
@@ -13374,6 +13376,7 @@
 		5A96FB602D97073C00917B12 /* CustomSelectorView */ = {
 			isa = PBXGroup;
 			children = (
+				218208DB2F9C0D1300A899D1 /* TabTrayIpadSelectorView.swift */,
 				8A0636F52DF0CDAD0076823A /* TabTraySelectorButtonModel.swift */,
 				5A96FB5E2D96DA9700917B12 /* TabTraySelectorView.swift */,
 			);
@@ -19273,6 +19276,7 @@
 				5AA0CC662A4B8F6100014E2A /* PasswordManagerCoordinator.swift in Sources */,
 				8A7368AD27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift in Sources */,
 				39E186DD2F7D98B600FD3FFA /* MerinoCategoryConfiguration.swift in Sources */,
+				218208DC2F9C0D1D00A899D1 /* TabTrayIpadSelectorView.swift in Sources */,
 				C7F5331A2E5799AA0089DEC7 /* ShortcutsLibraryTelemetry.swift in Sources */,
 				C2296FCC2A601C190046ECA6 /* IntensityVisualEffectView.swift in Sources */,
 				8ADC2A102A33758E00543DAA /* FxALaunchParams.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -371,6 +371,7 @@ struct AccessibilityIdentifiers {
         static let tabCell = "TabDisplayView.tabCell"
         static let closeButton = "tabCloseButton"
         static let tabsTray = "Tabs Tray"
+        static let iPadSelectionBackgroundView =  "TabTraySelectorView.selectionBackgroundView"
     }
 
     struct LibraryPanels {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTrayIpadSelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTrayIpadSelectorView.swift
@@ -9,6 +9,7 @@ class TabTrayiPadSelectorView: TabTraySelectorView {
     private struct iPadUX {
         static let stackViewHorizontalSpacing: CGFloat = 80
         static let verticalSpacing: CGFloat = 8
+        static let buttonHorizontalInsets: CGFloat = 16
     }
 
     private var selectionBackgroundConstraints: [NSLayoutConstraint] = []
@@ -18,6 +19,8 @@ class TabTrayiPadSelectorView: TabTraySelectorView {
         selectionBackgroundView.layer.cornerRadius = selectionBackgroundView.frame.height / 2
         if #available(iOS 26, *) {
             visualEffectView.layer.cornerRadius = containerView.bounds.height / 2
+        } else {
+            containerView.layer.cornerRadius = containerView.bounds.height / 2
         }
     }
 
@@ -33,6 +36,15 @@ class TabTrayiPadSelectorView: TabTraySelectorView {
     }
 
     override func setupConstraints() {
+        // On iOS 26 the outer pill is the visualEffectView — inset the stack so the
+        // selection pill sits inside it with breathing room. On iOS 18 the containerView itself
+        // is the outer pill, so the stack hugs its edges and the container hugs the buttons.
+        let stackVerticalInset: CGFloat = if #available(iOS 26, *) {
+            iPadUX.verticalSpacing
+        } else {
+            0
+        }
+
         NSLayoutConstraint.activate([
             containerView.topAnchor.constraint(equalTo: topAnchor, constant: iPadUX.verticalSpacing),
             containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -iPadUX.verticalSpacing),
@@ -41,11 +53,10 @@ class TabTrayiPadSelectorView: TabTraySelectorView {
             containerView.trailingAnchor.constraint(equalTo: trailingAnchor,
                                                     constant: -UX.containerHorizontalSpacing),
 
-            stackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: iPadUX.verticalSpacing),
+            stackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: stackVerticalInset),
             stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
                                                constant: iPadUX.stackViewHorizontalSpacing),
-            stackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor,
-                                              constant: -iPadUX.verticalSpacing),
+            stackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -stackVerticalInset),
             stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor,
                                                 constant: -iPadUX.stackViewHorizontalSpacing),
         ])
@@ -100,5 +111,27 @@ class TabTrayiPadSelectorView: TabTraySelectorView {
             selectionBackgroundView.trailingAnchor.constraint(equalTo: selectedButton.trailingAnchor)
         ]
         NSLayoutConstraint.activate(selectionBackgroundConstraints)
+    }
+
+    override func applyButtonWidthAnchor(on button: UIButton, with title: NSString) {
+        if let existingConstraint = button.constraints.first(where: { $0.firstAttribute == .width }) {
+            existingConstraint.isActive = false
+        }
+
+        let boldFont = FXFontStyles.Bold.body.systemFont()
+        let boldWidth = ceil(title.size(withAttributes: [.font: boldFont]).width)
+        let horizontalInsets = iPadUX.buttonHorizontalInsets * 2
+        button.widthAnchor.constraint(equalToConstant: boldWidth + horizontalInsets).isActive = true
+    }
+
+    override func applyTheme(theme: Theme) {
+        super.applyTheme(theme: theme)
+
+        if #unavailable(iOS 26) {
+            // The parent applies a translucent layer1 background on `self`, which is fine on iPhone
+            // where the bar is full width but on iPad it leaves a visible rectangle around the pill
+            // in private mode where the nav-bar tint and `layer1` differ.
+            backgroundColor = .clear
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTrayIpadSelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTrayIpadSelectorView.swift
@@ -5,126 +5,49 @@
 import UIKit
 import Common
 
-class TabTrayiPadSelectorView: UIView, ThemeApplicable {
-    // MARK: - UX Constants
-    struct UX {
-        static let horizontalSpacing: CGFloat = 12
-        static let cornerRadius: CGFloat = 12
-        static let verticalInsets: CGFloat = 8
-        static let horizontalInsets: CGFloat = 10
-        static let fontScaleDelta: CGFloat = 0.055
-        static let containerHorizontalSpacing: CGFloat = 16
+class TabTrayiPadSelectorView: TabTraySelectorView {
+    private struct iPadUX {
         static let stackViewHorizontalSpacing: CGFloat = 80
         static let verticalSpacing: CGFloat = 8
-        static let bottomSpacingIOS26: CGFloat = 16
     }
 
-    weak var delegate: TabTraySelectorDelegate?
-
-    private var theme: Theme
-    private var selectedIndex: Int
-    private var buttons: [TabTraySelectorButton] = []
-    private var buttonTitles: [String]
     private var selectionBackgroundConstraints: [NSLayoutConstraint] = []
-
-    private var tabTrayUtils: TabTrayUtils
-
-    private lazy var containerView: UIView = .build { view in
-        if #available(iOS 26, *) {
-            view.clipsToBounds = true
-        }
-    }
-
-    private lazy var selectionBackgroundView: UIView = .build { view in
-        view.clipsToBounds = true
-        view.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.iPadSelectionBackgroundView
-    }
-
-    private lazy var stackView: UIStackView = .build { stackView in
-        stackView.axis = .horizontal
-        stackView.spacing = UX.horizontalSpacing
-        stackView.distribution = .fill
-        stackView.alignment = .center
-    }
-
-    private lazy var visualEffectView: UIVisualEffectView = .build { view in
-#if canImport(FoundationModels)
-        if #available(iOS 26, *), !DeviceInfo.isRunningLiquidGlassEarlyBeta {
-            view.effect = UIGlassEffect(style: .regular)
-        } else {
-            view.effect = UIBlurEffect(style: .systemUltraThinMaterial)
-        }
-#else
-        view.effect = UIBlurEffect(style: .systemUltraThinMaterial)
-#endif
-    }
-
-    init(selectedIndex: Int,
-         theme: Theme,
-         buttonTitles: [String],
-         tabTrayUtils: TabTrayUtils = DefaultTabTrayUtils()) {
-        self.selectedIndex = selectedIndex
-        self.theme = theme
-        self.buttonTitles = buttonTitles
-        self.tabTrayUtils = tabTrayUtils
-        super.init(frame: .zero)
-        setup()
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
 
     override func layoutSubviews() {
         super.layoutSubviews()
-
         selectionBackgroundView.layer.cornerRadius = selectionBackgroundView.frame.height / 2
         if #available(iOS 26, *) {
             visualEffectView.layer.cornerRadius = containerView.bounds.height / 2
         }
     }
 
-    func updateSelectionProgress(fromIndex: Int, toIndex: Int, progress: CGFloat) {
-        updateSelectionBackground()
-        simulateFontWeightTransition(from: fromIndex, to: toIndex, progress: abs(progress))
-    }
-
-    func didFinishSelection(to index: Int) {
-        selectedIndex = index
-        adjustSelectedButtonFont(toIndex: index)
-    }
-
-    private func setup() {
+    override func setupViewHierarchy() {
         if #available(iOS 26, *) {
             addSubview(visualEffectView)
         }
         addSubview(containerView)
         containerView.addSubview(stackView)
         insertSubview(selectionBackgroundView, belowSubview: containerView)
+        selectionBackgroundView.clipsToBounds = true
+        selectionBackgroundView.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.iPadSelectionBackgroundView
+    }
 
-        for (index, title) in buttonTitles.enumerated() {
-            let button = createButton(with: index, title: title)
-            buttons.append(button)
-            stackView.addArrangedSubview(button)
-            applyButtonWidthAnchor(on: button, with: title as NSString)
-        }
-
+    override func setupConstraints() {
         NSLayoutConstraint.activate([
-            containerView.topAnchor.constraint(equalTo: topAnchor, constant: UX.verticalSpacing),
-            containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.verticalSpacing),
+            containerView.topAnchor.constraint(equalTo: topAnchor, constant: iPadUX.verticalSpacing),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -iPadUX.verticalSpacing),
             containerView.leadingAnchor.constraint(equalTo: leadingAnchor,
                                                    constant: UX.containerHorizontalSpacing),
             containerView.trailingAnchor.constraint(equalTo: trailingAnchor,
                                                     constant: -UX.containerHorizontalSpacing),
 
-            stackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: UX.verticalSpacing),
+            stackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: iPadUX.verticalSpacing),
             stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
-                                               constant: UX.stackViewHorizontalSpacing),
-            stackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -UX.verticalSpacing),
-            stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
-                                               constant: UX.stackViewHorizontalSpacing),
+                                               constant: iPadUX.stackViewHorizontalSpacing),
+            stackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor,
+                                              constant: -iPadUX.verticalSpacing),
             stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor,
-                                                constant: -UX.stackViewHorizontalSpacing),
+                                                constant: -iPadUX.stackViewHorizontalSpacing),
         ])
 
         if #available(iOS 26, *) {
@@ -135,40 +58,33 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
                 visualEffectView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
             ])
         }
-
-        updateSelectionBackground()
-        applyTheme(theme: theme)
     }
 
-    private func createButton(with index: Int, title: String) -> TabTraySelectorButton {
-        let button = TabTraySelectorButton()
-        let hint = String(format: .TabsTray.TabTraySelectorAccessibilityHint,
-                          NSNumber(value: index + 1),
-                          NSNumber(value: buttonTitles.count))
-        let font = index == selectedIndex
-            ? FXFontStyles.Bold.body.systemFont()
-            : FXFontStyles.Regular.body.systemFont()
-        let contentInsets = NSDirectionalEdgeInsets(
-            top: UX.verticalInsets,
-            leading: UX.horizontalInsets,
-            bottom: UX.verticalInsets,
-            trailing: UX.horizontalInsets
-        )
-        let viewModel = TabTraySelectorButtonModel(
-            title: title,
-            a11yIdentifier: "\(AccessibilityIdentifiers.TabTray.selectorCell)\(index)",
-            a11yHint: hint,
-            font: font,
-            contentInsets: contentInsets,
-            cornerRadius: UX.cornerRadius
-        )
-        button.configure(viewModel: viewModel)
-        button.applyTheme(theme: theme)
+    override func applyInitialConstraints() {
+        updateSelectionBackground()
+    }
 
-        button.tag = index
-        button.addTarget(self, action: #selector(sectionSelected(_:)), for: .touchUpInside)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
+    override func setupGestures() {
+        // No swipe gestures on iPad, the static layout selects via tap only.
+    }
+
+    override func updateSelectionProgress(fromIndex: Int, toIndex: Int, progress: CGFloat) {
+        updateSelectionBackground()
+        simulateFontWeightTransition(from: fromIndex, to: toIndex, progress: abs(progress))
+    }
+
+    override func selectNewSection(from fromIndex: Int, to toIndex: Int, sender: UIButton) {
+        guard buttons.indices.contains(fromIndex),
+              buttons.indices.contains(toIndex) else { return }
+
+        updateSelectionBackground()
+        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut]) {
+            self.layoutIfNeeded()
+        }
+        adjustSelectedButtonFont(toIndex: toIndex)
+
+        let panelType = TabTrayPanelType.getExperimentConvert(index: toIndex)
+        delegate?.didSelectSection(panelType: panelType)
     }
 
     private func updateSelectionBackground() {
@@ -177,94 +93,12 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
         let selectedButton = buttons[selectedIndex]
 
         NSLayoutConstraint.deactivate(selectionBackgroundConstraints)
-
         selectionBackgroundConstraints = [
             selectionBackgroundView.topAnchor.constraint(equalTo: selectedButton.topAnchor),
             selectionBackgroundView.leadingAnchor.constraint(equalTo: selectedButton.leadingAnchor),
             selectionBackgroundView.bottomAnchor.constraint(equalTo: selectedButton.bottomAnchor),
             selectionBackgroundView.trailingAnchor.constraint(equalTo: selectedButton.trailingAnchor)
         ]
-
         NSLayoutConstraint.activate(selectionBackgroundConstraints)
-    }
-
-    private func applyButtonWidthAnchor(on button: UIButton, with title: NSString) {
-        let boldFont = FXFontStyles.Bold.body.systemFont()
-        let boldWidth = ceil(title.size(withAttributes: [.font: boldFont]).width)
-        let horizontalInsets = UX.horizontalInsets * 2
-        button.widthAnchor.constraint(equalToConstant: boldWidth + horizontalInsets).isActive = true
-    }
-
-    @objc
-    private func sectionSelected(_ sender: UIButton) {
-        let oldValue = selectedIndex
-        selectedIndex = sender.tag
-        selectNewSection(from: oldValue, to: selectedIndex, sender: sender)
-    }
-
-    private func selectNewSection(from fromIndex: Int, to toIndex: Int, sender: UIButton) {
-        guard buttons.indices.contains(fromIndex),
-              buttons.indices.contains(toIndex) else { return }
-
-        animateSelectionBackground(to: sender)
-        adjustSelectedButtonFont(toIndex: toIndex)
-
-        let panelType = TabTrayPanelType.getExperimentConvert(index: toIndex)
-        delegate?.didSelectSection(panelType: panelType)
-    }
-
-    private func animateSelectionBackground(to button: UIButton) {
-        updateSelectionBackground()
-
-        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut]) {
-            self.layoutIfNeeded()
-        }
-    }
-
-    private func adjustSelectedButtonFont(toIndex: Int) {
-        for (index, button) in buttons.enumerated() {
-            button.transform = .identity
-            let isSelected = index == toIndex
-            button.isSelected = isSelected
-
-            let font = isSelected
-                ? FXFontStyles.Bold.body.systemFont()
-                : FXFontStyles.Regular.body.systemFont()
-            button.applySelectedFontChange(font: font)
-        }
-    }
-
-    private func simulateFontWeightTransition(from fromIndex: Int, to toIndex: Int, progress: CGFloat) {
-        guard buttons.indices.contains(fromIndex), buttons.indices.contains(toIndex) else { return }
-
-        let easedProgress = 1 - pow(1 - progress, 2)
-        for (index, button) in buttons.enumerated() {
-            if index == fromIndex {
-                let scale = 1.0 - UX.fontScaleDelta * easedProgress
-                button.transform = CGAffineTransform(scaleX: scale, y: scale)
-            } else if index == toIndex {
-                let scale = 1.0 + UX.fontScaleDelta * easedProgress
-                button.transform = CGAffineTransform(scaleX: scale, y: scale)
-            } else {
-                button.transform = .identity
-            }
-        }
-    }
-
-    // MARK: - ThemeApplicable
-
-    func applyTheme(theme: Theme) {
-        self.theme = theme
-
-        if #unavailable(iOS 26) {
-            let backgroundAlpha: CGFloat = tabTrayUtils.backgroundAlpha()
-            backgroundColor = theme.colors.layer1.withAlphaComponent(backgroundAlpha)
-        }
-
-        selectionBackgroundView.backgroundColor = theme.colors.layerEmphasis
-
-        for button in buttons {
-            button.applyTheme(theme: theme)
-        }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTrayIpadSelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTrayIpadSelectorView.swift
@@ -15,7 +15,7 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
         static let fontScaleDelta: CGFloat = 0.055
         static let containerHorizontalSpacing: CGFloat = 16
         static let stackViewHorizontalSpacing: CGFloat = 80
-        static let topSpacing: CGFloat = 8
+        static let verticalSpacing: CGFloat = 8
         static let bottomSpacingIOS26: CGFloat = 16
     }
 
@@ -78,7 +78,7 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        selectionBackgroundView.layer.cornerRadius = containerView.bounds.height / 2
+        selectionBackgroundView.layer.cornerRadius = selectionBackgroundView.frame.height / 2
         if #available(iOS 26, *) {
             visualEffectView.layer.cornerRadius = containerView.bounds.height / 2
         }
@@ -99,9 +99,8 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
             addSubview(visualEffectView)
         }
         addSubview(containerView)
-        containerView.addSubview(selectionBackgroundView)
         containerView.addSubview(stackView)
-        containerView.sendSubviewToBack(selectionBackgroundView)
+        insertSubview(selectionBackgroundView, belowSubview: containerView)
 
         for (index, title) in buttonTitles.enumerated() {
             let button = createButton(with: index, title: title)
@@ -111,17 +110,19 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
         }
 
         NSLayoutConstraint.activate([
-            containerView.topAnchor.constraint(equalTo: topAnchor, constant: UX.topSpacing),
-            containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.bottomSpacingIOS26),
+            containerView.topAnchor.constraint(equalTo: topAnchor, constant: UX.verticalSpacing),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.verticalSpacing),
             containerView.leadingAnchor.constraint(equalTo: leadingAnchor,
                                                    constant: UX.containerHorizontalSpacing),
             containerView.trailingAnchor.constraint(equalTo: trailingAnchor,
                                                     constant: -UX.containerHorizontalSpacing),
 
-            stackView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            stackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: UX.verticalSpacing),
             stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
                                                constant: UX.stackViewHorizontalSpacing),
-            stackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            stackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -UX.verticalSpacing),
+            stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
+                                               constant: UX.stackViewHorizontalSpacing),
             stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor,
                                                 constant: -UX.stackViewHorizontalSpacing),
         ])

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTrayIpadSelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTrayIpadSelectorView.swift
@@ -14,6 +14,7 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
         static let horizontalInsets: CGFloat = 10
         static let fontScaleDelta: CGFloat = 0.055
         static let containerHorizontalSpacing: CGFloat = 16
+        static let stackViewHorizontalSpacing: CGFloat = 80
         static let topSpacing: CGFloat = 8
         static let bottomSpacingIOS26: CGFloat = 16
     }
@@ -24,8 +25,7 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
     private var selectedIndex: Int
     private var buttons: [TabTraySelectorButton] = []
     private var buttonTitles: [String]
-//    private var selectionBackgroundWidthConstraint: NSLayoutConstraint?
-//    private var selectionBackgroundXConstraint: NSLayoutConstraint?
+    private var selectionBackgroundConstraints: [NSLayoutConstraint] = []
 
     private var tabTrayUtils: TabTrayUtils
 
@@ -36,9 +36,8 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
     }
 
     private lazy var selectionBackgroundView: UIView = .build { view in
-        if #unavailable(iOS 26) {
-            view.layer.cornerRadius = UX.cornerRadius
-        }
+        view.clipsToBounds = true
+        view.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.iPadSelectionBackgroundView
     }
 
     private lazy var stackView: UIStackView = .build { stackView in
@@ -79,14 +78,14 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
     override func layoutSubviews() {
         super.layoutSubviews()
 
+        selectionBackgroundView.layer.cornerRadius = containerView.bounds.height / 2
         if #available(iOS 26, *) {
-            selectionBackgroundView.layer.cornerRadius = selectionBackgroundView.frame.height / 2
-            visualEffectView.layer.cornerRadius = containerView.frame.height / 2
+            visualEffectView.layer.cornerRadius = containerView.bounds.height / 2
         }
     }
 
     func updateSelectionProgress(fromIndex: Int, toIndex: Int, progress: CGFloat) {
-        updateSelectionBackground(from: fromIndex, to: toIndex, progress: abs(progress))
+        updateSelectionBackground()
         simulateFontWeightTransition(from: fromIndex, to: toIndex, progress: abs(progress))
     }
 
@@ -102,6 +101,7 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
         addSubview(containerView)
         containerView.addSubview(selectionBackgroundView)
         containerView.addSubview(stackView)
+        containerView.sendSubviewToBack(selectionBackgroundView)
 
         for (index, title) in buttonTitles.enumerated() {
             let button = createButton(with: index, title: title)
@@ -110,29 +110,20 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
             applyButtonWidthAnchor(on: button, with: title as NSString)
         }
 
-        let bottomSpacing: CGFloat = if #available(iOS 26.0, *) {
-            -UX.bottomSpacingIOS26
-        } else {
-            0
-        }
-
-//        let bgCenterX = selectionBackgroundView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor)
-//        selectionBackgroundXConstraint = bgCenterX
-
         NSLayoutConstraint.activate([
             containerView.topAnchor.constraint(equalTo: topAnchor, constant: UX.topSpacing),
-            containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomSpacing),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.bottomSpacingIOS26),
             containerView.leadingAnchor.constraint(equalTo: leadingAnchor,
                                                    constant: UX.containerHorizontalSpacing),
             containerView.trailingAnchor.constraint(equalTo: trailingAnchor,
                                                     constant: -UX.containerHorizontalSpacing),
 
-            stackView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
-            stackView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
-            selectionBackgroundView.heightAnchor.constraint(equalTo: stackView.heightAnchor),
-            selectionBackgroundView.centerYAnchor.constraint(equalTo: stackView.centerYAnchor),
-            selectionBackgroundView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor)
-//            bgCenterX
+            stackView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
+                                               constant: UX.stackViewHorizontalSpacing),
+            stackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor,
+                                                constant: -UX.stackViewHorizontalSpacing),
         ])
 
         if #available(iOS 26, *) {
@@ -144,9 +135,7 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
             ])
         }
 
-        applyInitialConstraints()
-        addSwipeGestureRecognizer(direction: .right)
-        addSwipeGestureRecognizer(direction: .left)
+        updateSelectionBackground()
         applyTheme(theme: theme)
     }
 
@@ -181,56 +170,28 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
         return button
     }
 
-    private func applyInitialConstraints() {
+    private func updateSelectionBackground() {
         guard buttons.indices.contains(selectedIndex) else { return }
-        layoutIfNeeded()
 
         let selectedButton = buttons[selectedIndex]
-//        selectionBackgroundWidthConstraint = selectionBackgroundView.widthAnchor.constraint(
-//            equalToConstant: selectedButton.frame.width
-//        )
-//        selectionBackgroundWidthConstraint?.isActive = true
-        selectionBackgroundView.widthAnchor.constraint(equalToConstant: selectedButton.frame.width).isActive = true
 
-//        let buttonCenter = selectedButton.convert(selectedButton.bounds.center, to: containerView)
-//        selectionBackgroundXConstraint?.constant = buttonCenter.x - containerView.bounds.midX
+        NSLayoutConstraint.deactivate(selectionBackgroundConstraints)
+
+        selectionBackgroundConstraints = [
+            selectionBackgroundView.topAnchor.constraint(equalTo: selectedButton.topAnchor),
+            selectionBackgroundView.leadingAnchor.constraint(equalTo: selectedButton.leadingAnchor),
+            selectionBackgroundView.bottomAnchor.constraint(equalTo: selectedButton.bottomAnchor),
+            selectionBackgroundView.trailingAnchor.constraint(equalTo: selectedButton.trailingAnchor)
+        ]
+
+        NSLayoutConstraint.activate(selectionBackgroundConstraints)
     }
 
     private func applyButtonWidthAnchor(on button: UIButton, with title: NSString) {
-        if let existingConstraint = button.constraints.first(where: { $0.firstAttribute == .width }) {
-            existingConstraint.isActive = false
-        }
-
         let boldFont = FXFontStyles.Bold.body.systemFont()
         let boldWidth = ceil(title.size(withAttributes: [.font: boldFont]).width)
         let horizontalInsets = UX.horizontalInsets * 2
         button.widthAnchor.constraint(equalToConstant: boldWidth + horizontalInsets).isActive = true
-    }
-
-    // MARK: - Gesture Recognizers
-
-    private func addSwipeGestureRecognizer(direction: UISwipeGestureRecognizer.Direction) {
-        let gestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipeGesture(_:)))
-        gestureRecognizer.direction = direction
-        addGestureRecognizer(gestureRecognizer)
-    }
-
-    @objc
-    private func handleSwipeGesture(_ recognizer: UISwipeGestureRecognizer) {
-        switch recognizer.direction {
-        case .left:
-            let index = selectedIndex + 1
-            if buttons.indices.contains(index) {
-                sectionSelected(buttons[index])
-            }
-        case .right:
-            let index = selectedIndex - 1
-            if buttons.indices.contains(index) {
-                sectionSelected(buttons[index])
-            }
-        default:
-            break
-        }
     }
 
     @objc
@@ -252,13 +213,11 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
     }
 
     private func animateSelectionBackground(to button: UIButton) {
-//        selectionBackgroundWidthConstraint?.constant = button.frame.width
-//        let buttonCenter = button.convert(button.bounds.center, to: containerView)
-//        selectionBackgroundXConstraint?.constant = buttonCenter.x - containerView.bounds.midX
-//
-//        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut]) {
-//            self.layoutIfNeeded()
-//        }
+        updateSelectionBackground()
+
+        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut]) {
+            self.layoutIfNeeded()
+        }
     }
 
     private func adjustSelectedButtonFont(toIndex: Int) {
@@ -289,25 +248,6 @@ class TabTrayiPadSelectorView: UIView, ThemeApplicable {
                 button.transform = .identity
             }
         }
-    }
-
-    private func updateSelectionBackground(from fromIndex: Int,
-                                           to toIndex: Int,
-                                           progress: CGFloat) {
-        guard buttons.indices.contains(fromIndex), buttons.indices.contains(toIndex) else { return }
-
-        let fromButton = buttons[fromIndex]
-        let toButton = buttons[toIndex]
-
-        let fromCenter = fromButton.convert(fromButton.bounds.center, to: containerView)
-        let toCenter = toButton.convert(toButton.bounds.center, to: containerView)
-//        let interpolatedX = fromCenter.x + (toCenter.x - fromCenter.x) * progress
-//        selectionBackgroundXConstraint?.constant = interpolatedX - containerView.bounds.midX
-
-//        let interpolatedWidth = fromButton.bounds.width + (toButton.bounds.width - fromButton.bounds.width) * progress
-//        selectionBackgroundWidthConstraint?.constant = interpolatedWidth
-
-        layoutIfNeeded()
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTrayIpadSelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTrayIpadSelectorView.swift
@@ -1,0 +1,329 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+
+class TabTrayiPadSelectorView: UIView, ThemeApplicable {
+    // MARK: - UX Constants
+    struct UX {
+        static let horizontalSpacing: CGFloat = 12
+        static let cornerRadius: CGFloat = 12
+        static let verticalInsets: CGFloat = 8
+        static let horizontalInsets: CGFloat = 10
+        static let fontScaleDelta: CGFloat = 0.055
+        static let containerHorizontalSpacing: CGFloat = 16
+        static let topSpacing: CGFloat = 8
+        static let bottomSpacingIOS26: CGFloat = 16
+    }
+
+    weak var delegate: TabTraySelectorDelegate?
+
+    private var theme: Theme
+    private var selectedIndex: Int
+    private var buttons: [TabTraySelectorButton] = []
+    private var buttonTitles: [String]
+//    private var selectionBackgroundWidthConstraint: NSLayoutConstraint?
+//    private var selectionBackgroundXConstraint: NSLayoutConstraint?
+
+    private var tabTrayUtils: TabTrayUtils
+
+    private lazy var containerView: UIView = .build { view in
+        if #available(iOS 26, *) {
+            view.clipsToBounds = true
+        }
+    }
+
+    private lazy var selectionBackgroundView: UIView = .build { view in
+        if #unavailable(iOS 26) {
+            view.layer.cornerRadius = UX.cornerRadius
+        }
+    }
+
+    private lazy var stackView: UIStackView = .build { stackView in
+        stackView.axis = .horizontal
+        stackView.spacing = UX.horizontalSpacing
+        stackView.distribution = .fill
+        stackView.alignment = .center
+    }
+
+    private lazy var visualEffectView: UIVisualEffectView = .build { view in
+#if canImport(FoundationModels)
+        if #available(iOS 26, *), !DeviceInfo.isRunningLiquidGlassEarlyBeta {
+            view.effect = UIGlassEffect(style: .regular)
+        } else {
+            view.effect = UIBlurEffect(style: .systemUltraThinMaterial)
+        }
+#else
+        view.effect = UIBlurEffect(style: .systemUltraThinMaterial)
+#endif
+    }
+
+    init(selectedIndex: Int,
+         theme: Theme,
+         buttonTitles: [String],
+         tabTrayUtils: TabTrayUtils = DefaultTabTrayUtils()) {
+        self.selectedIndex = selectedIndex
+        self.theme = theme
+        self.buttonTitles = buttonTitles
+        self.tabTrayUtils = tabTrayUtils
+        super.init(frame: .zero)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        if #available(iOS 26, *) {
+            selectionBackgroundView.layer.cornerRadius = selectionBackgroundView.frame.height / 2
+            visualEffectView.layer.cornerRadius = containerView.frame.height / 2
+        }
+    }
+
+    func updateSelectionProgress(fromIndex: Int, toIndex: Int, progress: CGFloat) {
+        updateSelectionBackground(from: fromIndex, to: toIndex, progress: abs(progress))
+        simulateFontWeightTransition(from: fromIndex, to: toIndex, progress: abs(progress))
+    }
+
+    func didFinishSelection(to index: Int) {
+        selectedIndex = index
+        adjustSelectedButtonFont(toIndex: index)
+    }
+
+    private func setup() {
+        if #available(iOS 26, *) {
+            addSubview(visualEffectView)
+        }
+        addSubview(containerView)
+        containerView.addSubview(selectionBackgroundView)
+        containerView.addSubview(stackView)
+
+        for (index, title) in buttonTitles.enumerated() {
+            let button = createButton(with: index, title: title)
+            buttons.append(button)
+            stackView.addArrangedSubview(button)
+            applyButtonWidthAnchor(on: button, with: title as NSString)
+        }
+
+        let bottomSpacing: CGFloat = if #available(iOS 26.0, *) {
+            -UX.bottomSpacingIOS26
+        } else {
+            0
+        }
+
+//        let bgCenterX = selectionBackgroundView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor)
+//        selectionBackgroundXConstraint = bgCenterX
+
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: topAnchor, constant: UX.topSpacing),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomSpacing),
+            containerView.leadingAnchor.constraint(equalTo: leadingAnchor,
+                                                   constant: UX.containerHorizontalSpacing),
+            containerView.trailingAnchor.constraint(equalTo: trailingAnchor,
+                                                    constant: -UX.containerHorizontalSpacing),
+
+            stackView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+            selectionBackgroundView.heightAnchor.constraint(equalTo: stackView.heightAnchor),
+            selectionBackgroundView.centerYAnchor.constraint(equalTo: stackView.centerYAnchor),
+            selectionBackgroundView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor)
+//            bgCenterX
+        ])
+
+        if #available(iOS 26, *) {
+            NSLayoutConstraint.activate([
+                visualEffectView.topAnchor.constraint(equalTo: containerView.topAnchor),
+                visualEffectView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+                visualEffectView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+                visualEffectView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
+            ])
+        }
+
+        applyInitialConstraints()
+        addSwipeGestureRecognizer(direction: .right)
+        addSwipeGestureRecognizer(direction: .left)
+        applyTheme(theme: theme)
+    }
+
+    private func createButton(with index: Int, title: String) -> TabTraySelectorButton {
+        let button = TabTraySelectorButton()
+        let hint = String(format: .TabsTray.TabTraySelectorAccessibilityHint,
+                          NSNumber(value: index + 1),
+                          NSNumber(value: buttonTitles.count))
+        let font = index == selectedIndex
+            ? FXFontStyles.Bold.body.systemFont()
+            : FXFontStyles.Regular.body.systemFont()
+        let contentInsets = NSDirectionalEdgeInsets(
+            top: UX.verticalInsets,
+            leading: UX.horizontalInsets,
+            bottom: UX.verticalInsets,
+            trailing: UX.horizontalInsets
+        )
+        let viewModel = TabTraySelectorButtonModel(
+            title: title,
+            a11yIdentifier: "\(AccessibilityIdentifiers.TabTray.selectorCell)\(index)",
+            a11yHint: hint,
+            font: font,
+            contentInsets: contentInsets,
+            cornerRadius: UX.cornerRadius
+        )
+        button.configure(viewModel: viewModel)
+        button.applyTheme(theme: theme)
+
+        button.tag = index
+        button.addTarget(self, action: #selector(sectionSelected(_:)), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }
+
+    private func applyInitialConstraints() {
+        guard buttons.indices.contains(selectedIndex) else { return }
+        layoutIfNeeded()
+
+        let selectedButton = buttons[selectedIndex]
+//        selectionBackgroundWidthConstraint = selectionBackgroundView.widthAnchor.constraint(
+//            equalToConstant: selectedButton.frame.width
+//        )
+//        selectionBackgroundWidthConstraint?.isActive = true
+        selectionBackgroundView.widthAnchor.constraint(equalToConstant: selectedButton.frame.width).isActive = true
+
+//        let buttonCenter = selectedButton.convert(selectedButton.bounds.center, to: containerView)
+//        selectionBackgroundXConstraint?.constant = buttonCenter.x - containerView.bounds.midX
+    }
+
+    private func applyButtonWidthAnchor(on button: UIButton, with title: NSString) {
+        if let existingConstraint = button.constraints.first(where: { $0.firstAttribute == .width }) {
+            existingConstraint.isActive = false
+        }
+
+        let boldFont = FXFontStyles.Bold.body.systemFont()
+        let boldWidth = ceil(title.size(withAttributes: [.font: boldFont]).width)
+        let horizontalInsets = UX.horizontalInsets * 2
+        button.widthAnchor.constraint(equalToConstant: boldWidth + horizontalInsets).isActive = true
+    }
+
+    // MARK: - Gesture Recognizers
+
+    private func addSwipeGestureRecognizer(direction: UISwipeGestureRecognizer.Direction) {
+        let gestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipeGesture(_:)))
+        gestureRecognizer.direction = direction
+        addGestureRecognizer(gestureRecognizer)
+    }
+
+    @objc
+    private func handleSwipeGesture(_ recognizer: UISwipeGestureRecognizer) {
+        switch recognizer.direction {
+        case .left:
+            let index = selectedIndex + 1
+            if buttons.indices.contains(index) {
+                sectionSelected(buttons[index])
+            }
+        case .right:
+            let index = selectedIndex - 1
+            if buttons.indices.contains(index) {
+                sectionSelected(buttons[index])
+            }
+        default:
+            break
+        }
+    }
+
+    @objc
+    private func sectionSelected(_ sender: UIButton) {
+        let oldValue = selectedIndex
+        selectedIndex = sender.tag
+        selectNewSection(from: oldValue, to: selectedIndex, sender: sender)
+    }
+
+    private func selectNewSection(from fromIndex: Int, to toIndex: Int, sender: UIButton) {
+        guard buttons.indices.contains(fromIndex),
+              buttons.indices.contains(toIndex) else { return }
+
+        animateSelectionBackground(to: sender)
+        adjustSelectedButtonFont(toIndex: toIndex)
+
+        let panelType = TabTrayPanelType.getExperimentConvert(index: toIndex)
+        delegate?.didSelectSection(panelType: panelType)
+    }
+
+    private func animateSelectionBackground(to button: UIButton) {
+//        selectionBackgroundWidthConstraint?.constant = button.frame.width
+//        let buttonCenter = button.convert(button.bounds.center, to: containerView)
+//        selectionBackgroundXConstraint?.constant = buttonCenter.x - containerView.bounds.midX
+//
+//        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut]) {
+//            self.layoutIfNeeded()
+//        }
+    }
+
+    private func adjustSelectedButtonFont(toIndex: Int) {
+        for (index, button) in buttons.enumerated() {
+            button.transform = .identity
+            let isSelected = index == toIndex
+            button.isSelected = isSelected
+
+            let font = isSelected
+                ? FXFontStyles.Bold.body.systemFont()
+                : FXFontStyles.Regular.body.systemFont()
+            button.applySelectedFontChange(font: font)
+        }
+    }
+
+    private func simulateFontWeightTransition(from fromIndex: Int, to toIndex: Int, progress: CGFloat) {
+        guard buttons.indices.contains(fromIndex), buttons.indices.contains(toIndex) else { return }
+
+        let easedProgress = 1 - pow(1 - progress, 2)
+        for (index, button) in buttons.enumerated() {
+            if index == fromIndex {
+                let scale = 1.0 - UX.fontScaleDelta * easedProgress
+                button.transform = CGAffineTransform(scaleX: scale, y: scale)
+            } else if index == toIndex {
+                let scale = 1.0 + UX.fontScaleDelta * easedProgress
+                button.transform = CGAffineTransform(scaleX: scale, y: scale)
+            } else {
+                button.transform = .identity
+            }
+        }
+    }
+
+    private func updateSelectionBackground(from fromIndex: Int,
+                                           to toIndex: Int,
+                                           progress: CGFloat) {
+        guard buttons.indices.contains(fromIndex), buttons.indices.contains(toIndex) else { return }
+
+        let fromButton = buttons[fromIndex]
+        let toButton = buttons[toIndex]
+
+        let fromCenter = fromButton.convert(fromButton.bounds.center, to: containerView)
+        let toCenter = toButton.convert(toButton.bounds.center, to: containerView)
+//        let interpolatedX = fromCenter.x + (toCenter.x - fromCenter.x) * progress
+//        selectionBackgroundXConstraint?.constant = interpolatedX - containerView.bounds.midX
+
+//        let interpolatedWidth = fromButton.bounds.width + (toButton.bounds.width - fromButton.bounds.width) * progress
+//        selectionBackgroundWidthConstraint?.constant = interpolatedWidth
+
+        layoutIfNeeded()
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        self.theme = theme
+
+        if #unavailable(iOS 26) {
+            let backgroundAlpha: CGFloat = tabTrayUtils.backgroundAlpha()
+            backgroundColor = theme.colors.layer1.withAlphaComponent(backgroundAlpha)
+        }
+
+        selectionBackgroundView.backgroundColor = theme.colors.layerEmphasis
+
+        for button in buttons {
+            button.applyTheme(theme: theme)
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -26,36 +26,36 @@ class TabTraySelectorView: UIView, ThemeApplicable {
 
     weak var delegate: TabTraySelectorDelegate?
 
-    private var theme: Theme
-    private var selectedIndex: Int
-    private var buttons: [TabTraySelectorButton] = []
-    private var buttonTitles: [String]
+    var theme: Theme
+    var selectedIndex: Int
+    var buttons: [TabTraySelectorButton] = []
+    let buttonTitles: [String]
+    let tabTrayUtils: TabTrayUtils
+
     private var selectionBackgroundWidthConstraint: NSLayoutConstraint?
     private var stackViewOffsetConstraint: NSLayoutConstraint?
     private let edgeFadeGradientLayer = CAGradientLayer()
 
-    private var tabTrayUtils: TabTrayUtils
-
-    private lazy var containerView: UIView = .build { view in
+    lazy var containerView: UIView = .build { view in
         if #available(iOS 26, *) {
             view.clipsToBounds = true
         }
     }
 
-    private lazy var selectionBackgroundView: UIView = .build { view in
+    lazy var selectionBackgroundView: UIView = .build { view in
         if #unavailable(iOS 26) {
             view.layer.cornerRadius = UX.cornerRadius
         }
     }
 
-    private lazy var stackView: UIStackView = .build { stackView in
+    lazy var stackView: UIStackView = .build { stackView in
         stackView.axis = .horizontal
         stackView.spacing = UX.horizontalSpacing
         stackView.distribution = .fill
         stackView.alignment = .center
     }
 
-    private lazy var visualEffectView: UIVisualEffectView = .build { view in
+    lazy var visualEffectView: UIVisualEffectView = .build { view in
 #if canImport(FoundationModels)
         if #available(iOS 26, *), !DeviceInfo.isRunningLiquidGlassEarlyBeta {
             view.effect = UIGlassEffect(style: .regular)
@@ -104,13 +104,7 @@ class TabTraySelectorView: UIView, ThemeApplicable {
     }
 
     private func setup() {
-        if #available(iOS 26, *) {
-            addSubview(visualEffectView)
-        }
-        addSubview(containerView)
-        containerView.addSubview(selectionBackgroundView)
-        containerView.addSubview(stackView)
-        containerView.layer.mask = edgeFadeGradientLayer
+        setupViewHierarchy()
 
         for (index, title) in buttonTitles.enumerated() {
             let button = createButton(with: index, title: title)
@@ -119,6 +113,23 @@ class TabTraySelectorView: UIView, ThemeApplicable {
             applyButtonWidthAnchor(on: button, with: title as NSString)
         }
 
+        setupConstraints()
+        applyInitialConstraints()
+        setupGestures()
+        applyTheme(theme: theme)
+    }
+
+    func setupViewHierarchy() {
+        if #available(iOS 26, *) {
+            addSubview(visualEffectView)
+        }
+        addSubview(containerView)
+        containerView.addSubview(selectionBackgroundView)
+        containerView.addSubview(stackView)
+        containerView.layer.mask = edgeFadeGradientLayer
+    }
+
+    func setupConstraints() {
         let bottomSpacing: CGFloat = if #available(iOS 26.0, *) {
             -UX.bottomSpacingIOS26
         } else {
@@ -148,14 +159,14 @@ class TabTraySelectorView: UIView, ThemeApplicable {
                 visualEffectView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
             ])
         }
-
-        applyInitialConstraints()
-        addSwipeGestureRecognizer(direction: .right)
-        addSwipeGestureRecognizer(direction: .left)
-        applyTheme(theme: theme)
     }
 
-    private func createButton(with index: Int, title: String) -> TabTraySelectorButton {
+    func setupGestures() {
+        addSwipeGestureRecognizer(direction: .right)
+        addSwipeGestureRecognizer(direction: .left)
+    }
+
+    func createButton(with index: Int, title: String) -> TabTraySelectorButton {
         let button = TabTraySelectorButton()
         let hint = String(format: .TabsTray.TabTraySelectorAccessibilityHint,
                           NSNumber(value: index + 1),
@@ -186,7 +197,7 @@ class TabTraySelectorView: UIView, ThemeApplicable {
         return button
     }
 
-    private func applyInitialConstraints() {
+    func applyInitialConstraints() {
         guard buttons.indices.contains(selectedIndex) else { return }
         layoutIfNeeded()
 
@@ -211,7 +222,7 @@ class TabTraySelectorView: UIView, ThemeApplicable {
     ///
     /// This prevents visual layout shifts during font weight transitions (e.g., from regular to bold),
     /// ensuring consistent spacing and avoiding jitter in horizontally stacked button layouts.
-    private func applyButtonWidthAnchor(on button: UIButton, with title: NSString) {
+    func applyButtonWidthAnchor(on button: UIButton, with title: NSString) {
         if let existingConstraint = button.constraints.first(where: { $0.firstAttribute == .width }) {
             existingConstraint.isActive = false
         }
@@ -254,7 +265,7 @@ class TabTraySelectorView: UIView, ThemeApplicable {
         selectNewSection(from: oldValue, to: selectedIndex, sender: sender)
     }
 
-    private func selectNewSection(from fromIndex: Int, to toIndex: Int, sender: UIButton) {
+    func selectNewSection(from fromIndex: Int, to toIndex: Int, sender: UIButton) {
         guard buttons.indices.contains(fromIndex),
               buttons.indices.contains(toIndex) else { return }
 
@@ -287,7 +298,7 @@ class TabTraySelectorView: UIView, ThemeApplicable {
         })
     }
 
-    private func adjustSelectedButtonFont(toIndex: Int) {
+    func adjustSelectedButtonFont(toIndex: Int) {
         for (index, button) in buttons.enumerated() {
             button.transform = .identity
             let isSelected = index == toIndex
@@ -300,7 +311,7 @@ class TabTraySelectorView: UIView, ThemeApplicable {
         }
     }
 
-    private func simulateFontWeightTransition(from fromIndex: Int, to toIndex: Int, progress: CGFloat) {
+    func simulateFontWeightTransition(from fromIndex: Int, to toIndex: Int, progress: CGFloat) {
         guard buttons.indices.contains(fromIndex), buttons.indices.contains(toIndex) else { return }
 
         let easedProgress = 1 - pow(1 - progress, 2)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -23,7 +23,7 @@ class TabTraySelectorView: UIView, ThemeApplicable {
         static let topSpacing: CGFloat = 8
         static let bottomSpacingIOS26: CGFloat = 16
     }
-    
+
     weak var delegate: TabTraySelectorDelegate?
 
     private var theme: Theme

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -10,20 +10,20 @@ protocol TabTraySelectorDelegate: AnyObject {
     func didSelectSection(panelType: TabTrayPanelType)
 }
 
-// MARK: - UX Constants
-struct TabTraySelectorUX {
-    static let horizontalSpacing: CGFloat = 12
-    static let cornerRadius: CGFloat = 12
-    static let verticalInsets: CGFloat = 8
-    static let horizontalInsets: CGFloat = 10
-    static let fontScaleDelta: CGFloat = 0.055
-    static let stackViewLeadingTrailingPadding: CGFloat = 8
-    static let containerHorizontalSpacing: CGFloat = 16
-    static let topSpacing: CGFloat = 8
-    static let bottomSpacingIOS26: CGFloat = 16
-}
-
 class TabTraySelectorView: UIView, ThemeApplicable {
+    // MARK: - UX Constants
+    struct UX {
+        static let horizontalSpacing: CGFloat = 12
+        static let cornerRadius: CGFloat = 12
+        static let verticalInsets: CGFloat = 8
+        static let horizontalInsets: CGFloat = 10
+        static let fontScaleDelta: CGFloat = 0.055
+        static let stackViewLeadingTrailingPadding: CGFloat = 8
+        static let containerHorizontalSpacing: CGFloat = 16
+        static let topSpacing: CGFloat = 8
+        static let bottomSpacingIOS26: CGFloat = 16
+    }
+    
     weak var delegate: TabTraySelectorDelegate?
 
     private var theme: Theme
@@ -44,13 +44,13 @@ class TabTraySelectorView: UIView, ThemeApplicable {
 
     private lazy var selectionBackgroundView: UIView = .build { view in
         if #unavailable(iOS 26) {
-            view.layer.cornerRadius = TabTraySelectorUX.cornerRadius
+            view.layer.cornerRadius = UX.cornerRadius
         }
     }
 
     private lazy var stackView: UIStackView = .build { stackView in
         stackView.axis = .horizontal
-        stackView.spacing = TabTraySelectorUX.horizontalSpacing
+        stackView.spacing = UX.horizontalSpacing
         stackView.distribution = .fill
         stackView.alignment = .center
     }
@@ -120,19 +120,19 @@ class TabTraySelectorView: UIView, ThemeApplicable {
         }
 
         let bottomSpacing: CGFloat = if #available(iOS 26.0, *) {
-            -TabTraySelectorUX.bottomSpacingIOS26
+            -UX.bottomSpacingIOS26
         } else {
             0
         }
 
         NSLayoutConstraint.activate([
             containerView.topAnchor.constraint(equalTo: topAnchor,
-                                               constant: TabTraySelectorUX.topSpacing),
+                                               constant: UX.topSpacing),
             containerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomSpacing),
             containerView.leadingAnchor.constraint(equalTo: leadingAnchor,
-                                                   constant: TabTraySelectorUX.containerHorizontalSpacing),
+                                                   constant: UX.containerHorizontalSpacing),
             containerView.trailingAnchor.constraint(equalTo: trailingAnchor,
-                                                    constant: -TabTraySelectorUX.containerHorizontalSpacing),
+                                                    constant: -UX.containerHorizontalSpacing),
 
             stackView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
             selectionBackgroundView.heightAnchor.constraint(equalTo: stackView.heightAnchor),
@@ -164,10 +164,10 @@ class TabTraySelectorView: UIView, ThemeApplicable {
             ? FXFontStyles.Bold.body.systemFont()
             : FXFontStyles.Regular.body.systemFont()
         let contentInsets = NSDirectionalEdgeInsets(
-            top: TabTraySelectorUX.verticalInsets,
-            leading: TabTraySelectorUX.horizontalInsets,
-            bottom: TabTraySelectorUX.verticalInsets,
-            trailing: TabTraySelectorUX.horizontalInsets
+            top: UX.verticalInsets,
+            leading: UX.horizontalInsets,
+            bottom: UX.verticalInsets,
+            trailing: UX.horizontalInsets
         )
         let viewModel = TabTraySelectorButtonModel(
             title: title,
@@ -175,7 +175,7 @@ class TabTraySelectorView: UIView, ThemeApplicable {
             a11yHint: hint,
             font: font,
             contentInsets: contentInsets,
-            cornerRadius: TabTraySelectorUX.cornerRadius
+            cornerRadius: UX.cornerRadius
         )
         button.configure(viewModel: viewModel)
         button.applyTheme(theme: theme)
@@ -218,7 +218,7 @@ class TabTraySelectorView: UIView, ThemeApplicable {
 
         let boldFont = FXFontStyles.Bold.body.systemFont()
         let boldWidth = ceil(title.size(withAttributes: [.font: boldFont]).width)
-        let horizontalInsets = TabTraySelectorUX.horizontalInsets * 2
+        let horizontalInsets = UX.horizontalInsets * 2
         button.widthAnchor.constraint(equalToConstant: boldWidth + horizontalInsets).isActive = true
     }
 
@@ -307,11 +307,11 @@ class TabTraySelectorView: UIView, ThemeApplicable {
         for (index, button) in buttons.enumerated() {
             if index == fromIndex {
                 // Scale down as we move away
-                let scale = 1.0 - TabTraySelectorUX.fontScaleDelta * easedProgress
+                let scale = 1.0 - UX.fontScaleDelta * easedProgress
                 button.transform = CGAffineTransform(scaleX: scale, y: scale)
             } else if index == toIndex {
                 // Scale up as we approach
-                let scale = 1.0 + TabTraySelectorUX.fontScaleDelta * easedProgress
+                let scale = 1.0 + UX.fontScaleDelta * easedProgress
                 button.transform = CGAffineTransform(scaleX: scale, y: scale)
             } else {
                 // Reset others

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
@@ -41,6 +41,7 @@ class RemoteTabsViewController: UIViewController,
     weak var remoteTabsPanel: RemoteTabsPanel?
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
+    private let tabTrayUtils: TabTrayUtils
 
     var tableView: UITableView = .build()
     private var isShowingEmptyView: Bool { state.showingEmptyState != nil }
@@ -71,13 +72,15 @@ class RemoteTabsViewController: UIViewController,
          windowUUID: WindowUUID,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
-         logger: Logger = DefaultLogger.shared
+         logger: Logger = DefaultLogger.shared,
+         tabTrayUtils: TabTrayUtils = DefaultTabTrayUtils()
     ) {
         self.state = state
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
         self.logger = logger
+        self.tabTrayUtils = tabTrayUtils
         super.init(nibName: nil, bundle: nil)
 
         tableView.dataSource = self
@@ -204,26 +207,6 @@ class RemoteTabsViewController: UIViewController,
         guard let emptyStateReason = state.showingEmptyState else { return }
         emptyView.configure(config: emptyStateReason, delegate: remoteTabsPanel, isSyncing: isSyncing)
         emptyView.applyTheme(theme: retrieveTheme())
-    }
-
-    private func show(toast: Toast,
-                      afterWaiting delay: DispatchTimeInterval = Toast.UX.toastDelayBefore,
-                      duration: DispatchTimeInterval? = Toast.UX.toastDismissAfter) {
-        guard !isTabTrayUIExperimentsEnabled else { return }
-
-        if let buttonToast = toast as? ButtonToast {
-            self.buttonToast = buttonToast
-        }
-
-        toast.showToast(viewController: self, delay: delay, duration: duration) { toast in
-            [
-                toast.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor,
-                                               constant: Toast.UX.toastSidePadding),
-                toast.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor,
-                                                constant: -Toast.UX.toastSidePadding),
-                toast.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
-            ]
-        }
     }
 
     // MARK: - Refreshing TableView
@@ -483,9 +466,9 @@ class RemoteTabsViewController: UIViewController,
             emptyView.updateInsets(top: view.safeAreaInsets.top, bottom: 0)
         } else {
             let bottomInset = if emptyView.needsSafeArea {
-                DefaultTabTrayUtils().segmentedControlHeight + view.safeAreaInsets.bottom
+                tabTrayUtils.segmentedControlHeight + view.safeAreaInsets.bottom
             } else {
-                DefaultTabTrayUtils().segmentedControlHeight
+                tabTrayUtils.segmentedControlHeight
             }
 
             emptyView.updateInsets(top: 0, bottom: bottomInset)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -682,13 +682,7 @@ final class TabTrayViewController: UIViewController,
             panelContainer.topAnchor.constraint(equalTo: containerView.topAnchor),
             panelContainer.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             panelContainer.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            panelContainer.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
-
-            // Because experimentSegmentControl doesn't inherit from UISegmentControl
-            // we need to set height and width constraints
-            experimentSegmentControl.widthAnchor.constraint(equalToConstant:
-                                                                UX.NavigationMenu.iPadWidth),
-            experimentSegmentControl.heightAnchor.constraint(equalToConstant: tabTrayUtils.segmentedControlHeight)
+            panelContainer.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
         ])
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -484,6 +484,7 @@ final class TabTrayViewController: UIViewController,
         panelContainer.backgroundColor = swipeTheme.colors.layer3
 
         experimentSegmentControl.applyTheme(theme: swipeTheme)
+        experimentiPadSegmentControl.applyTheme(theme: swipeTheme)
         setupToolBarAppearance(theme: swipeTheme)
         setupNavigationBarAppearance(theme: swipeTheme)
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -153,6 +153,10 @@ final class TabTrayViewController: UIViewController,
         return selector
     }()
 
+    private var activeExperimentSegmentControl: TabTraySelectorView {
+        shouldUseiPadSetup() ? experimentiPadSegmentControl : experimentSegmentControl
+    }
+
     private func experimentConvertSelectedIndex() -> Int {
         // Temporary offset of numbers to account for the different order in the experiment - tabTrayUIExperiments
         // Order can be updated in TabTrayPanelType once the experiment is done
@@ -458,7 +462,7 @@ final class TabTrayViewController: UIViewController,
         panelContainer.backgroundColor = theme.colors.layer3
 
         if shouldUsePrivateOverride {
-            experimentSegmentControl.applyTheme(theme: theme)
+            activeExperimentSegmentControl.applyTheme(theme: theme)
 
             let userInterfaceStyle = tabTrayState.isPrivateMode ? .dark : theme.type.getInterfaceStyle()
             navigationController?.overrideUserInterfaceStyle = userInterfaceStyle
@@ -483,8 +487,7 @@ final class TabTrayViewController: UIViewController,
         syncTabButton.tintColor = swipeTheme.colors.iconPrimary
         panelContainer.backgroundColor = swipeTheme.colors.layer3
 
-        experimentSegmentControl.applyTheme(theme: swipeTheme)
-        experimentiPadSegmentControl.applyTheme(theme: swipeTheme)
+        activeExperimentSegmentControl.applyTheme(theme: swipeTheme)
         setupToolBarAppearance(theme: swipeTheme)
         setupNavigationBarAppearance(theme: swipeTheme)
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -138,6 +138,21 @@ final class TabTrayViewController: UIViewController,
         return selector
     }()
 
+    private lazy var experimentiPadSegmentControl: TabTrayiPadSelectorView = {
+        let selectedIndex = experimentConvertSelectedIndex()
+        let titles = [TabTrayPanelType.privateTabs.label,
+                     TabTrayPanelType.tabs.label,
+                     TabTrayPanelType.syncedTabs.label]
+        let selector = TabTrayiPadSelectorView(selectedIndex: selectedIndex,
+                                               theme: retrieveTheme(),
+                                               buttonTitles: titles)
+        selector.delegate = self
+        selector.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.navBarSegmentedControl
+
+        didSelectSection(panelType: tabTrayState.selectedPanel)
+        return selector
+    }()
+
     private func experimentConvertSelectedIndex() -> Int {
         // Temporary offset of numbers to account for the different order in the experiment - tabTrayUIExperiments
         // Order can be updated in TabTrayPanelType once the experiment is done
@@ -345,9 +360,16 @@ final class TabTrayViewController: UIViewController,
                 navigationItem.rightBarButtonItems = [doneButton]
             }
         case .regular:
-            navigationItem.titleView = tabTrayUtils.shouldDisplayExperimentUI() ? experimentSegmentControl : segmentedControl
+
+            navigationItem.titleView = getSegmentedControl()
         }
         updateToolbarItems()
+    }
+
+    func getSegmentedControl() -> UIView {
+        guard tabTrayUtils.shouldDisplayExperimentUI() else { return segmentedControl }
+
+        return shouldUseiPadSetup() ? experimentiPadSegmentControl : experimentSegmentControl
     }
 
     // MARK: - Redux
@@ -646,7 +668,7 @@ final class TabTrayViewController: UIViewController,
     }
 
     private func setupForiPadExperiment() {
-        navigationItem.titleView = experimentSegmentControl
+        navigationItem.titleView = getSegmentedControl()
         view.addSubviews(containerView)
         containerView.addSubview(panelContainer)
         setupBlurView()
@@ -664,7 +686,8 @@ final class TabTrayViewController: UIViewController,
 
             // Because experimentSegmentControl doesn't inherit from UISegmentControl
             // we need to set height and width constraints
-            experimentSegmentControl.widthAnchor.constraint(equalToConstant: UX.NavigationMenu.iPadWidth),
+            experimentSegmentControl.widthAnchor.constraint(equalToConstant:
+                                                                UX.NavigationMenu.iPadWidth),
             experimentSegmentControl.heightAnchor.constraint(equalToConstant: tabTrayUtils.segmentedControlHeight)
         ])
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15694)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33595)

## :bulb: Description
- Create `TabTrayiPadSelectorView` for iPad version since TabTraySelectorView logic to update center and width constraints move the selector view when selecting Sync.
- Move `TabTraySelectorUX` inside `TabTraySelector`
- Use `TabTrayUtils` and update feature flag usage 
- Remove unused showToast

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

