### PR TITLE
Add FXIOS-15758 [Translations] Centralize feature-flag gating into TranslationFeatureGate

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1417,6 +1417,8 @@
 		A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */; };
 		A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */; };
 		AA02D5EB2EB3D83200814F4C /* TranslationsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA02D5EA2EB3D82F00814F4C /* TranslationsAction.swift */; };
+		D4AFE9E1E5BD48AA832CDA68 /* TranslationFeatureGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82326CE4C7004543BDB5FE91 /* TranslationFeatureGate.swift */; };
+		A6389BA289C84E0B88817899 /* TranslationFeatureGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0954151A3822424D9DFCE8ED /* TranslationFeatureGateTests.swift */; };
 		AA24AD302E7C37C6008659A3 /* TrendingSearchClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD2F2E7C37BF008659A3 /* TrendingSearchClient.swift */; };
 		AA24AD322E7C3A8F008659A3 /* TrendingSearchClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD312E7C3A85008659A3 /* TrendingSearchClientTests.swift */; };
 		AA24AD342E7C3AD2008659A3 /* MockTrendingSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD332E7C3ACC008659A3 /* MockTrendingSearchEngine.swift */; };
@@ -10055,6 +10057,8 @@
 		A99A45579536045560D367CE /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/Storage.strings; sourceTree = "<group>"; };
 		A9B04AA7B21B939545F42DDF /* hi-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hi-IN"; path = "hi-IN.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		AA02D5EA2EB3D82F00814F4C /* TranslationsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsAction.swift; sourceTree = "<group>"; };
+		82326CE4C7004543BDB5FE91 /* TranslationFeatureGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationFeatureGate.swift; sourceTree = "<group>"; };
+		0954151A3822424D9DFCE8ED /* TranslationFeatureGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationFeatureGateTests.swift; sourceTree = "<group>"; };
 		AA0B46CCA57F0E0997CC0AEA /* ia */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ia; path = ia.lproj/Intro.strings; sourceTree = "<group>"; };
 		AA0B47C6B76C81D58AD910F1 /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		AA244A28A4D501F91E5C0FF2 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
@@ -14770,6 +14774,7 @@
 				AA02D5EA2EB3D82F00814F4C /* TranslationsAction.swift */,
 				AA5E81462EB12BD800919E60 /* TranslationsMiddleware.swift */,
 				AA5E81492EF5000000000001 /* PreferredTranslationLanguagesManager.swift */,
+				82326CE4C7004543BDB5FE91 /* TranslationFeatureGate.swift */,
 			);
 			path = Translations;
 			sourceTree = "<group>";
@@ -14816,6 +14821,7 @@
 				AAD9D64A2EB25B3200BFECAF /* TranslationsMiddlewareTests.swift */,
 				8C50DD742F56E1D00020E5C4 /* PreferredTranslationLanguagesManagerTests.swift */,
 				8C196D502F7D2B74006EB316 /* AutoTranslatePromptStateTests.swift */,
+				0954151A3822424D9DFCE8ED /* TranslationFeatureGateTests.swift */,
 			);
 			path = TranslationsTests;
 			sourceTree = "<group>";
@@ -19075,6 +19081,7 @@
 				C80E1A102A0943640025B9E1 /* UIFont+Extension.swift in Sources */,
 				C8680C5728BFDF7F00BC902A /* WallpaperThumbnailUtility.swift in Sources */,
 				AA5E81472EB12BDC00919E60 /* TranslationsMiddleware.swift in Sources */,
+				D4AFE9E1E5BD48AA832CDA68 /* TranslationFeatureGate.swift in Sources */,
 				AA5E81482EF5000000000001 /* PreferredTranslationLanguagesManager.swift in Sources */,
 				C23889DF2A4EFCE500429673 /* ShareSheetCoordinator.swift in Sources */,
 				E153FBAA2DD47C9B0040CE37 /* SearchBarLocationSaver.swift in Sources */,
@@ -20270,6 +20277,7 @@
 				399BA8002F901D9200CCC502 /* UserFeaturePreferenceManagerTests.swift in Sources */,
 				5A475E9129DB8AA7009C13FD /* MockDiskImageStore.swift in Sources */,
 				AAD9D64B2EB25B3500BFECAF /* TranslationsMiddlewareTests.swift in Sources */,
+				A6389BA289C84E0B88817899 /* TranslationFeatureGateTests.swift in Sources */,
 				C2506C952A6A8D2600F2B76E /* HistoryCoordinatorTests.swift in Sources */,
 				0B7B05432D64C08F007FD7AC /* MockURLProtocol.swift in Sources */,
 				8C61A2812F3371330021C88D /* BrowserViewControllerKVOTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -485,7 +485,7 @@ final class SettingsCoordinator: BaseCoordinator,
     }
 
     private func translationSettingsViewController() -> UIViewController {
-        if translationFeatureGate.shouldUsePickerUI {
+        if translationFeatureGate.isLanguagePickerEnabled {
             let viewController = TranslationPickerSettingsViewController(windowUUID: windowUUID)
             viewController.coordinator = self
             return viewController

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -485,7 +485,7 @@ final class SettingsCoordinator: BaseCoordinator,
     }
 
     private func translationSettingsViewController() -> UIViewController {
-        if featureFlagsProvider.isEnabled(.translationLanguagePicker) {
+        if translationFeatureGate.shouldUsePickerUI {
             let viewController = TranslationPickerSettingsViewController(windowUUID: windowUUID)
             viewController.coordinator = self
             return viewController

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -944,7 +944,7 @@ class BrowserViewController: UIViewController,
         executeNavigationAndDisplayActions()
 
         handleMicrosurvey(state: state)
-        if featureFlagsProvider.isEnabled(.translationLanguagePicker) {
+        if translationFeatureGate.isMultiLanguageFlowEnabled {
             handleAutoTranslatePrompt(state: state)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -944,7 +944,7 @@ class BrowserViewController: UIViewController,
         executeNavigationAndDisplayActions()
 
         handleMicrosurvey(state: state)
-        if translationFeatureGate.isMultiLanguageFlowEnabled {
+        if translationFeatureGate.isLanguagePickerEnabled {
             handleAutoTranslatePrompt(state: state)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -412,7 +412,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         tabInfo: MainMenuTabInfo,
         localeProvider: LocaleProvider
     ) -> MenuElement? {
-        guard featureFlagsProvider.isEnabled(.translationLanguagePicker),
+        guard translationFeatureGate.shouldUsePickerUI,
               let translationConfig = tabInfo.translationConfiguration,
               translationConfig.isTranslationFeatureEnabled,
               translationConfig.state != nil

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -412,7 +412,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         tabInfo: MainMenuTabInfo,
         localeProvider: LocaleProvider
     ) -> MenuElement? {
-        guard translationFeatureGate.shouldUsePickerUI,
+        guard translationFeatureGate.isLanguagePickerEnabled,
               let translationConfig = tabInfo.translationConfiguration,
               translationConfig.isTranslationFeatureEnabled,
               translationConfig.state != nil

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
@@ -69,7 +69,7 @@ struct TranslationConfiguration: Equatable, FeatureFlaggable {
     }
 
     var isMultiLanguageFlow: Bool {
-        guard translationFeatureGate.isMultiLanguageFlowEnabled else { return false }
+        guard translationFeatureGate.isLanguagePickerEnabled else { return false }
         guard let stored = prefs.stringForKey(PrefsKeys.Settings.translationPreferredLanguages),
               !stored.isEmpty else { return false }
         return stored.components(separatedBy: ",").count != 1

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
@@ -69,7 +69,7 @@ struct TranslationConfiguration: Equatable, FeatureFlaggable {
     }
 
     var isMultiLanguageFlow: Bool {
-        guard featureFlagsProvider.isEnabled(.translationLanguagePicker) else { return false }
+        guard translationFeatureGate.isMultiLanguageFlowEnabled else { return false }
         guard let stored = prefs.stringForKey(PrefsKeys.Settings.translationPreferredLanguages),
               !stored.isEmpty else { return false }
         return stored.components(separatedBy: ",").count != 1

--- a/firefox-ios/Client/Frontend/Translations/TranslationFeatureGate.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationFeatureGate.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/// Maps raw Nimbus flags to product-level capability decisions for the Translations feature.
+/// All `translationLanguagePicker` flag reads go through this gate, so that adding a
+/// Phase 3 path requires editing only this type, not individual call sites.
+struct TranslationFeatureGate {
+    private let featureFlagsProvider: FeatureFlagProviding
+
+    init(featureFlagsProvider: FeatureFlagProviding) {
+        self.featureFlagsProvider = featureFlagsProvider
+    }
+
+    /// Whether the multi-language translation flow is available (eligibility checks, auto-translate).
+    var isMultiLanguageFlowEnabled: Bool {
+        featureFlagsProvider.isEnabled(.translationLanguagePicker)
+    }
+
+    /// Whether the language-picker UI should be presented to the user.
+    var shouldUsePickerUI: Bool {
+        featureFlagsProvider.isEnabled(.translationLanguagePicker)
+    }
+}
+
+extension FeatureFlaggable {
+    var translationFeatureGate: TranslationFeatureGate {
+        TranslationFeatureGate(featureFlagsProvider: featureFlagsProvider)
+    }
+}

--- a/firefox-ios/Client/Frontend/Translations/TranslationFeatureGate.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationFeatureGate.swift
@@ -2,9 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// Maps raw Nimbus flags to product-level capability decisions for the Translations feature.
-/// All `translationLanguagePicker` flag reads go through this gate, so that adding a
-/// Phase 3 path requires editing only this type, not individual call sites.
+/// Single place that maps raw Nimbus flags to Translations capability decisions.
+/// Adding a Phase 3 flag requires editing only this type.
 struct TranslationFeatureGate {
     private let featureFlagsProvider: FeatureFlagProviding
 
@@ -12,13 +11,7 @@ struct TranslationFeatureGate {
         self.featureFlagsProvider = featureFlagsProvider
     }
 
-    /// Whether the multi-language translation flow is available (eligibility checks, auto-translate).
-    var isMultiLanguageFlowEnabled: Bool {
-        featureFlagsProvider.isEnabled(.translationLanguagePicker)
-    }
-
-    /// Whether the language-picker UI should be presented to the user.
-    var shouldUsePickerUI: Bool {
+    var isLanguagePickerEnabled: Bool {
         featureFlagsProvider.isEnabled(.translationLanguagePicker)
     }
 }

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -131,7 +131,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
         guard gestureType == .tap else { return }
 
         if translationConfiguration.state == .inactive,
-           featureFlagsProvider.isEnabled(.translationLanguagePicker) {
+           translationFeatureGate.shouldUsePickerUI {
             let capturedButton = action.buttonTapped
             Task {
                 let manager = PreferredTranslationLanguagesManager(prefs: profile.prefs)
@@ -219,7 +219,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
         for action: ToolbarMiddlewareAction,
         translationConfiguration: TranslationConfiguration
     ) {
-        guard featureFlagsProvider.isEnabled(.translationLanguagePicker) else { return }
+        guard translationFeatureGate.shouldUsePickerUI else { return }
 
         if translationConfiguration.state == .inactive {
             let capturedButton = action.buttonTapped
@@ -369,7 +369,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
     /// When the language picker flag is ON, returns the user's full preferred list.
     /// When OFF, returns only the primary device language (preserving legacy behavior).
     private func targetLanguagesForEligibilityCheck() async -> [String] {
-        if featureFlagsProvider.isEnabled(.translationLanguagePicker) {
+        if translationFeatureGate.isMultiLanguageFlowEnabled {
             let supported = await translationsService.fetchSupportedTargetLanguages()
             return manager.preferredLanguages(supportedTargetLanguages: supported)
         }

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -365,6 +365,9 @@ final class TranslationsMiddleware: FeatureFlaggable {
         return true
     }
 
+    /// Returns the list of target languages to check for translation eligibility.
+    /// When the language picker flag is ON, returns the user's full preferred list.
+    /// When OFF, returns only the primary device language (preserving legacy behavior).
     private func targetLanguagesForEligibilityCheck() async -> [String] {
         if translationFeatureGate.isLanguagePickerEnabled {
             let supported = await translationsService.fetchSupportedTargetLanguages()

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -131,7 +131,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
         guard gestureType == .tap else { return }
 
         if translationConfiguration.state == .inactive,
-           translationFeatureGate.shouldUsePickerUI {
+           translationFeatureGate.isLanguagePickerEnabled {
             let capturedButton = action.buttonTapped
             Task {
                 let manager = PreferredTranslationLanguagesManager(prefs: profile.prefs)
@@ -219,7 +219,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
         for action: ToolbarMiddlewareAction,
         translationConfiguration: TranslationConfiguration
     ) {
-        guard translationFeatureGate.shouldUsePickerUI else { return }
+        guard translationFeatureGate.isLanguagePickerEnabled else { return }
 
         if translationConfiguration.state == .inactive {
             let capturedButton = action.buttonTapped
@@ -365,11 +365,8 @@ final class TranslationsMiddleware: FeatureFlaggable {
         return true
     }
 
-    /// Returns the list of target languages to check for translation eligibility.
-    /// When the language picker flag is ON, returns the user's full preferred list.
-    /// When OFF, returns only the primary device language (preserving legacy behavior).
     private func targetLanguagesForEligibilityCheck() async -> [String] {
-        if translationFeatureGate.isMultiLanguageFlowEnabled {
+        if translationFeatureGate.isLanguagePickerEnabled {
             let supported = await translationsService.fetchSupportedTargetLanguages()
             return manager.preferredLanguages(supportedTargetLanguages: supported)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationFeatureGateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationFeatureGateTests.swift
@@ -6,47 +6,20 @@ import XCTest
 @testable import Client
 
 final class TranslationFeatureGateTests: XCTestCase {
-    // MARK: - isMultiLanguageFlowEnabled
-
-    func test_isMultiLanguageFlowEnabled_whenFlagOff_returnsFalse() {
+    func test_isLanguagePickerEnabled_whenFlagOff_returnsFalse() {
         let provider = MockNimbusFeatureFlags()
-        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
-        XCTAssertFalse(gate.isMultiLanguageFlowEnabled)
+        XCTAssertFalse(TranslationFeatureGate(featureFlagsProvider: provider).isLanguagePickerEnabled)
     }
 
-    func test_isMultiLanguageFlowEnabled_whenFlagOn_returnsTrue() {
+    func test_isLanguagePickerEnabled_whenFlagOn_returnsTrue() {
         let provider = MockNimbusFeatureFlags()
         provider.enabledFlags = [.translationLanguagePicker]
-        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
-        XCTAssertTrue(gate.isMultiLanguageFlowEnabled)
+        XCTAssertTrue(TranslationFeatureGate(featureFlagsProvider: provider).isLanguagePickerEnabled)
     }
 
-    func test_isMultiLanguageFlowEnabled_whenUnrelatedFlagOn_returnsFalse() {
+    func test_isLanguagePickerEnabled_whenUnrelatedFlagOn_returnsFalse() {
         let provider = MockNimbusFeatureFlags()
         provider.enabledFlags = [.translation]
-        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
-        XCTAssertFalse(gate.isMultiLanguageFlowEnabled)
-    }
-
-    // MARK: - shouldUsePickerUI
-
-    func test_shouldUsePickerUI_whenFlagOff_returnsFalse() {
-        let provider = MockNimbusFeatureFlags()
-        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
-        XCTAssertFalse(gate.shouldUsePickerUI)
-    }
-
-    func test_shouldUsePickerUI_whenFlagOn_returnsTrue() {
-        let provider = MockNimbusFeatureFlags()
-        provider.enabledFlags = [.translationLanguagePicker]
-        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
-        XCTAssertTrue(gate.shouldUsePickerUI)
-    }
-
-    func test_shouldUsePickerUI_whenUnrelatedFlagOn_returnsFalse() {
-        let provider = MockNimbusFeatureFlags()
-        provider.enabledFlags = [.translation]
-        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
-        XCTAssertFalse(gate.shouldUsePickerUI)
+        XCTAssertFalse(TranslationFeatureGate(featureFlagsProvider: provider).isLanguagePickerEnabled)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationFeatureGateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationFeatureGateTests.swift
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class TranslationFeatureGateTests: XCTestCase {
+    // MARK: - isMultiLanguageFlowEnabled
+
+    func test_isMultiLanguageFlowEnabled_whenFlagOff_returnsFalse() {
+        let provider = MockNimbusFeatureFlags()
+        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
+        XCTAssertFalse(gate.isMultiLanguageFlowEnabled)
+    }
+
+    func test_isMultiLanguageFlowEnabled_whenFlagOn_returnsTrue() {
+        let provider = MockNimbusFeatureFlags()
+        provider.enabledFlags = [.translationLanguagePicker]
+        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
+        XCTAssertTrue(gate.isMultiLanguageFlowEnabled)
+    }
+
+    func test_isMultiLanguageFlowEnabled_whenUnrelatedFlagOn_returnsFalse() {
+        let provider = MockNimbusFeatureFlags()
+        provider.enabledFlags = [.translation]
+        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
+        XCTAssertFalse(gate.isMultiLanguageFlowEnabled)
+    }
+
+    // MARK: - shouldUsePickerUI
+
+    func test_shouldUsePickerUI_whenFlagOff_returnsFalse() {
+        let provider = MockNimbusFeatureFlags()
+        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
+        XCTAssertFalse(gate.shouldUsePickerUI)
+    }
+
+    func test_shouldUsePickerUI_whenFlagOn_returnsTrue() {
+        let provider = MockNimbusFeatureFlags()
+        provider.enabledFlags = [.translationLanguagePicker]
+        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
+        XCTAssertTrue(gate.shouldUsePickerUI)
+    }
+
+    func test_shouldUsePickerUI_whenUnrelatedFlagOn_returnsFalse() {
+        let provider = MockNimbusFeatureFlags()
+        provider.enabledFlags = [.translation]
+        let gate = TranslationFeatureGate(featureFlagsProvider: provider)
+        XCTAssertFalse(gate.shouldUsePickerUI)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15758)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Introduces TranslationFeatureGate to replace all five direct isEnabled(.translationLanguagePicker) call sites with named capability methods (isMultiLanguageFlowEnabled, shouldUsePickerUI).

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

