### PR TITLE
Bugfix FXIOS-15787 [Homepage] Move ads telemetry callback off the main thread

### DIFF
--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsCallbackTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsCallbackTelemetry.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Foundation
 import MozillaAppServices
 import Shared
 import Storage
@@ -19,17 +20,23 @@ final class DefaultUnifiedAdsCallbackTelemetry: UnifiedAdsCallbackTelemetry, Fea
     private let networking: UnifiedTileNetworking
     private let logger: Logger
     private let sponsoredTileGleanTelemetry: SponsoredTileGleanTelemetry
+    private let adsClientCallbackQueue: DispatchQueueInterface
 
     init(
         adsClientFactory: MozAdsClientFactory = DefaultMozAdsClientFactory(),
         networking: UnifiedTileNetworking = DefaultUnifiedTileNetwork(with: NetworkUtils.defaultURLSession()),
         logger: Logger = DefaultLogger.shared,
-        sponsoredTileGleanTelemetry: SponsoredTileGleanTelemetry = DefaultSponsoredTileGleanTelemetry()
+        sponsoredTileGleanTelemetry: SponsoredTileGleanTelemetry = DefaultSponsoredTileGleanTelemetry(),
+        adsClientCallbackQueue: DispatchQueueInterface = DispatchQueue(
+            label: "org.mozilla.ios.unified-ads-callback-telemetry",
+            qos: .utility
+        )
     ) {
         self.adsClient = adsClientFactory.createClient()
         self.networking = networking
         self.logger = logger
         self.sponsoredTileGleanTelemetry = sponsoredTileGleanTelemetry
+        self.adsClientCallbackQueue = adsClientCallbackQueue
     }
 
     private var isAdsClientEnabled: Bool {
@@ -44,13 +51,21 @@ final class DefaultUnifiedAdsCallbackTelemetry: UnifiedAdsCallbackTelemetry, Fea
         }
 
         if isAdsClientEnabled {
-            do {
-                try adsClient.recordImpression(impressionUrl: siteInfo.impressionURL, options: nil)
-            } catch {
-                logger.log("Ads client recordImpression failed, falling back to legacy: \(error)",
-                           level: .warning,
-                           category: .homepage)
-                sendTelemetry(urlString: siteInfo.impressionURL, position: position)
+            let impressionURL = siteInfo.impressionURL
+            adsClientCallbackQueue.async { [adsClient, logger, networking] in
+                do {
+                    try adsClient.recordImpression(impressionUrl: impressionURL, options: nil)
+                } catch {
+                    logger.log("Ads client recordImpression failed, falling back to legacy: \(error)",
+                               level: .warning,
+                               category: .homepage)
+                    Self.sendTelemetry(
+                        urlString: impressionURL,
+                        position: position,
+                        networking: networking,
+                        logger: logger
+                    )
+                }
             }
         } else {
             sendTelemetry(urlString: siteInfo.impressionURL, position: position)
@@ -66,13 +81,21 @@ final class DefaultUnifiedAdsCallbackTelemetry: UnifiedAdsCallbackTelemetry, Fea
         }
 
         if isAdsClientEnabled {
-            do {
-                try adsClient.recordClick(clickUrl: siteInfo.clickURL, options: nil)
-            } catch {
-                logger.log("Ads client recordClick failed, falling back to legacy: \(error)",
-                           level: .warning,
-                           category: .homepage)
-                sendTelemetry(urlString: siteInfo.clickURL, position: position)
+            let clickURL = siteInfo.clickURL
+            adsClientCallbackQueue.async { [adsClient, logger, networking] in
+                do {
+                    try adsClient.recordClick(clickUrl: clickURL, options: nil)
+                } catch {
+                    logger.log("Ads client recordClick failed, falling back to legacy: \(error)",
+                               level: .warning,
+                               category: .homepage)
+                    Self.sendTelemetry(
+                        urlString: clickURL,
+                        position: position,
+                        networking: networking,
+                        logger: logger
+                    )
+                }
             }
         } else {
             sendTelemetry(urlString: siteInfo.clickURL, position: position)
@@ -81,6 +104,15 @@ final class DefaultUnifiedAdsCallbackTelemetry: UnifiedAdsCallbackTelemetry, Fea
     }
 
     private func sendTelemetry(urlString: String, position: Int) {
+        Self.sendTelemetry(urlString: urlString, position: position, networking: networking, logger: logger)
+    }
+
+    private static func sendTelemetry(
+        urlString: String,
+        position: Int,
+        networking: UnifiedTileNetworking,
+        logger: Logger
+    ) {
         guard var urlComponents = URLComponents(string: urlString) else {
             logger.log("The provided URL is invalid: \(String(describing: urlString))",
                        level: .warning,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsCallbackTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsCallbackTelemetryTests.swift
@@ -17,6 +17,7 @@ final class UnifiedAdsCallbackTelemetryTests: XCTestCase {
     private var logger: MockLogger!
     private var gleanWrapper: MockGleanWrapper!
     private var mockAdsClient: MockMozAdsClient!
+    private var adsClientCallbackQueue: MockDispatchQueue!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -26,6 +27,7 @@ final class UnifiedAdsCallbackTelemetryTests: XCTestCase {
         logger = MockLogger()
         gleanWrapper = MockGleanWrapper()
         mockAdsClient = MockMozAdsClient()
+        adsClientCallbackQueue = MockDispatchQueue()
     }
 
     override func tearDown() async throws {
@@ -33,6 +35,7 @@ final class UnifiedAdsCallbackTelemetryTests: XCTestCase {
         logger = nil
         gleanWrapper = nil
         mockAdsClient = nil
+        adsClientCallbackQueue = nil
         DependencyHelperMock().reset()
         try await super.tearDown()
     }
@@ -141,6 +144,7 @@ final class UnifiedAdsCallbackTelemetryTests: XCTestCase {
         }
 
         subject.sendImpressionTelemetry(tileSite: tileSite, position: 1)
+        XCTAssertEqual(adsClientCallbackQueue.asyncCalled, 1)
         XCTAssertEqual(mockAdsClient.recordImpressionCalledWith, siteInfo.impressionURL)
         XCTAssertNil(mockAdsClient.recordClickCalledWith)
     }
@@ -155,6 +159,7 @@ final class UnifiedAdsCallbackTelemetryTests: XCTestCase {
         }
 
         subject.sendClickTelemetry(tileSite: tileSite, position: 1)
+        XCTAssertEqual(adsClientCallbackQueue.asyncCalled, 1)
         XCTAssertEqual(mockAdsClient.recordClickCalledWith, siteInfo.clickURL)
         XCTAssertNil(mockAdsClient.recordImpressionCalledWith)
     }
@@ -163,6 +168,7 @@ final class UnifiedAdsCallbackTelemetryTests: XCTestCase {
         let subject = createSubject()
 
         subject.sendImpressionTelemetry(tileSite: tileSite, position: 1)
+        XCTAssertEqual(adsClientCallbackQueue.asyncCalled, 0)
         XCTAssertNil(mockAdsClient.recordImpressionCalledWith)
     }
 
@@ -170,6 +176,7 @@ final class UnifiedAdsCallbackTelemetryTests: XCTestCase {
         let subject = createSubject()
 
         subject.sendClickTelemetry(tileSite: tileSite, position: 1)
+        XCTAssertEqual(adsClientCallbackQueue.asyncCalled, 0)
         XCTAssertNil(mockAdsClient.recordClickCalledWith)
     }
 
@@ -180,6 +187,7 @@ final class UnifiedAdsCallbackTelemetryTests: XCTestCase {
         let subject = createSubject()
 
         subject.sendImpressionTelemetry(tileSite: tileSite, position: 1)
+        XCTAssertEqual(adsClientCallbackQueue.asyncCalled, 1)
         XCTAssertNil(mockAdsClient.recordImpressionCalledWith)
         XCTAssertEqual(networking.dataFromCalled, 1)
     }
@@ -191,6 +199,7 @@ final class UnifiedAdsCallbackTelemetryTests: XCTestCase {
         let subject = createSubject()
 
         subject.sendClickTelemetry(tileSite: tileSite, position: 1)
+        XCTAssertEqual(adsClientCallbackQueue.asyncCalled, 1)
         XCTAssertNil(mockAdsClient.recordClickCalledWith)
         XCTAssertEqual(networking.dataFromCalled, 1)
     }
@@ -203,7 +212,8 @@ final class UnifiedAdsCallbackTelemetryTests: XCTestCase {
             adsClientFactory: MockMozAdsClientFactory(mockClient: mockAdsClient),
             networking: networking,
             logger: logger,
-            sponsoredTileGleanTelemetry: sponsoredTileGleanTelemetry
+            sponsoredTileGleanTelemetry: sponsoredTileGleanTelemetry,
+            adsClientCallbackQueue: adsClientCallbackQueue
         )
 
         trackForMemoryLeaks(subject, file: file, line: line)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15787)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33770)

## :bulb: Description
- Move Rust ads-client impression/click telemetry callback calls onto a background queue to avoid blocking the main actor.

### 📝 Technical Notes:
- Homepage top site tiles impression tracking runs on the main actor. When a sponsored tile became visible, the client synchronously called Rust `recordImpression` / `recordClick` from that main-thread path.
- Inside the ads client, a synchronous callback request is performed. If that request took several seconds, the main thread was blocked.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

