### PR TITLE
Bugfix FXIOS-13321 Fix 'Find In Page' UI when resuming app in private tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
@@ -34,19 +34,19 @@ extension BrowserViewController {
     // Used only on iOS 15
     private func useCustomFindInteraction(isVisible: Bool, tab: Tab? = nil) {
         if isVisible {
-            if findInPageBar == nil {
+            if iOS15FindInPageBar == nil {
                 setupFindInPage()
             }
 
-            self.findInPageBar?.becomeFirstResponder()
-        } else if let findInPageBar = self.findInPageBar {
+            self.iOS15FindInPageBar?.becomeFirstResponder()
+        } else if let findInPageBar = self.iOS15FindInPageBar {
             removeFindInPage(findInPageBar, tab: tab)
         }
     }
 
     private func setupFindInPage() {
         let findInPageBar = FindInPageBar()
-        self.findInPageBar = findInPageBar
+        self.iOS15FindInPageBar = findInPageBar
         findInPageBar.delegate = self
 
         bottomContentStackView.addArrangedViewToBottom(findInPageBar, animated: false, completion: {
@@ -74,7 +74,7 @@ extension BrowserViewController {
         guard let webView = tab?.webView else { return }
         webView.evaluateJavascriptInDefaultContentWorld("__firefox__.findDone()")
         bottomContentStackView.removeArrangedView(findInPageBar)
-        self.findInPageBar = nil
+        self.iOS15FindInPageBar = nil
         updateConstraintsForFindInPageChanges()
     }
 
@@ -93,12 +93,12 @@ extension BrowserViewController: FindInPageBarDelegate, FindInPageHelperDelegate
     }
 
     func findInPage(didFindNextWithText text: String) {
-        findInPageBar?.endEditing(true)
+        iOS15FindInPageBar?.endEditing(true)
         find(text, function: "findNext")
     }
 
     func findInPage(didFindPreviousWithText text: String) {
-        findInPageBar?.endEditing(true)
+        iOS15FindInPageBar?.endEditing(true)
         find(text, function: "findPrevious")
     }
 
@@ -113,10 +113,10 @@ extension BrowserViewController: FindInPageBarDelegate, FindInPageHelperDelegate
     }
 
     func findInPageHelper(didUpdateCurrentResult currentResult: Int) {
-        findInPageBar?.currentResult = currentResult
+        iOS15FindInPageBar?.currentResult = currentResult
     }
 
     func findInPageHelper(didUpdateTotalResults totalResults: Int) {
-        findInPageBar?.totalResults = totalResults
+        iOS15FindInPageBar?.totalResults = totalResults
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -837,13 +837,9 @@ class BrowserViewController: UIViewController,
         processAppleIntelligenceState()
         privacyWindowHelper.removeWindow()
 
-        if let tab = tabManager.selectedTab {
-            if tab.isFindInPageMode {
-                refreshFindInPageUI()
-            } else {
-                // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)
-                scrollController.showToolbars(animated: false)
-            }
+        if let tab = tabManager.selectedTab, !tab.isFindInPageMode {
+            // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)
+            scrollController.showToolbars(animated: false)
         }
 
         navigationHandler?.showTermsOfUse(context: .appBecameActive)
@@ -1724,17 +1720,6 @@ class BrowserViewController: UIViewController,
 
         browserLayoutManager.updateOverKeyboardContainerConstraints(isBottomSearchBar: isBottomSearchBar,
                                                                     hasZoomPageBar: zoomPageBar != nil)
-    }
-
-    func refreshFindInPageUI() {
-        guard #available(iOS 16, *) else { return }
-        guard let tab =  tabManager.selectedTab else { return }
-        guard tab.isPrivate, let webView = tab.webView, webView.isFindInteractionEnabled else { return }
-
-        // Ensure keyboard is available and Find In Page UI is refreshed in PBM (FXIOS-13321)
-        let text = webView.findInteraction?.searchText
-        updateFindInPageVisibility(isVisible: true)
-        webView.findInteraction?.searchText = text ?? ""
     }
 
     // TODO: SnapKit removal clean up

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -101,7 +101,7 @@ class BrowserViewController: UIViewController,
     var searchController: SearchViewController?
     var searchSessionState: SearchSessionState?
     var searchLoader: SearchLoader?
-    var findInPageBar: FindInPageBar?
+    var iOS15FindInPageBar: FindInPageBar? /* TODO: Remove once we drop iOS 15 support */
     var zoomPageBar: ZoomPageBar?
     var addressBarPanGestureHandler: AddressBarPanGestureHandler?
     var microsurvey: MicrosurveyPromptView?
@@ -837,9 +837,20 @@ class BrowserViewController: UIViewController,
         processAppleIntelligenceState()
         privacyWindowHelper.removeWindow()
 
-        if let tab = tabManager.selectedTab, !tab.isFindInPageMode {
-            // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)
-            scrollController.showToolbars(animated: false)
+        if let tab = tabManager.selectedTab {
+            if tab.isFindInPageMode {
+                if #available(iOS 16, *) {
+                    if tab.isPrivate, let webView = tab.webView, webView.isFindInteractionEnabled {
+                        // Ensure keyboard is available and Find In Page UI is refreshed in PBM
+                        let text = webView.findInteraction?.searchText
+                        updateFindInPageVisibility(isVisible: true)
+                        webView.findInteraction?.searchText = text ?? ""
+                    }
+                }
+            } else {
+                // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)
+                scrollController.showToolbars(animated: false)
+            }
         }
 
         navigationHandler?.showTermsOfUse(context: .appBecameActive)
@@ -4438,7 +4449,7 @@ extension BrowserViewController: LegacyTabDelegate {
 
     func tab(_ tab: Tab, didSelectFindInPageForSelection selection: String) {
         updateFindInPageVisibility(isVisible: true, withSearchText: selection)
-        findInPageBar?.text = selection
+        iOS15FindInPageBar?.text = selection
     }
 
     func tab(_ tab: Tab, didSelectSearchWithFirefoxForSelection selection: String) {
@@ -5051,7 +5062,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
             )
         }
         tabManager.selectedTab?.setFindInPage(isBottomSearchBar: isBottomSearchBar,
-                                              doesFindInPageBarExist: findInPageBar != nil)
+                                              doesFindInPageBarExist: iOS15FindInPageBar != nil)
         guard isSwipingTabsEnabled else { return }
         addressBarPanGestureHandler?.enablePanGestureOnHomepageIfNeeded()
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -839,14 +839,7 @@ class BrowserViewController: UIViewController,
 
         if let tab = tabManager.selectedTab {
             if tab.isFindInPageMode {
-                if #available(iOS 16, *) {
-                    if tab.isPrivate, let webView = tab.webView, webView.isFindInteractionEnabled {
-                        // Ensure keyboard is available and Find In Page UI is refreshed in PBM
-                        let text = webView.findInteraction?.searchText
-                        updateFindInPageVisibility(isVisible: true)
-                        webView.findInteraction?.searchText = text ?? ""
-                    }
-                }
+                refreshFindInPageUI()
             } else {
                 // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)
                 scrollController.showToolbars(animated: false)
@@ -1731,6 +1724,17 @@ class BrowserViewController: UIViewController,
 
         browserLayoutManager.updateOverKeyboardContainerConstraints(isBottomSearchBar: isBottomSearchBar,
                                                                     hasZoomPageBar: zoomPageBar != nil)
+    }
+
+    func refreshFindInPageUI() {
+        guard #available(iOS 16, *) else { return }
+        guard let tab =  tabManager.selectedTab else { return }
+        guard tab.isPrivate, let webView = tab.webView, webView.isFindInteractionEnabled else { return }
+
+        // Ensure keyboard is available and Find In Page UI is refreshed in PBM (FXIOS-13321)
+        let text = webView.findInteraction?.searchText
+        updateFindInPageVisibility(isVisible: true)
+        webView.findInteraction?.searchText = text ?? ""
     }
 
     // TODO: SnapKit removal clean up

--- a/firefox-ios/Client/PrivacyWindowHelper.swift
+++ b/firefox-ios/Client/PrivacyWindowHelper.swift
@@ -16,7 +16,9 @@ final class PrivacyWindowHelper {
         privacyWindow?.rootViewController?.view.backgroundColor = color
         // Set the privacy window level to be above alert windows (highest in importance).
         privacyWindow?.windowLevel = .alert + 1
-        privacyWindow?.makeKeyAndVisible()
+        // Avoid makeKeyAndVisible(), becoming key steals first responder
+        // and causses iOS keyboard to dismiss on background/foreground in private mode.
+        privacyWindow?.isHidden = false
     }
 
     @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13321)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29001)

## :bulb: Description

- Fixes an issue where the Find In Page UI is positioned incorrectly in PBM after resuming the app
- Renames the `findInPageBar` so it's clear it is only for iOS 15 backwards-compat

For the Find In Page UI issues, the root problem is that the keyboard is dismissed, so the change here ensures the UI is updated so that the keyboard is available if search is active.

## 📸 Demo

https://github.com/user-attachments/assets/b9a42efd-b32c-4df4-9e92-773511bdb384

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

