### PR TITLE
Add FXIOS-15577 [Quick Answers] initial settings toggle

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -179,6 +179,7 @@ public struct PrefsKeys {
         public static let translationAutoTranslate = "settings.translationAutoTranslate"
         public static let translationAutoTranslatePromptShown = "settings.translationAutoTranslatePromptShown"
         public static let aiKillSwitchFeature = "settings.aiKillSwitchFeature"
+        public static let quickAnswersFeature = "settings.quickAnswersFeature"
     }
 
     // Activity Stream

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1419,9 +1419,13 @@
 		A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */; };
 		A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */; };
 		AA02D5EB2EB3D83200814F4C /* TranslationsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA02D5EA2EB3D82F00814F4C /* TranslationsAction.swift */; };
+		AA17157C2FB619C20090D2AE /* QuickAnswersSettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA17157A2FB619C20090D2AE /* QuickAnswersSettingTests.swift */; };
+		AA17157D2FB619C20090D2AE /* QuickAnswersSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1715792FB619C20090D2AE /* QuickAnswersSettingsViewControllerTests.swift */; };
 		AA24AD302E7C37C6008659A3 /* TrendingSearchClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD2F2E7C37BF008659A3 /* TrendingSearchClient.swift */; };
 		AA24AD322E7C3A8F008659A3 /* TrendingSearchClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD312E7C3A85008659A3 /* TrendingSearchClientTests.swift */; };
 		AA24AD342E7C3AD2008659A3 /* MockTrendingSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24AD332E7C3ACC008659A3 /* MockTrendingSearchEngine.swift */; };
+		AA25A74E2FB4C88600A55859 /* QuickAnswersSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA25A74D2FB4C88200A55859 /* QuickAnswersSetting.swift */; };
+		AA25A7512FB4C9CE00A55859 /* QuickAnswersSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA25A7502FB4C9C800A55859 /* QuickAnswersSettingsViewController.swift */; };
 		AA3CEBAD2ECB853400DDEFEF /* SearchTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CEBAC2ECB853400DDEFEF /* SearchTelemetryTests.swift */; };
 		AA459F872F630F3500D05D04 /* QuickAnswersKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA459F862F630F3500D05D04 /* QuickAnswersKit */; };
 		AA4D99432E857AF300BB039D /* MockRecentSearchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4D99422E857AEE00BB039D /* MockRecentSearchProvider.swift */; };
@@ -10083,10 +10087,14 @@
 		AA02D5EA2EB3D82F00814F4C /* TranslationsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsAction.swift; sourceTree = "<group>"; };
 		AA0B46CCA57F0E0997CC0AEA /* ia */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ia; path = ia.lproj/Intro.strings; sourceTree = "<group>"; };
 		AA0B47C6B76C81D58AD910F1 /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/LoginManager.strings; sourceTree = "<group>"; };
+		AA1715792FB619C20090D2AE /* QuickAnswersSettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersSettingsViewControllerTests.swift; sourceTree = "<group>"; };
+		AA17157A2FB619C20090D2AE /* QuickAnswersSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersSettingTests.swift; sourceTree = "<group>"; };
 		AA244A28A4D501F91E5C0FF2 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
 		AA24AD2F2E7C37BF008659A3 /* TrendingSearchClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingSearchClient.swift; sourceTree = "<group>"; };
 		AA24AD312E7C3A85008659A3 /* TrendingSearchClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingSearchClientTests.swift; sourceTree = "<group>"; };
 		AA24AD332E7C3ACC008659A3 /* MockTrendingSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTrendingSearchEngine.swift; sourceTree = "<group>"; };
+		AA25A74D2FB4C88200A55859 /* QuickAnswersSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersSetting.swift; sourceTree = "<group>"; };
+		AA25A7502FB4C9C800A55859 /* QuickAnswersSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersSettingsViewController.swift; sourceTree = "<group>"; };
 		AA3CEBAC2ECB853400DDEFEF /* SearchTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTelemetryTests.swift; sourceTree = "<group>"; };
 		AA4D99422E857AEE00BB039D /* MockRecentSearchProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRecentSearchProvider.swift; sourceTree = "<group>"; };
 		AA5001482F912F530065A279 /* ChangeMLPAEndpointSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeMLPAEndpointSetting.swift; sourceTree = "<group>"; };
@@ -12745,6 +12753,7 @@
 		2F44FC551A9E83E200FD20CC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				AA25A74F2FB4C9C000A55859 /* QuickAnswers */,
 				61DD72D32F59374E002BFEA6 /* AIControls */,
 				8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */,
 				BA4BB9962D7F371F006BD137 /* AppearanceSettings */,
@@ -13993,6 +14002,7 @@
 				B5BD90815183467AA5B28FDA /* TranslationSettingsStateTests.swift */,
 				B5BD90825183467AA5B28FDB /* TranslationSettingsMiddlewareTests.swift */,
 				B5BD90835183467AA5B28FDC /* TranslationSettingsViewControllerTests.swift */,
+				AA17157B2FB619C20090D2AE /* QuickAnswers */,
 				B5BD90845183467AA5B28FDD /* TranslationPickerSettingsViewControllerTests.swift */,
 				8C3B0B892F72767000E2C370 /* TranslationLanguagePickerViewControllerTests.swift */,
 				8C5E7E922F6B3C3F00A3DD27 /* TranslationSettingsDiffableDataSourceTests.swift */,
@@ -14016,6 +14026,7 @@
 		8A5D1CA22A30D661005AD35C /* General */ = {
 			isa = PBXGroup;
 			children = (
+				AA25A74D2FB4C88200A55859 /* QuickAnswersSetting.swift */,
 				61DD72D02F5936AF002BFEA6 /* AIControlsSetting.swift */,
 				AAD861A72E9E748100F6E0E0 /* TranslationSetting.swift */,
 				BCBE058B2E3A871B004B6039 /* SummarizeSetting.swift */,
@@ -14810,6 +14821,23 @@
 				96EB6C3D27D9266500A9D159 /* HistoryActionables.swift */,
 			);
 			path = HistoryPanel;
+			sourceTree = "<group>";
+		};
+		AA17157B2FB619C20090D2AE /* QuickAnswers */ = {
+			isa = PBXGroup;
+			children = (
+				AA1715792FB619C20090D2AE /* QuickAnswersSettingsViewControllerTests.swift */,
+				AA17157A2FB619C20090D2AE /* QuickAnswersSettingTests.swift */,
+			);
+			path = QuickAnswers;
+			sourceTree = "<group>";
+		};
+		AA25A74F2FB4C9C000A55859 /* QuickAnswers */ = {
+			isa = PBXGroup;
+			children = (
+				AA25A7502FB4C9C800A55859 /* QuickAnswersSettingsViewController.swift */,
+			);
+			path = QuickAnswers;
 			sourceTree = "<group>";
 		};
 		AA5E81452EB12BAB00919E60 /* Translations */ = {
@@ -19202,6 +19230,7 @@
 				80967F802D0A36890057F0C7 /* RecordedNimbusContext.swift in Sources */,
 				8AF99B4F29EF1BA700108DEC /* BrowserDelegate.swift in Sources */,
 				C87D8B802818333F00A6307D /* NimbusManager.swift in Sources */,
+				AA25A7512FB4C9CE00A55859 /* QuickAnswersSettingsViewController.swift in Sources */,
 				C45F44691D087DB600CB7EF0 /* TopTabsViewController.swift in Sources */,
 				8A0727462B4890B50071BB9F /* WebviewTelemetry.swift in Sources */,
 				8ADC2A212A3399DC00543DAA /* YourRightsSetting.swift in Sources */,
@@ -19221,6 +19250,7 @@
 				FA6B2AC21D41F02D00429414 /* String+Punycode.swift in Sources */,
 				E174963C2992B6A60096900A /* HostingTableViewSectionHeader.swift in Sources */,
 				5A2918CD2B522381002B197E /* ToastType.swift in Sources */,
+				AA25A74E2FB4C88600A55859 /* QuickAnswersSetting.swift in Sources */,
 				8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */,
 				EBFDB790211C83A5005CCA2F /* BrowserViewController+FindInPage.swift in Sources */,
 				21B359C62AEAC20300FF09E3 /* TabsSectionManager.swift in Sources */,
@@ -20552,6 +20582,8 @@
 				61497F3E2F68856600BC5ACA /* MockGeneralSettingsDelegate.swift in Sources */,
 				C283EED42E4E0F25008EB540 /* MockSummarizerConfigSource.swift in Sources */,
 				81AE06F62E3AA6A3002C3E58 /* MerinoProviderTests.swift in Sources */,
+				AA17157C2FB619C20090D2AE /* QuickAnswersSettingTests.swift in Sources */,
+				AA17157D2FB619C20090D2AE /* QuickAnswersSettingsViewControllerTests.swift in Sources */,
 				21B337BB29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift in Sources */,
 				6ADB651B285C03B100947EA4 /* DownloadHelperTests.swift in Sources */,
 				8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -780,6 +780,10 @@ struct AccessibilityIdentifiers {
             static let languagePickerList = "Settings.Translation.LanguagePickerList"
         }
 
+        struct QuickAnswers {
+            static let title = "Settings.QuickAnswers.Title"
+        }
+
         struct BlockImages {
             static let title = "Block Images"
         }

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -472,6 +472,14 @@ final class SettingsCoordinator: BaseCoordinator,
         router.push(viewController)
     }
 
+    func pressedQuickAnswers() {
+        let viewController = QuickAnswersSettingsViewController(
+            prefs: profile.prefs,
+            windowUUID: windowUUID
+        )
+        router.push(viewController)
+    }
+
     func pressedSummarize() {
         let viewController = SummarizeSettingsViewController(
             prefs: profile.prefs,

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -400,6 +400,10 @@ class AppSettingsTableViewController: SettingsTableViewController,
             generalSettings.append(SummarizeSetting(settings: self, settingsDelegate: parentCoordinator))
         }
 
+        if featureFlagsProvider.isEnabled(.quickAnswers) {
+            generalSettings.append(QuickAnswersSetting(settings: self, settingsDelegate: parentCoordinator))
+        }
+
         if featureFlagsProvider.isEnabled(.translation) {
             generalSettings.append(TranslationSetting(settings: self, settingsDelegate: parentCoordinator))
         }

--- a/firefox-ios/Client/Frontend/Settings/Main/General/GeneralSettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/GeneralSettingsDelegate.swift
@@ -34,6 +34,9 @@ protocol GeneralSettingsDelegate: AnyObject {
     func pressedBrowsing()
 
     @MainActor
+    func pressedQuickAnswers()
+
+    @MainActor
     func pressedSummarize()
 
     @MainActor

--- a/firefox-ios/Client/Frontend/Settings/Main/General/QuickAnswersSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/QuickAnswersSetting.swift
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+final class QuickAnswersSetting: Setting {
+    private weak var settingsDelegate: GeneralSettingsDelegate?
+    private let profile: Profile?
+
+    override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
+        return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
+    }
+
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.QuickAnswers.title
+    }
+
+    override var style: UITableViewCell.CellStyle { return .value1 }
+
+    override var status: NSAttributedString? {
+        guard let profile else { return nil }
+        let isSwitchOn = profile.prefs.boolForKey(PrefsKeys.Settings.quickAnswersFeature) ?? true
+        // TODO: - FXIOS-14720 Add Strings
+        let statusString: String = isSwitchOn ? "On" : "Off"
+        return NSAttributedString(string: statusString)
+    }
+
+    init(settings: SettingsTableViewController,
+         settingsDelegate: GeneralSettingsDelegate?) {
+        self.profile = settings.profile
+        self.settingsDelegate = settingsDelegate
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
+        // TODO: - FXIOS-14720 Add Strings
+        super.init(
+            title: NSAttributedString(
+                string: "Quick Answers",
+                attributes: [
+                    NSAttributedString.Key.foregroundColor: theme.colors.textPrimary
+                ]
+            )
+        )
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        settingsDelegate?.pressedQuickAnswers()
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/QuickAnswers/QuickAnswersSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/QuickAnswers/QuickAnswersSettingsViewController.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Shared
+
+final class QuickAnswersSettingsViewController: SettingsTableViewController {
+    let prefs: Prefs
+    init(prefs: Prefs, windowUUID: WindowUUID) {
+        self.prefs = prefs
+        super.init(style: .grouped, windowUUID: windowUUID)
+        // TODO: - FXIOS-14720 Add Strings
+        self.title = "Quick Answers"
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private var theme: Theme {
+        themeManager.getCurrentTheme(for: windowUUID)
+    }
+
+    override func generateSettings() -> [SettingSection] {
+        return [quickAnswersSection]
+    }
+
+    private var quickAnswersSection: SettingSection {
+        let enableFeatureSwitch = BoolSetting(
+            prefs: prefs,
+            theme: theme,
+            prefKey: PrefsKeys.Settings.quickAnswersFeature,
+            defaultValue: true,
+            // TODO: - FXIOS-14720 Add Strings
+            titleText: "Quick Answers"
+        ) { _ in
+            // TODO: FXIOS-15577 - Dispatch action to show or hide quick answers feature
+        }
+        return SettingSection(children: [enableFeatureSwitch])
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -391,6 +391,15 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(mockRouter.pushedViewController is UIHostingController<AppearanceSettingsView>)
     }
 
+    func testGeneralSettingsDelegate_pushedQuickAnswersSettings() {
+        let subject = createSubject()
+
+        subject.pressedQuickAnswers()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is QuickAnswersSettingsViewController)
+    }
+
     func testGeneralSettingsDelegate_pushedSummarizeSettings() {
         let subject = createSubject()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -72,6 +72,8 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
 
     func pressedBrowsing() {}
 
+    func pressedQuickAnswers() {}
+
     func pressedSummarize() {}
 
     func pressedTranslation() {}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/MockGeneralSettingsDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/MockGeneralSettingsDelegate.swift
@@ -5,6 +5,7 @@
 
 class MockGeneralSettingsDelegate: GeneralSettingsDelegate {
     var pressedAIControlsCalled = false
+    var pressedQuickAnswersCalled = false
 
     func pressedCustomizeAppIcon() {}
 
@@ -25,6 +26,10 @@ class MockGeneralSettingsDelegate: GeneralSettingsDelegate {
     func pressedTheme() {}
 
     func pressedBrowsing() {}
+
+    func pressedQuickAnswers() {
+        pressedQuickAnswersCalled = true
+    }
 
     func pressedSummarize() {}
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/QuickAnswers/QuickAnswersSettingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/QuickAnswers/QuickAnswersSettingTests.swift
@@ -1,0 +1,128 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import XCTest
+@testable import Client
+
+@MainActor
+final class QuickAnswersSettingTests: XCTestCase {
+    private var profile: MockProfile!
+    private var delegate: MockGeneralSettingsDelegate!
+    private var settings: SettingsTableViewController!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        profile = MockProfile()
+        delegate = MockGeneralSettingsDelegate()
+        settings = SettingsTableViewController(
+            style: .plain,
+            windowUUID: .XCTestDefaultUUID,
+            themeManager: MockThemeManager()
+        )
+        settings.profile = profile
+    }
+
+    override func tearDown() async throws {
+        profile = nil
+        delegate = nil
+        settings = nil
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    // MARK: - Init
+
+    func test_init_setsTitle() {
+        let subject = createSubject()
+        XCTAssertEqual(subject.title?.string, "Quick Answers")
+    }
+
+    func test_init_setsAccessibilityIdentifier() {
+        let subject = createSubject()
+        XCTAssertEqual(subject.accessibilityIdentifier, AccessibilityIdentifiers.Settings.QuickAnswers.title)
+    }
+
+    func test_init_setsStyleToValue1() {
+        let subject = createSubject()
+        XCTAssertEqual(subject.style, .value1)
+    }
+
+    // MARK: - Status
+
+    func test_status_showsOnWhenFeatureEnabled() {
+        profile.prefs.setBool(true, forKey: PrefsKeys.Settings.quickAnswersFeature)
+        let subject = createSubject()
+        XCTAssertEqual(subject.status?.string, "On")
+    }
+
+    func test_status_showsOffWhenFeatureDisabled() {
+        profile.prefs.setBool(false, forKey: PrefsKeys.Settings.quickAnswersFeature)
+        let subject = createSubject()
+        XCTAssertEqual(subject.status?.string, "Off")
+    }
+
+    func test_status_showsOnByDefault() {
+        let subject = createSubject()
+        XCTAssertEqual(subject.status?.string, "On")
+    }
+
+    // MARK: - onClick
+
+    func test_onClick_callsDelegateMethod() {
+        let subject = createSubject()
+        subject.onClick(nil)
+        XCTAssertTrue(delegate.pressedQuickAnswersCalled)
+    }
+
+    func test_onClick_callsDelegateMethodMultipleTimes() {
+        let subject = createSubject()
+        subject.onClick(nil)
+        XCTAssertTrue(delegate.pressedQuickAnswersCalled)
+
+        delegate.pressedQuickAnswersCalled = false
+        subject.onClick(nil)
+        XCTAssertTrue(delegate.pressedQuickAnswersCalled)
+    }
+
+    func test_onClick_withNavigationController() {
+        let subject = createSubject()
+        let navigationController = UINavigationController()
+        subject.onClick(navigationController)
+        XCTAssertTrue(delegate.pressedQuickAnswersCalled)
+    }
+
+    // MARK: - Title Attributes
+
+    func test_title_hasCorrectTextColor() {
+        let subject = createSubject()
+        let titleAttributes = subject.title?.attributes(at: 0, effectiveRange: nil)
+        let foregroundColor = titleAttributes?[.foregroundColor] as? UIColor
+        XCTAssertNotNil(foregroundColor)
+    }
+
+    // MARK: - Status Updates
+
+    func test_status_updatesWhenPreferenceChanges() {
+        let subject = createSubject()
+
+        profile.prefs.setBool(true, forKey: PrefsKeys.Settings.quickAnswersFeature)
+        XCTAssertEqual(subject.status?.string, "On")
+
+        profile.prefs.setBool(false, forKey: PrefsKeys.Settings.quickAnswersFeature)
+        XCTAssertEqual(subject.status?.string, "Off")
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> QuickAnswersSetting {
+        let subject = QuickAnswersSetting(
+            settings: settings,
+            settingsDelegate: delegate
+        )
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/QuickAnswers/QuickAnswersSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/QuickAnswers/QuickAnswersSettingsViewControllerTests.swift
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class QuickAnswersSettingsViewControllerTests: XCTestCase {
+    private var profile: MockProfile!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        profile = MockProfile()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() async throws {
+        profile = nil
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    // MARK: - Init
+    func test_init_setsTitle() {
+        let subject = createSubject()
+        XCTAssertEqual(subject.title, "Quick Answers")
+    }
+
+    // MARK: - generateSettings
+    func test_generateSettings_returnsOneSection() {
+        let subject = createSubject()
+        let sections = subject.generateSettings()
+        XCTAssertEqual(sections.count, 1)
+    }
+
+    func test_generateSettings_sectionHasOneSetting() throws {
+        let subject = createSubject()
+        let section = try XCTUnwrap(subject.generateSettings().first)
+        XCTAssertEqual(section.children.count, 1)
+    }
+
+    func test_generateSettings_settingIsBoolSetting() throws {
+        let subject = createSubject()
+        let section = try XCTUnwrap(subject.generateSettings().first)
+        XCTAssertTrue(section.children.first is BoolSetting)
+    }
+
+    func test_generateSettings_boolSettingUsesQuickAnswersFeaturePrefKey() throws {
+        let subject = createSubject()
+        let section = try XCTUnwrap(subject.generateSettings().first)
+        let boolSetting = try XCTUnwrap(section.children.first as? BoolSetting)
+        XCTAssertEqual(boolSetting.prefKey, PrefsKeys.Settings.quickAnswersFeature)
+    }
+
+    func test_generateSettings_boolSettingDefaultValueIsTrue() throws {
+        let subject = createSubject()
+        let section = try XCTUnwrap(subject.generateSettings().first)
+        let boolSetting = try XCTUnwrap(section.children.first as? BoolSetting)
+        XCTAssertTrue(try XCTUnwrap(boolSetting.getDefaultValue()))
+    }
+
+    func test_generateSettings_sectionHasNoTitle() throws {
+        let subject = createSubject()
+        let section = try XCTUnwrap(subject.generateSettings().first)
+        XCTAssertNil(section.title)
+    }
+
+    func test_generateSettings_sectionHasNoFooter() throws {
+        let subject = createSubject()
+        let section = try XCTUnwrap(subject.generateSettings().first)
+        XCTAssertNil(section.footerTitle)
+    }
+
+    // MARK: - Preference Integration
+    func test_boolSetting_readsPreferenceValue_whenEnabled() throws {
+        profile.prefs.setBool(true, forKey: PrefsKeys.Settings.quickAnswersFeature)
+        let subject = createSubject()
+        let section = try XCTUnwrap(subject.generateSettings().first)
+        let boolSetting = try XCTUnwrap(section.children.first as? BoolSetting)
+
+        let displayValue = profile.prefs.boolForKey(boolSetting.prefKey ?? "") ?? false
+        XCTAssertTrue(displayValue)
+    }
+
+    func test_boolSetting_readsPreferenceValue_whenDisabled() throws {
+        profile.prefs.setBool(false, forKey: PrefsKeys.Settings.quickAnswersFeature)
+        let subject = createSubject()
+        let section = try XCTUnwrap(subject.generateSettings().first)
+        let boolSetting = try XCTUnwrap(section.children.first as? BoolSetting)
+
+        let displayValue = profile.prefs.boolForKey(boolSetting.prefKey ?? "")
+        XCTAssertEqual(displayValue, false)
+    }
+
+    // MARK: - Helpers
+    private func createSubject() -> QuickAnswersSettingsViewController {
+        let subject = QuickAnswersSettingsViewController(
+            prefs: profile.prefs,
+            windowUUID: .XCTestDefaultUUID
+        )
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15577)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33374)

## :bulb: Description
Add initial settings toggle for the Quick Answers feature. We are waiting for strings so they will be hard coded for now. 

Note: There will be a follow up PR to hook up the settings with showing / hiding the feature. We will do this through Redux, which will add more code changes so keeping this PR small for now.

<img width="250" height="550" alt="Screenshot 2026-05-13 at 8 41 11 AM" src="https://github.com/user-attachments/assets/492b1744-5b3c-4f86-a161-33dcb2c3f838" />

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

