### PR TITLE
BugFix [World Cup] FXIOS-15863 return correct index of the countdown before and after WorldCup has started

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupAction.swift
@@ -11,6 +11,7 @@ struct WorldCupAction: Action {
     let actionType: any ActionType
     let shouldShowHomepageWorldCupSection: Bool
     let shouldShowMilestone2: Bool
+    let hasWorldCupStarted: Bool
     let selectedCountryId: String?
     let matches: [WorldCupMatches]
     let apiError: WorldCupLoadError?
@@ -24,6 +25,7 @@ struct WorldCupAction: Action {
         actionType: any ActionType,
         shouldShowHomepageWorldCupSection: Bool = false,
         shouldShowMilestone2: Bool = false,
+        hasWorldCupStarted: Bool = false,
         selectedCountryId: String? = nil,
         matches: [WorldCupMatches] = [],
         apiError: WorldCupLoadError? = nil,
@@ -33,6 +35,7 @@ struct WorldCupAction: Action {
         self.actionType = actionType
         self.shouldShowHomepageWorldCupSection = shouldShowHomepageWorldCupSection
         self.shouldShowMilestone2 = shouldShowMilestone2
+        self.hasWorldCupStarted = hasWorldCupStarted
         self.selectedCountryId = selectedCountryId
         self.matches = matches
         self.apiError = apiError

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -248,17 +248,12 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
         goToPage(initialPage(for: state, pageCount: pages.count))
     }
 
-    /// Resolves which page the swipe view should display first. With no team
-    /// selected we land on the closest upcoming match (provided by the
-    /// middleware via `state.defaultMatchIndex`) rather than the
-    /// chronologically latest card. Page 0 is the timer view, so match cards
-    /// are offset by one.
+    /// Resolves which page the swipe view should display first. The middleware
+    /// hands us the page index directly via `state.defaultMatchIndex`; we just
+    /// clamp it into the valid page range.
     private func initialPage(for state: WorldCupSectionState, pageCount: Int) -> Int {
-        guard state.isMilestone2, !state.matches.isEmpty, pageCount > 1 else {
-            return pageCount - 1
-        }
-        let target = 1 + state.defaultMatchIndex
-        return min(max(target, 0), pageCount - 1)
+        guard pageCount > 0 else { return 0 }
+        return min(max(state.defaultMatchIndex, 0), pageCount - 1)
     }
 
     private func makePages(for state: WorldCupSectionState) -> [PageContainer] {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCellFactory.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCellFactory.swift
@@ -9,10 +9,9 @@ import UIKit
 struct WorldCupCellFactory {
     /// Builds the subpages array from the given state
     static func makePages(from state: WorldCupSectionState) -> [UIView] {
-        let timerView = WorldCupTimerView(windowUUID: state.windowUUID)
-        timerView.configure(state: state)
-
         guard state.isMilestone2 else {
+            let timerView = WorldCupTimerView(windowUUID: state.windowUUID)
+            timerView.configure(state: state)
             return [timerView]
         }
 
@@ -27,6 +26,14 @@ struct WorldCupCellFactory {
             view.configure(with: $0)
             return view
         }
+        
+        // If the WorldCup has started and the user selected a team, we don't display
+        // anymore the timer view
+        if state.hasWorldCupStarted && state.selectedCountryId != nil {
+            return matchesViews
+        }
+        let timerView = WorldCupTimerView(windowUUID: state.windowUUID)
+        timerView.configure(state: state)
         return [timerView] + matchesViews
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCellFactory.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCellFactory.swift
@@ -26,7 +26,7 @@ struct WorldCupCellFactory {
             view.configure(with: $0)
             return view
         }
-        
+
         // If the WorldCup has started and the user selected a team, we don't display
         // anymore the timer view
         if state.hasWorldCupStarted && state.selectedCountryId != nil {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
@@ -92,8 +92,8 @@ struct WorldCupMatches: Equatable, Hashable {
     /// holds all matches on the same date. Each day's matches render in the
     /// compact `upcomingMatches` row — `featuredMatch` is left empty so a
     /// crowded day doesn't blow the card up vertically. Cards are ordered
-    /// chronologically (earliest day first); `defaultIndex` points at today's
-    /// card, or the next future day if today has no matches.
+    /// chronologically (earliest day first); `defaultIndex` is the page the
+    /// swipe view should land on first, with page 0 reserved for the timer.
     static func flattened(
         response: WorldCupMatchesResponse,
         liveIDs: Set<Int> = [],
@@ -117,11 +117,9 @@ struct WorldCupMatches: Equatable, Hashable {
                 upcomingMatches: nonLive.map { WorldCupMatch($0, localeProvider: localeProvider, timeOnly: true) }
             )
         }
-        let today = calendar.startOfDay(for: now)
-        let liveCardIndex = cards.firstIndex(where: \.isLive)
-        let firstFutureIndex = groups.firstIndex(where: { $0.day >= today })
-        let defaultIndex = liveCardIndex ?? firstFutureIndex ?? max(cards.count - 1, 0)
-        return (cards, defaultIndex)
+        // The timer view always sits at page 0 when there's no selected team,
+        // and that's where the swipe view should land first.
+        return (cards, 0)
     }
 
     private static func dayLabel(for day: Date, locale: Locale) -> String {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
@@ -69,6 +69,7 @@ final class WorldCupMiddleware {
                 actionType: WorldCupMiddlewareActionType.didUpdate,
                 shouldShowHomepageWorldCupSection: worldCupStore.isFeatureEnabledAndSectionEnabled,
                 shouldShowMilestone2: worldCupStore.isMilestone2,
+                hasWorldCupStarted: worldCupStore.hasWorldCupStarted,
                 selectedCountryId: worldCupStore.selectedTeam,
                 matches: snapshot.matches,
                 apiError: snapshot.apiError,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupSectionState.swift
@@ -12,6 +12,8 @@ struct WorldCupSectionState: StateType, Equatable, Hashable {
     var windowUUID: WindowUUID
     var shouldShowSection: Bool
     var isMilestone2: Bool
+    var hasWorldCupStarted: Bool
+    var selectedCountryId: String?
     var matches: [WorldCupMatches]
     var apiError: WorldCupLoadError?
     /// Index into `matches` of the card that should be visible first. Used by
@@ -23,6 +25,8 @@ struct WorldCupSectionState: StateType, Equatable, Hashable {
         self.windowUUID = windowUUID
         self.shouldShowSection = false
         self.isMilestone2 = false
+        self.hasWorldCupStarted = false
+        self.selectedCountryId = nil
         self.matches = []
         self.apiError = nil
         self.defaultMatchIndex = 0
@@ -32,6 +36,8 @@ struct WorldCupSectionState: StateType, Equatable, Hashable {
         windowUUID: WindowUUID,
         shouldShowSection: Bool,
         isMilestone2: Bool,
+        hasWorldCupStarted: Bool,
+        selectedCountryId: String?,
         matches: [WorldCupMatches],
         apiError: WorldCupLoadError?,
         defaultMatchIndex: Int
@@ -39,6 +45,8 @@ struct WorldCupSectionState: StateType, Equatable, Hashable {
         self.windowUUID = windowUUID
         self.shouldShowSection = shouldShowSection
         self.isMilestone2 = isMilestone2
+        self.hasWorldCupStarted = hasWorldCupStarted
+        self.selectedCountryId = selectedCountryId
         self.matches = matches
         self.apiError = apiError
         self.defaultMatchIndex = defaultMatchIndex
@@ -54,6 +62,8 @@ struct WorldCupSectionState: StateType, Equatable, Hashable {
                 windowUUID: action.windowUUID,
                 shouldShowSection: action.shouldShowHomepageWorldCupSection,
                 isMilestone2: action.shouldShowMilestone2,
+                hasWorldCupStarted: action.hasWorldCupStarted,
+                selectedCountryId: action.selectedCountryId,
                 matches: action.matches,
                 apiError: action.apiError,
                 defaultMatchIndex: action.defaultMatchIndex

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
@@ -70,13 +70,11 @@ struct WorldCupStore: WorldCupStoreProtocol, FeatureFlaggable {
     }
 
     var isMilestone2: Bool {
-        return true
         guard let enableDate = milestone2EnableDate else { return false }
         return dateProvider.now() >= enableDate
     }
 
     var hasWorldCupStarted: Bool {
-        return true
         guard let startDate = worldCupStartDate else { return false }
         return dateProvider.now() >= startDate
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
@@ -21,6 +21,9 @@ protocol WorldCupStoreProtocol {
     /// milestone 2 enable date has been reached.
     var isMilestone2: Bool { get }
 
+    /// Returns true when the World Cup countdown target date has been reached.
+    var hasWorldCupStarted: Bool { get }
+
     /// Saves the world cup section selection in the preference
     func setIsHomepageSectionEnabled(_ isEnabled: Bool)
 
@@ -67,12 +70,24 @@ struct WorldCupStore: WorldCupStoreProtocol, FeatureFlaggable {
     }
 
     var isMilestone2: Bool {
+        return true
         guard let enableDate = milestone2EnableDate else { return false }
         return dateProvider.now() >= enableDate
     }
 
+    var hasWorldCupStarted: Bool {
+        return true
+        guard let startDate = worldCupStartDate else { return false }
+        return dateProvider.now() >= startDate
+    }
+
     private var milestone2EnableDate: Date? {
         let dateString = nimbusFeature.value().milestone2EnableDate
+        return iso8601Formatter.date(from: dateString)
+    }
+
+    private var worldCupStartDate: Date? {
+        let dateString = nimbusFeature.value().countdownTargetDate
         return iso8601Formatter.date(from: dateString)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupCellFactoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupCellFactoryTests.swift
@@ -90,6 +90,48 @@ final class WorldCupCellFactoryTests: XCTestCase {
         XCTAssertTrue(pages.first is WorldCupTimerView)
     }
 
+    func test_makePages_whenWorldCupStarted_withSelectedTeam_returnsOnlyMatchCards() {
+        var state = WorldCupSectionState(windowUUID: .XCTestDefaultUUID)
+        state.isMilestone2 = true
+        state.hasWorldCupStarted = true
+        state.selectedCountryId = "FRA"
+        state.matches = [makeMatches(), makeMatches()]
+
+        let pages = WorldCupCellFactory.makePages(from: state)
+
+        XCTAssertEqual(pages.count, 2)
+        XCTAssertTrue(pages[0] is WorldCupMatchCardView)
+        XCTAssertTrue(pages[1] is WorldCupMatchCardView)
+    }
+
+    func test_makePages_whenWorldCupStarted_withoutSelectedTeam_returnsTimerFollowedByMatchCards() {
+        var state = WorldCupSectionState(windowUUID: .XCTestDefaultUUID)
+        state.isMilestone2 = true
+        state.hasWorldCupStarted = true
+        state.selectedCountryId = nil
+        state.matches = [makeMatches()]
+
+        let pages = WorldCupCellFactory.makePages(from: state)
+
+        XCTAssertEqual(pages.count, 2)
+        XCTAssertTrue(pages[0] is WorldCupTimerView)
+        XCTAssertTrue(pages[1] is WorldCupMatchCardView)
+    }
+
+    func test_makePages_whenWorldCupNotStarted_withSelectedTeam_returnsTimerFollowedByMatchCards() {
+        var state = WorldCupSectionState(windowUUID: .XCTestDefaultUUID)
+        state.isMilestone2 = true
+        state.hasWorldCupStarted = false
+        state.selectedCountryId = "FRA"
+        state.matches = [makeMatches()]
+
+        let pages = WorldCupCellFactory.makePages(from: state)
+
+        XCTAssertEqual(pages.count, 2)
+        XCTAssertTrue(pages[0] is WorldCupTimerView)
+        XCTAssertTrue(pages[1] is WorldCupMatchCardView)
+    }
+
     private func makeMatches() -> WorldCupMatches {
         return WorldCupMatches(
             phaseTitle: "Group Stage",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
@@ -270,7 +270,7 @@ struct WorldCupMatchesTests {
     }
 
     @Test
-    func test_flattened_defaultIndex_pointsAtToday() {
+    func test_flattened_defaultIndex_isAlwaysZero() {
         let response = WorldCupMatchesResponse(
             previous: [makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-06-10T18:00:00+00:00")],
             current: [makeMatch(id: 2, home: "ENG", away: "USA", date: "2026-06-12T18:00:00+00:00")],
@@ -283,47 +283,7 @@ struct WorldCupMatchesTests {
             calendar: utcCalendar()
         )
 
-        #expect(result.defaultIndex == 1)
-    }
-
-    @Test
-    func test_flattened_defaultIndex_pointsAtNextFutureDay_whenTodayHasNoMatches() {
-        let response = WorldCupMatchesResponse(
-            previous: [makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-06-10T18:00:00+00:00")],
-            current: nil,
-            next: [
-                makeMatch(id: 2, home: "ENG", away: "USA", date: "2026-06-13T18:00:00+00:00"),
-                makeMatch(id: 3, home: "FRA", away: "GER", date: "2026-06-14T18:00:00+00:00")
-            ]
-        )
-
-        let result = WorldCupMatches.flattened(
-            response: response,
-            now: parse("2026-06-11T09:00:00+00:00"),
-            calendar: utcCalendar()
-        )
-
-        #expect(result.defaultIndex == 1)
-    }
-
-    @Test
-    func test_flattened_defaultIndex_fallsBackToLastCard_whenEverythingIsInThePast() {
-        let response = WorldCupMatchesResponse(
-            previous: [
-                makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-06-10T18:00:00+00:00"),
-                makeMatch(id: 2, home: "ENG", away: "USA", date: "2026-06-11T18:00:00+00:00")
-            ],
-            current: nil,
-            next: nil
-        )
-
-        let result = WorldCupMatches.flattened(
-            response: response,
-            now: parse("2026-07-01T09:00:00+00:00"),
-            calendar: utcCalendar()
-        )
-
-        #expect(result.defaultIndex == 1)
+        #expect(result.defaultIndex == 0)
     }
 
     @Test
@@ -370,27 +330,6 @@ struct WorldCupMatchesTests {
 
         #expect(result.cards[0].featuredMatch.map(\.homeCode) == ["ARG", "ENG"])
         #expect(result.cards[0].upcomingMatches.isEmpty)
-    }
-
-    @Test
-    func test_flattened_defaultIndex_prefersLiveCardOverToday() {
-        let response = WorldCupMatchesResponse(
-            previous: nil,
-            current: nil,
-            next: [
-                makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-06-12T18:00:00+00:00"),
-                makeMatch(id: 2, home: "ENG", away: "USA", date: "2026-06-13T18:00:00+00:00")
-            ]
-        )
-
-        let result = WorldCupMatches.flattened(
-            response: response,
-            liveIDs: [2],
-            now: parse("2026-06-12T09:00:00+00:00"),
-            calendar: utcCalendar()
-        )
-
-        #expect(result.defaultIndex == 1)
     }
 
     @Test

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -627,7 +627,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.worldCupProvider = { _, _ in }
     }
 
-    func test_initialize_noTeam_whenDevTimelineEnabled_defaultIndexUsesServerNow() throws {
+    func test_initialize_noTeam_dispatchesTimerAsDefaultPage() throws {
         mockWorldCupStore.isFeatureEnabled = true
         mockWorldCupStore.isHomepageSectionEnabled = true
         mockWorldCupStore.isMilestone2 = true
@@ -655,7 +655,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let dispatched = try XCTUnwrap(latestWorldCupAction())
         XCTAssertEqual(dispatched.matches.count, 2)
-        XCTAssertEqual(dispatched.defaultMatchIndex, 1)
+        XCTAssertEqual(dispatched.defaultMatchIndex, 0)
         subject.worldCupProvider = { _, _ in }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupStoreTests.swift
@@ -23,6 +23,22 @@ final class WorldCupStoreTests: XCTestCase {
         try await super.tearDown()
     }
 
+    // MARK: - isFeatureEnabled
+
+    func test_isFeatureEnabled_whenNimbusFeatureEnabled_returnsTrue() {
+        setNimbusFeature(enabled: true)
+        let subject = createSubject()
+
+        XCTAssertTrue(subject.isFeatureEnabled)
+    }
+
+    func test_isFeatureEnabled_whenNimbusFeatureDisabled_returnsFalse() {
+        setNimbusFeature(enabled: false)
+        let subject = createSubject()
+
+        XCTAssertFalse(subject.isFeatureEnabled)
+    }
+
     // MARK: - isFeatureEnabledAndSectionEnabled
 
     func test_isFeatureEnabledAndSectionEnabled_withFeatureOnAndSectionOn_returnsTrue() {
@@ -98,6 +114,33 @@ final class WorldCupStoreTests: XCTestCase {
         XCTAssertFalse(subject.isMilestone2)
     }
 
+    // MARK: - hasWorldCupStarted
+
+    func test_hasWorldCupStarted_whenNowIsAfterStartDate_returnsTrue() {
+        setNimbusFeature(countdownTargetDate: "2026-06-11T19:00:00Z")
+        let subject = createSubject(
+            dateProvider: MockDateProvider(fixedDate: iso8601Date("2026-06-12T00:00:00Z"))
+        )
+
+        XCTAssertTrue(subject.hasWorldCupStarted)
+    }
+
+    func test_hasWorldCupStarted_whenNowIsBeforeStartDate_returnsFalse() {
+        setNimbusFeature(countdownTargetDate: "2026-06-11T19:00:00Z")
+        let subject = createSubject(
+            dateProvider: MockDateProvider(fixedDate: iso8601Date("2026-06-11T18:59:59Z"))
+        )
+
+        XCTAssertFalse(subject.hasWorldCupStarted)
+    }
+
+    func test_hasWorldCupStarted_whenStartDateIsInvalid_returnsFalse() {
+        setNimbusFeature(countdownTargetDate: "not-a-real-date")
+        let subject = createSubject(dateProvider: MockDateProvider(fixedDate: Date()))
+
+        XCTAssertFalse(subject.hasWorldCupStarted)
+    }
+
     // MARK: - setIsHomepageSectionEnabled
 
     func test_setIsHomepageSectionEnabled_writesToPrefs() {
@@ -124,6 +167,15 @@ final class WorldCupStoreTests: XCTestCase {
         )
     }
 
+    func test_setSelectedTeam_withNil_clearsPref() {
+        mockProfile.prefs.setString("ESP", forKey: PrefsKeys.Homepage.WorldCupSelectedCountry)
+        let subject = createSubject()
+
+        subject.setSelectedTeam(countryId: nil)
+
+        XCTAssertNil(mockProfile.prefs.stringForKey(PrefsKeys.Homepage.WorldCupSelectedCountry))
+    }
+
     // MARK: - Helpers
 
     private func createSubject(
@@ -138,10 +190,12 @@ final class WorldCupStoreTests: XCTestCase {
 
     private func setNimbusFeature(
         enabled: Bool = false,
-        milestone2EnableDate: String = "2026-05-10T19:00:00Z"
+        milestone2EnableDate: String = "2026-05-10T19:00:00Z",
+        countdownTargetDate: String = "2026-06-11T19:00:00Z"
     ) {
         FxNimbus.shared.features.worldCupWidgetFeature.with { _, _ in
             return WorldCupWidgetFeature(
+                countdownTargetDate: countdownTargetDate,
                 enabled: enabled,
                 milestone2EnableDate: milestone2EnableDate
             )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupStore.swift
@@ -11,6 +11,7 @@ final class MockWorldCupStore: WorldCupStoreProtocol {
     var isHomepageSectionEnabled = true
     var selectedTeam: String?
     var isMilestone2 = false
+    var hasWorldCupStarted = false
 
     var setIsHomepageSectionEnabledCalled = 0
     var lastSetIsHomepageSectionEnabledValue: Bool?


### PR DESCRIPTION
## :scroll: Tickets
### timer missing when team is not selected
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15863)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33932)

### After refreshing from an error page is not resized correctly
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15864)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33933)

## :bulb: Description
Add correct index calculation for the default selected Card in the `WorldCupCell` depending when the team is selected and when the WorldCup has started or not.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

