### PR TITLE
BugFix [World Cup] FXIOS-15844 performance when loading gif by adding caching to it

### DIFF
--- a/firefox-ios/Client/Extensions/UIImage+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIImage+Extension.swift
@@ -31,14 +31,23 @@ extension UIImage {
         return newImage
     }
 
+    nonisolated(unsafe) private static let gifCache = NSCache<NSString, UIImage>()
+
     /// Tries to load an `UIImage` from the content of a gif in the main `Bundle`
     ///
     /// The `frameDuration` it's set to 0.1 seconds as default but may be adjusted depending on the loaded gif.
     /// If `maxPixelSize` is provided, each frame is decoded as a thumbnail whose longest edge does not exceed
     /// that value in pixels, which can significantly reduce memory usage for large gifs.
+    /// Decoded results are cached per `name`/`maxPixelSize`/`frameDuration` combination to avoid re-decoding
+    /// the gif on subsequent calls.
     static func gifFromBundle(named name: String,
                               frameDuration: CGFloat = 0.1,
                               maxPixelSize: CGFloat? = nil) -> UIImage? {
+        let cacheKey = "\(name)|\(maxPixelSize ?? 0)|\(frameDuration)" as NSString
+        if let cached = gifCache.object(forKey: cacheKey) {
+            return cached
+        }
+
         guard let gifPath = Bundle.main.path(forResource: name, ofType: "gif"),
               let gifData = NSData(contentsOfFile: gifPath) as Data?,
               let source = CGImageSourceCreateWithData(gifData as CFData, nil) else {
@@ -68,6 +77,10 @@ extension UIImage {
             }
         }
 
-        return UIImage.animatedImage(with: frames, duration: Double(frameCount) * frameDuration)
+        let animated = UIImage.animatedImage(with: frames, duration: Double(frameCount) * frameDuration)
+        if let animated {
+            gifCache.setObject(animated, forKey: cacheKey)
+        }
+        return animated
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15844)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33891)

## :bulb: Description
Bug fix performance issue when loading the gif all the time upon `WorldCupCell` state updates by caching its value via `NSCache`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

