### PR TITLE
Refactor FXIOS-15748 [Deeplinks] Update SceneDelegate to handle deeplinks after startup flow

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -969,6 +969,7 @@
 		8A3FD2902FABB9BA001F5DE9 /* TabManagerClearHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FD28D2FABB9BA001F5DE9 /* TabManagerClearHistoryTests.swift */; };
 		8A3FD2912FABB9BA001F5DE9 /* TabManagerGetTabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FD28E2FABB9BA001F5DE9 /* TabManagerGetTabTests.swift */; };
 		8A3FD2922FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FD28F2FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift */; };
+		8A3FDEB82FAE5A4E001F5DE9 /* SceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FDEB72FAE5A4E001F5DE9 /* SceneDelegateTests.swift */; };
 		8A4190D22A6B0848001E8401 /* StatusBarOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4190D02A6B0843001E8401 /* StatusBarOverlayTests.swift */; };
 		8A4490922BF3BC2700E7E682 /* MicrosurveyPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4490912BF3BC2700E7E682 /* MicrosurveyPromptView.swift */; };
 		8A4490952BF3C42B00E7E682 /* MicrosurveyConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4490942BF3C42B00E7E682 /* MicrosurveyConfirmationView.swift */; };
@@ -9372,6 +9373,7 @@
 		8A3FD28D2FABB9BA001F5DE9 /* TabManagerClearHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerClearHistoryTests.swift; sourceTree = "<group>"; };
 		8A3FD28E2FABB9BA001F5DE9 /* TabManagerGetTabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerGetTabTests.swift; sourceTree = "<group>"; };
 		8A3FD28F2FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerReorderTabsTests.swift; sourceTree = "<group>"; };
+		8A3FDEB72FAE5A4E001F5DE9 /* SceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegateTests.swift; sourceTree = "<group>"; };
 		8A4190D02A6B0843001E8401 /* StatusBarOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarOverlayTests.swift; sourceTree = "<group>"; };
 		8A4490912BF3BC2700E7E682 /* MicrosurveyPromptView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicrosurveyPromptView.swift; sourceTree = "<group>"; };
 		8A4490942BF3C42B00E7E682 /* MicrosurveyConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyConfirmationView.swift; sourceTree = "<group>"; };
@@ -13609,6 +13611,7 @@
 				8A13FA882AD82BC8007527AB /* AppSendTabDelegateTests.swift */,
 				5AD3B6772CF650D000AFA1FE /* DefaultBrowserUtilityTests.swift */,
 				5AD3B67F2CF6674B00AFA1FE /* MockUIApplication.swift */,
+				8A3FDEB72FAE5A4E001F5DE9 /* SceneDelegateTests.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -20285,6 +20288,7 @@
 				C838FD612899A9BB0068F60B /* WallpaperURLProviderTests.swift in Sources */,
 				C25017362ECBAD0A0071506F /* MockRemoteSettingsClient.swift in Sources */,
 				8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */,
+				8A3FDEB82FAE5A4E001F5DE9 /* SceneDelegateTests.swift in Sources */,
 				EDD3348E2D109458004516D0 /* ShareTelemetryTests.swift in Sources */,
 				0EC57CE32CA31C5B002E3F04 /* PasswordGeneratorViewControllerTests.swift in Sources */,
 				3943A81D1E9807C700D4F6DC /* FxAPushMessageTest.swift in Sources */,

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -237,7 +237,15 @@ class SceneDelegate: UIResponder,
         sessionManager.launchSessionProvider.openedFromExternalSource = true
 
         if isDeeplinkOptimizationRefactorEnabled {
-            sceneCoordinator.findAndHandle(route: route)
+            AppEventQueue.wait(for: [.startupFlowComplete]) {
+                ensureMainThread { [weak self] in
+                    self?.logger.log("Start up flow done, will handle route",
+                                     level: .info,
+                                     category: .coordinator)
+                    sceneCoordinator.findAndHandle(route: route)
+                    AppEventQueue.signal(event: .recordStartupTimeOpenDeeplinkComplete)
+                }
+            }
         } else {
             AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(sceneCoordinator.windowUUID)]) {
                 ensureMainThread { [weak self] in

--- a/firefox-ios/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -199,6 +199,15 @@ final class EventQueue<QueueEventType: Hashable & Sendable>: @unchecked Sendable
         }
     }
 
+    /// Clears all signalled events and pending actions. Intended for use in tests only
+    /// to reset the global AppEventQueue between test cases.
+    func reset() {
+        mainQueue.ensureMainThread { [weak self] in
+            self?.signalledEvents.removeAll()
+            self?.actions.removeAll()
+        }
+    }
+
     /// Used to cancel an enqueued action using the token that was provided when the action was enqueued.
     /// - Returns: true if the action was canceled.
     ///

--- a/firefox-ios/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -202,6 +202,7 @@ final class EventQueue<QueueEventType: Hashable & Sendable>: @unchecked Sendable
     /// Clears all signalled events and pending actions. Intended for use in tests only
     /// to reset the global AppEventQueue between test cases.
     func reset() {
+        guard AppConstants.isRunningUnitTest else { assertionFailure("Test-only function called in production."); }
         mainQueue.ensureMainThread { [weak self] in
             self?.signalledEvents.removeAll()
             self?.actions.removeAll()

--- a/firefox-ios/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -202,7 +202,11 @@ final class EventQueue<QueueEventType: Hashable & Sendable>: @unchecked Sendable
     /// Clears all signalled events and pending actions. Intended for use in tests only
     /// to reset the global AppEventQueue between test cases.
     func reset() {
-        guard AppConstants.isRunningUnitTest else { assertionFailure("Test-only function called in production."); }
+        guard AppConstants.isRunningUnitTest else {
+            assertionFailure("Test-only function called in production.")
+            return
+        }
+
         mainQueue.ensureMainThread { [weak self] in
             self?.signalledEvents.removeAll()
             self?.actions.removeAll()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/SceneDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/SceneDelegateTests.swift
@@ -1,0 +1,148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+@testable import Client
+
+@MainActor
+final class SceneDelegateTests: XCTestCase, FeatureFlaggable {
+    private var mockSessionManager: MockAppSessionManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        AppEventQueue.reset()
+        DependencyHelperMock().bootstrapDependencies()
+        mockSessionManager = MockAppSessionManager()
+        setIsDeeplinkOptimizationRefactorEnabled(false)
+    }
+
+    override func tearDown() async throws {
+        mockSessionManager = nil
+        DependencyHelperMock().reset()
+        AppEventQueue.reset()
+        try await super.tearDown()
+    }
+
+    // MARK: - handle(route:) - openedFromExternalSource
+
+    func testHandleRoute_setsOpenedFromExternalSource_synchronously() throws {
+        AppEventQueue.signal(event: .startupFlowComplete)
+        let setup = try createSubjectWithCoordinator()
+
+        setup.delegate.scene(setup.scene, continue: makeSearchActivity())
+
+        XCTAssertTrue(mockSessionManager.launchSessionProvider.openedFromExternalSource)
+    }
+
+    // MARK: - handle(route:) timing - refactor enabled
+
+    func testHandleRoute_refactorEnabled_dispatchesAfterStartupFlowComplete() throws {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        AppEventQueue.signal(event: .startupFlowComplete)
+        let setup = try createSubjectWithCoordinator()
+
+        setup.delegate.scene(setup.scene, continue: makeSearchActivity())
+
+        XCTAssertNotNil(setup.coordinator.savedRoute)
+    }
+
+    func testHandleRoute_refactorEnabled_dispatchesWithoutTabRestoration() throws {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        AppEventQueue.signal(event: .startupFlowComplete)
+        let setup = try createSubjectWithCoordinator()
+        // tabRestoration NOT signalled for this coordinator's fresh windowUUID
+
+        setup.delegate.scene(setup.scene, continue: makeSearchActivity())
+
+        XCTAssertNotNil(setup.coordinator.savedRoute,
+                        "With refactor enabled route should dispatch without waiting for tabRestoration")
+    }
+
+    func testHandleRoute_refactorEnabled_doesNotDispatch_beforeStartupFlowComplete() throws {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        let setup = try createSubjectWithCoordinator()
+        // startupFlowComplete NOT signalled
+
+        let expectation = XCTestExpectation(description: "Route should not dispatch yet")
+        expectation.isInverted = true
+        AppEventQueue.wait(for: [.startupFlowComplete]) { expectation.fulfill() }
+
+        setup.delegate.scene(setup.scene, continue: makeSearchActivity())
+
+        wait(for: [expectation], timeout: 0.3)
+        XCTAssertNil(setup.coordinator.savedRoute,
+                     "With refactor enabled route should not dispatch before startupFlowComplete")
+    }
+
+    // MARK: - handle(route:) timing - refactor disabled
+
+    func testHandleRoute_refactorDisabled_doesNotDispatch_withOnlyStartupFlowComplete() throws {
+        setIsDeeplinkOptimizationRefactorEnabled(false)
+        AppEventQueue.signal(event: .startupFlowComplete)
+        let setup = try createSubjectWithCoordinator()
+        // tabRestoration NOT signalled for this coordinator's fresh windowUUID
+
+        setup.delegate.scene(setup.scene, continue: makeSearchActivity())
+
+        XCTAssertNil(setup.coordinator.savedRoute,
+                     "With refactor disabled route should wait for tabRestoration too")
+    }
+
+    func testHandleRoute_refactorDisabled_dispatchesAfterBothEvents() throws {
+        setIsDeeplinkOptimizationRefactorEnabled(false)
+        AppEventQueue.signal(event: .startupFlowComplete)
+        let setup = try createSubjectWithCoordinator()
+        AppEventQueue.signal(event: .tabRestoration(setup.coordinator.windowUUID))
+
+        setup.delegate.scene(setup.scene, continue: makeSearchActivity())
+
+        XCTAssertNotNil(setup.coordinator.savedRoute,
+                        "With refactor disabled route should dispatch after both events are signalled")
+    }
+
+    func testHandleRoute_refactorDisabled_dispatchesWhenTabRestorationSignalledAfterCall() throws {
+        setIsDeeplinkOptimizationRefactorEnabled(false)
+        AppEventQueue.signal(event: .startupFlowComplete)
+        let setup = try createSubjectWithCoordinator()
+
+        setup.delegate.scene(setup.scene, continue: makeSearchActivity())
+        XCTAssertNil(setup.coordinator.savedRoute, "Route should not have dispatched yet")
+
+        AppEventQueue.signal(event: .tabRestoration(setup.coordinator.windowUUID))
+
+        XCTAssertNotNil(setup.coordinator.savedRoute,
+                        "Route should dispatch once tabRestoration is signalled")
+    }
+
+    // MARK: - Helpers
+
+    private struct TestSubject {
+        let delegate: SceneDelegate
+        let coordinator: SceneCoordinator
+        let scene: UIWindowScene
+    }
+
+    private func createSubjectWithCoordinator() throws -> TestSubject {
+        let windowScene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+        let coordinator = SceneCoordinator(scene: windowScene,
+                                           introManager: MockIntroScreenManager(isModernEnabled: false))
+        let delegate = SceneDelegate()
+        delegate.sessionManager = mockSessionManager
+        delegate.sceneCoordinator = coordinator
+        return TestSubject(delegate: delegate, coordinator: coordinator, scene: windowScene)
+    }
+
+    private func makeSearchActivity() -> NSUserActivity {
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = URL(string: "https://example.com")
+        return activity
+    }
+
+    private func setIsDeeplinkOptimizationRefactorEnabled(_ enabled: Bool) {
+        FxNimbus.shared.features.deeplinkOptimizationRefactorFeature.with { _, _ in
+            return DeeplinkOptimizationRefactorFeature(enabled: enabled)
+        }
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15748)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33674)

## :bulb: Description
Re-adding some safety check under the `SceneDelegate` whenever the deeplinks refactor is enabled. We should wait for the event `startupFlowComplete` before we handle deeplinks. 

Start up flow is compromised of the following events:
    - `.profileInitialized`
    - `.preLaunchDependenciesComplete`
    - `.postLaunchDependenciesComplete`
    - `.accountManagerInitialized`
    - `.browserIsReady`

Added tests as well as part of those changes, which required a `reset()` method on the `EventQueue`.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

