### PR TITLE
Bugfix FXIOS-15826 [WC] Fix model for live and bucketing

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2267,6 +2267,7 @@
 		EDF567A22C8B51E100FDB09D /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = EDF567A12C8B51E100FDB09D /* Kingfisher */; };
 		EDFEE3F42DE670B8005ADE03 /* gleanProbes.xcfilelist in Resources */ = {isa = PBXBuildFile; fileRef = EDFEE3F32DE670B8005ADE03 /* gleanProbes.xcfilelist */; };
 		F00CA4012F00000000000003 /* WorldCupMatchesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000004 /* WorldCupMatchesResponse.swift */; };
+		F00CA4012F00000000000005 /* WorldCupLiveResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000006 /* WorldCupLiveResponse.swift */; };
 		F00CA4012F00000000000007 /* WorldCupAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000008 /* WorldCupAPIClient.swift */; };
 		F00CA4012F0000000000000D /* WorldCupAPIClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F0000000000000E /* WorldCupAPIClientProtocol.swift */; };
 		F00CA4012F0000000000000F /* WorldCupFetchStrategyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000010 /* WorldCupFetchStrategyProtocol.swift */; };
@@ -2275,6 +2276,7 @@
 		F00CA4012F00000000000015 /* WorldCupLoadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000016 /* WorldCupLoadError.swift */; };
 		F00CA4012F00000000000017 /* WorldCupBaseHostOverrideSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4012F00000000000018 /* WorldCupBaseHostOverrideSetting.swift */; };
 		F00CA4022F00000000000001 /* WorldCupMatchesResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000002 /* WorldCupMatchesResponseTests.swift */; };
+		F00CA4022F00000000000003 /* WorldCupLiveResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000004 /* WorldCupLiveResponseTests.swift */; };
 		F00CA4022F00000000000005 /* WorldCupFetchStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000006 /* WorldCupFetchStrategyTests.swift */; };
 		F00CA4022F00000000000007 /* MockWorldCupAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F00000000000008 /* MockWorldCupAPIClient.swift */; };
 		F00CA4022F00000000000009 /* WorldCupAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CA4022F0000000000000A /* WorldCupAPIClientTests.swift */; };
@@ -11662,6 +11664,7 @@
 		EFE04EF99B075B44BC9471D9 /* br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = br; path = br.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		EFE44E55AFFD127B71CA0D69 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		F00CA4012F00000000000004 /* WorldCupMatchesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupMatchesResponse.swift; sourceTree = "<group>"; };
+		F00CA4012F00000000000006 /* WorldCupLiveResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupLiveResponse.swift; sourceTree = "<group>"; };
 		F00CA4012F00000000000008 /* WorldCupAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupAPIClient.swift; sourceTree = "<group>"; };
 		F00CA4012F0000000000000E /* WorldCupAPIClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupAPIClientProtocol.swift; sourceTree = "<group>"; };
 		F00CA4012F00000000000010 /* WorldCupFetchStrategyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupFetchStrategyProtocol.swift; sourceTree = "<group>"; };
@@ -11670,6 +11673,7 @@
 		F00CA4012F00000000000016 /* WorldCupLoadError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupLoadError.swift; sourceTree = "<group>"; };
 		F00CA4012F00000000000018 /* WorldCupBaseHostOverrideSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupBaseHostOverrideSetting.swift; sourceTree = "<group>"; };
 		F00CA4022F00000000000002 /* WorldCupMatchesResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupMatchesResponseTests.swift; sourceTree = "<group>"; };
+		F00CA4022F00000000000004 /* WorldCupLiveResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupLiveResponseTests.swift; sourceTree = "<group>"; };
 		F00CA4022F00000000000006 /* WorldCupFetchStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupFetchStrategyTests.swift; sourceTree = "<group>"; };
 		F00CA4022F00000000000008 /* MockWorldCupAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWorldCupAPIClient.swift; sourceTree = "<group>"; };
 		F00CA4022F0000000000000A /* WorldCupAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupAPIClientTests.swift; sourceTree = "<group>"; };
@@ -13650,6 +13654,7 @@
 				8A6B79992CDBCE2E003C3077 /* TopSitesManagerTests.swift */,
 				C28EA9802FA2554800AEC3AD /* WorldCupCountdownModelTests.swift */,
 				F00CA4022F00000000000002 /* WorldCupMatchesResponseTests.swift */,
+				F00CA4022F00000000000004 /* WorldCupLiveResponseTests.swift */,
 				F00CA4022F0000000000000E /* WorldCupTeamsResponseTests.swift */,
 				F00CA4022F00000000000010 /* WorldCupLoadErrorTests.swift */,
 				F00CA4032F00000000000008 /* WorldCupMatchesTests.swift */,
@@ -15229,6 +15234,7 @@
 				C263CD112FB4C6D8002AC656 /* WorldCupCellFactory.swift */,
 				C263CD132FB4C6D8002AC658 /* WorldCupErrorView.swift */,
 				F00CA4012F00000000000004 /* WorldCupMatchesResponse.swift */,
+				F00CA4012F00000000000006 /* WorldCupLiveResponse.swift */,
 				F00CA4012F00000000000014 /* WorldCupTeamsResponse.swift */,
 				F00CA4012F00000000000016 /* WorldCupLoadError.swift */,
 				F00CA4032F00000000000002 /* WorldCupMatch.swift */,
@@ -19655,6 +19661,7 @@
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
 				C2A057E32FA8C32200100C24 /* WorldCupCell.swift in Sources */,
 				F00CA4012F00000000000003 /* WorldCupMatchesResponse.swift in Sources */,
+				F00CA4012F00000000000005 /* WorldCupLiveResponse.swift in Sources */,
 				F00CA4012F00000000000013 /* WorldCupTeamsResponse.swift in Sources */,
 				F00CA4012F00000000000015 /* WorldCupLoadError.swift in Sources */,
 				F00CA4032F00000000000001 /* WorldCupMatch.swift in Sources */,
@@ -20208,6 +20215,7 @@
 				D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */,
 				C28EA9812FA2554800AEC3AD /* WorldCupCountdownModelTests.swift in Sources */,
 				F00CA4022F00000000000001 /* WorldCupMatchesResponseTests.swift in Sources */,
+				F00CA4022F00000000000003 /* WorldCupLiveResponseTests.swift in Sources */,
 				F00CA4022F0000000000000D /* WorldCupTeamsResponseTests.swift in Sources */,
 				F00CA4022F0000000000000F /* WorldCupLoadErrorTests.swift in Sources */,
 				F00CA4032F00000000000007 /* WorldCupMatchesTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClient.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClient.swift
@@ -32,7 +32,7 @@ final class WorldCupAPIClient: WorldCupAPIClientProtocol, @unchecked Sendable {
 
     /// Convenience init that points the FFI at a custom host. Pass `nil` or
     /// an empty string to use the default merino host. Intended for local
-    /// dev/beta testing against a non-production merino instance. 
+    /// dev/beta testing against a non-production merino instance.
     convenience init(baseHost: String?,
                      matchesStrategy: WorldCupFetchStrategyProtocol = WorldCupNormalFetchStrategy(),
                      liveStrategy: WorldCupFetchStrategyProtocol = WorldCupNormalFetchStrategy(),
@@ -47,39 +47,33 @@ final class WorldCupAPIClient: WorldCupAPIClientProtocol, @unchecked Sendable {
 
     /// Low-level sync matches fetch + decode. Throws on FFI error or decode failure.
     /// Pass a 3-letter FIFA team key to filter the response to one team's fixtures.
-    func fetch(_ query: WorldCupQuery, team: String? = nil) throws -> WorldCupMatchesResponse? {
-        let options = Self.options(forTeam: team)
-        let json = switch query {
-        case .matches: try client.getMatches(options: options)
-        case .live:    try client.getLive(options: options)
-        }
-        return try decode(json)
+    func fetchMatches(team: String? = nil) throws -> WorldCupMatchesResponse? {
+        let json = try client.getMatches(options: Self.options(forTeam: team))
+        return try decode(json, as: WorldCupMatchesResponse.self)
+    }
+
+    /// Low-level sync live fetch + decode. Throws on FFI error or decode failure.
+    /// Pass a 3-letter FIFA team key to filter the response to one team's fixtures.
+    func fetchLive(team: String? = nil) throws -> WorldCupLiveResponse? {
+        let json = try client.getLive(options: Self.options(forTeam: team))
+        return try decode(json, as: WorldCupLiveResponse.self)
     }
 
     /// Low-level sync teams fetch + decode. Throws on FFI error or decode failure.
     /// Pass a 3-letter FIFA team key to scope the roster response.
     func fetchTeams(team: String? = nil) throws -> WorldCupTeamsResponse? {
         let json = try client.getTeams(options: Self.options(forTeam: team))
-        return try decodeTeams(json)
+        return try decode(json, as: WorldCupTeamsResponse.self)
     }
 
-    /// High-level async loader: delegates to the strategy configured for the
-    /// given query (live vs non-live). The strategy decides how to call `fetch`
-    /// (single attempt, retry, etc.) and returns the decoded merino response
-    /// or a `WorldCupLoadError` the UI can pattern-match on.
-    /// Callers transform the success response into a view-model.
-    func loadMatches(query: WorldCupQuery,
-                     team: String? = nil) async -> Result<WorldCupMatchesResponse?, WorldCupLoadError> {
-        let strategy: WorldCupFetchStrategyProtocol = switch query {
-        case .matches: matchesStrategy
-        case .live:    liveStrategy
-        }
-        return await strategy.loadMatches(using: self, query: query, team: team)
+    func loadMatches(team: String? = nil) async -> Result<WorldCupMatchesResponse?, WorldCupLoadError> {
+        await matchesStrategy.loadMatches(using: self, team: team)
     }
 
-    /// High-level async teams loader. Delegates to the configured teams
-    /// strategy and returns either the decoded response or a
-    /// `WorldCupLoadError` the UI can pattern-match on.
+    func loadLive(team: String? = nil) async -> Result<WorldCupLiveResponse?, WorldCupLoadError> {
+        await liveStrategy.loadLive(using: self, team: team)
+    }
+
     func loadTeams(team: String? = nil) async -> Result<WorldCupTeamsResponse?, WorldCupLoadError> {
         await teamsStrategy.loadTeams(using: self, team: team)
     }
@@ -113,13 +107,8 @@ final class WorldCupAPIClient: WorldCupAPIClientProtocol, @unchecked Sendable {
         )
     }
 
-    private func decode(_ json: String?) throws -> WorldCupMatchesResponse? {
+    private func decode<T: Decodable>(_ json: String?, as type: T.Type) throws -> T? {
         guard let data = json?.data(using: .utf8) else { return nil }
-        return try decoder.decode(WorldCupMatchesResponse.self, from: data)
-    }
-
-    private func decodeTeams(_ json: String?) throws -> WorldCupTeamsResponse? {
-        guard let data = json?.data(using: .utf8) else { return nil }
-        return try decoder.decode(WorldCupTeamsResponse.self, from: data)
+        return try decoder.decode(type, from: data)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClientProtocol.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAPIClientProtocol.swift
@@ -4,29 +4,32 @@
 
 import Foundation
 
-/// Which merino WCS endpoint to hit. Used by `WorldCupAPIClientProtocol`.
-enum WorldCupQuery: Equatable {
-    case matches, live
-}
-
 /// Surface for the merino World Cup matches client. Concrete impl lives in
 /// `WorldCupAPIClient`; mocks conform to the same protocol in tests.
+///
+/// The `/matches` and `/live` merino endpoints emit different JSON shapes —
+/// `{ previous/current/next }` vs `{ matches }` — so they get their own
+/// typed methods and response types rather than sharing a query enum.
 ///
 /// `team` (3-letter FIFA key) is the only filter exposed at this layer. The
 /// underlying FFI `WorldCupOptions` is intentionally hidden.
 protocol WorldCupAPIClientProtocol: Sendable {
     /// Low-level sync matches fetch + decode. Throws on FFI error or decode failure.
-    func fetch(_ query: WorldCupQuery, team: String?) throws -> WorldCupMatchesResponse?
+    func fetchMatches(team: String?) throws -> WorldCupMatchesResponse?
+
+    /// Low-level sync live fetch + decode. Throws on FFI error or decode failure.
+    func fetchLive(team: String?) throws -> WorldCupLiveResponse?
 
     /// Low-level sync teams fetch + decode. Throws on FFI error or decode failure.
     func fetchTeams(team: String?) throws -> WorldCupTeamsResponse?
 
-    /// High-level async loader: dispatches the matches fetch through the
-    /// configured fetch strategy and returns either the decoded merino
-    /// response or a `WorldCupLoadError` the UI can pattern-match on.
-    /// Callers transform the success response into a view-model.
-    func loadMatches(query: WorldCupQuery,
-                     team: String?) async -> Result<WorldCupMatchesResponse?, WorldCupLoadError>
+    /// High-level async loader for `/matches`. Dispatches through the configured
+    /// matches fetch strategy.
+    func loadMatches(team: String?) async -> Result<WorldCupMatchesResponse?, WorldCupLoadError>
+
+    /// High-level async loader for `/live`. Dispatches through the configured
+    /// live fetch strategy.
+    func loadLive(team: String?) async -> Result<WorldCupLiveResponse?, WorldCupLoadError>
 
     /// High-level async loader for the teams roster. Runs the blocking FFI
     /// call off-main and returns the decoded response or a `WorldCupLoadError`

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupFetchStrategyProtocol.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupFetchStrategyProtocol.swift
@@ -12,8 +12,10 @@ import Foundation
 /// `WorldCupAPIClient.init(matchesStrategy:liveStrategy:teamsStrategy:)`.
 protocol WorldCupFetchStrategyProtocol: Sendable {
     func loadMatches(using client: WorldCupAPIClientProtocol,
-                     query: WorldCupQuery,
                      team: String?) async -> Result<WorldCupMatchesResponse?, WorldCupLoadError>
+
+    func loadLive(using client: WorldCupAPIClientProtocol,
+                  team: String?) async -> Result<WorldCupLiveResponse?, WorldCupLoadError>
 
     func loadTeams(using client: WorldCupAPIClientProtocol,
                    team: String?) async -> Result<WorldCupTeamsResponse?, WorldCupLoadError>

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupLiveResponse.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupLiveResponse.swift
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Mirrors the JSON returned by the merino `/api/v1/wcs/live` endpoint
+/// (wrapped by `MozillaAppServices.WorldCupClient.getLive`). Distinct from
+/// `WorldCupMatchesResponse` because the live endpoint emits a flat
+/// `{ matches: [...] }` shape rather than the previous/current/next buckets
+/// of `/matches`. Reuses `WorldCupMatchesResponse.Match` since merino emits
+/// the same per-match shape on both endpoints.
+struct WorldCupLiveResponse: Decodable, Equatable {
+    let matches: [WorldCupMatchesResponse.Match]?
+
+    init(matches: [WorldCupMatchesResponse.Match]? = nil) {
+        self.matches = matches
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
@@ -49,8 +49,14 @@ struct WorldCupMatch: Equatable, Hashable {
         return formatter
     }
 
+    /// Parses a merino-style ISO8601 match date (e.g. `2026-06-12T18:00:00+00:00`).
+    /// Returns `nil` if the string can't be parsed.
+    static func parseDate(_ iso: String) -> Date? {
+        return isoFormatter.date(from: iso)
+    }
+
     private static func formattedDate(_ iso: String, locale: Locale) -> String {
-        guard let date = isoFormatter.date(from: iso) else { return iso }
+        guard let date = parseDate(iso) else { return iso }
         let formatter = DateFormatter()
         formatter.locale = locale
         formatter.setLocalizedDateFormatFromTemplate("MMMdjmm")

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
@@ -6,10 +6,6 @@ import Foundation
 import Shared
 
 struct WorldCupMatches: Equatable, Hashable {
-    /// Sentinel for the `limit` parameter on `flattened(response:limit:)`; means
-    /// "include every match in the response, no truncation".
-    static let unlimitedMatches = Int.max
-
     let phaseTitle: String
     let isLive: Bool
     let featuredMatch: [WorldCupMatch]
@@ -26,69 +22,150 @@ struct WorldCupMatches: Equatable, Hashable {
     }
 
     /// Single-card view used when a team is selected: the merino response is
-    /// already scoped to that team, so we put any past results plus the live
-    /// match (if any) into `featuredMatch` (the prominent top section), and
-    /// the next two scheduled matches into `upcomingMatches` (the compact
-    /// bottom list). If nothing has happened yet, the first scheduled match
-    /// is promoted to featured so the card never opens empty.
+    /// already scoped to that team. We don't trust the server's
+    /// `previous/current/next` labels for the featured/upcoming split — those
+    /// are anchored to whatever fetch date we sent (which is pinned to the
+    /// tournament-window floor so the API actually returns data
+    /// pre-tournament), not to the user's actual today. Instead we re-bucket
+    /// the flat list against `now`: past + today matches go to `featuredMatch`
+    /// (prominent top section), future matches go to `upcomingMatches` (the
+    /// compact bottom list, capped at two). If nothing has happened yet, the
+    /// first scheduled match is promoted to featured so the card never opens
+    /// empty. `liveIDs` is the set of `globalEventId`s reported by the `.live`
+    /// endpoint; `isLive` is set if any of this card's matches is in that set.
     init(response: WorldCupMatchesResponse,
+         liveIDs: Set<Int> = [],
+         now: Date = Date(),
+         calendar: Calendar = .current,
          localeProvider: LocaleProvider = SystemLocaleProvider()) {
-        let previous = response.previous ?? []
-        let live = response.current ?? []
-        let scheduled = response.next ?? []
+        let allMatches = (response.previous ?? []) + (response.current ?? []) + (response.next ?? [])
+        let today = calendar.startOfDay(for: now)
 
-        var featured = previous + live
-        var upcoming = scheduled
+        var pastOrToday: [WorldCupMatchesResponse.Match] = []
+        var future: [WorldCupMatchesResponse.Match] = []
+        for match in allMatches {
+            guard let parsed = WorldCupMatch.parseDate(match.date) else { continue }
+            if calendar.startOfDay(for: parsed) <= today {
+                pastOrToday.append(match)
+            } else {
+                future.append(match)
+            }
+        }
+
+        var featured = pastOrToday
+        var upcoming = future
         if featured.isEmpty, let firstScheduled = upcoming.first {
             featured = [firstScheduled]
             upcoming = Array(upcoming.dropFirst())
         }
         upcoming = Array(upcoming.prefix(2))
 
-        self.phaseTitle = Self.phaseTitle(from: response)
-        self.isLive = !live.isEmpty
+        let allIDs = allMatches.map(\.globalEventId)
+        self.phaseTitle = Self.phaseTitle(from: featured.first)
+        self.isLive = allIDs.contains(where: { liveIDs.contains($0) })
         self.featuredMatch = featured.map { WorldCupMatch($0, localeProvider: localeProvider) }
         self.upcomingMatches = upcoming.map { WorldCupMatch($0, localeProvider: localeProvider) }
     }
 
-    /// Multi-card view used when no team is selected: every match in the
-    /// response becomes its own one-match card (chronological: previous →
-    /// current → next), so swiping flips through the tournament one match at
-    /// a time. `limit` caps the count (default unlimited).
+    /// Multi-card view used when no team is selected: groups every match in
+    /// the response by calendar day (in `calendar`'s timezone) so each card
+    /// holds all matches on the same date. Each day's matches render in the
+    /// compact `upcomingMatches` row — `featuredMatch` is left empty so a
+    /// crowded day doesn't blow the card up vertically. Cards are ordered
+    /// chronologically (earliest day first); `defaultIndex` points at today's
+    /// card, or the next future day if today has no matches.
     static func flattened(
         response: WorldCupMatchesResponse,
-        limit: Int = unlimitedMatches,
+        liveIDs: Set<Int> = [],
+        now: Date = Date(),
+        calendar: Calendar = .current,
         localeProvider: LocaleProvider = SystemLocaleProvider()
-    ) -> [WorldCupMatches] {
-        let previous = response.previous ?? []
-        let live = response.current ?? []
-        let scheduled = response.next ?? []
-        let title = Self.phaseTitle(from: response)
-        let liveIDs = Set(live.map(\.globalEventId))
-        let ordered = previous + live + scheduled
-        return ordered.prefix(limit).map { match in
+    ) -> (cards: [WorldCupMatches], defaultIndex: Int) {
+        let allMatches = (response.previous ?? []) + (response.current ?? []) + (response.next ?? [])
+        let groups = groupedByDay(allMatches, calendar: calendar)
+        // No team selected: cards can span days/stages, so we use the generic
+        // group-stage label across the board. Stage-specific labels are only
+        // meaningful in the team-selected single-card view.
+        let title = String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel
+        let cards = groups.map { group in
             WorldCupMatches(
                 phaseTitle: title,
-                isLive: liveIDs.contains(match.globalEventId),
-                featuredMatch: [WorldCupMatch(match, localeProvider: localeProvider)],
-                upcomingMatches: []
+                isLive: group.matches.contains { liveIDs.contains($0.globalEventId) },
+                featuredMatch: [],
+                upcomingMatches: group.matches.map { WorldCupMatch($0, localeProvider: localeProvider) }
             )
+        }
+        let today = calendar.startOfDay(for: now)
+        let firstFutureIndex = groups.firstIndex(where: { $0.day >= today })
+        let defaultIndex = firstFutureIndex ?? max(cards.count - 1, 0)
+        return (cards, defaultIndex)
+    }
+
+    /// Maps a featured match to a localized phase label. For group-stage
+    /// matches we surface the group letter (e.g. "Group A") since both teams
+    /// in a group-stage fixture share a group. For knockout matches we use
+    /// the round label. Unknown or absent stages fall back to the generic
+    /// "Upcoming" label so a new merino stage string doesn't blank the title.
+    static func phaseTitle(from match: WorldCupMatchesResponse.Match?) -> String {
+        guard let match else {
+            return String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel
+        }
+        switch match.stage {
+        case "Group Stage":
+            let group = match.homeTeam.group ?? match.awayTeam.group
+            return Self.groupLabel(for: group)
+                ?? String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel
+        case "Round of 32":
+            return String.WorldCup.HomepageWidget.RoundPhase.Round32Label
+        case "Round of 16":
+            return String.WorldCup.HomepageWidget.RoundPhase.Round16Label
+        case "Quarterfinals":
+            return String.WorldCup.HomepageWidget.RoundPhase.QuarterFinalsLabel
+        case "Semifinals":
+            return String.WorldCup.HomepageWidget.RoundPhase.SemiFinalsLabel
+        case "Third Place":
+            return String.WorldCup.HomepageWidget.RoundPhase.ThirdPlaceLabel
+        case "Final":
+            return String.WorldCup.HomepageWidget.RoundPhase.FinalLabel
+        default:
+            return String.WorldCup.HomepageWidget.RoundPhase.UpcomingLabel
         }
     }
 
-    /// Maps the merino response to a localized phase label. Currently the only
-    /// reliable signal in the API is `team.group`. If any featured/upcoming
-    /// team carries a group assignment we're in group play. For knockout
-    /// rounds the merino payload doesn't yet carry a round identifier, so we
-    /// fall back to the generic "Upcoming" label until that exists upstream
-    /// or we count surviving teams from the response.
-    static func phaseTitle(from response: WorldCupMatchesResponse) -> String {
-        let activeMatches = (response.current ?? []) + (response.next ?? [])
-        let isGroupStage = activeMatches.contains { match in
-            match.homeTeam.group != nil || match.awayTeam.group != nil
+    private static func groupLabel(for group: String?) -> String? {
+        switch group {
+        case "Group A": return String.WorldCup.HomepageWidget.GroupPhase.GroupA
+        case "Group B": return String.WorldCup.HomepageWidget.GroupPhase.GroupB
+        case "Group C": return String.WorldCup.HomepageWidget.GroupPhase.GroupC
+        case "Group D": return String.WorldCup.HomepageWidget.GroupPhase.GroupD
+        case "Group E": return String.WorldCup.HomepageWidget.GroupPhase.GroupE
+        case "Group F": return String.WorldCup.HomepageWidget.GroupPhase.GroupF
+        case "Group G": return String.WorldCup.HomepageWidget.GroupPhase.GroupG
+        case "Group H": return String.WorldCup.HomepageWidget.GroupPhase.GroupH
+        case "Group I": return String.WorldCup.HomepageWidget.GroupPhase.GroupI
+        case "Group J": return String.WorldCup.HomepageWidget.GroupPhase.GroupJ
+        case "Group K": return String.WorldCup.HomepageWidget.GroupPhase.GroupK
+        case "Group L": return String.WorldCup.HomepageWidget.GroupPhase.GroupL
+        default: return nil
         }
-        return isGroupStage
-            ? String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel
-            : String.WorldCup.HomepageWidget.RoundPhase.UpcomingLabel
+    }
+
+    /// Groups `matches` by calendar day (using `calendar`'s timezone). Matches
+    /// whose ISO date fails to parse are skipped. Returned groups are sorted
+    /// by day in ascending order; within each group, matches keep their input
+    /// order so equal-day matches stay in the response's chronological order.
+    private static func groupedByDay(
+        _ matches: [WorldCupMatchesResponse.Match],
+        calendar: Calendar
+    ) -> [(day: Date, matches: [WorldCupMatchesResponse.Match])] {
+        var byDay: [Date: [WorldCupMatchesResponse.Match]] = [:]
+        var order: [Date] = []
+        for match in matches {
+            guard let parsed = WorldCupMatch.parseDate(match.date) else { continue }
+            let day = calendar.startOfDay(for: parsed)
+            if byDay[day] == nil { order.append(day) }
+            byDay[day, default: []].append(match)
+        }
+        return order.sorted().map { ($0, byDay[$0]!) }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchesResponse.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchesResponse.swift
@@ -6,7 +6,9 @@ import Foundation
 
 /// Mirrors the JSON returned by the merino `/api/v1/wcs/matches` endpoint
 /// (wrapped by `MozillaAppServices.WorldCupClient.getMatches`). The `live`
-/// endpoint returns the same shape but only populates `current`.
+/// endpoint emits a flat `{ matches: [...] }` shape and is decoded into
+/// `WorldCupLiveResponse` instead — don't confuse `current` here with "live".
+/// `current` just means "matches whose date equals the query `date=`".
 struct WorldCupMatchesResponse: Decodable, Equatable {
     let previous: [Match]?
     let current: [Match]?
@@ -29,6 +31,42 @@ struct WorldCupMatchesResponse: Decodable, Equatable {
         /// Not typing this since we don't want to couple the client too tightly to the API's exact status values,
         /// in case of future additions or changes.
         let statusType: String?
+        /// Tournament stage, e.g. "Group Stage", "Round of 32", "Round of 16",
+        /// "Quarterfinals", "Semifinals", "Third Place", "Final". Mapped to a
+        /// localized phase label by `WorldCupMatches.phaseTitle`. Untyped on
+        /// purpose so a new merino value doesn't fail decode — unknown values
+        /// fall back to a generic label.
+        let stage: String?
+
+        init(date: String,
+             globalEventId: Int,
+             homeTeam: Team,
+             awayTeam: Team,
+             period: String? = nil,
+             homeScore: Int? = nil,
+             awayScore: Int? = nil,
+             homeExtra: Int? = nil,
+             awayExtra: Int? = nil,
+             homePenalty: Int? = nil,
+             awayPenalty: Int? = nil,
+             clock: String? = nil,
+             statusType: String? = nil,
+             stage: String? = nil) {
+            self.date = date
+            self.globalEventId = globalEventId
+            self.homeTeam = homeTeam
+            self.awayTeam = awayTeam
+            self.period = period
+            self.homeScore = homeScore
+            self.awayScore = awayScore
+            self.homeExtra = homeExtra
+            self.awayExtra = awayExtra
+            self.homePenalty = homePenalty
+            self.awayPenalty = awayPenalty
+            self.clock = clock
+            self.statusType = statusType
+            self.stage = stage
+        }
     }
 
     struct Team: Decodable, Equatable {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Common
 import Redux
+import Shared
 
 /// The middleware responsible for all the actions related to the `WorldCup` feature.
 /// To keep it simple it dispatches only `WorldCupMiddlewareActionType.didUpdate`
@@ -19,7 +20,10 @@ final class WorldCupMiddleware {
 
     init(
         worldCupStore: WorldCupStoreProtocol = WorldCupStore(),
-        apiClient: WorldCupAPIClientProtocol? = try? WorldCupAPIClient()
+        apiClient: WorldCupAPIClientProtocol? = try? WorldCupAPIClient(
+            baseHost: (AppContainer.shared.resolve() as Profile)
+                .prefs.stringForKey(PrefsKeys.HomepageSettings.WorldCupBaseHost)
+        )
     ) {
         self.worldCupStore = worldCupStore
         self.apiClient = apiClient
@@ -71,25 +75,37 @@ final class WorldCupMiddleware {
         let selectedTeam = worldCupStore.selectedTeam
         matchesFetchTask?.cancel()
         matchesFetchTask = Task { [apiClient, weak self] in
-            let result = await apiClient.loadMatches(query: .matches, team: selectedTeam)
+            async let matchesResult = apiClient.loadMatches(team: selectedTeam)
+            async let liveResult = apiClient.loadLive(team: selectedTeam)
+            let (matches, live) = await (matchesResult, liveResult)
             guard !Task.isCancelled else { return }
-            switch result {
+            switch matches {
             case .success(let response):
                 guard let response else { return }
+                let liveIDs = Self.liveIDs(from: live)
                 if selectedTeam != nil {
-                    self?.matches = [WorldCupMatches(response: response)]
+                    self?.matches = [WorldCupMatches(response: response, liveIDs: liveIDs)]
                     self?.defaultMatchIndex = 0
                 } else {
-                    let flattened = WorldCupMatches.flattened(response: response)
-                    self?.matches = flattened
-                    let previousCount = response.previous?.count ?? 0
-                    let liveCount = response.current?.count ?? 0
-                    self?.defaultMatchIndex = min(previousCount + liveCount, max(flattened.count - 1, 0))
+                    let flattened = WorldCupMatches.flattened(response: response, liveIDs: liveIDs)
+                    self?.matches = flattened.cards
+                    self?.defaultMatchIndex = flattened.defaultIndex
                 }
                 self?.dispatchUpdate(windowUUID: windowUUID)
             case .failure(let error):
                 self?.dispatchUpdate(windowUUID: windowUUID, apiError: error)
             }
         }
+    }
+
+    /// Pulls the `globalEventId`s out of the `/live` endpoint response. A
+    /// failure on the live endpoint isn't fatal: the matches request already
+    /// gives us a usable view, we just lose the live badge for this refresh.
+    private static func liveIDs(
+        from result: Result<WorldCupLiveResponse?, WorldCupLoadError>
+    ) -> Set<Int> {
+        guard case let .success(response) = result,
+              let matches = response?.matches else { return [] }
+        return Set(matches.map(\.globalEventId))
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
@@ -9,12 +9,23 @@ import Foundation
 /// distinguish network failures from other failures.
 struct WorldCupNormalFetchStrategy: WorldCupFetchStrategyProtocol {
     func loadMatches(using client: WorldCupAPIClientProtocol,
-                     query: WorldCupQuery,
                      team: String?) async -> Result<WorldCupMatchesResponse?, WorldCupLoadError> {
         await Task.detached(priority: .userInitiated) {
             () -> Result<WorldCupMatchesResponse?, WorldCupLoadError> in
             do {
-                return .success(try client.fetch(query, team: team))
+                return .success(try client.fetchMatches(team: team))
+            } catch {
+                return .failure(WorldCupLoadError.from(error))
+            }
+        }.value
+    }
+
+    func loadLive(using client: WorldCupAPIClientProtocol,
+                  team: String?) async -> Result<WorldCupLiveResponse?, WorldCupLoadError> {
+        await Task.detached(priority: .userInitiated) {
+            () -> Result<WorldCupLiveResponse?, WorldCupLoadError> in
+            do {
+                return .success(try client.fetchLive(team: team))
             } catch {
                 return .failure(WorldCupLoadError.from(error))
             }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupAPIClientTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupAPIClientTests.swift
@@ -9,50 +9,50 @@ import Foundation
 @Suite("WorldCupAPIClient")
 struct WorldCupAPIClientTests {
     @Test
-    func test_loadMatches_withMatchesQuery_usesMatchesStrategy() async throws {
+    func test_loadMatches_usesMatchesStrategy() async throws {
         let matchesStrategy = MockWorldCupFetchStrategy()
         let liveStrategy = MockWorldCupFetchStrategy()
         let client = try WorldCupAPIClient(matchesStrategy: matchesStrategy,
                                            liveStrategy: liveStrategy)
 
-        _ = await client.loadMatches(query: .matches, team: nil)
+        _ = await client.loadMatches(team: nil)
 
-        #expect(matchesStrategy.callCount == 1)
-        #expect(matchesStrategy.lastQuery == .matches)
-        #expect(liveStrategy.callCount == 0)
+        #expect(matchesStrategy.matchesCallCount == 1)
+        #expect(liveStrategy.matchesCallCount == 0)
+        #expect(liveStrategy.liveCallCount == 0)
     }
 
     @Test
-    func test_loadMatches_withLiveQuery_usesLiveStrategy() async throws {
+    func test_loadLive_usesLiveStrategy() async throws {
         let matchesStrategy = MockWorldCupFetchStrategy()
         let liveStrategy = MockWorldCupFetchStrategy()
         let client = try WorldCupAPIClient(matchesStrategy: matchesStrategy,
                                            liveStrategy: liveStrategy)
 
-        _ = await client.loadMatches(query: .live, team: nil)
+        _ = await client.loadLive(team: nil)
 
-        #expect(liveStrategy.callCount == 1)
-        #expect(liveStrategy.lastQuery == .live)
-        #expect(matchesStrategy.callCount == 0)
+        #expect(liveStrategy.liveCallCount == 1)
+        #expect(matchesStrategy.liveCallCount == 0)
+        #expect(matchesStrategy.matchesCallCount == 0)
     }
 
     @Test
     func test_loadMatches_returnsStrategyResult() async throws {
-        let response = makeResponse()
-        let strategy = MockWorldCupFetchStrategy(result: .success(response))
+        let response = makeMatchesResponse()
+        let strategy = MockWorldCupFetchStrategy(matchesResult: .success(response))
         let client = try WorldCupAPIClient(matchesStrategy: strategy)
 
-        let result = await client.loadMatches(query: .matches, team: nil)
+        let result = await client.loadMatches(team: nil)
 
         #expect(result == .success(response))
     }
 
     @Test
     func test_loadMatches_returnsNil_whenStrategyReturnsNilSuccess() async throws {
-        let strategy = MockWorldCupFetchStrategy(result: .success(nil))
+        let strategy = MockWorldCupFetchStrategy(matchesResult: .success(nil))
         let client = try WorldCupAPIClient(matchesStrategy: strategy)
 
-        let result = await client.loadMatches(query: .matches, team: nil)
+        let result = await client.loadMatches(team: nil)
 
         #expect(result == .success(nil))
     }
@@ -60,10 +60,10 @@ struct WorldCupAPIClientTests {
     @Test
     func test_loadMatches_propagatesStrategyFailure() async throws {
         let failure = WorldCupLoadError.network(reason: "offline")
-        let strategy = MockWorldCupFetchStrategy(result: .failure(failure))
+        let strategy = MockWorldCupFetchStrategy(matchesResult: .failure(failure))
         let client = try WorldCupAPIClient(matchesStrategy: strategy)
 
-        let result = await client.loadMatches(query: .matches, team: nil)
+        let result = await client.loadMatches(team: nil)
 
         #expect(result == .failure(failure))
     }
@@ -73,9 +73,30 @@ struct WorldCupAPIClientTests {
         let strategy = MockWorldCupFetchStrategy()
         let client = try WorldCupAPIClient(matchesStrategy: strategy)
 
-        _ = await client.loadMatches(query: .matches, team: "BRA")
+        _ = await client.loadMatches(team: "BRA")
 
-        #expect(strategy.lastTeam == "BRA")
+        #expect(strategy.lastMatchesTeam == "BRA")
+    }
+
+    @Test
+    func test_loadLive_returnsStrategyResult() async throws {
+        let response = makeLiveResponse()
+        let strategy = MockWorldCupFetchStrategy(liveResult: .success(response))
+        let client = try WorldCupAPIClient(liveStrategy: strategy)
+
+        let result = await client.loadLive(team: nil)
+
+        #expect(result == .success(response))
+    }
+
+    @Test
+    func test_loadLive_forwardsTeam_toStrategy() async throws {
+        let strategy = MockWorldCupFetchStrategy()
+        let client = try WorldCupAPIClient(liveStrategy: strategy)
+
+        _ = await client.loadLive(team: "BRA")
+
+        #expect(strategy.lastLiveTeam == "BRA")
     }
 
     @Test
@@ -88,7 +109,7 @@ struct WorldCupAPIClientTests {
         _ = await client.loadTeams(team: nil)
 
         #expect(teamsStrategy.teamsCallCount == 1)
-        #expect(matchesStrategy.callCount == 0)
+        #expect(matchesStrategy.matchesCallCount == 0)
     }
 
     @Test
@@ -123,7 +144,7 @@ struct WorldCupAPIClientTests {
         #expect(strategy.lastTeamsTeam == "BRA")
     }
 
-    private func makeResponse() -> WorldCupMatchesResponse {
+    private func makeMatch() -> WorldCupMatchesResponse.Match {
         let homeTeam = WorldCupMatchesResponse.Team(
             key: "ENG",
             name: "England",
@@ -138,7 +159,7 @@ struct WorldCupAPIClientTests {
             group: nil,
             eliminated: false
         )
-        let match = WorldCupMatchesResponse.Match(
+        return WorldCupMatchesResponse.Match(
             date: "2026-05-11T14:00:00+00:00",
             globalEventId: 1,
             homeTeam: homeTeam,
@@ -153,7 +174,14 @@ struct WorldCupAPIClientTests {
             clock: "67",
             statusType: "live"
         )
-        return WorldCupMatchesResponse(previous: nil, current: [match], next: nil)
+    }
+
+    private func makeMatchesResponse() -> WorldCupMatchesResponse {
+        return WorldCupMatchesResponse(previous: nil, current: [makeMatch()], next: nil)
+    }
+
+    private func makeLiveResponse() -> WorldCupLiveResponse {
+        return WorldCupLiveResponse(matches: [makeMatch()])
     }
 
     private func makeTeamsResponse() -> WorldCupTeamsResponse {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupFetchStrategyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupFetchStrategyTests.swift
@@ -9,80 +9,99 @@ import Foundation
 @Suite("WorldCupNormalFetchStrategy")
 struct WorldCupFetchStrategyTests {
     @Test
-    func test_returnsSuccess_whenClientReturnsResponse() async {
-        let fixture = makeResponse()
-        let stub = MockWorldCupAPIClient(result: .success(fixture))
+    func test_loadMatches_returnsSuccess_whenClientReturnsResponse() async {
+        let fixture = makeMatchesResponse()
+        let stub = MockWorldCupAPIClient(matchesResult: .success(fixture))
         let strategy = WorldCupNormalFetchStrategy()
 
-        let result = await strategy.loadMatches(using: stub, query: .matches, team: nil)
+        let result = await strategy.loadMatches(using: stub, team: nil)
 
         #expect(result == .success(fixture))
     }
 
     @Test
-    func test_returnsSuccessNil_whenClientReturnsNil() async {
-        let stub = MockWorldCupAPIClient(result: .success(nil))
+    func test_loadMatches_returnsSuccessNil_whenClientReturnsNil() async {
+        let stub = MockWorldCupAPIClient(matchesResult: .success(nil))
         let strategy = WorldCupNormalFetchStrategy()
 
-        let result = await strategy.loadMatches(using: stub, query: .matches, team: nil)
+        let result = await strategy.loadMatches(using: stub, team: nil)
 
         #expect(result == .success(nil))
     }
 
     @Test
-    func test_returnsFailure_whenClientThrows() async {
-        let stub = MockWorldCupAPIClient(result: .failure(MockWorldCupClientError.network))
+    func test_loadMatches_returnsFailure_whenClientThrows() async {
+        let stub = MockWorldCupAPIClient(matchesResult: .failure(MockWorldCupClientError.network))
         let strategy = WorldCupNormalFetchStrategy()
 
-        let result = await strategy.loadMatches(using: stub, query: .matches, team: nil)
+        let result = await strategy.loadMatches(using: stub, team: nil)
 
         #expect(result == .failure(.other(code: nil, reason: "network")))
     }
 
     @Test
-    func test_callsFetchExactlyOnce_onSuccess() async {
-        let stub = MockWorldCupAPIClient(result: .success(makeResponse()))
+    func test_loadMatches_callsFetchExactlyOnce_onSuccess() async {
+        let stub = MockWorldCupAPIClient(matchesResult: .success(makeMatchesResponse()))
         let strategy = WorldCupNormalFetchStrategy()
 
-        _ = await strategy.loadMatches(using: stub, query: .matches, team: nil)
+        _ = await strategy.loadMatches(using: stub, team: nil)
 
-        #expect(stub.fetchCount == 1)
+        #expect(stub.matchesFetchCount == 1)
     }
 
     @Test
-    func test_doesNotRetry_onFailure() async {
-        let stub = MockWorldCupAPIClient(result: .failure(MockWorldCupClientError.network))
+    func test_loadMatches_doesNotRetry_onFailure() async {
+        let stub = MockWorldCupAPIClient(matchesResult: .failure(MockWorldCupClientError.network))
         let strategy = WorldCupNormalFetchStrategy()
 
-        _ = await strategy.loadMatches(using: stub, query: .matches, team: nil)
+        _ = await strategy.loadMatches(using: stub, team: nil)
 
-        #expect(stub.fetchCount == 1)
+        #expect(stub.matchesFetchCount == 1)
     }
 
     @Test
-    func test_forwardsQuery_toClient() async {
-        let stub = MockWorldCupAPIClient(result: .success(makeResponse()))
+    func test_loadMatches_forwardsTeam_toClient() async {
+        let stub = MockWorldCupAPIClient(matchesResult: .success(makeMatchesResponse()))
         let strategy = WorldCupNormalFetchStrategy()
 
-        _ = await strategy.loadMatches(using: stub, query: .live, team: nil)
+        _ = await strategy.loadMatches(using: stub, team: "BRA")
 
-        #expect(stub.lastQuery == .live)
+        #expect(stub.lastMatchesTeam == "BRA")
     }
 
     @Test
-    func test_forwardsTeam_toClient() async {
-        let stub = MockWorldCupAPIClient(result: .success(makeResponse()))
+    func test_loadLive_callsFetchLive_andReturnsResponse() async {
+        let fixture = makeLiveResponse()
+        let stub = MockWorldCupAPIClient(
+            matchesResult: .success(nil),
+            liveResult: .success(fixture)
+        )
         let strategy = WorldCupNormalFetchStrategy()
 
-        _ = await strategy.loadMatches(using: stub, query: .matches, team: "BRA")
+        let result = await strategy.loadLive(using: stub, team: nil)
 
-        #expect(stub.lastTeam == "BRA")
+        #expect(result == .success(fixture))
+        #expect(stub.liveFetchCount == 1)
+        #expect(stub.matchesFetchCount == 0)
+    }
+
+    @Test
+    func test_loadLive_forwardsTeam_toClient() async {
+        let stub = MockWorldCupAPIClient(
+            matchesResult: .success(nil),
+            liveResult: .success(makeLiveResponse())
+        )
+        let strategy = WorldCupNormalFetchStrategy()
+
+        _ = await strategy.loadLive(using: stub, team: "BRA")
+
+        #expect(stub.lastLiveTeam == "BRA")
     }
 
     @Test
     func test_loadTeams_returnsSuccess_whenClientReturnsResponse() async {
         let fixture = makeTeamsResponse()
-        let stub = MockWorldCupAPIClient(result: .success(nil), teamsResult: .success(fixture))
+        let stub = MockWorldCupAPIClient(matchesResult: .success(nil), teamsResult: .success(fixture))
         let strategy = WorldCupNormalFetchStrategy()
 
         let result = await strategy.loadTeams(using: stub, team: nil)
@@ -93,7 +112,7 @@ struct WorldCupFetchStrategyTests {
     @Test
     func test_loadTeams_returnsFailure_whenClientThrows() async {
         let stub = MockWorldCupAPIClient(
-            result: .success(nil),
+            matchesResult: .success(nil),
             teamsResult: .failure(MockWorldCupClientError.network)
         )
         let strategy = WorldCupNormalFetchStrategy()
@@ -106,7 +125,7 @@ struct WorldCupFetchStrategyTests {
     @Test
     func test_loadTeams_callsFetchTeamsExactlyOnce_onSuccess() async {
         let stub = MockWorldCupAPIClient(
-            result: .success(nil),
+            matchesResult: .success(nil),
             teamsResult: .success(makeTeamsResponse())
         )
         let strategy = WorldCupNormalFetchStrategy()
@@ -119,7 +138,7 @@ struct WorldCupFetchStrategyTests {
     @Test
     func test_loadTeams_forwardsTeam_toClient() async {
         let stub = MockWorldCupAPIClient(
-            result: .success(nil),
+            matchesResult: .success(nil),
             teamsResult: .success(makeTeamsResponse())
         )
         let strategy = WorldCupNormalFetchStrategy()
@@ -145,7 +164,7 @@ struct WorldCupFetchStrategyTests {
         ])
     }
 
-    private func makeResponse() -> WorldCupMatchesResponse {
+    private func makeMatch() -> WorldCupMatchesResponse.Match {
         let homeTeam = WorldCupMatchesResponse.Team(
             key: "ENG",
             name: "England",
@@ -153,7 +172,6 @@ struct WorldCupFetchStrategyTests {
             group: nil,
             eliminated: false
         )
-
         let awayTeam = WorldCupMatchesResponse.Team(
             key: "USA",
             name: "United States",
@@ -161,27 +179,28 @@ struct WorldCupFetchStrategyTests {
             group: nil,
             eliminated: false
         )
-
-        return WorldCupMatchesResponse(
-            previous: nil,
-            current: [
-                WorldCupMatchesResponse.Match(
-                    date: "2026-05-11T14:00:00+00:00",
-                    globalEventId: 1,
-                    homeTeam: homeTeam,
-                    awayTeam: awayTeam,
-                    period: "2",
-                    homeScore: 1,
-                    awayScore: 0,
-                    homeExtra: nil,
-                    awayExtra: nil,
-                    homePenalty: nil,
-                    awayPenalty: nil,
-                    clock: "67",
-                    statusType: "live"
-                )
-            ],
-            next: nil
+        return WorldCupMatchesResponse.Match(
+            date: "2026-05-11T14:00:00+00:00",
+            globalEventId: 1,
+            homeTeam: homeTeam,
+            awayTeam: awayTeam,
+            period: "2",
+            homeScore: 1,
+            awayScore: 0,
+            homeExtra: nil,
+            awayExtra: nil,
+            homePenalty: nil,
+            awayPenalty: nil,
+            clock: "67",
+            statusType: "live"
         )
+    }
+
+    private func makeMatchesResponse() -> WorldCupMatchesResponse {
+        WorldCupMatchesResponse(previous: nil, current: [makeMatch()], next: nil)
+    }
+
+    private func makeLiveResponse() -> WorldCupLiveResponse {
+        WorldCupLiveResponse(matches: [makeMatch()])
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupLiveResponseTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupLiveResponseTests.swift
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Testing
+import Foundation
+@testable import Client
+
+@Suite("WorldCupLiveResponse decoding")
+struct WorldCupLiveResponseTests {
+    // Representative payload modeled after the merino WCS /live fixture:
+    // a flat `matches` array (not the previous/current/next buckets of /matches).
+    // Verifies snake_case -> camelCase decoding and that nullable score fields
+    // decode cleanly for in-progress vs finished matches.
+    private let json = """
+    {
+      "matches": [{
+        "date": "2026-05-17T13:00:00+00:00",
+        "global_event_id": 1020,
+        "home_team": {
+          "key": "USA", "global_team_id": 90000872, "name": "United States", "region": "USA",
+          "colors": ["#B22234","#FFFFFF","#3C3B6E"], "icon_url": "https://example.com/usa.svg",
+          "group": "Group D", "eliminated": false
+        },
+        "away_team": {
+          "key": "ENG", "global_team_id": 90000858, "name": "England", "region": "ENG",
+          "colors": ["#FFFFFF","#CE1126"], "icon_url": "https://example.com/eng.svg",
+          "group": "Group L", "eliminated": false
+        },
+        "period": "FT", "home_score": 3, "away_score": 0,
+        "home_extra": null, "away_extra": null,
+        "home_penalty": null, "away_penalty": null,
+        "clock": "90", "updated": 1779019200, "stage": null,
+        "status": "Awarded", "status_type": "past", "query": null, "sport": "soccer"
+      }, {
+        "date": "2026-05-17T18:00:00+00:00",
+        "global_event_id": 1002,
+        "home_team": {
+          "key": "GER", "global_team_id": 90000947, "name": "Germany", "region": "GER",
+          "colors": [], "icon_url": null, "group": "Group E", "eliminated": false
+        },
+        "away_team": {
+          "key": "FRA", "global_team_id": 90000946, "name": "France", "region": "FRA",
+          "colors": [], "icon_url": null, "group": "Group I", "eliminated": false
+        },
+        "period": "FT(P)", "home_score": 1, "away_score": 1,
+        "home_extra": 1, "away_extra": 1,
+        "home_penalty": 5, "away_penalty": 4,
+        "clock": "120", "updated": 1779037200, "stage": null,
+        "status": "Final", "status_type": "past", "query": null, "sport": "soccer"
+      }]
+    }
+    """
+
+    @Test
+    func test_decodesMatchesArray() throws {
+        let response = try decode(json)
+
+        #expect(response.matches?.count == 2)
+
+        let first = try #require(response.matches?.first)
+        #expect(first.homeTeam.key == "USA")
+        #expect(first.awayTeam.key == "ENG")
+        #expect(first.homeScore == 3)
+        #expect(first.awayScore == 0)
+        #expect(first.clock == "90")
+        #expect(first.statusType == "past")
+        #expect(first.homeTeam.iconUrl == "https://example.com/usa.svg")
+    }
+
+    @Test
+    func test_decodesPenaltyShootout() throws {
+        let response = try decode(json)
+        let second = try #require(response.matches?.last)
+
+        #expect(second.homeExtra == 1)
+        #expect(second.awayExtra == 1)
+        #expect(second.homePenalty == 5)
+        #expect(second.awayPenalty == 4)
+        #expect(second.period == "FT(P)")
+    }
+
+    @Test
+    func test_decodesEmptyMatchesArray() throws {
+        let response = try decode(#"{ "matches": [] }"#)
+        #expect(response.matches?.isEmpty == true)
+    }
+
+    @Test
+    func test_decodesEmptyTopLevelObject() throws {
+        let response = try decode("{}")
+        #expect(response.matches == nil)
+    }
+
+    @Test
+    func test_decodesIgnoresUnknownTopLevelKeys() throws {
+        let response = try decode(#"{ "matches": [], "unknown_field": "ignored", "extra": 42 }"#)
+        #expect(response.matches?.isEmpty == true)
+    }
+
+    @Test
+    func test_responseEquality_sameContent() {
+        let responseA = WorldCupLiveResponse(matches: [])
+        let responseB = WorldCupLiveResponse(matches: [])
+        #expect(responseA == responseB)
+    }
+
+    @Test
+    func test_responseEquality_nilVsEmpty() {
+        let responseA = WorldCupLiveResponse(matches: nil)
+        let responseB = WorldCupLiveResponse(matches: [])
+        #expect(responseA != responseB)
+    }
+
+    @Test
+    func test_responseEquality_differentMatches() {
+        let team = WorldCupMatchesResponse.Team(
+            key: "ENG",
+            name: "England",
+            iconUrl: nil,
+            group: nil,
+            eliminated: false
+        )
+        let matchA = WorldCupMatchesResponse.Match(
+            date: "2026-05-11T14:00:00+00:00",
+            globalEventId: 1,
+            homeTeam: team,
+            awayTeam: team
+        )
+        let matchB = WorldCupMatchesResponse.Match(
+            date: "2026-05-11T14:00:00+00:00",
+            globalEventId: 2,
+            homeTeam: team,
+            awayTeam: team
+        )
+        #expect(WorldCupLiveResponse(matches: [matchA]) != WorldCupLiveResponse(matches: [matchB]))
+    }
+
+    private func decode(_ json: String) throws -> WorldCupLiveResponse {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(WorldCupLiveResponse.self, from: Data(json.utf8))
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
@@ -13,12 +13,20 @@ struct WorldCupMatchesTests {
         let response = WorldCupMatchesResponse(
             previous: nil,
             current: [
-                makeMatch(id: 1, home: "ENG", away: "USA",
+                makeMatch(id: 1,
+                          home: "ENG",
+                          away: "USA",
                           date: "2026-06-11T18:00:00+00:00",
-                          homeScore: 1, awayScore: 0, clock: "67"),
-                makeMatch(id: 2, home: "BRA", away: "GER",
+                          homeScore: 1,
+                          awayScore: 0,
+                          clock: "67"),
+                makeMatch(id: 2,
+                          home: "BRA",
+                          away: "GER",
                           date: "2026-06-12T15:00:00+00:00",
-                          homeScore: 2, awayScore: 2, clock: "90+15")
+                          homeScore: 2,
+                          awayScore: 2,
+                          clock: "90+15")
             ],
             next: [
                 makeMatch(id: 3, home: "ARG", away: "ENG", date: "2026-06-13T18:00:00+00:00"),
@@ -43,9 +51,12 @@ struct WorldCupMatchesTests {
     func test_init_withoutLiveIDs_isNotLiveEvenIfTodayHasMatches() {
         let response = WorldCupMatchesResponse(
             previous: nil,
-            current: [makeMatch(id: 1, home: "ENG", away: "USA",
+            current: [makeMatch(id: 1,
+                                home: "ENG",
+                                away: "USA",
                                 date: "2026-06-12T18:00:00+00:00",
-                                homeScore: 1, awayScore: 0)],
+                                homeScore: 1,
+                                awayScore: 0)],
             next: nil
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
@@ -9,21 +9,30 @@ import Foundation
 @Suite("WorldCupMatches view-model")
 struct WorldCupMatchesTests {
     @Test
-    func test_init_withLiveMatches_marksLiveAndUsesCurrentAsFeatured() {
+    func test_init_marksLive_andPutsPastAndTodayMatchesInFeatured() {
         let response = WorldCupMatchesResponse(
             previous: nil,
             current: [
-                makeMatch(home: "ENG", away: "USA", homeScore: 1, awayScore: 0, clock: "67"),
-                makeMatch(home: "BRA", away: "GER", homeScore: 2, awayScore: 2, clock: "90+15")
+                makeMatch(id: 1, home: "ENG", away: "USA",
+                          date: "2026-06-11T18:00:00+00:00",
+                          homeScore: 1, awayScore: 0, clock: "67"),
+                makeMatch(id: 2, home: "BRA", away: "GER",
+                          date: "2026-06-12T15:00:00+00:00",
+                          homeScore: 2, awayScore: 2, clock: "90+15")
             ],
             next: [
-                makeMatch(home: "ARG", away: "ENG"),
-                makeMatch(home: "FRA", away: "USA"),
-                makeMatch(home: "BRA", away: "GER")
+                makeMatch(id: 3, home: "ARG", away: "ENG", date: "2026-06-13T18:00:00+00:00"),
+                makeMatch(id: 4, home: "FRA", away: "USA", date: "2026-06-14T18:00:00+00:00"),
+                makeMatch(id: 5, home: "BRA", away: "GER", date: "2026-06-15T18:00:00+00:00")
             ]
         )
 
-        let model = WorldCupMatches(response: response)
+        let model = WorldCupMatches(
+            response: response,
+            liveIDs: [1],
+            now: parse("2026-06-12T20:00:00+00:00"),
+            calendar: utcCalendar()
+        )
 
         #expect(model.isLive)
         #expect(model.featuredMatch.map(\.homeCode) == ["ENG", "BRA"])
@@ -31,23 +40,81 @@ struct WorldCupMatchesTests {
     }
 
     @Test
-    func test_init_noLiveMatches_picksFirstScheduledAsFeaturedAndNextTwoAsUpcoming() {
+    func test_init_withoutLiveIDs_isNotLiveEvenIfTodayHasMatches() {
         let response = WorldCupMatchesResponse(
             previous: nil,
-            current: [],
+            current: [makeMatch(id: 1, home: "ENG", away: "USA",
+                                date: "2026-06-12T18:00:00+00:00",
+                                homeScore: 1, awayScore: 0)],
+            next: nil
+        )
+
+        let model = WorldCupMatches(
+            response: response,
+            liveIDs: [],
+            now: parse("2026-06-12T20:00:00+00:00"),
+            calendar: utcCalendar()
+        )
+
+        #expect(!model.isLive)
+    }
+
+    @Test
+    func test_init_withLiveIDs_thatDontMatchAnyMatch_isNotLive() {
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: [makeMatch(id: 1, home: "ENG", away: "USA")],
+            next: [makeMatch(id: 2, home: "BRA", away: "GER")]
+        )
+
+        let model = WorldCupMatches(response: response, liveIDs: [99])
+
+        #expect(!model.isLive)
+    }
+
+    @Test
+    func test_init_whenAllMatchesAreInTheFuture_promotesFirstToFeatured() {
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: nil,
             next: [
-                makeMatch(home: "ARG", away: "ENG"),
-                makeMatch(home: "FRA", away: "USA"),
-                makeMatch(home: "BRA", away: "GER"),
-                makeMatch(home: "POR", away: "ESP")
+                makeMatch(id: 1, home: "CAN", away: "BIH", date: "2026-06-12T21:00:00+00:00"),
+                makeMatch(id: 2, home: "CAN", away: "QAT", date: "2026-06-19T00:00:00+00:00"),
+                makeMatch(id: 3, home: "CHE", away: "CAN", date: "2026-06-24T21:00:00+00:00")
             ]
         )
 
-        let model = WorldCupMatches(response: response)
+        let model = WorldCupMatches(
+            response: response,
+            now: parse("2026-05-18T09:00:00+00:00"),
+            calendar: utcCalendar()
+        )
 
         #expect(!model.isLive)
-        #expect(model.featuredMatch.map(\.homeCode) == ["ARG"])
-        #expect(model.upcomingMatches.map(\.homeCode) == ["FRA", "BRA"])
+        #expect(model.featuredMatch.map(\.homeCode) == ["CAN"])
+        #expect(model.upcomingMatches.map(\.homeCode) == ["CAN", "CHE"])
+    }
+
+    @Test
+    func test_init_ignoresServerBucketing_andUsesRealTodayForSplit() {
+        // The merino payload buckets matches relative to the query date (the
+        // tournament floor, Jun 18). On May 18 the user's real today is well
+        // before any match, so everything should bucket as future regardless
+        // of which server label it carried.
+        let response = WorldCupMatchesResponse(
+            previous: [makeMatch(id: 1, home: "CAN", away: "BIH", date: "2026-06-12T21:00:00+00:00")],
+            current: [makeMatch(id: 2, home: "CAN", away: "QAT", date: "2026-06-19T00:00:00+00:00")],
+            next: [makeMatch(id: 3, home: "CHE", away: "CAN", date: "2026-06-24T21:00:00+00:00")]
+        )
+
+        let model = WorldCupMatches(
+            response: response,
+            now: parse("2026-05-18T09:00:00+00:00"),
+            calendar: utcCalendar()
+        )
+
+        #expect(model.featuredMatch.map(\.homeCode) == ["CAN"])
+        #expect(model.upcomingMatches.map(\.homeCode) == ["CAN", "CHE"])
     }
 
     @Test
@@ -60,10 +127,160 @@ struct WorldCupMatchesTests {
         #expect(model.upcomingMatches.isEmpty)
     }
 
+    // MARK: - flattened (grouped-by-day)
+
+    @Test
+    func test_flattened_groupsMatchesOnTheSameDayIntoOneCard() {
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: nil,
+            next: [
+                makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-06-12T18:00:00+00:00"),
+                makeMatch(id: 2, home: "ENG", away: "USA", date: "2026-06-12T21:00:00+00:00"),
+                makeMatch(id: 3, home: "FRA", away: "GER", date: "2026-06-13T15:00:00+00:00")
+            ]
+        )
+
+        let result = WorldCupMatches.flattened(
+            response: response,
+            now: parse("2026-06-10T12:00:00+00:00"),
+            calendar: utcCalendar()
+        )
+
+        #expect(result.cards.count == 2)
+        #expect(result.cards[0].upcomingMatches.map(\.homeCode) == ["ARG", "ENG"])
+        #expect(result.cards[1].upcomingMatches.map(\.homeCode) == ["FRA"])
+    }
+
+    @Test
+    func test_flattened_leavesFeaturedEmpty_soDayMatchesRenderInCompactRows() {
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: nil,
+            next: [makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-06-12T18:00:00+00:00")]
+        )
+
+        let result = WorldCupMatches.flattened(
+            response: response,
+            now: parse("2026-06-10T12:00:00+00:00"),
+            calendar: utcCalendar()
+        )
+
+        #expect(result.cards[0].featuredMatch.isEmpty)
+    }
+
+    @Test
+    func test_flattened_orderCardsChronologically() {
+        let response = WorldCupMatchesResponse(
+            previous: [makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-06-10T18:00:00+00:00")],
+            current: [makeMatch(id: 2, home: "ENG", away: "USA", date: "2026-06-12T18:00:00+00:00")],
+            next: [makeMatch(id: 3, home: "FRA", away: "GER", date: "2026-06-14T18:00:00+00:00")]
+        )
+
+        let result = WorldCupMatches.flattened(
+            response: response,
+            now: parse("2026-06-10T12:00:00+00:00"),
+            calendar: utcCalendar()
+        )
+
+        #expect(result.cards.map { $0.upcomingMatches.first?.homeCode } == ["ARG", "ENG", "FRA"])
+    }
+
+    @Test
+    func test_flattened_defaultIndex_pointsAtToday() {
+        let response = WorldCupMatchesResponse(
+            previous: [makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-06-10T18:00:00+00:00")],
+            current: [makeMatch(id: 2, home: "ENG", away: "USA", date: "2026-06-12T18:00:00+00:00")],
+            next: [makeMatch(id: 3, home: "FRA", away: "GER", date: "2026-06-14T18:00:00+00:00")]
+        )
+
+        let result = WorldCupMatches.flattened(
+            response: response,
+            now: parse("2026-06-12T09:00:00+00:00"),
+            calendar: utcCalendar()
+        )
+
+        #expect(result.defaultIndex == 1)
+    }
+
+    @Test
+    func test_flattened_defaultIndex_pointsAtNextFutureDay_whenTodayHasNoMatches() {
+        let response = WorldCupMatchesResponse(
+            previous: [makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-06-10T18:00:00+00:00")],
+            current: nil,
+            next: [
+                makeMatch(id: 2, home: "ENG", away: "USA", date: "2026-06-13T18:00:00+00:00"),
+                makeMatch(id: 3, home: "FRA", away: "GER", date: "2026-06-14T18:00:00+00:00")
+            ]
+        )
+
+        let result = WorldCupMatches.flattened(
+            response: response,
+            now: parse("2026-06-11T09:00:00+00:00"),
+            calendar: utcCalendar()
+        )
+
+        #expect(result.defaultIndex == 1)
+    }
+
+    @Test
+    func test_flattened_defaultIndex_fallsBackToLastCard_whenEverythingIsInThePast() {
+        let response = WorldCupMatchesResponse(
+            previous: [
+                makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-06-10T18:00:00+00:00"),
+                makeMatch(id: 2, home: "ENG", away: "USA", date: "2026-06-11T18:00:00+00:00")
+            ],
+            current: nil,
+            next: nil
+        )
+
+        let result = WorldCupMatches.flattened(
+            response: response,
+            now: parse("2026-07-01T09:00:00+00:00"),
+            calendar: utcCalendar()
+        )
+
+        #expect(result.defaultIndex == 1)
+    }
+
+    @Test
+    func test_flattened_marksCardLive_whenAnyMatchInDayIsInLiveIDs() {
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: [
+                makeMatch(id: 10, home: "ARG", away: "BRA", date: "2026-06-12T18:00:00+00:00"),
+                makeMatch(id: 11, home: "ENG", away: "USA", date: "2026-06-12T21:00:00+00:00")
+            ],
+            next: [makeMatch(id: 12, home: "FRA", away: "GER", date: "2026-06-13T15:00:00+00:00")]
+        )
+
+        let result = WorldCupMatches.flattened(
+            response: response,
+            liveIDs: [11],
+            now: parse("2026-06-12T20:00:00+00:00"),
+            calendar: utcCalendar()
+        )
+
+        #expect(result.cards[0].isLive)
+        #expect(!result.cards[1].isLive)
+    }
+
+    @Test
+    func test_flattened_emptyResponse_returnsEmptyCards() {
+        let response = WorldCupMatchesResponse(previous: nil, current: nil, next: nil)
+
+        let result = WorldCupMatches.flattened(response: response, calendar: utcCalendar())
+
+        #expect(result.cards.isEmpty)
+        #expect(result.defaultIndex == 0)
+    }
+
+    // MARK: - score formatting
+
     @Test
     func test_match_score_regulationOnly() {
         let match = WorldCupMatch(
-            makeMatch(home: "ENG", away: "USA", homeScore: 1, awayScore: 0, clock: "67")
+            makeMatch(id: 0, home: "ENG", away: "USA", homeScore: 1, awayScore: 0, clock: "67")
         )
         #expect(match.score?.score == "1 – 0")
         #expect(match.score?.clock == "67'")
@@ -72,6 +289,7 @@ struct WorldCupMatchesTests {
     @Test
     func test_match_score_withPenaltyShootout() {
         let match = WorldCupMatch(makeMatch(
+            id: 0,
             home: "GER",
             away: "FRA",
             homeScore: 1,
@@ -87,69 +305,65 @@ struct WorldCupMatchesTests {
     @Test
     func test_match_score_isNilForScheduledMatches() {
         let match = WorldCupMatch(
-            makeMatch(home: "ARG", away: "ENG", homeScore: nil, awayScore: nil)
+            makeMatch(id: 0, home: "ARG", away: "ENG", homeScore: nil, awayScore: nil)
         )
         #expect(match.score == nil)
     }
 
-    @Test
-    func test_phaseTitle_groupStage_whenTeamsHaveGroup() {
-        let response = WorldCupMatchesResponse(
-            previous: nil,
-            current: [makeMatch(home: "ENG", away: "USA", group: "Group C")],
-            next: nil
-        )
+    // MARK: - phaseTitle
 
-        #expect(WorldCupMatches.phaseTitle(from: response)
+    @Test
+    func test_phaseTitle_groupStage_usesGroupLetter() {
+        let match = makeMatch(id: 0, home: "ENG", away: "USA", group: "Group C", stage: "Group Stage")
+
+        #expect(WorldCupMatches.phaseTitle(from: match)
+                == String.WorldCup.HomepageWidget.GroupPhase.GroupC)
+    }
+
+    @Test
+    func test_phaseTitle_groupStage_fallsBackToGenericLabel_whenGroupMissing() {
+        let match = makeMatch(id: 0, home: "ENG", away: "USA", group: nil, stage: "Group Stage")
+
+        #expect(WorldCupMatches.phaseTitle(from: match)
                 == String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel)
     }
 
     @Test
-    func test_phaseTitle_groupStage_whenGroupOnlyInUpcoming() {
-        let response = WorldCupMatchesResponse(
-            previous: nil,
-            current: [],
-            next: [makeMatch(home: "ARG", away: "FRA", group: "Group A")]
-        )
+    func test_phaseTitle_knockoutStages_mapToLocalizedLabels() {
+        let mappings: [(String, String)] = [
+            ("Round of 32", String.WorldCup.HomepageWidget.RoundPhase.Round32Label),
+            ("Round of 16", String.WorldCup.HomepageWidget.RoundPhase.Round16Label),
+            ("Quarterfinals", String.WorldCup.HomepageWidget.RoundPhase.QuarterFinalsLabel),
+            ("Semifinals", String.WorldCup.HomepageWidget.RoundPhase.SemiFinalsLabel),
+            ("Third Place", String.WorldCup.HomepageWidget.RoundPhase.ThirdPlaceLabel),
+            ("Final", String.WorldCup.HomepageWidget.RoundPhase.FinalLabel)
+        ]
+        for (stage, expected) in mappings {
+            let match = makeMatch(id: 0, home: "BRA", away: "ARG", group: nil, stage: stage)
+            #expect(WorldCupMatches.phaseTitle(from: match) == expected)
+        }
+    }
 
-        #expect(WorldCupMatches.phaseTitle(from: response)
+    @Test
+    func test_phaseTitle_unknownStage_fallsBackToUpcoming() {
+        let match = makeMatch(id: 0, home: "BRA", away: "ARG", group: nil, stage: "Galactic Quarterfinals")
+
+        #expect(WorldCupMatches.phaseTitle(from: match)
+                == String.WorldCup.HomepageWidget.RoundPhase.UpcomingLabel)
+    }
+
+    @Test
+    func test_phaseTitle_nilMatch_fallsBackToGroupStage() {
+        #expect(WorldCupMatches.phaseTitle(from: nil)
                 == String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel)
     }
 
-    @Test
-    func test_phaseTitle_upcoming_whenNoTeamsHaveGroup() {
-        let response = WorldCupMatchesResponse(
-            previous: nil,
-            current: [makeMatch(home: "ENG", away: "USA", group: nil)],
-            next: [makeMatch(home: "BRA", away: "GER", group: nil)]
-        )
+    // MARK: - Helpers
 
-        #expect(WorldCupMatches.phaseTitle(from: response)
-                == String.WorldCup.HomepageWidget.RoundPhase.UpcomingLabel)
-    }
-
-    @Test
-    func test_phaseTitle_upcoming_whenResponseIsEmpty() {
-        let response = WorldCupMatchesResponse(previous: nil, current: nil, next: nil)
-
-        #expect(WorldCupMatches.phaseTitle(from: response)
-                == String.WorldCup.HomepageWidget.RoundPhase.UpcomingLabel)
-    }
-
-    @Test
-    func test_phaseTitle_ignoresPreviousMatches() {
-        let response = WorldCupMatchesResponse(
-            previous: [makeMatch(home: "BRA", away: "ARG", group: "Group A")],
-            current: nil,
-            next: nil
-        )
-
-        #expect(WorldCupMatches.phaseTitle(from: response)
-                == String.WorldCup.HomepageWidget.RoundPhase.UpcomingLabel)
-    }
-
-    private func makeMatch(home: String,
+    private func makeMatch(id: Int,
+                           home: String,
                            away: String,
+                           date: String = "2026-05-01T15:00:00+00:00",
                            homeScore: Int? = nil,
                            awayScore: Int? = nil,
                            homeExtra: Int? = nil,
@@ -157,7 +371,8 @@ struct WorldCupMatchesTests {
                            homePenalty: Int? = nil,
                            awayPenalty: Int? = nil,
                            clock: String? = nil,
-                           group: String? = nil) -> WorldCupMatchesResponse.Match {
+                           group: String? = nil,
+                           stage: String? = nil) -> WorldCupMatchesResponse.Match {
         let homeTeam = WorldCupMatchesResponse.Team(
             key: home,
             name: home,
@@ -173,8 +388,8 @@ struct WorldCupMatchesTests {
             eliminated: false
         )
         return WorldCupMatchesResponse.Match(
-            date: "2026-05-01T15:00:00+00:00",
-            globalEventId: 0,
+            date: date,
+            globalEventId: id,
             homeTeam: homeTeam,
             awayTeam: awayTeam,
             period: nil,
@@ -185,7 +400,20 @@ struct WorldCupMatchesTests {
             homePenalty: homePenalty,
             awayPenalty: awayPenalty,
             clock: clock,
-            statusType: nil
+            statusType: nil,
+            stage: stage
         )
+    }
+
+    private func utcCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }
+
+    private func parse(_ iso: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: iso)!
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -36,7 +36,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         mockWorldCupStore.isHomepageSectionEnabled = true
         mockWorldCupStore.isMilestone2 = false
         mockWorldCupStore.selectedTeam = "BRA"
-        let apiClient = MockWorldCupAPIClient(result: .success(makeResponse()))
+        let apiClient = MockWorldCupAPIClient(matchesResult: .success(makeResponse()))
         let subject = createSubject(apiClient: apiClient)
         let action = HomepageAction(
             windowUUID: .XCTestDefaultUUID,
@@ -59,7 +59,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertFalse(dispatched.shouldShowMilestone2)
         XCTAssertEqual(dispatched.selectedCountryId, "BRA")
         XCTAssertTrue(dispatched.matches.isEmpty)
-        XCTAssertEqual(apiClient.fetchCount, 0)
+        XCTAssertEqual(apiClient.matchesFetchCount, 0)
         subject.worldCupProvider = { _, _ in }
     }
 
@@ -67,7 +67,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         mockWorldCupStore.isFeatureEnabled = true
         mockWorldCupStore.isHomepageSectionEnabled = true
         mockWorldCupStore.isMilestone2 = true
-        let apiClient = MockWorldCupAPIClient(result: .success(makeResponse()))
+        let apiClient = MockWorldCupAPIClient(matchesResult: .success(makeResponse()))
         let subject = createSubject(apiClient: apiClient)
         let action = HomepageAction(
             windowUUID: .XCTestDefaultUUID,
@@ -87,7 +87,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, .didUpdate)
         XCTAssertTrue(dispatched.shouldShowMilestone2)
         XCTAssertEqual(dispatched.matches.count, 1)
-        XCTAssertEqual(apiClient.lastQuery, .matches)
+        XCTAssertEqual(apiClient.matchesFetchCount, 1)
+        XCTAssertEqual(apiClient.liveFetchCount, 1)
         subject.worldCupProvider = { _, _ in }
     }
 
@@ -96,7 +97,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
     func test_didChangeHomepageSettings_dispatchesDidUpdate() throws {
         mockWorldCupStore.isFeatureEnabled = true
         mockWorldCupStore.isHomepageSectionEnabled = false
-        let apiClient = MockWorldCupAPIClient(result: .success(makeResponse()))
+        let apiClient = MockWorldCupAPIClient(matchesResult: .success(makeResponse()))
         let subject = createSubject(apiClient: apiClient)
         let action = WorldCupAction(
             windowUUID: .XCTestDefaultUUID,
@@ -116,7 +117,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, .didUpdate)
         XCTAssertFalse(dispatched.shouldShowHomepageWorldCupSection)
         XCTAssertEqual(mockWorldCupStore.setIsHomepageSectionEnabledCalled, 0)
-        XCTAssertEqual(apiClient.fetchCount, 0)
+        XCTAssertEqual(apiClient.matchesFetchCount, 0)
         subject.worldCupProvider = { _, _ in }
     }
 
@@ -154,7 +155,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         mockWorldCupStore.isFeatureEnabled = true
         mockWorldCupStore.isHomepageSectionEnabled = true
         mockWorldCupStore.isMilestone2 = true
-        let apiClient = MockWorldCupAPIClient(result: .success(makeResponse()))
+        let apiClient = MockWorldCupAPIClient(matchesResult: .success(makeResponse()))
         let subject = createSubject(apiClient: apiClient)
         let action = WorldCupAction(
             windowUUID: .XCTestDefaultUUID,
@@ -173,7 +174,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockWorldCupStore.setSelectedTeamCalled, 1)
         XCTAssertEqual(mockWorldCupStore.lastSetSelectedTeamCountryId, "ARG")
         XCTAssertEqual(dispatched.matches.count, 1)
-        XCTAssertEqual(apiClient.lastQuery, .matches)
+        XCTAssertEqual(apiClient.matchesFetchCount, 1)
+        XCTAssertEqual(apiClient.liveFetchCount, 1)
         subject.worldCupProvider = { _, _ in }
     }
 
@@ -204,7 +206,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         mockWorldCupStore.isFeatureEnabled = true
         mockWorldCupStore.isHomepageSectionEnabled = true
         mockWorldCupStore.isMilestone2 = true
-        let apiClient = MockWorldCupAPIClient(result: .success(makeResponse()))
+        let apiClient = MockWorldCupAPIClient(matchesResult: .success(makeResponse()))
         let subject = createSubject(apiClient: apiClient)
         let action = WorldCupAction(
             windowUUID: .XCTestDefaultUUID,
@@ -221,7 +223,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WorldCupAction)
         XCTAssertEqual(dispatched.matches.count, 1)
         XCTAssertNil(dispatched.apiError)
-        XCTAssertEqual(apiClient.lastQuery, .matches)
+        XCTAssertEqual(apiClient.matchesFetchCount, 1)
+        XCTAssertEqual(apiClient.liveFetchCount, 1)
         subject.worldCupProvider = { _, _ in }
     }
 
@@ -229,7 +232,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         mockWorldCupStore.isFeatureEnabled = true
         mockWorldCupStore.isHomepageSectionEnabled = true
         mockWorldCupStore.isMilestone2 = true
-        let apiClient = MockWorldCupAPIClient(result: .failure(MockWorldCupClientError.network))
+        let apiClient = MockWorldCupAPIClient(matchesResult: .failure(MockWorldCupClientError.network))
         let subject = createSubject(apiClient: apiClient)
         let action = WorldCupAction(
             windowUUID: .XCTestDefaultUUID,
@@ -246,6 +249,143 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WorldCupAction)
         XCTAssertTrue(dispatched.matches.isEmpty)
         XCTAssertNotNil(dispatched.apiError)
+        subject.worldCupProvider = { _, _ in }
+    }
+
+    // MARK: - Live endpoint
+
+    func test_homepageInitialize_whenLiveEndpointReportsMatchAsLive_marksCardLive() throws {
+        mockWorldCupStore.isFeatureEnabled = true
+        mockWorldCupStore.isHomepageSectionEnabled = true
+        mockWorldCupStore.isMilestone2 = true
+        mockWorldCupStore.selectedTeam = "ARG"
+        let match = makeMatch(id: 42, home: "ARG", away: "BRA")
+        let matchesResponse = WorldCupMatchesResponse(previous: nil, current: [match], next: nil)
+        let liveResponse = WorldCupLiveResponse(matches: [match])
+        let apiClient = MockWorldCupAPIClient(
+            matchesResult: .success(matchesResponse),
+            liveResult: .success(liveResponse)
+        )
+        let subject = createSubject(apiClient: apiClient)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+
+        let expectation = XCTestExpectation(description: "didUpdate dispatched")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.worldCupProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WorldCupAction)
+        XCTAssertEqual(dispatched.matches.count, 1)
+        XCTAssertTrue(dispatched.matches.first?.isLive ?? false)
+        subject.worldCupProvider = { _, _ in }
+    }
+
+    func test_homepageInitialize_whenLiveEndpointEmpty_cardIsNotLive_evenWhenCurrentPopulated() throws {
+        mockWorldCupStore.isFeatureEnabled = true
+        mockWorldCupStore.isHomepageSectionEnabled = true
+        mockWorldCupStore.isMilestone2 = true
+        mockWorldCupStore.selectedTeam = "ARG"
+        let match = makeMatch(id: 42, home: "ARG", away: "BRA")
+        let matchesResponse = WorldCupMatchesResponse(previous: nil, current: [match], next: nil)
+        let liveResponse = WorldCupLiveResponse(matches: [])
+        let apiClient = MockWorldCupAPIClient(
+            matchesResult: .success(matchesResponse),
+            liveResult: .success(liveResponse)
+        )
+        let subject = createSubject(apiClient: apiClient)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+
+        let expectation = XCTestExpectation(description: "didUpdate dispatched")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.worldCupProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WorldCupAction)
+        XCTAssertEqual(dispatched.matches.count, 1)
+        XCTAssertFalse(dispatched.matches.first?.isLive ?? true)
+        subject.worldCupProvider = { _, _ in }
+    }
+
+    func test_homepageInitialize_whenLiveEndpointFails_stillReturnsMatchesAsNotLive() throws {
+        mockWorldCupStore.isFeatureEnabled = true
+        mockWorldCupStore.isHomepageSectionEnabled = true
+        mockWorldCupStore.isMilestone2 = true
+        mockWorldCupStore.selectedTeam = "ARG"
+        let match = makeMatch(id: 42, home: "ARG", away: "BRA")
+        let matchesResponse = WorldCupMatchesResponse(previous: nil, current: [match], next: nil)
+        let apiClient = MockWorldCupAPIClient(
+            matchesResult: .success(matchesResponse),
+            liveResult: .failure(MockWorldCupClientError.network)
+        )
+        let subject = createSubject(apiClient: apiClient)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+
+        let expectation = XCTestExpectation(description: "didUpdate dispatched")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.worldCupProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WorldCupAction)
+        XCTAssertNil(dispatched.apiError)
+        XCTAssertEqual(dispatched.matches.count, 1)
+        XCTAssertFalse(dispatched.matches.first?.isLive ?? true)
+        subject.worldCupProvider = { _, _ in }
+    }
+
+    // MARK: - Flattened grouping (no team selected)
+
+    func test_homepageInitialize_whenNoTeamSelected_groupsMatchesByDayIntoCards() throws {
+        mockWorldCupStore.isFeatureEnabled = true
+        mockWorldCupStore.isHomepageSectionEnabled = true
+        mockWorldCupStore.isMilestone2 = true
+        mockWorldCupStore.selectedTeam = nil
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: nil,
+            next: [
+                makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-06-12T18:00:00+00:00"),
+                makeMatch(id: 2, home: "ENG", away: "USA", date: "2026-06-12T21:00:00+00:00"),
+                makeMatch(id: 3, home: "FRA", away: "GER", date: "2026-06-13T15:00:00+00:00")
+            ]
+        )
+        let apiClient = MockWorldCupAPIClient(
+            matchesResult: .success(response),
+            liveResult: .success(WorldCupLiveResponse(matches: []))
+        )
+        let subject = createSubject(apiClient: apiClient)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+
+        let expectation = XCTestExpectation(description: "didUpdate dispatched")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.worldCupProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WorldCupAction)
+        XCTAssertEqual(dispatched.matches.count, 2)
+        XCTAssertEqual(dispatched.matches[0].upcomingMatches.count, 2)
+        XCTAssertTrue(dispatched.matches[0].featuredMatch.isEmpty)
+        XCTAssertEqual(dispatched.matches[1].upcomingMatches.count, 1)
+        XCTAssertTrue(dispatched.matches[1].featuredMatch.isEmpty)
         subject.worldCupProvider = { _, _ in }
     }
 
@@ -275,15 +415,26 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
     }
 
     private func makeResponse() -> WorldCupMatchesResponse {
+        return WorldCupMatchesResponse(
+            previous: nil,
+            current: nil,
+            next: [makeMatch(id: 1, home: "ARG", away: "BRA")]
+        )
+    }
+
+    private func makeMatch(id: Int,
+                           home: String,
+                           away: String,
+                           date: String = "2026-06-12T18:00:00+00:00") -> WorldCupMatchesResponse.Match {
         let homeTeam = WorldCupMatchesResponse.Team(
-            key: "ARG", name: "Argentina", iconUrl: nil, group: "Group A", eliminated: false
+            key: home, name: home, iconUrl: nil, group: "Group A", eliminated: false
         )
         let awayTeam = WorldCupMatchesResponse.Team(
-            key: "BRA", name: "Brazil", iconUrl: nil, group: "Group A", eliminated: false
+            key: away, name: away, iconUrl: nil, group: "Group A", eliminated: false
         )
-        let match = WorldCupMatchesResponse.Match(
-            date: "2026-06-12T18:00:00+00:00",
-            globalEventId: 1,
+        return WorldCupMatchesResponse.Match(
+            date: date,
+            globalEventId: id,
             homeTeam: homeTeam,
             awayTeam: awayTeam,
             period: nil,
@@ -296,7 +447,6 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
             clock: nil,
             statusType: "scheduled"
         )
-        return WorldCupMatchesResponse(previous: nil, current: nil, next: [match])
     }
 
     // MARK: - StoreTestUtility

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupAPIClient.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupAPIClient.swift
@@ -11,25 +11,34 @@ enum MockWorldCupClientError: Error {
 }
 
 final class MockWorldCupAPIClient: WorldCupAPIClientProtocol, @unchecked Sendable {
-    private let result: Result<WorldCupMatchesResponse?, Error>
+    private let matchesResult: Result<WorldCupMatchesResponse?, Error>
+    private let liveResult: Result<WorldCupLiveResponse?, Error>
     private let teamsResult: Result<WorldCupTeamsResponse?, Error>
-    private(set) var fetchCount = 0
-    private(set) var lastQuery: WorldCupQuery?
-    private(set) var lastTeam: String?
+    private(set) var matchesFetchCount = 0
+    private(set) var liveFetchCount = 0
     private(set) var fetchTeamsCount = 0
+    private(set) var lastMatchesTeam: String?
+    private(set) var lastLiveTeam: String?
     private(set) var lastTeamsTeam: String?
 
-    init(result: Result<WorldCupMatchesResponse?, Error>,
+    init(matchesResult: Result<WorldCupMatchesResponse?, Error>,
+         liveResult: Result<WorldCupLiveResponse?, Error> = .success(nil),
          teamsResult: Result<WorldCupTeamsResponse?, Error> = .success(nil)) {
-        self.result = result
+        self.matchesResult = matchesResult
+        self.liveResult = liveResult
         self.teamsResult = teamsResult
     }
 
-    func fetch(_ query: WorldCupQuery, team: String?) throws -> WorldCupMatchesResponse? {
-        fetchCount += 1
-        lastQuery = query
-        lastTeam = team
-        return try result.get()
+    func fetchMatches(team: String?) throws -> WorldCupMatchesResponse? {
+        matchesFetchCount += 1
+        lastMatchesTeam = team
+        return try matchesResult.get()
+    }
+
+    func fetchLive(team: String?) throws -> WorldCupLiveResponse? {
+        liveFetchCount += 1
+        lastLiveTeam = team
+        return try liveResult.get()
     }
 
     func fetchTeams(team: String?) throws -> WorldCupTeamsResponse? {
@@ -38,11 +47,19 @@ final class MockWorldCupAPIClient: WorldCupAPIClientProtocol, @unchecked Sendabl
         return try teamsResult.get()
     }
 
-    func loadMatches(query: WorldCupQuery,
-                     team: String?) async -> Result<WorldCupMatchesResponse?, WorldCupLoadError> {
-        lastQuery = query
-        lastTeam = team
-        switch result {
+    func loadMatches(team: String?) async -> Result<WorldCupMatchesResponse?, WorldCupLoadError> {
+        matchesFetchCount += 1
+        lastMatchesTeam = team
+        switch matchesResult {
+        case .success(let response): return .success(response)
+        case .failure(let error):    return .failure(WorldCupLoadError.from(error))
+        }
+    }
+
+    func loadLive(team: String?) async -> Result<WorldCupLiveResponse?, WorldCupLoadError> {
+        liveFetchCount += 1
+        lastLiveTeam = team
+        switch liveResult {
         case .success(let response): return .success(response)
         case .failure(let error):    return .failure(WorldCupLoadError.from(error))
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupFetchStrategy.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupFetchStrategy.swift
@@ -8,26 +8,35 @@ import Foundation
 
 final class MockWorldCupFetchStrategy: WorldCupFetchStrategyProtocol, @unchecked Sendable {
     private let matchesResult: Result<WorldCupMatchesResponse?, WorldCupLoadError>
+    private let liveResult: Result<WorldCupLiveResponse?, WorldCupLoadError>
     private let teamsResult: Result<WorldCupTeamsResponse?, WorldCupLoadError>
-    private(set) var callCount = 0
-    private(set) var lastQuery: WorldCupQuery?
-    private(set) var lastTeam: String?
+    private(set) var matchesCallCount = 0
+    private(set) var liveCallCount = 0
     private(set) var teamsCallCount = 0
+    private(set) var lastMatchesTeam: String?
+    private(set) var lastLiveTeam: String?
     private(set) var lastTeamsTeam: String?
 
-    init(result: Result<WorldCupMatchesResponse?, WorldCupLoadError> = .success(nil),
+    init(matchesResult: Result<WorldCupMatchesResponse?, WorldCupLoadError> = .success(nil),
+         liveResult: Result<WorldCupLiveResponse?, WorldCupLoadError> = .success(nil),
          teamsResult: Result<WorldCupTeamsResponse?, WorldCupLoadError> = .success(nil)) {
-        self.matchesResult = result
+        self.matchesResult = matchesResult
+        self.liveResult = liveResult
         self.teamsResult = teamsResult
     }
 
     func loadMatches(using client: WorldCupAPIClientProtocol,
-                     query: WorldCupQuery,
                      team: String?) async -> Result<WorldCupMatchesResponse?, WorldCupLoadError> {
-        callCount += 1
-        lastQuery = query
-        lastTeam = team
+        matchesCallCount += 1
+        lastMatchesTeam = team
         return matchesResult
+    }
+
+    func loadLive(using client: WorldCupAPIClientProtocol,
+                  team: String?) async -> Result<WorldCupLiveResponse?, WorldCupLoadError> {
+        liveCallCount += 1
+        lastLiveTeam = team
+        return liveResult
     }
 
     func loadTeams(using client: WorldCupAPIClientProtocol,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15826)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33852)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
  - Fixes the `/live` endpoint decoding
  - Derives the matches widget's phase title from merino's `stage` field + the team's `group`
  - Adds a multi-card view when no team is selected, grouping each day's matches into one card and defaulting to today's card (or the next future day)
  - Fetches `/matches` and `/live` in parallel from the middleware so the live badge no longer waits on the matches response
  - Splits the WCS API client into typed `loadMatches` / `loadLive` methods backed by separate response types, removing the shared `WorldCupQuery` enum


https://github.com/user-attachments/assets/acb57202-81de-474d-bb55-a1fd547f47c3



## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

