### PR TITLE
Add FXIOS-15198 [Quick Answers] handling errors

### DIFF
--- a/BrowserKit/Sources/QuickAnswersKit/Backend/DefaultQuickAnswersService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/DefaultQuickAnswersService.swift
@@ -61,13 +61,14 @@ final class DefaultQuickAnswersService: QuickAnswersService {
     }
 
     /// Performs a search for the given transcription using the ResultsService.
-    func search(text: String) async -> Result<SearchResult, SearchResultError> {
+    func search(text: String) async -> Result<SearchResult, ResultsServiceError> {
         do {
             let result = try await resultsService.fetchResults(for: text)
             return .success(result)
         } catch {
-            // TODO: FXIOS-15198 Handle errors appropriately
-            return .failure(.unknown)
+            let error = (error as? ResultsServiceError) ?? ResultsServiceError.unknown(error.localizedDescription)
+            // TODO: FXIOS-15579 Possibly add telemetry
+            return .failure(error)
         }
     }
 

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/QuickAnswersService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/QuickAnswersService.swift
@@ -28,10 +28,6 @@ struct SearchResult: Equatable {
     }
 }
 
-enum SearchResultError: Error, Equatable {
-    case unknown
-}
-
 protocol QuickAnswersService: Sendable {
     /// Starts the voice record operation and return a stream with the accumulated results from the speech.
     func record() async throws -> AsyncThrowingStream<SpeechResult, Error>
@@ -39,5 +35,5 @@ protocol QuickAnswersService: Sendable {
     func stopRecording() async throws
 
     /// Performs a search with the provided query text parameter.
-    func search(text: String) async -> Result<SearchResult, SearchResultError>
+    func search(text: String) async -> Result<SearchResult, ResultsServiceError>
 }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
@@ -22,12 +22,14 @@ final class DefaultResultsService: ResultsService {
 
     func fetchResults(for transcription: String) async throws -> SearchResult {
         let message: QuickAnswersMessage = LiteLLMMessage(role: .user, content: transcription)
-        // TODO: FXIOS-15198 - Handle mapping errors from request
-        let fullResponse = try await requestChatCompletion(for: message)
 
-        let citations = fullResponse.providerSpecificFields?.citations ?? []
-
-        return try formatResult(from: fullResponse.content, and: citations)
+        do {
+            let fullResponse = try await requestChatCompletion(for: message)
+            let citations = fullResponse.providerSpecificFields?.citations ?? []
+            return formatResult(from: fullResponse.content, and: citations)
+        } catch {
+            throw mapError(error)
+        }
     }
 
     private func requestChatCompletion(for message: QuickAnswersMessage) async throws -> QuickAnswersMessage {
@@ -40,7 +42,7 @@ final class DefaultResultsService: ResultsService {
         )
     }
 
-    private func formatResult(from answer: String, and citations: [Citation]) throws -> SearchResult {
+    private func formatResult(from answer: String, and citations: [Citation]) -> SearchResult {
         let sources = citations.map { citation in
             SearchResult.Source(
                 title: citation.title ?? "",
@@ -49,5 +51,25 @@ final class DefaultResultsService: ResultsService {
             )
         }
         return SearchResult(resultText: answer, sources: sources)
+    }
+
+    /// Maps underlying errors to `ResultsServiceError` types.
+    private func mapError(_ error: Error) -> ResultsServiceError {
+        switch error {
+        case LiteLLMClientError.requestCreationFailed:
+            return .requestCreationFailed
+        case LiteLLMClientError.invalidResponse(let statusCode) where statusCode == 429:
+            return .rateLimited
+        case LiteLLMClientError.invalidResponse(let statusCode) where statusCode == 403:
+            return .maxUsers
+        case LiteLLMClientError.invalidResponse(let statusCode) where statusCode == 413:
+            return .payloadTooLarge
+        case LiteLLMClientError.invalidResponse(let statusCode):
+            return .invalidResponse(statusCode: statusCode)
+        case LiteLLMClientError.noContent:
+            return .noMessage
+        case let e as LiteLLMClientError: return .unknown(e.localizedDescription)
+        default: return .unknown(error.localizedDescription)
+        }
     }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceError.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceError.swift
@@ -2,7 +2,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-enum ResultsServiceError: Error {
+enum ResultsServiceError: Error, Equatable {
+    case invalidResponse(statusCode: Int)
+    case noMessage
+    case rateLimited
+    case requestCreationFailed
+    case maxUsers
+    case payloadTooLarge
     case unableToCreateService
-    case unableToFetchResults
+    case unknown(String)
+
+    var shouldRetry: Bool {
+        switch self {
+        case .invalidResponse, .noMessage:
+            return false
+        default:
+            return true
+        }
+    }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/SpeechError.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/SpeechError.swift
@@ -11,5 +11,5 @@ enum SpeechError: Error, Equatable {
     case recognizerNotAvailable
     case speechRecognitionPermissionDenied(isFirstTime: Bool)
     case unableToSupportLocale
-    case unknown
+    case unknown(String)
 }

--- a/BrowserKit/Sources/QuickAnswersKit/UI/ErrorHandler.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/ErrorHandler.swift
@@ -53,7 +53,7 @@ final class ErrorHandler {
     }
 
     // MARK: - Search Errors
-    func handleSearchError(_ error: SearchResultError) {
+    func handleSearchError(_ error: ResultsServiceError) {
         // TODO: - FXIOS-15573 Handle Search errors
     }
 

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewModel.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewModel.swift
@@ -11,7 +11,7 @@ final class QuickAnswersViewModel {
         case initializationFailed
         case recordVoice(SpeechResult, SpeechError?)
         case loadingSearchResult
-        case showSearchResult(SearchResult, SearchResultError?)
+        case showSearchResult(SearchResult, ResultsServiceError?)
     }
 
     private let service: QuickAnswersService?
@@ -60,9 +60,8 @@ final class QuickAnswersViewModel {
                 break
             }
         } catch {
-            guard let error = error as? SpeechError else {
-                return
-            }
+            let error = (error as? SpeechError) ?? SpeechError.unknown(error.localizedDescription)
+            // TODO: FXIOS-15579 Possibly add telemetry
             onStateChange?(.recordVoice(.empty(), error))
         }
     }

--- a/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockTestQuickAnswersService.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockTestQuickAnswersService.swift
@@ -6,7 +6,7 @@
 
 final class MockTestQuickAnswersService: QuickAnswersService, @unchecked Sendable {
     var speechResults: [SpeechResult] = []
-    var searchResult: Result<SearchResult, SearchResultError> = .success(.empty())
+    var searchResult: Result<SearchResult, ResultsServiceError> = .success(.empty())
     var shouldThrowSpeechError = false
     var recordVoiceCalledCount = 0
     var stopRecordingCalledCount = 0
@@ -17,7 +17,7 @@ final class MockTestQuickAnswersService: QuickAnswersService, @unchecked Sendabl
         return AsyncThrowingStream { continuation in
             Task {
                 if shouldThrowSpeechError {
-                    continuation.finish(throwing: SpeechError.unknown)
+                    continuation.finish(throwing: SpeechError.unknown("Unknown error occurred"))
                     return
                 }
 
@@ -34,7 +34,7 @@ final class MockTestQuickAnswersService: QuickAnswersService, @unchecked Sendabl
         stopRecordingCalledCount += 1
     }
 
-    func search(text: String) async -> Result<SearchResult, SearchResultError> {
+    func search(text: String) async -> Result<SearchResult, ResultsServiceError> {
         searchCalledCount += 1
         try? await Task.sleep(nanoseconds: 50_000_000)
         return searchResult

--- a/BrowserKit/Tests/QuickAnswersKitTests/QuickAnswersViewModelTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/QuickAnswersViewModelTests.swift
@@ -70,12 +70,17 @@ final class QuickAnswersViewModelTests: XCTestCase {
         wait(for: [expectation])
 
         XCTAssertEqual(mockService.recordVoiceCalledCount, 1)
-        XCTAssertEqual(state, .recordVoice(.empty(), SpeechError.unknown))
+        guard case .recordVoice(let result, let error) = state else {
+            XCTFail("Expected recordVoice state")
+            return
+        }
+        XCTAssertEqual(result, .empty())
+        XCTAssertEqual(error, .unknown("Unknown error occurred"))
     }
 
     func testStartRecordingVoice_withSearchError_receivesError() {
         let speechResult = SpeechResult(text: "Hello", isFinal: true)
-        let searchError = SearchResultError.unknown
+        let searchError = ResultsServiceError.unknown("Test error")
         mockService.speechResults = [speechResult]
         mockService.searchResult = .failure(searchError)
         var states = [QuickAnswersViewModel.State]()
@@ -94,6 +99,7 @@ final class QuickAnswersViewModelTests: XCTestCase {
         XCTAssertEqual(states[0], .recordVoice(speechResult, nil))
         XCTAssertEqual(states[1], .loadingSearchResult)
         XCTAssertEqual(states[2], .showSearchResult(.empty(), searchError))
+        XCTAssertEqual(searchError, .unknown("Test error"))
     }
 
     // MARK: - Stop Recording Tests

--- a/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/DefaultResultsServiceTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/DefaultResultsServiceTests.swift
@@ -53,6 +53,95 @@ struct DefaultResultsServiceTests {
         #expect(result.sources.isEmpty)
     }
 
+    @Test
+    func test_fetchResults_mapsRequestCreationFailedError() async throws {
+        let client = MockLiteLLMClient()
+        client.respondWithError = LiteLLMClientError.requestCreationFailed
+        let subject = createSubject(client: client)
+
+        await #expect(throws: ResultsServiceError.requestCreationFailed) {
+            try await subject.fetchResults(for: "Query")
+        }
+    }
+
+    @Test
+    func test_fetchResults_mapsRateLimitedError() async throws {
+        let client = MockLiteLLMClient()
+        client.respondWithError = LiteLLMClientError.invalidResponse(statusCode: 429)
+        let subject = createSubject(client: client)
+
+        await #expect(throws: ResultsServiceError.rateLimited) {
+            try await subject.fetchResults(for: "Query")
+        }
+    }
+
+    @Test
+    func test_fetchResults_mapsMaxUsersError() async throws {
+        let client = MockLiteLLMClient()
+        client.respondWithError = LiteLLMClientError.invalidResponse(statusCode: 403)
+        let subject = createSubject(client: client)
+
+        await #expect(throws: ResultsServiceError.maxUsers) {
+            try await subject.fetchResults(for: "Query")
+        }
+    }
+
+    @Test
+    func test_fetchResults_mapsPayloadTooLargeError() async throws {
+        let client = MockLiteLLMClient()
+        client.respondWithError = LiteLLMClientError.invalidResponse(statusCode: 413)
+        let subject = createSubject(client: client)
+
+        await #expect(throws: ResultsServiceError.payloadTooLarge) {
+            try await subject.fetchResults(for: "Query")
+        }
+    }
+
+    @Test
+    func test_fetchResults_mapsInvalidResponseError() async throws {
+        let client = MockLiteLLMClient()
+        client.respondWithError = LiteLLMClientError.invalidResponse(statusCode: 500)
+        let subject = createSubject(client: client)
+
+        await #expect(throws: ResultsServiceError.invalidResponse(statusCode: 500)) {
+            try await subject.fetchResults(for: "Query")
+        }
+    }
+
+    @Test
+    func test_fetchResults_mapsNoContentError() async throws {
+        let client = MockLiteLLMClient()
+        client.respondWithError = LiteLLMClientError.noContent
+        let subject = createSubject(client: client)
+
+        await #expect(throws: ResultsServiceError.noMessage) {
+            try await subject.fetchResults(for: "Query")
+        }
+    }
+
+    @Test
+    func test_fetchResults_mapsOtherLiteLLMClientError() async throws {
+        let client = MockLiteLLMClient()
+        client.respondWithError = LiteLLMClientError.decodingFailed
+        let subject = createSubject(client: client)
+
+        await #expect(throws: ResultsServiceError.self) {
+            try await subject.fetchResults(for: "Query")
+        }
+    }
+
+    @Test
+    func test_fetchResults_mapsGenericError() async throws {
+        let client = MockLiteLLMClient()
+        struct TestError: Error {}
+        client.respondWithError = TestError()
+        let subject = createSubject(client: client)
+
+        await #expect(throws: ResultsServiceError.self) {
+            try await subject.fetchResults(for: "Query")
+        }
+    }
+
     // MARK: - Helper
     private func createSubject(
         client: LiteLLMClientProtocol,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15198)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Update handling error from server side. Followed similarly to the `SummarizerError` and added a few more specific errors from the [docs](https://firefox-ai.github.io/MLPA/#tag/LiteLLM/operation/chat_completion_v1_chat_completions_post).

Kept retry for `noMessage` and `invalidResponse` mainly. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

