### PR TITLE
[MTE-5320] - fixes for iOS 17.5 and 18.6 failures

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
@@ -84,7 +84,11 @@ class ClipBoardTests: BaseTestCase {
                 urlBarAddress.press(forDuration: 1)
             }
             app.otherElements.buttons["Paste"].waitAndTap()
-            mozWaitForValueContains(urlBarAddress, value: "https://www.example.com/")
+            if #available(iOS 18, *) {
+                mozWaitForValueContains(urlBarAddress, value: "https://www.example.com/")
+            } else {
+                mozWaitForValueContains(urlBarAddress, value: "http://www.example.com/")
+            }
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LibraryScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LibraryScreen.swift
@@ -22,6 +22,7 @@ final class LibraryScreen {
     private var bookmarkFolderCell: XCUIElement { sel.BOOKMARKS_FOLDER.element(in: app) }
     private var deleteButton: XCUIElement { sel.DELETE_BUTTON.element(in: app) }
     private var backButton: XCUIElement { sel.BACK_BUTTON.element(in: app) }
+    private var backButtoniOS18: XCUIElement { sel.BACK_BUTTON_iOS18.element(in: app) }
 
     func assertBookmarkExists(named name: String, timeout: TimeInterval = TIMEOUT_LONG) {
         let bookmarksTable = sel.BOOKMARKS_LIST.element(in: app)
@@ -130,7 +131,11 @@ final class LibraryScreen {
     }
 
     func tapBackButton() {
-        backButton.waitAndTap()
+        if #available(iOS 26, *) {
+            backButton.waitAndTap()
+        } else {
+            backButtoniOS18.firstMatch.waitAndTap()
+        }
     }
 
     func longPressAndSelectContextMenuOption(option: String) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/LibrarySelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/LibrarySelectors.swift
@@ -16,6 +16,7 @@ protocol LibrarySelectorsSet {
     var BOOKMARKS_FOLDER: Selector { get }
     var SAVE_BUTTON: Selector { get }
     var BACK_BUTTON: Selector { get }
+    var BACK_BUTTON_iOS18: Selector { get }
     var all: [Selector] { get }
 }
 
@@ -32,7 +33,8 @@ struct LibrarySelectors: LibrarySelectorsSet {
         static let titleTextFields = AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.titleTextField
         static let bookmarksFolder = AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.bookmarksFolder
         static let saveButton = AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.saveButton
-        static let backButton = AccessibilityIdentifiers.Settings.Search.backButtoniOS26
+        static let backButtoniOS26 = AccessibilityIdentifiers.Settings.Search.backButtoniOS26
+        static let backButtoniOS18 = "Bookmarks"
     }
 
     let BOOKMARKS_LIST = Selector.tableIdOrLabel(
@@ -54,8 +56,14 @@ struct LibrarySelectors: LibrarySelectorsSet {
     )
 
     let BACK_BUTTON = Selector.buttonId(
-        IDs.backButton,
-        description: "Boomark new folder back button",
+        IDs.backButtoniOS26,
+        description: "Boomark new folder back button for iOS 26",
+        groups: ["bookmark", "search"]
+    )
+
+    let BACK_BUTTON_iOS18 = Selector.buttonId(
+        IDs.backButtoniOS18,
+        description: "Boomark new folder back button for iOS 18 and lower",
         groups: ["bookmark", "search"]
     )
 
@@ -103,5 +111,5 @@ struct LibrarySelectors: LibrarySelectorsSet {
 
     var all: [Selector] { [BOOKMARKS_LIST, DELETE_BUTTON, SIGN_IN_BUTTON, BOOKMARK_EMPTY_STATE,
                            EDIT_BUTTON, BOTTOM_LEFT_BUTTON, TITLE_TEXT_FIELD, BOOKMARKS_FOLDER,
-                           DONE_BUTTON, BACK_BUTTON] }
+                           DONE_BUTTON, BACK_BUTTON, BACK_BUTTON_iOS18] }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5320

## :bulb: Description
Adjusted testClipboard and testEditModeRemainsActive to run on iOS 17.5 and iOS 18.6
