### PR TITLE
Bugfix FXIOS-15000 [Translations] Preserve script subtag for Chinese Simplified

### DIFF
--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
@@ -186,8 +186,12 @@ final class ASTranslationModelsFetcher: TranslationModelsFetcherProtocol {
     /// and model attachments for `Constants.pivotLanguage` -> deviceLanguage (e.g. `en` -> `fr`).
     /// NOTE: We don't fetch the reverse direction since for phase 1 we only support translating into device language.
     func prewarmResourcesForStartup() async {
-        guard let deviceLanguage = Locale.current.languageCode,
-          !deviceLanguage.isEmpty else {
+        let supported = Set(await fetchSupportedTargetLanguages())
+        let deviceLanguage = Locale.preferredLanguages.lazy.compactMap { tag in
+            PreferredTranslationLanguagesManager.matchingSupportedCode(for: tag, in: supported)
+        }.first
+
+        guard let deviceLanguage, !deviceLanguage.isEmpty else {
             logger.log("Device language code is unavailable.", level: .warning, category: .translations)
             return
         }

--- a/firefox-ios/Client/Frontend/Translations/PreferredTranslationLanguagesManager.swift
+++ b/firefox-ios/Client/Frontend/Translations/PreferredTranslationLanguagesManager.swift
@@ -49,6 +49,29 @@ final class PreferredTranslationLanguagesManager {
         prefs.setString(languages.joined(separator: ","), forKey: PrefsKeys.Settings.translationPreferredLanguages)
     }
 
+    // MARK: - Language Matching
+
+    /// Returns the most specific code in `supported` that matches a BCP-47 tag.
+    /// Tries the full tag, then language + script subtag, then language alone.
+    /// Required for languages where the script is meaningful (e.g. `zh-Hans` vs `zh`):
+    /// Remote Settings stores `zh-Hans`, but `Locale(identifier:).languageCode` drops the script.
+    nonisolated static func matchingSupportedCode(
+        for bcp47Tag: String,
+        in supported: Set<String>
+    ) -> String? {
+        if supported.contains(bcp47Tag) { return bcp47Tag }
+        let parts = bcp47Tag.split(separator: "-")
+        // BCP-47 script subtags are exactly 4 characters (e.g. "Hans", "Latn").
+        if parts.count >= 2, parts[1].count == 4 {
+            let languageScript = "\(parts[0])-\(parts[1])"
+            if supported.contains(languageScript) { return languageScript }
+        }
+        if let language = parts.first, supported.contains(String(language)) {
+            return String(language)
+        }
+        return nil
+    }
+
     // MARK: - Private
 
     private func loadStoredLanguages() -> [String]? {
@@ -62,11 +85,9 @@ final class PreferredTranslationLanguagesManager {
     private func buildInitialLanguages(supportedTargetLanguages: [String]) -> [String] {
         let supportedSet = Set(supportedTargetLanguages)
 
-        // Extract base language codes (e.g. "en-US" → "en") and filter against supported list.
         let preferred = Locale.preferredLanguages
-            .compactMap { tag -> String? in
-                let base = Locale(identifier: tag).languageCode ?? tag
-                return supportedSet.contains(base) ? base : nil
+            .compactMap { tag in
+                PreferredTranslationLanguagesManager.matchingSupportedCode(for: tag, in: supportedSet)
             }
 
         // Deduplicate while preserving order.

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
@@ -88,7 +88,8 @@ final class TranslationsService: TranslationsServiceProtocol {
     /// Tells the engine to discard translations for a document.
     func discardTranslations(for windowUUID: WindowUUID) async throws {
         let pageLanguage = try await detectPageLanguage(for: windowUUID)
-        guard let deviceLanguage = deviceLanguageCode() else {
+        let supported = await fetchSupportedTargetLanguages()
+        guard let deviceLanguage = deviceLanguageCode(supportedTargetLanguages: supported) else {
             throw TranslationsServiceError.deviceLanguageUnavailable
         }
 
@@ -168,8 +169,19 @@ final class TranslationsService: TranslationsServiceProtocol {
         return await modelsFetcher.fetchSupportedTargetLanguages()
     }
 
-    /// Returns the device language code for a given locale, if available.
-    private func deviceLanguageCode(using locale: Locale = .current) -> String? {
-        return locale.languageCode
+    /// Returns the best device-language code present in `supportedTargetLanguages`.
+    /// Walks `Locale.preferredLanguages` so script subtags (e.g. `zh-Hans`) are preserved
+    /// when they appear in the supported set.
+    private func deviceLanguageCode(supportedTargetLanguages: [String]) -> String? {
+        let supportedSet = Set(supportedTargetLanguages)
+        for tag in Locale.preferredLanguages {
+            if let match = PreferredTranslationLanguagesManager.matchingSupportedCode(
+                for: tag,
+                in: supportedSet
+            ) {
+                return match
+            }
+        }
+        return nil
     }
 }

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -173,23 +173,26 @@ final class TranslationsMiddleware: FeatureFlaggable {
                 }
             }
         } else if translationConfiguration.state == .inactive {
-            guard let deviceLanguage = Locale.current.languageCode else { return }
             let originatingTab = selectedTab(for: action.windowUUID)
-            let newFlowId = UUID()
-            translationFlowIds[action.windowUUID] = newFlowId
-            selectedTargetLanguages[action.windowUUID] = deviceLanguage
-            translationsTelemetry.translateButtonTapped(
-                isPrivate: toolbarState.isPrivateMode,
-                actionType: .willTranslate,
-                translationFlowId: newFlowId
-            )
-            self.handleUpdatingTranslationIcon(for: action, with: .loading, on: originatingTab)
-            self.retrieveTranslations(
-                for: action,
-                targetLanguage: deviceLanguage,
-                isPrivate: toolbarState.isPrivateMode,
-                on: originatingTab
-            )
+            let isPrivate = toolbarState.isPrivateMode
+            Task {
+                guard let deviceLanguage = await self.supportedDeviceLanguage() else { return }
+                let newFlowId = UUID()
+                self.translationFlowIds[action.windowUUID] = newFlowId
+                self.selectedTargetLanguages[action.windowUUID] = deviceLanguage
+                self.translationsTelemetry.translateButtonTapped(
+                    isPrivate: isPrivate,
+                    actionType: .willTranslate,
+                    translationFlowId: newFlowId
+                )
+                self.handleUpdatingTranslationIcon(for: action, with: .loading, on: originatingTab)
+                self.retrieveTranslations(
+                    for: action,
+                    targetLanguage: deviceLanguage,
+                    isPrivate: isPrivate,
+                    on: originatingTab
+                )
+            }
         } else if translationConfiguration.state == .active {
             let originatingTab = selectedTab(for: action.windowUUID)
             translationsTelemetry.translateButtonTapped(
@@ -387,11 +390,34 @@ final class TranslationsMiddleware: FeatureFlaggable {
     /// When the language picker flag is ON, returns the user's full preferred list.
     /// When OFF, returns only the primary device language (preserving legacy behavior).
     private func targetLanguagesForEligibilityCheck() async -> [String] {
+        let supported = await translationsService.fetchSupportedTargetLanguages()
         if featureFlagsProvider.isEnabled(.translationLanguagePicker) {
-            let supported = await translationsService.fetchSupportedTargetLanguages()
             return manager.preferredLanguages(supportedTargetLanguages: supported)
         }
-        return [localeProvider.current.languageCode].compactMap { $0 }
+        return [matchedDeviceLanguage(supportedTargetLanguages: supported)].compactMap { $0 }
+    }
+
+    /// Resolves the device language to the most specific code present in the supported set.
+    /// Uses BCP-47 tags from `localeProvider.preferredLanguages` so script subtags like
+    /// `zh-Hans` survive the lookup (Locale.languageCode would reduce them to `zh`).
+    private func matchedDeviceLanguage(supportedTargetLanguages: [String]) -> String? {
+        let supportedSet = Set(supportedTargetLanguages)
+        for tag in localeProvider.preferredLanguages {
+            if let match = PreferredTranslationLanguagesManager.matchingSupportedCode(
+                for: tag,
+                in: supportedSet
+            ) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    /// Convenience for callers (button taps, prewarm-style flows) that need just the
+    /// best-matching device language string after fetching supported languages.
+    private func supportedDeviceLanguage() async -> String? {
+        let supported = await translationsService.fetchSupportedTargetLanguages()
+        return matchedDeviceLanguage(supportedTargetLanguages: supported)
     }
 
     /// Checks whether the current page in the active tab is eligible for translation,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/PreferredTranslationLanguagesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/PreferredTranslationLanguagesManagerTests.swift
@@ -146,6 +146,48 @@ final class PreferredTranslationLanguagesManagerTests: XCTestCase {
         XCTAssertEqual(result, ["de"])
     }
 
+    // MARK: - matchingSupportedCode
+
+    func test_matchingSupportedCode_exactFullTag_returnsFullTag() {
+        let result = PreferredTranslationLanguagesManager.matchingSupportedCode(
+            for: "zh-Hans-CN",
+            in: ["zh-Hans-CN", "en"]
+        )
+        XCTAssertEqual(result, "zh-Hans-CN")
+    }
+
+    func test_matchingSupportedCode_languageScriptRegion_returnsLanguageScript() {
+        let result = PreferredTranslationLanguagesManager.matchingSupportedCode(
+            for: "zh-Hans-CN",
+            in: ["zh-Hans", "en"]
+        )
+        XCTAssertEqual(result, "zh-Hans")
+    }
+
+    func test_matchingSupportedCode_languageRegion_returnsLanguage() {
+        let result = PreferredTranslationLanguagesManager.matchingSupportedCode(
+            for: "en-US",
+            in: ["en", "fr"]
+        )
+        XCTAssertEqual(result, "en")
+    }
+
+    func test_matchingSupportedCode_languageScript_notSupported_fallsBackToLanguage() {
+        let result = PreferredTranslationLanguagesManager.matchingSupportedCode(
+            for: "zh-Hant-TW",
+            in: ["zh", "en"]
+        )
+        XCTAssertEqual(result, "zh")
+    }
+
+    func test_matchingSupportedCode_noOverlap_returnsNil() {
+        let result = PreferredTranslationLanguagesManager.matchingSupportedCode(
+            for: "sq-AL",
+            in: ["en", "fr"]
+        )
+        XCTAssertNil(result)
+    }
+
     // MARK: - Helpers
 
     private func createSubject() -> PreferredTranslationLanguagesManager {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15000)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32306)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Locale(identifier:).languageCode reduces "zh-Hans-CN" to "zh", but Remote Settings stores Chinese as "zh-Hans". This filtered Chinese-Simplified users out of supportedTargetLanguages, so the translate icon never appeared on translatable pages. Add a BCP-47-aware lookup that tries full tag, then language+script, then language alone, and use it at every device-language read site so the script survives intact.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


