### PR TITLE
Add FXIOS-15777 [WC] Initial client wrapper

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1151,6 +1151,7 @@
 		8A9D31642D1355EE00171502 /* MockFxBookmarkNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31632D1355E900171502 /* MockFxBookmarkNode.swift */; };
 		8A9D31662D13586500171502 /* MockFolderHierarchyFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31652D13586100171502 /* MockFolderHierarchyFetcher.swift */; };
 		8A9D31682D135A1300171502 /* MockBookmarksSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31672D135A1300171502 /* MockBookmarksSaver.swift */; };
+		F00CA4022F00000000000007 /* MockWorldCupAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000008 /* MockWorldCupAPIClient.swift */; };
 		8A9D316A2D135EB000171502 /* EditBookmarkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31692D135EB000171502 /* EditBookmarkViewModelTests.swift */; };
 		8A9E041B2D4D08350022ED90 /* BookmarkConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9E041A2D4D08350022ED90 /* BookmarkConfiguration.swift */; };
 		8A9E041D2D4D09240022ED90 /* BookmarksSectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9E041C2D4D09230022ED90 /* BookmarksSectionState.swift */; };
@@ -1628,6 +1629,13 @@
 		C29B64872AD69D0200F3244B /* QRCodeCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64862AD69D0200F3244B /* QRCodeCoordinatorTests.swift */; };
 		C29B64EE2AD937D500F3244B /* QRCodeNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64ED2AD937D400F3244B /* QRCodeNavigationHandler.swift */; };
 		C2A057E32FA8C32200100C24 /* WorldCupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A057E22FA8C32200100C24 /* WorldCupCell.swift */; };
+		F00CA4012F00000000000003 /* WorldCupMatchesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000004 /* WorldCupMatchesResponse.swift */; };
+		F00CA4012F00000000000007 /* WorldCupAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000008 /* WorldCupAPIClient.swift */; };
+		F00CA4012F0000000000000D /* WorldCupAPIClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F0000000000000E /* WorldCupAPIClientProtocol.swift */; };
+		F00CA4012F0000000000000F /* WorldCupFetchStrategyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000010 /* WorldCupFetchStrategyProtocol.swift */; };
+		F00CA4012F00000000000011 /* WorldCupNormalFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000012 /* WorldCupNormalFetchStrategy.swift */; };
+		F00CA4022F00000000000001 /* WorldCupMatchesResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000002 /* WorldCupMatchesResponseTests.swift */; };
+		F00CA4022F00000000000005 /* WorldCupFetchStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000006 /* WorldCupFetchStrategyTests.swift */; };
 		C2A72A672A76938C002ACCE2 /* DownloadsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A662A76938C002ACCE2 /* DownloadsCoordinator.swift */; };
 		C2A72A692A769460002ACCE2 /* ReadingListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A682A769460002ACCE2 /* ReadingListCoordinator.swift */; };
 		C2A72A6B2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A6A2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift */; };
@@ -9566,6 +9574,7 @@
 		8A9D31632D1355E900171502 /* MockFxBookmarkNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFxBookmarkNode.swift; sourceTree = "<group>"; };
 		8A9D31652D13586100171502 /* MockFolderHierarchyFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFolderHierarchyFetcher.swift; sourceTree = "<group>"; };
 		8A9D31672D135A1300171502 /* MockBookmarksSaver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBookmarksSaver.swift; sourceTree = "<group>"; };
+		F00CA4022F00000000000008 /* MockWorldCupAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWorldCupAPIClient.swift; sourceTree = "<group>"; };
 		8A9D31692D135EB000171502 /* EditBookmarkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditBookmarkViewModelTests.swift; sourceTree = "<group>"; };
 		8A9E041A2D4D08350022ED90 /* BookmarkConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkConfiguration.swift; sourceTree = "<group>"; };
 		8A9E041C2D4D09230022ED90 /* BookmarksSectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksSectionState.swift; sourceTree = "<group>"; };
@@ -10420,6 +10429,13 @@
 		C29B64862AD69D0200F3244B /* QRCodeCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeCoordinatorTests.swift; sourceTree = "<group>"; };
 		C29B64ED2AD937D400F3244B /* QRCodeNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeNavigationHandler.swift; sourceTree = "<group>"; };
 		C2A057E22FA8C32200100C24 /* WorldCupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupCell.swift; sourceTree = "<group>"; };
+		F00CA4012F00000000000004 /* WorldCupMatchesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupMatchesResponse.swift; sourceTree = "<group>"; };
+		F00CA4012F00000000000008 /* WorldCupAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupAPIClient.swift; sourceTree = "<group>"; };
+		F00CA4012F0000000000000E /* WorldCupAPIClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupAPIClientProtocol.swift; sourceTree = "<group>"; };
+		F00CA4012F00000000000010 /* WorldCupFetchStrategyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupFetchStrategyProtocol.swift; sourceTree = "<group>"; };
+		F00CA4012F00000000000012 /* WorldCupNormalFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupNormalFetchStrategy.swift; sourceTree = "<group>"; };
+		F00CA4022F00000000000002 /* WorldCupMatchesResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupMatchesResponseTests.swift; sourceTree = "<group>"; };
+		F00CA4022F00000000000006 /* WorldCupFetchStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupFetchStrategyTests.swift; sourceTree = "<group>"; };
 		C2A72A662A76938C002ACCE2 /* DownloadsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsCoordinator.swift; sourceTree = "<group>"; };
 		C2A72A682A769460002ACCE2 /* ReadingListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListCoordinator.swift; sourceTree = "<group>"; };
 		C2A72A6A2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -15120,6 +15136,11 @@
 			children = (
 				C250A68F2FAC875200BFB1AD /* WorldCupMatchCardView.swift */,
 				C2A057E22FA8C32200100C24 /* WorldCupCell.swift */,
+				F00CA4012F00000000000004 /* WorldCupMatchesResponse.swift */,
+				F00CA4012F00000000000008 /* WorldCupAPIClient.swift */,
+				F00CA4012F0000000000000E /* WorldCupAPIClientProtocol.swift */,
+				F00CA4012F00000000000010 /* WorldCupFetchStrategyProtocol.swift */,
+				F00CA4012F00000000000012 /* WorldCupNormalFetchStrategy.swift */,
 				C2EA234B2FA0B8AE004B6338 /* WorldCupTimerView.swift */,
 				C2EA23552FA1B8AE004B6340 /* WorldCupTelemetry.swift */,
 				C2EA23502FA1B8AE004B6339 /* WorldCupCountdownModel.swift */,
@@ -15454,6 +15475,7 @@
 				0B7B05402D64C087007FD7AC /* MockURLResponse.swift */,
 				0B7B053E2D64C022007FD7AC /* MockTabWebView.swift */,
 				8A9D31672D135A1300171502 /* MockBookmarksSaver.swift */,
+				F00CA4022F00000000000008 /* MockWorldCupAPIClient.swift */,
 				8A9D31652D13586100171502 /* MockFolderHierarchyFetcher.swift */,
 				45D5EDBF292D619000311934 /* MockablePinnedSites.swift */,
 				434CD57729F6FC4500A0D04B /* MockAppAuthenticator.swift */,
@@ -16870,6 +16892,8 @@
 				8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */,
 				03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */,
 				C28EA9802FA2554800AEC3AD /* WorldCupCountdownModelTests.swift */,
+				F00CA4022F00000000000002 /* WorldCupMatchesResponseTests.swift */,
+				F00CA4022F00000000000006 /* WorldCupFetchStrategyTests.swift */,
 				C28EA9832FA2554900AEC3AE /* WorldCupTelemetryTests.swift */,
 				1D62C5262EE8E77C00C6BCB9 /* RelayControllerTests.swift */,
 				8AFA66012CA2935C0008D0F6 /* RemoteSettings */,
@@ -19528,6 +19552,11 @@
 				D3972BF41C22412B00035B87 /* TitleActivityItemProvider.swift in Sources */,
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
 				C2A057E32FA8C32200100C24 /* WorldCupCell.swift in Sources */,
+				F00CA4012F00000000000003 /* WorldCupMatchesResponse.swift in Sources */,
+				F00CA4012F00000000000007 /* WorldCupAPIClient.swift in Sources */,
+				F00CA4012F0000000000000D /* WorldCupAPIClientProtocol.swift in Sources */,
+				F00CA4012F0000000000000F /* WorldCupFetchStrategyProtocol.swift in Sources */,
+				F00CA4012F00000000000011 /* WorldCupNormalFetchStrategy.swift in Sources */,
 				212985E42A6F078800546684 /* ScreenState.swift in Sources */,
 				D51EA5BA26406A0000334331 /* ExperimentsBranchesViewController.swift in Sources */,
 				C84655F728879EF100861B4A /* WallpaperManager.swift in Sources */,
@@ -20070,6 +20099,8 @@
 				E1AEC17A286E0CF500062E29 /* WebViewNavigationHandlerTests.swift in Sources */,
 				D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */,
 				C28EA9812FA2554800AEC3AD /* WorldCupCountdownModelTests.swift in Sources */,
+				F00CA4022F00000000000001 /* WorldCupMatchesResponseTests.swift in Sources */,
+				F00CA4022F00000000000005 /* WorldCupFetchStrategyTests.swift in Sources */,
 				C28EA9822FA2554900AEC3AE /* WorldCupTelemetryTests.swift in Sources */,
 				EDC3D3552CB70A3F00C62DE3 /* OpenSearchEngineTests.swift in Sources */,
 				E571EE7E28756A130051D9AA /* StoryProviderTests.swift in Sources */,
@@ -20244,6 +20275,7 @@
 				C869915728917809007ACC5C /* NetworkingMock.swift in Sources */,
 				ED575BD32D00F9D00056BCDA /* MockTemporaryDocument.swift in Sources */,
 				8A9D31682D135A1300171502 /* MockBookmarksSaver.swift in Sources */,
+				F00CA4022F00000000000007 /* MockWorldCupAPIClient.swift in Sources */,
 				C2886BB22EC4AB58007AE6C3 /* TinyRouterTests.swift in Sources */,
 				8A4190D22A6B0848001E8401 /* StatusBarOverlayTests.swift in Sources */,
 				C2500D7C2ECB4A600071506F /* MockTranslationModelsFetcher.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1152,6 +1152,8 @@
 		8A9D31662D13586500171502 /* MockFolderHierarchyFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31652D13586100171502 /* MockFolderHierarchyFetcher.swift */; };
 		8A9D31682D135A1300171502 /* MockBookmarksSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31672D135A1300171502 /* MockBookmarksSaver.swift */; };
 		F00CA4022F00000000000007 /* MockWorldCupAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000008 /* MockWorldCupAPIClient.swift */; };
+		F00CA4022F00000000000009 /* WorldCupAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F0000000000000A /* WorldCupAPIClientTests.swift */; };
+		F00CA4022F0000000000000B /* MockWorldCupFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F0000000000000C /* MockWorldCupFetchStrategy.swift */; };
 		8A9D316A2D135EB000171502 /* EditBookmarkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31692D135EB000171502 /* EditBookmarkViewModelTests.swift */; };
 		8A9E041B2D4D08350022ED90 /* BookmarkConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9E041A2D4D08350022ED90 /* BookmarkConfiguration.swift */; };
 		8A9E041D2D4D09240022ED90 /* BookmarksSectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9E041C2D4D09230022ED90 /* BookmarksSectionState.swift */; };
@@ -9575,6 +9577,8 @@
 		8A9D31652D13586100171502 /* MockFolderHierarchyFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFolderHierarchyFetcher.swift; sourceTree = "<group>"; };
 		8A9D31672D135A1300171502 /* MockBookmarksSaver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBookmarksSaver.swift; sourceTree = "<group>"; };
 		F00CA4022F00000000000008 /* MockWorldCupAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWorldCupAPIClient.swift; sourceTree = "<group>"; };
+		F00CA4022F0000000000000A /* WorldCupAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupAPIClientTests.swift; sourceTree = "<group>"; };
+		F00CA4022F0000000000000C /* MockWorldCupFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWorldCupFetchStrategy.swift; sourceTree = "<group>"; };
 		8A9D31692D135EB000171502 /* EditBookmarkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditBookmarkViewModelTests.swift; sourceTree = "<group>"; };
 		8A9E041A2D4D08350022ED90 /* BookmarkConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkConfiguration.swift; sourceTree = "<group>"; };
 		8A9E041C2D4D09230022ED90 /* BookmarksSectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksSectionState.swift; sourceTree = "<group>"; };
@@ -15476,6 +15480,7 @@
 				0B7B053E2D64C022007FD7AC /* MockTabWebView.swift */,
 				8A9D31672D135A1300171502 /* MockBookmarksSaver.swift */,
 				F00CA4022F00000000000008 /* MockWorldCupAPIClient.swift */,
+				F00CA4022F0000000000000C /* MockWorldCupFetchStrategy.swift */,
 				8A9D31652D13586100171502 /* MockFolderHierarchyFetcher.swift */,
 				45D5EDBF292D619000311934 /* MockablePinnedSites.swift */,
 				434CD57729F6FC4500A0D04B /* MockAppAuthenticator.swift */,
@@ -16894,6 +16899,7 @@
 				C28EA9802FA2554800AEC3AD /* WorldCupCountdownModelTests.swift */,
 				F00CA4022F00000000000002 /* WorldCupMatchesResponseTests.swift */,
 				F00CA4022F00000000000006 /* WorldCupFetchStrategyTests.swift */,
+				F00CA4022F0000000000000A /* WorldCupAPIClientTests.swift */,
 				C28EA9832FA2554900AEC3AE /* WorldCupTelemetryTests.swift */,
 				1D62C5262EE8E77C00C6BCB9 /* RelayControllerTests.swift */,
 				8AFA66012CA2935C0008D0F6 /* RemoteSettings */,
@@ -20276,6 +20282,8 @@
 				ED575BD32D00F9D00056BCDA /* MockTemporaryDocument.swift in Sources */,
 				8A9D31682D135A1300171502 /* MockBookmarksSaver.swift in Sources */,
 				F00CA4022F00000000000007 /* MockWorldCupAPIClient.swift in Sources */,
+				F00CA4022F0000000000000B /* MockWorldCupFetchStrategy.swift in Sources */,
+				F00CA4022F00000000000009 /* WorldCupAPIClientTests.swift in Sources */,
 				C2886BB22EC4AB58007AE6C3 /* TinyRouterTests.swift in Sources */,
 				8A4190D22A6B0848001E8401 /* StatusBarOverlayTests.swift in Sources */,
 				C2500D7C2ECB4A600071506F /* MockTranslationModelsFetcher.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClient.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClient.swift
@@ -55,4 +55,3 @@ final class WorldCupAPIClient: WorldCupAPIClientProtocol, @unchecked Sendable {
         return try decoder.decode(WorldCupMatchesResponse.self, from: data)
     }
 }
-

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClient.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClient.swift
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import MozillaAppServices
+
+/// Thin Swift wrapper around the FFI-generated `MozillaAppServices.WorldCupClient`.
+/// Exposes the merino WCS endpoints as parsed Swift values, isolating callers from
+/// raw JSON strings and from the FFI surface itself (which simplifies mocking in tests).
+final class WorldCupAPIClient: WorldCupAPIClientProtocol, @unchecked Sendable {
+    static let emptyOptions = WorldCupOptions(limit: nil, teams: nil, acceptLanguage: nil)
+    static let emptyConfig = WorldCupConfig(baseHost: nil)
+
+    private let client: WorldCupClient
+    private let decoder: JSONDecoder
+    private let matchesStrategy: WorldCupFetchStrategyProtocol
+    private let liveStrategy: WorldCupFetchStrategyProtocol
+
+    init(config: WorldCupConfig = WorldCupAPIClient.emptyConfig,
+         matchesStrategy: WorldCupFetchStrategyProtocol = WorldCupNormalFetchStrategy(),
+         liveStrategy: WorldCupFetchStrategyProtocol = WorldCupNormalFetchStrategy()) throws {
+        self.client = try WorldCupClient(config: config)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        self.decoder = decoder
+        self.matchesStrategy = matchesStrategy
+        self.liveStrategy = liveStrategy
+    }
+
+    /// Low-level sync fetch + decode. Throws on FFI error or decode failure.
+    func fetch(_ query: WorldCupQuery,
+               options: WorldCupOptions = WorldCupAPIClient.emptyOptions) throws -> WorldCupMatchesResponse? {
+        let json = switch query {
+        case .matches: try client.getMatches(options: options)
+        case .live:    try client.getLive(options: options)
+        }
+        return try decode(json)
+    }
+
+    /// High-level async loader: delegates to the strategy configured for the
+    /// given query (live vs non-live). The strategy decides how to call `fetch`
+    /// (single attempt, retry, etc.) and builds the `WorldCupMatches` view-model.
+    func loadMatches(query: WorldCupQuery,
+                     phase: WorldCupMatches.Phase) async -> WorldCupMatches? {
+        let strategy: WorldCupFetchStrategyProtocol = switch query {
+        case .matches: matchesStrategy
+        case .live:    liveStrategy
+        }
+        return await strategy.loadMatches(using: self, query: query, phase: phase)
+    }
+
+    private func decode(_ json: String?) throws -> WorldCupMatchesResponse? {
+        guard let data = json?.data(using: .utf8) else { return nil }
+        return try decoder.decode(WorldCupMatchesResponse.self, from: data)
+    }
+}
+

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClient.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClient.swift
@@ -40,14 +40,14 @@ final class WorldCupAPIClient: WorldCupAPIClientProtocol, @unchecked Sendable {
 
     /// High-level async loader: delegates to the strategy configured for the
     /// given query (live vs non-live). The strategy decides how to call `fetch`
-    /// (single attempt, retry, etc.) and builds the `WorldCupMatches` view-model.
-    func loadMatches(query: WorldCupQuery,
-                     phase: WorldCupMatches.Phase) async -> WorldCupMatches? {
+    /// (single attempt, retry, etc.) and returns the decoded merino response.
+    /// Callers transform the response into a view-model.
+    func loadMatches(query: WorldCupQuery) async -> WorldCupMatchesResponse? {
         let strategy: WorldCupFetchStrategyProtocol = switch query {
         case .matches: matchesStrategy
         case .live:    liveStrategy
         }
-        return await strategy.loadMatches(using: self, query: query, phase: phase)
+        return await strategy.loadMatches(using: self, query: query)
     }
 
     private func decode(_ json: String?) throws -> WorldCupMatchesResponse? {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClientProtocol.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClientProtocol.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import MozillaAppServices
+
+/// Which merino WCS endpoint to hit. Used by `WorldCupAPIClientProtocol`.
+enum WorldCupQuery: Equatable {
+    case matches, live
+}
+
+/// Surface for the merino World Cup matches client. Concrete impl lives in
+/// `WorldCupAPIClient`; mocks conform to the same protocol in tests.
+protocol WorldCupAPIClientProtocol: Sendable {
+    /// Low-level sync fetch + decode. Throws on FFI error or decode failure.
+    func fetch(_ query: WorldCupQuery, options: WorldCupOptions) throws -> WorldCupMatchesResponse?
+
+    /// High-level async loader: dispatches the fetch through the configured
+    /// fetch strategy and returns the decoded merino response. `nil` if the
+    /// strategy fails. Callers transform the response into a view-model.
+    func loadMatches(query: WorldCupQuery) async -> WorldCupMatchesResponse?
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupFetchStrategyProtocol.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupFetchStrategyProtocol.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Policy that drives how the matches response is loaded — single attempt,
+/// retry with backoff, etc. Each strategy is a complete recipe: it receives
+/// the low-level client and is responsible for orchestrating the call(s) and
+/// returning the decoded response. Add a new conformer (e.g. exponential
+/// backoff) without changing call sites by passing it to
+/// `WorldCupAPIClient.init(matchesStrategy:liveStrategy:)`.
+protocol WorldCupFetchStrategyProtocol: Sendable {
+    func loadMatches(using client: WorldCupAPIClientProtocol,
+                     query: WorldCupQuery) async -> WorldCupMatchesResponse?
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchesResponse.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchesResponse.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Mirrors the JSON returned by the merino `/api/v1/wcs/matches` endpoint
+/// (wrapped by `MozillaAppServices.WorldCupClient.getMatches`). The `live`
+/// endpoint returns the same shape but only populates `current`.
+struct WorldCupMatchesResponse: Decodable, Equatable {
+    let previous: [Match]?
+    let current: [Match]?
+    let next: [Match]?
+
+    struct Match: Decodable, Equatable {
+        let date: String
+        let globalEventId: Int
+        let homeTeam: Team
+        let awayTeam: Team
+        let period: String?
+        let homeScore: Int?
+        let awayScore: Int?
+        let homeExtra: Int?
+        let awayExtra: Int?
+        let homePenalty: Int?
+        let awayPenalty: Int?
+        let clock: String?
+        /// "past", "live", or "scheduled".
+        /// Not typing this since we don't want to couple the client too tightly to the API's exact status values,
+        /// in case of future additions or changes.
+        let statusType: String?
+    }
+
+    struct Team: Decodable, Equatable {
+        /// 3-letter FIFA-style team key (e.g. `BRA`, `ENG`, `USA`).
+        let key: String
+        let name: String
+        let iconUrl: String?
+        let group: String?
+        let eliminated: Bool?
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Default fetch strategy. A single attempt with no retry. Returns `nil` on
+/// any failure (FFI error, decode error, missing payload).
+struct WorldCupNormalFetchStrategy: WorldCupFetchStrategyProtocol {
+    func loadMatches(using client: WorldCupAPIClientProtocol,
+                     query: WorldCupQuery) async -> WorldCupMatchesResponse? {
+        await Task.detached(priority: .userInitiated) { () -> WorldCupMatchesResponse? in
+            try? client.fetch(query, options: WorldCupAPIClient.emptyOptions)
+        }.value
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupAPIClient.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupAPIClient.swift
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import Foundation
+import MozillaAppServices
+
+enum MockWorldCupClientError: Error {
+    case network
+}
+
+final class MockWorldCupAPIClient: WorldCupAPIClientProtocol, @unchecked Sendable {
+    private let result: Result<WorldCupMatchesResponse?, Error>
+    private(set) var fetchCount = 0
+    private(set) var lastQuery: WorldCupQuery?
+
+    init(result: Result<WorldCupMatchesResponse?, Error>) {
+        self.result = result
+    }
+
+    func fetch(_ query: WorldCupQuery, options: WorldCupOptions) throws -> WorldCupMatchesResponse? {
+        fetchCount += 1
+        lastQuery = query
+        return try result.get()
+    }
+
+    /// Not exercised by current callers — strategies call `fetch` directly.
+    /// Provided to satisfy the protocol.
+    func loadMatches(query: WorldCupQuery) async -> WorldCupMatchesResponse? {
+        nil
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupFetchStrategy.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupFetchStrategy.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import Foundation
+
+final class MockWorldCupFetchStrategy: WorldCupFetchStrategyProtocol, @unchecked Sendable {
+    private let result: WorldCupMatchesResponse?
+    private(set) var callCount = 0
+    private(set) var lastQuery: WorldCupQuery?
+
+    init(result: WorldCupMatchesResponse? = nil) {
+        self.result = result
+    }
+
+    func loadMatches(using client: WorldCupAPIClientProtocol,
+                     query: WorldCupQuery) async -> WorldCupMatchesResponse? {
+        callCount += 1
+        lastQuery = query
+        return result
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WorldCupAPIClientTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WorldCupAPIClientTests.swift
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Testing
+import Foundation
+import MozillaAppServices
+@testable import Client
+
+@Suite("WorldCupAPIClient")
+struct WorldCupAPIClientTests {
+    @Test
+    func test_loadMatches_withMatchesQuery_usesMatchesStrategy() async throws {
+        let matchesStrategy = MockWorldCupFetchStrategy()
+        let liveStrategy = MockWorldCupFetchStrategy()
+        let client = try WorldCupAPIClient(matchesStrategy: matchesStrategy,
+                                           liveStrategy: liveStrategy)
+
+        _ = await client.loadMatches(query: .matches)
+
+        #expect(matchesStrategy.callCount == 1)
+        #expect(matchesStrategy.lastQuery == .matches)
+        #expect(liveStrategy.callCount == 0)
+    }
+
+    @Test
+    func test_loadMatches_withLiveQuery_usesLiveStrategy() async throws {
+        let matchesStrategy = MockWorldCupFetchStrategy()
+        let liveStrategy = MockWorldCupFetchStrategy()
+        let client = try WorldCupAPIClient(matchesStrategy: matchesStrategy,
+                                           liveStrategy: liveStrategy)
+
+        _ = await client.loadMatches(query: .live)
+
+        #expect(liveStrategy.callCount == 1)
+        #expect(liveStrategy.lastQuery == .live)
+        #expect(matchesStrategy.callCount == 0)
+    }
+
+    @Test
+    func test_loadMatches_returnsStrategyResult() async throws {
+        let response = makeResponse()
+        let strategy = MockWorldCupFetchStrategy(result: response)
+        let client = try WorldCupAPIClient(matchesStrategy: strategy)
+
+        let result = await client.loadMatches(query: .matches)
+
+        #expect(result == response)
+    }
+
+    @Test
+    func test_loadMatches_returnsNil_whenStrategyReturnsNil() async throws {
+        let strategy = MockWorldCupFetchStrategy(result: nil)
+        let client = try WorldCupAPIClient(matchesStrategy: strategy)
+
+        let result = await client.loadMatches(query: .matches)
+
+        #expect(result == nil)
+    }
+
+    @Test
+    func test_emptyOptions_hasAllNilFields() {
+        let options = WorldCupAPIClient.emptyOptions
+        #expect(options.limit == nil)
+        #expect(options.teams == nil)
+        #expect(options.acceptLanguage == nil)
+    }
+
+    private func makeResponse() -> WorldCupMatchesResponse {
+        let homeTeam = WorldCupMatchesResponse.Team(
+            key: "ENG",
+            name: "England",
+            iconUrl: nil,
+            group: nil,
+            eliminated: false
+        )
+        let awayTeam = WorldCupMatchesResponse.Team(
+            key: "USA",
+            name: "United States",
+            iconUrl: nil,
+            group: nil,
+            eliminated: false
+        )
+        let match = WorldCupMatchesResponse.Match(
+            date: "2026-05-11T14:00:00+00:00",
+            globalEventId: 1,
+            homeTeam: homeTeam,
+            awayTeam: awayTeam,
+            period: "2",
+            homeScore: 1,
+            awayScore: 0,
+            homeExtra: nil,
+            awayExtra: nil,
+            homePenalty: nil,
+            awayPenalty: nil,
+            clock: "67",
+            statusType: "live"
+        )
+        return WorldCupMatchesResponse(previous: nil, current: [match], next: nil)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WorldCupFetchStrategyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WorldCupFetchStrategyTests.swift
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Testing
+import Foundation
+import MozillaAppServices
+@testable import Client
+
+@Suite("WorldCupNormalFetchStrategy")
+struct WorldCupFetchStrategyTests {
+    @Test
+    func test_returnsResponse_whenClientReturnsResponse() async {
+        let fixture = makeResponse()
+        let stub = MockWorldCupAPIClient(result: .success(fixture))
+        let strategy = WorldCupNormalFetchStrategy()
+
+        let response = await strategy.loadMatches(using: stub, query: .matches)
+
+        #expect(response == fixture)
+    }
+
+    @Test
+    func test_returnsNil_whenClientReturnsNil() async {
+        let stub = MockWorldCupAPIClient(result: .success(nil))
+        let strategy = WorldCupNormalFetchStrategy()
+
+        let response = await strategy.loadMatches(using: stub, query: .matches)
+
+        #expect(response == nil)
+    }
+
+    @Test
+    func test_returnsNil_whenClientThrows() async {
+        let stub = MockWorldCupAPIClient(result: .failure(MockWorldCupClientError.network))
+        let strategy = WorldCupNormalFetchStrategy()
+
+        let response = await strategy.loadMatches(using: stub, query: .matches)
+
+        #expect(response == nil)
+    }
+
+    @Test
+    func test_callsFetchExactlyOnce_onSuccess() async {
+        let stub = MockWorldCupAPIClient(result: .success(makeResponse()))
+        let strategy = WorldCupNormalFetchStrategy()
+
+        _ = await strategy.loadMatches(using: stub, query: .matches)
+
+        #expect(stub.fetchCount == 1)
+    }
+
+    @Test
+    func test_doesNotRetry_onFailure() async {
+        let stub = MockWorldCupAPIClient(result: .failure(MockWorldCupClientError.network))
+        let strategy = WorldCupNormalFetchStrategy()
+
+        _ = await strategy.loadMatches(using: stub, query: .matches)
+
+        #expect(stub.fetchCount == 1)
+    }
+
+    @Test
+    func test_forwardsQuery_toClient() async {
+        let stub = MockWorldCupAPIClient(result: .success(makeResponse()))
+        let strategy = WorldCupNormalFetchStrategy()
+
+        _ = await strategy.loadMatches(using: stub, query: .live)
+
+        #expect(stub.lastQuery == .live)
+    }
+
+    private func makeResponse() -> WorldCupMatchesResponse {
+        let homeTeam = WorldCupMatchesResponse.Team(
+            key: "ENG",
+            name: "England",
+            iconUrl: nil,
+            group: nil,
+            eliminated: false
+        )
+
+        let awayTeam = WorldCupMatchesResponse.Team(
+            key: "USA",
+            name: "United States",
+            iconUrl: nil,
+            group: nil,
+            eliminated: false
+        )
+
+        return WorldCupMatchesResponse(
+            previous: nil,
+            current: [
+                WorldCupMatchesResponse.Match(
+                    date: "2026-05-11T14:00:00+00:00",
+                    globalEventId: 1,
+                    homeTeam: homeTeam,
+                    awayTeam: awayTeam,
+                    period: "2",
+                    homeScore: 1,
+                    awayScore: 0,
+                    homeExtra: nil,
+                    awayExtra: nil,
+                    homePenalty: nil,
+                    awayPenalty: nil,
+                    clock: "67",
+                    statusType: "live"
+                )
+            ],
+            next: nil
+        )
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WorldCupMatchesResponseTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WorldCupMatchesResponseTests.swift
@@ -87,6 +87,125 @@ struct WorldCupMatchesResponseTests {
         #expect(scheduled.awayTeam.iconUrl == nil)
     }
 
+    @Test
+    func test_decodesPreviousSection_withPenaltyShootout() throws {
+        let json = """
+        {
+          "previous": [{
+            "date": "2026-04-29T18:00:00+00:00",
+            "global_event_id": 999,
+            "home_team": {
+              "key": "GER", "name": "Germany",
+              "icon_url": null, "group": "Group A", "eliminated": false
+            },
+            "away_team": {
+              "key": "FRA", "name": "France",
+              "icon_url": null, "group": "Group A", "eliminated": false
+            },
+            "period": "FT(P)",
+            "home_score": 1, "away_score": 1,
+            "home_extra": 1, "away_extra": 1,
+            "home_penalty": 5, "away_penalty": 4,
+            "clock": "120", "status_type": "past"
+          }]
+        }
+        """
+        let response = try decode(json)
+        let past = try #require(response.previous?.first)
+
+        #expect(response.previous?.count == 1)
+        #expect(response.current == nil)
+        #expect(response.next == nil)
+        #expect(past.homeExtra == 1)
+        #expect(past.awayExtra == 1)
+        #expect(past.homePenalty == 5)
+        #expect(past.awayPenalty == 4)
+        #expect(past.period == "FT(P)")
+        #expect(past.statusType == "past")
+        #expect(past.homeTeam.group == "Group A")
+        #expect(past.awayTeam.eliminated == false)
+    }
+
+    @Test
+    func test_decodesEmptyTopLevelObject() throws {
+        let response = try decode("{}")
+        #expect(response.previous == nil)
+        #expect(response.current == nil)
+        #expect(response.next == nil)
+    }
+
+    @Test
+    func test_decodesEmptyArrays() throws {
+        let response = try decode(#"{ "previous": [], "current": [], "next": [] }"#)
+        #expect(response.previous?.isEmpty == true)
+        #expect(response.current?.isEmpty == true)
+        #expect(response.next?.isEmpty == true)
+    }
+
+    @Test
+    func test_decodesIgnoresUnknownTopLevelKeys() throws {
+        let response = try decode(#"{ "current": [], "unknown_field": "ignored", "extra": 42 }"#)
+        #expect(response.current?.isEmpty == true)
+    }
+
+    @Test
+    func test_responseEquality_sameContent() {
+        let responseA = WorldCupMatchesResponse(previous: nil, current: nil, next: nil)
+        let responseB = WorldCupMatchesResponse(previous: nil, current: nil, next: nil)
+        #expect(responseA == responseB)
+    }
+
+    @Test
+    func test_responseEquality_differentBuckets() {
+        let responseA = WorldCupMatchesResponse(previous: nil, current: nil, next: nil)
+        let responseB = WorldCupMatchesResponse(previous: nil, current: [], next: nil)
+        #expect(responseA != responseB)
+    }
+
+    @Test
+    func test_matchEquality() {
+        let team = WorldCupMatchesResponse.Team(
+            key: "ENG",
+            name: "England",
+            iconUrl: nil,
+            group: nil,
+            eliminated: false
+        )
+        let matchA = WorldCupMatchesResponse.Match(
+            date: "2026-05-11T14:00:00+00:00",
+            globalEventId: 1,
+            homeTeam: team,
+            awayTeam: team,
+            period: nil,
+            homeScore: nil,
+            awayScore: nil,
+            homeExtra: nil,
+            awayExtra: nil,
+            homePenalty: nil,
+            awayPenalty: nil,
+            clock: nil,
+            statusType: nil
+        )
+        let matchB = matchA
+        let matchC = WorldCupMatchesResponse.Match(
+            date: "2026-05-11T14:00:00+00:00",
+            globalEventId: 2,
+            homeTeam: team,
+            awayTeam: team,
+            period: nil,
+            homeScore: nil,
+            awayScore: nil,
+            homeExtra: nil,
+            awayExtra: nil,
+            homePenalty: nil,
+            awayPenalty: nil,
+            clock: nil,
+            statusType: nil
+        )
+        #expect(matchA == matchB)
+        #expect(matchA != matchC)
+    }
+
     private func decode(_ json: String) throws -> WorldCupMatchesResponse {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WorldCupMatchesResponseTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WorldCupMatchesResponseTests.swift
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Testing
+import Foundation
+@testable import Client
+
+@Suite("WorldCupMatchesResponse decoding")
+struct WorldCupMatchesResponseTests {
+    // Representative payload modeled after the merino WCS fixture: one live match
+    // (with PK fields), one scheduled match (with null scores). Verifies snake_case
+    // -> camelCase decoding and that null-vs-missing optional fields decode cleanly.
+    private let json = """
+    {
+      "current": [{
+        "date": "2026-04-30T14:00:00+00:00",
+        "global_event_id": 1002,
+        "home_team": {
+          "key": "ENG", "global_team_id": 5, "name": "England", "region": "ENG",
+          "colors": ["White","Red"], "icon_url": "https://example.com/eng.png",
+          "group": "Group C", "eliminated": false,
+          "standing": {"wins":0,"losses":0,"draws":0,"points":0}
+        },
+        "away_team": {
+          "key": "USA", "global_team_id": 6, "name": "United States", "region": "USA",
+          "colors": ["Navy","White","Red"], "icon_url": "https://example.com/usa.png",
+          "group": "Group C", "eliminated": false,
+          "standing": {"wins":0,"losses":0,"draws":0,"points":0}
+        },
+        "period": "2", "home_score": 1, "away_score": 0,
+        "home_extra": null, "away_extra": null,
+        "home_penalty": null, "away_penalty": null,
+        "clock": "67", "updated": 1, "status": "In Progress",
+        "status_type": "live", "query": null, "sport": "soccer"
+      }],
+      "next": [{
+        "date": "2026-05-01T15:00:00+00:00",
+        "global_event_id": 1004,
+        "home_team": {
+          "key": "ARG", "global_team_id": 2, "name": "Argentina", "region": "ARG",
+          "colors": [], "icon_url": null, "group": "Group A", "eliminated": false,
+          "standing": {"wins":0,"losses":0,"draws":0,"points":0}
+        },
+        "away_team": {
+          "key": "ENG", "global_team_id": 5, "name": "England", "region": "ENG",
+          "colors": [], "icon_url": null, "group": "Group C", "eliminated": false,
+          "standing": {"wins":0,"losses":0,"draws":0,"points":0}
+        },
+        "period": "1", "home_score": null, "away_score": null,
+        "home_extra": null, "away_extra": null,
+        "home_penalty": null, "away_penalty": null,
+        "clock": "0", "updated": 1, "status": "Scheduled",
+        "status_type": "scheduled", "query": null, "sport": "soccer"
+      }]
+    }
+    """
+
+    @Test
+    func test_decodesLiveAndNextSections() throws {
+        let response = try decode(json)
+
+        #expect(response.previous == nil)
+        #expect(response.current?.count == 1)
+        #expect(response.next?.count == 1)
+
+        let live = try #require(response.current?.first)
+        #expect(live.homeTeam.key == "ENG")
+        #expect(live.awayTeam.key == "USA")
+        #expect(live.homeScore == 1)
+        #expect(live.awayScore == 0)
+        #expect(live.clock == "67")
+        #expect(live.statusType == "live")
+        #expect(live.homeTeam.iconUrl == "https://example.com/eng.png")
+    }
+
+    @Test
+    func test_decodesScheduledMatchWithNullScores() throws {
+        let response = try decode(json)
+        let scheduled = try #require(response.next?.first)
+
+        #expect(scheduled.homeScore == nil)
+        #expect(scheduled.awayScore == nil)
+        #expect(scheduled.homePenalty == nil)
+        #expect(scheduled.awayPenalty == nil)
+        #expect(scheduled.statusType == "scheduled")
+        #expect(scheduled.awayTeam.iconUrl == nil)
+    }
+
+    private func decode(_ json: String) throws -> WorldCupMatchesResponse {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(WorldCupMatchesResponse.self, from: Data(json.utf8))
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15777)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33746)

## :bulb: Description
This PR:
- Adds `WorldCupAPIClient` which will be used to pull in match data ( either live or scheduled ).
- Adds a fetch strategy. For now, it's basic but the plan is to implement exponential backoff later.
- Adds tests.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

