### PR TITLE
Issue 33612 - Migrate DatabaseFixtureTest to TAE navigation

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DatabaseFixtureTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DatabaseFixtureTest.swift
@@ -54,27 +54,27 @@ class DatabaseFixtureTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2459133
-    func testHistoryDatabaseFixture() throws {
-        toolbarScreen.assertTabsButtonExists()
-        toolbarScreen.tapSettingsMenuButton()
-        mainMenuScreen.tapHistory()
+   func testHistoryDatabaseFixture() throws {
+       toolbarScreen.assertTabsButtonExists()
+       toolbarScreen.tapSettingsMenuButton()
+       mainMenuScreen.tapHistory()
 
-        let historyList = app.tables["History List"].firstMatch
-        mozWaitForElementToExist(historyList)
+       let historyList = app.tables["History List"].firstMatch
+       mozWaitForElementToExist(historyList)
 
-        do {
-            let snapshot = try app.tables["History List"].snapshot()
-            let historyList = snapshot.children.count
-            if #available(iOS 18, *) {
-                XCTAssertEqual(historyList, 105, "There should be 105 entries in the history list")
-            } else {
-                // For iOS 18, the scrollbars (vertical and horizontal) are included in the table
-                XCTAssertEqual(historyList, 103, "There should be 103 entries in the history list")
-            }
-        } catch {
-            XCTFail("Failed to take snapshot: \(error)")
-        }
+       do {
+           let snapshot = try app.tables["History List"].snapshot()
+           let historyList = snapshot.children.count
+           if #available(iOS 18, *) {
+               XCTAssertEqual(historyList, 105, "There should be 105 entries in the history list")
+           } else {
+               // For iOS 18, the scrollbars (vertical and horizontal) are included in the table
+               XCTAssertEqual(historyList, 103, "There should be 103 entries in the history list")
+           }
+       } catch {
+           XCTFail("Failed to take snapshot: \(error)")
+       }
 
-        app.terminate()
-    }
+       app.terminate()
+   }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DatabaseFixtureTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DatabaseFixtureTest.swift
@@ -6,6 +6,9 @@ import Common
 import XCTest
 
 class DatabaseFixtureTest: BaseTestCase {
+    private var toolbarScreen: ToolbarScreen!
+    private var mainMenuScreen: MainMenuScreen!
+
     let fixtures = [
         "testBookmarksDatabaseFixture": "testBookmarksDatabase1000-places.db",
         "testHistoryDatabaseFixture": "testHistoryDatabase100-places.db"
@@ -22,15 +25,15 @@ class DatabaseFixtureTest: BaseTestCase {
                            LaunchArguments.SkipContextualHints,
                            LaunchArguments.DisableAnimations]
         try await super.setUp()
+        toolbarScreen = ToolbarScreen(app: app)
+        mainMenuScreen = MainMenuScreen(app: app)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2458579
     func testBookmarksDatabaseFixture() {
-        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
-        let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
-        mozWaitForElementToExist(tabsButton)
-
-        navigator.goto(LibraryPanel_Bookmarks)
+        toolbarScreen.assertTabsButtonExists()
+        toolbarScreen.tapSettingsMenuButton()
+        mainMenuScreen.tapBookmarks()
 
         // Ensure 'Bookmarks List' exists before taking a snapshot to avoid expensive retries.
         // Return firstMatch to avoid traversing the entire { Window, Window } element tree.
@@ -51,28 +54,27 @@ class DatabaseFixtureTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2459133
-   func testHistoryDatabaseFixture() throws {
-       let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
-       mozWaitForElementToExist(tabsButton)
+    func testHistoryDatabaseFixture() throws {
+        toolbarScreen.assertTabsButtonExists()
+        toolbarScreen.tapSettingsMenuButton()
+        mainMenuScreen.tapHistory()
 
-       navigator.goto(LibraryPanel_History)
+        let historyList = app.tables["History List"].firstMatch
+        mozWaitForElementToExist(historyList)
 
-       let historyList = app.tables["History List"].firstMatch
-       mozWaitForElementToExist(historyList)
+        do {
+            let snapshot = try app.tables["History List"].snapshot()
+            let historyList = snapshot.children.count
+            if #available(iOS 18, *) {
+                XCTAssertEqual(historyList, 105, "There should be 105 entries in the history list")
+            } else {
+                // For iOS 18, the scrollbars (vertical and horizontal) are included in the table
+                XCTAssertEqual(historyList, 103, "There should be 103 entries in the history list")
+            }
+        } catch {
+            XCTFail("Failed to take snapshot: \(error)")
+        }
 
-       do {
-           let snapshot = try app.tables["History List"].snapshot()
-           let historyList = snapshot.children.count
-           if #available(iOS 18, *) {
-               XCTAssertEqual(historyList, 105, "There should be 105 entries in the history list")
-           } else {
-               // For iOS 18, the scrollbars (vertical and horizontal) are included in the table
-               XCTAssertEqual(historyList, 103, "There should be 103 entries in the history list")
-           }
-       } catch {
-           XCTFail("Failed to take snapshot: \(error)")
-       }
-
-       app.terminate()
-   }
+        app.terminate()
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MainMenuScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MainMenuScreen.swift
@@ -39,4 +39,16 @@ final class MainMenuScreen {
         BaseTestCase().mozWaitForElementToExist(settings)
         settings.waitAndTap()
     }
+
+    func tapBookmarks() {
+        let bookmarks = sel.BOOKMARKS_BUTTON.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(bookmarks)
+        bookmarks.waitAndTap()
+    }
+
+    func tapHistory() {
+        let history = sel.HISTORY_BUTTON.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(history)
+        history.waitAndTap()
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15703)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33612)

## :bulb: Description

  Migrates `DatabaseFixtureTest` away from legacy `navigator.goto(...)` navigation for the Bookmarks and History database fixture UI tests.

  Changes:
  - Adds `MainMenuScreen.tapBookmarks()`.
  - Adds `MainMenuScreen.tapHistory()`.
  - Updates `DatabaseFixtureTest` to use `ToolbarScreen` and `MainMenuScreen` page screen objects.
  - Keeps the existing fixture setup and list count assertions unchanged.

  Validation:
  - `testBookmarksDatabaseFixture` passed.
  - `testHistoryDatabaseFixture` passed.
  - Final `xcodebuild build-for-testing` passed.

  ## :movie_camera: Demos
  N/A, test-only navigation refactor with no user-facing UI changes.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

