### PR TITLE
Add FXIOS-15790 [Newsfeed Categories] Enable categories and pinned headers in dev

### DIFF
--- a/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRedesignFeature.yaml
@@ -43,5 +43,5 @@ features:
           search-bar: false
           bookmarks-section-default: false
           jbi-section-default: false
-          categories-enabled: false
-          pinned-header-enabled: false
+          categories-enabled: true
+          pinned-header-enabled: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15790)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33771)

## :bulb: Description
- Turn on `stories-enabled` and `pinned-header-enabled` flags in dev

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

