### PR TITLE
Bugfix FXIOS-15834 [WC] TBD shouldn't show in group stages

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
@@ -34,12 +34,13 @@ struct WorldCupMatch: Equatable, Hashable {
     }
 
     init(_ match: WorldCupMatchesResponse.Match,
-         localeProvider: LocaleProvider = SystemLocaleProvider()) {
+         localeProvider: LocaleProvider = SystemLocaleProvider(),
+         timeOnly: Bool = false) {
         self.homeCode = match.homeTeam.key
         self.awayCode = match.awayTeam.key
         self.homeFlagAssetName = match.homeTeam.key
         self.awayFlagAssetName = match.awayTeam.key
-        self.date = Self.formattedDate(match.date, locale: localeProvider.current)
+        self.date = Self.formattedDate(match.date, locale: localeProvider.current, timeOnly: timeOnly)
         self.score = Self.score(from: match)
     }
 
@@ -56,11 +57,11 @@ struct WorldCupMatch: Equatable, Hashable {
         return frac.date(from: iso)
     }
 
-    private static func formattedDate(_ iso: String, locale: Locale) -> String {
+    private static func formattedDate(_ iso: String, locale: Locale, timeOnly: Bool = false) -> String {
         guard let date = parseDate(iso) else { return iso }
         let formatter = DateFormatter()
         formatter.locale = locale
-        formatter.setLocalizedDateFormatFromTemplate("MMMdjmm")
+        formatter.setLocalizedDateFormatFromTemplate(timeOnly ? "jmm" : "MMMdjmm")
         return formatter.string(from: date)
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
@@ -34,6 +34,12 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
         label.adjustsFontForContentSizeCategory = true
     }
 
+    private lazy var dateLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+
     private lazy var moreOptionsButton: UIButton = .build { button in
         let changeTeamAction = UIAction(
             title: .WorldCup.HomepageWidget.ChangeTeamLabel,
@@ -124,6 +130,7 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
         liveLabelContainer.addSubview(liveLabel)
 
         headerStack.addArrangedSubview(titleLabel)
+        headerStack.addArrangedSubview(dateLabel)
         headerStack.addArrangedSubview(liveLabelContainer)
         // spacer view
         headerStack.addArrangedSubview(UIView())
@@ -177,7 +184,9 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
 
         rebuildFeaturedMatches(matches: model.featuredMatch)
         rebuildUpcomingRows(matches: model.upcomingMatches)
-        titleLabel.text = model.dateLabel.map { "\(model.phaseTitle) · \($0)" } ?? model.phaseTitle
+        titleLabel.text = model.phaseTitle
+        dateLabel.text = model.dateLabel.map { "\(UX.liveLabelDotText) \($0)" }
+        dateLabel.isHidden = model.isLive
         liveLabelContainer.isHidden = !model.isLive
     }
 
@@ -250,6 +259,7 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
 
     func applyTheme(theme: Theme) {
         titleLabel.textColor = theme.colors.textPrimary
+        dateLabel.textColor = theme.colors.textSecondary
         moreOptionsButton.tintColor = theme.colors.iconSecondary
         upcomingStackDivider.backgroundColor = theme.colors.borderSecondary
         liveLabelContainer.backgroundColor = theme.colors.gradientAIStrongStop1

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
@@ -177,7 +177,7 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
 
         rebuildFeaturedMatches(matches: model.featuredMatch)
         rebuildUpcomingRows(matches: model.upcomingMatches)
-        titleLabel.text = model.phaseTitle
+        titleLabel.text = model.dateLabel.map { "\(model.phaseTitle) · \($0)" } ?? model.phaseTitle
         liveLabelContainer.isHidden = !model.isLive
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
@@ -7,15 +7,18 @@ import Shared
 
 struct WorldCupMatches: Equatable, Hashable {
     let phaseTitle: String
+    let dateLabel: String?
     let isLive: Bool
     let featuredMatch: [WorldCupMatch]
     let upcomingMatches: [WorldCupMatch]
 
     init(phaseTitle: String,
+         dateLabel: String? = nil,
          isLive: Bool,
          featuredMatch: [WorldCupMatch],
          upcomingMatches: [WorldCupMatch]) {
         self.phaseTitle = phaseTitle
+        self.dateLabel = dateLabel
         self.isLive = isLive
         self.featuredMatch = featuredMatch
         self.upcomingMatches = upcomingMatches
@@ -78,6 +81,7 @@ struct WorldCupMatches: Equatable, Hashable {
 
         let allIDs = allMatches.map(\.globalEventId)
         self.phaseTitle = Self.phaseTitle(from: featured.first)
+        self.dateLabel = nil
         self.isLive = allIDs.contains(where: { liveIDs.contains($0) })
         self.featuredMatch = featured.map { WorldCupMatch($0, localeProvider: localeProvider) }
         self.upcomingMatches = upcoming.map { WorldCupMatch($0, localeProvider: localeProvider) }
@@ -97,20 +101,20 @@ struct WorldCupMatches: Equatable, Hashable {
         calendar: Calendar = .current,
         localeProvider: LocaleProvider = SystemLocaleProvider()
     ) -> (cards: [WorldCupMatches], defaultIndex: Int) {
-        let allMatches = (response.previous ?? []) + (response.current ?? []) + (response.next ?? [])
+        let allMatches = ((response.previous ?? []) + (response.current ?? []) + (response.next ?? []))
+            .filter { $0.stage == "Group Stage" }
         let groups = groupedByDay(allMatches, calendar: calendar)
-        // No team selected: cards can span days/stages, so we use the generic
-        // group-stage label across the board. Stage-specific labels are only
-        // meaningful in the team-selected single-card view.
         let title = String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel
         let cards = groups.map { group -> WorldCupMatches in
             let liveMatches = group.matches.filter { liveIDs.contains($0.globalEventId) }
             let nonLive = group.matches.filter { !liveIDs.contains($0.globalEventId) }
             return WorldCupMatches(
                 phaseTitle: title,
+                // Day shown once at top; rows render time-only.
+                dateLabel: dayLabel(for: group.day, locale: localeProvider.current),
                 isLive: !liveMatches.isEmpty,
-                featuredMatch: liveMatches.map { WorldCupMatch($0, localeProvider: localeProvider) },
-                upcomingMatches: nonLive.map { WorldCupMatch($0, localeProvider: localeProvider) }
+                featuredMatch: liveMatches.map { WorldCupMatch($0, localeProvider: localeProvider, timeOnly: true) },
+                upcomingMatches: nonLive.map { WorldCupMatch($0, localeProvider: localeProvider, timeOnly: true) }
             )
         }
         let today = calendar.startOfDay(for: now)
@@ -118,6 +122,13 @@ struct WorldCupMatches: Equatable, Hashable {
         let firstFutureIndex = groups.firstIndex(where: { $0.day >= today })
         let defaultIndex = liveCardIndex ?? firstFutureIndex ?? max(cards.count - 1, 0)
         return (cards, defaultIndex)
+    }
+
+    private static func dayLabel(for day: Date, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("MMMd")
+        return formatter.string(from: day)
     }
 
     /// Maps a featured match to a localized phase label. For group-stage

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
@@ -522,7 +522,7 @@ struct WorldCupMatchesTests {
                            awayPenalty: Int? = nil,
                            clock: String? = nil,
                            group: String? = nil,
-                           stage: String? = nil) -> WorldCupMatchesResponse.Match {
+                           stage: String? = "Group Stage") -> WorldCupMatchesResponse.Match {
         let homeTeam = WorldCupMatchesResponse.Team(
             key: home,
             name: home,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -720,7 +720,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
                            home: String,
                            away: String,
                            date: String = "2026-06-12T18:00:00+00:00",
-                           statusType: String = "scheduled") -> WorldCupMatchesResponse.Match {
+                           statusType: String = "scheduled",
+                           stage: String? = "Group Stage") -> WorldCupMatchesResponse.Match {
         let homeTeam = WorldCupMatchesResponse.Team(
             key: home, name: home, iconUrl: nil, group: "Group A", eliminated: false
         )
@@ -740,7 +741,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
             homePenalty: nil,
             awayPenalty: nil,
             clock: nil,
-            statusType: statusType
+            statusType: statusType,
+            stage: stage
         )
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15834)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33869)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Filters group stages properly so TBD matches don't show up
- Adds day near Group Stage title

<img width="328" height="228" alt="Screenshot 2026-05-18 at 15 33 40" src="https://github.com/user-attachments/assets/5afc3b3b-cb6a-4b9b-890f-116be552fed7" />

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

