### PR TITLE
Bugfix FXIOS-15487 Temporary sitecompat workaround for Google AI keyboard issues

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1860,7 +1860,9 @@ class BrowserViewController: UIViewController,
         }
 
         // Temporary sitecompat workaround for FXIOS-15487. See comments in `bug15487_isGoogleAIPage()`.
-        if tabManager.selectedTab?.bug15487_isGoogleAIPage() ?? false {
+        if tabManager.selectedTab?.bug15487_isGoogleAIPage() ?? false,
+           traitCollection.verticalSizeClass != .compact,
+           traitCollection.horizontalSizeClass != .regular {
             overKeyboardContainer.removeKeyboardSpacer()
             return
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1859,6 +1859,12 @@ class BrowserViewController: UIViewController,
             return
         }
 
+        // Temporary sitecompat workaround for FXIOS-15487. See comments in `bug15487_isGoogleAIPage()`.
+        if tabManager.selectedTab?.bug15487_isGoogleAIPage() ?? false {
+            overKeyboardContainer.removeKeyboardSpacer()
+            return
+        }
+
         // To avoid some UI glitches, when authentication is in progress
         // we don't need to update/change keyboard spacer
         guard !appAuthenticator.isAuthenticating else { return }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1860,7 +1860,10 @@ class BrowserViewController: UIViewController,
         }
 
         // Temporary sitecompat workaround for FXIOS-15487. See comments in `bug15487_isGoogleAIPage()`.
-        if tabManager.selectedTab?.bug15487_isGoogleAIPage() ?? false,
+        let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: windowUUID)
+        let isEditing = toolbarState?.addressToolbar.isEditing == true
+        if !isEditing,
+           tabManager.selectedTab?.bug15487_isGoogleAIPage() ?? false,
            traitCollection.verticalSizeClass != .compact,
            traitCollection.horizontalSizeClass != .regular {
             overKeyboardContainer.removeKeyboardSpacer()

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -884,12 +884,12 @@ class Tab: NSObject,
     // MARK: - Temporary UI Workaround Hack/Fix (FXIOS-15487)
 
     func bug15487_isGoogleAIPage() -> Bool {
-        // This is a fragile hack. Implications have been discussed with Product team and we've decided
+        // Temporary UI workaround. Implications have been discussed with Product team and we've decided
         // to implement this for now to help alleviate difficulties for users using Google AI search.
         // We attempt to detect Google AI page here and if so this is used by the BVC to avoid presenting
         // our normal over-keyboard UI, which unfortunately causes the iOS keyboard to be dismissed due to
         // the size of Firefox's UI coupled with how we are resizing the WKWebView in our iOS browser.
-        // Longer-term fix is forthcoming.
+        // A longer-term fix is being discussed & is forthcoming.
         guard let url, let host = url.host else { return false }
         let hostLower = host.lowercased()
         guard hostLower.hasPrefix("www.google.") || hostLower.hasPrefix("google.") else { return false }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -881,6 +881,23 @@ class Tab: NSObject,
         }
     }
 
+    // MARK: - Temporary UI Workaround Hack/Fix (FXIOS-15487)
+
+    func bug15487_isGoogleAIPage() -> Bool {
+        // This is a fragile hack. Implications have been discussed with Product team and we've decided
+        // to implement this for now to help alleviate difficulties for users using Google AI search.
+        // We attempt to detect Google AI page here and if so this is used by the BVC to avoid presenting
+        // our normal over-keyboard UI, which unfortunately causes the iOS keyboard to be dismissed due to
+        // the size of Firefox's UI coupled with how we are resizing the WKWebView in our iOS browser.
+        // Longer-term fix is forthcoming.
+        guard let url, let host = url.host else { return false }
+        let hostLower = host.lowercased()
+        guard hostLower.hasPrefix("www.google.") || hostLower.hasPrefix("google.") else { return false }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else { return false }
+        return queryItems.contains(where: { $0.name == "udm" && $0.value == "50" })
+    }
+
     // MARK: - Temporary Document handling - PDF Refactor
 
     /// Retrieves the session cookies attached to the current `WKWebView` managed by the `Tab`

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -890,9 +890,8 @@ class Tab: NSObject,
         // our normal over-keyboard UI, which unfortunately causes the iOS keyboard to be dismissed due to
         // the size of Firefox's UI coupled with how we are resizing the WKWebView in our iOS browser.
         // A longer-term fix is being discussed & is forthcoming.
-        guard let url, let host = url.host else { return false }
-        let hostLower = host.lowercased()
-        guard hostLower.hasPrefix("www.google.") || hostLower.hasPrefix("google.") else { return false }
+        guard let url, let domain = url.shortDomain else { return false }
+        guard domain == "google" else { return false }
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let queryItems = components.queryItems else { return false }
         return queryItems.contains(where: { $0.name == "udm" && $0.value == "50" })


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15487)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33229)

## :bulb: Description

Temporary workaround to alleviate usability issues on Google AI search page. This is not a robust fix, and it will not address every scenario in which the bug is happening (and the bug will also occur on other websites).

👉 The team is aware of the root problem and a longer-term fix is being discussed. For now this just attempts to provide some temporary relief for users.

❗ **Important note:** the fix here is to avoid adding our normal keyboard spacer UI. This means that our normal over-keyboard UI will _not be displayed_ above the keyboard. This is an unfortunate trade-off but it will allow use of the Google AI search page and the implications have been discussed with Product team. Additionally this workaround is extremely targeted; this code has no effect on iPad, iPhone landscape, or non-google-AI pages, so impact should be minimal.

## :movie_camera: Demos

**Before**

https://github.com/user-attachments/assets/99e173e9-8143-47b0-b251-8c34604a15b1

**After**

https://github.com/user-attachments/assets/c78f3f26-7ee9-4186-89a1-865daa937944

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

