### PR TITLE
Add FXIOS-15796 [Microsurvey] Add ability to randomize microsurvey options

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -10,6 +10,7 @@ protocol MessageDataProtocol {
     var title: String? { get }
     var text: String { get }
     var buttonLabel: String? { get }
+    var shouldRandomizeOptions: Bool { get }
     var experiment: String? { get }
     var actionParams: [String: String] { get }
     var microsurveyConfig: MicrosurveyConfig? { get }
@@ -88,6 +89,13 @@ struct GleanPlumbMessage {
     /// Embedding apps should not read from this directly.
     var options: [String] {
         return data.microsurveyConfig?.options ?? []
+    }
+
+    /// Should the message randomize the options presented.
+    ///
+    /// Embedding apps should not read from this directly.
+    var shouldRandomizeOptions: Bool {
+        data.shouldRandomizeOptions
     }
 
     /// The icon for this message if it has a microsurvey configuration.

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
@@ -41,6 +41,7 @@ class MicrosurveySurfaceManager: MicrosurveyManager {
         )
         let promptButtonLabel = message.buttonLabel ?? .Microsurvey.Prompt.TakeSurveyButton
         let options = !message.options.isEmpty ? message.options : defaultSurveyOptions
+        let shouldRandomizeOptions = message.shouldRandomizeOptions
         let icon = message.icon
         let utmContent = message.utmContent
 
@@ -49,7 +50,7 @@ class MicrosurveySurfaceManager: MicrosurveyManager {
             promptTitle: promptTitle,
             promptButtonLabel: promptButtonLabel,
             surveyQuestion: surveyQuestion,
-            surveyOptions: options,
+            surveyOptions: shouldRandomizeOptions ? options.shuffled() : options,
             icon: icon,
             utmContent: utmContent
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageStoreTests.swift
@@ -83,6 +83,7 @@ class MockMessageData: MessageDataProtocol {
     var title: String?
     var text: String
     var buttonLabel: String?
+    var shouldRandomizeOptions: Bool
     var experiment: String?
     var actionParams: [String: String]
     var microsurveyConfig: MicrosurveyConfig?
@@ -93,6 +94,7 @@ class MockMessageData: MessageDataProtocol {
         title: String? = "Title",
         text: String = "text",
         buttonLabel: String? = "Tap",
+        shouldRandomizeOptions: Bool = false,
         actionParams: [String: String] = [:],
         microsurveyConfig: MicrosurveyConfig? = nil
     ) {
@@ -101,6 +103,7 @@ class MockMessageData: MessageDataProtocol {
         self.title = title
         self.text = text
         self.buttonLabel = buttonLabel
+        self.shouldRandomizeOptions = shouldRandomizeOptions
         self.actionParams = actionParams
         self.microsurveyConfig = microsurveyConfig
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveySurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveySurfaceManagerTests.swift
@@ -128,6 +128,7 @@ class MockMicrosurveyMessageDataProtocol: MessageDataProtocol {
     var title: String? = "title label test"
     var text = "text label test"
     var buttonLabel: String? = "button label test"
+    var shouldRandomizeOptions = false
     var experiment: String?
     var actionParams: [String: String] = [:]
     var microsurveyConfig: MicrosurveyConfig? = MicrosurveyConfig(options: ["yes", "no"])

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanPlumbMessageManagerProtocol.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanPlumbMessageManagerProtocol.swift
@@ -54,6 +54,7 @@ class MockMessageDataProtocol: MessageDataProtocol {
     var title: String? = "Test"
     var text = "This is a test"
     var buttonLabel: String? = "This is a test button label"
+    var shouldRandomizeOptions = false
     var experiment: String?
     var actionParams: [String: String] = [:]
     var microsurveyConfig: MicrosurveyConfig?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
@@ -150,6 +150,7 @@ class MockNotificationMessageDataProtocol: MessageDataProtocol {
     var title: String? = "title label test"
     var text = "text label test"
     var buttonLabel: String? = "button label test"
+    var shouldRandomizeOptions = false
     var experiment: String?
     var actionParams: [String: String] = [:]
     var microsurveyConfig: MicrosurveyConfig?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SurveySurface/SurveySurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SurveySurface/SurveySurfaceManagerTests.swift
@@ -150,6 +150,7 @@ class MockSurveyMessageDataProtocol: MessageDataProtocol {
     var title: String? = "title label test"
     var text = "text label test"
     var buttonLabel: String? = "button label test"
+    var shouldRandomizeOptions = false
     var experiment: String?
     var actionParams: [String: String] = [:]
     var microsurveyConfig: MicrosurveyConfig?

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -51,6 +51,7 @@ import:
                 title: Microsurvey/Microsurvey.Prompt.TitleLabel.v127
                 text: "How satisfied are you with your Firefox homepage?" # Should not show this message if this is nil
                 button-label: Microsurvey/Microsurvey.Prompt.Button.v127
+                should-randomize-options: false
                 microsurveyConfig:
                   utm-content: homepage
                   icon: homeLarge
@@ -73,6 +74,7 @@ import:
                   - NEVER
                 text: ResearchSurface/Body.Text.v112
                 button-label: ResearchSurface/PrimaryButton.Label.v112
+                should-randomize-options: false
                 action: OPEN_URL
                 action-params:
                   url: https://www.macrumors.com

--- a/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
@@ -18,7 +18,7 @@ features:
     meta-bug: ~
     documentation:
       - name: User documentation
-        url:  https://experimenter.info/messaging/mobile-messaging
+        url: https://experimenter.info/messaging/mobile-messaging
     contacts:
       # Nimbus team
       - jhugman@mozilla.com
@@ -37,7 +37,6 @@ features:
     allow-coenrollment: true
 
     variables:
-
       messages:
         description: >
           A growable collection of messages, where the
@@ -89,8 +88,8 @@ features:
     defaults:
       - value:
           triggers:
-              ALWAYS: "true"
-              NEVER: "false"
+            ALWAYS: "true"
+            NEVER: "false"
 
 objects:
   MessageData:
@@ -130,6 +129,11 @@ objects:
           The text on the button. If no text
           is present, the whole message is clickable.
         default: null
+      should-randomize-options:
+        type: Boolean
+        description: >
+          Will randomize the provided MicrosurveyConfig options
+        default: false
       style:
         type: StyleName
         description: >
@@ -162,7 +166,7 @@ objects:
         type: Option<ExperimentSlug>
         description: The experiment slug that this message is involved in.
         default: null
-        
+
       microsurveyConfig:
         type: Option<MicrosurveyConfig>
         description: Optional configuration data for a microsurvey.
@@ -188,7 +192,7 @@ objects:
 
   MicrosurveyConfig:
     description: >
-        Attributes relating to microsurvey messaging.
+      Attributes relating to microsurvey messaging.
     fields:
       utm-content:
         description: The name used to provide as the utm_content parameter for the privacy notice.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33784)

## :bulb: Description
Adds a randomizer option to messaging.

| Before | After |
| - | - |
| <img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-13 at 10 08 00" src="https://github.com/user-attachments/assets/cd9d4ffb-8e9c-4b92-b92c-787227c60ca9" /> | <img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-13 at 10 16 12" src="https://github.com/user-attachments/assets/dc70f853-64bb-4aae-aa1a-e4c90f20d3e9" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

