### PR TITLE
Bugfix FXIOS-15125 ⁃ The inline PDF viewer is not working properly

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -878,8 +878,13 @@ extension BrowserViewController: WKNavigationDelegate {
         // NOTE: This should only happen if the request/response came from the main frame, otherwise
         // we may end up overriding the "Share Page With..." action to share a temp file that is not
         // representative of the contents of the web view.
+        // Validate pathExtension to avoid edge cases where the response MIME type is PDF but the URL
+        // actually serves HTML content
         if navigationResponse.isForMainFrame, let tab = tabManager[webView] {
-            if response.mimeType == MIMEType.PDF, let request {
+            if response.mimeType == MIMEType.PDF,
+               let request,
+               let url = request.url,
+               url.pathExtension.lowercased() == "pdf" {
                 if !tab.shouldDownloadDocument(request) {
                     return .allow
                 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15125)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32557)

## :bulb: Description
Handling an edge case when mimeType is PDF but URL have HTML content

## :movie_camera: Demos

https://github.com/user-attachments/assets/cc26ef7b-4476-486e-9d7a-5cbff8db11a4



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

