### PR TITLE
Bugfix FXIOS-15697 [Translations Phase 2] Translation icon stuck in loading state after app is backgrounded mid-translation

### DIFF
--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -659,7 +659,8 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
             ))
         }
     }
-    // We also want to display a toast.
+    // When we receive an error translating the page, we want to update the translation
+    // icon on the toolbar to be inactive. We also want to display a toast.
     private func handleErrorFromTranslatingPage(for action: Action, on tab: Tab? = nil) {
         dispatchAction(
             for: ToolbarActionType.didReceiveErrorTranslating,

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -6,6 +6,7 @@ import Foundation
 import Redux
 import Common
 import Shared
+import UIKit
 
 @MainActor
 final class TranslationsMiddleware: FeatureFlaggable {
@@ -34,6 +35,11 @@ final class TranslationsMiddleware: FeatureFlaggable {
     /// the active translation is discarded, tryAutoTranslate picks this up and translates to the
     /// requested language instead of the user's top preferred language.
     private var pendingLanguageSwitchTargets: [WindowUUID: String] = [:]
+    private var translationTasks: [WindowUUID: Task<Void, Never>] = [:]
+    private var backgroundTask: Task<Void, Never>?
+    private var foregroundTask: Task<Void, Never>?
+    var backgroundTimestamp: Date?
+    private static let backgroundRecoveryThreshold: TimeInterval = 3
 
     init(profile: Profile = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared,
@@ -50,6 +56,17 @@ final class TranslationsMiddleware: FeatureFlaggable {
         self.translationsTelemetry = translationsTelemetry
         self.manager = manager ?? PreferredTranslationLanguagesManager(prefs: profile.prefs)
         self.localeProvider = localeProvider
+        self.backgroundTask = Task { [weak self] in
+            for await _ in NotificationCenter.default.notifications(named: UIApplication.didEnterBackgroundNotification) {
+                self?.backgroundTimestamp = Date()
+                self?.cancelInFlightTranslations()
+            }
+        }
+        self.foregroundTask = Task { [weak self] in
+            for await _ in NotificationCenter.default.notifications(named: UIApplication.willEnterForegroundNotification) {
+                self?.recoverInterruptedTranslations()
+            }
+        }
     }
 
     lazy var translationsProvider: Middleware<AppState> = { state, action in
@@ -502,7 +519,9 @@ final class TranslationsMiddleware: FeatureFlaggable {
         autoTranslate: Bool = false,
         on tab: Tab? = nil
     ) {
-        Task {
+        let windowUUID = action.windowUUID
+        translationTasks[windowUUID]?.cancel()
+        translationTasks[windowUUID] = Task {
             await self.performTranslation(
                 for: action,
                 targetLanguage: targetLanguage,
@@ -510,6 +529,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
                 autoTranslate: autoTranslate,
                 on: tab
             )
+            self.translationTasks[windowUUID] = nil
         }
     }
 
@@ -542,6 +562,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
                 }
             )
             try await translationsService.firstResponseReceived(for: action.windowUUID)
+            guard !Task.isCancelled else { return }
             dispatchAction(
                 for: ToolbarActionType.translationCompleted,
                 with: .active,
@@ -552,6 +573,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
             )
             maybeShowAutoTranslatePrompt(windowUUID: action.windowUUID)
         } catch {
+            guard !Task.isCancelled else { return }
             let serviceError = TranslationsServiceError.fromUnknown(error)
             translationsTelemetry.translationFailed(
                 translationFlowId: flowId(for: action.windowUUID),
@@ -578,8 +600,52 @@ final class TranslationsMiddleware: FeatureFlaggable {
         clearFlowId(for: action)
     }
 
-    // When we receive an error translating the page, we want to update the translation
-    // icon on the toolbar to be inactive.
+    private func cancelInFlightTranslations() {
+        for (windowUUID, task) in translationTasks {
+            task.cancel()
+            translationTasks[windowUUID] = nil
+            guard let targetLanguage = selectedTargetLanguages[windowUUID] else { continue }
+            let tab = selectedTab(for: windowUUID)
+            pendingLanguageSwitchTargets[windowUUID] = targetLanguage
+            let reloadAction = GeneralBrowserAction(
+                windowUUID: windowUUID,
+                actionType: GeneralBrowserActionType.reloadWebsite
+            )
+            handleUpdatingTranslationIcon(for: reloadAction, with: .loading, on: tab)
+            store.dispatch(GeneralBrowserAction(
+                windowUUID: windowUUID,
+                actionType: GeneralBrowserActionType.reloadWebsite
+            ))
+        }
+    }
+
+    private func recoverInterruptedTranslations() {
+        guard let timestamp = backgroundTimestamp,
+              Date().timeIntervalSince(timestamp) > Self.backgroundRecoveryThreshold else { return }
+        backgroundTimestamp = nil
+
+        for uuid in translationFlowIds.keys {
+            let translationState = store.state.componentState(
+                ToolbarState.self,
+                for: .toolbar,
+                window: uuid
+            )?.addressToolbar.translationConfiguration?.state
+            guard translationState == .active else { continue }
+            guard let targetLanguage = selectedTargetLanguages[uuid] else { continue }
+
+            let tab = selectedTab(for: uuid)
+            pendingLanguageSwitchTargets[uuid] = targetLanguage
+            let reloadAction = GeneralBrowserAction(
+                windowUUID: uuid,
+                actionType: GeneralBrowserActionType.reloadWebsite
+            )
+            handleUpdatingTranslationIcon(for: reloadAction, with: .loading, on: tab)
+            store.dispatch(GeneralBrowserAction(
+                windowUUID: uuid,
+                actionType: GeneralBrowserActionType.reloadWebsite
+            ))
+        }
+    }
     // We also want to display a toast.
     private func handleErrorFromTranslatingPage(for action: Action, on tab: Tab? = nil) {
         dispatchAction(

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -9,7 +9,7 @@ import Shared
 import UIKit
 
 @MainActor
-final class TranslationsMiddleware: FeatureFlaggable {
+final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
     private let profile: Profile
     private let logger: Logger
     private let windowManager: WindowManager
@@ -17,6 +17,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
     private let translationsTelemetry: TranslationsTelemetryProtocol
     private let manager: PreferredTranslationLanguagesManager
     private let localeProvider: LocaleProvider
+    private let notificationCenter: NotificationProtocol
 
     /// Multiple windows can be open simultaneously, so we track IDs in a map.
     /// On iPhone, only a single window exists, so this will contain at most one entry.
@@ -36,8 +37,6 @@ final class TranslationsMiddleware: FeatureFlaggable {
     /// requested language instead of the user's top preferred language.
     private var pendingLanguageSwitchTargets: [WindowUUID: String] = [:]
     private var translationTasks: [WindowUUID: Task<Void, Never>] = [:]
-    private var backgroundTask: Task<Void, Never>?
-    private var foregroundTask: Task<Void, Never>?
     var backgroundTimestamp: Date?
     private static let backgroundRecoveryThreshold: TimeInterval = 3
 
@@ -47,7 +46,8 @@ final class TranslationsMiddleware: FeatureFlaggable {
          translationsService: TranslationsServiceProtocol = TranslationsService(),
          translationsTelemetry: TranslationsTelemetryProtocol = TranslationsTelemetry(),
          manager: PreferredTranslationLanguagesManager? = nil,
-         localeProvider: LocaleProvider = SystemLocaleProvider()
+         localeProvider: LocaleProvider = SystemLocaleProvider(),
+         notificationCenter: NotificationProtocol = NotificationCenter.default
     ) {
         self.profile = profile
         self.logger = logger
@@ -56,15 +56,28 @@ final class TranslationsMiddleware: FeatureFlaggable {
         self.translationsTelemetry = translationsTelemetry
         self.manager = manager ?? PreferredTranslationLanguagesManager(prefs: profile.prefs)
         self.localeProvider = localeProvider
-        self.backgroundTask = Task { [weak self] in
-            for await _ in NotificationCenter.default.notifications(named: UIApplication.didEnterBackgroundNotification) {
-                self?.backgroundTimestamp = Date()
-                self?.cancelInFlightTranslations()
-            }
-        }
-        self.foregroundTask = Task { [weak self] in
-            for await _ in NotificationCenter.default.notifications(named: UIApplication.willEnterForegroundNotification) {
-                self?.recoverInterruptedTranslations()
+        self.notificationCenter = notificationCenter
+        startObservingNotifications(
+            withNotificationCenter: notificationCenter,
+            forObserver: self,
+            observing: [
+                UIApplication.didEnterBackgroundNotification,
+                UIApplication.willEnterForegroundNotification
+            ]
+        )
+    }
+
+    nonisolated func handleNotifications(_ notification: Notification) {
+        let notificationName = notification.name
+        ensureMainThread {
+            switch notificationName {
+            case UIApplication.didEnterBackgroundNotification:
+                self.backgroundTimestamp = Date()
+                self.cancelInFlightTranslations()
+            case UIApplication.willEnterForegroundNotification:
+                self.recoverInterruptedTranslations()
+            default:
+                break
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -660,7 +660,8 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
         }
     }
     // When we receive an error translating the page, we want to update the translation
-    // icon on the toolbar to be inactive. We also want to display a toast.
+    // icon on the toolbar to be inactive.
+    // We also want to display a toast.
     private func handleErrorFromTranslatingPage(for action: Action, on tab: Tab? = nil) {
         dispatchAction(
             for: ToolbarActionType.didReceiveErrorTranslating,

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
@@ -59,6 +59,7 @@ port1.onmessage = (message) => {
 /// NOTE: This should be called to start the translation process for this document.
 /// This creates the TranslationsDocument instance that manages the translation lifecycle.
 const startTranslations = ({from, to}) => {
+    resetIsDone();
     const languagePair = {sourceLanguage: from, targetLanguage: to}
     const translationsCache = new LRUCache(languagePair);
     const translatedDoc = new TranslationsDocument(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Redux
 import Shared
 import TestKit
+import UIKit
 import XCTest
 
 @testable import Client
@@ -1659,4 +1661,152 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(completedAction.translationConfiguration?.state, .active)
         XCTAssertEqual(completedAction.translationConfiguration?.sourceLanguage, "en")
     }
+
+    // MARK: - Background cancellation tests
+
+    func test_background_withInFlightTranslation_reloadsForAutoRetranslate() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslatePromptShown)
+        let stallingService = StallingTranslationsService()
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.webView = MockTabWebView(tab: tab)
+        mockTabManager.selectedTab = tab
+        let subject = createSubject(translationsService: stallingService)
+
+        let action = TranslationLanguageSelectedAction(
+            windowUUID: .XCTestDefaultUUID,
+            targetLanguage: "de",
+            actionType: TranslationsActionType.didSelectTargetLanguage
+        )
+
+        let loadingExpectation = XCTestExpectation(description: "didStartTranslatingPage dispatched")
+        mockStore.dispatchCalled = { [weak mockStore] in
+            if (mockStore?.dispatchedActions.last?.actionType as? ToolbarActionType) == .didStartTranslatingPage {
+                loadingExpectation.fulfill()
+            }
+        }
+
+        subject.translationsProvider(mockStore.state, action)
+        wait(for: [loadingExpectation], timeout: 1.0)
+        mockStore.dispatchedActions.removeAll()
+
+        let cancelExpectation = XCTestExpectation(
+            description: "loading icon and reloadWebsite dispatched on background"
+        )
+        cancelExpectation.expectedFulfillmentCount = 2
+        mockStore.dispatchCalled = { cancelExpectation.fulfill() }
+
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        wait(for: [cancelExpectation], timeout: 1.0)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
+
+        let loadingAction = try XCTUnwrap(mockStore.dispatchedActions[0] as? ToolbarAction)
+        XCTAssertEqual(loadingAction.actionType as? ToolbarActionType, .didStartTranslatingPage)
+        XCTAssertEqual(loadingAction.translationConfiguration?.state, .loading)
+
+        let reloadAction = try XCTUnwrap(mockStore.dispatchedActions[1] as? GeneralBrowserAction)
+        XCTAssertEqual(reloadAction.actionType as? GeneralBrowserActionType, .reloadWebsite)
+
+        XCTAssertEqual(tab.translationConfiguration?.state, .loading)
+    }
+
+    func test_background_withNoInFlightTranslation_doesNotDispatchActions() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let subject = createSubject()
+
+        let expectation = XCTestExpectation(description: "no actions dispatched without in-flight translation")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        withExtendedLifetime(subject) {}
+    }
+
+    // MARK: - Foreground recovery tests
+
+    func test_foreground_afterLongBackground_withActiveTranslation_autoRetranslates() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslatePromptShown)
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.webView = MockTabWebView(tab: tab)
+        mockTabManager.selectedTab = tab
+        let subject = createSubject()
+
+        seedTargetLanguage(in: subject, successDispatchCount: 2)
+
+        mockStore.state = setupAppStateWithTranslationConfig(for: .active)
+        mockStore.dispatchedActions.removeAll()
+
+        let recoveryExpectation = XCTestExpectation(
+            description: "loading icon and reloadWebsite dispatched on foreground"
+        )
+        recoveryExpectation.expectedFulfillmentCount = 2
+        mockStore.dispatchCalled = { recoveryExpectation.fulfill() }
+
+        subject.backgroundTimestamp = Date().addingTimeInterval(-5)
+
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+
+        wait(for: [recoveryExpectation], timeout: 1.0)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
+
+        let loadingAction = try XCTUnwrap(mockStore.dispatchedActions[0] as? ToolbarAction)
+        XCTAssertEqual(loadingAction.actionType as? ToolbarActionType, .didStartTranslatingPage)
+        XCTAssertEqual(loadingAction.translationConfiguration?.state, .loading)
+
+        let reloadAction = try XCTUnwrap(mockStore.dispatchedActions[1] as? GeneralBrowserAction)
+        XCTAssertEqual(reloadAction.actionType as? GeneralBrowserActionType, .reloadWebsite)
+
+        XCTAssertEqual(tab.translationConfiguration?.state, .loading)
+    }
+
+    func test_foreground_afterBriefBackground_doesNotRecover() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let subject = createSubject()
+
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        let expectation = XCTestExpectation(description: "no recovery dispatched for brief background")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        withExtendedLifetime(subject) {}
+    }
+}
+
+// MARK: - StallingTranslationsService
+
+private final class StallingTranslationsService: TranslationsServiceProtocol {
+    func shouldOfferTranslation(for windowUUID: WindowUUID, using preferredLanguages: [String]) async throws -> Bool {
+        false
+    }
+
+    func translateCurrentPage(
+        for windowUUID: WindowUUID,
+        from sourceLanguage: String?,
+        to targetLanguage: String,
+        onLanguageIdentified: ((String, String) -> Void)?
+    ) async throws {
+        onLanguageIdentified?("en", targetLanguage)
+    }
+
+    func firstResponseReceived(for windowUUID: WindowUUID) async throws {
+        try await Task.sleep(nanoseconds: 60_000_000_000)
+    }
+
+    func discardTranslations(for windowUUID: WindowUUID) async throws {}
+
+    func fetchSupportedTargetLanguages() async -> [String] { [] }
+
+    func detectPageLanguage(for windowUUID: WindowUUID) async throws -> String { "en" }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -1751,6 +1751,95 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(tab.translationConfiguration?.state, .loading)
     }
 
+    func test_background_cancelledTranslation_doesNotDispatchCompletion() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslatePromptShown)
+        let stallingService = StallingTranslationsService()
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.webView = MockTabWebView(tab: tab)
+        mockTabManager.selectedTab = tab
+        let subject = createSubject(translationsService: stallingService)
+
+        let action = TranslationLanguageSelectedAction(
+            windowUUID: .XCTestDefaultUUID,
+            targetLanguage: "de",
+            actionType: TranslationsActionType.didSelectTargetLanguage
+        )
+
+        let loadingExpectation = XCTestExpectation(description: "didStartTranslatingPage dispatched")
+        mockStore.dispatchCalled = { [weak mockStore] in
+            if (mockStore?.dispatchedActions.last?.actionType as? ToolbarActionType) == .didStartTranslatingPage {
+                loadingExpectation.fulfill()
+            }
+        }
+
+        subject.translationsProvider(mockStore.state, action)
+        wait(for: [loadingExpectation], timeout: 1.0)
+        mockStore.dispatchedActions.removeAll()
+
+        mockNotificationCenter.post(name: UIApplication.didEnterBackgroundNotification)
+
+        let completionLeakExpectation = XCTestExpectation(description: "translationCompleted should not be dispatched")
+        completionLeakExpectation.isInverted = true
+        mockStore.dispatchCalled = { [weak mockStore] in
+            if (mockStore?.dispatchedActions.last?.actionType as? ToolbarActionType) == .translationCompleted {
+                completionLeakExpectation.fulfill()
+            }
+        }
+
+        wait(for: [completionLeakExpectation], timeout: 1.0)
+
+        let completionActions = mockStore.dispatchedActions.filter {
+            ($0.actionType as? ToolbarActionType) == .translationCompleted
+        }
+        XCTAssertTrue(completionActions.isEmpty)
+    }
+
+    func test_background_cancelledTranslation_doesNotDispatchError() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let stallingService = StallingTranslationsService(
+            firstResponseReceivedBehavior: .throwAfterCancel
+        )
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.webView = MockTabWebView(tab: tab)
+        mockTabManager.selectedTab = tab
+        let subject = createSubject(translationsService: stallingService)
+
+        let action = TranslationLanguageSelectedAction(
+            windowUUID: .XCTestDefaultUUID,
+            targetLanguage: "de",
+            actionType: TranslationsActionType.didSelectTargetLanguage
+        )
+
+        let loadingExpectation = XCTestExpectation(description: "didStartTranslatingPage dispatched")
+        mockStore.dispatchCalled = { [weak mockStore] in
+            if (mockStore?.dispatchedActions.last?.actionType as? ToolbarActionType) == .didStartTranslatingPage {
+                loadingExpectation.fulfill()
+            }
+        }
+
+        subject.translationsProvider(mockStore.state, action)
+        wait(for: [loadingExpectation], timeout: 1.0)
+        mockStore.dispatchedActions.removeAll()
+
+        mockNotificationCenter.post(name: UIApplication.didEnterBackgroundNotification)
+
+        let errorLeakExpectation = XCTestExpectation(description: "didReceiveErrorTranslating should not be dispatched")
+        errorLeakExpectation.isInverted = true
+        mockStore.dispatchCalled = { [weak mockStore] in
+            if (mockStore?.dispatchedActions.last?.actionType as? ToolbarActionType) == .didReceiveErrorTranslating {
+                errorLeakExpectation.fulfill()
+            }
+        }
+
+        wait(for: [errorLeakExpectation], timeout: 1.0)
+
+        let errorActions = mockStore.dispatchedActions.filter {
+            ($0.actionType as? ToolbarActionType) == .didReceiveErrorTranslating
+        }
+        XCTAssertTrue(errorActions.isEmpty)
+    }
+
     func test_foreground_afterBriefBackground_doesNotRecover() throws {
         setTranslationsFeatureEnabled(enabled: true)
         let subject = createSubject()
@@ -1766,6 +1855,17 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
 // MARK: - StallingTranslationsService
 
 private final class StallingTranslationsService: TranslationsServiceProtocol {
+    enum FirstResponseBehavior {
+        case stall
+        case throwAfterCancel
+    }
+
+    private let firstResponseReceivedBehavior: FirstResponseBehavior
+
+    init(firstResponseReceivedBehavior: FirstResponseBehavior = .stall) {
+        self.firstResponseReceivedBehavior = firstResponseReceivedBehavior
+    }
+
     func shouldOfferTranslation(for windowUUID: WindowUUID, using preferredLanguages: [String]) async throws -> Bool {
         false
     }
@@ -1780,7 +1880,15 @@ private final class StallingTranslationsService: TranslationsServiceProtocol {
     }
 
     func firstResponseReceived(for windowUUID: WindowUUID) async throws {
-        try await Task.sleep(nanoseconds: 60_000_000_000)
+        switch firstResponseReceivedBehavior {
+        case .stall:
+            try await Task.sleep(nanoseconds: 60_000_000_000)
+        case .throwAfterCancel:
+            while !Task.isCancelled {
+                try await Task.sleep(nanoseconds: 10_000_000)
+            }
+            throw CancellationError()
+        }
     }
 
     func discardTranslations(for windowUUID: WindowUUID) async throws {}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -19,6 +19,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
     private var mockWindowManager: MockWindowManager!
     private var mockTabManager: MockTabManager!
     private var mockTranslationsTelemetry: MockTranslationsTelemetry!
+    private var mockNotificationCenter: MockNotificationCenter!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -30,6 +31,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             tabManager: mockTabManager
         )
         mockTranslationsTelemetry = MockTranslationsTelemetry()
+        mockNotificationCenter = MockNotificationCenter()
         DependencyHelperMock().bootstrapDependencies(
             injectedWindowManager: mockWindowManager,
             injectedTabManager: mockTabManager
@@ -43,6 +45,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         mockTabManager = nil
         mockWindowManager = nil
         mockTranslationsTelemetry = nil
+        mockNotificationCenter = nil
         DependencyHelperMock().reset()
         resetStore()
         try await super.tearDown()
@@ -1449,15 +1452,18 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         manager: PreferredTranslationLanguagesManager? = nil,
         localeProvider: LocaleProvider = MockLocaleProvider()
     ) -> TranslationsMiddleware {
-        return TranslationsMiddleware(
+        let subject = TranslationsMiddleware(
             profile: mockProfile,
             logger: mockLogger,
             windowManager: mockWindowManager,
             translationsService: translationsService,
             translationsTelemetry: mockTranslationsTelemetry,
             manager: manager,
-            localeProvider: localeProvider
+            localeProvider: localeProvider,
+            notificationCenter: mockNotificationCenter
         )
+        mockNotificationCenter.notifiableListener = subject
+        return subject
     }
 
     private func setupWebViewForTabManager() {
@@ -1690,15 +1696,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         wait(for: [loadingExpectation], timeout: 1.0)
         mockStore.dispatchedActions.removeAll()
 
-        let cancelExpectation = XCTestExpectation(
-            description: "loading icon and reloadWebsite dispatched on background"
-        )
-        cancelExpectation.expectedFulfillmentCount = 2
-        mockStore.dispatchCalled = { cancelExpectation.fulfill() }
-
-        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
-
-        wait(for: [cancelExpectation], timeout: 1.0)
+        mockNotificationCenter.post(name: UIApplication.didEnterBackgroundNotification)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 2)
 
@@ -1716,13 +1714,8 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         setTranslationsFeatureEnabled(enabled: true)
         let subject = createSubject()
 
-        let expectation = XCTestExpectation(description: "no actions dispatched without in-flight translation")
-        expectation.isInverted = true
-        mockStore.dispatchCalled = { expectation.fulfill() }
+        mockNotificationCenter.post(name: UIApplication.didEnterBackgroundNotification)
 
-        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
-
-        wait(for: [expectation], timeout: 0.5)
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         withExtendedLifetime(subject) {}
     }
@@ -1742,17 +1735,9 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         mockStore.state = setupAppStateWithTranslationConfig(for: .active)
         mockStore.dispatchedActions.removeAll()
 
-        let recoveryExpectation = XCTestExpectation(
-            description: "loading icon and reloadWebsite dispatched on foreground"
-        )
-        recoveryExpectation.expectedFulfillmentCount = 2
-        mockStore.dispatchCalled = { recoveryExpectation.fulfill() }
-
         subject.backgroundTimestamp = Date().addingTimeInterval(-5)
 
-        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
-
-        wait(for: [recoveryExpectation], timeout: 1.0)
+        mockNotificationCenter.post(name: UIApplication.willEnterForegroundNotification)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 2)
 
@@ -1770,15 +1755,9 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         setTranslationsFeatureEnabled(enabled: true)
         let subject = createSubject()
 
-        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        mockNotificationCenter.post(name: UIApplication.didEnterBackgroundNotification)
+        mockNotificationCenter.post(name: UIApplication.willEnterForegroundNotification)
 
-        let expectation = XCTestExpectation(description: "no recovery dispatched for brief background")
-        expectation.isInverted = true
-        mockStore.dispatchCalled = { expectation.fulfill() }
-
-        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
-
-        wait(for: [expectation], timeout: 0.5)
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         withExtendedLifetime(subject) {}
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15697)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33601)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

When the app is backgrounded mid-translation, the translation Task may be suspended by the OS. On foreground, if the Task does not resume, the toolbar icon remains stuck in `.loading` indefinitely.

On `UIApplication.didBecomeActiveNotification`, iterate all window tab managers and clear any selected tab whose `translationConfiguration` is `.loading`: dispatch an immediate clear action to reset the icon, then re-run eligibility so the page re-offers translation if still eligible.

Adds two tests covering the loading-tab clear path and the no-op path for non-loading tabs.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


