### PR TITLE
Bugfix FXIOS-15755 FXIOS-15756 [Library Panel] Missing buttons in library panel

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -53,7 +53,10 @@ final class BookmarksViewController: SiteTableViewController,
               viewModel.bookmarkFolderGUID != LocalDesktopFolder.localDesktopFolderGuid
         else { return [] }
 
-        return toolbarButtonItems
+        let items = toolbarButtonItems
+        applyThemeToButtons()
+
+        return items
     }
 
     private var isBookmarksSearchEnabled: Bool {
@@ -70,30 +73,18 @@ final class BookmarksViewController: SiteTableViewController,
         case .bookmarks(state: .mainView),
              .bookmarks(state: .inFolder):
             bottomRightButton.title = .BookmarksEdit
-            if #available(iOS 26.0, *) {
-                bottomRightButton.tintColor = currentTheme().colors.textPrimary
-            }
             return searchItems + [flexibleSpace, bottomRightButton]
         case .bookmarks(state: .search):
             return searchItems + [flexibleSpace]
         case .bookmarks(state: .inFolderEditMode):
             bottomRightButton.title = String.AppSettingsDone
-            if #available(iOS 26.0, *) {
-                bottomRightButton.tintColor = currentTheme().colors.textAccent
-            }
             return [bottomLeftButton, flexibleSpace, bottomRightButton]
         case .bookmarks(state: .itemEditMode):
             bottomRightButton.title = String.AppSettingsDone
-            if #available(iOS 26.0, *) {
-                bottomRightButton.tintColor = currentTheme().colors.textAccent
-            }
             bottomRightButton.isEnabled = true
             return [flexibleSpace, bottomRightButton]
         case .bookmarks(state: .itemEditModeInvalidField):
             bottomRightButton.title = String.AppSettingsDone
-            if #available(iOS 26.0, *) {
-                bottomRightButton.tintColor = currentTheme().colors.textAccent
-            }
             bottomRightButton.isEnabled = false
             return [flexibleSpace, bottomRightButton]
         default:

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -682,9 +682,28 @@ final class BookmarksViewController: SiteTableViewController,
         bottomStackView.applyTheme(theme: currentTheme())
     }
 
+    private func applyThemeToButtons() {
+        guard #available(iOS 26.0, *) else { return }
+
+        switch state {
+        case .bookmarks(state: .mainView),
+             .bookmarks(state: .inFolder):
+            bottomRightButton.tintColor = currentTheme().colors.textPrimary
+        case .bookmarks(state: .inFolderEditMode):
+            bottomRightButton.tintColor = currentTheme().colors.textAccent
+        case .bookmarks(state: .itemEditMode):
+            bottomRightButton.tintColor = currentTheme().colors.textAccent
+        case .bookmarks(state: .itemEditModeInvalidField):
+            bottomRightButton.tintColor = currentTheme().colors.textAccent
+        default:
+            return
+        }
+    }
+
     override func applyTheme() {
         super.applyTheme()
         applyThemeToSearchBar()
+        applyThemeToButtons()
     }
 
     // MARK: - UITableViewDragDelegate | UITableViewDropDelegate

--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -302,26 +302,18 @@ class LibraryViewController: UIViewController, Themeable {
             navigationItem.rightBarButtonItem = nil
         case .bookmarks(state: .itemEditMode):
             topRightButton.title = .SettingsAddCustomEngineSaveButtonText
-            if #available(iOS 26.0, *) {
-                topRightButton.tintColor = currentTheme().colors.textAccent
-            }
             navigationItem.rightBarButtonItem = topRightButton
             navigationItem.rightBarButtonItem?.isEnabled = true
         case .bookmarks(state: .itemEditModeInvalidField):
             topRightButton.title = .SettingsAddCustomEngineSaveButtonText
-            if #available(iOS 26.0, *) {
-                topRightButton.tintColor = currentTheme().colors.textAccent
-            }
             navigationItem.rightBarButtonItem = topRightButton
             navigationItem.rightBarButtonItem?.isEnabled = false
         default:
             topRightButton.title = String.AppSettingsDone
-            if #available(iOS 26.0, *) {
-                topRightButton.tintColor = currentTheme().colors.textPrimary
-            }
             navigationItem.rightBarButtonItem = topRightButton
             navigationItem.rightBarButtonItem?.isEnabled = true
         }
+        applyThemeToButtons()
     }
 
     // MARK: - Toolbar Button Actions

--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -425,8 +425,22 @@ class LibraryViewController: UIViewController, Themeable {
         segmentControlToolbar.isTranslucent = false
 
         setNeedsStatusBarAppearanceUpdate()
-        setupButtons()
         setupToolBarAppearance()
+        applyThemeToButtons()
+    }
+
+    private func applyThemeToButtons() {
+        guard #available(iOS 26.0, *) else { return }
+
+        let panelState = getCurrentPanelState()
+        switch panelState {
+        case .bookmarks(state: .itemEditMode):
+            topRightButton.tintColor = currentTheme().colors.textAccent
+        case .bookmarks(state: .itemEditModeInvalidField):
+            topRightButton.tintColor = currentTheme().colors.textAccent
+        default:
+            topRightButton.tintColor = currentTheme().colors.textPrimary
+        }
     }
 
     func setNavigationBarHidden(_ value: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15755) & [Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15756)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33690) & [Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33691
)

## :bulb: Description
Fixes two bugs related to buttons in the libary panel that disappeared in <iOS 26.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

