### PR TITLE
Bugfix FXIOS-15428 Escape should end editing on iPad 

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -673,4 +673,30 @@ final class AddressToolbarContainer: UIView,
     func applyUIMode(isPrivate: Bool, theme: Theme) {
         applyProgressBarTheme(isPrivateMode: isPrivate, theme: theme)
     }
+
+    // MARK: - Key Command Utilities
+
+    override var keyCommands: [UIKeyCommand]? {
+        let defaultCommands: [UIKeyCommand]? = super.keyCommands
+        guard UIDevice.current.userInterfaceIdiom == .pad else { return defaultCommands }
+
+        return (defaultCommands ?? []) + [
+            UIKeyCommand(
+                action: #selector(escapeKeyCommand),
+                input: UIKeyCommand.inputEscape,
+                modifierFlags: []
+            )
+        ]
+    }
+
+    @objc
+    private func escapeKeyCommand() {
+        guard let windowUUID else { return }
+        store.dispatch(ToolbarMiddlewareAction(
+            buttonType: .cancelEdit,
+            gestureType: .tap,
+            windowUUID: windowUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton
+        ))
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -692,6 +692,8 @@ final class AddressToolbarContainer: UIView,
     @objc
     private func escapeKeyCommand() {
         guard let windowUUID else { return }
+        guard state?.addressToolbar.isEditing ?? false else { return }
+
         store.dispatch(ToolbarMiddlewareAction(
             buttonType: .cancelEdit,
             gestureType: .tap,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15428)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33096)

## :bulb: Description

Escape key during on iPad should end keyboard editing.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

