### PR TITLE
Bugfix FXIOS-15690 Prevent shifting domain to the left when editing URL then cancelling in Reader View Mode

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -197,6 +197,11 @@ final class LocationView: UIView,
         configureURLTextField(config)
         configureA11y(config)
 
+        // Must be called before updateIconContainer. The overflow check inside updateIconContainer measures
+        // urlTextField.text to determine layout; without this call the text still holds the raw URL instead
+        // of the normalized host, causing overflow to trigger incorrectly in reader mode
+        // and producing a visible shift when the lock icon is hidden.
+
         formatAndTruncateURLTextField()
         updateIconContainer(isURLTextFieldCentered: isURLTextFieldCentered,
                             locationTextFieldTrailingPadding: uxConfig.locationTextFieldTrailingPadding)

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -60,12 +60,13 @@ final class LocationView: UIView,
     /// Determines if the URL text field's content is wider than the visible area, accounting for a safe offset.
     /// An additional offset (default is 0) used when reader mode is available,
     /// to ensure the text does not overlap the icon when the view is constrained to its superview.
-    private func isURLTextFieldWiderThanVisibleArea(safeOffset offset: CGFloat = 0) -> Bool {
+    private func isNormalizedHostWiderThanVisibleArea(safeOffset offset: CGFloat = 0) -> Bool {
         guard let text = urlTextField.text, let font = urlTextField.font, !scrollAlpha.isZero else {
             return false
         }
+        let (_, normalizedHost) = URL.getSubdomainAndHost(from: text)
         let locationViewVisibleWidth = frame.width - iconContainerStackView.frame.width - UX.horizontalSpace - offset
-        let urlTextFieldWidth = text.size(withAttributes: [.font: font]).width
+        let urlTextFieldWidth = normalizedHost.size(withAttributes: [.font: font]).width
 
         return urlTextFieldWidth >= locationViewVisibleWidth
     }
@@ -196,10 +197,6 @@ final class LocationView: UIView,
         configureURLTextField(config)
         configureA11y(config)
 
-        // Must be called before updateIconContainer. The overflow check inside updateIconContainer measures
-        // urlTextField.text to determine layout; without this call the text still holds the raw URL instead
-        // of the normalized host, causing overflow to trigger incorrectly in reader mode
-        // and producing a visible shift when the lock icon is hidden.
         formatAndTruncateURLTextField()
         updateIconContainer(isURLTextFieldCentered: isURLTextFieldCentered,
                             locationTextFieldTrailingPadding: uxConfig.locationTextFieldTrailingPadding)
@@ -220,19 +217,19 @@ final class LocationView: UIView,
 
     private func layoutContainerView(isEditing: Bool, isURLTextFieldCentered: Bool) {
         var newConstraints: [NSLayoutConstraint] = []
-        if isEditing || !isURLTextFieldCentered || isURLTextFieldWiderThanVisibleArea() {
+        if isEditing || !isURLTextFieldCentered || isNormalizedHostWiderThanVisibleArea() {
             // leading alignment configuration
             newConstraints = [
                 containerView.leadingAnchor.constraint(equalTo: leadingAnchor),
                 containerView.trailingAnchor.constraint(equalTo: trailingAnchor),
             ]
-        } else if isURLTextFieldWiderThanVisibleArea(safeOffset: UX.safeOffset) {
+        } else if isNormalizedHostWiderThanVisibleArea(safeOffset: UX.safeOffset) {
             newConstraints = [
                 containerView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
                 containerView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
                 containerView.centerXAnchor.constraint(equalTo: centerXAnchor)
             ]
-        } else if let superview, !isURLTextFieldWiderThanVisibleArea(safeOffset: UX.safeOffset) {
+        } else if let superview, !isNormalizedHostWiderThanVisibleArea(safeOffset: UX.safeOffset) {
             newConstraints = [
                 containerView.leadingAnchor.constraint(greaterThanOrEqualTo: superview.leadingAnchor),
                 containerView.trailingAnchor.constraint(lessThanOrEqualTo: superview.trailingAnchor),
@@ -325,7 +322,7 @@ final class LocationView: UIView,
     }
 
     private func updateGradient() {
-        let showGradientForLongURL = isURLTextFieldWiderThanVisibleArea() && !isEditing
+        let showGradientForLongURL = isNormalizedHostWiderThanVisibleArea() && !isEditing
         gradientView.isHidden = !showGradientForLongURL
         // Use the containerView height since gradient's view height could be still not updated here
         // This can avoid to call containerView.layoutIfNeeded() which is an expensive call.
@@ -334,7 +331,7 @@ final class LocationView: UIView,
     }
 
     private func updateURLTextFieldLeadingConstraintBasedOnState() {
-        let shouldAdjustForOverflow = isURLTextFieldWiderThanVisibleArea() && !isEditing
+        let shouldAdjustForOverflow = isNormalizedHostWiderThanVisibleArea() && !isEditing
         let shouldAdjustForNonEmpty = !isURLTextFieldEmpty && !isEditing
 
         func handleOverflowAdjustment() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15690)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33590)

## :bulb: Description
When cancelling URL editing in Reader View Mode, the domain would visually shift to the right. This was caused by the overflow check measuring urlTextField.text which still holds the raw URL during state transitions, incorrectly triggering the overflow adjustment which sets a phantom lock icon width in reader mode (since there is no lock icon), pushing the domain to the right. Fixed by measuring the normalized host directly instead, and removed the now-redundant call ordering comment in configure().

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

