### PR TITLE
Bugfix [FXIOS-15551] Tab leak investigation WebContextMenuActionsProviders

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -34,9 +34,10 @@ class WebContextMenuActionsProvider {
                 title: .ContextMenuOpenInNewTab,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus),
                 identifier: UIAction.Identifier(rawValue: "linkContextMenu.openInNewTab")
-            ) { _ in
+            ) { [weak self, weak currentTab] _ in
+                guard let currentTab else { return }
                 addTab(url, false, currentTab)
-                self.recordOptionSelectedTelemetry(option: .openInNewTab)
+                self?.recordOptionSelectedTelemetry(option: .openInNewTab)
             })
     }
 
@@ -47,9 +48,10 @@ class WebContextMenuActionsProvider {
                 title: .ContextMenuOpenInNewPrivateTab,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.privateMode),
                 identifier: UIAction.Identifier("linkContextMenu.openInNewPrivateTab")
-            ) { _ in
+            ) { [weak self, weak currentTab] _ in
+                guard let currentTab else { return }
                 addTab(url, true, currentTab)
-                self.recordOptionSelectedTelemetry(option: .openInNewPrivateTab)
+                self?.recordOptionSelectedTelemetry(option: .openInNewPrivateTab)
             })
     }
 
@@ -60,9 +62,9 @@ class WebContextMenuActionsProvider {
                 title: .ContextMenuBookmarkLink,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
                 identifier: UIAction.Identifier("linkContextMenu.bookmarkLink")
-            ) { _ in
+            ) { [weak self] _ in
                 addBookmark(url.absoluteString, title, nil)
-                self.recordOptionSelectedTelemetry(option: .bookmarkLink)
+                self?.recordOptionSelectedTelemetry(option: .bookmarkLink)
                 BookmarksTelemetry().addBookmark(eventLabel: .pageActionMenu)
             }
         )
@@ -82,9 +84,9 @@ class WebContextMenuActionsProvider {
                 title: .RemoveBookmarkContextMenuTitle,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
                 identifier: UIAction.Identifier("linkContextMenu.removeBookmarkLink")
-            ) { _ in
+            ) { [weak self] _ in
                 removeBookmark(urlString, title, nil)
-                self.recordOptionSelectedTelemetry(option: .removeBookmark)
+                self?.recordOptionSelectedTelemetry(option: .removeBookmark)
                 BookmarksTelemetry().deleteBookmark(eventLabel: .pageActionMenu)
             }
         )
@@ -98,8 +100,9 @@ class WebContextMenuActionsProvider {
                 StandardImageIdentifiers.Large.download
             ),
             identifier: UIAction.Identifier("linkContextMenu.download")
-        ) { _ in
+        ) { [weak self, weak currentTab] _ in
             ensureMainThread {
+                guard let currentTab else { return }
                 // This checks if download is a blob, if yes, begin blob download process
                 if !DownloadContentScript.requestBlobDownload(url: url, tab: currentTab) {
                     // if not a blob, set pendingDownloadWebView and load the request in
@@ -108,7 +111,7 @@ class WebContextMenuActionsProvider {
                     assignWebView(currentTab.webView)
                     let request = URLRequest(url: url)
                     currentTab.webView?.load(request)
-                    self.recordOptionSelectedTelemetry(option: .downloadLink)
+                    self?.recordOptionSelectedTelemetry(option: .downloadLink)
                 }
             }
         })
@@ -120,9 +123,9 @@ class WebContextMenuActionsProvider {
             title: .ContextMenuCopyLink,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.link),
             identifier: UIAction.Identifier("linkContextMenu.copyLink")
-        ) { _ in
+        ) { [weak self] _ in
             UIPasteboard.general.url = url
-            self.recordOptionSelectedTelemetry(option: .copyLink)
+            self?.recordOptionSelectedTelemetry(option: .copyLink)
         })
     }
 
@@ -137,7 +140,7 @@ class WebContextMenuActionsProvider {
             title: .ContextMenuShareLink,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.share),
             identifier: UIAction.Identifier("linkContextMenu.share")
-        ) { _ in
+        ) { [weak self] _ in
             guard let tab = tabManager[webView],
                   let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper
             else { return }
@@ -154,7 +157,7 @@ class WebContextMenuActionsProvider {
                 toastContainer: contentContainer,
                 popoverArrowDirection: .unknown
             )
-            self.recordOptionSelectedTelemetry(option: .shareLink)
+            self?.recordOptionSelectedTelemetry(option: .shareLink)
         })
     }
 
@@ -165,7 +168,7 @@ class WebContextMenuActionsProvider {
         actions.append(UIAction(
             title: .ContextMenuSaveImage,
             identifier: UIAction.Identifier("linkContextMenu.saveImage")
-        ) { _ in
+        ) { [weak self] _ in
             getImageData(url) { data in
                 if url.pathExtension.lowercased() == "gif" {
                     PHPhotoLibrary.shared().performChanges {
@@ -179,7 +182,7 @@ class WebContextMenuActionsProvider {
                     }
                 }
             }
-            self.recordOptionSelectedTelemetry(option: .saveImage)
+            self?.recordOptionSelectedTelemetry(option: .saveImage)
         })
     }
 
@@ -188,24 +191,27 @@ class WebContextMenuActionsProvider {
         actions.append(UIAction(
             title: .ContextMenuCopyImage,
             identifier: UIAction.Identifier("linkContextMenu.copyImage")
-        ) { _ in
+        ) { [weak self] _ in
+            guard let self else { return }
             // put the actual image on the clipboard
             // do this asynchronously just in case we're in a low bandwidth situation
             let pasteboard = UIPasteboard.general
             pasteboard.url = url as URL
             let changeCount = pasteboard.changeCount
             let application = UIApplication.shared
-            self.taskId = application.beginBackgroundTask(expirationHandler: {
-                application.endBackgroundTask(self.taskId)
+            self.taskId = application.beginBackgroundTask(expirationHandler: { [weak self] in
+                guard let taskId = self?.taskId else { return }
+                application.endBackgroundTask(taskId)
             })
 
             makeURLSession(
                 userAgent: UserAgent.fxaUserAgent,
                 configuration: URLSessionConfiguration.defaultMPTCP
-            ).dataTask(with: url) { (data, response, error) in
+            ).dataTask(with: url) { [weak self] (data, response, error) in
                 ensureMainThread {
+                    guard let taskId = self?.taskId else { return }
                     guard validatedHTTPResponse(response, statusCode: 200..<300) != nil else {
-                        application.endBackgroundTask(self.taskId)
+                        application.endBackgroundTask(taskId)
                         return
                     }
 
@@ -218,7 +224,7 @@ class WebContextMenuActionsProvider {
                         pasteboard.addImageWithData(imageData, forURL: url)
                     }
 
-                    application.endBackgroundTask(self.taskId)
+                    application.endBackgroundTask(taskId)
                 }
             }.resume()
             self.recordOptionSelectedTelemetry(option: .copyImage)
@@ -230,9 +236,9 @@ class WebContextMenuActionsProvider {
         actions.append(UIAction(
             title: .ContextMenuCopyImageLink,
             identifier: UIAction.Identifier("linkContextMenu.copyImageLink")
-        ) { _ in
+        ) { [weak self] _ in
             UIPasteboard.general.url = url as URL
-            self.recordOptionSelectedTelemetry(option: .copyImageLink)
+            self?.recordOptionSelectedTelemetry(option: .copyImageLink)
         })
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -340,10 +340,10 @@ extension BrowserViewController: WKUIDelegate {
                                              buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
         let toast = ButtonToast(viewModel: viewModel,
                                 theme: self.currentTheme(),
-                                completion: { buttonPressed in
-            if buttonPressed {
-                self.tabManager.selectTab(tab)
-                self.overlayManager.switchTab(shouldCancelLoading: true)
+                                completion: { [weak self, weak tab] buttonPressed in
+            if buttonPressed, let tab {
+                self?.tabManager.selectTab(tab)
+                self?.overlayManager.switchTab(shouldCancelLoading: true)
             }
         })
         show(toast: toast)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15551)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33329)

## :bulb: Description
- Fix tab leak in `WebContextMenuActionsProviders` that retained Tabs and caused leak.
- Add a fix for `Toast` shown when a new tab is created to switch to that tabs.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

