### PR TITLE
Bugfix FXIOS-15857 [Newsfeed Categories] Fix search results disappearance after rotation

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1629,6 +1629,9 @@ class BrowserViewController: UIViewController,
                 : [topBlurView, bottomBlurView, topTouchArea, statusBarOverlay, header,
                    bottomContentStackView, bottomContainer, overKeyboardContainer]
             frontViews.filter { $0.superview === view }.forEach(view.bringSubviewToFront)
+            if let searchView = searchController?.view, searchView.superview === view {
+                view.bringSubviewToFront(searchView)
+            }
         }
 
         guard let homepageViewController = contentContainer.contentController as? HomepageViewController else { return }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerConstraintTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerConstraintTests.swift
@@ -226,9 +226,8 @@ final class BrowserViewControllerConstraintTests: BrowserViewControllerConstrain
     }
 
     func test_updateContentContainerTopConstraint_keepsSearchControllerAboveHomepage() throws {
-        let featureFlags = MockNimbusFeatureFlags()
-        featureFlags.enabledFlags = [.homepagePinnedHeader, .homepageStoryCategories]
-        let subject = createSubject(featureFlagProvider: featureFlags)
+        setupNimbusHomepagePinnedHeaderTesting(isEnabled: true)
+        let subject = createSubject()
         let homepage = MockHomepageContentViewController()
 
         subject.showSearchController()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerConstraintTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerConstraintTests.swift
@@ -225,6 +225,22 @@ final class BrowserViewControllerConstraintTests: BrowserViewControllerConstrain
         XCTAssertNotNil(subject.bottomContentStackView.superview)
     }
 
+    func test_updateContentContainerTopConstraint_keepsSearchControllerAboveHomepage() throws {
+        let featureFlags = MockNimbusFeatureFlags()
+        featureFlags.enabledFlags = [.homepagePinnedHeader, .homepageStoryCategories]
+        let subject = createSubject(featureFlagProvider: featureFlags)
+        let homepage = MockHomepageContentViewController()
+
+        subject.showSearchController()
+        subject.contentContainer.update(content: homepage)
+        subject.updateContentContainerTopConstraint()
+
+        let searchView = try XCTUnwrap(subject.searchController?.view)
+        let searchIndex = try XCTUnwrap(subject.view.subviews.firstIndex(of: searchView))
+        let contentIndex = try XCTUnwrap(subject.view.subviews.firstIndex(of: subject.contentContainer))
+        XCTAssertGreaterThan(searchIndex, contentIndex)
+    }
+
     func test_readerModeBar_hasConstraintsWhenPresent() {
         let subject = createSubject()
 
@@ -300,4 +316,8 @@ final class BrowserViewControllerConstraintTests: BrowserViewControllerConstrain
              constraint.secondAttribute == firstAttribute)
         }
     }
+}
+
+private final class MockHomepageContentViewController: UIViewController, ContentContainable {
+    var contentType: ContentType { .homepage }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerConstraintTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerConstraintTests.swift
@@ -228,14 +228,19 @@ final class BrowserViewControllerConstraintTests: BrowserViewControllerConstrain
     func test_updateContentContainerTopConstraint_keepsSearchControllerAboveHomepage() throws {
         setupNimbusHomepagePinnedHeaderTesting(isEnabled: true)
         let subject = createSubject()
+        let searchController = createSearchController()
         let homepage = MockHomepageContentViewController()
 
-        subject.showSearchController()
+        subject.searchController = searchController
+        subject.view.addSubview(searchController.view)
+        defer {
+            searchController.view.removeFromSuperview()
+            subject.searchController = nil
+        }
         subject.contentContainer.update(content: homepage)
         subject.updateContentContainerTopConstraint()
 
-        let searchView = try XCTUnwrap(subject.searchController?.view)
-        let searchIndex = try XCTUnwrap(subject.view.subviews.firstIndex(of: searchView))
+        let searchIndex = try XCTUnwrap(subject.view.subviews.firstIndex(of: searchController.view))
         let contentIndex = try XCTUnwrap(subject.view.subviews.firstIndex(of: subject.contentContainer))
         XCTAssertGreaterThan(searchIndex, contentIndex)
     }
@@ -293,6 +298,28 @@ final class BrowserViewControllerConstraintTests: BrowserViewControllerConstrain
             [.leading, .trailing, .bottom, .height].contains($0.firstAttribute)
         }
         return relevantConstraints.count
+    }
+
+    private func createSearchController() -> SearchViewController {
+        let searchEnginesManager = SearchEnginesManager(
+            prefs: profile.prefs,
+            files: profile.files,
+            engineProvider: MockSearchEngineProvider()
+        )
+        let searchViewModel = SearchViewModel(
+            isPrivate: false,
+            isBottomSearchBar: false,
+            profile: profile,
+            model: searchEnginesManager,
+            tabManager: tabManager,
+            trendingSearchClient: MockTrendingSearchClient(),
+            recentSearchProvider: MockRecentSearchProvider()
+        )
+        return SearchViewController(
+            profile: profile,
+            viewModel: searchViewModel,
+            tabManager: tabManager
+        )
     }
 
     /// Check if two sibling views are connected by a constraint

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerConstraintTestsBase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerConstraintTestsBase.swift
@@ -27,9 +27,20 @@ class BrowserViewControllerConstraintTestsBase: XCTestCase {
     }
 
     // MARK: - Subject Creation
-    func createSubject(isFeatureFlagEnabled: Bool = false, isBottomSearchBar: Bool = true) -> BrowserViewController {
+    func createSubject(
+        isFeatureFlagEnabled: Bool = false,
+        isBottomSearchBar: Bool = true,
+        featureFlagProvider: FeatureFlagProviding? = nil
+    ) -> BrowserViewController {
         // Setup feature flag to disabled by default and override only in the test that need it
         setupNimbusSnapKitRemovalTesting(isEnabled: isFeatureFlagEnabled)
+        if let featureFlagProvider {
+            DependencyHelperMock().bootstrapDependencies(
+                injectedProfile: profile,
+                injectedTabManager: tabManager,
+                injectedFeatureFlagProvider: featureFlagProvider
+            )
+        }
         let subject = BrowserViewController(profile: profile,
                                             tabManager: tabManager)
         subject.isBottomSearchBar = isBottomSearchBar

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerConstraintTestsBase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerConstraintTestsBase.swift
@@ -16,6 +16,7 @@ class BrowserViewControllerConstraintTestsBase: XCTestCase {
         tabManager = MockTabManager()
         DependencyHelperMock().bootstrapDependencies(injectedTabManager: tabManager)
         profile = MockProfile()
+        setupNimbusHomepagePinnedHeaderTesting(isEnabled: false)
     }
 
     override func tearDown() async throws {
@@ -27,20 +28,9 @@ class BrowserViewControllerConstraintTestsBase: XCTestCase {
     }
 
     // MARK: - Subject Creation
-    func createSubject(
-        isFeatureFlagEnabled: Bool = false,
-        isBottomSearchBar: Bool = true,
-        featureFlagProvider: FeatureFlagProviding? = nil
-    ) -> BrowserViewController {
+    func createSubject(isFeatureFlagEnabled: Bool = false, isBottomSearchBar: Bool = true) -> BrowserViewController {
         // Setup feature flag to disabled by default and override only in the test that need it
         setupNimbusSnapKitRemovalTesting(isEnabled: isFeatureFlagEnabled)
-        if let featureFlagProvider {
-            DependencyHelperMock().bootstrapDependencies(
-                injectedProfile: profile,
-                injectedTabManager: tabManager,
-                injectedFeatureFlagProvider: featureFlagProvider
-            )
-        }
         let subject = BrowserViewController(profile: profile,
                                             tabManager: tabManager)
         subject.isBottomSearchBar = isBottomSearchBar
@@ -60,6 +50,15 @@ class BrowserViewControllerConstraintTestsBase: XCTestCase {
     func setupNimbusSnapKitRemovalTesting(isEnabled: Bool) {
         FxNimbus.shared.features.snapkitRemovalRefactor.with { _, _ in
             return SnapkitRemovalRefactor(enabled: isEnabled)
+        }
+    }
+
+    func setupNimbusHomepagePinnedHeaderTesting(isEnabled: Bool) {
+        FxNimbus.shared.features.homepageRedesignFeature.with { _, _ in
+            return HomepageRedesignFeature(
+                categoriesEnabled: isEnabled,
+                pinnedHeaderEnabled: isEnabled
+            )
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15857)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33922)

## :bulb: Description
- Ensures active search suggestions view stays above homepage content when homepage pinned header layout updates run during rotation.

### 📝 Technical Notes:
- `updateContentContainerTopConstraint()` was bringing the `contentContainer` to the front when the homepage pinned header was enabled, and during rotation, that method runs again while search is active, so the homepage could visually cover `SearchViewController`. Search was not actually dismissed, it was still in the hierarchy, but hidden behind the content container, so we now resurface the active `SearchViewController` view after pinned homepage z-order updates
- Weird re-layout behavior of the `SearchViewController` (that you see in the after video) was a pre-existing issue
- This is a fairly targeted fix for the regression. The larger issue is that `updateContentContainerTopConstraint()` handles both layout constraints and view z-ordering and because that method runs from broad lifecycle paths like rotation/layout updates, it can unintentionally change z-ordering unless every active overlay is accounted for 😞 

## :movie_camera: Demos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/87fae2d6-ceb2-4890-95a5-be72fd984d2e

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/534b5eb0-ddbb-4052-ac00-f57e60ea1e2f

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

