### PR TITLE
Bugfix FXIOS-15496 [Minimal address bar] Empty space between minimal address bar and toolbar under certain steps

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4997,15 +4997,6 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        if #available(iOS 26.0, *), isBottomSearchBar {
-            store.dispatch(
-                ToolbarAction(
-                    scrollAlpha: 1,
-                    windowUUID: windowUUID,
-                    actionType: ToolbarActionType.scrollAlphaNeedsUpdate
-                )
-            )
-        }
         keyboardState = nil
         if !isSnapKitRemovalEnabled {
             updateViewConstraints()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1726,14 +1726,14 @@ class BrowserViewController: UIViewController,
     private func updateSnapKitOverKeyboardContainerConstraints() {
         guard !isSnapKitRemovalEnabled else { return }
 
+        let existingOffset = overKeyboardContainerConstraint?.layoutConstraint?.constant ?? 0
+
         overKeyboardContainer.snp.remakeConstraints { make in
-            if let scrollController = scrollController as? LegacyTabScrollProvider {
-                let constraint = make.bottom.equalTo(bottomContainer.snp.top).constraint
-                scrollController.overKeyboardContainerConstraint = ConstraintReference(snapKit: constraint)
-            } else {
-                let constraint = make.bottom.equalTo(bottomContainer.snp.top).constraint
-                overKeyboardContainerConstraint = ConstraintReference(snapKit: constraint)
-            }
+            // Apply same constraints update we do in native path we 
+            let constraint = make.bottom.equalTo(bottomContainer.snp.top).offset(existingOffset).constraint
+            let reference = ConstraintReference(snapKit: constraint)
+            overKeyboardContainerConstraint = reference
+            (scrollController as? LegacyTabScrollProvider)?.overKeyboardContainerConstraint = reference
 
             if !isBottomSearchBar, zoomPageBar != nil {
                 make.height.greaterThanOrEqualTo(0)
@@ -1748,15 +1748,13 @@ class BrowserViewController: UIViewController,
     private func updateSnapKitBottomContainerConstraints() {
         guard !isSnapKitRemovalEnabled else { return }
 
-        bottomContainer.snp.remakeConstraints { make in
-            let constraint = make.bottom.equalTo(view.snp.bottom).constraint
-            let constraintReference = ConstraintReference(snapKit: constraint)
+        let existingOffset = bottomContainerConstraint?.layoutConstraint?.constant ?? 0
 
-            if let scrollController = scrollController as? LegacyTabScrollProvider {
-                scrollController.bottomContainerConstraint = constraintReference
-            } else {
-                bottomContainerConstraint = constraintReference
-            }
+        bottomContainer.snp.remakeConstraints { make in
+            let constraint = make.bottom.equalTo(view.snp.bottom).offset(existingOffset).constraint
+            let reference = ConstraintReference(snapKit: constraint)
+            bottomContainerConstraint = reference
+            (scrollController as? LegacyTabScrollProvider)?.bottomContainerConstraint = reference
             make.leading.trailing.equalTo(view)
         }
     }
@@ -1776,9 +1774,7 @@ class BrowserViewController: UIViewController,
     private func updateSnapkitConstraintsForKeyboard() {
         guard !isSnapKitRemovalEnabled else { return }
 
-        if let tab = tabManager.selectedTab, tab.isFindInPageMode {
-            scrollController.hideToolbars(animated: false)
-        } else {
+        if tabManager.selectedTab?.isFindInPageMode == false {
             adjustBottomSearchBarForKeyboard()
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerKeyboardConstraintTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerKeyboardConstraintTests.swift
@@ -16,6 +16,7 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
 
     func test_keyboardWillShow_withSnapKit_BottomToolbar_viewsHaveRightHeight() {
         let subject = createSubject()
+        selectTabWithFindInPage()
         let state = createKeyboardState()
         let keyboardHelper = createKeyboardHelper()
         XCTAssertEqual(subject.overKeyboardContainer.subviews.count, 1)
@@ -64,6 +65,7 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
 
     func test_keyboardDidShow_withSnapkit_BottomToolbar_viewsHaveRightHeight() {
         let subject = createSubject()
+        selectTabWithFindInPage()
         let state = createKeyboardState()
         let keyboardHelper = createKeyboardHelper()
         XCTAssertEqual(subject.overKeyboardContainer.subviews.count, 1)
@@ -109,6 +111,7 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
 
     func test_keyboardWillHide_withSnapKit_BottomToolbar_viewsHaveRightHeight() {
         let subject = createSubject()
+        selectTabWithFindInPage()
         let keyboardHelper = createKeyboardHelper()
 
         // Show keyboard first
@@ -174,6 +177,7 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
 
     func test_keyboardWillChange_withSnapKit_BottomToolbar_viewsHaveRightHeight() {
         let subject = createSubject()
+        selectTabWithFindInPage()
         let keyboardHelper = createKeyboardHelper()
 
         // Show keyboard first


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15496)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33248)

## :bulb: Description
Working on it as part of [FXIOS-15788](https://mozilla-hub.atlassian.net/browse/FXIOS-15788) decided to open a fix for the bug because it tackles two bugs in one. Both bugs follow the same steps but are reproducible in different OS and snapkit removal state

Bug #1: iOS 18 snapkit removal disabled. The workaround is to reuse existing constraints for overKeyboard and bottomContainer to restore the constant once Find in page is dismissed, similar to what we do in `BrowserViewControllerLayoutManager` for the native constraint path.

Bug #2: iOS 26 snapkit removal enabled. The bug in this case it was an extra call to dispatch `ToolbarActionType.scrollAlphaNeedsUpdate` action in keyboard helper `keyboardWillHideWithState` in this case we were triggering an alpha change that is unnecessary and on top of that we were triggering with alpha 1 visible always without taking into account the address bar state. `scrollAlphaNeedsUpdate` is already trigger in at least two code paths related to the address bar and tab scroll controller reacting to changes of the keyboard


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code



[FXIOS-15788]: https://mozilla-hub.atlassian.net/browse/FXIOS-15788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ