### PR TITLE
Add FXIOS-15712 [Newsfeed Categories] Scroll to newsfeed on header tap

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -778,6 +778,9 @@ final class HomepageViewController: UIViewController,
             selectedNewsfeedCategoryID: currentHomepageTabState.selectedNewsfeedCategoryID,
             newsfeedCategoryPickerOffsetX: currentHomepageTabState.newsfeedCategoryPickerOffsetX,
             onCategoryPickerScroll: updateNewsfeedCategoryPickerOffsetX,
+            onNewsAffordanceTap: { [weak self] in
+                self?.scrollNewsfeedToTop(onlyIfScrolledPastHeader: false, animated: true)
+            },
             onSelection: updatedSelectedNewsfeedCategory
         )
         newsTransitionHeaderCell.setTransitionProgress(newsTransitionProgress())
@@ -1098,7 +1101,7 @@ final class HomepageViewController: UIViewController,
 
         // If the user switches categories while scrolled through the newsfeed, jump back to the
         // offset where the pinned news header sits at the top before replacing the story items.
-        scrollNewsfeedToTop(for: activeTabUUID)
+        scrollNewsfeedToTop()
 
         homepageTabStateStore.updateState(for: activeTabUUID) { state in
             state.selectedNewsfeedCategoryID = selectedNewsfeedCategoryID
@@ -1134,15 +1137,17 @@ final class HomepageViewController: UIViewController,
         )
     }
 
-    private func scrollNewsfeedToTop(for tabUUID: TabUUID) {
-        guard let collectionView,
-              let targetOffsetY = newsfeedHeaderPinnedOffsetY(),
-              collectionView.contentOffset.y > targetOffsetY
+    private func scrollNewsfeedToTop(onlyIfScrolledPastHeader: Bool = true, animated: Bool = false) {
+        guard let activeTabUUID,
+              let collectionView,
+              let targetOffsetY = newsfeedHeaderPinnedOffsetY()
         else { return }
 
+        guard !onlyIfScrolledPastHeader || collectionView.contentOffset.y > targetOffsetY else { return }
+
         let targetOffset = CGPoint(x: collectionView.contentOffset.x, y: targetOffsetY)
-        collectionView.setContentOffset(targetOffset, animated: false)
-        homepageTabStateStore.updateState(for: tabUUID) { state in
+        collectionView.setContentOffset(targetOffset, animated: animated)
+        homepageTabStateStore.updateState(for: activeTabUUID) { state in
             state.scrollOffsetY = targetOffsetY
         }
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsAffordanceHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsAffordanceHeaderView.swift
@@ -46,10 +46,14 @@ final class NewsAffordanceHeaderView: UIView, ThemeApplicable {
         label.text = .FirefoxHomepage.Pocket.NewsAffordanceLabel
     }
 
+    private var onTap: (() -> Void)?
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         accessibilityLabel = .FirefoxHomepage.Pocket.NewsAffordanceLabel
+        accessibilityTraits = .button
         setupLayout()
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
     }
 
     required init?(coder: NSCoder) {
@@ -61,6 +65,15 @@ final class NewsAffordanceHeaderView: UIView, ThemeApplicable {
         chevronImageView.tintColor = color
         newsIconImageView.tintColor = color
         newsLabel.textColor = color
+    }
+
+    func configure(onTap: (() -> Void)?) {
+        self.onTap = onTap
+    }
+
+    @objc
+    private func handleTap() {
+        onTap?()
     }
 
     private func setupLayout() {

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsAffordanceHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsAffordanceHeaderView.swift
@@ -47,7 +47,7 @@ final class NewsAffordanceHeaderView: UIView, ThemeApplicable {
         label.text = .FirefoxHomepage.Pocket.NewsAffordanceLabel
     }
 
-    private var onTap: (() -> Void)?
+    private var onTap: (@MainActor () -> Void)?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -67,7 +67,7 @@ final class NewsAffordanceHeaderView: UIView, ThemeApplicable {
         newsLabel.textColor = color
     }
 
-    func configure(onTap: (() -> Void)?) {
+    func configure(onTap: (@MainActor () -> Void)?) {
         self.onTap = onTap
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsAffordanceHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsAffordanceHeaderView.swift
@@ -33,6 +33,7 @@ final class NewsAffordanceHeaderView: UIView, ThemeApplicable {
         stackView.alignment = .center
         stackView.distribution = .fill
         stackView.spacing = UX.iconSpacing
+        stackView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.handleTap)))
     }
 
     private lazy var newsIconImageView: UIImageView = .build { imageView in
@@ -53,7 +54,6 @@ final class NewsAffordanceHeaderView: UIView, ThemeApplicable {
         accessibilityLabel = .FirefoxHomepage.Pocket.NewsAffordanceLabel
         accessibilityTraits = .button
         setupLayout()
-        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
     }
 
     required init?(coder: NSCoder) {
@@ -86,10 +86,12 @@ final class NewsAffordanceHeaderView: UIView, ThemeApplicable {
         addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: topAnchor, constant: UX.stackTopInset),
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.stackHorizontalInset),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.stackHorizontalInset),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.stackBottomInset),
+            stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            stackView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: UX.stackTopInset),
+            stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: UX.stackHorizontalInset),
+            stackView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -UX.stackHorizontalInset),
+            stackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -UX.stackBottomInset),
 
             chevronImageView.widthAnchor.constraint(equalToConstant: UX.chevronSize),
             chevronImageView.heightAnchor.constraint(equalToConstant: UX.chevronSize),

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
@@ -84,10 +84,12 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         selectedNewsfeedCategoryID: String? = nil,
         newsfeedCategoryPickerOffsetX: CGFloat? = nil,
         onCategoryPickerScroll: ((CGFloat) -> Void)? = nil,
+        onNewsAffordanceTap: (() -> Void)? = nil,
         onSelection: (@MainActor @Sendable (String?) -> Void)? = nil
     ) {
         self.transitionEnabled = transitionEnabled
         newsAffordanceHeaderView.applyTheme(theme: theme)
+        newsAffordanceHeaderView.configure(onTap: onNewsAffordanceTap)
         sectionTitleHeaderView.configure(
             sectionHeaderConfiguration: sectionHeaderConfiguration,
             moreButtonAction: nil,

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
@@ -84,7 +84,7 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         selectedNewsfeedCategoryID: String? = nil,
         newsfeedCategoryPickerOffsetX: CGFloat? = nil,
         onCategoryPickerScroll: ((CGFloat) -> Void)? = nil,
-        onNewsAffordanceTap: (() -> Void)? = nil,
+        onNewsAffordanceTap: (@MainActor () -> Void)? = nil,
         onSelection: (@MainActor @Sendable (String?) -> Void)? = nil
     ) {
         self.transitionEnabled = transitionEnabled


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15712)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33621)

## :bulb: Description
- Scroll the homepage to the newsfeed section when the affordance header is tapped

## :movie_camera: Demos
https://github.com/user-attachments/assets/447ca148-a190-4dc0-8a94-904fd8d6796f

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

