### PR TITLE
 Refactor FXIOS-15770 [Microsurvey] Convert MicrosurveyTests to TAE

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -6,6 +6,12 @@ import Common
 import XCTest
 
 final class MicrosurveyTests: BaseTestCase {
+    private var microsurveyScreen: MicrosurveyScreen!
+    private var browserScreen: BrowserScreen!
+    private var toolbarScreen: ToolbarScreen!
+    private var tabTrayScreen: TabTrayScreen!
+    private var settingScreen: SettingScreen!
+
     override func setUp() async throws {
         launchArguments = [
             LaunchArguments.SkipIntro,
@@ -13,46 +19,33 @@ final class MicrosurveyTests: BaseTestCase {
         ]
         try await super.setUp()
         app.launch()
+        microsurveyScreen = MicrosurveyScreen(app: app)
+        browserScreen = BrowserScreen(app: app)
+        toolbarScreen = ToolbarScreen(app: app)
+        tabTrayScreen = TabTrayScreen(app: app)
+        settingScreen = SettingScreen(app: app)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2776931
     func testShowMicrosurvey() {
         generateTriggerForMicrosurvey()
-        let continueButton = app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton]
-        continueButton.waitAndTap()
+        microsurveyScreen.tapTakeSurveyButton()
 
-        waitForElementsToExist(
-            [
-                app.images[AccessibilityIdentifiers.Microsurvey.Survey.firefoxLogo],
-                app.buttons[AccessibilityIdentifiers.Microsurvey.Survey.closeButton]
-            ]
-        )
-        let tablesQuery = app.scrollViews.otherElements.tables
-        let firstOption = tablesQuery.cells.firstMatch
-        firstOption.waitAndTap()
-        mozWaitForElementToExist(firstOption)
-        XCTAssertEqual(firstOption.label, "Very satisfied")
-        mozWaitForValueContains(firstOption, value: "1 out of 6")
-
-        let secondOption = tablesQuery.cells["Neutral"]
-        mozWaitForElementToExist(secondOption)
-        XCTAssertEqual(secondOption.label, "Neutral")
-        mozWaitForValueContains(secondOption, value: "Unselected, 3 out of 6")
+        microsurveyScreen.assertSurveyExists()
+        microsurveyScreen.tapFirstSurveyOption()
+        microsurveyScreen.assertFirstSurveyOptionSelected()
+        microsurveyScreen.assertSurveyOptionUnselected(label: "Neutral")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2776934
     func testCloseButtonDismissesSurveyAndPrompt() {
         generateTriggerForMicrosurvey()
-        let continueButton = app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton]
-        continueButton.waitAndTap()
+        microsurveyScreen.tapTakeSurveyButton()
 
-        app.buttons[AccessibilityIdentifiers.Microsurvey.Survey.closeButton].waitAndTap()
+        microsurveyScreen.tapSurveyCloseButton()
 
-        mozWaitForElementToNotExist(app.images[AccessibilityIdentifiers.Microsurvey.Survey.firefoxLogo])
-        mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Microsurvey.Survey.closeButton])
-        mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton])
-        mozWaitForElementToNotExist(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo])
-        mozWaitForElementToNotExist(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton])
+        microsurveyScreen.assertSurveyDismissed()
+        microsurveyScreen.assertPromptDismissed()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2776933
@@ -64,17 +57,9 @@ final class MicrosurveyTests: BaseTestCase {
         app.terminate()
         app.launch()
         generateTriggerForMicrosurvey()
-        waitForElementsToExist(
-            [
-                app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton],
-                app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo],
-                app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton]
-            ]
-        )
-        app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].waitAndTap()
-        mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton])
-        mozWaitForElementToNotExist(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo])
-        mozWaitForElementToNotExist(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton])
+        microsurveyScreen.assertPromptExists()
+        microsurveyScreen.tapPromptCloseButton()
+        microsurveyScreen.assertPromptDismissed()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2776932
@@ -83,28 +68,27 @@ final class MicrosurveyTests: BaseTestCase {
             throw XCTSkip("Toolbar option not available for iPad")
         }
         navigator.nowAt(NewTabScreen)
-        navigator.goto(ToolbarSettings)
-        navigator.performAction(Action.SelectToolbarBottom)
-        navigator.goto(HomePanelsScreen)
+        navigator.goto(SettingsScreen)
+        settingScreen.navigateToToolbarSettings()
+        settingScreen.selectBottomToolbar()
+        settingScreen.tapBackToSettings()
+        settingScreen.closeSettingsWithDoneButton()
         generateTriggerForMicrosurvey()
 
-        XCTAssertFalse(app.otherElements[AccessibilityIdentifiers.Toolbar.topBorder].exists)
+        microsurveyScreen.assertTopBorderHidden()
 
-        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton].exists)
-        XCTAssertTrue(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo].exists)
-        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists)
-        app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].waitAndTap()
-        XCTAssertFalse(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists)
+        microsurveyScreen.assertPromptExists()
+        microsurveyScreen.tapPromptCloseButton()
+        microsurveyScreen.assertPromptDismissed()
 
-        XCTAssertTrue(app.otherElements[AccessibilityIdentifiers.Toolbar.topBorder].exists)
+        microsurveyScreen.assertTopBorderVisible()
     }
 
     private func generateTriggerForMicrosurvey() {
-        navigator.nowAt(NewTabScreen)
-        navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
-        navigator.performAction(Action.OpenNewTabFromTabTray)
-        navigator.nowAt(BrowserTab)
-        navigator.openURL(path(forTestPage: url_2["url"]!))
+        toolbarScreen.tapOnTabsButton()
+        tabTrayScreen.switchToPrivateMode()
+        tabTrayScreen.tapOnNewTabButton()
+        browserScreen.navigateToURL(path(forTestPage: url_2["url"]!))
         waitUntilPageLoad()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MicrosurveyScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MicrosurveyScreen.swift
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@MainActor
+final class MicrosurveyScreen {
+    private let app: XCUIApplication
+    private let sel: MicrosurveySelectorsSet
+
+    init(app: XCUIApplication, selectors: MicrosurveySelectorsSet = MicrosurveySelectors()) {
+        self.app = app
+        self.sel = selectors
+    }
+
+    private var promptFirefoxLogo: XCUIElement { sel.PROMPT_FIREFOX_LOGO.element(in: app) }
+    private var promptCloseButton: XCUIElement { sel.PROMPT_CLOSE_BUTTON.element(in: app) }
+    private var takeSurveyButton: XCUIElement { sel.TAKE_SURVEY_BUTTON.element(in: app) }
+    private var surveyFirefoxLogo: XCUIElement { sel.SURVEY_FIREFOX_LOGO.element(in: app) }
+    private var surveyCloseButton: XCUIElement { sel.SURVEY_CLOSE_BUTTON.element(in: app) }
+    private var firstSurveyOption: XCUIElement { app.scrollViews.otherElements.tables.cells.firstMatch }
+    private var topBorder: XCUIElement { sel.TOP_BORDER.element(in: app) }
+
+    func tapTakeSurveyButton() {
+        takeSurveyButton.waitAndTap()
+    }
+
+    func tapSurveyCloseButton() {
+        surveyCloseButton.waitAndTap()
+    }
+
+    func tapPromptCloseButton() {
+        promptCloseButton.waitAndTap()
+    }
+
+    func assertPromptExists() {
+        BaseTestCase().waitForElementsToExist([
+            takeSurveyButton,
+            promptFirefoxLogo,
+            promptCloseButton
+        ])
+    }
+
+    func assertPromptDismissed() {
+        BaseTestCase().mozWaitForElementToNotExist(takeSurveyButton)
+        BaseTestCase().mozWaitForElementToNotExist(promptFirefoxLogo)
+        BaseTestCase().mozWaitForElementToNotExist(promptCloseButton)
+    }
+
+    func assertSurveyExists() {
+        BaseTestCase().waitForElementsToExist([
+            surveyFirefoxLogo,
+            surveyCloseButton
+        ])
+    }
+
+    func assertSurveyDismissed() {
+        BaseTestCase().mozWaitForElementToNotExist(surveyFirefoxLogo)
+        BaseTestCase().mozWaitForElementToNotExist(surveyCloseButton)
+    }
+
+    func tapFirstSurveyOption() {
+        firstSurveyOption.waitAndTap()
+    }
+
+    func assertFirstSurveyOptionSelected() {
+        BaseTestCase().mozWaitForElementToExist(firstSurveyOption)
+        XCTAssertEqual(firstSurveyOption.label, "Very satisfied")
+        BaseTestCase().mozWaitForValueContains(firstSurveyOption, value: "1 out of 6")
+    }
+
+    func assertSurveyOptionUnselected(label: String) {
+        let option = sel.surveyOption(label: label).element(in: app)
+        BaseTestCase().mozWaitForElementToExist(option)
+        XCTAssertEqual(option.label, label)
+        BaseTestCase().mozWaitForValueContains(option, value: "Unselected, 3 out of 6")
+    }
+
+    func assertTopBorderHidden() {
+        XCTAssertFalse(topBorder.exists)
+    }
+
+    func assertTopBorderVisible() {
+        XCTAssertTrue(topBorder.exists)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
@@ -21,6 +21,8 @@ final class SettingScreen {
         app.tables.cells.switches["Offer to Open Copied Links, When opening Firefox"]
     }
     private var translationCell: XCUIElement { sel.TRANSLATION_CELL_TITLE.element(in: app) }
+    private var toolbarCell: XCUIElement { sel.TOOLBAR_CELL.element(in: app) }
+    private var bottomToolbarButton: XCUIElement { sel.BOTTOM_TOOLBAR_BUTTON.element(in: app) }
 
     func closeSettingsWithDoneButton() {
         let doneButton = sel.DONE_BUTTON.element(in: app)
@@ -184,6 +186,16 @@ final class SettingScreen {
         let cell = sel.BROWSING_CELL_TITLE.element(in: app)
         BaseTestCase().mozWaitForElementToExist(cell)
         cell.waitAndTap()
+    }
+
+    func navigateToToolbarSettings() {
+        BaseTestCase().mozWaitForElementToExist(toolbarCell)
+        toolbarCell.waitAndTap()
+    }
+
+    func selectBottomToolbar() {
+        BaseTestCase().mozWaitForElementToExist(bottomToolbarButton)
+        bottomToolbarButton.waitAndTap()
     }
 
     func navigateToDisplaySettings() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
@@ -79,6 +79,17 @@ final class TabTrayScreen {
         newTabButton.waitAndTap()
     }
 
+    func switchToPrivateMode() {
+        let privateModeButton: XCUIElement
+        if BaseTestCase().iPad() {
+            privateModeButton = app.navigationBars.segmentedControls.buttons.element(boundBy: 1)
+        } else {
+            privateModeButton = app.buttons["\(AccessibilityIdentifiers.TabTray.selectorCell)0"]
+        }
+        BaseTestCase().mozWaitForElementToExist(privateModeButton)
+        privateModeButton.waitAndTap()
+    }
+
     func assertNewTabButtonExist() {
         BaseTestCase().mozWaitForElementToExist(newTabButton)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/MicrosurveySelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/MicrosurveySelectors.swift
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+protocol MicrosurveySelectorsSet {
+    var PROMPT_FIREFOX_LOGO: Selector { get }
+    var PROMPT_CLOSE_BUTTON: Selector { get }
+    var TAKE_SURVEY_BUTTON: Selector { get }
+    var SURVEY_FIREFOX_LOGO: Selector { get }
+    var SURVEY_CLOSE_BUTTON: Selector { get }
+    var TOP_BORDER: Selector { get }
+    func surveyOption(label: String) -> Selector
+    var all: [Selector] { get }
+}
+
+struct MicrosurveySelectors: MicrosurveySelectorsSet {
+    private enum IDs {
+        static let promptFirefoxLogo = AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo
+        static let promptCloseButton = AccessibilityIdentifiers.Microsurvey.Prompt.closeButton
+        static let takeSurveyButton = AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton
+        static let surveyFirefoxLogo = AccessibilityIdentifiers.Microsurvey.Survey.firefoxLogo
+        static let surveyCloseButton = AccessibilityIdentifiers.Microsurvey.Survey.closeButton
+        static let topBorder = AccessibilityIdentifiers.Toolbar.topBorder
+    }
+
+    let PROMPT_FIREFOX_LOGO = Selector.imageId(
+        IDs.promptFirefoxLogo,
+        description: "Microsurvey prompt Firefox logo",
+        groups: ["microsurvey", "prompt"]
+    )
+
+    let PROMPT_CLOSE_BUTTON = Selector.buttonId(
+        IDs.promptCloseButton,
+        description: "Microsurvey prompt close button",
+        groups: ["microsurvey", "prompt"]
+    )
+
+    let TAKE_SURVEY_BUTTON = Selector.buttonId(
+        IDs.takeSurveyButton,
+        description: "Microsurvey prompt take survey button",
+        groups: ["microsurvey", "prompt"]
+    )
+
+    let SURVEY_FIREFOX_LOGO = Selector.imageId(
+        IDs.surveyFirefoxLogo,
+        description: "Microsurvey survey Firefox logo",
+        groups: ["microsurvey", "survey"]
+    )
+
+    let SURVEY_CLOSE_BUTTON = Selector.buttonId(
+        IDs.surveyCloseButton,
+        description: "Microsurvey survey close button",
+        groups: ["microsurvey", "survey"]
+    )
+
+    let TOP_BORDER = Selector.otherElementId(
+        IDs.topBorder,
+        description: "Toolbar top border",
+        groups: ["toolbar"]
+    )
+
+    func surveyOption(label: String) -> Selector {
+        Selector.cellByLabel(
+            label,
+            description: "Microsurvey survey option \(label)",
+            groups: ["microsurvey", "survey"]
+        )
+    }
+
+    var all: [Selector] { [
+        PROMPT_FIREFOX_LOGO,
+        PROMPT_CLOSE_BUTTON,
+        TAKE_SURVEY_BUTTON,
+        SURVEY_FIREFOX_LOGO,
+        SURVEY_CLOSE_BUTTON,
+        TOP_BORDER
+    ] }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SettingsSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SettingsSelectors.swift
@@ -41,6 +41,7 @@ protocol SettingsSelectorsSet {
     var BROWSING_LINKS_SECTION: Selector { get }
     var BLOCK_POPUPS_SWITCH: Selector { get }
     var TOOLBAR_CELL: Selector { get }
+    var BOTTOM_TOOLBAR_BUTTON: Selector { get }
     var DEFAULT_BROWSER_CELL: Selector { get }
     var SEARCH_CELL: Selector { get }
     var BROWSING_CELL_TITLE: Selector { get }
@@ -78,6 +79,7 @@ struct SettingsSelectors: SettingsSelectorsSet {
         static let connectSetting = AccessibilityIdentifiers.Settings.ConnectSetting.title
         static let settingTitle = "Settings"
         static let toolbarCellSettings = AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting
+        static let bottomToolbarButton = AccessibilityIdentifiers.Settings.SearchBar.bottomSetting
         static let defaultBrowserSettings = AccessibilityIdentifiers.Settings.DefaultBrowser.defaultBrowser
         static let searchCellTitle = AccessibilityIdentifiers.Settings.Search.title
         static let browsingCellTitle = AccessibilityIdentifiers.Settings.Browsing.title
@@ -246,6 +248,12 @@ struct SettingsSelectors: SettingsSelectorsSet {
         groups: ["settings"]
     )
 
+    let BOTTOM_TOOLBAR_BUTTON = Selector.buttonId(
+        IDs.bottomToolbarButton,
+        description: "Bottom toolbar setting button",
+        groups: ["settings"]
+    )
+
     let DEFAULT_BROWSER_CELL = Selector.tableCellById(
         IDs.defaultBrowserSettings,
         description: "Default browser cell in Settings",
@@ -379,13 +387,12 @@ struct SettingsSelectors: SettingsSelectorsSet {
     }
 
     var all: [Selector] {
-            [SETTINGS_TABLE, DONE_BUTTON, SETTINGS_TITLE, AUTOFILLS_PASSWORDS_CELL, CLEAR_DATA_CELL,
-             CLOSE_PRIVATE_TABS_SWITCH, CONTENT_BLOCKER_CELL, NOTIFICATIONS_CELL,
-             PRIVACY_POLICY_CELL, LOGINS_CELL, CREDIT_CARDS_CELL, ADDRESS_CELL,
-             CLEAR_PRIVATE_DATA_CELL, ALERT_OK_BUTTON, NEW_TAB_CELL, TITLE, TABLE,
-             BROWSING_LINKS_SECTION, NAVIGATIONBAR, CONNECT_SETTING, BLOCK_POPUPS_SWITCH,
-             TOOLBAR_CELL, DEFAULT_BROWSER_CELL, SEARCH_CELL, BROWSING_CELL_TITLE,
-             BLOCK_IMAGES_SWITCH_TITLE, NO_IMAGE_MODE_STATUS_SWITCH, TRANSLATION_CELL_TITLE,
-             SEND_DATA_CELL, SEND_CRASH_REPORTS_CELL]
-        }
+        [SETTINGS_TABLE, DONE_BUTTON, SETTINGS_TITLE, AUTOFILLS_PASSWORDS_CELL, CLEAR_DATA_CELL,
+         CLOSE_PRIVATE_TABS_SWITCH, CONTENT_BLOCKER_CELL, NOTIFICATIONS_CELL,
+         PRIVACY_POLICY_CELL, LOGINS_CELL, CREDIT_CARDS_CELL, ADDRESS_CELL,
+         CLEAR_PRIVATE_DATA_CELL, ALERT_OK_BUTTON, NEW_TAB_CELL, TITLE, TABLE, BROWSING_LINKS_SECTION,
+         NAVIGATIONBAR, CONNECT_SETTING, BLOCK_POPUPS_SWITCH, TOOLBAR_CELL, BOTTOM_TOOLBAR_BUTTON, DEFAULT_BROWSER_CELL,
+         SEARCH_CELL, BROWSING_CELL_TITLE, BLOCK_IMAGES_SWITCH_TITLE, NO_IMAGE_MODE_STATUS_SWITCH,
+         TRANSLATION_CELL_TITLE, SEND_DATA_CELL, SEND_CRASH_REPORTS_CELL]
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15770)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33727)

 ## :bulb: Description

  Converted `MicrosurveyTests` to the TAE page object pattern.

  Changes:
  - Added `MicrosurveySelectors` for microsurvey prompt, survey, options, and toolbar border elements.
  - Added `MicrosurveyScreen` to own microsurvey interactions and assertions.
  - Refactored `MicrosurveyTests` to use screen objects instead of direct microsurvey `app.*` queries.
  - Rewrote the microsurvey trigger helper to use existing screen methods instead of legacy `navigator.toggleOn`,
  `navigator.performAction`, and `navigator.openURL`.
  - Added focused `SettingScreen` and `TabTrayScreen` helpers needed by the migrated flow.

  Validation:
  - Ran `git diff --check`.
  - Ran `xcrun swiftc -parse` on the changed Swift files.
  - Ran `testURLBorderHiddenWhenMicrosurveyPromptShown` locally and fixed the settings back-navigation issue found during execution.

## :movie_camera: Demos
<img width="725" height="450" alt="Screenshot 2026-05-14 at 2 00 40 AM" src="https://github.com/user-attachments/assets/d8b078ea-865b-4a9a-b63e-a2c741015100" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

