### PR TITLE
[MTE-5314] - fixes for SearchSettingsUITests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
@@ -186,12 +186,6 @@ final class SettingScreen {
         cell.waitAndTap()
     }
 
-    func navigateToSearchSettings() {
-        let searchCell = sel.SEARCH_CELL.element(in: app)
-        BaseTestCase().mozWaitForElementToExist(searchCell)
-        searchCell.waitAndTap()
-    }
-
     func navigateToDisplaySettings() {
         let cell = sel.DISPLAY_THEME_CELL.element(in: app)
         BaseTestCase().mozWaitForElementToExist(cell)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -11,8 +11,8 @@ let customSearchEngine = ["name": "youtube", "url": "https://youtube.com/search?
 class SearchSettingsUITests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2435664
     func testDefaultSearchEngine() {
-        let settingScreen = SettingScreen(app: app)
-        settingScreen.navigateToSearchSettings()
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(SearchSettings)
         // Check the default browser
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
         mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine1])
@@ -26,8 +26,8 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353247
     func testCustomSearchEngineIsEditable() {
-        let settingScreen = SettingScreen(app: app)
-        settingScreen.navigateToSearchSettings()
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(SearchSettings)
         // Add a custom search engine
         addCustomSearchEngine()
         // Check that the custom search appears on the list
@@ -57,8 +57,8 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353248
     func testCustomSearchEngineAsDefaultIsNotEditable() {
-        let settingScreen = SettingScreen(app: app)
-        settingScreen.navigateToSearchSettings()
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(SearchSettings)
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
 
@@ -77,8 +77,8 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353249
     func testNavigateToSearchPickerTurnsOffEditing() {
-        let settingScreen = SettingScreen(app: app)
-        settingScreen.navigateToSearchSettings()
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(SearchSettings)
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
 
@@ -109,8 +109,8 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353250
     func testDeletingLastCustomEngineExitsEditing() {
-        let settingScreen = SettingScreen(app: app)
-        settingScreen.navigateToSearchSettings()
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(SearchSettings)
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
         // Add a custom search engine


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5314

## :bulb: Description
This [PR](https://github.com/mozilla-mobile/firefox-ios/pull/33477) broke SearchSettingsUITests tests.
I have added back the old navigation, because the newly added function navigateToSearchSettings didn't perform any actual navigation. It was just a tap on the a search cell
I see there was this [task](https://github.com/mozilla-mobile/firefox-ios/issues/33413) where the request was to replace the navigation with the new TAE framework. The question is, do we want also the navigation to be converted?
