### PR TITLE
Refactor FXIOS-15750 [Tab manager deeplink] Refactor startup metrics

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -63,7 +63,7 @@ class AppDelegate: UIResponder,
         willFinishLaunchingWithOptions
         launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        startRecordingStartupOpenURLTime()
+        shareTelemetry.recordOpenDeeplinkTime()
         // Configure app information for BrowserKit, needed for logger
         BrowserKitInformation.shared.configure(buildChannel: AppConstants.buildChannel,
                                                nightlyAppVersion: AppConstants.nightlyAppVersion,
@@ -107,28 +107,6 @@ class AppDelegate: UIResponder,
         Tab.ChangeUserAgent.performMigration()
 
         return true
-    }
-
-    private func startRecordingStartupOpenURLTime() {
-        shareTelemetry.recordOpenDeeplinkTime()
-        nonisolated(unsafe) var recordCompleteToken: ActionToken?
-        nonisolated(unsafe) var recordCancelledToken: ActionToken?
-        recordCompleteToken = AppEventQueue.wait(for: .recordStartupTimeOpenDeeplinkComplete) { [weak self] in
-            ensureMainThread { [weak self] in
-                self?.shareTelemetry.sendOpenDeeplinkTimeRecord()
-                guard let recordCancelledToken, let recordCompleteToken  else { return }
-                AppEventQueue.cancelAction(token: recordCancelledToken)
-                AppEventQueue.cancelAction(token: recordCompleteToken)
-            }
-        }
-        recordCancelledToken = AppEventQueue.wait(for: .recordStartupTimeOpenDeeplinkCancelled) { [weak self] in
-            ensureMainThread { [weak self] in
-                self?.shareTelemetry.cancelOpenURLTimeRecord()
-                guard let recordCancelledToken, let recordCompleteToken  else { return }
-                AppEventQueue.cancelAction(token: recordCancelledToken)
-                AppEventQueue.cancelAction(token: recordCompleteToken)
-            }
-        }
     }
 
     func application(

--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -51,6 +51,8 @@ class DependencyHelper {
         appDelegate.gleanUsageReportingMetricsService
         AppContainer.shared.register(service: gleanUsageReportingMetricsService)
 
+        AppContainer.shared.register(service: appDelegate.shareTelemetry)
+
         let featureFlagsProvider = FeatureFlagsProvider(prefs: profile.prefs)
         AppContainer.shared.register(service: featureFlagsProvider as FeatureFlagProviding)
 

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -20,6 +20,7 @@ class SceneDelegate: UIResponder,
 
     var sceneCoordinator: SceneCoordinator?
     var routeBuilder = RouteBuilder()
+    var shareTelemetry: ShareTelemetry = AppContainer.shared.resolve()
 
     private let logger: Logger = DefaultLogger.shared
     private let tabErrorTelemetryHelper = TabErrorTelemetryHelper.shared
@@ -60,7 +61,7 @@ class SceneDelegate: UIResponder,
         sceneCoordinator.start()
         handle(connectionOptions: connectionOptions)
         if !sessionManager.launchSessionProvider.openedFromExternalSource {
-            AppEventQueue.signal(event: .recordStartupTimeOpenDeeplinkCancelled)
+            shareTelemetry.cancelOpenURLTimeRecord()
         }
     }
 
@@ -243,7 +244,7 @@ class SceneDelegate: UIResponder,
                                      level: .info,
                                      category: .coordinator)
                     sceneCoordinator.findAndHandle(route: route)
-                    AppEventQueue.signal(event: .recordStartupTimeOpenDeeplinkComplete)
+                    self?.shareTelemetry.sendOpenDeeplinkTimeRecord()
                 }
             }
         } else {
@@ -253,7 +254,7 @@ class SceneDelegate: UIResponder,
                                      level: .info,
                                      category: .coordinator)
                     sceneCoordinator.findAndHandle(route: route)
-                    AppEventQueue.signal(event: .recordStartupTimeOpenDeeplinkComplete)
+                    self?.shareTelemetry.sendOpenDeeplinkTimeRecord()
                 }
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -21,10 +21,6 @@ public enum AppEvent: AppEventType {
     case accountManagerInitialized
     case browserIsReady
 
-    // Events: Open Deeplink startup time record
-    case recordStartupTimeOpenDeeplinkComplete
-    case recordStartupTimeOpenDeeplinkCancelled
-
     // Activities: Profile Syncing
     case profileSyncing
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/SceneDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/SceneDelegateTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Glean
 import XCTest
 import Common
 @testable import Client
@@ -9,17 +10,20 @@ import Common
 @MainActor
 final class SceneDelegateTests: XCTestCase, FeatureFlaggable {
     private var mockSessionManager: MockAppSessionManager!
+    private var mockGleanWrapper: MockGleanWrapper!
 
     override func setUp() async throws {
         try await super.setUp()
         AppEventQueue.reset()
         DependencyHelperMock().bootstrapDependencies()
         mockSessionManager = MockAppSessionManager()
+        mockGleanWrapper = MockGleanWrapper()
         setIsDeeplinkOptimizationRefactorEnabled(false)
     }
 
     override func tearDown() async throws {
         mockSessionManager = nil
+        mockGleanWrapper = nil
         DependencyHelperMock().reset()
         AppEventQueue.reset()
         try await super.tearDown()
@@ -116,6 +120,31 @@ final class SceneDelegateTests: XCTestCase, FeatureFlaggable {
                         "Route should dispatch once tabRestoration is signalled")
     }
 
+    // MARK: - Telemetry
+
+    func testHandleRoute_refactorEnabled_recordsDeeplinkTimeOnSuccess() throws {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        AppEventQueue.signal(event: .startupFlowComplete)
+        let setup = try createSubjectWithCoordinator()
+        setup.delegate.shareTelemetry.recordOpenDeeplinkTime()
+
+        setup.delegate.scene(setup.scene, continue: makeSearchActivity())
+
+        XCTAssertEqual(mockGleanWrapper.stopAndAccumulateCalled, 1)
+    }
+
+    func testHandleRoute_refactorDisabled_recordsDeeplinkTimeOnSuccess() throws {
+        setIsDeeplinkOptimizationRefactorEnabled(false)
+        AppEventQueue.signal(event: .startupFlowComplete)
+        let setup = try createSubjectWithCoordinator()
+        setup.delegate.shareTelemetry.recordOpenDeeplinkTime()
+        AppEventQueue.signal(event: .tabRestoration(setup.coordinator.windowUUID))
+
+        setup.delegate.scene(setup.scene, continue: makeSearchActivity())
+
+        XCTAssertEqual(mockGleanWrapper.stopAndAccumulateCalled, 1)
+    }
+
     // MARK: - Helpers
 
     private struct TestSubject {
@@ -131,6 +160,7 @@ final class SceneDelegateTests: XCTestCase, FeatureFlaggable {
         let delegate = SceneDelegate()
         delegate.sessionManager = mockSessionManager
         delegate.sceneCoordinator = coordinator
+        delegate.shareTelemetry = ShareTelemetry(gleanWrapper: mockGleanWrapper)
         return TestSubject(delegate: delegate, coordinator: coordinator, scene: windowScene)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/SceneDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/SceneDelegateTests.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Glean
 import XCTest
 import Common
 @testable import Client

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -70,6 +70,8 @@ final class DependencyHelperMock {
         MockGleanUsageReportingMetricsService(profile: profile)
         AppContainer.shared.register(service: gleanUsageReportingMetricsService)
 
+        AppContainer.shared.register(service: ShareTelemetry())
+
         let featureFlagProvider = injectedFeatureFlagProvider ?? FeatureFlagsProvider(prefs: profile.prefs)
         AppContainer.shared.register(service: featureFlagProvider as FeatureFlagProviding)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15750)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33675)

## :bulb: Description
Simplifies how deeplink startup telemetry is recorded by removing the `AppEventQueue` events that were previously used to bridge `AppDelegate` and `SceneDelegate`. The telemetry callsites should be easy to reason about. The start is in `willFinishLaunchingWithOptions`, and stop/cancel is in `handle(route:)` and `scene(willConnectTo:)` respectively.

The function `startRecordingStartupOpenURLTime` in `AppDelegate` was setting up event queue listeners that crossed threading boundaries, which became harder to manage with the Swift 6 migration. Moving to a shared `ShareTelemetry` instance via `AppContainer` lets `SceneDelegate` call the telemetry methods directly, keeping the logic self-contained and easier to follow.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

