### PR TITLE
Bugfix FXIOS-15051 [Homepage] Apply theme to firefox logo header on wallpaper change

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -99,15 +99,21 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
         state: HomepageState,
         selectedNewsfeedCategoryID: String? = nil,
         jumpBackInDisplayConfig: JumpBackInSectionLayoutConfiguration,
+        reconfigureHeader: Bool = false,
         animatingDifferences: Bool = true,
         completion: (() -> Void)? = nil
     ) {
         var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeItem>()
 
         let textColor = state.wallpaperState.wallpaperConfiguration.textColor
+        let headerItem = HomeItem.header(state.headerState)
 
         snapshot.appendSections([.header])
-        snapshot.appendItems([.header(state.headerState)], toSection: .header)
+        snapshot.appendItems([headerItem], toSection: .header)
+
+        if reconfigureHeader {
+            snapshot.reconfigureItems([headerItem])
+        }
 
         if state.shouldShowPrivacyNotice {
             snapshot.appendSections([.privacyNotice])

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -421,9 +421,13 @@ final class HomepageViewController: UIViewController,
         // this is a quick workaround to avoid blocking the main thread by calling apply snapshot many times.
         if homepageState != state {
             let animatingDifferences = state.availableContentHeight == homepageState.availableContentHeight
+            let shouldReconfigureHeader = shouldReconfigureHomepageHeader(for: state)
             self.homepageState = state
 
-            refreshHomepageDataSourceSnapshot(animatingDifferences: animatingDifferences) { [weak self] in
+            refreshHomepageDataSourceSnapshot(
+                reconfigureHeader: shouldReconfigureHeader,
+                animatingDifferences: animatingDifferences
+            ) { [weak self] in
                 self?.collectionView?.layoutIfNeeded()
                 self?.updateNewsTransitionHeaderProgress()
             }
@@ -1134,15 +1138,23 @@ final class HomepageViewController: UIViewController,
         }
     }
 
-    private func refreshHomepageDataSourceSnapshot(animatingDifferences: Bool = true, completion: (() -> Void)? = nil) {
+    private func refreshHomepageDataSourceSnapshot(reconfigureHeader: Bool = false,
+                                                   animatingDifferences: Bool = true,
+                                                   completion: (() -> Void)? = nil) {
         dataSource?.updateSnapshot(
             state: homepageState,
             selectedNewsfeedCategoryID: currentHomepageTabState.selectedNewsfeedCategoryID,
             jumpBackInDisplayConfig: getJumpBackInDisplayConfig(),
+            reconfigureHeader: reconfigureHeader,
             animatingDifferences: animatingDifferences
         ) {
             completion?()
         }
+    }
+
+    private func shouldReconfigureHomepageHeader(for state: HomepageState) -> Bool {
+        return state.wallpaperState.wallpaperConfiguration.logoTextColor !=
+            homepageState.wallpaperState.wallpaperConfiguration.logoTextColor
     }
 
     /// Applies the active `HomepageTabState`'s relevant properties to the category picker without rebuilding the section.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15051)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32408)

## :bulb: Description
- Fix the homepage Firefox logo tint not updating after switching wallpapers.

### 📝 Technical Notes:
- Most homepage sections update correctly because their diffable section or item identity includes the wallpaper text color, so wallpaper changes cause those cells to be refreshed. The Firefox logo header did not include wallpaper color in its item identity, so diffable kept the existing header cell and its stale tint.
- This updates the homepage snapshot flow to explicitly reconfigure the header item when the wallpaper logo text color changes, forcing the header cell to reapply its theme


## :movie_camera: Demos
| Before | After |
| ------------- | ------------- |
| <img width="603" height="1311" alt="simulator_screenshot_22FAB755-71C4-40AF-AFDA-7B269582AEB2" src="https://github.com/user-attachments/assets/f0986008-d0a4-4bec-8bfe-37b3fe991522" /> | <img width="603" height="1311" alt="simulator_screenshot_F5059088-4D07-466D-8F8E-A2FEBA1497A0" src="https://github.com/user-attachments/assets/3099c72b-509d-4f0d-9af8-b9cf459dde3e" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

