### PR TITLE
Refactor FXIOS-15740 [Danger] Adjust code coverage check for new files

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -135,9 +135,9 @@ class CodeCoverageGate {
             }
         }
 
-        var insufficientChangesMessage: String? {
+        var insufficientChangesMessage: String {
             switch self {
-            case .newFiles: return nil
+            case .newFiles: return "No new file had significant enough changes for the coverage gate to run."
             case .modifiedFiles: return "No modified file had significant enough changes for the coverage gate to run."
             }
         }
@@ -173,14 +173,12 @@ class CodeCoverageGate {
         // Ignore tiny edits: only gate files with at least `type.minimumLines`
         let gated = candidates.filter { addedLines(in: $0) >= type.minimumLines }
 
-        if let msg = type.insufficientChangesMessage {
-            guard !gated.isEmpty else {
-                markdown("""
-                ### ✅ \(type.label) code coverage
-                \(msg)
-                """)
-                return
-            }
+        guard !gated.isEmpty else {
+            markdown("""
+            ### ✅ \(type.label) code coverage
+            \(type.insufficientChangesMessage)
+            """)
+            return
         }
 
         // Collect failures

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -20,7 +20,9 @@ if releaseCheck.isReleaseBranch {
     checkForSpecificFileChange()
     checkForGleanFileChange()
     CodeUsageDetector().checkForCodeUsage()
-    CodeCoverageGate().failOnNewFilesWithoutCoverage()
+    let coverageGate = CodeCoverageGate()
+    coverageGate.failOnNewFilesWithoutCoverage()
+    coverageGate.failOnModifiedFilesWithLowCoverage()
     BrowserViewControllerChecker().failsOnAddedExtension()
     checkCodeCoverage()
 }
@@ -101,26 +103,13 @@ class CodeCoverageGate {
     private let coverageBypassLabel = "ignore-code-coverage"
     private let jsonPath = "coverage.json"
     private let minimumAddedLines = 5
+    private let minimumModifiedLines = 20
 
     func failOnNewFilesWithoutCoverage() {
-        guard let data = FileManager.default.contents(atPath: jsonPath),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let targets = json["targets"] as? [[String: Any]] else {
-            fail("Could not parse coverage.json for per-file coverage")
-            return
-        }
+        guard let coverageFiles = parseCoverageFiles() else { return }
 
-        let coverageFiles: [[String: Any]] = targets.flatMap { $0["files"] as? [[String: Any]] ?? [] }
         // Consider created Swift files, excluding Tests & Generated
-        // Excluding `danger.git.modifiedFiles` for now
-        let candidates = (danger.git.createdFiles).filter {
-            $0.hasSuffix(".swift") &&
-            !$0.contains("Tests/") &&
-            !$0.contains("/Generated/") &&
-            !$0.contains("/Strings.swift") &&
-            !$0.contains("/AccessibilityIdentifiers.swift") &&
-            !$0.contains("Protocol.swift")
-        }
+        let candidates = swiftSourceCandidates(from: danger.git.createdFiles)
 
         guard !candidates.isEmpty else {
             markdown("""
@@ -131,28 +120,7 @@ class CodeCoverageGate {
         }
 
         // Ignore tiny edits: only gate files with at least `minimumAddedLines`
-        func addedLines(_ file: String) -> Int {
-            switch saferFileDiff(for: file) {
-            case .success(let diff):
-                switch diff.changes {
-                case .created(let newLines):
-                    return newLines.count
-                case .deleted:
-                    return 0
-                case .modified(let hunks), .renamed(_, let hunks):
-                    return hunks.reduce(0) { acc, h in
-                        acc + h.lines.filter {
-                            let s = String(describing: $0)
-                            return s.hasPrefix("+") && !s.hasPrefix("+++")
-                        }.count
-                    }
-                }
-            case .failure:
-                return 999 // if diff fails, be conservative and mention it
-            }
-        }
-
-        let gated = candidates.filter { addedLines($0) >= minimumAddedLines }
+        let gated = candidates.filter { addedLines(in: $0) >= minimumAddedLines }
         // Collect failures
         var rows: [String] = []
         for file in gated {
@@ -182,15 +150,110 @@ class CodeCoverageGate {
             return
         }
 
+        reportCoverageFailure(rows: rows, label: "New file")
+    }
+
+    func failOnModifiedFilesWithLowCoverage() {
+        guard let coverageFiles = parseCoverageFiles() else { return }
+
+        let candidates = swiftSourceCandidates(from: danger.git.modifiedFiles)
+
+        guard !candidates.isEmpty else {
+            markdown("""
+            ### ✅ Existing file code coverage
+            No modified file detected so code coverage gate wasn't ran.
+            """)
+            return
+        }
+
+        let gated = candidates.filter { addedLines(in: $0) >= minimumModifiedLines }
+
+        guard !gated.isEmpty else {
+            markdown("""
+            ### ✅ Existing file code coverage
+            No modified file had significant enough changes for the coverage gate to run.
+            """)
+            return
+        }
+
+        var rows: [String] = []
+        for file in gated {
+            let entry = coverageMatch(repoPath: file, coverageFiles: coverageFiles)
+            let percent: Double = {
+                guard let entry, let raw = entry["lineCoverage"] as? Double else { return 0 }
+                return raw <= 1.000001 ? raw * 100.0 : raw
+            }()
+
+            let lineCount = countLines(in: file)
+            let threshold = scaledPercentageForOldFiles(for: Double(lineCount)) * 100.0
+
+            if percent + 0.0001 < threshold {
+                rows.append("| `\(file)` | \(formatPct(percent)) | \(formatPct(threshold)) |")
+            }
+        }
+
+        guard !rows.isEmpty else {
+            markdown("""
+            ### ✅ Existing file code coverage
+            All modified files meet their thresholds.
+            """)
+            return
+        }
+
+        reportCoverageFailure(rows: rows, label: "Existing file")
+    }
+
+    private func swiftSourceCandidates(from files: [String]) -> [String] {
+        files.filter {
+            $0.hasSuffix(".swift") &&
+            !$0.contains("Tests/") &&
+            !$0.contains("/Generated/") &&
+            !$0.contains("/Strings.swift") &&
+            !$0.contains("/AccessibilityIdentifiers.swift") &&
+            !$0.contains("Protocol.swift")
+        }
+    }
+
+    private func parseCoverageFiles() -> [[String: Any]]? {
+        guard let data = FileManager.default.contents(atPath: jsonPath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let targets = json["targets"] as? [[String: Any]] else {
+            fail("Could not parse coverage.json for per-file coverage")
+            return nil
+        }
+        return targets.flatMap { $0["files"] as? [[String: Any]] ?? [] }
+    }
+
+    private func addedLines(in file: String) -> Int {
+        switch saferFileDiff(for: file) {
+        case .success(let diff):
+            switch diff.changes {
+            case .created(let newLines):
+                return newLines.count
+            case .deleted:
+                return 0
+            case .modified(let hunks), .renamed(_, let hunks):
+                return hunks.reduce(0) { acc, h in
+                    acc + h.lines.filter {
+                        let s = String(describing: $0)
+                        return s.hasPrefix("+") && !s.hasPrefix("+++")
+                    }.count
+                }
+            }
+        case .failure:
+            return 999 // if diff fails, be conservative and mention it
+        }
+    }
+
+    private func reportCoverageFailure(rows: [String], label: String) {
         let header = """
-        ### ❌ New file code coverage
-        The following new file(s) are below their scaled coverage:
+        ### ❌ \(label) code coverage
+        The following file(s) are below their scaled coverage:
 
         | File | Coverage | Required |
         |---|---:|---:|
         \(rows.joined(separator: "\n"))
         """
-
         if hasLabel(coverageBypassLabel) {
             warn("\(header)\n\n*Bypass label `\(coverageBypassLabel)` detected — reporting as warnings only for this PR.*")
         } else {
@@ -204,7 +267,7 @@ class CodeCoverageGate {
     /// Maps an input value to a percentage using logarithmic scaling.
     /// - Parameter x: Input value (must be > 0)
     /// - Returns: A value between 0.5 and 0.8 for inputs between 10 and 500
-    func scaledPercentage(for x: Double) -> Double {
+    private func scaledPercentage(for x: Double) -> Double {
         precondition(x > 0, "Input must be greater than 0")
 
         let minX = 10.0
@@ -213,6 +276,26 @@ class CodeCoverageGate {
         let maxY = 0.7
 
         // Clamp to min/max bounds
+        if x <= minX { return minY }
+        if x >= maxX { return maxY }
+
+        let numerator = log(x / minX)
+        let denominator = log(maxX / minX)
+
+        return minY + (maxY - minY) * (numerator / denominator)
+    }
+
+    /// Maps an input value to a percentage using logarithmic scaling, with lower bounds for existing files.
+    /// - Parameter x: Input value (must be > 0)
+    /// - Returns: A value between 0.1 and 0.25 for inputs between 10 and 500
+    private func scaledPercentageForOldFiles(for x: Double) -> Double {
+        precondition(x > 0, "Input must be greater than 0")
+
+        let minX = 10.0
+        let maxX = 500.0
+        let minY = 0.10
+        let maxY = 0.25
+
         if x <= minX { return minY }
         if x >= maxX { return maxY }
 

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -210,7 +210,9 @@ class CodeCoverageGate {
             !$0.contains("/Generated/") &&
             !$0.contains("/Strings.swift") &&
             !$0.contains("/AccessibilityIdentifiers.swift") &&
-            !$0.contains("Protocol.swift")
+            !$0.contains("ImageIdentifiers.swift") &&
+            !$0.contains("Protocol.swift") &&
+            !$0.contains("Dangerfile.swift")
         }
     }
 

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -21,8 +21,8 @@ if releaseCheck.isReleaseBranch {
     checkForGleanFileChange()
     CodeUsageDetector().checkForCodeUsage()
     let coverageGate = CodeCoverageGate()
-    coverageGate.failOnNewFilesWithoutCoverage()
-    coverageGate.failOnModifiedFilesWithLowCoverage()
+    coverageGate.failOnFiles(type: .newFiles)
+    coverageGate.failOnFiles(type: .modifiedFiles)
     BrowserViewControllerChecker().failsOnAddedExtension()
     checkCodeCoverage()
 }
@@ -102,25 +102,87 @@ func checkCodeCoverage() {
 class CodeCoverageGate {
     private let coverageBypassLabel = "ignore-code-coverage"
     private let jsonPath = "coverage.json"
-    private let minimumAddedLines = 5
-    private let minimumModifiedLines = 20
 
-    func failOnNewFilesWithoutCoverage() {
+    enum CoverageType {
+        case newFiles
+        case modifiedFiles
+
+        var sourceFiles: [String] {
+            switch self {
+            case .newFiles: return danger.git.createdFiles
+            case .modifiedFiles: return danger.git.modifiedFiles
+            }
+        }
+
+        var minimumLines: Int {
+            switch self {
+            case .newFiles: return 5
+            case .modifiedFiles: return 20
+            }
+        }
+
+        var label: String {
+            switch self {
+            case .newFiles: return "New file"
+            case .modifiedFiles: return "Existing file"
+            }
+        }
+
+        var emptyMessage: String {
+            switch self {
+            case .newFiles: return "No new file detected so code coverage gate wasn't ran."
+            case .modifiedFiles: return "No modified file detected so code coverage gate wasn't ran."
+            }
+        }
+
+        var insufficientChangesMessage: String? {
+            switch self {
+            case .newFiles: return nil
+            case .modifiedFiles: return "No modified file had significant enough changes for the coverage gate to run."
+            }
+        }
+
+        var allPassMessage: String {
+            switch self {
+            case .newFiles: return "All new files meet their thresholds**."
+            case .modifiedFiles: return "All modified files meet their thresholds."
+            }
+        }
+
+        var thresholdRange: (min: Double, max: Double) {
+            switch self {
+            case .newFiles: return (min: 0.4, max: 0.7)
+            case .modifiedFiles: return (min: 0.10, max: 0.25)
+            }
+        }
+    }
+
+    func failOnFiles(type: CoverageType) {
         guard let coverageFiles = parseCoverageFiles() else { return }
 
-        // Consider created Swift files, excluding Tests & Generated
-        let candidates = swiftSourceCandidates(from: danger.git.createdFiles)
+        let candidates = swiftSourceCandidates(from: type.sourceFiles)
 
         guard !candidates.isEmpty else {
             markdown("""
-            ### ✅ New file code coverage
-            No new file detected so code coverage gate wasn't ran.
+            ### ✅ \(type.label) code coverage
+            \(type.emptyMessage)
             """)
             return
         }
 
-        // Ignore tiny edits: only gate files with at least `minimumAddedLines`
-        let gated = candidates.filter { addedLines(in: $0) >= minimumAddedLines }
+        // Ignore tiny edits: only gate files with at least `type.minimumLines`
+        let gated = candidates.filter { addedLines(in: $0) >= type.minimumLines }
+
+        if let msg = type.insufficientChangesMessage {
+            guard !gated.isEmpty else {
+                markdown("""
+                ### ✅ \(type.label) code coverage
+                \(msg)
+                """)
+                return
+            }
+        }
+
         // Collect failures
         var rows: [String] = []
         for file in gated {
@@ -135,7 +197,7 @@ class CodeCoverageGate {
 
             // Calculate threshold based on file length
             let lineCount = countLines(in: file)
-            let threshold = scaledPercentage(for: Double(lineCount)) * 100.0
+            let threshold = scaledPercentage(for: Double(lineCount), in: type.thresholdRange) * 100.0
 
             if percent + 0.0001 < threshold { // epsilon for float stability
                 rows.append("| `\(file)` | \(formatPct(percent)) | \(formatPct(threshold)) |")
@@ -144,63 +206,13 @@ class CodeCoverageGate {
 
         guard !rows.isEmpty else {
             markdown("""
-            ### ✅ New file code coverage
-            All new files meet their thresholds**.
+            ### ✅ \(type.label) code coverage
+            \(type.allPassMessage)
             """)
             return
         }
 
-        reportCoverageFailure(rows: rows, label: "New file")
-    }
-
-    func failOnModifiedFilesWithLowCoverage() {
-        guard let coverageFiles = parseCoverageFiles() else { return }
-
-        let candidates = swiftSourceCandidates(from: danger.git.modifiedFiles)
-
-        guard !candidates.isEmpty else {
-            markdown("""
-            ### ✅ Existing file code coverage
-            No modified file detected so code coverage gate wasn't ran.
-            """)
-            return
-        }
-
-        let gated = candidates.filter { addedLines(in: $0) >= minimumModifiedLines }
-
-        guard !gated.isEmpty else {
-            markdown("""
-            ### ✅ Existing file code coverage
-            No modified file had significant enough changes for the coverage gate to run.
-            """)
-            return
-        }
-
-        var rows: [String] = []
-        for file in gated {
-            let entry = coverageMatch(repoPath: file, coverageFiles: coverageFiles)
-            let percent: Double = {
-                guard let entry, let raw = entry["lineCoverage"] as? Double else { return 0 }
-                return raw <= 1.000001 ? raw * 100.0 : raw
-            }()
-
-            let lineCount = countLines(in: file)
-            let threshold = scaledPercentageForOldFiles(for: Double(lineCount)) * 100.0
-
-            if percent + 0.0001 < threshold {
-                rows.append("| `\(file)` | \(formatPct(percent)) | \(formatPct(threshold)) |")
-            }
-        }
-
-        guard !rows.isEmpty else {
-            markdown("""
-            ### ✅ Existing file code coverage
-            All modified files meet their thresholds.
-            """)
-            return
-        }
-
-        reportCoverageFailure(rows: rows, label: "Existing file")
+        reportCoverageFailure(rows: rows, label: type.label)
     }
 
     private func swiftSourceCandidates(from files: [String]) -> [String] {
@@ -266,45 +278,24 @@ class CodeCoverageGate {
         }
     }
 
-    /// Maps an input value to a percentage using logarithmic scaling.
+    /// Maps an input value to a percentage using logarithmic scaling within the given range.
     /// - Parameter x: Input value (must be > 0)
-    /// - Returns: A value between 0.5 and 0.8 for inputs between 10 and 500
-    private func scaledPercentage(for x: Double) -> Double {
+    /// - Parameter range: The output min/max bounds for the scaling
+    /// - Returns: A scaled value within `range` for inputs between 10 and 500
+    private func scaledPercentage(for x: Double, in range: (min: Double, max: Double)) -> Double {
         precondition(x > 0, "Input must be greater than 0")
 
         let minX = 10.0
         let maxX = 500.0
-        let minY = 0.4
-        let maxY = 0.7
 
         // Clamp to min/max bounds
-        if x <= minX { return minY }
-        if x >= maxX { return maxY }
+        if x <= minX { return range.min }
+        if x >= maxX { return range.max }
 
         let numerator = log(x / minX)
         let denominator = log(maxX / minX)
 
-        return minY + (maxY - minY) * (numerator / denominator)
-    }
-
-    /// Maps an input value to a percentage using logarithmic scaling, with lower bounds for existing files.
-    /// - Parameter x: Input value (must be > 0)
-    /// - Returns: A value between 0.1 and 0.25 for inputs between 10 and 500
-    private func scaledPercentageForOldFiles(for x: Double) -> Double {
-        precondition(x > 0, "Input must be greater than 0")
-
-        let minX = 10.0
-        let maxX = 500.0
-        let minY = 0.10
-        let maxY = 0.25
-
-        if x <= minX { return minY }
-        if x >= maxX { return maxY }
-
-        let numerator = log(x / minX)
-        let denominator = log(maxX / minX)
-
-        return minY + (maxY - minY) * (numerator / denominator)
+        return range.min + (range.max - range.min) * (numerator / denominator)
     }
 
     /// Counts the number of lines in a file


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15740)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33672)

## :bulb: Description
We have a calculated threshold depending on the file length for new files. With this addition, we'll have another threshold (lower) for old files. It's purposefully very low to make sure we're not blocking the PR review processes too much. If it's going well we can increase that threshold. 

| File size  | New file threshold | Old file threshold |
|------------|--------------------|--------------------|
| ~10 lines  | 40%                | 10%                |
| ~100 lines | 54%                | 17%                |
| ~500 lines | 70%                | 25%                |

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

