### PR TITLE
Bugfix FXIOS-15654 [Translations] AutoTranslate prompt stays visible when bottom toolbar minimizes on scroll

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -680,7 +680,6 @@ private extension LegacyTabScrollController {
 
             if isBottomSearchBar && overKeyboardOffset == 0 {
                 overKeyboardContainer?.updateAlphaForSubviews(alpha)
-                overKeyboardContainer?.superview?.layoutIfNeeded()
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -677,6 +677,11 @@ private extension LegacyTabScrollController {
 
             zoomPageBar?.updateAlphaForSubviews(alpha)
             zoomPageBar?.superview?.layoutIfNeeded()
+
+            if isBottomSearchBar && overKeyboardOffset == 0 {
+                overKeyboardContainer?.updateAlphaForSubviews(alpha)
+                overKeyboardContainer?.superview?.layoutIfNeeded()
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/ToolbarViewProtocol.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/ToolbarViewProtocol.swift
@@ -132,6 +132,10 @@ final class ToolbarAnimator {
         updateBottomToolbarConstraints(bottomContainerOffset: bottomContainerOffset,
                                        overKeyboardContainerOffset: overKeyboardContainerOffset)
 
+        if overKeyboardContainerOffset == 0 {
+            view?.overKeyboardContainer.updateAlphaForSubviews(alpha)
+        }
+
         delegate?.dispatchScrollAlphaChange(alpha: alpha)
     }
 
@@ -184,6 +188,9 @@ final class ToolbarAnimator {
             }
             self.updateBottomToolbarConstraints(bottomContainerOffset: bottomOffset,
                                                 overKeyboardContainerOffset: overkeyboardOffset)
+            if overkeyboardOffset == 0 {
+                view.overKeyboardContainer.updateAlphaForSubviews(alpha)
+            }
         }
 
         self.delegate?.dispatchScrollAlphaChange(alpha: alpha)

--- a/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
+++ b/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
@@ -8,7 +8,7 @@ import Redux
 import Shared
 import UIKit
 
-final class AutoTranslatePromptView: UIView, ThemeApplicable, Notifiable {
+final class AutoTranslatePromptView: UIView, AlphaDimmable, ThemeApplicable, Notifiable {
     private struct UX {
         static let borderThickness: CGFloat = 1.0
         static let contentPadding = NSDirectionalEdgeInsets(
@@ -149,6 +149,12 @@ final class AutoTranslatePromptView: UIView, ThemeApplicable, Notifiable {
             ensureMainThread { self.adjustLayout() }
         default: break
         }
+    }
+
+    // MARK: - AlphaDimmable
+
+    func updateAlphaForSubviews(_ alpha: CGFloat) {
+        self.alpha = alpha
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/ToolbarAnimatorTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/ToolbarAnimatorTest.swift
@@ -88,6 +88,52 @@ final class ToolbarAnimatorTests: XCTestCase {
         XCTAssertNoThrow(subject.updateToolbarTransition(progress: 10, towards: .collapsed))
     }
 
+    func test_hideToolbar_withBottomSearchBar_withZeroOverKeyboardHeight_fadesOverKeyboardSubviews() {
+        let zeroOverKeyboardContext = ToolbarContext(overKeyboardContainerHeight: 0,
+                                                    bottomContainerHeight: 80,
+                                                    headerHeight: -44)
+        let subject = ToolbarAnimator(context: zeroOverKeyboardContext)
+        let mockViewZero = MockToolbarView()
+        mockViewZero.isBottomSearchBar = true
+        let alphaDimmableSubview = MockAlphaDimmableView()
+        mockViewZero.overKeyboardContainer.addArrangedSubview(alphaDimmableSubview)
+        subject.view = mockViewZero
+        subject.delegate = delegate
+
+        subject.hideToolbar()
+
+        XCTAssertEqual(alphaDimmableSubview.lastAlpha, 0)
+    }
+
+    func test_showToolbar_withBottomSearchBar_withZeroOverKeyboardHeight_restoresOverKeyboardSubviewsAlpha() {
+        let zeroOverKeyboardContext = ToolbarContext(overKeyboardContainerHeight: 0,
+                                                    bottomContainerHeight: 80,
+                                                    headerHeight: -44)
+        let subject = ToolbarAnimator(context: zeroOverKeyboardContext)
+        let mockViewZero = MockToolbarView()
+        mockViewZero.isBottomSearchBar = true
+        let alphaDimmableSubview = MockAlphaDimmableView()
+        alphaDimmableSubview.alpha = 0
+        mockViewZero.overKeyboardContainer.addArrangedSubview(alphaDimmableSubview)
+        subject.view = mockViewZero
+        subject.delegate = delegate
+
+        subject.showToolbar()
+
+        XCTAssertEqual(alphaDimmableSubview.lastAlpha, 1)
+    }
+
+    func test_hideToolbar_withBottomSearchBar_withNonZeroOverKeyboardHeight_doesNotFadeOverKeyboardSubviews() {
+        let subject = createSubject()
+        mockView.isBottomSearchBar = true
+        let alphaDimmableSubview = MockAlphaDimmableView()
+        mockView.overKeyboardContainer.addArrangedSubview(alphaDimmableSubview)
+
+        subject.hideToolbar()
+
+        XCTAssertNil(alphaDimmableSubview.lastAlpha)
+    }
+
     // MARK: - Private
     private func createSubject() -> ToolbarAnimator {
         let subject = ToolbarAnimator(context: context)
@@ -117,5 +163,15 @@ final class MockToolbarAnimatorDelegate: ToolbarAnimator.Delegate {
 
     func dispatchScrollAlphaChange(alpha: CGFloat) {
         receivedAlphaValue = alpha
+    }
+}
+
+// MARK: - Mock AlphaDimmable View
+final class MockAlphaDimmableView: UIView, AlphaDimmable {
+    var lastAlpha: CGFloat?
+
+    func updateAlphaForSubviews(_ alpha: CGFloat) {
+        lastAlpha = alpha
+        self.alpha = alpha
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/ToolbarAnimatorTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/ToolbarAnimatorTest.swift
@@ -90,8 +90,8 @@ final class ToolbarAnimatorTests: XCTestCase {
 
     func test_hideToolbar_withBottomSearchBar_withZeroOverKeyboardHeight_fadesOverKeyboardSubviews() {
         let zeroOverKeyboardContext = ToolbarContext(overKeyboardContainerHeight: 0,
-                                                    bottomContainerHeight: 80,
-                                                    headerHeight: -44)
+                                                     bottomContainerHeight: 80,
+                                                     headerHeight: -44)
         let subject = ToolbarAnimator(context: zeroOverKeyboardContext)
         let mockViewZero = MockToolbarView()
         mockViewZero.isBottomSearchBar = true
@@ -107,8 +107,8 @@ final class ToolbarAnimatorTests: XCTestCase {
 
     func test_showToolbar_withBottomSearchBar_withZeroOverKeyboardHeight_restoresOverKeyboardSubviewsAlpha() {
         let zeroOverKeyboardContext = ToolbarContext(overKeyboardContainerHeight: 0,
-                                                    bottomContainerHeight: 80,
-                                                    headerHeight: -44)
+                                                     bottomContainerHeight: 80,
+                                                     headerHeight: -44)
         let subject = ToolbarAnimator(context: zeroOverKeyboardContext)
         let mockViewZero = MockToolbarView()
         mockViewZero.isBottomSearchBar = true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15654)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33529)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Make `AutoTranslatePromptView` conform to `AlphaDimmable` and call `overKeyboardContainer.updateAlphaForSubviews()` in both `ToolbarAnimator` and `LegacyTabScrollController` when offset is zero (no physical movement), so the prompt fades in sync with the toolbar.


https://github.com/user-attachments/assets/e2ca33c6-50f5-4b6a-9164-79db63ba99bd




## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


