### PR TITLE
[MTE-5319] - convert search settings navigation to TAE

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
@@ -323,4 +323,10 @@ final class SettingScreen {
             switchElement.waitAndTap()
         }
     }
+
+    func navigateToSearchSettings() {
+        let searchCell = sel.SEARCH_CELL.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(searchCell)
+        searchCell.waitAndTap()
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -9,10 +9,22 @@ let defaultSearchEngine2 = "Bing"
 let customSearchEngine = ["name": "youtube", "url": "https://youtube.com/search?q=%s"]
 
 class SearchSettingsUITests: BaseTestCase {
+    private var settingScreen: SettingScreen!
+    private var toolbarScreen: ToolbarScreen!
+    private var mainMenuScreen: MainMenuScreen!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        toolbarScreen = ToolbarScreen(app: app)
+        mainMenuScreen = MainMenuScreen(app: app)
+        settingScreen = SettingScreen(app: app)
+        toolbarScreen.tapSettingsMenuButton()
+        mainMenuScreen.tapSettings()
+        settingScreen.navigateToSearchSettings()
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2435664
     func testDefaultSearchEngine() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(SearchSettings)
         // Check the default browser
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
         mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine1])
@@ -26,8 +38,6 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353247
     func testCustomSearchEngineIsEditable() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(SearchSettings)
         // Add a custom search engine
         addCustomSearchEngine()
         // Check that the custom search appears on the list
@@ -57,8 +67,6 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353248
     func testCustomSearchEngineAsDefaultIsNotEditable() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(SearchSettings)
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
 
@@ -77,8 +85,6 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353249
     func testNavigateToSearchPickerTurnsOffEditing() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(SearchSettings)
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
 
@@ -109,8 +115,6 @@ class SearchSettingsUITests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353250
     func testDeletingLastCustomEngineExitsEditing() {
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(SearchSettings)
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
         // Add a custom search engine


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5319

## :bulb: Description
Convert SearchSettingsUITests tests navigation to TAE
