### PR TITLE
Add [World Cup] FXIOS-15718 Scrollable homepage worldcup card

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1614,6 +1614,7 @@
 		C29B64832AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64822AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift */; };
 		C29B64872AD69D0200F3244B /* QRCodeCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64862AD69D0200F3244B /* QRCodeCoordinatorTests.swift */; };
 		C29B64EE2AD937D500F3244B /* QRCodeNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64ED2AD937D400F3244B /* QRCodeNavigationHandler.swift */; };
+		C2A057E32FA8C32200100C24 /* WorldCupScrollableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A057E22FA8C32200100C24 /* WorldCupScrollableCell.swift */; };
 		C2A72A672A76938C002ACCE2 /* DownloadsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A662A76938C002ACCE2 /* DownloadsCoordinator.swift */; };
 		C2A72A692A769460002ACCE2 /* ReadingListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A682A769460002ACCE2 /* ReadingListCoordinator.swift */; };
 		C2A72A6B2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A6A2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift */; };
@@ -2290,7 +2291,7 @@
 		FA6B2AC21D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
 		FA6B2AC41D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
 		FA9293D41D6580E100AC8D33 /* QRCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9293D31D6580E100AC8D33 /* QRCodeViewController.swift */; };
-		FF0001AA2F000007000AAAAA /* WorldcupSectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0001AA2F000004000AAAAA /* WorldcupSectionState.swift */; };
+		FF0001AA2F000007000AAAAA /* WorldCupSectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0001AA2F000004000AAAAA /* WorldCupSectionState.swift */; };
 		FF0002AA2F000002000BBBBB /* ClearablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0002AA2F000001000BBBBB /* ClearablesTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -10371,6 +10372,7 @@
 		C29B64822AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockQRCodeParentCoordinator.swift; sourceTree = "<group>"; };
 		C29B64862AD69D0200F3244B /* QRCodeCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeCoordinatorTests.swift; sourceTree = "<group>"; };
 		C29B64ED2AD937D400F3244B /* QRCodeNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeNavigationHandler.swift; sourceTree = "<group>"; };
+		C2A057E22FA8C32200100C24 /* WorldCupScrollableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupScrollableCell.swift; sourceTree = "<group>"; };
 		C2A72A662A76938C002ACCE2 /* DownloadsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsCoordinator.swift; sourceTree = "<group>"; };
 		C2A72A682A769460002ACCE2 /* ReadingListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListCoordinator.swift; sourceTree = "<group>"; };
 		C2A72A6A2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -11694,7 +11696,7 @@
 		FE3B4273905FC3005AD8D665 /* hsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hsb; path = hsb.lproj/Intro.strings; sourceTree = "<group>"; };
 		FE864D8695CDDBFCA933AE76 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = "ko.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		FEBD422B91171A97887B19BC /* ast */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ast; path = ast.lproj/Shared.strings; sourceTree = "<group>"; };
-		FF0001AA2F000004000AAAAA /* WorldcupSectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldcupSectionState.swift; sourceTree = "<group>"; };
+		FF0001AA2F000004000AAAAA /* WorldCupSectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupSectionState.swift; sourceTree = "<group>"; };
 		FF0002AA2F000001000BBBBB /* ClearablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearablesTests.swift; sourceTree = "<group>"; };
 		FF0C48F58DE0387A8E383D09 /* ta */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ta; path = ta.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		FF374BAA8FB31A2CE67D6C0A /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/HistoryPanel.strings"; sourceTree = "<group>"; };
@@ -15056,9 +15058,10 @@
 		C2D7AC3B2F9B5D750090EC28 /* WorldCup */ = {
 			isa = PBXGroup;
 			children = (
+				C2A057E22FA8C32200100C24 /* WorldCupScrollableCell.swift */,
 				C2EA234B2FA0B8AE004B6338 /* WorldCupTimerCell.swift */,
 				C2EA23502FA1B8AE004B6339 /* WorldCupCountdownModel.swift */,
-				FF0001AA2F000004000AAAAA /* WorldcupSectionState.swift */,
+				FF0001AA2F000004000AAAAA /* WorldCupSectionState.swift */,
 				C2D7AC3C2F9B5DC30090EC28 /* WorldCupAction.swift */,
 				C27AB7062F9B85A50085439A /* WorldCupCountry.swift */,
 				C27AB7072F9B85A50085439A /* WorldCupCountryPickerView.swift */,
@@ -19203,7 +19206,7 @@
 				39F4C10A2045DB2E00746155 /* FocusHelper.swift in Sources */,
 				81CAE4DB2B1A2C220040C78A /* BrowserViewControllerState.swift in Sources */,
 				8AED23062D400098000FF624 /* HomepageMessageCardCell.swift in Sources */,
-				FF0001AA2F000007000AAAAA /* WorldcupSectionState.swift in Sources */,
+				FF0001AA2F000007000AAAAA /* WorldCupSectionState.swift in Sources */,
 				C2886E062EC5E010007AE6C3 /* ModelsRoute.swift in Sources */,
 				E1442FCF294782D9003680B0 /* UIView+Screenshot.swift in Sources */,
 				8AA0A6652CAC6B7100AC7EB3 /* HomepageSectionLayoutProvider.swift in Sources */,
@@ -19460,6 +19463,7 @@
 				C8E531C829E5EB6100E03FEF /* RouteBuilder.swift in Sources */,
 				D3972BF41C22412B00035B87 /* TitleActivityItemProvider.swift in Sources */,
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
+				C2A057E32FA8C32200100C24 /* WorldCupScrollableCell.swift in Sources */,
 				212985E42A6F078800546684 /* ScreenState.swift in Sources */,
 				D51EA5BA26406A0000334331 /* ExperimentsBranchesViewController.swift in Sources */,
 				C84655F728879EF100861B4A /* WallpaperManager.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1614,7 +1614,7 @@
 		C29B64832AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64822AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift */; };
 		C29B64872AD69D0200F3244B /* QRCodeCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64862AD69D0200F3244B /* QRCodeCoordinatorTests.swift */; };
 		C29B64EE2AD937D500F3244B /* QRCodeNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64ED2AD937D400F3244B /* QRCodeNavigationHandler.swift */; };
-		C2A057E32FA8C32200100C24 /* WorldCupScrollableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A057E22FA8C32200100C24 /* WorldCupScrollableCell.swift */; };
+		C2A057E32FA8C32200100C24 /* WorldCupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A057E22FA8C32200100C24 /* WorldCupCell.swift */; };
 		C2A72A672A76938C002ACCE2 /* DownloadsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A662A76938C002ACCE2 /* DownloadsCoordinator.swift */; };
 		C2A72A692A769460002ACCE2 /* ReadingListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A682A769460002ACCE2 /* ReadingListCoordinator.swift */; };
 		C2A72A6B2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A6A2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift */; };
@@ -1638,7 +1638,7 @@
 		C2DFB1452ECE62EE004E20AB /* MockTranslationsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DFB1442ECE62E8004E20AB /* MockTranslationsService.swift */; };
 		C2DFB1472ECE686E004E20AB /* TranslationsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DFB1462ECE6866004E20AB /* TranslationsServiceTests.swift */; };
 		C2E4F4C62F62F959002A8524 /* MockMainMenuCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E4F4C52F62F959002A8524 /* MockMainMenuCoordinatorDelegate.swift */; };
-		C2EA234C2FA0B8AE004B6338 /* WorldCupTimerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EA234B2FA0B8AE004B6338 /* WorldCupTimerCell.swift */; };
+		C2EA234C2FA0B8AE004B6338 /* WorldCupTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EA234B2FA0B8AE004B6338 /* WorldCupTimerView.swift */; };
 		C2EA23512FA1B8AE004B6339 /* WorldCupCountdownModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EA23502FA1B8AE004B6339 /* WorldCupCountdownModel.swift */; };
 		C2EA23522FA1B8AE004B6340 /* WorldCupNowOverrideSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EA23532FA1B8AE004B6340 /* WorldCupNowOverrideSetting.swift */; };
 		C2EA23542FA1B8AE004B6341 /* WorldCupResetDismissedSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EA23552FA1B8AE004B6341 /* WorldCupResetDismissedSetting.swift */; };
@@ -10372,7 +10372,7 @@
 		C29B64822AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockQRCodeParentCoordinator.swift; sourceTree = "<group>"; };
 		C29B64862AD69D0200F3244B /* QRCodeCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeCoordinatorTests.swift; sourceTree = "<group>"; };
 		C29B64ED2AD937D400F3244B /* QRCodeNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeNavigationHandler.swift; sourceTree = "<group>"; };
-		C2A057E22FA8C32200100C24 /* WorldCupScrollableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupScrollableCell.swift; sourceTree = "<group>"; };
+		C2A057E22FA8C32200100C24 /* WorldCupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupCell.swift; sourceTree = "<group>"; };
 		C2A72A662A76938C002ACCE2 /* DownloadsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsCoordinator.swift; sourceTree = "<group>"; };
 		C2A72A682A769460002ACCE2 /* ReadingListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListCoordinator.swift; sourceTree = "<group>"; };
 		C2A72A6A2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -10402,7 +10402,7 @@
 		C2DFB1462ECE6866004E20AB /* TranslationsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsServiceTests.swift; sourceTree = "<group>"; };
 		C2E4F4C52F62F959002A8524 /* MockMainMenuCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMainMenuCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		C2E645149EB18AD0BDBB9696 /* zh-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/Search.strings"; sourceTree = "<group>"; };
-		C2EA234B2FA0B8AE004B6338 /* WorldCupTimerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupTimerCell.swift; sourceTree = "<group>"; };
+		C2EA234B2FA0B8AE004B6338 /* WorldCupTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupTimerView.swift; sourceTree = "<group>"; };
 		C2EA23502FA1B8AE004B6339 /* WorldCupCountdownModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupCountdownModel.swift; sourceTree = "<group>"; };
 		C2EA23532FA1B8AE004B6340 /* WorldCupNowOverrideSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupNowOverrideSetting.swift; sourceTree = "<group>"; };
 		C2EA23552FA1B8AE004B6341 /* WorldCupResetDismissedSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupResetDismissedSetting.swift; sourceTree = "<group>"; };
@@ -15058,8 +15058,8 @@
 		C2D7AC3B2F9B5D750090EC28 /* WorldCup */ = {
 			isa = PBXGroup;
 			children = (
-				C2A057E22FA8C32200100C24 /* WorldCupScrollableCell.swift */,
-				C2EA234B2FA0B8AE004B6338 /* WorldCupTimerCell.swift */,
+				C2A057E22FA8C32200100C24 /* WorldCupCell.swift */,
+				C2EA234B2FA0B8AE004B6338 /* WorldCupTimerView.swift */,
 				C2EA23502FA1B8AE004B6339 /* WorldCupCountdownModel.swift */,
 				FF0001AA2F000004000AAAAA /* WorldCupSectionState.swift */,
 				C2D7AC3C2F9B5DC30090EC28 /* WorldCupAction.swift */,
@@ -19463,7 +19463,7 @@
 				C8E531C829E5EB6100E03FEF /* RouteBuilder.swift in Sources */,
 				D3972BF41C22412B00035B87 /* TitleActivityItemProvider.swift in Sources */,
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
-				C2A057E32FA8C32200100C24 /* WorldCupScrollableCell.swift in Sources */,
+				C2A057E32FA8C32200100C24 /* WorldCupCell.swift in Sources */,
 				212985E42A6F078800546684 /* ScreenState.swift in Sources */,
 				D51EA5BA26406A0000334331 /* ExperimentsBranchesViewController.swift in Sources */,
 				C84655F728879EF100861B4A /* WallpaperManager.swift in Sources */,
@@ -19896,7 +19896,7 @@
 				E19F86032D6F4B51007453A7 /* ToolbarLayoutStyle.swift in Sources */,
 				C2886BAA2EC4A42F007AE6C3 /* TinyRouter.swift in Sources */,
 				8ADC2A182A33775F00543DAA /* FxASignInViewParameters.swift in Sources */,
-				C2EA234C2FA0B8AE004B6338 /* WorldCupTimerCell.swift in Sources */,
+				C2EA234C2FA0B8AE004B6338 /* WorldCupTimerView.swift in Sources */,
 				C2EA23512FA1B8AE004B6339 /* WorldCupCountdownModel.swift in Sources */,
 				8A83B7482A264FB7002FF9AC /* LibraryCoordinator.swift in Sources */,
 				C2F336EB2ECE44840071588A /* TranslationsServiceProtocol.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -57,7 +57,7 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
         /// a filtered feed and in the full "All" feed as one continuous item, which causes it to preserve
         /// that story's on-screen position as stories are inserted above it.
         case merino(MerinoStoryConfiguration, String?)
-        case worldcupCard
+        case worldcupCard(WorldCupSectionState)
         case spacer
 
         static var cellTypes: [ReusableCell.Type] {
@@ -72,7 +72,7 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
                 SyncedTabCell.self,
                 BookmarksCell.self,
                 StoryCell.self,
-                WorldCupTimerCell.self,
+                WorldCupCell.self,
                 HomepageSpacerCell.self
             ]
         }
@@ -131,7 +131,10 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
 
         if state.worldcupState.shouldShowSection, featureFlagsProvider.isEnabled(.worldCupWidget) {
             snapshot.appendSections([.worldcup(textColor)])
-            snapshot.appendItems([.worldcupCard], toSection: .worldcup(textColor))
+            snapshot.appendItems(
+                [.worldcupCard(state.worldcupState)],
+                toSection: .worldcup(textColor)
+            )
         }
 
         if let (tabs, configuration) = getJumpBackInTabs(with: state.jumpBackInState, and: jumpBackInDisplayConfig) {

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -608,13 +608,9 @@ final class HomepageViewController: UIViewController,
             }
         case .merino(let story, _):
             return configureMerinoCell(story, at: indexPath)
-        case .worldcupCard:
-            return configuredCell(cellType: WorldCupTimerCell.self, at: indexPath) { cell in
-                cell.configure(theme: currentTheme) { [weak self] in
-                    self?.openWorldCupLink()
-                } onDismiss: { [weak self] in
-                    self?.dispatchWorldCupCardClosed()
-                }
+        case .worldcupCard(let state):
+            return configuredCell(cellType: WorldCupCell.self, at: indexPath) { cell in
+                cell.configure(with: state, theme: currentTheme)
             }
         case .spacer:
             return configuredCell(cellType: HomepageSpacerCell.self, at: indexPath) { _ in }
@@ -966,21 +962,6 @@ final class HomepageViewController: UIViewController,
         dispatchNavigationBrowserAction(
             with: NavigationDestination(.tabTray(type)),
             actionType: NavigationBrowserActionType.tapOnJumpBackInShowAllButton
-        )
-    }
-
-    private func openWorldCupLink() {
-        guard let url = URL(string: "https://www.fifa.com/tournaments/mens/worldcup/canadamexicousa2026/scores-fixtures") else { return }
-        navigateToNewTab(with: url)
-    }
-
-    private func dispatchWorldCupCardClosed() {
-        store.dispatch(
-            WorldCupAction(
-                windowUUID: windowUUID,
-                actionType: WorldCupActionType.closedCard,
-                shouldShowHomepageWorldCupSection: false
-            )
         )
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -610,7 +610,9 @@ final class HomepageViewController: UIViewController,
             return configureMerinoCell(story, at: indexPath)
         case .worldcupCard(let state):
             return configuredCell(cellType: WorldCupCell.self, at: indexPath) { cell in
-                cell.configure(with: state, theme: currentTheme)
+                cell.configure(with: state, theme: currentTheme) { [weak self] animated in
+                    self?.relayoutForCellHeightChange(animated: animated)
+                }
             }
         case .spacer:
             return configuredCell(cellType: HomepageSpacerCell.self, at: indexPath) { _ in }
@@ -627,6 +629,17 @@ final class HomepageViewController: UIViewController,
         }
         configure(cell)
         return cell
+    }
+
+    private func relayoutForCellHeightChange(animated: Bool) {
+        guard let collectionView else { return }
+        if animated {
+            collectionView.performBatchUpdates(nil)
+        } else {
+            UIView.performWithoutAnimation {
+                collectionView.performBatchUpdates(nil)
+            }
+        }
     }
 
     private func configurePrivacyNoticeCell(cell: PrivacyNoticeCell) {

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -610,8 +610,8 @@ final class HomepageViewController: UIViewController,
             return configureMerinoCell(story, at: indexPath)
         case .worldcupCard(let state):
             return configuredCell(cellType: WorldCupCell.self, at: indexPath) { cell in
-                cell.configure(with: state, theme: currentTheme) { [weak self] animated in
-                    self?.relayoutForCellHeightChange(animated: animated)
+                cell.configure(with: state, theme: currentTheme) { [weak self] in
+                    self?.relayoutForCellHeightChange()
                 }
             }
         case .spacer:
@@ -631,15 +631,9 @@ final class HomepageViewController: UIViewController,
         return cell
     }
 
-    private func relayoutForCellHeightChange(animated: Bool) {
+    private func relayoutForCellHeightChange() {
         guard let collectionView else { return }
-        if animated {
-            collectionView.performBatchUpdates(nil)
-        } else {
-            UIView.performWithoutAnimation {
-                collectionView.performBatchUpdates(nil)
-            }
-        }
+        collectionView.performBatchUpdates(nil)
     }
 
     private func configurePrivacyNoticeCell(cell: PrivacyNoticeCell) {

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -849,7 +849,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         let containerWidth = normalizedDimension(environment.container.contentSize.width)
         let cell = WorldCupCell()
-        cell.configure(with: state.worldcupState, theme: LightTheme())
+        cell.configure(with: state.worldcupState, theme: LightTheme(), onHeightChange: { _ in })
         let cellHeight = HomepageDimensionCalculator.fittingHeight(for: cell, width: containerWidth)
 
         return cellHeight + UX.spacingBetweenSections

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -849,7 +849,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         let containerWidth = normalizedDimension(environment.container.contentSize.width)
         let cell = WorldCupCell()
-        cell.configure(with: state.worldcupState, theme: LightTheme(), onHeightChange: { _ in })
+        cell.configure(with: state.worldcupState, theme: LightTheme(), onHeightChange: {})
         let cellHeight = HomepageDimensionCalculator.fittingHeight(for: cell, width: containerWidth)
 
         return cellHeight + UX.spacingBetweenSections

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -848,7 +848,8 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
               featureFlagsProvider.isEnabled(.worldCupWidget) else { return 0 }
 
         let containerWidth = normalizedDimension(environment.container.contentSize.width)
-        let cell = WorldCupTimerCell()
+        let cell = WorldCupCell()
+        cell.configure(with: state.worldcupState, theme: LightTheme())
         let cellHeight = HomepageDimensionCalculator.fittingHeight(for: cell, width: containerWidth)
 
         return cellHeight + UX.spacingBetweenSections

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -17,7 +17,7 @@ struct HomepageState: ScreenState, Equatable {
     let searchState: SearchBarState
     let jumpBackInState: JumpBackInSectionState
     let bookmarkState: BookmarksSectionState
-    let worldcupState: WorldcupSectionState
+    let worldcupState: WorldCupSectionState
     let merinoState: MerinoState
     let wallpaperState: WallpaperState
 
@@ -69,7 +69,7 @@ struct HomepageState: ScreenState, Equatable {
             searchState: SearchBarState(windowUUID: windowUUID),
             jumpBackInState: JumpBackInSectionState(windowUUID: windowUUID),
             bookmarkState: BookmarksSectionState(windowUUID: windowUUID),
-            worldcupState: WorldcupSectionState(windowUUID: windowUUID),
+            worldcupState: WorldCupSectionState(windowUUID: windowUUID),
             merinoState: MerinoState(windowUUID: windowUUID),
             wallpaperState: WallpaperState(windowUUID: windowUUID),
             isZeroSearch: false,
@@ -88,7 +88,7 @@ struct HomepageState: ScreenState, Equatable {
         searchState: SearchBarState,
         jumpBackInState: JumpBackInSectionState,
         bookmarkState: BookmarksSectionState,
-        worldcupState: WorldcupSectionState,
+        worldcupState: WorldCupSectionState,
         merinoState: MerinoState,
         wallpaperState: WallpaperState,
         isZeroSearch: Bool,
@@ -151,7 +151,7 @@ struct HomepageState: ScreenState, Equatable {
             searchState: SearchBarState.reducer(state.searchState, action),
             jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
             bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldcupSectionState.reducer(state.worldcupState, action),
+            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
             merinoState: MerinoState.reducer(state.merinoState, action),
             wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
             shouldTriggerImpression: false
@@ -169,7 +169,7 @@ struct HomepageState: ScreenState, Equatable {
             searchState: SearchBarState.reducer(state.searchState, action),
             jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
             bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldcupSectionState.reducer(state.worldcupState, action),
+            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
             merinoState: MerinoState.reducer(state.merinoState, action),
             wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
             isZeroSearch: isZeroSearch,
@@ -194,7 +194,7 @@ struct HomepageState: ScreenState, Equatable {
             searchState: SearchBarState.reducer(state.searchState, action),
             jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
             bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldcupSectionState.reducer(state.worldcupState, action),
+            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
             merinoState: MerinoState.reducer(state.merinoState, action),
             wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
             shouldTriggerImpression: false,
@@ -212,7 +212,7 @@ struct HomepageState: ScreenState, Equatable {
             searchState: SearchBarState.reducer(state.searchState, action),
             jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
             bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldcupSectionState.reducer(state.worldcupState, action),
+            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
             merinoState: MerinoState.reducer(state.merinoState, action),
             wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
             shouldTriggerImpression: false,
@@ -229,7 +229,7 @@ struct HomepageState: ScreenState, Equatable {
             searchState: SearchBarState.reducer(state.searchState, action),
             jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
             bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldcupSectionState.reducer(state.worldcupState, action),
+            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
             merinoState: MerinoState.reducer(state.merinoState, action),
             wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
             shouldTriggerImpression: true
@@ -245,7 +245,7 @@ struct HomepageState: ScreenState, Equatable {
             searchState: SearchBarState.reducer(state.searchState, action),
             jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
             bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldcupSectionState.reducer(state.worldcupState, action),
+            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
             merinoState: MerinoState.reducer(state.merinoState, action),
             wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
             shouldTriggerImpression: false,
@@ -262,7 +262,7 @@ struct HomepageState: ScreenState, Equatable {
             searchState: SearchBarState.reducer(state.searchState, action),
             jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
             bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldcupSectionState.reducer(state.worldcupState, action),
+            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
             merinoState: MerinoState.reducer(state.merinoState, action),
             wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
             shouldTriggerImpression: false
@@ -276,7 +276,7 @@ struct HomepageState: ScreenState, Equatable {
             searchState: SearchBarState.defaultState(from: state.searchState),
             jumpBackInState: JumpBackInSectionState.defaultState(from: state.jumpBackInState),
             bookmarkState: BookmarksSectionState.defaultState(from: state.bookmarkState),
-            worldcupState: WorldcupSectionState.defaultState(from: state.worldcupState),
+            worldcupState: WorldCupSectionState.defaultState(from: state.worldcupState),
             merinoState: MerinoState.defaultState(from: state.merinoState),
             wallpaperState: WallpaperState.defaultState(from: state.wallpaperState),
             shouldTriggerImpression: false

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -40,7 +40,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
         control.hidesForSinglePage = true
         control.isUserInteractionEnabled = false
     }
-    
+
     private var pageConstraints: [NSLayoutConstraint] = []
     private var scrollViewHeightConstraint: NSLayoutConstraint?
     private var pageControlHeightConstraint: NSLayoutConstraint?
@@ -104,7 +104,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
             pagesStack.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor),
         ])
     }
-    
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateScrollViewHeight(for: pageControl.currentPage, animated: true)
@@ -125,7 +125,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
 
     private func rebuildPages(for state: WorldCupSectionState) {
         removePageViews()
-        
+
         let pages = makePages(for: state)
         pageControl.numberOfPages = pages.count
         scrollView.isScrollEnabled = pages.count > 1
@@ -146,7 +146,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
 
         updateScrollViewHeight(for: 0, animated: false)
     }
-    
+
     private func makePages(for state: WorldCupSectionState) -> [UIView] {
         return [WorldCupTimerView(windowUUID: state.windowUUID)]
     }
@@ -161,7 +161,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
             verticalFittingPriority: .fittingSizeLevel
         ).height
         guard scrollViewHeightConstraint?.constant != targetHeight else { return }
-        
+
         if animated {
             UIView.animate(
                 withDuration: UX.heightChangeAnimationDuration,
@@ -217,7 +217,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
             setupShadow(theme: theme)
         }
     }
-    
+
     private func setupShadow(theme: Theme) {
         contentView.layer.shadowColor = theme.colors.shadowDefault.cgColor
         contentView.layer.shadowOpacity = HomepageUX.shadowOpacity

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -5,15 +5,13 @@
 import Common
 import Foundation
 
-/// A homepage cell that pages through an arbitrary set of subviews with a page-indicator.
-/// The cell dynamically resizes its height to match the currently visible page.
-/// When there is only one subview, scrolling is disabled and the page indicator is hidden.
 final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCell, ThemeApplicable, Blurrable {
     private struct UX {
-        static let rootContainerCornerRadius: CGFloat = 26
+        static let rootContainerCornerRadius: CGFloat = 16
         static let padding: CGFloat = 16
         static let pageControlHeight: CGFloat = 6.0
-        static let pageControlTopPadding: CGFloat = 4
+        static let pageControlTopPadding: CGFloat = 16.0
+        static let heightChangeAnimationDuration: TimeInterval = 0.15
     }
 
     // MARK: - UI Elements
@@ -23,43 +21,35 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
         view.clipsToBounds = true
     }
 
-    private let scrollView: UIScrollView = .build { scrollView in
+    private lazy var scrollView: UIScrollView = .build { scrollView in
         scrollView.isPagingEnabled = true
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.showsVerticalScrollIndicator = false
         scrollView.contentInsetAdjustmentBehavior = .never
         scrollView.bounces = false
         scrollView.clipsToBounds = true
+        scrollView.delegate = self
     }
 
     private let pagesStack: UIStackView = .build { stack in
         stack.axis = .horizontal
-        stack.spacing = 0
+        stack.alignment = .center
     }
 
     private let pageControl: UIPageControl = .build { control in
-        control.currentPage = 0
         control.hidesForSinglePage = true
         control.isUserInteractionEnabled = false
     }
-
-    // MARK: - State
-
-    private var pageViews: [UIView] = []
+    
     private var pageConstraints: [NSLayoutConstraint] = []
     private var scrollViewHeightConstraint: NSLayoutConstraint?
     private var pageControlHeightConstraint: NSLayoutConstraint?
-    private var currentPage = 0
+    private var pageControlTopConstraint: NSLayoutConstraint?
     private var currentState: WorldCupSectionState?
-    private var onHeightChange: ((_ animated: Bool) -> Void)?
-
-    // MARK: - Inits
+    private var onHeightChange: (() -> Void)?
 
     override init(frame: CGRect) {
         super.init(frame: .zero)
-
-        isAccessibilityElement = false
-        scrollView.delegate = self
         setupLayout()
     }
 
@@ -67,63 +57,9 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Public
-
-    /// Configures the cell with the given state, displaying its pages as full-width subviews.
-    /// The cell height adapts to the currently visible page's height.
-    /// When there is a single page, scrolling is disabled and the page indicator is hidden.
-    /// Subviews are only rebuilt when the state changes; theme is always reapplied.
-    /// `onHeightChange` is invoked when the cell needs the parent collection view to relayout
-    /// to reflect a new height.
-    func configure(
-        with state: WorldCupSectionState,
-        theme: Theme,
-        onHeightChange: @escaping (_ animated: Bool) -> Void
-    ) {
-        self.onHeightChange = onHeightChange
-        if currentState != state {
-            currentState = state
-            rebuildPages(for: state)
-        }
-        applyTheme(theme: theme)
-    }
-
-    private func makeSubviews(for state: WorldCupSectionState) -> [UIView] {
-        let view = UIView()
-        view.backgroundColor = .red
-        view.heightAnchor.constraint(equalToConstant: 200.0).isActive = true
-        return [WorldCupTimerView(windowUUID: state.windowUUID), view]
-    }
-
-    private func rebuildPages(for state: WorldCupSectionState) {
-        removePageViews()
-
-        let subviews = makeSubviews(for: state)
-        pageViews = subviews
-        pageControl.numberOfPages = subviews.count
-        scrollView.isScrollEnabled = subviews.count > 1
-        pageControlHeightConstraint?.constant = subviews.count > 1 ? UX.pageControlHeight : 0
-
-        var constraints: [NSLayoutConstraint] = []
-        for view in subviews {
-            view.translatesAutoresizingMaskIntoConstraints = false
-            pagesStack.addArrangedSubview(view)
-            constraints.append(view.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor))
-        }
-        NSLayoutConstraint.activate(constraints)
-        pageConstraints = constraints
-
-        scrollView.contentOffset = .zero
-        pageControl.currentPage = 0
-        currentPage = 0
-
-        updateScrollViewHeight(for: 0, animated: false)
-    }
-
     // MARK: - Layout
 
     private func setupLayout() {
-        contentView.backgroundColor = .clear
         scrollView.addSubview(pagesStack)
         rootContainer.addSubviews(scrollView, pageControl)
         contentView.addSubview(rootContainer)
@@ -133,12 +69,15 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
 
         let pageControlHeight = pageControl.heightAnchor.constraint(equalToConstant: UX.pageControlHeight)
         pageControlHeightConstraint = pageControlHeight
+        let pageControlTopConstraint = pageControl.topAnchor.constraint(equalTo: scrollView.bottomAnchor,
+                                                                        constant: UX.pageControlTopPadding)
+        self.pageControlTopConstraint = pageControlTopConstraint
 
         NSLayoutConstraint.activate([
             rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor),
             rootContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             rootContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).priority(.defaultHigh),
 
             scrollView.topAnchor.constraint(equalTo: rootContainer.topAnchor,
                                             constant: UX.padding),
@@ -148,11 +87,12 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
                                                  constant: -UX.padding),
             heightConstraint,
 
-            pageControl.topAnchor.constraint(equalTo: scrollView.bottomAnchor,
-                                             constant: UX.pageControlTopPadding),
+            pageControlTopConstraint,
             pageControl.centerXAnchor.constraint(equalTo: rootContainer.centerXAnchor),
             pageControl.bottomAnchor.constraint(equalTo: rootContainer.bottomAnchor,
                                                 constant: -UX.padding),
+            pageControl.leadingAnchor.constraint(equalTo: rootContainer.leadingAnchor, constant: UX.padding),
+            pageControl.trailingAnchor.constraint(equalTo: rootContainer.trailingAnchor, constant: -UX.padding),
             pageControlHeight,
 
             pagesStack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
@@ -164,9 +104,55 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
             pagesStack.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor),
         ])
     }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        updateScrollViewHeight(for: pageControl.currentPage, animated: true)
+    }
+
+    func configure(
+        with state: WorldCupSectionState,
+        theme: Theme,
+        onHeightChange: @escaping () -> Void
+    ) {
+        self.onHeightChange = onHeightChange
+        if currentState != state {
+            currentState = state
+            rebuildPages(for: state)
+        }
+        applyTheme(theme: theme)
+    }
+
+    private func rebuildPages(for state: WorldCupSectionState) {
+        removePageViews()
+        
+        let pages = makePages(for: state)
+        pageControl.numberOfPages = pages.count
+        scrollView.isScrollEnabled = pages.count > 1
+        pageControlHeightConstraint?.constant = pages.count > 1 ? UX.pageControlHeight : 0
+        pageControlTopConstraint?.constant = pages.count > 1 ? UX.pageControlTopPadding : 0
+
+        var constraints: [NSLayoutConstraint] = []
+        for view in pages {
+            view.translatesAutoresizingMaskIntoConstraints = false
+            pagesStack.addArrangedSubview(view)
+            constraints.append(view.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor))
+        }
+        NSLayoutConstraint.activate(constraints)
+        pageConstraints = constraints
+
+        scrollView.contentOffset = .zero
+        pageControl.currentPage = 0
+
+        updateScrollViewHeight(for: 0, animated: false)
+    }
+    
+    private func makePages(for state: WorldCupSectionState) -> [UIView] {
+        return [WorldCupTimerView(windowUUID: state.windowUUID)]
+    }
 
     private func updateScrollViewHeight(for page: Int, animated: Bool) {
-        guard let view = pageViews[safe: page] else { return }
+        guard let view = pagesStack.arrangedSubviews[safe: page] else { return }
 
         let targetHeight = view.systemLayoutSizeFitting(
             CGSize(width: scrollView.frame.width > 0 ? scrollView.frame.width : bounds.width,
@@ -174,45 +160,48 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         ).height
-
         guard scrollViewHeightConstraint?.constant != targetHeight else { return }
-        scrollViewHeightConstraint?.constant = targetHeight
-
-        onHeightChange?(animated)
+        
+        if animated {
+            UIView.animate(
+                withDuration: UX.heightChangeAnimationDuration,
+                animations: {
+                    self.scrollViewHeightConstraint?.constant = targetHeight
+                    self.contentView.layoutIfNeeded()
+                    self.onHeightChange?()
+                }
+            )
+        } else {
+            scrollViewHeightConstraint?.constant = targetHeight
+            onHeightChange?()
+        }
     }
 
     private func removePageViews() {
         NSLayoutConstraint.deactivate(pageConstraints)
         pageConstraints.removeAll()
         pagesStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        pageViews.removeAll()
     }
 
     // MARK: - UIScrollViewDelegate
-    
+
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let pageWidth = scrollView.frame.width
         guard pageWidth > 0 else { return }
         let newPage = Int(round(scrollView.contentOffset.x / pageWidth))
-        guard newPage != currentPage else { return }
-        currentPage = newPage
+        guard newPage != pageControl.currentPage else { return }
         pageControl.currentPage = newPage
         updateScrollViewHeight(for: newPage, animated: true)
-    }
-
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let pageWidth = scrollView.frame.width
-        guard pageWidth > 0 else { return }
-        pageControl.currentPage = Int(round(scrollView.contentOffset.x / pageWidth))
     }
 
     // MARK: - ThemeApplicable
 
     func applyTheme(theme: Theme) {
+        contentView.backgroundColor = .clear
         pageControl.currentPageIndicatorTintColor = theme.colors.iconPrimary
         pageControl.pageIndicatorTintColor = theme.colors.iconSecondary
         adjustBlur(theme: theme)
-        pageViews
+        pagesStack.arrangedSubviews
             .compactMap { $0 as? ThemeApplicable }
             .forEach { $0.applyTheme(theme: theme) }
     }
@@ -230,10 +219,6 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
     }
     
     private func setupShadow(theme: Theme) {
-        contentView.layer.shadowPath = UIBezierPath(
-            roundedRect: contentView.bounds,
-            cornerRadius: UX.rootContainerCornerRadius
-        ).cgPath
         contentView.layer.shadowColor = theme.colors.shadowDefault.cgColor
         contentView.layer.shadowOpacity = HomepageUX.shadowOpacity
         contentView.layer.shadowOffset = HomepageUX.shadowOffset

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -8,7 +8,7 @@ import Foundation
 /// A homepage cell that pages through an arbitrary set of subviews with a page-indicator.
 /// The cell dynamically resizes its height to match the currently visible page.
 /// When there is only one subview, scrolling is disabled and the page indicator is hidden.
-final class WorldCupScrollableCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurrable {
+final class WorldCupCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurrable {
     private struct UX {
         static let generalCornerRadius: CGFloat = 16
         static let contentInsets = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
@@ -48,7 +48,9 @@ final class WorldCupScrollableCell: UICollectionViewCell, ReusableCell, ThemeApp
     private var pageViews: [UIView] = []
     private var pageConstraints: [NSLayoutConstraint] = []
     private var scrollViewHeightConstraint: NSLayoutConstraint?
+    private var pageControlHeightConstraint: NSLayoutConstraint?
     private var currentPage = 0
+    private var currentState: WorldCupSectionState?
 
     // MARK: - Inits
 
@@ -71,43 +73,50 @@ final class WorldCupScrollableCell: UICollectionViewCell, ReusableCell, ThemeApp
         scrollView.contentOffset = .zero
         pageControl.currentPage = 0
         currentPage = 0
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        contentView.layer.shadowPath = UIBezierPath(
-            roundedRect: contentView.bounds,
-            cornerRadius: UX.generalCornerRadius
-        ).cgPath
+        currentState = nil
     }
 
     // MARK: - Public
 
-    /// Replaces the current content with the given subviews, displayed as full-width pages.
+    /// Configures the cell with the given state, displaying its pages as full-width subviews.
     /// The cell height adapts to the currently visible page's height.
-    /// When there is a single subview, scrolling is disabled and the page indicator is hidden.
-    func configure(with subviews: [UIView], theme: Theme) {
-        removePageViews()
-        scrollView.contentOffset = .zero
-        pageControl.currentPage = 0
-        currentPage = 0
+    /// When there is a single page, scrolling is disabled and the page indicator is hidden.
+    /// Subviews are only rebuilt when the state changes; theme is always reapplied.
+    func configure(with state: WorldCupSectionState, theme: Theme) {
+        if currentState != state {
+            currentState = state
+            rebuildPages(for: state)
+        }
+        applyTheme(theme: theme)
+    }
 
+    private func makeSubviews(for state: WorldCupSectionState) -> [UIView] {
+        return [WorldCupTimerView(windowUUID: state.windowUUID)]
+    }
+
+    private func rebuildPages(for state: WorldCupSectionState) {
+        removePageViews()
+
+        let subviews = makeSubviews(for: state)
         pageViews = subviews
         pageControl.numberOfPages = subviews.count
         scrollView.isScrollEnabled = subviews.count > 1
+        pageControlHeightConstraint?.constant = subviews.count > 1 ? UX.pageControlHeight : 0
 
         var constraints: [NSLayoutConstraint] = []
         for view in subviews {
+            view.translatesAutoresizingMaskIntoConstraints = false
             pagesStack.addArrangedSubview(view)
             constraints.append(view.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor))
         }
         NSLayoutConstraint.activate(constraints)
         pageConstraints = constraints
 
-        // Set initial scroll view height to first page
-        updateScrollViewHeight(for: 0, animated: false)
+        scrollView.contentOffset = .zero
+        pageControl.currentPage = 0
+        currentPage = 0
 
-        applyTheme(theme: theme)
+        updateScrollViewHeight(for: 0, animated: false)
     }
 
     // MARK: - Layout
@@ -120,6 +129,9 @@ final class WorldCupScrollableCell: UICollectionViewCell, ReusableCell, ThemeApp
 
         let heightConstraint = scrollView.heightAnchor.constraint(equalToConstant: 0)
         scrollViewHeightConstraint = heightConstraint
+
+        let pageControlHeight = pageControl.heightAnchor.constraint(equalToConstant: UX.pageControlHeight)
+        pageControlHeightConstraint = pageControlHeight
 
         NSLayoutConstraint.activate([
             rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor),
@@ -140,7 +152,7 @@ final class WorldCupScrollableCell: UICollectionViewCell, ReusableCell, ThemeApp
             pageControl.centerXAnchor.constraint(equalTo: rootContainer.centerXAnchor),
             pageControl.bottomAnchor.constraint(equalTo: rootContainer.bottomAnchor,
                                                 constant: -UX.contentInsets.bottom),
-            pageControl.heightAnchor.constraint(equalToConstant: UX.pageControlHeight),
+            pageControlHeight,
 
             pagesStack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
             pagesStack.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
@@ -200,13 +212,15 @@ final class WorldCupScrollableCell: UICollectionViewCell, ReusableCell, ThemeApp
         pageControl.currentPageIndicatorTintColor = theme.colors.iconPrimary
         pageControl.pageIndicatorTintColor = theme.colors.iconSecondary
         adjustBlur(theme: theme)
+        pageViews
+            .compactMap { $0 as? ThemeApplicable }
+            .forEach { $0.applyTheme(theme: theme) }
     }
 
     // MARK: - Blurrable
 
     func adjustBlur(theme: Theme) {
         if shouldApplyWallpaperBlur {
-            rootContainer.layoutIfNeeded()
             rootContainer.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
         } else {
             rootContainer.removeVisualEffectView()
@@ -218,7 +232,7 @@ final class WorldCupScrollableCell: UICollectionViewCell, ReusableCell, ThemeApp
 
 // MARK: - UIScrollViewDelegate
 
-extension WorldCupScrollableCell: UIScrollViewDelegate {
+extension WorldCupCell: UIScrollViewDelegate {
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let pageWidth = scrollView.frame.width
         guard pageWidth > 0 else { return }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -8,18 +8,18 @@ import Foundation
 /// A homepage cell that pages through an arbitrary set of subviews with a page-indicator.
 /// The cell dynamically resizes its height to match the currently visible page.
 /// When there is only one subview, scrolling is disabled and the page indicator is hidden.
-final class WorldCupCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurrable {
+final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCell, ThemeApplicable, Blurrable {
     private struct UX {
-        static let generalCornerRadius: CGFloat = 16
-        static let contentInsets = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
-        static let pageControlHeight: CGFloat = 20
-        static let pageControlBottomSpacing: CGFloat = 4
+        static let rootContainerCornerRadius: CGFloat = 26
+        static let padding: CGFloat = 16
+        static let pageControlHeight: CGFloat = 6.0
+        static let pageControlTopPadding: CGFloat = 4
     }
 
     // MARK: - UI Elements
 
     private let rootContainer: UIView = .build { view in
-        view.layer.cornerRadius = UX.generalCornerRadius
+        view.layer.cornerRadius = UX.rootContainerCornerRadius
         view.clipsToBounds = true
     }
 
@@ -51,6 +51,7 @@ final class WorldCupCell: UICollectionViewCell, ReusableCell, ThemeApplicable, B
     private var pageControlHeightConstraint: NSLayoutConstraint?
     private var currentPage = 0
     private var currentState: WorldCupSectionState?
+    private var onHeightChange: ((_ animated: Bool) -> Void)?
 
     // MARK: - Inits
 
@@ -58,7 +59,6 @@ final class WorldCupCell: UICollectionViewCell, ReusableCell, ThemeApplicable, B
         super.init(frame: .zero)
 
         isAccessibilityElement = false
-
         scrollView.delegate = self
         setupLayout()
     }
@@ -67,22 +67,20 @@ final class WorldCupCell: UICollectionViewCell, ReusableCell, ThemeApplicable, B
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        removePageViews()
-        scrollView.contentOffset = .zero
-        pageControl.currentPage = 0
-        currentPage = 0
-        currentState = nil
-    }
-
     // MARK: - Public
 
     /// Configures the cell with the given state, displaying its pages as full-width subviews.
     /// The cell height adapts to the currently visible page's height.
     /// When there is a single page, scrolling is disabled and the page indicator is hidden.
     /// Subviews are only rebuilt when the state changes; theme is always reapplied.
-    func configure(with state: WorldCupSectionState, theme: Theme) {
+    /// `onHeightChange` is invoked when the cell needs the parent collection view to relayout
+    /// to reflect a new height.
+    func configure(
+        with state: WorldCupSectionState,
+        theme: Theme,
+        onHeightChange: @escaping (_ animated: Bool) -> Void
+    ) {
+        self.onHeightChange = onHeightChange
         if currentState != state {
             currentState = state
             rebuildPages(for: state)
@@ -91,7 +89,10 @@ final class WorldCupCell: UICollectionViewCell, ReusableCell, ThemeApplicable, B
     }
 
     private func makeSubviews(for state: WorldCupSectionState) -> [UIView] {
-        return [WorldCupTimerView(windowUUID: state.windowUUID)]
+        let view = UIView()
+        view.backgroundColor = .red
+        view.heightAnchor.constraint(equalToConstant: 200.0).isActive = true
+        return [WorldCupTimerView(windowUUID: state.windowUUID), view]
     }
 
     private func rebuildPages(for state: WorldCupSectionState) {
@@ -140,18 +141,18 @@ final class WorldCupCell: UICollectionViewCell, ReusableCell, ThemeApplicable, B
             rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
 
             scrollView.topAnchor.constraint(equalTo: rootContainer.topAnchor,
-                                            constant: UX.contentInsets.top),
+                                            constant: UX.padding),
             scrollView.leadingAnchor.constraint(equalTo: rootContainer.leadingAnchor,
-                                                constant: UX.contentInsets.left),
+                                                constant: UX.padding),
             scrollView.trailingAnchor.constraint(equalTo: rootContainer.trailingAnchor,
-                                                 constant: -UX.contentInsets.right),
+                                                 constant: -UX.padding),
             heightConstraint,
 
             pageControl.topAnchor.constraint(equalTo: scrollView.bottomAnchor,
-                                             constant: UX.pageControlBottomSpacing),
+                                             constant: UX.pageControlTopPadding),
             pageControl.centerXAnchor.constraint(equalTo: rootContainer.centerXAnchor),
             pageControl.bottomAnchor.constraint(equalTo: rootContainer.bottomAnchor,
-                                                constant: -UX.contentInsets.bottom),
+                                                constant: -UX.padding),
             pageControlHeight,
 
             pagesStack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
@@ -177,15 +178,7 @@ final class WorldCupCell: UICollectionViewCell, ReusableCell, ThemeApplicable, B
         guard scrollViewHeightConstraint?.constant != targetHeight else { return }
         scrollViewHeightConstraint?.constant = targetHeight
 
-        guard let collectionView = superview as? UICollectionView else { return }
-
-        if animated {
-            collectionView.performBatchUpdates(nil)
-        } else {
-            UIView.performWithoutAnimation {
-                collectionView.performBatchUpdates(nil)
-            }
-        }
+        onHeightChange?(animated)
     }
 
     private func removePageViews() {
@@ -195,15 +188,22 @@ final class WorldCupCell: UICollectionViewCell, ReusableCell, ThemeApplicable, B
         pageViews.removeAll()
     }
 
-    private func setupShadow(theme: Theme) {
-        contentView.layer.shadowPath = UIBezierPath(
-            roundedRect: contentView.bounds,
-            cornerRadius: UX.generalCornerRadius
-        ).cgPath
-        contentView.layer.shadowColor = theme.colors.shadowDefault.cgColor
-        contentView.layer.shadowOpacity = HomepageUX.shadowOpacity
-        contentView.layer.shadowOffset = HomepageUX.shadowOffset
-        contentView.layer.shadowRadius = HomepageUX.shadowRadius
+    // MARK: - UIScrollViewDelegate
+    
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        let pageWidth = scrollView.frame.width
+        guard pageWidth > 0 else { return }
+        let newPage = Int(round(scrollView.contentOffset.x / pageWidth))
+        guard newPage != currentPage else { return }
+        currentPage = newPage
+        pageControl.currentPage = newPage
+        updateScrollViewHeight(for: newPage, animated: true)
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let pageWidth = scrollView.frame.width
+        guard pageWidth > 0 else { return }
+        pageControl.currentPage = Int(round(scrollView.contentOffset.x / pageWidth))
     }
 
     // MARK: - ThemeApplicable
@@ -228,24 +228,15 @@ final class WorldCupCell: UICollectionViewCell, ReusableCell, ThemeApplicable, B
             setupShadow(theme: theme)
         }
     }
-}
-
-// MARK: - UIScrollViewDelegate
-
-extension WorldCupCell: UIScrollViewDelegate {
-    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        let pageWidth = scrollView.frame.width
-        guard pageWidth > 0 else { return }
-        let newPage = Int(round(scrollView.contentOffset.x / pageWidth))
-        guard newPage != currentPage else { return }
-        currentPage = newPage
-        pageControl.currentPage = newPage
-        updateScrollViewHeight(for: newPage, animated: true)
-    }
-
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let pageWidth = scrollView.frame.width
-        guard pageWidth > 0 else { return }
-        pageControl.currentPage = Int(round(scrollView.contentOffset.x / pageWidth))
+    
+    private func setupShadow(theme: Theme) {
+        contentView.layer.shadowPath = UIBezierPath(
+            roundedRect: contentView.bounds,
+            cornerRadius: UX.rootContainerCornerRadius
+        ).cgPath
+        contentView.layer.shadowColor = theme.colors.shadowDefault.cgColor
+        contentView.layer.shadowOpacity = HomepageUX.shadowOpacity
+        contentView.layer.shadowOffset = HomepageUX.shadowOffset
+        contentView.layer.shadowRadius = HomepageUX.shadowRadius
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupScrollableCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupScrollableCell.swift
@@ -1,0 +1,237 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+
+/// A homepage cell that pages through an arbitrary set of subviews with a page-indicator.
+/// The cell dynamically resizes its height to match the currently visible page.
+/// When there is only one subview, scrolling is disabled and the page indicator is hidden.
+final class WorldCupScrollableCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurrable {
+    private struct UX {
+        static let generalCornerRadius: CGFloat = 16
+        static let contentInsets = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
+        static let pageControlHeight: CGFloat = 20
+        static let pageControlBottomSpacing: CGFloat = 4
+    }
+
+    // MARK: - UI Elements
+
+    private let rootContainer: UIView = .build { view in
+        view.layer.cornerRadius = UX.generalCornerRadius
+        view.clipsToBounds = true
+    }
+
+    private let scrollView: UIScrollView = .build { scrollView in
+        scrollView.isPagingEnabled = true
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.bounces = false
+        scrollView.clipsToBounds = true
+    }
+
+    private let pagesStack: UIStackView = .build { stack in
+        stack.axis = .horizontal
+        stack.spacing = 0
+    }
+
+    private let pageControl: UIPageControl = .build { control in
+        control.currentPage = 0
+        control.hidesForSinglePage = true
+        control.isUserInteractionEnabled = false
+    }
+
+    // MARK: - State
+
+    private var pageViews: [UIView] = []
+    private var pageConstraints: [NSLayoutConstraint] = []
+    private var scrollViewHeightConstraint: NSLayoutConstraint?
+    private var currentPage = 0
+
+    // MARK: - Inits
+
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+
+        isAccessibilityElement = false
+
+        scrollView.delegate = self
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        removePageViews()
+        scrollView.contentOffset = .zero
+        pageControl.currentPage = 0
+        currentPage = 0
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        contentView.layer.shadowPath = UIBezierPath(
+            roundedRect: contentView.bounds,
+            cornerRadius: UX.generalCornerRadius
+        ).cgPath
+    }
+
+    // MARK: - Public
+
+    /// Replaces the current content with the given subviews, displayed as full-width pages.
+    /// The cell height adapts to the currently visible page's height.
+    /// When there is a single subview, scrolling is disabled and the page indicator is hidden.
+    func configure(with subviews: [UIView], theme: Theme) {
+        removePageViews()
+        scrollView.contentOffset = .zero
+        pageControl.currentPage = 0
+        currentPage = 0
+
+        pageViews = subviews
+        pageControl.numberOfPages = subviews.count
+        scrollView.isScrollEnabled = subviews.count > 1
+
+        var constraints: [NSLayoutConstraint] = []
+        for view in subviews {
+            pagesStack.addArrangedSubview(view)
+            constraints.append(view.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor))
+        }
+        NSLayoutConstraint.activate(constraints)
+        pageConstraints = constraints
+
+        // Set initial scroll view height to first page
+        updateScrollViewHeight(for: 0, animated: false)
+
+        applyTheme(theme: theme)
+    }
+
+    // MARK: - Layout
+
+    private func setupLayout() {
+        contentView.backgroundColor = .clear
+        scrollView.addSubview(pagesStack)
+        rootContainer.addSubviews(scrollView, pageControl)
+        contentView.addSubview(rootContainer)
+
+        let heightConstraint = scrollView.heightAnchor.constraint(equalToConstant: 0)
+        scrollViewHeightConstraint = heightConstraint
+
+        NSLayoutConstraint.activate([
+            rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor),
+            rootContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            rootContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            scrollView.topAnchor.constraint(equalTo: rootContainer.topAnchor,
+                                            constant: UX.contentInsets.top),
+            scrollView.leadingAnchor.constraint(equalTo: rootContainer.leadingAnchor,
+                                                constant: UX.contentInsets.left),
+            scrollView.trailingAnchor.constraint(equalTo: rootContainer.trailingAnchor,
+                                                 constant: -UX.contentInsets.right),
+            heightConstraint,
+
+            pageControl.topAnchor.constraint(equalTo: scrollView.bottomAnchor,
+                                             constant: UX.pageControlBottomSpacing),
+            pageControl.centerXAnchor.constraint(equalTo: rootContainer.centerXAnchor),
+            pageControl.bottomAnchor.constraint(equalTo: rootContainer.bottomAnchor,
+                                                constant: -UX.contentInsets.bottom),
+            pageControl.heightAnchor.constraint(equalToConstant: UX.pageControlHeight),
+
+            pagesStack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            pagesStack.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            pagesStack.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            pagesStack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+
+            // Pin stack height to the scroll view's visible frame to prevent vertical scrolling.
+            pagesStack.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor),
+        ])
+    }
+
+    private func updateScrollViewHeight(for page: Int, animated: Bool) {
+        guard let view = pageViews[safe: page] else { return }
+
+        let targetHeight = view.systemLayoutSizeFitting(
+            CGSize(width: scrollView.frame.width > 0 ? scrollView.frame.width : bounds.width,
+                   height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+
+        guard scrollViewHeightConstraint?.constant != targetHeight else { return }
+        scrollViewHeightConstraint?.constant = targetHeight
+
+        guard let collectionView = superview as? UICollectionView else { return }
+
+        if animated {
+            collectionView.performBatchUpdates(nil)
+        } else {
+            UIView.performWithoutAnimation {
+                collectionView.performBatchUpdates(nil)
+            }
+        }
+    }
+
+    private func removePageViews() {
+        NSLayoutConstraint.deactivate(pageConstraints)
+        pageConstraints.removeAll()
+        pagesStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        pageViews.removeAll()
+    }
+
+    private func setupShadow(theme: Theme) {
+        contentView.layer.shadowPath = UIBezierPath(
+            roundedRect: contentView.bounds,
+            cornerRadius: UX.generalCornerRadius
+        ).cgPath
+        contentView.layer.shadowColor = theme.colors.shadowDefault.cgColor
+        contentView.layer.shadowOpacity = HomepageUX.shadowOpacity
+        contentView.layer.shadowOffset = HomepageUX.shadowOffset
+        contentView.layer.shadowRadius = HomepageUX.shadowRadius
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        pageControl.currentPageIndicatorTintColor = theme.colors.iconPrimary
+        pageControl.pageIndicatorTintColor = theme.colors.iconSecondary
+        adjustBlur(theme: theme)
+    }
+
+    // MARK: - Blurrable
+
+    func adjustBlur(theme: Theme) {
+        if shouldApplyWallpaperBlur {
+            rootContainer.layoutIfNeeded()
+            rootContainer.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
+        } else {
+            rootContainer.removeVisualEffectView()
+            rootContainer.backgroundColor = theme.colors.layer5
+            setupShadow(theme: theme)
+        }
+    }
+}
+
+// MARK: - UIScrollViewDelegate
+
+extension WorldCupScrollableCell: UIScrollViewDelegate {
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        let pageWidth = scrollView.frame.width
+        guard pageWidth > 0 else { return }
+        let newPage = Int(round(scrollView.contentOffset.x / pageWidth))
+        guard newPage != currentPage else { return }
+        currentPage = newPage
+        pageControl.currentPage = newPage
+        updateScrollViewHeight(for: newPage, animated: true)
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let pageWidth = scrollView.frame.width
+        guard pageWidth > 0 else { return }
+        pageControl.currentPage = Int(round(scrollView.contentOffset.x / pageWidth))
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupSectionState.swift
@@ -8,7 +8,7 @@ import Shared
 import UIKit
 
 /// State for the World Cup promo card displayed on the homepage.
-struct WorldcupSectionState: StateType, Equatable, Hashable {
+struct WorldCupSectionState: StateType, Equatable, Hashable {
     var windowUUID: WindowUUID
     var shouldShowSection: Bool
 
@@ -25,18 +25,18 @@ struct WorldcupSectionState: StateType, Equatable, Hashable {
     static let reducer: Reducer<Self> = { state, action in
         switch action.actionType {
         case WorldCupActionType.closedCard:
-            return WorldcupSectionState(windowUUID: state.windowUUID, shouldShowSection: false)
+            return WorldCupSectionState(windowUUID: state.windowUUID, shouldShowSection: false)
         case WorldCupActionType.didChangeHomepageSettings:
             guard let show = (action as? WorldCupAction)?.shouldShowHomepageWorldCupSection else {
                 return state
             }
-            return WorldcupSectionState(windowUUID: state.windowUUID, shouldShowSection: show)
+            return WorldCupSectionState(windowUUID: state.windowUUID, shouldShowSection: show)
         default:
             return state
         }
     }
 
-    static func defaultState(from state: WorldcupSectionState) -> WorldcupSectionState {
+    static func defaultState(from state: WorldCupSectionState) -> WorldCupSectionState {
         return state
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
@@ -7,14 +7,9 @@ import ComponentLibrary
 import Shared
 import UIKit
 
-final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, ThemeApplicable {
+final class WorldCupTimerView: UIView, ThemeApplicable {
     private struct UX {
-        static let cardCornerRadius: CGFloat = 24
-        static let cardPaddingTop: CGFloat = 18
-        static let cardPaddingBottom: CGFloat = 18
-        static let cardPaddingLeading: CGFloat = 20
-        static let cardPaddingTrailing: CGFloat = 20
-        static let cardContentSpacing: CGFloat = 8.0
+        static let contentSpacing: CGFloat = 8.0
         static let timerVerticalPadding: CGFloat = 8
         static let timerHorizontalPadding: CGFloat = 64
         static let timerSegmentSpacing: CGFloat = 8.0
@@ -26,21 +21,17 @@ final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, Th
         static let heroFrameDuration = 0.04
         static let heroInitialFramePosition = 0.7
         static let heroAnimationRepeatCount = 2
+        static let scheduleURL = "https://www.fifa.com/tournaments/mens/worldcup/canadamexicousa2026/scores-fixtures"
     }
 
+    private let windowUUID: WindowUUID
+    private let profile: Profile
     private var countdownModel: WorldCupCountdownModel?
-    var onCTATapped: (() -> Void)?
-    var onDismiss: (() -> Void)?
 
     private var heroVisibleConstraints: [NSLayoutConstraint] = []
     private var heroHiddenConstraints: [NSLayoutConstraint] = []
 
     // MARK: - UI
-
-    private lazy var cardView: UIView = .build { view in
-        view.layer.cornerRadius = UX.cardCornerRadius
-        view.clipsToBounds = true
-    }
 
     private lazy var heroImageView: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
@@ -91,7 +82,6 @@ final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, Th
 
     private lazy var timerStack: UIStackView = .build { stack in
         stack.axis = .horizontal
-        stack.alignment = .center
         stack.distribution = .equalSpacing
         stack.spacing = UX.timerSegmentSpacing
     }
@@ -107,7 +97,7 @@ final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, Th
         button.setContentCompressionResistancePriority(.required, for: .vertical)
         button.addAction(
             UIAction { [weak self] _ in
-                self?.onCTATapped?()
+                self?.handleCTATap()
             },
             for: .touchUpInside)
     }
@@ -120,7 +110,7 @@ final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, Th
         button.accessibilityLabel = .WorldCup.HomepageWidget.FollowTeamCard.CloseButtonAccessibilityLabel
         button.addAction(
             UIAction { [weak self] _ in
-                self?.onDismiss?()
+                self?.handleDismissTap()
             },
             for: .touchUpInside)
     }
@@ -128,15 +118,21 @@ final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, Th
     private lazy var leftContentStack: UIStackView = .build { stack in
         stack.axis = .vertical
         stack.alignment = .leading
-        stack.spacing = UX.cardContentSpacing
+        stack.spacing = UX.contentSpacing
         stack.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
 
     // MARK: - Init
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(
+        windowUUID: WindowUUID,
+        profile: Profile = AppContainer.shared.resolve()
+    ) {
+        self.windowUUID = windowUUID
+        self.profile = profile
+        super.init(frame: .zero)
         setupLayout()
+        startCountdown()
     }
 
     required init?(coder: NSCoder) {
@@ -161,32 +157,26 @@ final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, Th
         leftContentStack.addArrangedSubview(timerContainer)
         leftContentStack.addArrangedSubview(ctaButton)
 
-        cardView.addSubviews(leftContentStack, heroImageView, dismissButton)
-        contentView.addSubview(cardView)
+        addSubviews(leftContentStack, heroImageView, dismissButton)
 
         NSLayoutConstraint.activate([
-            cardView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            cardView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            cardView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            cardView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-
-            heroImageView.centerYAnchor.constraint(equalTo: cardView.centerYAnchor),
+            heroImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
             heroImageView.trailingAnchor.constraint(
                 equalTo: dismissButton.leadingAnchor,
                 constant: -UX.heroImageTrailingPadding
             ),
             heroImageView.widthAnchor.constraint(lessThanOrEqualToConstant: UX.heroImageWidth),
             heroImageView.heightAnchor.constraint(lessThanOrEqualToConstant: UX.heroImageWidth),
-            heroImageView.topAnchor.constraint(equalTo: cardView.topAnchor).priority(.defaultLow),
-            heroImageView.bottomAnchor.constraint(equalTo: cardView.bottomAnchor).priority(.defaultLow),
+            heroImageView.topAnchor.constraint(equalTo: topAnchor).priority(.defaultLow),
+            heroImageView.bottomAnchor.constraint(equalTo: bottomAnchor).priority(.defaultLow),
 
-            dismissButton.topAnchor.constraint(equalTo: cardView.topAnchor, constant: UX.cardPaddingTop),
-            dismissButton.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -UX.cardPaddingTrailing),
+            dismissButton.topAnchor.constraint(equalTo: topAnchor),
+            dismissButton.trailingAnchor.constraint(equalTo: trailingAnchor),
             dismissButton.widthAnchor.constraint(equalToConstant: UX.dismissButtonSize.width),
             dismissButton.heightAnchor.constraint(equalToConstant: UX.dismissButtonSize.height),
 
-            leftContentStack.topAnchor.constraint(equalTo: cardView.topAnchor, constant: UX.cardPaddingTop),
-            leftContentStack.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: UX.cardPaddingLeading),
+            leftContentStack.topAnchor.constraint(equalTo: topAnchor),
+            leftContentStack.leadingAnchor.constraint(equalTo: leadingAnchor),
 
             timerStack.topAnchor.constraint(
                 equalTo: timerContainer.topAnchor,
@@ -206,10 +196,7 @@ final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, Th
                 constant: -UX.timerHorizontalPadding
             ).priority(.defaultLow),
 
-            leftContentStack.bottomAnchor.constraint(
-                equalTo: cardView.bottomAnchor,
-                constant: -UX.cardPaddingBottom
-            ),
+            leftContentStack.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
 
         heroVisibleConstraints = [
@@ -217,10 +204,7 @@ final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, Th
         ]
 
         heroHiddenConstraints = [
-            leftContentStack.trailingAnchor.constraint(
-                equalTo: cardView.trailingAnchor,
-                constant: -UX.cardPaddingTrailing
-            ),
+            leftContentStack.trailingAnchor.constraint(equalTo: trailingAnchor),
         ]
 
         updateA11yLayout()
@@ -276,26 +260,16 @@ final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, Th
         return stack
     }
 
-    // MARK: - Configure
+    // MARK: - Countdown
 
-    func configure(
-        theme: Theme,
-        profile: Profile = AppContainer.shared.resolve(),
-        onCTATapped: @escaping () -> Void,
-        onDismiss: @escaping () -> Void
-    ) {
-        self.onCTATapped = onCTATapped
-        self.onDismiss = onDismiss
+    private func startCountdown() {
         let model = WorldCupCountdownModel(prefs: profile.prefs)
         model.onCountdownUpdated = { [weak self] countdown in
             self?.apply(countdown: countdown)
         }
         model.start()
         countdownModel = model
-        applyTheme(theme: theme)
     }
-
-    // MARK: - Countdown
 
     private func apply(countdown: WorldCupCountdown) {
         dayValueLabel.text = String(format: "%02d", countdown.days)
@@ -329,14 +303,32 @@ final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, Th
         NSLayoutConstraint.activate(isA11y ? heroHiddenConstraints : heroVisibleConstraints)
     }
 
-    // MARK: - Blurrable
+    // MARK: - Actions
 
-    func adjustBlur(theme: Theme) {
-        if shouldApplyWallpaperBlur {
-            cardView.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
-        } else {
-            cardView.removeVisualEffectView()
-        }
+    private func handleCTATap() {
+        guard let url = URL(string: UX.scheduleURL) else { return }
+        store.dispatch(
+            NavigationBrowserAction(
+                navigationDestination: NavigationDestination(
+                    .newTab,
+                    url: url,
+                    isPrivate: false,
+                    selectNewTab: true
+                ),
+                windowUUID: windowUUID,
+                actionType: NavigationBrowserActionType.tapOnCell
+            )
+        )
+    }
+
+    private func handleDismissTap() {
+        store.dispatch(
+            WorldCupAction(
+                windowUUID: windowUUID,
+                actionType: WorldCupActionType.closedCard,
+                shouldShowHomepageWorldCupSection: false
+            )
+        )
     }
 
     // MARK: - ThemeApplicable
@@ -350,11 +342,7 @@ final class WorldCupTimerCell: UICollectionViewCell, ReusableCell, Blurrable, Th
             $0.textColor = theme.colors.textPrimary
         }
         dismissButton.imageView?.tintColor = theme.colors.textPrimary
-        backgroundColor = .clear
-        adjustBlur(theme: theme)
         ctaButton.applyTheme(theme: theme)
-        cardView.backgroundColor = theme.colors.layer5
         timerContainer.backgroundColor = theme.colors.layer3
-        cardView.applyShadow(FxShadow.shadow200, theme: theme)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class WorldCupTimerView: UIView, ThemeApplicable {
     private struct UX {
-        static let contentSpacing: CGFloat = 8.0
+        static let leftContentStackSpacing: CGFloat = 16.0
         static let timerVerticalPadding: CGFloat = 8
         static let timerHorizontalPadding: CGFloat = 64
         static let timerSegmentSpacing: CGFloat = 8.0
@@ -58,6 +58,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
         label.text = String.WorldCup.HomepageWidget.CountDown.Title
         label.textAlignment = .natural
         label.setContentCompressionResistancePriority(.required, for: .vertical)
+        label.setContentHuggingPriority(.required, for: .vertical)
     }
 
     private lazy var timerContainer: UIView = .build { view in
@@ -86,7 +87,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
         stack.spacing = UX.timerSegmentSpacing
     }
 
-    private lazy var ctaButton: PrimaryRoundedGlassButton = .build { [weak self] button in
+    private lazy var ctaButton: PrimaryRoundedButton = .build { [weak self] button in
         let buttonViewModel = PrimaryRoundedButtonViewModel(
             title: String.WorldCup.HomepageWidget.CountDown.ViewScheduleButtonLabel,
             a11yIdentifier: ""
@@ -95,6 +96,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
         button.configuration?.titleLineBreakMode = .byWordWrapping
         button.titleLabel?.numberOfLines = 0
         button.setContentCompressionResistancePriority(.required, for: .vertical)
+        button.setContentHuggingPriority(.required, for: .vertical)
         button.addAction(
             UIAction { [weak self] _ in
                 self?.handleCTATap()
@@ -118,9 +120,8 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
     private lazy var leftContentStack: UIStackView = .build { stack in
         stack.axis = .vertical
         stack.alignment = .leading
-        stack.spacing = UX.contentSpacing
+        stack.spacing = UX.leftContentStackSpacing
         stack.setContentCompressionResistancePriority(.required, for: .horizontal)
-        stack.setContentHuggingPriority(.required, for: .vertical)
     }
 
     // MARK: - Init

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
@@ -15,6 +15,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
         static let timerSegmentSpacing: CGFloat = 8.0
         static let dismissButtonSize = CGSize(width: 16, height: 16)
         static let heroImageWidth: CGFloat = 160
+        static let heroImageHeight: CGFloat = 140.0
         static let heroImageTrailingPadding: CGFloat = 12.0
         static let heroGifName = "kitHeroGif"
         static let heroImageName = "kitHero"
@@ -65,6 +66,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
         view.clipsToBounds = true
         view.isAccessibilityElement = true
         view.accessibilityTraits = .staticText
+        view.setContentCompressionResistancePriority(.required, for: .vertical)
     }
 
     private lazy var dayValueLabel: UILabel = makeValueLabel()
@@ -85,6 +87,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
         stack.axis = .horizontal
         stack.distribution = .equalSpacing
         stack.spacing = UX.timerSegmentSpacing
+        stack.setContentCompressionResistancePriority(.required, for: .vertical)
     }
 
     private lazy var ctaButton: PrimaryRoundedButton = .build { [weak self] button in
@@ -95,8 +98,6 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
         button.configure(viewModel: buttonViewModel)
         button.configuration?.titleLineBreakMode = .byWordWrapping
         button.titleLabel?.numberOfLines = 0
-        button.setContentCompressionResistancePriority(.required, for: .vertical)
-        button.setContentHuggingPriority(.required, for: .vertical)
         button.addAction(
             UIAction { [weak self] _ in
                 self?.handleCTATap()
@@ -168,7 +169,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
                 constant: -UX.heroImageTrailingPadding
             ),
             heroImageView.widthAnchor.constraint(lessThanOrEqualToConstant: UX.heroImageWidth),
-            heroImageView.heightAnchor.constraint(lessThanOrEqualToConstant: UX.heroImageWidth),
+            heroImageView.heightAnchor.constraint(lessThanOrEqualToConstant: UX.heroImageHeight),
             heroImageView.topAnchor.constraint(equalTo: topAnchor).priority(.defaultLow),
             heroImageView.bottomAnchor.constraint(equalTo: bottomAnchor).priority(.defaultLow),
 
@@ -291,8 +292,6 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        guard previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory
-        else { return }
         updateA11yLayout()
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
@@ -120,6 +120,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
         stack.alignment = .leading
         stack.spacing = UX.contentSpacing
         stack.setContentCompressionResistancePriority(.required, for: .horizontal)
+        stack.setContentHuggingPriority(.required, for: .vertical)
     }
 
     // MARK: - Init


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15718)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33632)

## :bulb: Description
Add `WorldCupCell` to support scroll trough card on the world cup section

## :movie_camera: Demos

https://github.com/user-attachments/assets/55a4bdca-ed25-45c7-8752-9d5b578f064f

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

