### PR TITLE
Add FXIOS-14354 [TabManagerTests] Add privacy mode tests

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1308,6 +1308,7 @@
 		8AFC09592FA54A240070CA11 /* TabManagerTestsBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFC09562FA54A240070CA11 /* TabManagerTestsBase.swift */; };
 		8AFC095A2FA54A240070CA11 /* TabManagerOlderTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFC09522FA54A240070CA11 /* TabManagerOlderTabsTests.swift */; };
 		8AFC095B2FA54A240070CA11 /* TabManagerRestoreTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFC09552FA54A240070CA11 /* TabManagerRestoreTabsTests.swift */; };
+		8AFC1B792FAAAA3D0070CA11 /* TabManagerPrivacyModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFC1B782FAAAA3D0070CA11 /* TabManagerPrivacyModeTests.swift */; };
 		8AFC4E472CAF53E100C54B43 /* RemoteDataTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFC4E462CAF53E100C54B43 /* RemoteDataTypeTests.swift */; };
 		8AFCE50529DDF38300B1B253 /* LaunchScreenViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50429DDF38300B1B253 /* LaunchScreenViewControllerTests.swift */; };
 		8AFCE50729DE0CD500B1B253 /* LaunchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */; };
@@ -9673,6 +9674,7 @@
 		8AFC09542FA54A240070CA11 /* TabManagerRemoveTabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerRemoveTabTests.swift; sourceTree = "<group>"; };
 		8AFC09552FA54A240070CA11 /* TabManagerRestoreTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerRestoreTabsTests.swift; sourceTree = "<group>"; };
 		8AFC09562FA54A240070CA11 /* TabManagerTestsBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerTestsBase.swift; sourceTree = "<group>"; };
+		8AFC1B782FAAAA3D0070CA11 /* TabManagerPrivacyModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerPrivacyModeTests.swift; sourceTree = "<group>"; };
 		8AFC4E462CAF53E100C54B43 /* RemoteDataTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteDataTypeTests.swift; sourceTree = "<group>"; };
 		8AFCE50429DDF38300B1B253 /* LaunchScreenViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenViewControllerTests.swift; sourceTree = "<group>"; };
 		8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -14506,6 +14508,7 @@
 				39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */,
 				8AFC09522FA54A240070CA11 /* TabManagerOlderTabsTests.swift */,
 				8AFC09532FA54A240070CA11 /* TabManagerPreserveTabsTests.swift */,
+				8AFC1B782FAAAA3D0070CA11 /* TabManagerPrivacyModeTests.swift */,
 				8AFC09542FA54A240070CA11 /* TabManagerRemoveTabTests.swift */,
 				8AFC09552FA54A240070CA11 /* TabManagerRestoreTabsTests.swift */,
 				5A475E8929DB87F2009C13FD /* TabManagerTests.swift */,
@@ -20219,6 +20222,7 @@
 				0B6AB0412DCA3CB900F03AF6 /* DocumentLoggerTests.swift in Sources */,
 				215360652D9475DA00D9B8E6 /* BrowsingSettingsViewControllerTests.swift in Sources */,
 				FF0002AA2F000002000BBBBB /* ClearablesTests.swift in Sources */,
+				8AFC1B792FAAAA3D0070CA11 /* TabManagerPrivacyModeTests.swift in Sources */,
 				C2B808B12A77FA3F00A65487 /* DownloadsCoordinatorTests.swift in Sources */,
 				C2DFB1452ECE62EE004E20AB /* MockTranslationsService.swift in Sources */,
 				354F8FAB2E0985B9007DFFEB /* SearchBarStateTests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerPrivacyModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerPrivacyModeTests.swift
@@ -1,0 +1,236 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import XCTest
+import Shared
+@testable import Client
+
+final class TabManagerPrivacyModeTests: TabManagerTestsBase {
+    // MARK: - switchPrivacyMode
+
+    @MainActor
+    func testSwitchPrivacyMode_fromNormalTab_noPrivateTabs_createsNewPrivateTab() {
+        let subject = createSubject(tabs: generateTabs(ofType: .normal, count: 2))
+        guard let normalTab = subject.normalTabs.first else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+        subject.selectTab(normalTab)
+
+        XCTAssertEqual(subject.normalTabs.count, 2)
+        XCTAssertEqual(subject.privateTabs.count, 0)
+        XCTAssertFalse(subject.selectedTab?.isPrivate ?? true)
+
+        let result = subject.switchPrivacyMode()
+
+        XCTAssertEqual(result, .createdNewTab)
+        XCTAssertEqual(subject.privateTabs.count, 1)
+        XCTAssertTrue(subject.selectedTab?.isPrivate ?? false)
+    }
+
+    @MainActor
+    func testSwitchPrivacyMode_fromNormalTab_existingPrivateTabs_selectsMostRecentPrivateTab() {
+        let normalTabs = generateTabs(ofType: .normal, count: 2)
+        let privateTabs = generateTabs(ofType: .privateAny, count: 3)
+        let subject = createSubject(tabs: normalTabs + privateTabs)
+
+        guard let normalTab = subject.normalTabs.first,
+              let recentPrivateTab = subject.privateTabs.last else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+
+        // Make the last private tab the most recently executed
+        subject.privateTabs.forEach { $0.lastExecutedTime = Date().dayBefore.toTimestamp() }
+        recentPrivateTab.lastExecutedTime = Date().toTimestamp()
+
+        subject.selectTab(normalTab)
+
+        XCTAssertEqual(subject.normalTabs.count, 2)
+        XCTAssertEqual(subject.privateTabs.count, 3)
+        XCTAssertFalse(subject.selectedTab?.isPrivate ?? true)
+
+        let result = subject.switchPrivacyMode()
+
+        XCTAssertEqual(result, .usedExistingTab)
+        XCTAssertEqual(subject.privateTabs.count, 3, "No new private tab should be created")
+        XCTAssertEqual(subject.selectedTab, recentPrivateTab)
+    }
+
+    @MainActor
+    func testSwitchPrivacyMode_fromPrivateTab_selectsMostRecentNormalTab() {
+        let normalTabs = generateTabs(ofType: .normal, count: 3)
+        let privateTabs = generateTabs(ofType: .privateAny, count: 2)
+        let subject = createSubject(tabs: normalTabs + privateTabs)
+
+        guard let privateTab = subject.privateTabs.first,
+              let recentNormalTab = subject.normalTabs.last else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+
+        // Make the last normal tab the most recently executed
+        subject.normalTabs.forEach { $0.lastExecutedTime = Date().dayBefore.toTimestamp() }
+        recentNormalTab.lastExecutedTime = Date().toTimestamp()
+
+        subject.selectTab(privateTab)
+
+        XCTAssertEqual(subject.normalTabs.count, 3)
+        XCTAssertEqual(subject.privateTabs.count, 2)
+        XCTAssertTrue(subject.selectedTab?.isPrivate ?? false)
+
+        let result = subject.switchPrivacyMode()
+
+        XCTAssertEqual(result, .usedExistingTab)
+        XCTAssertEqual(subject.selectedTab, recentNormalTab)
+        XCTAssertFalse(subject.selectedTab?.isPrivate ?? true)
+    }
+
+    @MainActor
+    func testSwitchPrivacyMode_noSelectedTab_returnsUsedExistingTab() {
+        let subject = createSubject(tabs: [])
+
+        XCTAssertNil(subject.selectedTab)
+
+        let result = subject.switchPrivacyMode()
+
+        XCTAssertEqual(result, .usedExistingTab, "Should return usedExistingTab when no tab is selected")
+        XCTAssertEqual(subject.tabs.count, 0, "No tabs should be created when selectedTab is nil")
+    }
+
+    // MARK: - removeAllPrivateTabs (triggered via selectTab)
+
+    @MainActor
+    func testRemoveAllPrivateTabs_whenSelectingNormalTab_withClosePrivateTabsEnabled() {
+        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.Settings.closePrivateTabs] = true
+        let normalTabs = generateTabs(ofType: .normal, count: 3)
+        let privateTabs = generateTabs(ofType: .privateAny, count: 3)
+        let subject = createSubject(tabs: normalTabs + privateTabs)
+
+        guard let privateTab = subject.privateTabs.first,
+              let normalTab = subject.normalTabs.first else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+
+        subject.selectTab(privateTab)
+
+        XCTAssertEqual(subject.normalTabs.count, 3)
+        XCTAssertEqual(subject.privateTabs.count, 3)
+        XCTAssertTrue(subject.selectedTab?.isPrivate ?? false)
+
+        // Select a normal tab — this should trigger removeAllPrivateTabs
+        subject.selectTab(normalTab)
+
+        XCTAssertEqual(subject.privateTabs.count, 0, "All private tabs should be removed")
+        XCTAssertEqual(subject.normalTabs.count, 3, "Normal tabs should be untouched")
+        XCTAssertEqual(subject.tabs.count, 3)
+        XCTAssertFalse(subject.selectedTab?.isPrivate ?? true)
+    }
+
+    @MainActor
+    func testRemoveAllPrivateTabs_whenSelectingNormalTab_withClosePrivateTabsDisabled() {
+        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.Settings.closePrivateTabs] = false
+        let normalTabs = generateTabs(ofType: .normal, count: 3)
+        let privateTabs = generateTabs(ofType: .privateAny, count: 3)
+        let subject = createSubject(tabs: normalTabs + privateTabs)
+
+        guard let privateTab = subject.privateTabs.first,
+              let normalTab = subject.normalTabs.first else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+
+        subject.selectTab(privateTab)
+        subject.selectTab(normalTab)
+
+        XCTAssertEqual(subject.privateTabs.count, 3, "Private tabs should be preserved when setting is disabled")
+        XCTAssertEqual(subject.normalTabs.count, 3)
+    }
+
+    @MainActor
+    func testRemoveAllPrivateTabs_resetsSelectedIndex_whenSelectedTabIsPrivate() {
+        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.Settings.closePrivateTabs] = true
+        let normalTabs = generateTabs(ofType: .normal, count: 2)
+        let privateTabs = generateTabs(ofType: .privateAny, count: 2)
+        let subject = createSubject(tabs: normalTabs + privateTabs)
+
+        guard let privateTab = subject.privateTabs.first,
+              let normalTab = subject.normalTabs.first else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+
+        subject.selectTab(privateTab)
+        XCTAssertTrue(subject.selectedTab?.isPrivate ?? false)
+
+        subject.selectTab(normalTab)
+
+        XCTAssertEqual(subject.privateTabs.count, 0)
+        XCTAssertEqual(subject.selectedTab, normalTab)
+        XCTAssertGreaterThanOrEqual(subject.selectedIndex, 0, "Selected index should point to the new normal tab")
+    }
+
+    @MainActor
+    func testRemoveAllPrivateTabs_notifiesDelegateForEachRemovedTab() {
+        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.Settings.closePrivateTabs] = true
+        let normalTabs = generateTabs(ofType: .normal, count: 2)
+        let privateTabs = generateTabs(ofType: .privateAny, count: 3)
+        let subject = createSubject(tabs: normalTabs + privateTabs)
+
+        let delegate = MockTabManagerDelegatePrivacyTests()
+        subject.addDelegate(delegate)
+
+        guard let privateTab = subject.privateTabs.first,
+              let normalTab = subject.normalTabs.first else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+
+        subject.selectTab(privateTab)
+        delegate.reset()
+
+        subject.selectTab(normalTab)
+
+        XCTAssertEqual(delegate.didRemoveTabCallCount, 3, "Delegate should be notified once per removed private tab")
+        XCTAssertTrue(delegate.removedTabs.allSatisfy { $0.isPrivate }, "All removed tabs should be private")
+    }
+
+    @MainActor
+    func testRemoveAllPrivateTabs_doesNotRemoveTabs_whenNoPrivateTabsExist() {
+        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.Settings.closePrivateTabs] = true
+        let normalTabs = generateTabs(ofType: .normal, count: 3)
+        let subject = createSubject(tabs: normalTabs)
+
+        guard let firstNormal = subject.normalTabs.first,
+              let secondNormal = subject.normalTabs[safe: 1] else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+
+        subject.selectTab(firstNormal)
+        subject.selectTab(secondNormal)
+
+        XCTAssertEqual(subject.normalTabs.count, 3, "Normal tabs should be untouched when no private tabs exist")
+        XCTAssertEqual(subject.privateTabs.count, 0)
+    }
+}
+
+// MARK: - MockTabManagerDelegatePrivacyTests
+
+private class MockTabManagerDelegatePrivacyTests: TabManagerDelegate {
+    var didRemoveTabCallCount = 0
+    var removedTabs = [Tab]()
+
+    func reset() {
+        didRemoveTabCallCount = 0
+        removedTabs = []
+    }
+
+    func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
+        didRemoveTabCallCount += 1
+        removedTabs.append(tab)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerPrivacyModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerPrivacyModeTests.swift
@@ -31,7 +31,8 @@ final class TabManagerPrivacyModeTests: TabManagerTestsBase {
     }
 
     @MainActor
-    func testSwitchPrivacyMode_fromNormalTab_existingPrivateTabs_selectsMostRecentPrivateTab() {
+    func testSwitchPrivacyMode_fromNormalTab_existingPrivateTabs_closePrivateTabsDisabled_selectsMostRecentPrivateTab() {
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.Settings.closePrivateTabs)
         let normalTabs = generateTabs(ofType: .normal, count: 2)
         let privateTabs = generateTabs(ofType: .privateAny, count: 3)
         let subject = createSubject(tabs: normalTabs + privateTabs)
@@ -57,6 +58,33 @@ final class TabManagerPrivacyModeTests: TabManagerTestsBase {
         XCTAssertEqual(result, .usedExistingTab)
         XCTAssertEqual(subject.privateTabs.count, 3, "No new private tab should be created")
         XCTAssertEqual(subject.selectedTab, recentPrivateTab)
+    }
+
+    @MainActor
+    func testSwitchPrivacyMode_fromNormalTab_closePrivateTabsEnabled_createsNewPrivateTab() {
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.closePrivateTabs)
+        let normalTabs = generateTabs(ofType: .normal, count: 2)
+        let privateTabs = generateTabs(ofType: .privateAny, count: 3)
+        let subject = createSubject(tabs: normalTabs + privateTabs)
+
+        guard let privateTab = subject.privateTabs.first,
+              let normalTab = subject.normalTabs.first else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+
+        // Simulate leaving private mode: switching back to a normal tab wipes all private tabs
+        subject.selectTab(privateTab)
+        subject.selectTab(normalTab)
+
+        XCTAssertEqual(subject.privateTabs.count, 0, "Private tabs should have been deleted when leaving private mode")
+        XCTAssertFalse(subject.selectedTab?.isPrivate ?? true)
+
+        let result = subject.switchPrivacyMode()
+
+        XCTAssertEqual(result, .createdNewTab)
+        XCTAssertEqual(subject.privateTabs.count, 1, "A new private tab should be created since existing ones were wiped")
+        XCTAssertTrue(subject.selectedTab?.isPrivate ?? false)
     }
 
     @MainActor
@@ -104,7 +132,7 @@ final class TabManagerPrivacyModeTests: TabManagerTestsBase {
 
     @MainActor
     func testRemoveAllPrivateTabs_whenSelectingNormalTab_withClosePrivateTabsEnabled() {
-        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.Settings.closePrivateTabs] = true
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.closePrivateTabs)
         let normalTabs = generateTabs(ofType: .normal, count: 3)
         let privateTabs = generateTabs(ofType: .privateAny, count: 3)
         let subject = createSubject(tabs: normalTabs + privateTabs)
@@ -132,7 +160,7 @@ final class TabManagerPrivacyModeTests: TabManagerTestsBase {
 
     @MainActor
     func testRemoveAllPrivateTabs_whenSelectingNormalTab_withClosePrivateTabsDisabled() {
-        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.Settings.closePrivateTabs] = false
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.Settings.closePrivateTabs)
         let normalTabs = generateTabs(ofType: .normal, count: 3)
         let privateTabs = generateTabs(ofType: .privateAny, count: 3)
         let subject = createSubject(tabs: normalTabs + privateTabs)
@@ -152,7 +180,7 @@ final class TabManagerPrivacyModeTests: TabManagerTestsBase {
 
     @MainActor
     func testRemoveAllPrivateTabs_resetsSelectedIndex_whenSelectedTabIsPrivate() {
-        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.Settings.closePrivateTabs] = true
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.closePrivateTabs)
         let normalTabs = generateTabs(ofType: .normal, count: 2)
         let privateTabs = generateTabs(ofType: .privateAny, count: 2)
         let subject = createSubject(tabs: normalTabs + privateTabs)
@@ -175,7 +203,7 @@ final class TabManagerPrivacyModeTests: TabManagerTestsBase {
 
     @MainActor
     func testRemoveAllPrivateTabs_notifiesDelegateForEachRemovedTab() {
-        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.Settings.closePrivateTabs] = true
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.closePrivateTabs)
         let normalTabs = generateTabs(ofType: .normal, count: 2)
         let privateTabs = generateTabs(ofType: .privateAny, count: 3)
         let subject = createSubject(tabs: normalTabs + privateTabs)
@@ -200,7 +228,7 @@ final class TabManagerPrivacyModeTests: TabManagerTestsBase {
 
     @MainActor
     func testRemoveAllPrivateTabs_doesNotRemoveTabs_whenNoPrivateTabsExist() {
-        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.Settings.closePrivateTabs] = true
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.closePrivateTabs)
         let normalTabs = generateTabs(ofType: .normal, count: 3)
         let subject = createSubject(tabs: normalTabs)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14354)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31103)

## :bulb: Description
Adds unit tests for `TabManagerImplementation` covering `switchPrivacyMode` and `removeAllPrivateTabs` (triggered via `selectTab`), including both `closePrivateTabs` enabled and disabled scenarios.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code