### PR TITLE
Add FXIOS-15791 [WC] Initial data model

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1637,6 +1637,9 @@
 		F00CA4012F0000000000000D /* WorldCupAPIClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F0000000000000E /* WorldCupAPIClientProtocol.swift */; };
 		F00CA4012F0000000000000F /* WorldCupFetchStrategyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000010 /* WorldCupFetchStrategyProtocol.swift */; };
 		F00CA4012F00000000000011 /* WorldCupNormalFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000012 /* WorldCupNormalFetchStrategy.swift */; };
+		F00CA4032F00000000000001 /* WorldCupMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4032F00000000000002 /* WorldCupMatch.swift */; };
+		F00CA4032F00000000000003 /* WorldCupMatches.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4032F00000000000004 /* WorldCupMatches.swift */; };
+		F00CA4032F00000000000007 /* WorldCupMatchesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4032F00000000000008 /* WorldCupMatchesTests.swift */; };
 		F00CA4022F00000000000001 /* WorldCupMatchesResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000002 /* WorldCupMatchesResponseTests.swift */; };
 		F00CA4022F00000000000005 /* WorldCupFetchStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000006 /* WorldCupFetchStrategyTests.swift */; };
 		C2A72A672A76938C002ACCE2 /* DownloadsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A662A76938C002ACCE2 /* DownloadsCoordinator.swift */; };
@@ -10436,6 +10439,9 @@
 		C29B64ED2AD937D400F3244B /* QRCodeNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeNavigationHandler.swift; sourceTree = "<group>"; };
 		C2A057E22FA8C32200100C24 /* WorldCupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupCell.swift; sourceTree = "<group>"; };
 		F00CA4012F00000000000004 /* WorldCupMatchesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupMatchesResponse.swift; sourceTree = "<group>"; };
+		F00CA4032F00000000000002 /* WorldCupMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupMatch.swift; sourceTree = "<group>"; };
+		F00CA4032F00000000000004 /* WorldCupMatches.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupMatches.swift; sourceTree = "<group>"; };
+		F00CA4032F00000000000008 /* WorldCupMatchesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupMatchesTests.swift; sourceTree = "<group>"; };
 		F00CA4012F00000000000008 /* WorldCupAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupAPIClient.swift; sourceTree = "<group>"; };
 		F00CA4012F0000000000000E /* WorldCupAPIClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupAPIClientProtocol.swift; sourceTree = "<group>"; };
 		F00CA4012F00000000000010 /* WorldCupFetchStrategyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupFetchStrategyProtocol.swift; sourceTree = "<group>"; };
@@ -15144,6 +15150,8 @@
 				C250A68F2FAC875200BFB1AD /* WorldCupMatchCardView.swift */,
 				C2A057E22FA8C32200100C24 /* WorldCupCell.swift */,
 				F00CA4012F00000000000004 /* WorldCupMatchesResponse.swift */,
+				F00CA4032F00000000000002 /* WorldCupMatch.swift */,
+				F00CA4032F00000000000004 /* WorldCupMatches.swift */,
 				F00CA4012F00000000000008 /* WorldCupAPIClient.swift */,
 				F00CA4012F0000000000000E /* WorldCupAPIClientProtocol.swift */,
 				F00CA4012F00000000000010 /* WorldCupFetchStrategyProtocol.swift */,
@@ -16901,6 +16909,7 @@
 				03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */,
 				C28EA9802FA2554800AEC3AD /* WorldCupCountdownModelTests.swift */,
 				F00CA4022F00000000000002 /* WorldCupMatchesResponseTests.swift */,
+				F00CA4032F00000000000008 /* WorldCupMatchesTests.swift */,
 				F00CA4022F00000000000006 /* WorldCupFetchStrategyTests.swift */,
 				F00CA4022F0000000000000A /* WorldCupAPIClientTests.swift */,
 				C28EA9832FA2554900AEC3AE /* WorldCupTelemetryTests.swift */,
@@ -19562,6 +19571,8 @@
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
 				C2A057E32FA8C32200100C24 /* WorldCupCell.swift in Sources */,
 				F00CA4012F00000000000003 /* WorldCupMatchesResponse.swift in Sources */,
+				F00CA4032F00000000000001 /* WorldCupMatch.swift in Sources */,
+				F00CA4032F00000000000003 /* WorldCupMatches.swift in Sources */,
 				F00CA4012F00000000000007 /* WorldCupAPIClient.swift in Sources */,
 				F00CA4012F0000000000000D /* WorldCupAPIClientProtocol.swift in Sources */,
 				F00CA4012F0000000000000F /* WorldCupFetchStrategyProtocol.swift in Sources */,
@@ -20109,6 +20120,7 @@
 				D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */,
 				C28EA9812FA2554800AEC3AD /* WorldCupCountdownModelTests.swift in Sources */,
 				F00CA4022F00000000000001 /* WorldCupMatchesResponseTests.swift in Sources */,
+				F00CA4032F00000000000007 /* WorldCupMatchesTests.swift in Sources */,
 				F00CA4022F00000000000005 /* WorldCupFetchStrategyTests.swift in Sources */,
 				C28EA9822FA2554900AEC3AE /* WorldCupTelemetryTests.swift in Sources */,
 				EDC3D3552CB70A3F00C62DE3 /* OpenSearchEngineTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -133,6 +133,10 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
     private var currentState: WorldCupSectionState?
     private var onHeightChange: (() -> Void)?
     private var lastScrollViewWidth: CGFloat = 0
+    private var currentTheme: Theme?
+    private weak var matchesCardView: WorldCupMatchCardView?
+    private var matchesFetchTask: Task<Void, Never>?
+    private let apiClient: WorldCupAPIClientProtocol? = try? WorldCupAPIClient()
 
     override init(frame: CGRect) {
         super.init(frame: .zero)
@@ -214,6 +218,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
         onHeightChange: @escaping () -> Void
     ) {
         self.onHeightChange = onHeightChange
+        self.currentTheme = theme
         if currentState != state {
             currentState = state
             rebuildPages(for: state)
@@ -243,7 +248,41 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
     }
 
     private func makePages(for state: WorldCupSectionState) -> [UIView] {
-        return [PageContainer(content: WorldCupTimerView(windowUUID: state.windowUUID))]
+        let card = WorldCupMatchCardView(windowUUID: state.windowUUID)
+        card.configure(with: Self.emptyMatches, theme: currentTheme ?? LightTheme())
+        matchesCardView = card
+        scheduleMatchesFetch()
+
+        let contents: [UIView] = [
+            WorldCupTimerView(windowUUID: state.windowUUID),
+            card
+        ]
+        return contents.map { PageContainer(content: $0) }
+    }
+
+    /// Empty state shown while the merino fetch is in flight — no live pill,
+    /// no matches. Replaced on first successful fetch.
+    private static let emptyMatches = WorldCupMatches(
+        phaseTitle: String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel,
+        isLive: false,
+        featuredMatch: [],
+        upcomingMatches: []
+    )
+
+    /// Kicks off a real merino fetch via `WorldCupAPIClient` and reconfigures the
+    /// matches card when there is data. 
+    private func scheduleMatchesFetch() {
+        matchesFetchTask?.cancel()
+        guard let apiClient = self.apiClient else { return }
+        matchesFetchTask = Task { [weak self, apiClient] in
+            let response = await apiClient.loadMatches(query: .matches)
+            guard let response,
+                  !Task.isCancelled,
+                  let self,
+                  let card = self.matchesCardView else { return }
+            let matches = WorldCupMatches(response: response)
+            card.configure(with: matches, theme: self.currentTheme ?? LightTheme())
+        }
     }
 
     private func updateScrollViewHeight(for page: Int, animated: Bool, completion: (() -> Void)? = nil) {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// View-ready single match, built from a `WorldCupMatchesResponse.Match`.
+/// Fields are pre-formatted for direct display by the homepage matches widget.
+struct WorldCupMatch: Equatable {
+    struct Score: Equatable {
+        let score: String
+        let clock: String
+    }
+
+    let homeFlagAssetName: String
+    let homeCode: String
+    let awayFlagAssetName: String
+    let awayCode: String
+    let date: String
+    let score: Score?
+
+    init(homeFlagAssetName: String,
+         homeCode: String,
+         awayFlagAssetName: String,
+         awayCode: String,
+         date: String,
+         score: Score?) {
+        self.homeFlagAssetName = homeFlagAssetName
+        self.homeCode = homeCode
+        self.awayFlagAssetName = awayFlagAssetName
+        self.awayCode = awayCode
+        self.date = date
+        self.score = score
+    }
+
+    init(_ match: WorldCupMatchesResponse.Match,
+         localeProvider: LocaleProvider = SystemLocaleProvider()) {
+        self.homeCode = match.homeTeam.key
+        self.awayCode = match.awayTeam.key
+        // TODO: FXIOS-15778: Rename flag imageset names to 3-letter FIFA codes
+        // (br -> bra, us -> usa, etc.) so the team key can be used directly.
+        self.homeFlagAssetName = match.homeTeam.key.lowercased()
+        self.awayFlagAssetName = match.awayTeam.key.lowercased()
+        self.date = Self.formattedDate(match.date, locale: localeProvider.current)
+        self.score = Self.score(from: match)
+    }
+
+    nonisolated(unsafe) private static let isoFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static func formattedDate(_ iso: String, locale: Locale) -> String {
+        guard let date = isoFormatter.date(from: iso) else { return iso }
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("EEEMMMd")
+        return formatter.string(from: date)
+    }
+
+    private static func score(from match: WorldCupMatchesResponse.Match) -> Score? {
+        guard let home = match.homeScore, let away = match.awayScore else { return nil }
+        return Score(
+            score: scoreText(home: home, away: away,
+                             homePenalty: match.homePenalty,
+                             awayPenalty: match.awayPenalty),
+            clock: clockText(match.clock)
+        )
+    }
+
+    private static func scoreText(home: Int, away: Int,
+                                  homePenalty: Int?, awayPenalty: Int?) -> String {
+        if let homePK = homePenalty, let awayPK = awayPenalty {
+            return "\(home) (\(homePK)) – \(away) (\(awayPK))"
+        }
+        return "\(home) – \(away)"
+    }
+
+    private static func clockText(_ clock: String?) -> String {
+        clock.map { "\($0)'" } ?? ""
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
@@ -62,15 +62,19 @@ struct WorldCupMatch: Equatable {
     private static func score(from match: WorldCupMatchesResponse.Match) -> Score? {
         guard let home = match.homeScore, let away = match.awayScore else { return nil }
         return Score(
-            score: scoreText(home: home, away: away,
-                             homePenalty: match.homePenalty,
-                             awayPenalty: match.awayPenalty),
+            score: scoreText(
+                    home: home,
+                    away: away,
+                    homePenalty: match.homePenalty,
+                    awayPenalty: match.awayPenalty),
             clock: clockText(match.clock)
         )
     }
 
-    private static func scoreText(home: Int, away: Int,
-                                  homePenalty: Int?, awayPenalty: Int?) -> String {
+    private static func scoreText(home: Int,
+                                  away: Int,
+                                  homePenalty: Int?,
+                                  awayPenalty: Int?) -> String {
         if let homePK = homePenalty, let awayPK = awayPenalty {
             return "\(home) (\(homePK)) – \(away) (\(awayPK))"
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
@@ -25,42 +25,12 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
         static let liveLabelDotText = "•"
     }
 
-    /// A single match displayed in the card (either as a featured match or in the
-    /// upcoming-matches list below).
-    struct Match: Equatable {
-        struct Score: Equatable {
-            let score: String
-            let clock: String
-        }
-        let homeFlagAssetName: String
-        let homeCode: String
-        let awayFlagAssetName: String
-        let awayCode: String
-        let date: String
-        let score: Score?
-    }
-
-    struct Model: Equatable {
-        let phaseTitle: String
-        let phaseDate: String
-        let isLive: Bool
-        let featuredMatch: [Match]
-        let upcomingMatches: [Match]
-    }
-
     // MARK: - UI
 
     private lazy var titleLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.font = FXFontStyles.Bold.subheadline.scaledFont()
-        label.adjustsFontForContentSizeCategory = true
-    }
-
-    private lazy var dateLabel: UILabel = .build { label in
-        label.numberOfLines = 0
-        label.font = FXFontStyles.Regular.subheadline.scaledFont()
-        label.lineBreakMode = .byWordWrapping
         label.adjustsFontForContentSizeCategory = true
     }
 
@@ -127,7 +97,7 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
     // MARK: - State
 
     private let windowUUID: WindowUUID
-    private var model: Model?
+    private var model: WorldCupMatches?
     private var featuredDividers: [UIView] = []
 
     // MARK: - Init
@@ -149,7 +119,6 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
         liveLabelContainer.addSubview(liveLabel)
 
         headerStack.addArrangedSubview(titleLabel)
-        headerStack.addArrangedSubview(dateLabel)
         headerStack.addArrangedSubview(liveLabelContainer)
         // spacer view
         headerStack.addArrangedSubview(UIView())
@@ -197,24 +166,18 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
 
     // MARK: - Configuration
 
-    func configure(with model: Model, theme: Theme) {
+    func configure(with model: WorldCupMatches, theme: Theme) {
         guard model != self.model else { return }
         self.model = model
 
         rebuildFeaturedMatches(matches: model.featuredMatch)
         rebuildUpcomingRows(matches: model.upcomingMatches)
-        refreshHeader(model: model)
+        titleLabel.text = model.phaseTitle
+        liveLabelContainer.isHidden = !model.isLive
         applyTheme(theme: theme)
     }
 
-    private func refreshHeader(model: Model) {
-        titleLabel.text = model.phaseTitle
-        dateLabel.text = model.phaseDate
-        liveLabelContainer.isHidden = !model.isLive
-        dateLabel.isHidden = model.isLive
-    }
-
-    private func rebuildFeaturedMatches(matches: [Match]) {
+    private func rebuildFeaturedMatches(matches: [WorldCupMatch]) {
         featuredMatchesStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
         featuredDividers.forEach { $0.removeFromSuperview() }
         featuredDividers.removeAll()
@@ -239,7 +202,7 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
         }
     }
 
-    private func rebuildUpcomingRows(matches: [Match]) {
+    private func rebuildUpcomingRows(matches: [WorldCupMatch]) {
         upcomingStack.isHidden = matches.isEmpty
         upcomingStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
@@ -261,7 +224,6 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
 
     func applyTheme(theme: Theme) {
         titleLabel.textColor = theme.colors.textPrimary
-        dateLabel.textColor = theme.colors.textSecondary
         moreOptionsButton.tintColor = theme.colors.iconSecondary
         upcomingStackDivider.backgroundColor = theme.colors.borderSecondary
         liveLabelContainer.backgroundColor = theme.colors.gradientAIStrongStop1
@@ -418,7 +380,7 @@ private final class FeaturedMatchView: UIView, ThemeApplicable {
         scoreContainer.layer.cornerRadius = scoreContainer.frame.height / 2
     }
 
-    func configure(with match: WorldCupMatchCardView.Match) {
+    func configure(with match: WorldCupMatch) {
         homeColumn.flagView.image = UIImage(named: match.homeFlagAssetName)
         homeColumn.codeLabel.text = match.homeCode
         awayColumn.flagView.image = UIImage(named: match.awayFlagAssetName)
@@ -557,7 +519,7 @@ private final class UpcomingMatchRow: UIView, ThemeApplicable {
         }
     }
 
-    func configure(with match: WorldCupMatchCardView.Match) {
+    func configure(with match: WorldCupMatch) {
         homeFlagView.image = UIImage(named: match.homeFlagAssetName)
         homeCodeLabel.text = match.homeCode
         awayFlagView.image = UIImage(named: match.awayFlagAssetName)

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+struct WorldCupMatches: Equatable {
+    let phaseTitle: String
+    let isLive: Bool
+    /// One or two featured matches. When two are provided, a divider is rendered between them.
+    let featuredMatch: [WorldCupMatch]
+    /// The next two games after `featuredMatch`. Anything beyond two entries is ignored.
+    let upcomingMatches: [WorldCupMatch]
+
+    init(phaseTitle: String,
+         isLive: Bool,
+         featuredMatch: [WorldCupMatch],
+         upcomingMatches: [WorldCupMatch]) {
+        self.phaseTitle = phaseTitle
+        self.isLive = isLive
+        self.featuredMatch = featuredMatch
+        self.upcomingMatches = upcomingMatches
+    }
+
+    /// Selection rule:
+    /// - If `current` (live) matches exist, those are featured (up to 2) and `isLive` is `true`;
+    ///   `upcomingMatches` is the first two of `next`.
+    /// - Otherwise the first scheduled match becomes featured, `isLive` is `false`, and the
+    ///   following two scheduled matches become `upcomingMatches`.
+    init(response: WorldCupMatchesResponse,
+         localeProvider: LocaleProvider = SystemLocaleProvider()) {
+        let live = response.current ?? []
+        let scheduled = response.next ?? []
+
+        let featured: [WorldCupMatchesResponse.Match]
+        let upcoming: [WorldCupMatchesResponse.Match]
+
+        if live.isEmpty {
+            featured = Array(scheduled.prefix(1))
+            upcoming = Array(scheduled.dropFirst(1).prefix(2))
+            self.isLive = false
+        } else {
+            featured = Array(live.prefix(2))
+            upcoming = Array(scheduled.prefix(2))
+            self.isLive = true
+        }
+
+        self.phaseTitle = Self.phaseTitle(from: response)
+        self.featuredMatch = featured.map { WorldCupMatch($0, localeProvider: localeProvider) }
+        self.upcomingMatches = upcoming.map { WorldCupMatch($0, localeProvider: localeProvider) }
+    }
+
+    /// Maps the merino response to a localized phase label. Currently the only
+    /// reliable signal in the API is `team.group`. If any featured/upcoming
+    /// team carries a group assignment we're in group play. For knockout
+    /// rounds the merino payload doesn't yet carry a round identifier, so we
+    /// fall back to the generic "Upcoming" label until that exists upstream
+    /// or we count surviving teams from the response.
+    static func phaseTitle(from response: WorldCupMatchesResponse) -> String {
+        let activeMatches = (response.current ?? []) + (response.next ?? [])
+        let isGroupStage = activeMatches.contains { match in
+            match.homeTeam.group != nil || match.awayTeam.group != nil
+        }
+        return isGroupStage
+            ? String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel
+            : String.WorldCup.HomepageWidget.RoundPhase.UpcomingLabel
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WorldCupMatchesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WorldCupMatchesTests.swift
@@ -1,0 +1,191 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Testing
+import Foundation
+@testable import Client
+
+@Suite("WorldCupMatches view-model")
+struct WorldCupMatchesTests {
+    @Test
+    func test_init_withLiveMatches_marksLiveAndUsesCurrentAsFeatured() {
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: [
+                makeMatch(home: "ENG", away: "USA", homeScore: 1, awayScore: 0, clock: "67"),
+                makeMatch(home: "BRA", away: "GER", homeScore: 2, awayScore: 2, clock: "90+15")
+            ],
+            next: [
+                makeMatch(home: "ARG", away: "ENG"),
+                makeMatch(home: "FRA", away: "USA"),
+                makeMatch(home: "BRA", away: "GER")
+            ]
+        )
+
+        let model = WorldCupMatches(response: response)
+
+        #expect(model.isLive)
+        #expect(model.featuredMatch.map(\.homeCode) == ["ENG", "BRA"])
+        #expect(model.upcomingMatches.map(\.homeCode) == ["ARG", "FRA"])
+    }
+
+    @Test
+    func test_init_noLiveMatches_picksFirstScheduledAsFeaturedAndNextTwoAsUpcoming() {
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: [],
+            next: [
+                makeMatch(home: "ARG", away: "ENG"),
+                makeMatch(home: "FRA", away: "USA"),
+                makeMatch(home: "BRA", away: "GER"),
+                makeMatch(home: "POR", away: "ESP")
+            ]
+        )
+
+        let model = WorldCupMatches(response: response)
+
+        #expect(!model.isLive)
+        #expect(model.featuredMatch.map(\.homeCode) == ["ARG"])
+        #expect(model.upcomingMatches.map(\.homeCode) == ["FRA", "BRA"])
+    }
+
+    @Test
+    func test_init_emptyResponse_returnsEmptyArrays() {
+        let response = WorldCupMatchesResponse(previous: nil, current: nil, next: nil)
+        let model = WorldCupMatches(response: response)
+
+        #expect(!model.isLive)
+        #expect(model.featuredMatch.isEmpty)
+        #expect(model.upcomingMatches.isEmpty)
+    }
+
+    @Test
+    func test_match_score_regulationOnly() {
+        let match = WorldCupMatch(
+            makeMatch(home: "ENG", away: "USA", homeScore: 1, awayScore: 0, clock: "67")
+        )
+        #expect(match.score?.score == "1 – 0")
+        #expect(match.score?.clock == "67'")
+    }
+
+    @Test
+    func test_match_score_withPenaltyShootout() {
+        let match = WorldCupMatch(makeMatch(
+            home: "GER",
+            away: "FRA",
+            homeScore: 1,
+            awayScore: 1,
+            homePenalty: 5,
+            awayPenalty: 4,
+            clock: "120"
+        ))
+        #expect(match.score?.score == "1 (5) – 1 (4)")
+        #expect(match.score?.clock == "120'")
+    }
+
+    @Test
+    func test_match_score_isNilForScheduledMatches() {
+        let match = WorldCupMatch(
+            makeMatch(home: "ARG", away: "ENG", homeScore: nil, awayScore: nil)
+        )
+        #expect(match.score == nil)
+    }
+
+    @Test
+    func test_phaseTitle_groupStage_whenTeamsHaveGroup() {
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: [makeMatch(home: "ENG", away: "USA", group: "Group C")],
+            next: nil
+        )
+
+        #expect(WorldCupMatches.phaseTitle(from: response)
+                == String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel)
+    }
+
+    @Test
+    func test_phaseTitle_groupStage_whenGroupOnlyInUpcoming() {
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: [],
+            next: [makeMatch(home: "ARG", away: "FRA", group: "Group A")]
+        )
+
+        #expect(WorldCupMatches.phaseTitle(from: response)
+                == String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel)
+    }
+
+    @Test
+    func test_phaseTitle_upcoming_whenNoTeamsHaveGroup() {
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: [makeMatch(home: "ENG", away: "USA", group: nil)],
+            next: [makeMatch(home: "BRA", away: "GER", group: nil)]
+        )
+
+        #expect(WorldCupMatches.phaseTitle(from: response)
+                == String.WorldCup.HomepageWidget.RoundPhase.UpcomingLabel)
+    }
+
+    @Test
+    func test_phaseTitle_upcoming_whenResponseIsEmpty() {
+        let response = WorldCupMatchesResponse(previous: nil, current: nil, next: nil)
+
+        #expect(WorldCupMatches.phaseTitle(from: response)
+                == String.WorldCup.HomepageWidget.RoundPhase.UpcomingLabel)
+    }
+
+    @Test
+    func test_phaseTitle_ignoresPreviousMatches() {
+        let response = WorldCupMatchesResponse(
+            previous: [makeMatch(home: "BRA", away: "ARG", group: "Group A")],
+            current: nil,
+            next: nil
+        )
+
+        #expect(WorldCupMatches.phaseTitle(from: response)
+                == String.WorldCup.HomepageWidget.RoundPhase.UpcomingLabel)
+    }
+
+    private func makeMatch(home: String,
+                           away: String,
+                           homeScore: Int? = nil,
+                           awayScore: Int? = nil,
+                           homeExtra: Int? = nil,
+                           awayExtra: Int? = nil,
+                           homePenalty: Int? = nil,
+                           awayPenalty: Int? = nil,
+                           clock: String? = nil,
+                           group: String? = nil) -> WorldCupMatchesResponse.Match {
+        let homeTeam = WorldCupMatchesResponse.Team(
+            key: home,
+            name: home,
+            iconUrl: nil,
+            group: group,
+            eliminated: false
+        )
+        let awayTeam = WorldCupMatchesResponse.Team(
+            key: away,
+            name: away,
+            iconUrl: nil,
+            group: group,
+            eliminated: false
+        )
+        return WorldCupMatchesResponse.Match(
+            date: "2026-05-01T15:00:00+00:00",
+            globalEventId: 0,
+            homeTeam: homeTeam,
+            awayTeam: awayTeam,
+            period: nil,
+            homeScore: homeScore,
+            awayScore: awayScore,
+            homeExtra: homeExtra,
+            awayExtra: awayExtra,
+            homePenalty: homePenalty,
+            awayPenalty: awayPenalty,
+            clock: clock,
+            statusType: nil
+        )
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15791)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33773)

## :bulb: Description
This PR:
  - Adds `WorldCupMatch` and `WorldCupMatches` view-models that builds from a `WorldCupMatchesResponse`                                                    
  - Adds WorldCupMatches.phaseTitle(from:) that derives a localized header label from the merino response — uses team.group to detect group stage (backend still needs a round field for QF/SF/Final)               
  - Adds tests

<img width="338" height="318" alt="Screenshot 2026-05-12 at 13 47 46" src="https://github.com/user-attachments/assets/6b31fef1-4eaa-4210-b4e9-a68a8f551a2e" />


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

