### PR TITLE
Refactor NO_TICKET Avoid force-unwrapping of `pointOrigin` in pan gesture

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1461,6 +1461,8 @@
 		AB4FB4DC2C89FB10005EF0CC /* BlockedTrackerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4FB4D82C89FB0E005EF0CC /* BlockedTrackerCell.swift */; };
 		AB4FB4DD2C89FB10005EF0CC /* BlockedTrackersTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4FB4D92C89FB0F005EF0CC /* BlockedTrackersTableView.swift */; };
 		AB4FB4E12C90491F005EF0CC /* BlockedTrackersTableViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4FB4DF2C9048D1005EF0CC /* BlockedTrackersTableViewControllerTests.swift */; };
+		A545CC0C21C148228C7EC0A1 /* EnhancedTrackingProtectionMenuVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E270802C896845E2B6624BCE /* EnhancedTrackingProtectionMenuVCTests.swift */; };
+		AE33D4D2A3E444FD9DCBA2E8 /* TrackingProtectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6741EF98F0E46D595EE4FA9 /* TrackingProtectionViewControllerTests.swift */; };
 		AB7D4C3129ACAED100626427 /* Tab+ChangeUserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7D4C3029ACAED100626427 /* Tab+ChangeUserAgentTests.swift */; };
 		AB8EE2D32C750E6100BD0A6B /* TrackingProtectionVerifiedByView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8EE2D22C750E6100BD0A6B /* TrackingProtectionVerifiedByView.swift */; };
 		AB936A692C05F2B100600F82 /* TrackingProtectionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB936A682C05F2B100600F82 /* TrackingProtectionButton.swift */; };
@@ -10163,6 +10165,8 @@
 		AB4FB4D82C89FB0E005EF0CC /* BlockedTrackerCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockedTrackerCell.swift; sourceTree = "<group>"; };
 		AB4FB4D92C89FB0F005EF0CC /* BlockedTrackersTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockedTrackersTableView.swift; sourceTree = "<group>"; };
 		AB4FB4DF2C9048D1005EF0CC /* BlockedTrackersTableViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedTrackersTableViewControllerTests.swift; sourceTree = "<group>"; };
+		E270802C896845E2B6624BCE /* EnhancedTrackingProtectionMenuVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedTrackingProtectionMenuVCTests.swift; sourceTree = "<group>"; };
+		C6741EF98F0E46D595EE4FA9 /* TrackingProtectionViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionViewControllerTests.swift; sourceTree = "<group>"; };
 		AB7C4D658AB44D577390B61F /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/Menu.strings; sourceTree = "<group>"; };
 		AB7D4C3029ACAED100626427 /* Tab+ChangeUserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tab+ChangeUserAgentTests.swift"; sourceTree = "<group>"; };
 		AB8EE2D22C750E6100BD0A6B /* TrackingProtectionVerifiedByView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionVerifiedByView.swift; sourceTree = "<group>"; };
@@ -15102,6 +15106,8 @@
 				AB9CBC062C53B76400102610 /* TrackingProtectionStateTests.swift */,
 				0A7693602C7DD19500103A6D /* CertificatesViewModelTests.swift */,
 				AB4FB4DF2C9048D1005EF0CC /* BlockedTrackersTableViewControllerTests.swift */,
+				E270802C896845E2B6624BCE /* EnhancedTrackingProtectionMenuVCTests.swift */,
+				C6741EF98F0E46D595EE4FA9 /* TrackingProtectionViewControllerTests.swift */,
 			);
 			path = TrackingProtectionTests;
 			sourceTree = "<group>";
@@ -20636,6 +20642,8 @@
 				8A7A26E329D4ACF300EA76F1 /* SceneCoordinatorTests.swift in Sources */,
 				213047E62F2153B1007ECEDA /* PageZoomSettingsViewModelTests.swift in Sources */,
 				AB4FB4E12C90491F005EF0CC /* BlockedTrackersTableViewControllerTests.swift in Sources */,
+				A545CC0C21C148228C7EC0A1 /* EnhancedTrackingProtectionMenuVCTests.swift in Sources */,
+				AE33D4D2A3E444FD9DCBA2E8 /* TrackingProtectionViewControllerTests.swift in Sources */,
 				8A6B79A02CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift in Sources */,
 				39C137972655798A003DC662 /* NimbusIntegrationTests.swift in Sources */,
 				8AD3AFC52D143F1200CFC887 /* HomepageDimensionCalculatorTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -492,7 +492,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
         // Setting x based on window calculation because we don't want
         // users to move the frame side ways, only straight up or down
         view.frame.origin = CGPoint(x: originalXPosition,
-                                    y: self.pointOrigin!.y + translation.y)
+                                    y: (self.pointOrigin?.y ?? originalYPosition) + translation.y)
 
         if sender.state == .ended {
             let dragVelocity = sender.velocity(in: view)

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -704,7 +704,7 @@ class TrackingProtectionViewController: UIViewController,
         // Setting x based on window calculation because we don't want
         // users to move the frame side ways, only straight up or down
         view.frame.origin = CGPoint(x: originalXPosition,
-                                    y: self.pointOrigin!.y + translation.y)
+                                    y: (self.pointOrigin?.y ?? originalYPosition) + translation.y)
 
         if sender.state == .ended {
             let dragVelocity = sender.velocity(in: view)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/EnhancedTrackingProtectionMenuVCTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/EnhancedTrackingProtectionMenuVCTests.swift
@@ -10,7 +10,7 @@ import Common
 final class EnhancedTrackingProtectionMenuVCTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
-        await DependencyHelperMock().bootstrapDependencies()
+        DependencyHelperMock().bootstrapDependencies()
     }
 
     override func tearDown() async throws {
@@ -30,8 +30,10 @@ final class EnhancedTrackingProtectionMenuVCTests: XCTestCase {
 
         subject.panGestureRecognizerAction(sender: mockGesture)
 
-        XCTAssertEqual(subject.view.frame.origin,
-                       CGPoint(x: initialOrigin.x, y: initialOrigin.y + translationY))
+        XCTAssertEqual(
+            subject.view.frame.origin,
+            CGPoint(x: initialOrigin.x, y: initialOrigin.y + translationY)
+        )
     }
 
     func testPanGestureRecognizerAction_endedStateWhenPointOriginIsNil_restoresFrameToOriginalOrigin() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/EnhancedTrackingProtectionMenuVCTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/EnhancedTrackingProtectionMenuVCTests.swift
@@ -7,7 +7,7 @@ import Common
 @testable import Client
 
 @MainActor
-final class EnhancedTrackingProtectionVCTests: XCTestCase {
+final class EnhancedTrackingProtectionMenuVCTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         await DependencyHelperMock().bootstrapDependencies()
@@ -18,30 +18,25 @@ final class EnhancedTrackingProtectionVCTests: XCTestCase {
         try await super.tearDown()
     }
 
-    /// Regression test: prior to the fix, `panGestureRecognizerAction` force-unwrapped `pointOrigin`,
-    /// which is only set inside `viewDidLayoutSubviews`. If the pan gesture fired before the first
-    /// layout pass (e.g. after a memory warning or a rapid present/dismiss cycle), the app crashed
-    /// with `EXC_BAD_INSTRUCTION`. The handler must now tolerate a nil `pointOrigin`.
-    func testPanGestureRecognizerAction_beforeLayoutPass_doesNotCrash() {
-        let subject = makeSUT()
-        subject.loadViewIfNeeded()
-        // Intentionally do NOT call viewDidLayoutSubviews -- pointOrigin stays nil.
+    func testPanGestureRecognizerAction_changedStateWhenPointOriginIsNil_updatesFrameOriginUsingViewOrigin() {
+        let subject = createSubject()
+        let initialOrigin = subject.view.frame.origin
+        let translationY: CGFloat = 50
 
         let mockGesture = MockPanGestureRecognizer()
         mockGesture.mockState = .changed
-        mockGesture.mockTranslation = CGPoint(x: 0, y: 50)
+        mockGesture.mockTranslation = CGPoint(x: 0, y: translationY)
         mockGesture.mockVelocity = .zero
 
         subject.panGestureRecognizerAction(sender: mockGesture)
 
-        XCTAssertNotNil(subject.view, "View should still exist after gesture without prior layout pass")
+        XCTAssertEqual(subject.view.frame.origin,
+                       CGPoint(x: initialOrigin.x, y: initialOrigin.y + translationY))
     }
 
-    /// The .ended branch should also be safe when pointOrigin is still nil — both unwrap sites
-    /// must handle the nil case consistently.
-    func testPanGestureRecognizerAction_endedStateBeforeLayout_doesNotCrash() {
-        let subject = makeSUT()
-        subject.loadViewIfNeeded()
+    func testPanGestureRecognizerAction_endedStateWhenPointOriginIsNil_restoresFrameToOriginalOrigin() {
+        let subject = createSubject()
+        let initialOrigin = subject.view.frame.origin
 
         let mockGesture = MockPanGestureRecognizer()
         mockGesture.mockState = .ended
@@ -50,12 +45,12 @@ final class EnhancedTrackingProtectionVCTests: XCTestCase {
 
         subject.panGestureRecognizerAction(sender: mockGesture)
 
-        XCTAssertNotNil(subject.view)
+        XCTAssertEqual(subject.view.frame.origin, initialOrigin)
     }
 
     // MARK: - Helpers
 
-    private func makeSUT() -> EnhancedTrackingProtectionMenuVC {
+    private func createSubject() -> EnhancedTrackingProtectionMenuVC {
         let viewModel = EnhancedTrackingProtectionMenuVM(
             url: URL(string: "https://example.com")!,
             displayTitle: "example.com",
@@ -70,7 +65,6 @@ final class EnhancedTrackingProtectionVCTests: XCTestCase {
     }
 }
 
-/// Test double allowing us to drive the pan gesture handler deterministically.
 private final class MockPanGestureRecognizer: UIPanGestureRecognizer {
     var mockState: UIGestureRecognizer.State = .began
     var mockTranslation: CGPoint = .zero

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/EnhancedTrackingProtectionVCTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/EnhancedTrackingProtectionVCTests.swift
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+@testable import Client
+
+@MainActor
+final class EnhancedTrackingProtectionVCTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        await DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() async throws {
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    /// Regression test: prior to the fix, `panGestureRecognizerAction` force-unwrapped `pointOrigin`,
+    /// which is only set inside `viewDidLayoutSubviews`. If the pan gesture fired before the first
+    /// layout pass (e.g. after a memory warning or a rapid present/dismiss cycle), the app crashed
+    /// with `EXC_BAD_INSTRUCTION`. The handler must now tolerate a nil `pointOrigin`.
+    func testPanGestureRecognizerAction_beforeLayoutPass_doesNotCrash() {
+        let subject = makeSUT()
+        subject.loadViewIfNeeded()
+        // Intentionally do NOT call viewDidLayoutSubviews -- pointOrigin stays nil.
+
+        let mockGesture = MockPanGestureRecognizer()
+        mockGesture.mockState = .changed
+        mockGesture.mockTranslation = CGPoint(x: 0, y: 50)
+        mockGesture.mockVelocity = .zero
+
+        subject.panGestureRecognizerAction(sender: mockGesture)
+
+        XCTAssertNotNil(subject.view, "View should still exist after gesture without prior layout pass")
+    }
+
+    /// The .ended branch should also be safe when pointOrigin is still nil — both unwrap sites
+    /// must handle the nil case consistently.
+    func testPanGestureRecognizerAction_endedStateBeforeLayout_doesNotCrash() {
+        let subject = makeSUT()
+        subject.loadViewIfNeeded()
+
+        let mockGesture = MockPanGestureRecognizer()
+        mockGesture.mockState = .ended
+        mockGesture.mockTranslation = CGPoint(x: 0, y: 20)
+        mockGesture.mockVelocity = .zero
+
+        subject.panGestureRecognizerAction(sender: mockGesture)
+
+        XCTAssertNotNil(subject.view)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT() -> EnhancedTrackingProtectionMenuVC {
+        let viewModel = EnhancedTrackingProtectionMenuVM(
+            url: URL(string: "https://example.com")!,
+            displayTitle: "example.com",
+            connectionSecure: true,
+            globalETPIsEnabled: true,
+            contentBlockerStatus: .noBlockedURLs
+        )
+        return EnhancedTrackingProtectionMenuVC(
+            viewModel: viewModel,
+            windowUUID: .XCTestDefaultUUID
+        )
+    }
+}
+
+/// Test double allowing us to drive the pan gesture handler deterministically.
+private final class MockPanGestureRecognizer: UIPanGestureRecognizer {
+    var mockState: UIGestureRecognizer.State = .began
+    var mockTranslation: CGPoint = .zero
+    var mockVelocity: CGPoint = .zero
+
+    init() {
+        super.init(target: nil, action: nil)
+    }
+
+    override var state: UIGestureRecognizer.State {
+        get { mockState }
+        set { mockState = newValue }
+    }
+
+    override func translation(in view: UIView?) -> CGPoint {
+        return mockTranslation
+    }
+
+    override func velocity(in view: UIView?) -> CGPoint {
+        return mockVelocity
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/TrackingProtectionViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/TrackingProtectionViewControllerTests.swift
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+@testable import Client
+
+@MainActor
+final class TrackingProtectionViewControllerTests: XCTestCase {
+    private var mockProfile: MockProfile!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await DependencyHelperMock().bootstrapDependencies()
+        mockProfile = MockProfile()
+    }
+
+    override func tearDown() async throws {
+        mockProfile = nil
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    /// Regression test: prior to the fix, `panGestureRecognizerAction` force-unwrapped `pointOrigin`,
+    /// which is only set inside `viewDidLayoutSubviews`. If the pan gesture fired before the first
+    /// layout pass (e.g. after a memory warning or a rapid present/dismiss cycle), the app crashed
+    /// with `EXC_BAD_INSTRUCTION`. The handler must now tolerate a nil `pointOrigin`.
+    func testPanGestureRecognizerAction_beforeLayoutPass_doesNotCrash() {
+        let subject = makeSUT()
+        subject.loadViewIfNeeded()
+        // Intentionally do NOT call viewDidLayoutSubviews -- pointOrigin stays nil.
+
+        let mockGesture = MockPanGestureRecognizer()
+        mockGesture.mockState = .changed
+        mockGesture.mockTranslation = CGPoint(x: 0, y: 50)
+        mockGesture.mockVelocity = .zero
+
+        subject.panGestureRecognizerAction(sender: mockGesture)
+
+        XCTAssertNotNil(subject.view, "View should still exist after gesture without prior layout pass")
+    }
+
+    /// The .ended branch should also be safe when pointOrigin is still nil.
+    func testPanGestureRecognizerAction_endedStateBeforeLayout_doesNotCrash() {
+        let subject = makeSUT()
+        subject.loadViewIfNeeded()
+
+        let mockGesture = MockPanGestureRecognizer()
+        mockGesture.mockState = .ended
+        mockGesture.mockTranslation = CGPoint(x: 0, y: 20)
+        mockGesture.mockVelocity = .zero
+
+        subject.panGestureRecognizerAction(sender: mockGesture)
+
+        XCTAssertNotNil(subject.view)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT() -> TrackingProtectionViewController {
+        let model = TrackingProtectionModel(
+            userDefaults: nil,
+            url: URL(string: "https://example.com")!,
+            displayTitle: "example.com",
+            connectionSecure: true,
+            globalETPIsEnabled: true,
+            contentBlockerStatus: .noBlockedURLs,
+            contentBlockerStats: nil,
+            selectedTab: nil
+        )
+        return TrackingProtectionViewController(
+            viewModel: model,
+            profile: mockProfile,
+            windowUUID: .XCTestDefaultUUID
+        )
+    }
+}
+
+/// Test double allowing us to drive the pan gesture handler deterministically.
+private final class MockPanGestureRecognizer: UIPanGestureRecognizer {
+    var mockState: UIGestureRecognizer.State = .began
+    var mockTranslation: CGPoint = .zero
+    var mockVelocity: CGPoint = .zero
+
+    init() {
+        super.init(target: nil, action: nil)
+    }
+
+    override var state: UIGestureRecognizer.State {
+        get { mockState }
+        set { mockState = newValue }
+    }
+
+    override func translation(in view: UIView?) -> CGPoint {
+        return mockTranslation
+    }
+
+    override func velocity(in view: UIView?) -> CGPoint {
+        return mockVelocity
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/TrackingProtectionViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/TrackingProtectionViewControllerTests.swift
@@ -12,7 +12,7 @@ final class TrackingProtectionViewControllerTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        await DependencyHelperMock().bootstrapDependencies()
+        DependencyHelperMock().bootstrapDependencies()
         mockProfile = MockProfile()
     }
 
@@ -34,8 +34,10 @@ final class TrackingProtectionViewControllerTests: XCTestCase {
 
         subject.panGestureRecognizerAction(sender: mockGesture)
 
-        XCTAssertEqual(subject.view.frame.origin,
-                       CGPoint(x: initialOrigin.x, y: initialOrigin.y + translationY))
+        XCTAssertEqual(
+            subject.view.frame.origin,
+            CGPoint(x: initialOrigin.x, y: initialOrigin.y + translationY)
+        )
     }
 
     func testPanGestureRecognizerAction_endedStateWhenPointOriginIsNil_restoresFrameToOriginalOrigin() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/TrackingProtectionViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/TrackingProtectionViewControllerTests.swift
@@ -22,29 +22,25 @@ final class TrackingProtectionViewControllerTests: XCTestCase {
         try await super.tearDown()
     }
 
-    /// Regression test: prior to the fix, `panGestureRecognizerAction` force-unwrapped `pointOrigin`,
-    /// which is only set inside `viewDidLayoutSubviews`. If the pan gesture fired before the first
-    /// layout pass (e.g. after a memory warning or a rapid present/dismiss cycle), the app crashed
-    /// with `EXC_BAD_INSTRUCTION`. The handler must now tolerate a nil `pointOrigin`.
-    func testPanGestureRecognizerAction_beforeLayoutPass_doesNotCrash() {
-        let subject = makeSUT()
-        subject.loadViewIfNeeded()
-        // Intentionally do NOT call viewDidLayoutSubviews -- pointOrigin stays nil.
+    func testPanGestureRecognizerAction_changedStateWhenPointOriginIsNil_updatesFrameOriginUsingViewOrigin() {
+        let subject = createSubject()
+        let initialOrigin = subject.view.frame.origin
+        let translationY: CGFloat = 50
 
         let mockGesture = MockPanGestureRecognizer()
         mockGesture.mockState = .changed
-        mockGesture.mockTranslation = CGPoint(x: 0, y: 50)
+        mockGesture.mockTranslation = CGPoint(x: 0, y: translationY)
         mockGesture.mockVelocity = .zero
 
         subject.panGestureRecognizerAction(sender: mockGesture)
 
-        XCTAssertNotNil(subject.view, "View should still exist after gesture without prior layout pass")
+        XCTAssertEqual(subject.view.frame.origin,
+                       CGPoint(x: initialOrigin.x, y: initialOrigin.y + translationY))
     }
 
-    /// The .ended branch should also be safe when pointOrigin is still nil.
-    func testPanGestureRecognizerAction_endedStateBeforeLayout_doesNotCrash() {
-        let subject = makeSUT()
-        subject.loadViewIfNeeded()
+    func testPanGestureRecognizerAction_endedStateWhenPointOriginIsNil_restoresFrameToOriginalOrigin() {
+        let subject = createSubject()
+        let initialOrigin = subject.view.frame.origin
 
         let mockGesture = MockPanGestureRecognizer()
         mockGesture.mockState = .ended
@@ -53,12 +49,12 @@ final class TrackingProtectionViewControllerTests: XCTestCase {
 
         subject.panGestureRecognizerAction(sender: mockGesture)
 
-        XCTAssertNotNil(subject.view)
+        XCTAssertEqual(subject.view.frame.origin, initialOrigin)
     }
 
     // MARK: - Helpers
 
-    private func makeSUT() -> TrackingProtectionViewController {
+    private func createSubject() -> TrackingProtectionViewController {
         let model = TrackingProtectionModel(
             userDefaults: nil,
             url: URL(string: "https://example.com")!,
@@ -77,7 +73,6 @@ final class TrackingProtectionViewControllerTests: XCTestCase {
     }
 }
 
-/// Test double allowing us to drive the pan gesture handler deterministically.
 private final class MockPanGestureRecognizer: UIPanGestureRecognizer {
     var mockState: UIGestureRecognizer.State = .began
     var mockTranslation: CGPoint = .zero


### PR DESCRIPTION
## :bulb: Description

Fixes a potential crash in the Tracking Protection menus where `pointOrigin!` was force-unwrapped inside `panGestureRecognizerAction(sender:)`. The property is optional and only initialized in `viewDidLayoutSubviews`, so if the pan gesture fires before the first layout pass (e.g. after a memory warning, a rapid present/dismiss cycle, or in automated UI tests) the app crashes with `EXC_BAD_INSTRUCTION`.

The same bug pattern existed in **two files** (duplicated code path):

- `firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift` — line 495
- `firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift` — line 707

### The fix

The force-unwrap is replaced with the same safe-fallback pattern the surrounding code already uses just a few lines later (L504 / L716), defaulting to the current view origin (`originalYPosition`) when `pointOrigin` has not yet been set:

```swift
// Before
view.frame.origin = CGPoint(x: originalXPosition,
                            y: self.pointOrigin!.y + translation.y)

// After
view.frame.origin = CGPoint(x: originalXPosition,
                            y: (self.pointOrigin?.y ?? originalYPosition) + translation.y)
```

Behavior is **identical** in the common case where `pointOrigin` has been initialized (which is the only case the previous code handled correctly). Only the previously-crashing edge case is corrected.

### Regression tests

Two new test files exercise the gesture handler with `pointOrigin` still nil (i.e. before `viewDidLayoutSubviews` ran) and verify the call no longer crashes:

- `firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/EnhancedTrackingProtectionVCTests.swift`
- `firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/TrackingProtectionViewControllerTests.swift`

Both test files follow the existing `TrackingProtectionTests` test-suite pattern (`XCTest`, `@MainActor`, `@testable import Client`, `DependencyHelperMock().bootstrapDependencies()`) and use a `MockPanGestureRecognizer` test double to drive the handler deterministically.

## :movie_camera: Demos

N/A — no visual change. Behavior is identical when `pointOrigin` is set (the common case). Only the previously-crashing edge case is corrected.

<details>
<summary>Static-grep verification</summary>

```bash
$ grep -rn "pointOrigin!" firefox-ios/Client --include="*.swift"
# (no output -- 0 hits)
```

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — N/A (no visible UI change)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review — N/A
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n — N/A
- [x] If needed, I updated documentation and added comments to complex code — no new code comments needed; fix uses the existing pattern from elsewhere in the same file.