### PR TITLE
Bugfix FXIOS-15453 [Homepage Newsfeed] Allow square story thumbnails to render as full-size hero images in StoryCell

### DIFF
--- a/BrowserKit/Sources/SiteImageView/HeroImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageView.swift
@@ -19,6 +19,7 @@ public final class HeroImageView: UIView, SiteImageView {
     var uniqueID: UUID?
     var imageFetcher: SiteImageHandler
     var currentURLString: String?
+    private var ignoresAspectRatio = false
     private var completionHandler: (() -> Void)?
 
     private lazy var heroImageView: UIImageView = .build { imageView in
@@ -61,6 +62,7 @@ public final class HeroImageView: UIView, SiteImageView {
     // MARK: - Public
 
     public func setHeroImage(_ viewModel: HeroImageViewModel) {
+        ignoresAspectRatio = viewModel.ignoresAspectRatio
         setupHeroImageLayout(viewModel: viewModel)
         setURL(viewModel.urlStringRequest, type: viewModel.type)
     }
@@ -91,8 +93,8 @@ public final class HeroImageView: UIView, SiteImageView {
     }
 
     func setImage(image: UIImage) {
-        // If hero image is a square use it as a favicon
-        guard image.size.width == image.size.height else {
+        // Square hero images default to favicon presentation unless the caller opts into hero rendering.
+        guard !ignoresAspectRatio, image.size.width == image.size.height else {
             setHeroImage(image: image)
             return
         }
@@ -136,6 +138,8 @@ public final class HeroImageView: UIView, SiteImageView {
     private func setHeroImage(image: UIImage) {
         setFallBackFaviconVisibility(isHidden: true)
         heroImageView.image = image
+
+        completionHandler?()
     }
 
     private func setFallbackFavicon(image: UIImage) {

--- a/BrowserKit/Sources/SiteImageView/HeroImageViewModel.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageViewModel.swift
@@ -12,6 +12,7 @@ public protocol HeroImageViewModel {
     var faviconBorderWidth: CGFloat { get }
     var heroImageSize: CGSize { get }
     var fallbackFaviconSize: CGSize { get }
+    var ignoresAspectRatio: Bool { get }
 }
 
 public struct DefaultHeroImageViewModel: HeroImageViewModel {
@@ -22,6 +23,7 @@ public struct DefaultHeroImageViewModel: HeroImageViewModel {
     public var faviconBorderWidth: CGFloat
     public var heroImageSize: CGSize
     public var fallbackFaviconSize: CGSize
+    public var ignoresAspectRatio: Bool
 
     public init(
         urlStringRequest: String,
@@ -29,7 +31,8 @@ public struct DefaultHeroImageViewModel: HeroImageViewModel {
         faviconCornerRadius: CGFloat,
         faviconBorderWidth: CGFloat,
         heroImageSize: CGSize,
-        fallbackFaviconSize: CGSize
+        fallbackFaviconSize: CGSize,
+        ignoresAspectRatio: Bool = false
     ) {
         self.type = .heroImage
         self.urlStringRequest = urlStringRequest
@@ -38,5 +41,6 @@ public struct DefaultHeroImageViewModel: HeroImageViewModel {
         self.faviconBorderWidth = faviconBorderWidth
         self.heroImageSize = heroImageSize
         self.fallbackFaviconSize = fallbackFaviconSize
+        self.ignoresAspectRatio = ignoresAspectRatio
     }
 }

--- a/firefox-ios/Client/Frontend/Home/HomepageHeroImageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageHeroImageViewModel.swift
@@ -13,6 +13,7 @@ struct HomepageHeroImageViewModel: HeroImageViewModel {
     let faviconBorderWidth: CGFloat
     let heroImageSize: CGSize
     let fallbackFaviconSize: CGSize
+    let ignoresAspectRatio: Bool
 
     init(
         urlStringRequest: String,
@@ -21,7 +22,8 @@ struct HomepageHeroImageViewModel: HeroImageViewModel {
         faviconCornerRadius: CGFloat = HomepageUX.generalCornerRadius,
         faviconBorderWidth: CGFloat = HomepageUX.generalBorderWidth,
         heroImageSize: CGSize,
-        fallbackFaviconSize: CGSize = HomepageUX.fallbackFaviconSize
+        fallbackFaviconSize: CGSize = HomepageUX.fallbackFaviconSize,
+        ignoresAspectRatio: Bool = false
     ) {
         self.urlStringRequest = urlStringRequest
         self.type = type
@@ -30,5 +32,6 @@ struct HomepageHeroImageViewModel: HeroImageViewModel {
         self.faviconBorderWidth = faviconBorderWidth
         self.heroImageSize = heroImageSize
         self.fallbackFaviconSize = fallbackFaviconSize
+        self.ignoresAspectRatio = ignoresAspectRatio
     }
 }

--- a/firefox-ios/Client/Frontend/StoriesFeed/StoryCell.swift
+++ b/firefox-ios/Client/Frontend/StoriesFeed/StoryCell.swift
@@ -80,7 +80,8 @@ class StoryCell: UICollectionViewCell,
         let heroImageViewModel = HomepageHeroImageViewModel(urlStringRequest: story.imageURL?.absoluteString ?? "",
                                                             generalCornerRadius: UX.thumbnailCornerRadius,
                                                             faviconCornerRadius: UX.thumbnailCornerRadius,
-                                                            heroImageSize: UX.thumbnailSize)
+                                                            heroImageSize: UX.thumbnailSize,
+                                                            ignoresAspectRatio: true)
         thumbnailImageView.setHeroImage(heroImageViewModel)
 
         titleLabel.text = story.title


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15453)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33141)

## :bulb: Description
- Allow homepage story cells to render square thumbnails (1:1 aspect ratio) as hero images.

### 📝 Technical Notes: 
- `HeroImageView` previously treated all square hero images as favicon fallbacks. This change adds an `ignoresAspectRatio` opt-in on `HeroImageViewModel` so that we don't do this for story hero images as we always want them to be full size.

## :movie_camera: Demos
| Before | After |
| ------------- | ------------- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-11 at 16 47 02" src="https://github.com/user-attachments/assets/38df9e1f-9cd0-445c-9d48-332705958430" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-11 at 16 25 26" src="https://github.com/user-attachments/assets/dec99a9e-b9ac-4671-8d13-3f1f96208d39" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

