### PR TITLE
Add FXIOS-15757 [Translations] Derive toolbar enabled state from Redux instead of prefs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2658,7 +2658,14 @@ class BrowserViewController: UIViewController,
             lockIconImageName: lockIconImageName,
             lockIconNeedsTheming: lockIconNeedsTheming,
             safeListedURLImageName: safeListedURLImageName,
-            translationConfiguration: tab.translationConfiguration ?? TranslationConfiguration(prefs: profile.prefs),
+            translationConfiguration: tab.translationConfiguration ?? TranslationConfiguration(
+                prefs: profile.prefs,
+                isUserSettingEnabled: store.state.componentState(
+                    ToolbarState.self,
+                    for: .toolbar,
+                    window: windowUUID
+                )?.isTranslationsEnabled ?? true
+            ),
             windowUUID: windowUUID,
             actionType: ToolbarActionType.urlDidChange)
         store.dispatch(action)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -1164,9 +1164,14 @@ struct AddressBarState: StateType, Sendable, Equatable {
         // We need to do this check because of existing architecture
         // in which the state is updated after
         // we configure the button, so we need to check action too.
-        let isFeatureEnabledFromAction = action.translationConfiguration?.isTranslationFeatureEnabled ?? false
-        let isFeatureEnabledFromState = addressBarState.translationConfiguration?.isTranslationFeatureEnabled ?? false
-        let shouldShowTranslationIcon = isFeatureEnabledFromAction || isFeatureEnabledFromState
+        // When the action explicitly provides a config, use it as the authority (e.g. settings toggle).
+        // Only fall back to state when the action carries no config.
+        let shouldShowTranslationIcon: Bool
+        if let actionConfig = action.translationConfiguration {
+            shouldShowTranslationIcon = actionConfig.isTranslationFeatureEnabled
+        } else {
+            shouldShowTranslationIcon = addressBarState.translationConfiguration?.isTranslationFeatureEnabled ?? false
+        }
         guard shouldShowTranslationIcon else { return nil }
         let iconState = action.translationConfiguration?.state ?? addressBarState.translationConfiguration?.state
         guard let iconState else { return nil }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -35,6 +35,7 @@ struct ToolbarAction: Action {
     let shouldShowKeyboard: Bool?
     let shouldAnimate: Bool?
     let middleButton: NavigationBarMiddleButtonType?
+    let isTranslationsEnabled: Bool?
     let translationConfiguration: TranslationConfiguration?
     let previousTabScreenshot: UIImage?
     let nextTabScreenshot: UIImage?
@@ -65,6 +66,7 @@ struct ToolbarAction: Action {
          shouldShowKeyboard: Bool? = nil,
          shouldAnimate: Bool? = nil,
          middleButton: NavigationBarMiddleButtonType? = nil,
+         isTranslationsEnabled: Bool? = nil,
          translationConfiguration: TranslationConfiguration? = nil,
          previousTabScreenshot: UIImage? = nil,
          nextTabScreenshot: UIImage? = nil,
@@ -98,6 +100,7 @@ struct ToolbarAction: Action {
         self.shouldAnimate = shouldAnimate
         self.canSummarize = canSummarize
         self.middleButton = middleButton
+        self.isTranslationsEnabled = isTranslationsEnabled
         self.translationConfiguration = translationConfiguration
         self.previousTabScreenshot = previousTabScreenshot
         self.nextTabScreenshot = nextTabScreenshot

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -96,6 +96,7 @@ final class ToolbarMiddleware {
                 addressBorderPosition: borderPosition,
                 displayNavBorder: displayBorder,
                 middleButton: middleButton,
+                isTranslationsEnabled: prefs.boolForKey(PrefsKeys.Settings.translationsFeature) ?? true,
                 windowUUID: uuid,
                 actionType: ToolbarActionType.didLoadToolbars)
             store.dispatch(action)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -24,6 +24,7 @@ struct ToolbarState: ScreenState, Sendable {
     var canShowNavigationHint: Bool
     var shouldAnimate: Bool
     var isTranslucent: Bool
+    var isTranslationsEnabled: Bool
     var previousTabScreenshot: UIImage?
     var nextTabScreenshot: UIImage?
 
@@ -54,6 +55,7 @@ struct ToolbarState: ScreenState, Sendable {
                   canShowNavigationHint: toolbarState.canShowNavigationHint,
                   shouldAnimate: toolbarState.shouldAnimate,
                   isTranslucent: toolbarState.isTranslucent,
+                  isTranslationsEnabled: toolbarState.isTranslationsEnabled,
                   previousTabScreenshot: toolbarState.previousTabScreenshot,
                   nextTabScreenshot: toolbarState.nextTabScreenshot
         )
@@ -78,6 +80,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: false,
             shouldAnimate: true,
             isTranslucent: false,
+            isTranslationsEnabled: true,
             previousTabScreenshot: nil,
             nextTabScreenshot: nil
         )
@@ -101,6 +104,7 @@ struct ToolbarState: ScreenState, Sendable {
         canShowNavigationHint: Bool,
         shouldAnimate: Bool,
         isTranslucent: Bool,
+        isTranslationsEnabled: Bool = true,
         previousTabScreenshot: UIImage?,
         nextTabScreenshot: UIImage?
     ) {
@@ -121,6 +125,7 @@ struct ToolbarState: ScreenState, Sendable {
         self.canShowNavigationHint = canShowNavigationHint
         self.shouldAnimate = shouldAnimate
         self.isTranslucent = isTranslucent
+        self.isTranslationsEnabled = isTranslationsEnabled
         self.previousTabScreenshot = previousTabScreenshot
         self.nextTabScreenshot = nextTabScreenshot
     }
@@ -221,6 +226,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: state.canShowNavigationHint,
             shouldAnimate: state.shouldAnimate,
             isTranslucent: isTranslucent,
+            isTranslationsEnabled: toolbarAction.isTranslationsEnabled ?? state.isTranslationsEnabled,
             previousTabScreenshot: state.previousTabScreenshot,
             nextTabScreenshot: state.nextTabScreenshot
         )
@@ -248,6 +254,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: state.canShowNavigationHint,
             shouldAnimate: toolbarAction.shouldAnimate ?? state.shouldAnimate,
             isTranslucent: toolbarAction.isTranslucent ?? state.isTranslucent,
+            isTranslationsEnabled: toolbarAction.isTranslationsEnabled ?? state.isTranslationsEnabled,
             previousTabScreenshot: state.previousTabScreenshot,
             nextTabScreenshot: state.nextTabScreenshot
         )
@@ -274,6 +281,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: state.canShowNavigationHint,
             shouldAnimate: state.shouldAnimate,
             isTranslucent: state.isTranslucent,
+            isTranslationsEnabled: state.isTranslationsEnabled,
             previousTabScreenshot: state.previousTabScreenshot,
             nextTabScreenshot: state.nextTabScreenshot
         )
@@ -300,6 +308,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: state.canShowNavigationHint,
             shouldAnimate: state.shouldAnimate,
             isTranslucent: state.isTranslucent,
+            isTranslationsEnabled: state.isTranslationsEnabled,
             previousTabScreenshot: state.previousTabScreenshot,
             nextTabScreenshot: state.nextTabScreenshot
         )
@@ -326,6 +335,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: state.canShowNavigationHint,
             shouldAnimate: state.shouldAnimate,
             isTranslucent: state.isTranslucent,
+            isTranslationsEnabled: state.isTranslationsEnabled,
             previousTabScreenshot: toolbarAction.previousTabScreenshot,
             nextTabScreenshot: toolbarAction.nextTabScreenshot
         )
@@ -357,6 +367,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: state.canShowNavigationHint,
             shouldAnimate: state.shouldAnimate,
             isTranslucent: state.isTranslucent,
+            isTranslationsEnabled: state.isTranslationsEnabled,
             previousTabScreenshot: state.previousTabScreenshot,
             nextTabScreenshot: state.nextTabScreenshot
         )
@@ -383,6 +394,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: state.canShowNavigationHint,
             shouldAnimate: state.shouldAnimate,
             isTranslucent: state.isTranslucent,
+            isTranslationsEnabled: state.isTranslationsEnabled,
             previousTabScreenshot: state.previousTabScreenshot,
             nextTabScreenshot: state.nextTabScreenshot
         )
@@ -409,6 +421,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: state.canShowNavigationHint,
             shouldAnimate: state.shouldAnimate,
             isTranslucent: state.isTranslucent,
+            isTranslationsEnabled: state.isTranslationsEnabled,
             previousTabScreenshot: state.previousTabScreenshot,
             nextTabScreenshot: state.nextTabScreenshot
         )
@@ -435,6 +448,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: true,
             shouldAnimate: state.shouldAnimate,
             isTranslucent: state.isTranslucent,
+            isTranslationsEnabled: state.isTranslationsEnabled,
             previousTabScreenshot: state.previousTabScreenshot,
             nextTabScreenshot: state.nextTabScreenshot
         )
@@ -461,6 +475,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: false,
             shouldAnimate: state.shouldAnimate,
             isTranslucent: state.isTranslucent,
+            isTranslationsEnabled: state.isTranslationsEnabled,
             previousTabScreenshot: state.previousTabScreenshot,
             nextTabScreenshot: state.nextTabScreenshot
         )
@@ -490,6 +505,7 @@ struct ToolbarState: ScreenState, Sendable {
             canShowNavigationHint: state.canShowNavigationHint,
             shouldAnimate: state.shouldAnimate,
             isTranslucent: state.isTranslucent,
+            isTranslationsEnabled: state.isTranslationsEnabled,
             previousTabScreenshot: state.previousTabScreenshot,
             nextTabScreenshot: state.nextTabScreenshot
         )
@@ -521,6 +537,7 @@ struct ToolbarState: ScreenState, Sendable {
                             canShowNavigationHint: state.canShowNavigationHint,
                             shouldAnimate: state.shouldAnimate,
                             isTranslucent: state.isTranslucent,
+                            isTranslationsEnabled: state.isTranslationsEnabled,
                             previousTabScreenshot: state.previousTabScreenshot,
                             nextTabScreenshot: state.nextTabScreenshot)
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/TranslationsConfiguration.swift
@@ -52,6 +52,7 @@ struct TranslationConfiguration: Equatable, FeatureFlaggable {
     }
 
     let prefs: Prefs
+    let isUserSettingEnabled: Bool
     let state: IconState?
     /// The language code the page was translated to, if in the active state (e.g. "en", "fr").
     let translatedToLanguage: String?
@@ -61,8 +62,15 @@ struct TranslationConfiguration: Equatable, FeatureFlaggable {
     // We initially set icon state as nil until we can detect the
     // web page and determine if we should show the translation icon
     // and set the icon to .inactive state.
-    init(prefs: Prefs, state: IconState? = nil, translatedToLanguage: String? = nil, sourceLanguage: String? = nil) {
+    init(
+        prefs: Prefs,
+        isUserSettingEnabled: Bool = true,
+        state: IconState? = nil,
+        translatedToLanguage: String? = nil,
+        sourceLanguage: String? = nil
+    ) {
         self.prefs = prefs
+        self.isUserSettingEnabled = isUserSettingEnabled
         self.state = state
         self.translatedToLanguage = translatedToLanguage
         self.sourceLanguage = sourceLanguage
@@ -75,17 +83,14 @@ struct TranslationConfiguration: Equatable, FeatureFlaggable {
         return stored.components(separatedBy: ",").count != 1
     }
 
-    /// Determines whether to show the translate icon on the toolbar
-    /// The experiment needs to be turned on and the user settings needs to be enabled
-    /// If user has not toggled the settings, then we enable the feature by default
+    /// Determines whether to show the translate icon on the toolbar.
+    /// The experiment needs to be turned on and the user setting needs to be enabled.
     var isTranslationFeatureEnabled: Bool {
-        let isExperimentOn = featureFlagsProvider.isEnabled(.translation)
-        let isSettingsEnabled = prefs.boolForKey(PrefsKeys.Settings.translationsFeature) ?? true
-        return isExperimentOn && isSettingsEnabled
+        return featureFlagsProvider.isEnabled(.translation) && isUserSettingEnabled
     }
 
     static func == (lhs: TranslationConfiguration, rhs: TranslationConfiguration) -> Bool {
-        return lhs.isTranslationFeatureEnabled == rhs.isTranslationFeatureEnabled
+        return lhs.isUserSettingEnabled == rhs.isUserSettingEnabled
             && lhs.state == rhs.state
             && lhs.translatedToLanguage == rhs.translatedToLanguage
             && lhs.sourceLanguage == rhs.sourceLanguage

--- a/firefox-ios/Client/Frontend/Settings/AIControls/AIControlsModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/AIControls/AIControlsModel.swift
@@ -77,7 +77,10 @@ class AIControlsModel: ObservableObject,
     ) {
         self.prefs = prefs
         self.windowUUID = windowUUID
-        self.translationConfiguration = translationConfiguration ?? TranslationConfiguration(prefs: prefs)
+        self.translationConfiguration = translationConfiguration ?? TranslationConfiguration(
+            prefs: prefs,
+            isUserSettingEnabled: prefs.boolForKey(PrefsKeys.Settings.translationsFeature) ?? true
+        )
         self.summarizerConfiguration = summarizerConfiguration
         self.settingsTelemetry = settingsTelemetry
         self.logger = logger

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
@@ -75,7 +75,8 @@ final class TranslationSettingsMiddleware {
                 )
             }
             store.dispatch(ToolbarAction(
-                translationConfiguration: TranslationConfiguration(prefs: prefs),
+                isTranslationsEnabled: newValue,
+                translationConfiguration: TranslationConfiguration(prefs: prefs, isUserSettingEnabled: newValue),
                 windowUUID: action.windowUUID,
                 actionType: ToolbarActionType.didTranslationSettingsChange
             ))

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsViewController.swift
@@ -36,9 +36,15 @@ final class TranslationSettingsViewController: SettingsTableViewController {
             titleText: .Settings.Translation.ToggleTitle
         ) { [weak self] _ in
             guard let self else { return }
+            let isEnabled = self.prefs.boolForKey(PrefsKeys.Settings.translationsFeature) ?? true
             store.dispatch(
                 ToolbarAction(
-                    translationConfiguration: TranslationConfiguration(prefs: self.prefs, state: .inactive),
+                    isTranslationsEnabled: isEnabled,
+                    translationConfiguration: TranslationConfiguration(
+                        prefs: self.prefs,
+                        isUserSettingEnabled: isEnabled,
+                        state: .inactive
+                    ),
                     windowUUID: self.windowUUID,
                     actionType: ToolbarActionType.didTranslationSettingsChange
                 )

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -95,7 +95,7 @@ final class TranslationsMiddleware: FeatureFlaggable {
     }
 
     private func handleTranslationSettingsChange(action: ToolbarAction, windowUUID: WindowUUID) {
-        if action.translationConfiguration?.isTranslationFeatureEnabled == false {
+        if action.isTranslationsEnabled == false {
             for uuid in translationFlowIds.keys {
                 let translationState = store.state.componentState(
                     ToolbarState.self,
@@ -114,7 +114,8 @@ final class TranslationsMiddleware: FeatureFlaggable {
         selectedTargetLanguages[windowUUID] = nil
         translationFlowIds[windowUUID] = nil
         restoringWindows.remove(windowUUID)
-        guard action.translationConfiguration?.isTranslationFeatureEnabled == true else { return }
+        guard featureFlagsProvider.isEnabled(.translation),
+              action.isTranslationsEnabled ?? true else { return }
         checkTranslationsAreEligible(for: action)
     }
 
@@ -399,7 +400,19 @@ final class TranslationsMiddleware: FeatureFlaggable {
     private func checkTranslationsAreEligible(for action: ToolbarAction) {
         // Pre-capture the tab so a tab switch mid-flight doesn't stomp the new active tab's state.
         let originatingTab = selectedTab(for: action.windowUUID)
-        guard action.translationConfiguration?.isTranslationFeatureEnabled == true else { return }
+        // action.isTranslationsEnabled carries the explicit new value for settings-change actions
+        // (where store.state hasn't been updated yet). For urlDidChange it is nil, so we fall back
+        // to ToolbarState which is always up-to-date by the time urlDidChange fires.
+        let translationsEnabled = action.isTranslationsEnabled ?? (store.state.componentState(
+            ToolbarState.self,
+            for: .toolbar,
+            window: action.windowUUID
+        )?.isTranslationsEnabled ?? true)
+
+        guard featureFlagsProvider.isEnabled(.translation), translationsEnabled else {
+            dispatchClearTranslationIcon(windowUUID: action.windowUUID, on: originatingTab)
+            return
+        }
 
         // Translation requires a live HTML DOM. PDFs and images have no translatable
         // text structure, so suppress the icon without running language detection.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -522,7 +522,6 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
 
     func test_urlDidChangeAction_withTranslationConfiguration_andTranslationsSettingsEnabled_showsNoTranslateButton() {
         setTranslationsFeatureEnabled(enabled: true)
-        mockProfile.prefs.setBool(false, forKey: PrefsKeys.Settings.translationsFeature)
         setupStore()
         let initialState = createSubject()
         let reducer = addressBarReducer()
@@ -531,7 +530,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
             initialState,
             ToolbarAction(
                 url: URL(string: "http://mozilla.com"),
-                translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+                translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs, isUserSettingEnabled: false),
                 windowUUID: windowUUID,
                 actionType: ToolbarActionType.urlDidChange
             )
@@ -540,6 +539,31 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.windowUUID, windowUUID)
         XCTAssertEqual(newState.leadingPageActions.count, 1)
         XCTAssertEqual(newState.leadingPageActions[0].actionType, .share)
+    }
+
+    func test_urlDidChangeAction_withTranslationConfiguration_reduxSettingsEnabled_showsTranslateButton() {
+        setTranslationsFeatureEnabled(enabled: true)
+        setupStore()
+        let initialState = createSubject()
+        let reducer = addressBarReducer()
+
+        let newState = reducer(
+            initialState,
+            ToolbarAction(
+                url: URL(string: "http://mozilla.com"),
+                translationConfiguration: TranslationConfiguration(
+                    prefs: mockProfile.prefs,
+                    isUserSettingEnabled: true,
+                    state: .inactive
+                ),
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.urlDidChange
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, windowUUID)
+        XCTAssertEqual(newState.leadingPageActions.count, 2)
+        XCTAssertEqual(newState.leadingPageActions[1].actionType, .translate)
     }
 
     func test_urlDidChangeAction_withTranslationConfiguration_andFFDisabled_doesNotIncludeTranslateButton() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -875,11 +875,11 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
 
     func test_didTranslationSettingsChange_withFeatureDisabled_doesNotDispatchAction() throws {
         setTranslationsFeatureEnabled(enabled: true)
-        mockProfile.prefs.setBool(false, forKey: PrefsKeys.Settings.translationsFeature)
         let mockTranslationService = MockTranslationsService(shouldOfferTranslationResult: .success(true))
         let subject = createSubject(translationsService: mockTranslationService)
         let action = ToolbarAction(
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            isTranslationsEnabled: false,
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs, isUserSettingEnabled: false),
             windowUUID: .XCTestDefaultUUID,
             actionType: ToolbarActionType.didTranslationSettingsChange
         )
@@ -949,13 +949,13 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
 
     func test_didTranslationSettingsChange_clearsStoredTargetLanguageForRetry() throws {
         setTranslationsFeatureEnabled(enabled: true)
-        mockProfile.prefs.setBool(false, forKey: PrefsKeys.Settings.translationsFeature)
         let subject = createSubject()
 
         seedTargetLanguage(in: subject, successDispatchCount: 2)
 
         let toggleAction = ToolbarAction(
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            isTranslationsEnabled: false,
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs, isUserSettingEnabled: false),
             windowUUID: .XCTestDefaultUUID,
             actionType: ToolbarActionType.didTranslationSettingsChange
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -904,7 +904,8 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         mockStore.state = setupAppState(translationState: .active)
 
         let action = ToolbarAction(
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            isTranslationsEnabled: false,
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs, isUserSettingEnabled: false),
             windowUUID: .XCTestDefaultUUID,
             actionType: ToolbarActionType.didTranslationSettingsChange
         )
@@ -932,7 +933,8 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         mockStore.state = setupAppState(translationState: .inactive)
 
         let action = ToolbarAction(
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            isTranslationsEnabled: false,
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs, isUserSettingEnabled: false),
             windowUUID: .XCTestDefaultUUID,
             actionType: ToolbarActionType.didTranslationSettingsChange
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15757)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Removes the direct prefs read from TranslationConfiguration.isTranslationFeatureEnabled. The enabled state is now sourced from TranslationSettingsState.isTranslationsEnabled in the Redux tree, so toggling translations in Settings immediately reflects in the toolbar without requiring a page reload.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

