### PR TITLE
Add FXIOS-15820 [Danger] Add new Danger CI checks with CodeUsageDetector

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -526,6 +526,9 @@ class CodeUsageDetector {
         case swiftUIText
         case task
         case notifiable
+        case unsafe
+        case cspHeader
+        case sha256
 
         var bundledHeader: String {
             switch self {
@@ -544,6 +547,12 @@ class CodeUsageDetector {
                 return "### 🧑‍💻 New `Task {}` detected\nNew `Task {}` added. Please add a concurrency reviewer on your PR: \(contacts)"
             case .notifiable:
                 return "### ⚠️ `NotificationCenter.default.addObserver` detected\nPlease prefer Notifiable over `NotificationCenter` unless specific circumstances."
+            case .unsafe:
+                return "### 🔒 Security: `unsafe` keyword detected in JavaScript file\n. Please request a security review."
+            case .cspHeader:
+                return "### 🔒 Security: `Content-Security-Policy` header change detected\n. Please request a security review."
+            case .sha256:
+                return "### 🔒 Security: `SHA256` change detected\n. Please request a security review."
             }
         }
 
@@ -563,6 +572,21 @@ class CodeUsageDetector {
                 return " Task {"
             case .notifiable:
                 return "NotificationCenter.default.addObserver("
+            case .unsafe:
+                return "unsafe"
+            case .cspHeader:
+                return "Content-Security-Policy"
+            case .sha256:
+                return "sha256"
+            }
+        }
+
+        func applies(to file: String) -> Bool {
+            switch self {
+            case .unsafe, .cspHeader, .sha256:
+                return file.hasSuffix(".swift") || file.hasSuffix(".js")
+            default:
+                return file.contains(".swift")
             }
         }
 
@@ -597,9 +621,10 @@ class CodeUsageDetector {
     func checkForCodeUsage() {
         var detections: [Detection] = []
         let editedFiles = danger.git.modifiedFiles + danger.git.createdFiles
-        // Iterate through each added and modified file, running the checks on swift files only
-        for file in editedFiles where file.contains(".swift") && !file.contains("Dangerfile") {
-            // For modified, renamed hunks, or created new lines detect code usage to avoid in PR
+        for file in editedFiles where !file.contains("Dangerfile") {
+            let applicable = Keywords.allCases.filter { $0.applies(to: file) }
+            guard !applicable.isEmpty else { continue }
+
             switch saferFileDiff(for: file) {
             case let .success(diff):
                 if file == BrowserViewControllerChecker.bvcPath {
@@ -607,9 +632,9 @@ class CodeUsageDetector {
                 }
                 switch diff.changes {
                 case let .modified(hunks), let .renamed(_, hunks):
-                    detections += collect(keywords: Keywords.allCases, inHunks: hunks, file: file)
+                    detections += collect(keywords: applicable, inHunks: hunks, file: file)
                 case let .created(newLines):
-                    detections += collect(keywords: Keywords.allCases, inLines: newLines, file: file)
+                    detections += collect(keywords: applicable, inLines: newLines, file: file)
                 case .deleted:
                     break // do not warn on deleted lines
                 }

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -514,6 +514,7 @@ class CodeUsageDetector {
         let keyword: Keywords
         let file: String
         let lineNumber: Int
+        let isRemoval: Bool
     }
 
     private enum Keywords: CaseIterable {
@@ -548,11 +549,11 @@ class CodeUsageDetector {
             case .notifiable:
                 return "### ⚠️ `NotificationCenter.default.addObserver` detected\nPlease prefer Notifiable over `NotificationCenter` unless specific circumstances."
             case .unsafe:
-                return "### 🔒 Security: `unsafe` keyword detected in JavaScript file\n. Please request a security review."
+                return "### 🔒 Security: CSP `unsafe-` detected\nPlease request a security review."
             case .cspHeader:
-                return "### 🔒 Security: `Content-Security-Policy` header change detected\n. Please request a security review."
+                return "### 🔒 Security: `Content-Security-Policy` change detected\nPlease request a security review."
             case .sha256:
-                return "### 🔒 Security: `SHA256` change detected\n. Please request a security review."
+                return "### 🔒 Security: `sha256` hash changes detected\nPlease request a security review."
             }
         }
 
@@ -573,7 +574,7 @@ class CodeUsageDetector {
             case .notifiable:
                 return "NotificationCenter.default.addObserver("
             case .unsafe:
-                return "unsafe"
+                return "unsafe-"
             case .cspHeader:
                 return "Content-Security-Policy"
             case .sha256:
@@ -607,6 +608,22 @@ class CodeUsageDetector {
                 return true
             default:
                 return false
+            }
+        }
+
+        // Default is true, expect for some additions that aren't worth flagging
+        var detectsAdditions: Bool {
+            switch self {
+            case .sha256: return false
+            default: return true
+            }
+        }
+
+        // Most code removals we don't want to flag, expect for some
+        var detectsRemovals: Bool {
+            switch self {
+            case .cspHeader, .sha256: return true
+            default: return false
             }
         }
     }
@@ -652,14 +669,17 @@ class CodeUsageDetector {
     }
 
     private func emitBundled(keyword: Keywords, detections: [Detection]) {
-        let rows = detections.map { "| `\($0.file)` | \($0.lineNumber) |" }.joined(separator: "\n")
+        // You can add the `danger-bypass` label with a justification to bypass this check.
+        let rows = detections.map { "| `\($0.file)` | \($0.lineNumber) | \($0.isRemoval ? "Removed" : "Added") |" }.joined(separator: "\n")
         let fullMessage = """
         \(keyword.bundledHeader)
 
-        | File | Line |
-        |---|---|
+        | File | Line | Change |
+        |---|---|---|
         \(rows)
+        \nYou can add the `danger-bypass` label with a justification to bypass those checks.\nPlease add a comment explaining why the checks are by-passed.
         """
+
         if keyword.shouldComment {
             markdown(fullMessage)
         } else if keyword.shouldWarn {
@@ -678,16 +698,26 @@ class CodeUsageDetector {
         var detections: [Detection] = []
         for hunk in hunks {
             var newLineCount = 0
+            var oldLineCount = 0
             for line in hunk.lines {
-                let isAddedLine = "\(line)".starts(with: "+")
-                let isRemovedLine = "\(line)".starts(with: "-")
-                // Make sure our newLineCount is proper to fail on correct line number
-                guard isAddedLine || !isRemovedLine else { continue }
-                newLineCount += 1
-                // Collect only added lines having the particular keyword
-                guard isAddedLine && String(describing: line).contains(keyword.keyword) else { continue }
-                let lineNumber = hunk.newLineStart + newLineCount - 1
-                detections.append(Detection(keyword: keyword, file: file, lineNumber: lineNumber))
+                let lineStr = String(describing: line)
+                let isAddedLine = lineStr.starts(with: "+")
+                let isRemovedLine = lineStr.starts(with: "-")
+                if isRemovedLine {
+                    oldLineCount += 1
+                    if keyword.detectsRemovals && lineStr.contains(keyword.keyword) {
+                        let lineNumber = hunk.oldLineStart + oldLineCount - 1
+                        detections.append(Detection(keyword: keyword, file: file, lineNumber: lineNumber, isRemoval: true))
+                    }
+                } else {
+                    // Context or added line: exists in both old and new file
+                    newLineCount += 1
+                    oldLineCount += 1
+                    if isAddedLine && keyword.detectsAdditions && lineStr.contains(keyword.keyword) {
+                        let lineNumber = hunk.newLineStart + newLineCount - 1
+                        detections.append(Detection(keyword: keyword, file: file, lineNumber: lineNumber, isRemoval: false))
+                    }
+                }
             }
         }
         return detections
@@ -699,9 +729,10 @@ class CodeUsageDetector {
 
     private func collect(keyword: Keywords, inLines lines: [String], file: String) -> [Detection] {
         guard !shouldSkip(keyword, for: file) else { return [] }
+        guard keyword.detectsAdditions else { return [] }
         return lines.enumerated().compactMap { index, line in
             guard line.contains(keyword.keyword) else { return nil }
-            return Detection(keyword: keyword, file: file, lineNumber: index + 1)
+            return Detection(keyword: keyword, file: file, lineNumber: index + 1, isRemoval: false)
         }
     }
 }

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -669,7 +669,6 @@ class CodeUsageDetector {
     }
 
     private func emitBundled(keyword: Keywords, detections: [Detection]) {
-        // You can add the `danger-bypass` label with a justification to bypass this check.
         let rows = detections.map { "| `\($0.file)` | \($0.lineNumber) | \($0.isRemoval ? "Removed" : "Added") |" }.joined(separator: "\n")
         let fullMessage = """
         \(keyword.bundledHeader)
@@ -677,7 +676,6 @@ class CodeUsageDetector {
         | File | Line | Change |
         |---|---|---|
         \(rows)
-        \nYou can add the `danger-bypass` label with a justification to bypass those checks.\nPlease add a comment explaining why the checks are by-passed.
         """
 
         if keyword.shouldComment {
@@ -769,7 +767,10 @@ private func failOrWarn(_ message: String) {
         Since bypass label \(bypassLabel) detected we are reporting as warning only for this PR.
         """)
     } else {
-        fail(message)
+        fail("""
+        \(message)
+        You can add the \(bypassLabel) label on the PR to by-pass the checks.\nIf you use it, please add a comment explaining why.
+        """)
     }
 }
 

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -529,7 +529,6 @@ class CodeUsageDetector {
         case notifiable
         case unsafe
         case cspHeader
-        case sha256
 
         var bundledHeader: String {
             switch self {
@@ -552,8 +551,6 @@ class CodeUsageDetector {
                 return "### 🔒 Security: CSP `unsafe-` detected\nPlease request a security review."
             case .cspHeader:
                 return "### 🔒 Security: `Content-Security-Policy` change detected\nPlease request a security review."
-            case .sha256:
-                return "### 🔒 Security: `sha256` hash changes detected\nPlease request a security review."
             }
         }
 
@@ -577,14 +574,12 @@ class CodeUsageDetector {
                 return "unsafe-"
             case .cspHeader:
                 return "Content-Security-Policy"
-            case .sha256:
-                return "sha256"
             }
         }
 
         func applies(to file: String) -> Bool {
             switch self {
-            case .unsafe, .cspHeader, .sha256:
+            case .unsafe, .cspHeader:
                 return file.hasSuffix(".swift") || file.hasSuffix(".js")
             default:
                 return file.contains(".swift")
@@ -611,18 +606,10 @@ class CodeUsageDetector {
             }
         }
 
-        // Default is true, expect for some additions that aren't worth flagging
-        var detectsAdditions: Bool {
-            switch self {
-            case .sha256: return false
-            default: return true
-            }
-        }
-
-        // Most code removals we don't want to flag, expect for some
+        // Default is false, expect for some code removals that we want to flag
         var detectsRemovals: Bool {
             switch self {
-            case .cspHeader, .sha256: return true
+            case .cspHeader: return true
             default: return false
             }
         }
@@ -711,7 +698,7 @@ class CodeUsageDetector {
                     // Context or added line: exists in both old and new file
                     newLineCount += 1
                     oldLineCount += 1
-                    if isAddedLine && keyword.detectsAdditions && lineStr.contains(keyword.keyword) {
+                    if isAddedLine && lineStr.contains(keyword.keyword) {
                         let lineNumber = hunk.newLineStart + newLineCount - 1
                         detections.append(Detection(keyword: keyword, file: file, lineNumber: lineNumber, isRemoval: false))
                     }
@@ -727,7 +714,6 @@ class CodeUsageDetector {
 
     private func collect(keyword: Keywords, inLines lines: [String], file: String) -> [Detection] {
         guard !shouldSkip(keyword, for: file) else { return [] }
-        guard keyword.detectsAdditions else { return [] }
         return lines.enumerated().compactMap { index, line in
             guard line.contains(keyword.keyword) else { return nil }
             return Detection(keyword: keyword, file: file, lineNumber: index + 1, isRemoval: false)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15820)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33836)

## :bulb: Description
Following discussion with Daniel, I am proposing to add new Danger checks to detect some possible security changes, i.e. if those keywords are detected in code removed or added. There's always the possibility to add the `danger-bypass` label on a PR to turn the failures into warnings, and this would unblock the PR. The goal is just to raise a question mark and review whenever we detect those changes.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

