### PR TITLE
Bugfix FXIOS-15443 ⁃ [Pull to refresh] [Intermittent] - Empty refresh icon is displayed icon is displayed

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
@@ -136,6 +136,7 @@ class PullRefreshView: UIView,
         if scrollView.contentOffset.y < -threshold {
             blinkBackgroundProgressViewIfNeeded()
             scheduleEasterEgg()
+            updateElementAlpha()
         } else if scrollView.contentOffset.y != 0.0 {
             easterEggTimer?.cancel()
             easterEggTimer = nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15443)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33122)

## :bulb: Description
Update icon alpha when is necessary


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>

https://github.com/user-attachments/assets/441bb5d2-215b-4cf2-abd0-06826a497c1e


</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

