### PR TITLE
Bugfix FXIOS-15723 [Unit test] Investigate flaky test testLoadPage_withCertificateErrorWithoutUnderlyingError_stillAddsCertErrorQuery()

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ErrorPageHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ErrorPageHandlerTests.swift
@@ -9,6 +9,16 @@ import Shared
 @testable import Client
 
 final class ErrorPageHandlerTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        await DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() async throws {
+        DependencyHelperMock().reset()
+        try super.tearDownWithError()
+    }
+
     @MainActor
     func testResponseForErrorWebPage_withCertificateErrorWithoutCertErrorQuery_usesFallbackAndDoesNotCrash() {
         assertErrorPageContainsCertError(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15723)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33640)

## :bulb: Description
- Add setup and tearDown to avoid crash related to AppContainer not being initialized

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

