### PR TITLE
Bugfix FXIOS-15806 [Homepage] Fix pinned homepage webview flicker over bottom toolbar

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1625,7 +1625,7 @@ class BrowserViewController: UIViewController,
             contentContainerTopConstraint?.isActive = true
 
             let frontViews = shouldPinContentContainerToScreenTop
-                ? [contentContainer, bottomContentStackView, bottomContainer, overKeyboardContainer]
+                ? [contentContainer, bottomBlurView, bottomContentStackView, bottomContainer, overKeyboardContainer]
                 : [topBlurView, bottomBlurView, topTouchArea, statusBarOverlay, header,
                    bottomContentStackView, bottomContainer, overKeyboardContainer]
             frontViews.filter { $0.superview === view }.forEach(view.bringSubviewToFront)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15806)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33807)

## :bulb: Description
- Fix a brief webview flicker over the bottom toolbar when navigating from a webview back to the homepage

### 📝 Technical Notes:
- Changes to BVC UI from #33585 caused `contentContainer` to be promoted over other BVC UI while the retained WKWebView could briefly draw before the bottom toolbar backing was brought above it.
- `bottomBlurView` was not included in the pinned z-order stack, so the webview could briefly show through the bottom toolbar. `bottomBlurView` has is now added above contentContainer in the BVC UI ordering when pinned header is enabled.
- Issue was confined to only the bottom address bar/toolbar
- Issue only occurs when the `pinned-header-enabled` homepage feature flag was enabled, since those BVC UI changes are gated behind it

## :movie_camera: Demos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/79d65375-be1d-47f5-9bb6-e71acafd6040

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/f3bd695c-617b-40b5-ba8c-e6a8b0277c69

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

