### PR TITLE
Bugfix FXIOS-15442 Prevent faded buttons on theme change in Library panel

### DIFF
--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -425,6 +425,7 @@ class LibraryViewController: UIViewController, Themeable {
         segmentControlToolbar.isTranslucent = false
 
         setNeedsStatusBarAppearanceUpdate()
+        setupButtons()
         setupToolBarAppearance()
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15442)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33121)

## :bulb: Description
`applyTheme()` was not calling `setupButtons()`, leaving the buttons stale when the system theme changed until a layout pass eventually corrected it. Fix: call `setupButtons()` inside `applyTheme()` so buttons update immediately on theme change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

