### PR TITLE
Remove FXIOS-15684 [Unit Test] flaky Rust tests temporarily

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -313,6 +313,11 @@
       }
     },
     {
+      "skippedTests" : [
+        "EventStoreTests\/testAdvancingTimeIntoTheFuture()",
+        "NimbusTests",
+        "SyncManagerTelemetryTests\/testSendsAddressesAndGlobalPings()"
+      ],
       "target" : {
         "containerPath" : "container:..\/MozillaRustComponents",
         "identifier" : "MozillaRustComponentsTests",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15684)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33574)

## :bulb: Description
Disabling these tests in our `MozillaRustComponents` package to run in our pipeline to save Bitrise credits and avoid pain points with developers re-running CI pipeline. Our next step is to revisit these tests and possibly do a refactoring as the logs show that `Glean` is causing the crashes during setup related to the `Nimbus` tests. The `SyncManagerTelemetryTests` is not related to `Nimbus`, but saw it was flaky so will take a look at a later date.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

