### PR TITLE
Bugfix FXIOS-15775 [Unit Test] search bar homepage tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
@@ -363,7 +363,7 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
     }
 
-    func test_didTapButtonToolbarAction_withHomepageSearch_andNoSearchButtonType_triggersGeneralBrowserAction() {
+    func test_didTapButtonToolbarAction_withHomepageSearch_andNoSearchButtonType_doesNotTriggersGeneralBrowserAction() {
         setupStoreForSearchBar()
         let subject = createSubject()
 
@@ -376,7 +376,16 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         )
         subject.newState(state: newState)
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        let didEnteredZeroSearchScreenDispatched = mockStore.dispatchedActions.contains { action in
+            guard let action = action as? GeneralBrowserAction,
+                  let actionType = action.actionType as? GeneralBrowserActionType else { return false }
+            if case .enteredZeroSearchScreen = actionType {
+                XCTFail("Expected entered zero search screen to not dispatch")
+                return true
+            }
+            return false
+        }
+        XCTAssertFalse(didEnteredZeroSearchScreenDispatched)
     }
 
     func test_didTapButtonToolbarAction_withoutHomepageSearch_andSearchButtonType_doesNotTriggersGeneralBrowserAction() {
@@ -392,7 +401,16 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         )
         subject.newState(state: newState)
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        let didEnteredZeroSearchScreenDispatched = mockStore.dispatchedActions.contains { action in
+            guard let action = action as? GeneralBrowserAction,
+                  let actionType = action.actionType as? GeneralBrowserActionType else { return false }
+            if case .enteredZeroSearchScreen = actionType {
+                XCTFail("Expected entered zero search screen to not dispatch")
+                return true
+            }
+            return false
+        }
+        XCTAssertFalse(didEnteredZeroSearchScreenDispatched)
     }
 
     func test_didTapButtonToolbarAction_withoutHomepageSearch_andNoSearchButtonType_doesNotTriggersGeneralBrowserAction() {
@@ -407,7 +425,16 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         )
         subject.newState(state: newState)
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        let didEnteredZeroSearchScreenDispatched = mockStore.dispatchedActions.contains { action in
+            guard let action = action as? GeneralBrowserAction,
+                  let actionType = action.actionType as? GeneralBrowserActionType else { return false }
+            if case .enteredZeroSearchScreen = actionType {
+                XCTFail("Expected entered zero search screen to not dispatch")
+                return true
+            }
+            return false
+        }
+        XCTAssertFalse(didEnteredZeroSearchScreenDispatched)
     }
 
     func testNewState_whenSummarizeDisplayRequested() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15775)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33733)

## :bulb: Description
Update checking dispatch action called to be more specific to the tests. Although I was unable to trigger the failures locally, I notice that the `ToolbarMiddlewareActionType.didTapButton` was now being used in multiple places which may dispatch a `GeneralBrowserAction`. So to keep tests specific, I only check for the specific action we cared about. 

In the tests related to `HomepageSearch` and `didTapButtonToolbarAction`, we are checking that the `GeneralBrowserActionType.enteredZeroSearchScreen` is being called. So in the tests where we don't want to call that action, I check for it instead of explicitly saying no actions were dispatched.

While I'm not 100% sure this will fix the issue, it will bring us closer to investigating.
## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

