### PR TITLE
Add FXIOS-15764 [Newsfeed Categories] News header transition snapping

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -314,12 +314,16 @@ final class HomepageViewController: UIViewController,
     }
 
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        snapNewsTransitionHeaderIfNeeded()
         saveVerticalScrollOffset()
         trackVisibleItemImpressions()
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        saveVerticalScrollOffset()
+        if !decelerate {
+            snapNewsTransitionHeaderIfNeeded()
+            saveVerticalScrollOffset()
+        }
         trackVisibleItemImpressions()
     }
 
@@ -875,6 +879,20 @@ final class HomepageViewController: UIViewController,
         let normalizedOffset = collectionView.contentOffset.y + collectionView.adjustedContentInset.top
         let progress = normalizedOffset / NewsTransitionHeaderCell.UX.transitionDistance
         return min(max(progress, 0), 1)
+    }
+
+    /// Snaps the news transition header to either the start or end of the transition when scrolling stops mid-transition.
+    private func snapNewsTransitionHeaderIfNeeded() {
+        guard isNewsTransitionEnabled(), let collectionView else { return }
+
+        let normalizedOffset = collectionView.contentOffset.y + collectionView.adjustedContentInset.top
+        guard let targetNormalizedOffset = NewsTransitionHeaderCell.UX.snappedTransitionOffset(for: normalizedOffset)
+        else { return }
+
+        let targetOffset = CGPoint(x: collectionView.contentOffset.x,
+                                   y: targetNormalizedOffset - collectionView.adjustedContentInset.top)
+        collectionView.setContentOffset(targetOffset, animated: true)
+        updateNewsTransitionHeaderProgress()
     }
 
     // MARK: - Screenshotable

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/NewsTransitionHeaderCell.swift
@@ -17,6 +17,14 @@ final class NewsTransitionHeaderCell: UICollectionReusableView,
         static let pickerTranslationStartProgress: CGFloat = 0.2
         static let transitioningZPosition: CGFloat = -1
         static let pinnedZPosition: CGFloat = 1
+
+        static func snappedTransitionOffset(for normalizedOffset: CGFloat) -> CGFloat? {
+            guard normalizedOffset > 0,
+                  normalizedOffset < transitionDistance
+            else { return nil }
+
+            return normalizedOffset < transitionDistance / 2 ? 0 : transitionDistance
+        }
     }
 
     private lazy var newsAffordanceHeaderView: NewsAffordanceHeaderView = .build()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15764)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33713)

## :bulb: Description
- Snap the news header to the beginning or end of it's transition (whichever is closest) if homepage scroll dragging/decelerating ends within the headers transition range

## :movie_camera: Demos

https://github.com/user-attachments/assets/f496f453-7e65-4bde-9def-79a9a0af17d8

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

