### PR TITLE
Bugfix FXIOS-15732 [Translations] Hide translate icon for non-HTML content

### DIFF
--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -381,9 +381,16 @@ final class TranslationsMiddleware: FeatureFlaggable {
     private func checkTranslationsAreEligible(for action: ToolbarAction) {
         // Pre-capture the tab so a tab switch mid-flight doesn't stomp the new active tab's state.
         let originatingTab = selectedTab(for: action.windowUUID)
-        Task {
-            guard action.translationConfiguration?.isTranslationFeatureEnabled == true else { return }
+        guard action.translationConfiguration?.isTranslationFeatureEnabled == true else { return }
 
+        // Translation requires a live HTML DOM. PDFs and images have no translatable
+        // text structure, so suppress the icon without running language detection.
+        if let mimeType = originatingTab?.mimeType, mimeType != MIMEType.HTML {
+            dispatchClearTranslationIcon(windowUUID: action.windowUUID, on: originatingTab)
+            return
+        }
+
+        Task {
             do {
                 let preferredLanguages = await targetLanguagesForEligibilityCheck()
                 let isEligible = try await translationsService.shouldOfferTranslation(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -381,6 +381,70 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertNil(tab.translationConfiguration)
     }
 
+    /// PDF MIME type suppresses the translate icon without calling language detection.
+    func test_urlDidChangeAction_withPDFMimeType_dispatchesClearAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let mockTranslationService = MockTranslationsService(
+            shouldOfferTranslationResult: .success(true)
+        )
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.mimeType = MIMEType.PDF
+        tab.translationConfiguration = TranslationConfiguration(prefs: mockProfile.prefs, state: .inactive)
+        mockTabManager.selectedTab = tab
+
+        let subject = createSubject(translationsService: mockTranslationService)
+        let action = ToolbarAction(
+            url: URL(string: "https://www.example.com/document.pdf"),
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.urlDidChange
+        )
+
+        let expectation = XCTestExpectation(description: "receivedTranslationLanguage clear dispatched for PDF")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
+        XCTAssertNil(actionCalled.translationConfiguration)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarActionType, .receivedTranslationLanguage)
+        XCTAssertNil(tab.translationConfiguration)
+    }
+
+    /// Image MIME type suppresses the translate icon without calling language detection.
+    func test_urlDidChangeAction_withImageMimeType_dispatchesClearAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let mockTranslationService = MockTranslationsService(
+            shouldOfferTranslationResult: .success(true)
+        )
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.mimeType = MIMEType.JPEG
+        tab.translationConfiguration = TranslationConfiguration(prefs: mockProfile.prefs, state: .inactive)
+        mockTabManager.selectedTab = tab
+
+        let subject = createSubject(translationsService: mockTranslationService)
+        let action = ToolbarAction(
+            url: URL(string: "https://www.example.com/photo.jpg"),
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.urlDidChange
+        )
+
+        let expectation = XCTestExpectation(description: "receivedTranslationLanguage clear dispatched for image")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider(mockStore.state, action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
+        XCTAssertNil(actionCalled.translationConfiguration)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarActionType, .receivedTranslationLanguage)
+        XCTAssertNil(tab.translationConfiguration)
+    }
+
     /// Mid-eligibility tab switch: result lands on the originating tab, not the new active tab.
     func test_urlDidChangeAction_tabSwitchMidEligibility_persistsOnOriginatingTab() throws {
         setTranslationsFeatureEnabled(enabled: true)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15732)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33661)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Skip language detection and clear the translate icon when the tab's MIME type is set to anything other than text/html (e.g. PDF, image). The MIME type is available on the tab before urlDidChange fires, so no timing risk.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


