### PR TITLE
Fix FXIOS-15636 [History] Back button remains after popping from Recently Closed Tabs

### DIFF
--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -806,6 +806,8 @@ extension HistoryPanel {
 extension HistoryPanel {
     func handleLeftTopButton() {
         updatePanelState(newState: .history(state: .mainView))
+        let userInfo: [String: Any] = ["state": state]
+        NotificationCenter.default.post(name: .LibraryPanelStateDidChange, object: nil, userInfo: userInfo)
     }
 
     func handleRightTopButton() {

--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -334,7 +334,10 @@ class LibraryViewController: UIViewController, Themeable {
         }
 
         navController.popViewController(animated: true)
-        currentPanel.handleLeftTopButton()
+        // After popping, notify the newly revealed panel so it can update its state
+        if let newPanel = getCurrentPanel() {
+            newPanel.handleLeftTopButton()
+        }
     }
 
     @objc


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15636)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33496)

# :bulb: Description
## Problem
When navigating to History → Recently Closed Tabs and popping back, the back button (<) in the top-left corner remains visible.
## Root Cause
When the user taps "Recently Closed", handleHistoryActionableTapped sets HistoryPanel's state to .inFolder. In topLeftButtonAction, currentPanel was captured before popViewController, so handleLeftTopButton() was called on RecentlyClosedTabsPanel (default no-op) instead of HistoryPanel. The state was never reset to .mainView.

## Fix

- LibraryViewController.topLeftButtonAction: Call handleLeftTopButton() on the new current panel after the pop (not the popped one).

- HistoryPanel.handleLeftTopButton: Post .LibraryPanelStateDidChange notification to propagate the state change and trigger an immediate layout update.

## :movie_camera: Demos

https://github.com/user-attachments/assets/28279e08-47ad-4f81-a022-bc53b90f0bf1



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

