### PR TITLE
Refactor FXIOS-15446 [AccessibilityIdentifiers] Remove unused identifiers

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -93,7 +93,6 @@ struct AccessibilityIdentifiers {
         }
 
         struct HeaderView {
-            static let mainButton = "MainMenu.MainButton"
             static let closeButton = "MainMenu.CloseMenuButton"
         }
 
@@ -112,7 +111,6 @@ struct AccessibilityIdentifiers {
         static let whatsNew = "MainMenu.WhatsNew"
         static let saveToReadingList = "MainMenu.SaveToReadingList"
         static let addToShortcuts = "MainMenu.AddToShortcuts"
-        static let bookmarkThisPage = "MainMenu.BookmarkThisPage"
         static let bookmarkPage = "MainMenu.BookmarkPage"
         static let print = "MainMenu.Print"
         static let share = "MainMenu.Share"
@@ -300,12 +298,6 @@ struct AccessibilityIdentifiers {
         public static let back = "Back"
     }
 
-    struct SaveCardPrompt {
-        struct Prompt {
-            static let closeButton = "a11yCloseButton"
-        }
-    }
-
     struct Microsurvey {
         struct Prompt {
             static let firefoxLogo = "Microsurvey.Prompt.FirefoxLogo"
@@ -481,7 +473,6 @@ struct AccessibilityIdentifiers {
     }
 
     struct Upgrade {
-        static let backgroundImage = "Upgrade.BackgroundImage"
         static let upgrade = "upgrade."
         static let closeButton = "Upgrade.CloseButton"
         static let pageControl = "Upgrade.PageControl"
@@ -888,7 +879,6 @@ struct AccessibilityIdentifiers {
         static let rememberCreditCardHeader = "RememberCreditCard.Header"
         static let yesButton = "RememberCreditCard.yesButton"
         static let manageCardsButton = "RememberCreditCard.manageCardsButton"
-        static let notNowButton = "RememberCreditCard.notNowButton"
     }
 
     enum Autofill {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15446)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33127)

## :bulb: Description
- Removed 5 unused accessibility identifiers in the `Client` scope that were flagged by Periphery.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

