### PR TITLE
Refactor FXIOS-15885 [UI Tests] Update A11yOnboardingTests to use TAE

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yOnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yOnboardingTests.swift
@@ -6,17 +6,18 @@ import Common
 import XCTest
 
 class A11yOnboardingTests: BaseTestCase {
-    var currentScreen = 0
-    var rootA11yId: String {
-        return "\(AccessibilityIdentifiers.Onboarding.onboarding)\(currentScreen)"
-    }
+    private var onboardingScreen: OnboardingScreen!
+    private var firefoxHomePageScreen: FirefoxHomePageScreen!
+
+    private var rootA11yId: String { onboardingScreen.rootA11yId }
 
     override func setUp() async throws {
         launchArguments = [LaunchArguments.ClearProfile,
                            LaunchArguments.DisableAnimations,
                            LaunchArguments.SkipSplashScreenExperiment]
-        currentScreen = 0
         try await super.setUp()
+        onboardingScreen = OnboardingScreen(app: app, flowType: .legacy)
+        firefoxHomePageScreen = FirefoxHomePageScreen(app: app)
     }
 
     override func tearDown() async throws {
@@ -31,61 +32,38 @@ class A11yOnboardingTests: BaseTestCase {
         // swiftlint:enable large_tuple
         guard #available(iOS 17.0, *), !skipPlatform else { return }
 
-        // Complete the First run from first screen to the latest one
-        // Check that the first's tour screen is shown as well as all the elements in there
-        waitForElementsToExist(
-            [
-                app.images["\(rootA11yId)ImageView"],
-                app.staticTexts["\(rootA11yId)TitleLabel"],
-                app.staticTexts["\(rootA11yId)DescriptionLabel"],
-                app.buttons["\(rootA11yId)PrimaryButton"],
-                app.buttons["\(rootA11yId)SecondaryButton"],
-                app.buttons["\(AccessibilityIdentifiers.Onboarding.closeButton)"],
-                app.pageIndicators["\(AccessibilityIdentifiers.Onboarding.pageControl)"]
-            ]
-        )
+        // Screen 0: first tour screen, including close button and page control
+        onboardingScreen.waitForCurrentScreenElements(checkCloseButton: true, checkPageControl: true)
         try app.performAccessibilityAudit()
         checkMissingLabels(missingLabels: &missingLabels)
 
         // Swipe to the second screen
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
-        currentScreen += 1
-        waitForElementsToExist(
-            [
-                app.images["\(rootA11yId)ImageView"],
-                app.staticTexts["\(rootA11yId)TitleLabel"],
-                app.staticTexts["\(rootA11yId)DescriptionLabel"],
-                app.buttons["\(rootA11yId)PrimaryButton"],
-            ]
-        )
+        onboardingScreen.goToNextScreenViaSecondary()
+        onboardingScreen.waitForCurrentScreenElements()
         try app.performAccessibilityAudit()
         checkMissingLabels(missingLabels: &missingLabels)
 
         // Swipe to the third screen
-        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
-        currentScreen += 1
-        mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"])
+        onboardingScreen.goToNextScreenViaSecondary()
+        onboardingScreen.waitForCurrentScreenElements()
         try app.performAccessibilityAudit()
         checkMissingLabels(missingLabels: &missingLabels)
 
         // Swipe to the fourth screen
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
-        currentScreen += 1
-        mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
+        onboardingScreen.goToNextScreenViaSecondary()
+        onboardingScreen.waitForCurrentScreenElements()
         try app.performAccessibilityAudit()
         checkMissingLabels(missingLabels: &missingLabels)
 
         // Swipe to the fifth screen
-        app.buttons["\(rootA11yId)PrimaryButton"].tap()
-        currentScreen += 1
-        mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
+        onboardingScreen.goToNextScreenViaPrimary()
+        onboardingScreen.waitForCurrentScreenElements()
         try app.performAccessibilityAudit()
         checkMissingLabels(missingLabels: &missingLabels)
 
         // Finish onboarding
-        app.buttons["\(rootA11yId)PrimaryButton"].tap()
-        let topSites = app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
-        mozWaitForElementToExist(topSites)
+        onboardingScreen.goToNextScreenViaPrimary()
+        firefoxHomePageScreen.assertTopSitesItemCellExist()
 
         // Generate Report
         A11yUtils.generateAndAttachReport(missingLabels: missingLabels, testName: sanitizedTestName, generateCsv: false)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yOnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yOnboardingTests.swift
@@ -31,8 +31,8 @@ class A11yOnboardingTests: BaseTestCase {
         var missingLabels: [A11yUtils.MissingAccessibilityElement] = []
         // swiftlint:enable large_tuple
         guard #available(iOS 17.0, *), !skipPlatform else { return }
-
-        // Screen 0: first tour screen, including close button and page control
+        // Complete the first run from first screen to the latest one
+        // Check that the first tour screen is shown as well as all it's elements
         onboardingScreen.waitForCurrentScreenElements(checkCloseButton: true, checkPageControl: true)
         try app.performAccessibilityAudit()
         checkMissingLabels(missingLabels: &missingLabels)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15885)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Update the A11yOnboardingTests To Use the [TAE Framework](https://github.com/mozilla-mobile/firefox-ios/wiki/Test-Automation-Efficiency-UI-Testing-Guide-for-Firefox-iOS)


