### PR TITLE
BugFix [World Cup] FXIOS-15841 hide correctly loading ball during updates 

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -23,7 +23,7 @@ private final class PageContainer: UIView, ThemeApplicable {
         image.image = UIImage(named: UX.loadingImage)
         image.isAccessibilityElement = false
         image.contentMode = .scaleAspectFit
-        image.alpha = 0.0
+        image.isHidden = true
     }
 
     init(content: UIView) {
@@ -57,7 +57,7 @@ private final class PageContainer: UIView, ThemeApplicable {
     /// Sets the Content visibility and hides the loading image in case the `isVisible` is set to true.
     func setContentVisibility(_ isVisible: Bool) {
         content.alpha = isVisible ? UX.visibleAlpha : UX.hiddenAlpha
-        loadingImageView.alpha = isVisible ? UX.hiddenAlpha : UX.visibleAlpha
+        loadingImageView.isHidden = isVisible
         if isVisible {
             stopSpinning()
         } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15841)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33833)

## :bulb: Description
Bug fix loading ball showing during updates of the `WorldCupCell`.

## :movie_camera: Demos


https://github.com/user-attachments/assets/ca2ceb64-bc56-4073-a415-726846d935ad


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

