### PR TITLE
Add FXIOS-15804 [WC] Add baseURL override for QA testing

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -114,6 +114,8 @@ public struct PrefsKeys {
         public static let JumpBackInSection = "JumpBackInSectionUserPrefsKey"
         public static let WorldCupSection = "WorldCupSectionUserPrefsKey"
         public static let WorldCupNowOverride = "worldCupNowOverrideKey"
+        /// Override for the merino WCS base host
+        public static let WorldCupBaseHost = "worldCupBaseHostKey"
     }
 
     public struct Homepage {

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2267,6 +2267,7 @@
 		F00CA4012F00000000000011 /* WorldCupNormalFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000012 /* WorldCupNormalFetchStrategy.swift */; };
 		F00CA4012F00000000000013 /* WorldCupTeamsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000014 /* WorldCupTeamsResponse.swift */; };
 		F00CA4012F00000000000015 /* WorldCupLoadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000016 /* WorldCupLoadError.swift */; };
+		F00CA4012F00000000000017 /* WorldCupBaseHostOverrideSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000018 /* WorldCupBaseHostOverrideSetting.swift */; };
 		F00CA4022F00000000000001 /* WorldCupMatchesResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000002 /* WorldCupMatchesResponseTests.swift */; };
 		F00CA4022F0000000000000D /* WorldCupTeamsResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F0000000000000E /* WorldCupTeamsResponseTests.swift */; };
 		F00CA4022F0000000000000F /* WorldCupLoadErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000010 /* WorldCupLoadErrorTests.swift */; };
@@ -11649,6 +11650,7 @@
 		F00CA4012F00000000000012 /* WorldCupNormalFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupNormalFetchStrategy.swift; sourceTree = "<group>"; };
 		F00CA4012F00000000000014 /* WorldCupTeamsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupTeamsResponse.swift; sourceTree = "<group>"; };
 		F00CA4012F00000000000016 /* WorldCupLoadError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupLoadError.swift; sourceTree = "<group>"; };
+		F00CA4012F00000000000018 /* WorldCupBaseHostOverrideSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupBaseHostOverrideSetting.swift; sourceTree = "<group>"; };
 		F00CA4022F00000000000002 /* WorldCupMatchesResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupMatchesResponseTests.swift; sourceTree = "<group>"; };
 		F00CA4022F0000000000000E /* WorldCupTeamsResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupTeamsResponseTests.swift; sourceTree = "<group>"; };
 		F00CA4022F00000000000010 /* WorldCupLoadErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupLoadErrorTests.swift; sourceTree = "<group>"; };
@@ -13842,6 +13844,7 @@
 				1DA710062AE7106B00677F6B /* AppDataUsageReportSetting.swift */,
 				1D1418772DC92DFC004BBFAD /* ChangeRSServerSetting.swift */,
 				AA5001482F912F530065A279 /* ChangeMLPAEndpointSetting.swift */,
+				F00CA4012F00000000000018 /* WorldCupBaseHostOverrideSetting.swift */,
 				8A3EF7FE2A2FCFBB00796E3A /* ChangeToChinaSetting.swift */,
 				8A093D7C2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift */,
 				8A3EF7F12A2FCF4000796E3A /* DeleteExportedDataSetting.swift */,
@@ -19172,6 +19175,7 @@
 				21618A8A2A4389F700A5189E /* PresentedComponentsState.swift in Sources */,
 				8CC617092C35463B001C7688 /* AddressModifiedStatus.swift in Sources */,
 				AA5001492F912F610065A279 /* ChangeMLPAEndpointSetting.swift in Sources */,
+				F00CA4012F00000000000017 /* WorldCupBaseHostOverrideSetting.swift in Sources */,
 				EB1C84BF212EFFBF001489DF /* BrowserViewController+ReaderMode.swift in Sources */,
 				81020C922BB5AFA2007B8481 /* OnboardingMultipleChoiceButtonView.swift in Sources */,
 				96D95016270238500079D39D /* MainThreadThrottler.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClient.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClient.swift
@@ -30,6 +30,21 @@ final class WorldCupAPIClient: WorldCupAPIClientProtocol, @unchecked Sendable {
         self.teamsStrategy = teamsStrategy
     }
 
+    /// Convenience init that points the FFI at a custom host. Pass `nil` or
+    /// an empty string to use the default merino host. Intended for local
+    /// dev/beta testing against a non-production merino instance. 
+    convenience init(baseHost: String?,
+                     matchesStrategy: WorldCupFetchStrategyProtocol = WorldCupNormalFetchStrategy(),
+                     liveStrategy: WorldCupFetchStrategyProtocol = WorldCupNormalFetchStrategy(),
+                     teamsStrategy: WorldCupFetchStrategyProtocol = WorldCupNormalFetchStrategy()) throws {
+        let trimmed = baseHost?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let host = (trimmed?.isEmpty == false) ? trimmed : nil
+        try self.init(config: WorldCupConfig(baseHost: host),
+                      matchesStrategy: matchesStrategy,
+                      liveStrategy: liveStrategy,
+                      teamsStrategy: teamsStrategy)
+    }
+
     /// Low-level sync matches fetch + decode. Throws on FFI error or decode failure.
     /// Pass a 3-letter FIFA team key to filter the response to one team's fixtures.
     func fetch(_ query: WorldCupQuery, team: String? = nil) throws -> WorldCupMatchesResponse? {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -4,6 +4,7 @@
 
 import Common
 import Foundation
+import Shared
 
 private final class PageContainer: UIView, ThemeApplicable {
     private struct UX {
@@ -136,7 +137,11 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
     private var currentTheme: Theme?
     private weak var matchesCardView: WorldCupMatchCardView?
     private var matchesFetchTask: Task<Void, Never>?
-    private let apiClient: WorldCupAPIClientProtocol? = try? WorldCupAPIClient()
+    private let apiClient: WorldCupAPIClientProtocol? = {
+        let profile: Profile = AppContainer.shared.resolve()
+        let baseHost = profile.prefs.stringForKey(PrefsKeys.HomepageSettings.WorldCupBaseHost)
+        return try? WorldCupAPIClient(baseHost: baseHost)
+    }()
 
     override init(frame: CGRect) {
         super.init(frame: .zero)

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -543,6 +543,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         ]
 
         #if MOZ_CHANNEL_beta || MOZ_CHANNEL_developer
+        hiddenDebugOptions.append(WorldCupBaseHostOverrideSetting(settings: self))
         hiddenDebugOptions.append(ChangeMLPAEndpointSetting(settings: self))
         hiddenDebugOptions.append(DeleteAppAttestKeySetting(settings: self))
         hiddenDebugOptions.append(PrivacyNoticeUpdate(settings: self))

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/WorldCupBaseHostOverrideSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/WorldCupBaseHostOverrideSetting.swift
@@ -7,11 +7,12 @@ import Common
 import Shared
 
 /// Debug-menu setting that overrides the merino WCS base host (e.g. point at
-/// a local server). Dev/beta only — exposed via `HiddenSetting`, which is
-/// gated by the debug menu unlock.
+/// a local server). This is for dev/beta only and is exposed via `HiddenSetting`.
 final class WorldCupBaseHostOverrideSetting: HiddenSetting {
     private let prefsKey = PrefsKeys.HomepageSettings.WorldCupBaseHost
-    private let prefs: Prefs = { return (AppContainer.shared.resolve() as Profile).prefs }()
+    private let prefs: Prefs = { 
+        return (AppContainer.shared.resolve() as Profile).prefs 
+    }()
 
     private var override: String? { prefs.stringForKey(prefsKey) }
 
@@ -37,12 +38,12 @@ final class WorldCupBaseHostOverrideSetting: HiddenSetting {
     override func onClick(_ navigationController: UINavigationController?) {
         let alert = UIAlertController(
             title: "Override merino host",
-            message: "Enter a host (e.g. `127.0.0.1:8000` or `https://my.dev`). Leave empty to use the default.",
+            message: "Enter a host (e.g. `https://127.0.0.1:8000/` or `https://my.dev`). Leave empty to use the default.",
             preferredStyle: .alert
         )
         alert.addTextField { textField in
             textField.text = self.override
-            textField.placeholder = "merino.services.mozilla.com"
+            textField.placeholder = "https://merino.services.mozilla.com/"
             textField.autocapitalizationType = .none
             textField.autocorrectionType = .no
             textField.keyboardType = .URL

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/WorldCupBaseHostOverrideSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/WorldCupBaseHostOverrideSetting.swift
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+import Shared
+
+/// Debug-menu setting that overrides the merino WCS base host (e.g. point at
+/// a local server). Dev/beta only — exposed via `HiddenSetting`, which is
+/// gated by the debug menu unlock.
+final class WorldCupBaseHostOverrideSetting: HiddenSetting {
+    private let prefsKey = PrefsKeys.HomepageSettings.WorldCupBaseHost
+    private let prefs: Prefs = { return (AppContainer.shared.resolve() as Profile).prefs }()
+
+    private var override: String? { prefs.stringForKey(prefsKey) }
+
+    override var title: NSAttributedString? {
+        guard let theme else { return nil }
+        return NSAttributedString(
+            string: "World Cup: Override merino host",
+            attributes: [.foregroundColor: theme.colors.textPrimary]
+        )
+    }
+
+    override var status: NSAttributedString? {
+        guard let theme else { return nil }
+        let label = override?.isEmpty == false
+            ? "Set to \(override ?? "")"
+            : "Using default merino host"
+        return NSAttributedString(
+            string: label,
+            attributes: [.foregroundColor: theme.colors.textSecondary]
+        )
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        let alert = UIAlertController(
+            title: "Override merino host",
+            message: "Enter a host (e.g. `127.0.0.1:8000` or `https://my.dev`). Leave empty to use the default.",
+            preferredStyle: .alert
+        )
+        alert.addTextField { textField in
+            textField.text = self.override
+            textField.placeholder = "merino.services.mozilla.com"
+            textField.autocapitalizationType = .none
+            textField.autocorrectionType = .no
+            textField.keyboardType = .URL
+        }
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Clear", style: .destructive) { [weak self] _ in
+            guard let self else { return }
+            self.prefs.removeObjectForKey(self.prefsKey)
+        })
+        alert.addAction(UIAlertAction(title: "Save", style: .default) { [weak self] _ in
+            guard let self else { return }
+            let value = alert.textFields?.first?.text?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if value.isEmpty {
+                self.prefs.removeObjectForKey(self.prefsKey)
+            } else {
+                self.prefs.setString(value, forKey: self.prefsKey)
+            }
+        })
+        settings.present(alert, animated: true)
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/WorldCupBaseHostOverrideSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/WorldCupBaseHostOverrideSetting.swift
@@ -10,8 +10,8 @@ import Shared
 /// a local server). This is for dev/beta only and is exposed via `HiddenSetting`.
 final class WorldCupBaseHostOverrideSetting: HiddenSetting {
     private let prefsKey = PrefsKeys.HomepageSettings.WorldCupBaseHost
-    private let prefs: Prefs = { 
-        return (AppContainer.shared.resolve() as Profile).prefs 
+    private let prefs: Prefs = {
+        return (AppContainer.shared.resolve() as Profile).prefs
     }()
 
     private var override: String? { prefs.stringForKey(prefsKey) }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15804)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33804)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Adds override hidden setting for QA team so they can test with different payloads.

@cyndichin there is no easy way now to test this but I added a log 
```rust
info!("[dbg][issam]Sending request to WorldCup API: {}", request.url);
```
inside AS [here](https://github.com/mozilla/application-services/blob/06c391e81c367d1059d601c812f379875d7ef0a3/components/merino/src/worldcup/http.rs#L50) and I see it's picked up:
<img width="621" height="180" alt="Screenshot 2026-05-13 at 21 08 06" src="https://github.com/user-attachments/assets/c79b5661-7edb-415d-8b9b-214a3e33bdd9" />

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

