### PR TITLE
Add FXIOS-15577 [Quick Answers] middleware to observe setting changes

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1445,6 +1445,9 @@
 		AAB434062E82F0600075E47F /* MockTrendingSearchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB434052E82F05C0075E47F /* MockTrendingSearchProvider.swift */; };
 		AAB5AF382EDDCF600051EF6E /* MockLocaleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB5AF372EDDCF5A0051EF6E /* MockLocaleProvider.swift */; };
 		AAB5B7882EE077BB0051EF6E /* TranslationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB5B7872EE077BB0051EF6E /* TranslationTests.swift */; };
+		AAD00A772FBB412800123E8C /* QuickAnswersMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD00A752FBB412800123E8C /* QuickAnswersMiddleware.swift */; };
+		AAD00A792FBB412800123E8C /* QuickAnswersAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD00A742FBB412800123E8C /* QuickAnswersAction.swift */; };
+		AAD00A7C2FBB53EC00123E8C /* QuickAnswersMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD00A7B2FBB53EC00123E8C /* QuickAnswersMiddlewareTests.swift */; };
 		AAD1CD872EAABA8100BEC90A /* TranslationsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1CD862EAABA7C00BEC90A /* TranslationsConfiguration.swift */; };
 		AAD861A82E9E748700F6E0E0 /* TranslationSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD861A72E9E748100F6E0E0 /* TranslationSetting.swift */; };
 		AAD861AB2E9E75AB00F6E0E0 /* TranslationSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD861AA2E9E75A100F6E0E0 /* TranslationSettingsViewController.swift */; };
@@ -10124,6 +10127,9 @@
 		AAB434052E82F05C0075E47F /* MockTrendingSearchProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTrendingSearchProvider.swift; sourceTree = "<group>"; };
 		AAB5AF372EDDCF5A0051EF6E /* MockLocaleProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocaleProvider.swift; sourceTree = "<group>"; };
 		AAB5B7872EE077BB0051EF6E /* TranslationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationTests.swift; sourceTree = "<group>"; };
+		AAD00A742FBB412800123E8C /* QuickAnswersAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersAction.swift; sourceTree = "<group>"; };
+		AAD00A752FBB412800123E8C /* QuickAnswersMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersMiddleware.swift; sourceTree = "<group>"; };
+		AAD00A7B2FBB53EC00123E8C /* QuickAnswersMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersMiddlewareTests.swift; sourceTree = "<group>"; };
 		AAD1CD862EAABA7C00BEC90A /* TranslationsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsConfiguration.swift; sourceTree = "<group>"; };
 		AAD861A72E9E748100F6E0E0 /* TranslationSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationSetting.swift; sourceTree = "<group>"; };
 		AAD861AA2E9E75A100F6E0E0 /* TranslationSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationSettingsViewController.swift; sourceTree = "<group>"; };
@@ -14885,6 +14891,23 @@
 			path = Translations;
 			sourceTree = "<group>";
 		};
+		AAD00A732FBB410000123E8C /* QuickAnswers */ = {
+			isa = PBXGroup;
+			children = (
+				AAD00A742FBB412800123E8C /* QuickAnswersAction.swift */,
+				AAD00A752FBB412800123E8C /* QuickAnswersMiddleware.swift */,
+			);
+			path = QuickAnswers;
+			sourceTree = "<group>";
+		};
+		AAD00A7A2FBB534500123E8C /* QuickAnswers */ = {
+			isa = PBXGroup;
+			children = (
+				AAD00A7B2FBB53EC00123E8C /* QuickAnswersMiddlewareTests.swift */,
+			);
+			path = QuickAnswers;
+			sourceTree = "<group>";
+		};
 		AAD861A92E9E757D00F6E0E0 /* Translation */ = {
 			isa = PBXGroup;
 			children = (
@@ -16995,6 +17018,7 @@
 				8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */,
 				03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */,
 				1D62C5262EE8E77C00C6BCB9 /* RelayControllerTests.swift */,
+				AAD00A7A2FBB534500123E8C /* QuickAnswers */,
 				8AFA66012CA2935C0008D0F6 /* RemoteSettings */,
 				F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */,
 				615532D32D7AA5F30046347F /* ScreenshotHelperTests.swift */,
@@ -17137,6 +17161,7 @@
 				C8BD875D2A0C23F500CD803A /* Onboarding */,
 				0E456F132C541C8F00EE93BF /* PasswordGenerator */,
 				E63ED8DF1BFD254E0097D08E /* PasswordManagement */,
+				AAD00A732FBB410000123E8C /* QuickAnswers */,
 				F84B21F51A0910F600AAB793 /* Reader */,
 				2F44FC551A9E83E200FD20CC /* Settings */,
 				D3972BF01C22412B00035B87 /* Share */,
@@ -19886,6 +19911,8 @@
 				ED67B2962D0C921600BDC599 /* ShareTelemetry.swift in Sources */,
 				63B2132A2CCA797400A466DB /* NativeErrorPageState.swift in Sources */,
 				8ADAE4222A33A113007BF926 /* SendDataSetting.swift in Sources */,
+				AAD00A772FBB412800123E8C /* QuickAnswersMiddleware.swift in Sources */,
+				AAD00A792FBB412800123E8C /* QuickAnswersAction.swift in Sources */,
 				C8EDDBF229DF1159003A4C07 /* URLScanner.swift in Sources */,
 				EBB89504219398E500EB91A0 /* TrackingProtectionPageStats.swift in Sources */,
 				D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */,
@@ -20208,6 +20235,7 @@
 				C25020842ECDE75D0071506F /* MockTranslationsSchemeHandler.swift in Sources */,
 				8A7A26E829D4C0FE00EA76F1 /* IntroScreenManagerTests.swift in Sources */,
 				E1AEC17A286E0CF500062E29 /* WebViewNavigationHandlerTests.swift in Sources */,
+				AAD00A7C2FBB53EC00123E8C /* QuickAnswersMiddlewareTests.swift in Sources */,
 				D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */,
 				C28EA9812FA2554800AEC3AD /* WorldCupCountdownModelTests.swift in Sources */,
 				F00CA4022F00000000000001 /* WorldCupMatchesResponseTests.swift in Sources */,

--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -76,6 +76,7 @@ enum FeatureFlagID: String, CaseIterable {
         case .hntSponsoredShortcuts: return FlagKeys.SponsoredShortcuts
         case .sentFromFirefox: return FlagKeys.SentFromFirefox
         case .startAtHome: return FlagKeys.StartAtHome
+        case .quickAnswers: return PrefsKeys.Settings.quickAnswersFeature
         default: return nil
         }
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Header/HeaderState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Header/HeaderState.swift
@@ -13,6 +13,7 @@ struct HeaderState: StateType, Equatable, Hashable {
     var windowUUID: WindowUUID
     var isPrivate: Bool
     var showiPadSetup: Bool
+    var showQuickAnswersButton: Bool
 
     init(
         windowUUID: WindowUUID,
@@ -21,18 +22,21 @@ struct HeaderState: StateType, Equatable, Hashable {
         self.init(
             windowUUID: windowUUID,
             isPrivate: isPrivate,
-            showiPadSetup: false
+            showiPadSetup: false,
+            showQuickAnswersButton: false
         )
     }
 
     private init(
         windowUUID: WindowUUID,
         isPrivate: Bool,
-        showiPadSetup: Bool
+        showiPadSetup: Bool,
+        showQuickAnswersButton: Bool
     ) {
         self.windowUUID = windowUUID
         self.isPrivate = isPrivate
         self.showiPadSetup = showiPadSetup
+        self.showQuickAnswersButton = showQuickAnswersButton
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -44,6 +48,8 @@ struct HeaderState: StateType, Equatable, Hashable {
         switch action.actionType {
         case HomepageActionType.initialize:
             return handleInitializeAction(for: state, with: action)
+        case QuickAnswersMiddlewareActionType.didInitialize, QuickAnswersMiddlewareActionType.didUpdateSettings:
+            return handleQuickAnswersAction(for: state, with: action)
         case HomepageActionType.traitCollectionDidChange,
              HomepageActionType.viewWillAppear:
             return handleTraitCollectionDidChangeAction(for: state, with: action)
@@ -60,7 +66,18 @@ struct HeaderState: StateType, Equatable, Hashable {
         }
         return state.copyWithUpdates(
             isPrivate: false,
-            showiPadSetup: showiPadSetup
+            showiPadSetup: showiPadSetup,
+        )
+    }
+
+    private static func handleQuickAnswersAction(for state: HeaderState, with action: Action) -> HeaderState {
+        guard let quickAnswersAction = action as? QuickAnswersMiddlewareAction,
+              let showQuickAnswers = quickAnswersAction.isQuickAnswersEnabled
+        else {
+            return defaultState(from: state)
+        }
+        return state.copyWithUpdates(
+            showQuickAnswersButton: showQuickAnswers,
         )
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/Header/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Header/HomepageHeaderCell.swift
@@ -88,7 +88,7 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable, F
 
             logoContainerView.addSubview(logoStackView)
             stackContainer.addArrangedSubview(logoContainerView)
-            if featureFlagsProvider.isEnabled(.quickAnswers), !headerState.isPrivate {
+            if headerState.showQuickAnswersButton, !headerState.isPrivate {
                 if headerState.showiPadSetup {
                     // On iPad, add button directly to contentView so logo remains centered
                     contentView.addSubview(quickAnswersButton)

--- a/firefox-ios/Client/Frontend/QuickAnswers/QuickAnswersAction.swift
+++ b/firefox-ios/Client/Frontend/QuickAnswers/QuickAnswersAction.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+
+struct QuickAnswersAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+    let isSettingOn: Bool?
+
+    init(isSettingOn: Bool? = nil,
+         windowUUID: WindowUUID,
+         actionType: ActionType
+    ) {
+        self.isSettingOn = isSettingOn
+        self.windowUUID = windowUUID
+        self.actionType = actionType
+    }
+}
+
+struct QuickAnswersMiddlewareAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+    let isQuickAnswersEnabled: Bool?
+
+    init(isQuickAnswersEnabled: Bool? = nil,
+         windowUUID: WindowUUID,
+         actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.actionType = actionType
+        self.isQuickAnswersEnabled = isQuickAnswersEnabled
+    }
+}
+
+enum QuickAnswersActionType: ActionType {
+    case didSettingsChange
+}
+
+enum QuickAnswersMiddlewareActionType: ActionType {
+    case didInitialize
+    case didUpdateSettings
+}

--- a/firefox-ios/Client/Frontend/QuickAnswers/QuickAnswersMiddleware.swift
+++ b/firefox-ios/Client/Frontend/QuickAnswers/QuickAnswersMiddleware.swift
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import Shared
+
+@MainActor
+final class QuickAnswersMiddleware {
+    private let prefs: Prefs
+    let featureFlagsProvider: FeatureFlagProviding
+    let userPreferences: UserFeaturePreferring
+
+    private var isQuickAnswersEnabled: Bool {
+        let isFeatureFlagEnabled = featureFlagsProvider.isEnabled(.quickAnswers)
+        let isUserPreferencesEnabled = userPreferences.getPreferenceFor(.quickAnswers)
+        return isFeatureFlagEnabled && isUserPreferencesEnabled
+    }
+
+    init(
+        profile: Profile = AppContainer.shared.resolve(),
+        featureFlagsProvider: FeatureFlagProviding = AppContainer.shared.resolve(),
+        userPreferences: UserFeaturePreferring = AppContainer.shared.resolve()
+    ) {
+        self.prefs = profile.prefs
+        self.featureFlagsProvider = featureFlagsProvider
+        self.userPreferences = userPreferences
+    }
+
+    lazy var quickAnswersProvider: Middleware<AppState> = { state, action in
+        switch action.actionType {
+        case HomepageActionType.initialize, HomepageActionType.viewWillAppear:
+            self.handleInitializeAction(action: action)
+        case QuickAnswersActionType.didSettingsChange:
+            self.handleDidSettingsChangeAction(action: action)
+        default:
+            break
+        }
+    }
+
+    private func handleInitializeAction(action: Action) {
+        store.dispatch(QuickAnswersMiddlewareAction(
+            isQuickAnswersEnabled: isQuickAnswersEnabled,
+            windowUUID: action.windowUUID,
+            actionType: QuickAnswersMiddlewareActionType.didInitialize
+        ))
+    }
+
+    private func handleDidSettingsChangeAction(action: Action) {
+        store.dispatch(QuickAnswersMiddlewareAction(
+            isQuickAnswersEnabled: isQuickAnswersEnabled,
+            windowUUID: action.windowUUID,
+            actionType: QuickAnswersMiddlewareActionType.didUpdateSettings
+        ))
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/QuickAnswers/QuickAnswersSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/QuickAnswers/QuickAnswersSettingsViewController.swift
@@ -34,8 +34,17 @@ final class QuickAnswersSettingsViewController: SettingsTableViewController {
             defaultValue: true,
             // TODO: - FXIOS-14720 Add Strings
             titleText: "Quick Answers"
-        ) { _ in
-            // TODO: FXIOS-15577 - Dispatch action to show or hide quick answers feature
+        ) { [weak self] _ in
+            guard let self else { return }
+            // Instead of passing the updated value here, we are using determining
+            // whether the feature should be shown in the middleware so that we use the userPreferencesProvider
+            // as the source of truth.
+            store.dispatch(
+                QuickAnswersAction(
+                    windowUUID: self.windowUUID,
+                    actionType: QuickAnswersActionType.didSettingsChange
+                )
+            )
         }
         return SettingSection(children: [enableFeatureSwitch])
     }

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -85,6 +85,7 @@ let middlewares = [
     BookmarksMiddleware().bookmarksProvider,
     WorldCupMiddleware().worldCupProvider,
     HomepageMiddleware(notificationCenter: NotificationCenter.default).homepageProvider,
+    QuickAnswersMiddleware().quickAnswersProvider,
     StartAtHomeMiddleware().startAtHomeProvider,
     ShortcutsLibraryMiddleware().shortcutsLibraryProvider,
     SummarizerMiddleware().summarizerProvider,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/QuickAnswers/QuickAnswersMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/QuickAnswers/QuickAnswersMiddlewareTests.swift
@@ -1,0 +1,195 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import Shared
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class QuickAnswersMiddlewareTests: XCTestCase, StoreTestUtility {
+    private var mockStore: MockStoreForMiddleware<AppState>!
+    private var mockProfile: MockProfile!
+    private var mockFeatureFlags: MockNimbusFeatureFlags!
+    private var mockUserPreferences: MockUserFeaturePreferences!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockProfile = MockProfile()
+        mockFeatureFlags = MockNimbusFeatureFlags()
+        mockUserPreferences = MockUserFeaturePreferences()
+        DependencyHelperMock().bootstrapDependencies(
+            injectedFeatureFlagProvider: mockFeatureFlags,
+            injectedUserFeaturePreferences: mockUserPreferences
+        )
+        setupStore()
+    }
+
+    override func tearDown() async throws {
+        resetStore()
+        DependencyHelperMock().reset()
+        mockUserPreferences = nil
+        mockFeatureFlags = nil
+        mockProfile = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - didSettingsChange
+    func test_didSettingsChange_dispatchesMiddlewareAction() throws {
+        mockFeatureFlags.enabledFlags = [.quickAnswers]
+        mockUserPreferences.setPreferenceFor(.quickAnswers, to: true)
+
+        let subject = createSubject()
+        let action = QuickAnswersAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: QuickAnswersActionType.didSettingsChange
+        )
+
+        subject.quickAnswersProvider(mockStore.state, action)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
+        let dispatchedActionType = try XCTUnwrap(dispatchedAction.actionType as? QuickAnswersMiddlewareActionType)
+
+        XCTAssertEqual(dispatchedActionType, QuickAnswersMiddlewareActionType.didUpdateSettings)
+        XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, true)
+    }
+
+    func test_didSettingsChange_whenFeatureFlagDisabled_dispatchesFalse() throws {
+        mockFeatureFlags.enabledFlags = []
+        mockUserPreferences.setPreferenceFor(.quickAnswers, to: true)
+
+        let subject = createSubject()
+        let action = QuickAnswersAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: QuickAnswersActionType.didSettingsChange
+        )
+
+        subject.quickAnswersProvider(mockStore.state, action)
+
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
+        XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, false)
+    }
+
+    func test_didSettingsChange_whenUserPreferenceDisabled_dispatchesFalse() throws {
+        mockFeatureFlags.enabledFlags = [.quickAnswers]
+        mockUserPreferences.setPreferenceFor(.quickAnswers, to: false)
+
+        let subject = createSubject()
+        let action = QuickAnswersAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: QuickAnswersActionType.didSettingsChange
+        )
+
+        subject.quickAnswersProvider(mockStore.state, action)
+
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
+        XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, false)
+    }
+
+    func test_didSettingsChange_whenBothDisabled_dispatchesFalse() throws {
+        mockFeatureFlags.enabledFlags = []
+        mockUserPreferences.setPreferenceFor(.quickAnswers, to: false)
+
+        let subject = createSubject()
+        let action = QuickAnswersAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: QuickAnswersActionType.didSettingsChange
+        )
+
+        subject.quickAnswersProvider(mockStore.state, action)
+
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
+        XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, false)
+    }
+
+    // MARK: - initialize (via HomepageActionType)
+    func test_initialize_dispatchesDidInitializeAction() throws {
+        mockFeatureFlags.enabledFlags = [.quickAnswers]
+        mockUserPreferences.setPreferenceFor(.quickAnswers, to: true)
+
+        let subject = createSubject()
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+
+        subject.quickAnswersProvider(mockStore.state, action)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
+        let dispatchedActionType = try XCTUnwrap(dispatchedAction.actionType as? QuickAnswersMiddlewareActionType)
+
+        XCTAssertEqual(dispatchedActionType, QuickAnswersMiddlewareActionType.didInitialize)
+        XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, true)
+    }
+
+    func test_initialize_whenFeatureFlagDisabled_dispatchesDisabledState() throws {
+        mockFeatureFlags.enabledFlags = []
+        mockUserPreferences.setPreferenceFor(.quickAnswers, to: true)
+
+        let subject = createSubject()
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+
+        subject.quickAnswersProvider(mockStore.state, action)
+
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
+        XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, false)
+    }
+
+    func test_initialize_whenUserPreferenceDisabled_dispatchesDisabledState() throws {
+        mockFeatureFlags.enabledFlags = [.quickAnswers]
+        mockUserPreferences.setPreferenceFor(.quickAnswers, to: false)
+
+        let subject = createSubject()
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+
+        subject.quickAnswersProvider(mockStore.state, action)
+
+        let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
+        XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, false)
+    }
+
+    // MARK: - StoreTestUtility
+    func setupAppState() -> AppState {
+        return AppState(
+            presentedComponents: PresentedComponentsState(
+                components: [
+                    .homepage(
+                        HomepageState(
+                            windowUUID: .XCTestDefaultUUID
+                        )
+                    ),
+                ]
+            )
+        )
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> QuickAnswersMiddleware {
+        let subject = QuickAnswersMiddleware(
+            profile: mockProfile,
+            featureFlagsProvider: mockFeatureFlags,
+            userPreferences: mockUserPreferences
+        )
+        return subject
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15577)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33374)

## :bulb: Description
Add `QuickAnswersMiddleware` to handle observing settings change and ensuring the `HeaderState` updates after responding to the action.

## :movie_camera: Demos
https://github.com/user-attachments/assets/0bb6813d-9179-4c7a-9cb6-965ed2960111

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

