### PR TITLE
Bugfix FXIOS-15709 [Unit test] Investigate flaky test testSettingsCoordinatorDelegate_didFinishSettings_removesChild()

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -58,6 +58,8 @@ final class SearchSettingsTableViewController: ThemedTableViewController,
     private let profile: Profile
     private let model: SearchEnginesManager
     private let logger: Logger
+    let featureFlagsProvider: FeatureFlagProviding
+    let userPreferences: UserFeaturePreferring
 
     var shouldHidePrivateModeFirefoxSuggestSetting: Bool {
         return !model.shouldShowBookmarksSuggestions &&
@@ -72,6 +74,11 @@ final class SearchSettingsTableViewController: ThemedTableViewController,
 
     var isRecentSearchesEnabled: Bool {
         return featureFlagsProvider.isEnabled(.recentSearches)
+    }
+
+    private var isFirefoxSuggestFeatureEnabled: Bool {
+        featureFlagsProvider.isEnabled(.firefoxSuggestFeature)
+        && userPreferences.getPreferenceFor(.firefoxSuggestFeature)
     }
 
     // Determines how to display the pre search settings based on the feature flags
@@ -125,10 +132,14 @@ final class SearchSettingsTableViewController: ThemedTableViewController,
 
     init(profile: Profile,
          searchEnginesManager: SearchEnginesManager = AppContainer.shared.resolve(),
+         featureFlagsProvider: FeatureFlagProviding = AppContainer.shared.resolve(),
+         userPreferences: UserFeaturePreferring = AppContainer.shared.resolve(),
          windowUUID: WindowUUID,
          logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.logger = logger
+        self.featureFlagsProvider = featureFlagsProvider
+        self.userPreferences = userPreferences
         model = searchEnginesManager
 
         super.init(windowUUID: windowUUID)
@@ -492,9 +503,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController,
         case .searchEnginesSuggestions:
             return SearchSuggestItem.allCases.count
         case .firefoxSuggestSettings:
-            return featureFlagsProvider.isEnabled(.firefoxSuggestFeature)
-            && userPreferences.getPreferenceFor(.firefoxSuggestFeature)
-            ? FirefoxSuggestItem.allCases.count : 3
+            return isFirefoxSuggestFeatureEnabled ? FirefoxSuggestItem.allCases.count : 3
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15709)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33617)

## :bulb: Description
Initialize/store feature flags and userPref to avoid direct AppContainer usage during UIKit usage 

This was an interesting failure and thanks to the crash logs and Claude for processing them, I think this gives us a have better idea of some of the crashes we are seeing in test and we have talk in our latest Unit test meetings, it's good to know when we revisit our dependency injection for tests

The `async throws setUp` introduces a yield point, the moment it hits `try await super.setUp()`, the run loop is free to process pending work. If a previous test left any UIKit lifecycle work deferred (navigation transitions, layout passes, etc.), that work can fire right in that window, after the previous test's `tearDown` reset AppContainer but before the current test's `bootstrapDependencies` has run. So any class that calls AppContainer.shared.resolve() lazily (instead of at init time) is exposed to that gap. 

cc: @adudenamedruby @ih-codes  


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

