### PR TITLE
Add FXIOS-15737 [Tab leak] test to detect tab leak

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -69,6 +69,10 @@ struct AccessibilityIdentifiers {
             static let contentView = "contentView"
         }
 
+        struct Tab {
+            static let automationTestLeakIndicator = "Tab.LeakIndicatorElement"
+        }
+
         static let overKeyboardContainer = "Browser.overKeyboardContainer"
         static let headerContainer = "Browser.headerContainer"
         static let bottomContainer = "Browser.bottomContainer"

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -593,7 +593,6 @@ class Tab: NSObject,
     /// Keep final cleanup in deinit as a safety net, but add call in close() explicitly
     /// because retained tabs may delay deinit and keep resources alive.
     deinit {
-#if DEBUG
         if Thread.isMainThread {
             MainActor.assumeIsolated {
                 // Note: this has no effect in production. This view is only
@@ -601,7 +600,7 @@ class Tab: NSObject,
                 uiTestLeakView?.removeFromSuperview()
             }
         }
-
+#if DEBUG
         debugTabCount -= 1
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         func checkTabCount(failures: Int) {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -469,6 +469,9 @@ class Tab: NSObject,
 
     private var temporaryDocumentsSession: TemporaryDocumentSession = [:]
 
+    // MARK: - Tab leaks detection view
+    private var uiTestLeakView: UIView?
+
     // MARK: - Dependencies
     var profile: Profile
     private let fileManager: FileManagerProtocol
@@ -591,6 +594,14 @@ class Tab: NSObject,
     /// because retained tabs may delay deinit and keep resources alive.
     deinit {
 #if DEBUG
+        if Thread.isMainThread {
+            MainActor.assumeIsolated {
+                // Note: this has no effect in production. This view is only
+                // created during automation testing as a sentinel UI element.
+                uiTestLeakView?.removeFromSuperview()
+            }
+        }
+
         debugTabCount -= 1
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         func checkTabCount(failures: Int) {
@@ -644,6 +655,7 @@ class Tab: NSObject,
         webView = nil
 
         deleteDownloadedDocuments(docsURL: temporaryDocumentsSession)
+        addUITestMemoryLeakDetectionUIElement()
     }
 
     func goBack() {
@@ -1037,5 +1049,30 @@ class Tab: NSObject,
 
     func imageContentBlockingEnabled() -> Bool {
         return noImageMode
+    }
+
+    // MARK: - Automation Support
+
+    /// No effect in production. This function creates a sentinel UI element which
+    /// can be detected by our automated tests if the Tab is leaked after it is closed.
+    private func addUITestMemoryLeakDetectionUIElement() {
+        guard AppConstants.isRunningUITests, let keyWindow = UIWindow.keyWindow else { return }
+
+        class TAB_LEAK_DETECTED: UIButton { }
+
+        guard let root = keyWindow.rootViewController else { fatalError() }
+        let uiTestScreen = UIScreen.main.bounds
+        let viewFrame = CGRect(x: uiTestScreen.width / 2.0,
+                               y: uiTestScreen.height / 2.0,
+                               width: 5,
+                               height: 5)
+        let leakIdentifierView = TAB_LEAK_DETECTED(frame: viewFrame)
+        leakIdentifierView.backgroundColor = UIColor.white
+        leakIdentifierView.accessibilityIdentifier = AccessibilityIdentifiers.Browser.Tab.automationTestLeakIndicator
+        leakIdentifierView.isAccessibilityElement = true
+        leakIdentifierView.isUserInteractionEnabled = true
+        leakIdentifierView.accessibilityTraits = [.button]
+        root.view.addSubview(leakIdentifierView)
+        uiTestLeakView = leakIdentifierView
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
@@ -212,4 +212,9 @@ final class TabTrayScreen {
         let leakDetectionView = app.buttons[AccessibilityIdentifiers.Browser.WebView.automationTestLeakIndicator]
         BaseTestCase().mozWaitForElementToNotExist(leakDetectionView, timeout: timeout)
     }
+
+    func assertNoTabLeakDetected(timeout: TimeInterval = TIMEOUT) {
+        let leakDetectionView = app.buttons[AccessibilityIdentifiers.Browser.Tab.automationTestLeakIndicator]
+        BaseTestCase().mozWaitForElementToNotExist(leakDetectionView, timeout: timeout)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -371,6 +371,26 @@ class TabsTests: BaseTestCase {
         tabTrayScreen.assertNoWebViewLeakDetected()
     }
 
+    // Smoketest
+    // This tests for leaks of the Tab object, ensuring that Tab instances are released
+    // after a tab is closed. If this test fails, it means that either:
+    // A) We've introduced a regression that leaks the Tab instance
+    // B) There is a bug in the sentinel UI element (make sure it's accessible)
+    func testCloseTabFreesTabObject_NoMemoryLeak() {
+        toolBarScreen = ToolbarScreen(app: app)
+        tabTrayScreen = TabTrayScreen(app: app)
+
+        toolBarScreen.assertTabsButtonExists()
+        navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+        waitUntilPageLoad()
+
+        waitForTabsButton()
+        navigator.goto(TabTray)
+        tabTrayScreen.longPressTabCellAtIndex(0)
+        tabTrayScreen.tapCloseTabFromContextMenu()
+        tabTrayScreen.assertNoTabLeakDetected()
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2306867
     func testCloseOneTabUndo() throws {
         throw XCTSkip("Undo toast no longer available")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -368,7 +368,10 @@ class TabsTests: BaseTestCase {
         navigator.goto(TabTray)
         tabTrayScreen.longPressTabCellAtIndex(0)
         tabTrayScreen.tapCloseTabFromContextMenu()
-        tabTrayScreen.assertNoWebViewLeakDetected()
+        // Tab teardown has more deferred async work than the WKWebView (notably the
+        // `await pauseAllMediaPlayback()` step in close()), so dealloc can land later
+        // on slower CI simulators. Using TIMEOUT_LONG instead
+        tabTrayScreen.assertNoWebViewLeakDetected(timeout: TIMEOUT_LONG)
     }
 
     // Smoketest


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15737)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33667)

## :bulb: Description
- Add tab leak detection UI Test based in existing WKWebview test.

Note: We have a known leak related to media playing webview I will add a UI test to catch this scenario once is fixed 


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

