### PR TITLE
Add FXIOS-14354 [TabManager] Add tab manager tests

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -966,6 +966,9 @@
 		8A3EF8132A2FD07A00796E3A /* ResetContextualHints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF8122A2FD07A00796E3A /* ResetContextualHints.swift */; };
 		8A3EF8152A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF8142A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift */; };
 		8A3EF8172A2FD2B900796E3A /* AdvancedAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF8162A2FD2B900796E3A /* AdvancedAccountSettings.swift */; };
+		8A3FD2902FABB9BA001F5DE9 /* TabManagerClearHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FD28D2FABB9BA001F5DE9 /* TabManagerClearHistoryTests.swift */; };
+		8A3FD2912FABB9BA001F5DE9 /* TabManagerGetTabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FD28E2FABB9BA001F5DE9 /* TabManagerGetTabTests.swift */; };
+		8A3FD2922FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FD28F2FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift */; };
 		8A4190D22A6B0848001E8401 /* StatusBarOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4190D02A6B0843001E8401 /* StatusBarOverlayTests.swift */; };
 		8A4490922BF3BC2700E7E682 /* MicrosurveyPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4490912BF3BC2700E7E682 /* MicrosurveyPromptView.swift */; };
 		8A4490952BF3C42B00E7E682 /* MicrosurveyConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4490942BF3C42B00E7E682 /* MicrosurveyConfirmationView.swift */; };
@@ -9345,6 +9348,9 @@
 		8A3EF8122A2FD07A00796E3A /* ResetContextualHints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetContextualHints.swift; sourceTree = "<group>"; };
 		8A3EF8142A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenFiftyTabsDebugOption.swift; sourceTree = "<group>"; };
 		8A3EF8162A2FD2B900796E3A /* AdvancedAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedAccountSettings.swift; sourceTree = "<group>"; };
+		8A3FD28D2FABB9BA001F5DE9 /* TabManagerClearHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerClearHistoryTests.swift; sourceTree = "<group>"; };
+		8A3FD28E2FABB9BA001F5DE9 /* TabManagerGetTabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerGetTabTests.swift; sourceTree = "<group>"; };
+		8A3FD28F2FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerReorderTabsTests.swift; sourceTree = "<group>"; };
 		8A4190D02A6B0843001E8401 /* StatusBarOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarOverlayTests.swift; sourceTree = "<group>"; };
 		8A4490912BF3BC2700E7E682 /* MicrosurveyPromptView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicrosurveyPromptView.swift; sourceTree = "<group>"; };
 		8A4490942BF3C42B00E7E682 /* MicrosurveyConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyConfirmationView.swift; sourceTree = "<group>"; };
@@ -14508,10 +14514,13 @@
 				8A9BA6BE2F7C4D5B00D892C4 /* RemoteTabCreatorTests.swift */,
 				AB7D4C3029ACAED100626427 /* Tab+ChangeUserAgentTests.swift */,
 				39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */,
+				8A3FD28D2FABB9BA001F5DE9 /* TabManagerClearHistoryTests.swift */,
+				8A3FD28E2FABB9BA001F5DE9 /* TabManagerGetTabTests.swift */,
 				8AFC09522FA54A240070CA11 /* TabManagerOlderTabsTests.swift */,
 				8AFC09532FA54A240070CA11 /* TabManagerPreserveTabsTests.swift */,
 				8AFC1B782FAAAA3D0070CA11 /* TabManagerPrivacyModeTests.swift */,
 				8AFC09542FA54A240070CA11 /* TabManagerRemoveTabTests.swift */,
+				8A3FD28F2FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift */,
 				8AFC09552FA54A240070CA11 /* TabManagerRestoreTabsTests.swift */,
 				5A475E8929DB87F2009C13FD /* TabManagerTests.swift */,
 				8AFC09562FA54A240070CA11 /* TabManagerTestsBase.swift */,
@@ -20353,6 +20362,9 @@
 				2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */,
 				CA24B52224ABD7D40093848C /* PasswordManagerViewModelTests.swift in Sources */,
 				8A4B14872CF8D81800FCE2D0 /* UnifiedAdsProviderTests.swift in Sources */,
+				8A3FD2902FABB9BA001F5DE9 /* TabManagerClearHistoryTests.swift in Sources */,
+				8A3FD2912FABB9BA001F5DE9 /* TabManagerGetTabTests.swift in Sources */,
+				8A3FD2922FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift in Sources */,
 				E169C6E82979CA0E0017B8D7 /* URLMailTests.swift in Sources */,
 				8A7A26E129D4785900EA76F1 /* MockRouter.swift in Sources */,
 				965C3C96293431FC006499ED /* MockLaunchSessionProvider.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerClearHistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerClearHistoryTests.swift
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import XCTest
+import Shared
+@testable import Client
+
+final class TabManagerClearHistoryTests: TabManagerTestsBase {
+    // MARK: - clearAllTabsHistory
+
+    @MainActor
+    func testClearAllTabsHistory_replacesSelectedTab_withNewTab() {
+        let normalTabs = generateTabs(ofType: .normal, count: 3)
+        let subject = createSubject(tabs: normalTabs)
+        guard let originalTab = subject.normalTabs.first else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+        let originalUUID = originalTab.tabUUID
+        let originalCount = subject.tabs.count
+
+        subject.selectTab(originalTab)
+        subject.clearAllTabsHistory()
+
+        XCTAssertEqual(subject.tabs.count, originalCount, "Tab count should remain the same (one added, one removed)")
+        XCTAssertFalse(
+            subject.tabs.contains { $0.tabUUID == originalUUID },
+            "Original selected tab should have been removed"
+        )
+        XCTAssertNotNil(subject.selectedTab, "A new tab should be selected")
+    }
+
+    @MainActor
+    func testClearAllTabsHistory_preservesPrivacyMode_forNewTab() {
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.Settings.closePrivateTabs)
+        let privateTabs = generateTabs(ofType: .privateAny, count: 2)
+        let subject = createSubject(tabs: privateTabs)
+        guard let originalTab = subject.privateTabs.first else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+
+        subject.selectTab(originalTab)
+        subject.clearAllTabsHistory()
+
+        XCTAssertTrue(subject.selectedTab?.isPrivate ?? false, "New selected tab should preserve private mode")
+    }
+
+    @MainActor
+    func testClearAllTabsHistory_doesNothing_whenNoSelectedTab() {
+        let subject = createSubject(tabs: [])
+
+        XCTAssertNil(subject.selectedTab)
+        subject.clearAllTabsHistory()
+
+        XCTAssertEqual(subject.tabs.count, 0, "No tabs should be created when there is no selected tab")
+    }
+
+    @MainActor
+    func testClearAllTabsHistory_doesNothing_whenSelectedTabHasNoURL() {
+        let tab = Tab(profile: mockProfile, windowUUID: tabWindowUUID)
+        tab.url = nil
+        let subject = createSubject(tabs: [tab])
+        subject.selectTab(tab)
+
+        XCTAssertNil(subject.selectedTab?.url)
+        subject.clearAllTabsHistory()
+
+        XCTAssertEqual(subject.tabs.count, 1, "Tab count should not change when selected tab has no URL")
+        XCTAssertEqual(subject.selectedTab?.tabUUID, tab.tabUUID, "Original tab should still be selected")
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerGetTabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerGetTabTests.swift
@@ -60,7 +60,7 @@ final class TabManagerGetTabTests: TabManagerTestsBase {
     @MainActor
     func testGetTabForURL_returnsNil_whenNoTabMatchesURL() {
         let subject = createSubject()
-        subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
+        _ = subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
 
         let result = subject.getTabForURL(URL(string: "https://example.com/")!)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerGetTabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerGetTabTests.swift
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import WebKit
+import XCTest
+import Shared
+@testable import Client
+
+final class TabManagerGetTabTests: TabManagerTestsBase {
+    // MARK: - getTabForUUID
+
+    @MainActor
+    func testGetTabForUUID_returnsMatchingTab() {
+        let tabs = generateTabs(ofType: .normal, count: 3)
+        let subject = createSubject(tabs: tabs)
+        guard let target = subject.tabs[safe: 1] else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+
+        let result = subject.getTabForUUID(uuid: target.tabUUID)
+
+        XCTAssertEqual(result, target)
+    }
+
+    @MainActor
+    func testGetTabForUUID_returnsNil_whenUUIDNotFound() {
+        let tabs = generateTabs(ofType: .normal, count: 3)
+        let subject = createSubject(tabs: tabs)
+
+        let result = subject.getTabForUUID(uuid: "non-existent-uuid")
+
+        XCTAssertNil(result)
+    }
+
+    @MainActor
+    func testGetTabForUUID_returnsNil_whenNoTabsExist() {
+        let subject = createSubject(tabs: [])
+
+        let result = subject.getTabForUUID(uuid: "any-uuid")
+
+        XCTAssertNil(result)
+    }
+
+    // MARK: - getTabForURL
+
+    @MainActor
+    func testGetTabForURL_returnsMatchingTab() {
+        // addTab(URLRequest) calls webView.load(_:), which sets webView.url to the request URL immediately.
+        let subject = createSubject()
+        let addedTab = subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
+
+        let result = subject.getTabForURL(URL(string: "https://mozilla.com/")!)
+
+        XCTAssertEqual(result, addedTab)
+    }
+
+    @MainActor
+    func testGetTabForURL_returnsNil_whenNoTabMatchesURL() {
+        let subject = createSubject()
+        subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
+
+        let result = subject.getTabForURL(URL(string: "https://example.com/")!)
+
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Subscript [index]
+
+    @MainActor
+    func testSubscriptIndex_returnsCorrectTab_forValidIndex() {
+        let tabs = generateTabs(ofType: .normal, count: 3)
+        let subject = createSubject(tabs: tabs)
+
+        XCTAssertEqual(subject[0], tabs[0])
+        XCTAssertEqual(subject[1], tabs[1])
+        XCTAssertEqual(subject[2], tabs[2])
+    }
+
+    @MainActor
+    func testSubscriptIndex_returnsNil_forOutOfBoundsIndex() {
+        let tabs = generateTabs(ofType: .normal, count: 3)
+        let subject = createSubject(tabs: tabs)
+
+        XCTAssertNil(subject[3])
+        XCTAssertNil(subject[100])
+    }
+
+    // MARK: - Subscript [webView]
+
+    @MainActor
+    func testSubscriptWebView_returnsCorrectTab_whenWebViewMatches() {
+        let subject = createSubject(tabs: [])
+        // addTab creates a tab via configureTab, which calls createWebview and gives the tab a real webView
+        let tab = subject.addTab()
+
+        guard let webView = tab.webView else {
+            XCTFail("Tab created via addTab should have a webView")
+            return
+        }
+
+        XCTAssertEqual(subject[webView], tab)
+    }
+
+    @MainActor
+    func testSubscriptWebView_returnsNil_whenNoTabHasMatchingWebView() {
+        let tabs = generateTabs(ofType: .normal, count: 3)
+        let subject = createSubject(tabs: tabs)
+        let unrelatedWebView = WKWebView()
+
+        XCTAssertNil(subject[unrelatedWebView])
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerReorderTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerReorderTabsTests.swift
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import XCTest
+import Shared
+@testable import Client
+
+final class TabManagerReorderTabsTests: TabManagerTestsBase {
+    // MARK: - reorderTabs
+
+    @MainActor
+    func testReorderTabs_movesTabForward_withinNormalTabs() {
+        let normalTabs = generateTabs(ofType: .normal, count: 3)
+        let subject = createSubject(tabs: normalTabs)
+        let firstTab = subject.normalTabs[0]
+
+        subject.reorderTabs(isPrivate: false, fromIndex: 0, toIndex: 2)
+
+        XCTAssertEqual(subject.normalTabs[2], firstTab, "Tab should have moved to index 2")
+    }
+
+    @MainActor
+    func testReorderTabs_movesTabBackward_withinNormalTabs() {
+        let normalTabs = generateTabs(ofType: .normal, count: 3)
+        let subject = createSubject(tabs: normalTabs)
+        let lastTab = subject.normalTabs[2]
+
+        subject.reorderTabs(isPrivate: false, fromIndex: 2, toIndex: 0)
+
+        XCTAssertEqual(subject.normalTabs[0], lastTab, "Tab should have moved to index 0")
+    }
+
+    @MainActor
+    func testReorderTabs_doesNotAffectPrivateTabs_whenReorderingNormalTabs() {
+        let normalTabs = generateTabs(ofType: .normal, count: 3)
+        let privateTabs = generateTabs(ofType: .privateAny, count: 2)
+        let subject = createSubject(tabs: normalTabs + privateTabs)
+        let privateTabsBeforeReorder = subject.privateTabs
+
+        subject.reorderTabs(isPrivate: false, fromIndex: 0, toIndex: 2)
+
+        XCTAssertEqual(subject.privateTabs, privateTabsBeforeReorder, "Private tabs should be unaffected")
+    }
+
+    @MainActor
+    func testReorderTabs_reordersPrivateTabs_independently() {
+        let normalTabs = generateTabs(ofType: .normal, count: 2)
+        let privateTabs = generateTabs(ofType: .privateAny, count: 3)
+        let subject = createSubject(tabs: normalTabs + privateTabs)
+        let firstPrivateTab = subject.privateTabs[0]
+        let normalTabsBeforeReorder = subject.normalTabs
+
+        subject.reorderTabs(isPrivate: true, fromIndex: 0, toIndex: 2)
+
+        XCTAssertEqual(subject.privateTabs[2], firstPrivateTab, "First private tab should have moved to index 2")
+        XCTAssertEqual(subject.normalTabs, normalTabsBeforeReorder, "Normal tabs should be unaffected")
+    }
+
+    @MainActor
+    func testReorderTabs_updatesSelectedIndex_afterReorder() {
+        let normalTabs = generateTabs(ofType: .normal, count: 3)
+        let subject = createSubject(tabs: normalTabs)
+        guard let firstTab = subject.normalTabs.first else {
+            XCTFail("Test did not meet preconditions")
+            return
+        }
+
+        subject.selectTab(firstTab)
+        XCTAssertEqual(subject.selectedIndex, 0)
+
+        subject.reorderTabs(isPrivate: false, fromIndex: 0, toIndex: 2)
+
+        XCTAssertEqual(subject.selectedTab, firstTab, "Selected tab should remain the same")
+        XCTAssertEqual(subject.selectedIndex, 2, "Selected index should reflect the tab's new position")
+    }
+
+    @MainActor
+    func testReorderTabs_doesNothing_whenIndexOutOfBounds() {
+        let normalTabs = generateTabs(ofType: .normal, count: 3)
+        let subject = createSubject(tabs: normalTabs)
+        let tabsBeforeReorder = subject.normalTabs
+
+        subject.reorderTabs(isPrivate: false, fromIndex: 10, toIndex: 0)
+        XCTAssertEqual(subject.normalTabs, tabsBeforeReorder, "Order should not change when fromIndex is out of bounds")
+
+        subject.reorderTabs(isPrivate: false, fromIndex: 0, toIndex: 10)
+        XCTAssertEqual(subject.normalTabs, tabsBeforeReorder, "Order should not change when toIndex is out of bounds")
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -19,32 +19,6 @@ final class TabManagerTests: TabManagerTestsBase {
     }
 
     @MainActor
-    func testTabIndexSubscript() {
-        let subject = createSubject(tabs: generateTabs(count: 5))
-        let tab = subject[0]
-        XCTAssertNotNil(tab)
-    }
-
-    // MARK: - Get tabs
-
-    @MainActor
-    func testGetTabForUUID() {
-        let subject = createSubject(tabs: generateTabs(count: 1))
-        let uuid = subject.tabs.first!.tabUUID
-        let tab = subject.getTabForUUID(uuid: uuid)
-        XCTAssertEqual(tab, subject.tabs.first)
-    }
-
-    // This test has to be run on the main thread since we are messing with the WebView.
-    @MainActor
-    func testGetTabForURL() {
-        let subject = createSubject()
-        let addedTab = subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
-        let tab = subject.getTabForURL(URL(string: "https://mozilla.com/")!)
-        XCTAssertEqual(tab, addedTab)
-    }
-
-    @MainActor
     func testGetTabsAndChangeLastExecutedTime() {
         setupNimbusTabTrayUIExperimentTesting(isEnabled: false)
         let totalTabCount = 3


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14354)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31103)

## :bulb: Description
Adds unit tests for `getTabForUUID`, `getTabForURL`, index/webView subscripts, `reorderTabs`, and `clearAllTabsHistory`. Also moves the existing get-tab tests from `TabManagerTests` into the new dedicated file.

This is my last PR in my series of "let's try to improve TabManager tests"

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

