### PR TITLE
Bugfix FXIOS-15617 Prevent skeleton bars from not being shown when launching with address bar on top then moving it to bottom

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1272,8 +1272,7 @@ class BrowserViewController: UIViewController,
             profile: profile,
             searchEnginesManager: searchEnginesManager,
             delegate: self,
-            isUnifiedSearchEnabled: isUnifiedSearchEnabled,
-            isBottomSearchBar: isBottomSearchBar
+            isUnifiedSearchEnabled: isUnifiedSearchEnabled
         )
         addressToolbarContainer.applyTheme(theme: currentTheme())
         addressToolbarContainer.addToParent(parent: isBottomSearchBar ? overKeyboardContainer : header)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1272,7 +1272,8 @@ class BrowserViewController: UIViewController,
             profile: profile,
             searchEnginesManager: searchEnginesManager,
             delegate: self,
-            isUnifiedSearchEnabled: isUnifiedSearchEnabled
+            isUnifiedSearchEnabled: isUnifiedSearchEnabled,
+            isBottomSearchBar: isBottomSearchBar
         )
         addressToolbarContainer.applyTheme(theme: currentTheme())
         addressToolbarContainer.addToParent(parent: isBottomSearchBar ? overKeyboardContainer : header)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -423,16 +423,12 @@ final class AddressToolbarContainer: UIView,
 
     private func setupToolbarConstraints(isBottomSearchBar: Bool) {
         addSubview(toolbar)
-        if toolbarHelper.isSwipingTabsEnabled && isBottomSearchBar {
-            insertSubview(leftSkeletonAddressBar, aboveSubview: toolbar)
-            insertSubview(rightSkeletonAddressBar, aboveSubview: toolbar)
 
-            toolbar.leadingAnchor.constraint(equalTo: leftSkeletonAddressBar.trailingAnchor).isActive = true
-            toolbar.trailingAnchor.constraint(equalTo: rightSkeletonAddressBar.leadingAnchor).isActive = true
-        } else {
-            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
-        }
+        insertSubview(leftSkeletonAddressBar, aboveSubview: toolbar)
+        insertSubview(rightSkeletonAddressBar, aboveSubview: toolbar)
+
+        toolbar.leadingAnchor.constraint(equalTo: leftSkeletonAddressBar.trailingAnchor).isActive = true
+        toolbar.trailingAnchor.constraint(equalTo: rightSkeletonAddressBar.leadingAnchor).isActive = true
 
         NSLayoutConstraint.activate([
             toolbar.topAnchor.constraint(equalTo: topAnchor),
@@ -441,8 +437,6 @@ final class AddressToolbarContainer: UIView,
     }
 
     private func setupSkeletonAddressBarsLayout(isBottomSearchBar: Bool) {
-        guard toolbarHelper.isSwipingTabsEnabled, isBottomSearchBar else { return }
-
         NSLayoutConstraint.activate([
             leftSkeletonAddressBar.topAnchor.constraint(equalTo: topAnchor),
             leftSkeletonAddressBar.trailingAnchor.constraint(equalTo: leadingAnchor),

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -182,13 +182,12 @@ final class AddressToolbarContainer: UIView,
         searchEnginesManager: SearchEnginesManagerProvider,
         delegate: AddressToolbarContainerDelegate,
         isUnifiedSearchEnabled: Bool,
-        isBottomSearchBar: Bool
     ) {
         self.windowUUID = windowUUID
         self.profile = profile
         self.delegate = delegate
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
-        setupLayout(isBottomSearchBar: isBottomSearchBar)
+        setupLayout()
         subscribeToRedux()
     }
 
@@ -320,7 +319,7 @@ final class AddressToolbarContainer: UIView,
         let isReaderModeActive = state?.addressToolbar.readerModeState == .active
         if isReaderModeActive {
             // when the user scrolls the webpage the address toolbar gets hidden by changing its alpha
-            regularToolbar.alpha = alpha
+            regularToolbar.alpha = 3
         }
         updateSkeletonAddressBarsAlpha(to: alpha)
     }
@@ -394,7 +393,7 @@ final class AddressToolbarContainer: UIView,
         rightSkeletonAddressBar.alpha = alpha
     }
 
-    private func setupLayout(isBottomSearchBar: Bool) {
+    private func setupLayout() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(onContainerTapped))
         addGestureRecognizer(tapGesture)
 
@@ -406,8 +405,8 @@ final class AddressToolbarContainer: UIView,
             progressBar.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
 
-        setupToolbarConstraints(isBottomSearchBar: isBottomSearchBar)
-        setupSkeletonAddressBarsLayout(isBottomSearchBar: isBottomSearchBar)
+        setupToolbarConstraints()
+        setupSkeletonAddressBarsLayout()
 
         addSubview(addNewTabView)
         addNewTabLeadingConstraint = addNewTabView.leadingAnchor.constraint(equalTo: trailingAnchor)
@@ -421,7 +420,7 @@ final class AddressToolbarContainer: UIView,
         addNewTabLeadingConstraint?.isActive = true
     }
 
-    private func setupToolbarConstraints(isBottomSearchBar: Bool) {
+    private func setupToolbarConstraints() {
         addSubview(toolbar)
 
         insertSubview(leftSkeletonAddressBar, aboveSubview: toolbar)
@@ -436,7 +435,7 @@ final class AddressToolbarContainer: UIView,
         ])
     }
 
-    private func setupSkeletonAddressBarsLayout(isBottomSearchBar: Bool) {
+    private func setupSkeletonAddressBarsLayout() {
         NSLayoutConstraint.activate([
             leftSkeletonAddressBar.topAnchor.constraint(equalTo: topAnchor),
             leftSkeletonAddressBar.trailingAnchor.constraint(equalTo: leadingAnchor),

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -182,12 +182,13 @@ final class AddressToolbarContainer: UIView,
         searchEnginesManager: SearchEnginesManagerProvider,
         delegate: AddressToolbarContainerDelegate,
         isUnifiedSearchEnabled: Bool,
+        isBottomSearchBar: Bool
     ) {
         self.windowUUID = windowUUID
         self.profile = profile
         self.delegate = delegate
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
-        setupLayout()
+        setupLayout(isBottomSearchBar: isBottomSearchBar)
         subscribeToRedux()
     }
 
@@ -319,7 +320,7 @@ final class AddressToolbarContainer: UIView,
         let isReaderModeActive = state?.addressToolbar.readerModeState == .active
         if isReaderModeActive {
             // when the user scrolls the webpage the address toolbar gets hidden by changing its alpha
-            regularToolbar.alpha = 3
+            regularToolbar.alpha = alpha
         }
         updateSkeletonAddressBarsAlpha(to: alpha)
     }
@@ -393,7 +394,7 @@ final class AddressToolbarContainer: UIView,
         rightSkeletonAddressBar.alpha = alpha
     }
 
-    private func setupLayout() {
+    private func setupLayout(isBottomSearchBar: Bool) {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(onContainerTapped))
         addGestureRecognizer(tapGesture)
 
@@ -405,8 +406,8 @@ final class AddressToolbarContainer: UIView,
             progressBar.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
 
-        setupToolbarConstraints()
-        setupSkeletonAddressBarsLayout()
+        setupToolbarConstraints(isBottomSearchBar: isBottomSearchBar)
+        setupSkeletonAddressBarsLayout(isBottomSearchBar: isBottomSearchBar)
 
         addSubview(addNewTabView)
         addNewTabLeadingConstraint = addNewTabView.leadingAnchor.constraint(equalTo: trailingAnchor)
@@ -420,14 +421,18 @@ final class AddressToolbarContainer: UIView,
         addNewTabLeadingConstraint?.isActive = true
     }
 
-    private func setupToolbarConstraints() {
+    private func setupToolbarConstraints(isBottomSearchBar: Bool) {
         addSubview(toolbar)
+        if toolbarHelper.isSwipingTabsEnabled && isBottomSearchBar {
+            insertSubview(leftSkeletonAddressBar, aboveSubview: toolbar)
+            insertSubview(rightSkeletonAddressBar, aboveSubview: toolbar)
 
-        insertSubview(leftSkeletonAddressBar, aboveSubview: toolbar)
-        insertSubview(rightSkeletonAddressBar, aboveSubview: toolbar)
-
-        toolbar.leadingAnchor.constraint(equalTo: leftSkeletonAddressBar.trailingAnchor).isActive = true
-        toolbar.trailingAnchor.constraint(equalTo: rightSkeletonAddressBar.leadingAnchor).isActive = true
+            toolbar.leadingAnchor.constraint(equalTo: leftSkeletonAddressBar.trailingAnchor).isActive = true
+            toolbar.trailingAnchor.constraint(equalTo: rightSkeletonAddressBar.leadingAnchor).isActive = true
+        } else {
+            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+        }
 
         NSLayoutConstraint.activate([
             toolbar.topAnchor.constraint(equalTo: topAnchor),
@@ -435,7 +440,9 @@ final class AddressToolbarContainer: UIView,
         ])
     }
 
-    private func setupSkeletonAddressBarsLayout() {
+    private func setupSkeletonAddressBarsLayout(isBottomSearchBar: Bool) {
+        guard toolbarHelper.isSwipingTabsEnabled, isBottomSearchBar else { return }
+
         NSLayoutConstraint.activate([
             leftSkeletonAddressBar.topAnchor.constraint(equalTo: topAnchor),
             leftSkeletonAddressBar.trailingAnchor.constraint(equalTo: leadingAnchor),

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -120,10 +120,11 @@ final class AddressToolbarContainer: UIView,
     private var addNewTabTopConstraint: NSLayoutConstraint?
     private var addNewTabBottomConstraint: NSLayoutConstraint?
 
+    private var toolbarLeadingConstraint: NSLayoutConstraint?
+    private var toolbarTrailingConstraint: NSLayoutConstraint?
+
     private var progressBarTopConstraint: NSLayoutConstraint?
     private var progressBarBottomConstraint: NSLayoutConstraint?
-
-    private var didAddSkeletons = false
 
     private func calculateToolbarTrailingSpace() -> CGFloat {
         if shouldDisplayCompact {
@@ -261,8 +262,9 @@ final class AddressToolbarContainer: UIView,
             return
         }
 
-        if !didAddSkeletons {
-            setupSkeletonsAfterStartup()
+        if leftSkeletonAddressBar.superview == nil {
+            setupBottomToolbar()
+            setupSkeletonAddressBarsLayout(isBottomSearchBar: true)
         }
 
         let tabs = selectedTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
@@ -276,14 +278,32 @@ final class AddressToolbarContainer: UIView,
         rightSkeletonAddressBar.isHidden = forwardTab == nil
     }
 
-    private func setupSkeletonsAfterStartup() {
+    private func setupBottomToolbar() {
         insertSubview(leftSkeletonAddressBar, aboveSubview: toolbar)
         insertSubview(rightSkeletonAddressBar, aboveSubview: toolbar)
 
-        toolbar.leadingAnchor.constraint(equalTo: leftSkeletonAddressBar.trailingAnchor).isActive = true
-        toolbar.trailingAnchor.constraint(equalTo: rightSkeletonAddressBar.leadingAnchor).isActive = true
+        toolbarLeadingConstraint?.isActive = false
+        toolbarTrailingConstraint?.isActive = false
 
-        setupSkeletonAddressBarsLayout(isBottomSearchBar: true)
+        toolbarLeadingConstraint = toolbar.leadingAnchor.constraint(equalTo: leftSkeletonAddressBar.trailingAnchor)
+        toolbarTrailingConstraint = toolbar.trailingAnchor.constraint(equalTo: rightSkeletonAddressBar.leadingAnchor)
+
+        toolbarLeadingConstraint?.isActive = true
+        toolbarTrailingConstraint?.isActive = true
+    }
+
+    private func setupTopToolbar() {
+        leftSkeletonAddressBar.removeFromSuperview()
+        rightSkeletonAddressBar.removeFromSuperview()
+
+        toolbarLeadingConstraint?.isActive = false
+        toolbarTrailingConstraint?.isActive = false
+
+        toolbarLeadingConstraint = toolbar.leadingAnchor.constraint(equalTo: leadingAnchor)
+        toolbarTrailingConstraint = toolbar.trailingAnchor.constraint(equalTo: trailingAnchor)
+
+        toolbarLeadingConstraint?.isActive = true
+        toolbarTrailingConstraint?.isActive = true
     }
 
     override func becomeFirstResponder() -> Bool {
@@ -440,14 +460,9 @@ final class AddressToolbarContainer: UIView,
     private func setupToolbarConstraints(isBottomSearchBar: Bool) {
         addSubview(toolbar)
         if toolbarHelper.isSwipingTabsEnabled && isBottomSearchBar {
-            insertSubview(leftSkeletonAddressBar, aboveSubview: toolbar)
-            insertSubview(rightSkeletonAddressBar, aboveSubview: toolbar)
-
-            toolbar.leadingAnchor.constraint(equalTo: leftSkeletonAddressBar.trailingAnchor).isActive = true
-            toolbar.trailingAnchor.constraint(equalTo: rightSkeletonAddressBar.leadingAnchor).isActive = true
+            setupBottomToolbar()
         } else {
-            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+            setupTopToolbar()
         }
 
         NSLayoutConstraint.activate([
@@ -470,8 +485,6 @@ final class AddressToolbarContainer: UIView,
             rightSkeletonAddressBar.bottomAnchor.constraint(equalTo: bottomAnchor),
             rightSkeletonAddressBar.widthAnchor.constraint(equalTo: widthAnchor, constant: -UX.skeletonBarWidthOffset)
         ])
-
-        didAddSkeletons = true
     }
 
     private func updateProgressBarPosition(_ position: AddressToolbarPosition) {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -123,6 +123,8 @@ final class AddressToolbarContainer: UIView,
     private var progressBarTopConstraint: NSLayoutConstraint?
     private var progressBarBottomConstraint: NSLayoutConstraint?
 
+    private var didAddSkeletons = false
+
     private func calculateToolbarTrailingSpace() -> CGFloat {
         if shouldDisplayCompact {
             return UX.toolbarHorizontalPadding
@@ -259,6 +261,10 @@ final class AddressToolbarContainer: UIView,
             return
         }
 
+        if !didAddSkeletons {
+            setupSkeletonsAfterStartup()
+        }
+
         let tabs = selectedTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         guard let index = tabs.firstIndex(where: { $0 === selectedTab }) else { return }
 
@@ -268,6 +274,16 @@ final class AddressToolbarContainer: UIView,
         configureSkeletonAddressBars(previousTab: previousTab, forwardTab: forwardTab)
         leftSkeletonAddressBar.isHidden = previousTab == nil
         rightSkeletonAddressBar.isHidden = forwardTab == nil
+    }
+
+    private func setupSkeletonsAfterStartup() {
+        insertSubview(leftSkeletonAddressBar, aboveSubview: toolbar)
+        insertSubview(rightSkeletonAddressBar, aboveSubview: toolbar)
+
+        toolbar.leadingAnchor.constraint(equalTo: leftSkeletonAddressBar.trailingAnchor).isActive = true
+        toolbar.trailingAnchor.constraint(equalTo: rightSkeletonAddressBar.leadingAnchor).isActive = true
+
+        setupSkeletonAddressBarsLayout(isBottomSearchBar: true)
     }
 
     override func becomeFirstResponder() -> Bool {
@@ -454,6 +470,8 @@ final class AddressToolbarContainer: UIView,
             rightSkeletonAddressBar.bottomAnchor.constraint(equalTo: bottomAnchor),
             rightSkeletonAddressBar.widthAnchor.constraint(equalTo: widthAnchor, constant: -UX.skeletonBarWidthOffset)
         ])
+
+        didAddSkeletons = true
     }
 
     private func updateProgressBarPosition(_ position: AddressToolbarPosition) {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -263,7 +263,7 @@ final class AddressToolbarContainer: UIView,
         }
 
         if leftSkeletonAddressBar.superview == nil {
-            setupBottomToolbar()
+            applyBottomLayoutConstraints()
             setupSkeletonAddressBarsLayout(isBottomSearchBar: true)
         }
 
@@ -278,7 +278,7 @@ final class AddressToolbarContainer: UIView,
         rightSkeletonAddressBar.isHidden = forwardTab == nil
     }
 
-    private func setupBottomToolbar() {
+    private func applyBottomLayoutConstraints() {
         insertSubview(leftSkeletonAddressBar, aboveSubview: toolbar)
         insertSubview(rightSkeletonAddressBar, aboveSubview: toolbar)
 
@@ -292,7 +292,7 @@ final class AddressToolbarContainer: UIView,
         toolbarTrailingConstraint?.isActive = true
     }
 
-    private func setupTopToolbar() {
+    private func applyTopLayoutConstraints() {
         leftSkeletonAddressBar.removeFromSuperview()
         rightSkeletonAddressBar.removeFromSuperview()
 
@@ -460,9 +460,9 @@ final class AddressToolbarContainer: UIView,
     private func setupToolbarConstraints(isBottomSearchBar: Bool) {
         addSubview(toolbar)
         if toolbarHelper.isSwipingTabsEnabled && isBottomSearchBar {
-            setupBottomToolbar()
+            applyBottomLayoutConstraints()
         } else {
-            setupTopToolbar()
+            applyTopLayoutConstraints()
         }
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15617)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33463)

## :bulb: Description
The app only adds skeleton bars to the layout at startup when the address bar is positioned at the bottom. This means that if the app launches with the address bar at the top and is later moved to the bottom, the skeleton bars are never added and therefore missing. The fix introduces a flag on the container that tracks whether the skeletons have been added. The function responsible for updating skeleton visibility now checks this flag and lazily adds them if needed. Once added, they persist regardless of address bar position until the app is restarted.

Note: The initial approach was to always keep the skeletons in the layout and toggle visibility, but given the UI hang issues from a few months ago, this lazy-add workaround was chosen to avoid regressing that work.

Note: IMO the toolbar is probably due for a refactor at some point for a cleaner solution 😄

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

