### PR TITLE
Add [World Cup] FXIOS-15836 Telemetry for milestone 2

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -89,6 +89,8 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
                 return .bookmark
             case .merino:
                 return .story
+            case .worldcupCard:
+                return .worldCupWidget
             default:
                 return nil
             }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCountryPickerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCountryPickerView.swift
@@ -36,6 +36,7 @@ struct WorldCupCountryPickerView: View, ThemeableView {
     @Environment(\.dismiss) private var dismissAction
 
     @State var selectedTeam: String?
+    private let telemetry = WorldCupTelemetry()
     private let regions = WorldCupCountryData.regions
     private var gridColumns: [GridItem] {
         [GridItem(.adaptive(minimum: UX.gridMinTileWidth), spacing: UX.gridSpacing)]
@@ -69,7 +70,7 @@ struct WorldCupCountryPickerView: View, ThemeableView {
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
-                        dismissAction()
+                        closeButtonTapped()
                     }
                     label: {
                         Image(StandardImageIdentifiers.Large.cross)
@@ -189,6 +190,13 @@ struct WorldCupCountryPickerView: View, ThemeableView {
 
     // MARK: - Action Dispatch
 
+    private func closeButtonTapped() {
+        if selectedTeam == nil {
+            telemetry.countryDeselected()
+        }
+        dismissAction()
+    }
+
     private func dispatchSelectTeam(_ country: WorldCupCountry) {
         guard country.id != selectedTeam else {
             selectedTeam = nil
@@ -201,6 +209,7 @@ struct WorldCupCountryPickerView: View, ThemeableView {
             )
             return
         }
+        telemetry.countrySelected(fifaCode: country.id)
         store.dispatch(
             WorldCupAction(
                 windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupErrorView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupErrorView.swift
@@ -24,6 +24,7 @@ final class WorldCupErrorView: UIView, ThemeApplicable {
     }
 
     private let windowUUID: WindowUUID
+    private let telemetry = WorldCupTelemetry()
 
     // MARK: - UI
 
@@ -114,6 +115,7 @@ final class WorldCupErrorView: UIView, ThemeApplicable {
     }
 
     private func handleRefreshTap() {
+        telemetry.errorRefreshButtonTapped()
         store.dispatch(
             WorldCupAction(
                 windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
@@ -242,6 +242,7 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
     // MARK: - Actions
 
     private func navigateToTeamSelection() {
+        telemetry.countrySelectorDisplayed()
         store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(.worldCupCountryPicker),
@@ -255,6 +256,7 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
         let homeTeamName = WorldCupCountry.localizedName(forID: match.homeCode)
         let awayTeamName = WorldCupCountry.localizedName(forID: match.awayCode)
         let query = "\(homeTeamName) vs \(awayTeamName) \(String.Settings.Homepage.CustomizeFirefoxHome.WorldCup) 2026"
+        telemetry.matchClicked(match: "\(match.homeCode)/\(match.awayCode)")
         store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(
@@ -268,7 +270,7 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
     }
 
     private func dismiss() {
-        telemetry.closeButtonTapped()
+        telemetry.widgetDismissed()
         store.dispatch(
             WorldCupAction(
                 windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTelemetry.swift
@@ -11,11 +11,37 @@ struct WorldCupTelemetry {
         self.gleanWrapper = gleanWrapper
     }
 
-    func closeButtonTapped() {
+    func closeCountdownWidgetButtonTapped() {
        gleanWrapper.recordEvent(for: GleanMetrics.WorldCupCountdownWidget.closeButton)
     }
 
     func viewScheduleTapped() {
         gleanWrapper.recordEvent(for: GleanMetrics.WorldCupCountdownWidget.viewSchedule)
+    }
+
+    func countrySelected(fifaCode: String) {
+        let extra = GleanMetrics.WorldCupWidget.CountrySelectedExtra(fifaCode: fifaCode)
+        gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.countrySelected, extras: extra)
+    }
+
+    func countryDeselected() {
+        gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.countryDeselected)
+    }
+
+    func widgetDismissed() {
+        gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.widgetDismissed)
+    }
+
+    func errorRefreshButtonTapped() {
+        gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.errorRefreshButton)
+    }
+
+    func matchClicked(match: String) {
+        let extra = GleanMetrics.WorldCupWidget.MatchClickedExtra(match: match)
+        gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.matchClicked, extras: extra)
+    }
+
+    func countrySelectorDisplayed() {
+        gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.countrySelectorDisplayed)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
@@ -281,7 +281,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
             ),
             attributes: .destructive,
             handler: { [weak self] _ in
-                self?.dismiss()
+                self?.dismissWidget()
             }
         )
         let menu = UIMenu(children: [changeTeamAction, removeAction])
@@ -317,7 +317,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
         actionButton.largeContentTitle = .WorldCup.HomepageWidget.FollowTeamCard.CloseButtonAccessibilityLabel
         actionButton.addAction(
             UIAction { [weak self] _ in
-                self?.dismiss()
+                self?.dismissCountdown()
             },
             for: .touchUpInside)
     }
@@ -366,6 +366,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
     // MARK: - Actions
 
     private func navigateToTeamSelection() {
+        telemetry.countrySelectorDisplayed()
         store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(.worldCupCountryPicker),
@@ -391,8 +392,22 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
         )
     }
 
-    private func dismiss() {
-        telemetry.closeButtonTapped()
+    /// Called on milestone1 when we only show the countdown card.
+    /// It records a different telemetry then `dismissWidget`.
+    private func dismissCountdown() {
+        telemetry.closeCountdownWidgetButtonTapped()
+        store.dispatch(
+            WorldCupAction(
+                windowUUID: windowUUID,
+                actionType: WorldCupActionType.removeHomepageCard,
+            )
+        )
+    }
+
+    /// Called on milestone2 and more when show the full match list.
+    /// It records a different telemetry then `dismissCountdown`
+    private func dismissWidget() {
+        telemetry.widgetDismissed()
         store.dispatch(
             WorldCupAction(
                 windowUUID: windowUUID,

--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -1324,10 +1324,12 @@ homepage:
       - jump_back_in
       - bookmarks
       - stories
+      - world_cup_widget
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/26216
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/26234
+      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
+++ b/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
@@ -35,3 +35,79 @@ world_cup_countdown_widget:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-12-01"
+
+world_cup_widget:
+  country_selected:
+    type: event
+    description: |
+      Records when the user selects a country to follow in the country picker.
+    extra_keys:
+      fifa_code:
+        description: The FIFA code of the country selected by the user.
+        type: string
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-12-01"
+  country_deselected:
+    type: event
+    description: |
+      Records when the user doesn't select a country or deselect a country in the country picker.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-12-01"
+  widget_dismissed:
+    type: event
+    description: |
+      Records when the WorldCup widget is dismissed by the user.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-12-01"
+  error_refresh_button:
+    type: event
+    description: |
+      Records when the user taps on the refresh button when an error is displayed on the WorldCup widget.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-12-01"
+  match_clicked:
+    type: event
+    description: |
+      Records when the user taps on a match in the WorldCup widget.
+    extra_keys:
+      match:
+        description: The identifier of the match that was clicked i.e USA/MEX.
+        type: string
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-12-01"
+  country_selector_displayed:
+    type: event
+    description: |
+      Records when the country selector screen is displayed to the user.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-12-01"

--- a/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
@@ -15,6 +15,7 @@ struct HomepageTelemetry {
         case bookmark = "bookmark"
         case bookmarkShowAll = "bookmarks_show_all_button"
         case story = "story"
+        case worldCupWidget = "world_cup_widget"
 
         var sectionName: String {
             switch self {
@@ -26,6 +27,8 @@ struct HomepageTelemetry {
                 return "bookmarks"
             case .story:
                 return "stories"
+            case .worldCupWidget:
+                return self.rawValue
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupTelemetryTests.swift
@@ -20,10 +20,10 @@ final class WorldCupTelemetryTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_closeButtonTapped_recordsEvent() throws {
+    func test_closeCountdownWidgetButtonTapped_recordsEvent() throws {
         let subject = createSubject()
 
-        subject.closeButtonTapped()
+        subject.closeCountdownWidgetButtonTapped()
 
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let expectedMetricType = type(of: GleanMetrics.WorldCupCountdownWidget.closeButton)
@@ -48,10 +48,106 @@ final class WorldCupTelemetryTests: XCTestCase {
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 
+    func test_countrySelected_recordsEventWithFifaCodeExtra() throws {
+        let event = GleanMetrics.WorldCupWidget.countrySelected
+        typealias EventExtrasType = GleanMetrics.WorldCupWidget.CountrySelectedExtra
+
+        let subject = createSubject()
+        let expectedFifaCode = "USA"
+        let expectedMetricType = type(of: event)
+
+        subject.countrySelected(fifaCode: expectedFifaCode)
+
+        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.fifaCode, expectedFifaCode)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func test_countryDeselected_recordsEvent() throws {
+        let subject = createSubject()
+
+        subject.countryDeselected()
+
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
+        let expectedMetricType = type(of: GleanMetrics.WorldCupWidget.countryDeselected)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func test_widgetDismissed_recordsEvent() throws {
+        let subject = createSubject()
+
+        subject.widgetDismissed()
+
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
+        let expectedMetricType = type(of: GleanMetrics.WorldCupWidget.widgetDismissed)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func test_errorRefreshButtonTapped_recordsEvent() throws {
+        let subject = createSubject()
+
+        subject.errorRefreshButtonTapped()
+
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
+        let expectedMetricType = type(of: GleanMetrics.WorldCupWidget.errorRefreshButton)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func test_matchClicked_recordsEventWithMatchExtra() throws {
+        let event = GleanMetrics.WorldCupWidget.matchClicked
+        typealias EventExtrasType = GleanMetrics.WorldCupWidget.MatchClickedExtra
+
+        let subject = createSubject()
+        let expectedMatch = "USA/MEX"
+        let expectedMetricType = type(of: event)
+
+        subject.matchClicked(match: expectedMatch)
+
+        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.match, expectedMatch)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func test_countrySelectorDisplayed_recordsEvent() throws {
+        let subject = createSubject()
+
+        subject.countrySelectorDisplayed()
+
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
+        let expectedMetricType = type(of: GleanMetrics.WorldCupWidget.countrySelectorDisplayed)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
     func test_multipleEvents_recordedIndependently() {
         let subject = createSubject()
 
-        subject.closeButtonTapped()
+        subject.closeCountdownWidgetButtonTapped()
         subject.viewScheduleTapped()
 
         XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 2)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15836)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33877)

## :bulb: Description
Add missing Telemetry for WorldCup milestone 2

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

