### PR TITLE
Bugfix FXIOS-15594 [Homepage] Prevent homepage scroll offset jumps

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -164,7 +164,7 @@ final class BrowserCoordinator: BaseCoordinator,
             logger.log("Unable to embed new homepage", level: .debug, category: .coordinator)
         }
         self.homepageViewController = homepageController
-        homepageController.restoreVerticalScrollOffset()
+        homepageController.restoreVerticalScrollOffset(force: didEmbed)
 
         if didEmbed {
             // [FXIOS-13651] Fix for WKWebView memory leak. (See comments on related PR.)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3278,6 +3278,7 @@ class BrowserViewController: UIViewController,
     func showTabTray(withFocusOnUnselectedTab tabToFocus: Tab? = nil,
                      focusedSegment: TabTrayPanelType? = nil) {
         updateFindInPageVisibility(isVisible: false)
+        (contentContainer.contentController as? HomepageViewController)?.stopScrollingAndSaveVerticalScrollOffset()
 
         let isPrivateTab = tabManager.selectedTab?.isPrivate ?? false
         let selectedSegment: TabTrayPanelType = focusedSegment ?? (isPrivateTab ? .privateTabs : .tabs)

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -258,8 +258,11 @@ final class HomepageViewController: UIViewController,
 
     // Called when the homepage is displayed to make sure it's vertical scroll position is persisted.
     // If no scroll position exists for tab, scroll the homepage to the top
-    func restoreVerticalScrollOffset() {
-        activeTabUUID = tabManager.selectedTab?.tabUUID
+    func restoreVerticalScrollOffset(force: Bool = true) {
+        let selectedTabUUID = tabManager.selectedTab?.tabUUID
+        guard force || activeTabUUID != selectedTabUUID else { return }
+
+        activeTabUUID = selectedTabUUID
         guard let activeTabUUID,
               let homepageScrollOffset = homepageTabStateStore.state(for: activeTabUUID).scrollOffsetY
         else {
@@ -275,6 +278,12 @@ final class HomepageViewController: UIViewController,
             collectionView.setContentOffset(CGPoint(x: 0, y: -collectionView.adjustedContentInset.top), animated: animated)
             handleScroll(collectionView, isUserInteraction: false)
         }
+    }
+
+    func stopScrollingAndSaveVerticalScrollOffset() {
+        guard let collectionView else { return }
+        collectionView.setContentOffset(collectionView.contentOffset, animated: false)
+        saveVerticalScrollOffset()
     }
 
     func updateTopContentInset(_ topInset: CGFloat) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -146,6 +146,36 @@ final class BrowserCoordinatorTests: XCTestCase,
         XCTAssertEqual(firstHomepage, secondHomepage)
     }
 
+    func testShowHomepage_whenAlreadyEmbedded_doesNotRestoreScrollOffset() throws {
+        let tab = MockTab(profile: profile, windowUUID: windowUUID)
+        tabManager.tabs = [tab]
+        tabManager.selectedTab = tab
+        homepageTabStateStore.updateState(for: tab.tabUUID) { $0.scrollOffsetY = 180 }
+        let subject = createSubject()
+
+        subject.showHomepage(
+            overlayManager: overlayModeManager,
+            isZeroSearch: true,
+            statusBarScrollDelegate: scrollDelegate,
+            toastContainer: UIView()
+        )
+
+        let homepageViewController = try XCTUnwrap(subject.homepageViewController)
+        let collectionView = try XCTUnwrap(
+            homepageViewController.view.subviews.first(where: { $0 is UICollectionView }) as? UICollectionView
+        )
+        collectionView.contentOffset = CGPoint(x: 0, y: 75)
+
+        subject.showHomepage(
+            overlayManager: overlayModeManager,
+            isZeroSearch: true,
+            statusBarScrollDelegate: scrollDelegate,
+            toastContainer: UIView()
+        )
+
+        XCTAssertEqual(collectionView.contentOffset.y, 75)
+    }
+
     // MARK: - Show new homepage
 
     func testShowNewHomepage_setsProperViewController() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
@@ -381,6 +381,31 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(collectionView.contentOffset, CGPoint(x: 0, y: -collectionView.adjustedContentInset.top))
     }
 
+    func test_restoreContentOffset_whenNotForcedAndSameTab_doesNotRestoreStoredOffset() {
+        let tabManager = HomepageRestoreContentOffsetTabManager()
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tabManager.tabs = [tab]
+        tabManager.selectedTab = tab
+        homepageTabStateStore.updateState(for: tab.tabUUID) { $0.scrollOffsetY = 180 }
+        let subject = createSubject(tabManager: tabManager)
+
+        subject.loadViewIfNeeded()
+        subject.viewWillAppear(false)
+
+        guard let collectionView = subject.view.subviews.first(where: {
+            $0 is UICollectionView
+        }) as? UICollectionView else {
+            XCTFail()
+            return
+        }
+
+        collectionView.contentOffset = CGPoint(x: 0, y: 75)
+
+        subject.restoreVerticalScrollOffset(force: false)
+
+        XCTAssertEqual(collectionView.contentOffset.y, 75)
+    }
+
     func test_viewDidDisappear_savesVerticalScrollOffset() {
         let tabManager = HomepageRestoreContentOffsetTabManager()
         let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
@@ -401,6 +426,30 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         collectionView.contentOffset = CGPoint(x: 0, y: 140)
 
         subject.viewWillDisappear(false)
+
+        XCTAssertEqual(homepageTabStateStore.state(for: tab.tabUUID).scrollOffsetY, 140)
+    }
+
+    func test_stopScrollingAndSaveVerticalScrollOffset_savesCurrentOffset() {
+        let tabManager = HomepageRestoreContentOffsetTabManager()
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tabManager.tabs = [tab]
+        tabManager.selectedTab = tab
+        let subject = createSubject(tabManager: tabManager)
+
+        subject.loadViewIfNeeded()
+        subject.viewWillAppear(false)
+
+        guard let collectionView = subject.view.subviews.first(where: {
+            $0 is UICollectionView
+        }) as? UICollectionView else {
+            XCTFail()
+            return
+        }
+
+        collectionView.contentOffset = CGPoint(x: 0, y: 140)
+
+        subject.stopScrollingAndSaveVerticalScrollOffset()
 
         XCTAssertEqual(homepageTabStateStore.state(for: tab.tabUUID).scrollOffsetY, 140)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15594)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33405)

## :bulb: Description
- Prevents homepage scroll position jumps when tapping toolbar actions while the homepage is scrolling

### 📝 Technical Notes:
- `BrowserCoordinator::showHomepage()` is called frequently, so only force homepage scroll restoration when the homepage is newly embedded. Skip restoring the saved tab offset when `showHomepage` is re-entered for the same active tab.
- Stop homepage collection view scrolling and save the current offset before presenting tab tray.

## :movie_camera: Demos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/036ee2bc-d75b-4bd7-bfdd-724c21809ed1

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/154a8827-1300-40ab-a1e0-ec21456533f4

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

