### PR TITLE
BugFix [World Cup] FXIOS-15829 memory leak on WorldCup cell

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -57,7 +57,7 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
         /// a filtered feed and in the full "All" feed as one continuous item, which causes it to preserve
         /// that story's on-screen position as stories are inserted above it.
         case merino(MerinoStoryConfiguration, String?)
-        case worldcupCard(WorldCupSectionState)
+        case worldcupCard
         case spacer
 
         static var cellTypes: [ReusableCell.Type] {
@@ -138,9 +138,10 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
         if state.worldcupState.shouldShowSection {
             snapshot.appendSections([.worldcup(textColor)])
             snapshot.appendItems(
-                [.worldcupCard(state.worldcupState)],
+                [.worldcupCard],
                 toSection: .worldcup(textColor)
             )
+            snapshot.reconfigureItems([.worldcupCard])
         }
 
         if let (tabs, configuration) = getJumpBackInTabs(with: state.jumpBackInState, and: jumpBackInDisplayConfig) {

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -660,9 +660,9 @@ final class HomepageViewController: UIViewController,
             }
         case .merino(let story, _):
             return configureMerinoCell(story, at: indexPath)
-        case .worldcupCard(let state):
+        case .worldcupCard:
             return configuredCell(cellType: WorldCupCell.self, at: indexPath) { cell in
-                cell.configure(with: state, theme: currentTheme) { [weak self] height in
+                cell.configure(with: homepageState.worldcupState, theme: currentTheme) { [weak self] height in
                     self?.sectionProvider.setWorldCupCellHeight(height)
                     self?.relayoutForCellHeightChange()
                 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -877,7 +877,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
               state.worldcupState.shouldShowSection else { return 0 }
 
         let cellHeight = lastKnownWorldCupCellHeight ?? UX.MessageCardConstants.height
-        return cellHeight
+        return cellHeight + UX.spacingBetweenSections
     }
 
     /// Returns the height that the spacer should be, before accounting for vertical stories peeking above the fold.

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -23,6 +23,7 @@ private final class PageContainer: UIView, ThemeApplicable {
         image.image = UIImage(named: UX.loadingImage)
         image.isAccessibilityElement = false
         image.contentMode = .scaleAspectFit
+        image.alpha = 0.0
     }
 
     init(content: UIView) {
@@ -51,7 +52,6 @@ private final class PageContainer: UIView, ThemeApplicable {
             loadingImageView.widthAnchor.constraint(equalToConstant: UX.loadingImageSize),
             loadingImageView.heightAnchor.constraint(equalToConstant: UX.loadingImageSize),
         ])
-        startSpinning()
     }
 
     /// Sets the Content visibility and hides the loading image in case the `isVisible` is set to true.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15829)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33861)

## :bulb: Description
Fix memory leak on WorldCup cell being retained from its `UICollectionView` upon state change.


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

