### PR TITLE
Refactor FXIOS-15704 [UI Test] Convert UrlBarTests to TAE

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -15,6 +15,7 @@ final class BrowserScreen {
     }
 
     private var addressBar: XCUIElement { sel.ADDRESS_BAR.element(in: app) }
+	private var searchEngineLogo: XCUIElement { sel.SEARCH_ENGINE_LOGO.element(in: app) }
     private var cancelButton: XCUIElement { sel.CANCEL_BUTTON_URL_BAR.element(in: app) }
     private var bookText: XCUIElement { sel.BOOK_OF_MOZILLA_TEXT.element(in: app) }
     private var bookTextInTable: XCUIElement { sel.BOOK_OF_MOZILLA_TEXT_IN_TABLE.element(in: app) }
@@ -26,7 +27,6 @@ final class BrowserScreen {
     }
 
     func assertSearchEngineLogoExists(timeout: TimeInterval = TIMEOUT) {
-		let searchEngineLogo = app.images[AccessibilityIdentifiers.Browser.AddressToolbar.searchEngine]
         BaseTestCase().mozWaitForElementToExist(searchEngineLogo, timeout: timeout)
         XCTAssertTrue(searchEngineLogo.isLeftOf(rightElement: addressBar))
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -25,6 +25,12 @@ final class BrowserScreen {
         BaseTestCase().mozWaitForValueContains(addressBar, value: value, timeout: timeout)
     }
 
+    func assertSearchEngineLogoExists(timeout: TimeInterval = TIMEOUT) {
+		let searchEngineLogo = app.images[AccessibilityIdentifiers.Browser.AddressToolbar.searchEngine]
+        BaseTestCase().mozWaitForElementToExist(searchEngineLogo, timeout: timeout)
+        XCTAssertTrue(searchEngineLogo.isLeftOf(rightElement: addressBar))
+    }
+
     func handleHumanVerification() {
         let checkboxValidation = app.webViews["Web content"].staticTexts["Verify you are human"]
         if checkboxValidation.exists {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
@@ -6,6 +6,7 @@ import XCTest
 
 protocol BrowserSelectorsSet {
     var ADDRESS_BAR: Selector { get }
+    var SEARCH_ENGINE_LOGO: Selector { get }
     var DOWNLOADS_TOAST_BUTTON: Selector { get }
     var BACK_BUTTON: Selector { get }
     var MENU_BUTTON: Selector { get }
@@ -34,6 +35,7 @@ protocol BrowserSelectorsSet {
 struct BrowserSelectors: BrowserSelectorsSet {
     private enum IDs {
         static let addressBar = AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField
+        static let searchEngineLogo = AccessibilityIdentifiers.Browser.AddressToolbar.searchEngine
         static let backButton = AccessibilityIdentifiers.Toolbar.backButton
         static let menuButton = "Menu"
         static let clearTextLabel = "Clear text"
@@ -54,6 +56,12 @@ struct BrowserSelectors: BrowserSelectorsSet {
     let ADDRESS_BAR = Selector.textFieldId(
         IDs.addressBar,
         description: "Browser address bar",
+        groups: ["browser"]
+    )
+
+    let SEARCH_ENGINE_LOGO = Selector.imageId(
+        IDs.searchEngineLogo,
+        description: "Search engine logo in the address toolbar",
         groups: ["browser"]
     )
 
@@ -195,7 +203,7 @@ struct BrowserSelectors: BrowserSelectorsSet {
         )
     }
 
-    var all: [Selector] { [ADDRESS_BAR, DOWNLOADS_TOAST_BUTTON, BACK_BUTTON,
+    var all: [Selector] { [ADDRESS_BAR, SEARCH_ENGINE_LOGO, DOWNLOADS_TOAST_BUTTON, BACK_BUTTON,
                            MENU_BUTTON, STATIC_TEXT_MOZILLA, STATIC_TEXT_EXAMPLE_DOMAIN,
                            CLEAR_TEXT_BUTTON, CANCEL_BUTTON_URL_BAR, PRIVATE_BROWSING, CANCEL_BUTTON,
                            LINK_RFC_2606, BOOK_OF_MOZILLA_TEXT, ADDRESSTOOLBAR_LOCKICON, ADDRESSTOOLBAR_LOCKICON_OFF,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
@@ -52,7 +52,7 @@ class UrlBarTests: BaseTestCase {
         toolbarScreen.tapSettingsMenuButton()
         mainMenuScreen.tapSettings()
         settingScreen.navigateToSearchSettings()
-        // Add a custom search engine and add it as default search engine
+        // Change default search engine
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
         mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine1])
         defaultSearchEngine.waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
@@ -6,25 +6,39 @@ import Foundation
 import XCTest
 
 class UrlBarTests: BaseTestCase {
+    private var browserScreen: BrowserScreen!
+    private var toolbarScreen: ToolbarScreen!
+    private var mainMenuScreen: MainMenuScreen!
+    private var tabTrayScreen: TabTrayScreen!
+    private var settingScreen: SettingScreen!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        browserScreen = BrowserScreen(app: app)
+        toolbarScreen = ToolbarScreen(app: app)
+        mainMenuScreen = MainMenuScreen(app: app)
+        tabTrayScreen = TabTrayScreen(app: app)
+        settingScreen = SettingScreen(app: app)
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2306888
     func testNewTabUrlBar() {
         // Visit any website and select the URL bar
-        navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+        browserScreen.navigateToURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
         waitUntilPageLoad()
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
+        browserScreen.tapOnAddressBar()
         // The keyboard is brought up.
-        XCTAssertTrue(urlBarAddress.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
+        browserScreen.assertAddressBarHasKeyboardFocus()
         // Tap cancel button
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
+        browserScreen.tapCancelButtonOnUrlBarExist()
         // The keyboard is dismissed
         XCTAssertFalse(urlBarAddress.value(forKey: "hasKeyboardFocus") as? Bool ?? true)
         // Select the tab tray and add a new tab
         waitForTabsButton()
-        navigator.goto(TabTray)
-        navigator.performAction(Action.OpenNewTabFromTabTray)
+        toolbarScreen.tapOnTabsButton()
+        tabTrayScreen.tapOnNewTabButton()
         // The URL bar is empty on the new tab
-        let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
-        XCTAssertEqual(url.value as? String, "Search or enter address")
+        browserScreen.assertAddressBarContains(value: "Search or enter address")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306887
@@ -33,39 +47,39 @@ class UrlBarTests: BaseTestCase {
         // Type a search term and hit "go"
         typeSearchTermAndHitGo(searchTerm: "Firefox")
         // The search is conducted correctly through the default search engine
-        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField], value: "google.com")
+        browserScreen.assertAddressBarContains(value: "google.com")
+        // Navigate to SearchSettings
+        toolbarScreen.tapSettingsMenuButton()
+        mainMenuScreen.tapSettings()
+        settingScreen.navigateToSearchSettings()
         // Add a custom search engine and add it as default search engine
-        navigator.goto(SearchSettings)
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
         mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine1])
         defaultSearchEngine.waitAndTap()
         app.tables.staticTexts[defaultSearchEngine2].waitAndTap()
         mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine2])
-        navigator.goto(SettingsScreen)
-        app.navigationBars.buttons["Done"].waitAndTap()
-        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
+		// Close settings and add a new tab
+        settingScreen.tapBackToSettings()
+        settingScreen.closeSettingsWithDoneButton()
+        toolbarScreen.tapOnNewTabButton()
         tapUrlBarValidateKeyboardAndIcon()
+        // Type a search term and hit "go"
         typeSearchTermAndHitGo(searchTerm: "Firefox")
         // The search is conducted correctly through the default search engine
-        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField], value: "bing.com")
+        browserScreen.assertAddressBarContains(value: "bing.com")
     }
 
     private func tapUrlBarValidateKeyboardAndIcon() {
         // Tap on the URL bar
         waitForTabsButton()
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
+        browserScreen.tapOnAddressBar()
         // The keyboard pops up and the default search icon is correctly displayed in the URL bar
-        XCTAssertTrue(urlBarAddress.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
-        let keyboardCount = app.keyboards.count
-        XCTAssert(keyboardCount > 0, "The keyboard is not shown")
-        let searchEngineLogo = app.images[AccessibilityIdentifiers.Browser.AddressToolbar.searchEngine]
-        mozWaitForElementToExist(searchEngineLogo)
-        XCTAssertTrue(searchEngineLogo.isLeftOf(rightElement: urlBarAddress))
+        browserScreen.assertAddressBarHasKeyboardFocus()
+        browserScreen.assertSearchEngineLogoExists()
     }
 
     private func typeSearchTermAndHitGo(searchTerm: String) {
-        urlBarAddress.typeText(searchTerm)
-        waitUntilPageLoad()
+		browserScreen.typeOnSearchBar(text: searchTerm)
         app.buttons["Go"].waitAndTap()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15704)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33613)

## :bulb: Description
- Migrate `UrlBarTests` to the TAE page object model.
- Replace remaining navigator calls with screen helpers in `BrowserScreen`, `ToolbarScreen`, `TabTrayScreen`, and `SettingScreen`.
- Add the `SEARCH_ENGINE_LOGO` selector used by `BrowserScreen`.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
